### PR TITLE
feat(mcp): add query-web-overview and query-web-stats wrappers

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4671,6 +4671,167 @@
             "required": ["id", "tool_call_id", "content"],
             "type": "object"
         },
+        "AssistantWebAnalyticsQueryBase": {
+            "additionalProperties": false,
+            "description": "Shared filter set across all web-analytics assistant queries.\n\nMirrors `WebAnalyticsQueryBase` but drops noisy fields agents shouldn't set (`samplingFactor`, `aggregation_group_type_index`, `dataColorTheme`, deprecated/legacy options).",
+            "properties": {
+                "compareFilter": {
+                    "$ref": "#/definitions/CompareFilter",
+                    "description": "Compare the current period to a prior period. Disabled by default. Enabling roughly doubles query cost — leave it off unless the user explicitly asks for a period-over-period comparison."
+                },
+                "conversionGoal": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Conversion goal — pass an `actionId` (must belong to the current project) or a `customEventName`. Adds conversion columns to the response. Disables the pre-aggregated fast path — only set when the user explicitly asks about a conversion."
+                },
+                "dateRange": {
+                    "$ref": "#/definitions/AssistantDateRangeFilter",
+                    "description": "Date range for the query. Defaults to the last 7 days when omitted. Keep ranges short — the backend has no upper bound and large windows on the slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can be expensive."
+                },
+                "doPathCleaning": {
+                    "default": false,
+                    "description": "Apply the team's path-cleaning rules to URL-style breakdowns.",
+                    "type": "boolean"
+                },
+                "filterTestAccounts": {
+                    "default": false,
+                    "description": "Exclude internal and test users by applying the team's test-account filter.",
+                    "type": "boolean"
+                },
+                "properties": {
+                    "$ref": "#/definitions/WebAnalyticsPropertyFilters",
+                    "default": [],
+                    "description": "Property filters applied to the query. Accepts event, person, session, or cohort filters."
+                }
+            },
+            "type": "object"
+        },
+        "AssistantWebOverviewQuery": {
+            "additionalProperties": false,
+            "description": "High-level web-analytics KPIs over a period: visitors, pageviews, sessions, average session duration, and bounce rate. Returns a small list of metric tuples with optional period-over-period comparison.\n\nUse this when the user asks \"how is the site doing?\", \"what are the topline web numbers?\", or wants a snapshot of overall traffic health.",
+            "properties": {
+                "compareFilter": {
+                    "$ref": "#/definitions/CompareFilter",
+                    "description": "Compare the current period to a prior period. Disabled by default. Enabling roughly doubles query cost — leave it off unless the user explicitly asks for a period-over-period comparison."
+                },
+                "conversionGoal": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Conversion goal — pass an `actionId` (must belong to the current project) or a `customEventName`. Adds conversion columns to the response. Disables the pre-aggregated fast path — only set when the user explicitly asks about a conversion."
+                },
+                "dateRange": {
+                    "$ref": "#/definitions/AssistantDateRangeFilter",
+                    "description": "Date range for the query. Defaults to the last 7 days when omitted. Keep ranges short — the backend has no upper bound and large windows on the slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can be expensive."
+                },
+                "doPathCleaning": {
+                    "default": false,
+                    "description": "Apply the team's path-cleaning rules to URL-style breakdowns.",
+                    "type": "boolean"
+                },
+                "filterTestAccounts": {
+                    "default": false,
+                    "description": "Exclude internal and test users by applying the team's test-account filter.",
+                    "type": "boolean"
+                },
+                "kind": {
+                    "const": "WebOverviewQuery",
+                    "type": "string"
+                },
+                "properties": {
+                    "$ref": "#/definitions/WebAnalyticsPropertyFilters",
+                    "default": [],
+                    "description": "Property filters applied to the query. Accepts event, person, session, or cohort filters."
+                }
+            },
+            "required": ["kind"],
+            "type": "object"
+        },
+        "AssistantWebStatsTableQuery": {
+            "additionalProperties": false,
+            "description": "Tabular web-analytics breakdown — top pages, UTMs, devices, browsers, countries, etc. — with visitors, pageviews, and optional bounce rate / average time on page columns.\n\nThis is the right query for \"top pages with bounce rate\" (set `breakdownBy=Page` and `includeBounceRate=true`) and for entry/exit-page navigation analysis (`breakdownBy=InitialPage|ExitPage|PreviousPage`).",
+            "properties": {
+                "breakdownBy": {
+                    "$ref": "#/definitions/WebStatsBreakdown",
+                    "description": "Required. Property to break down the table by. The full enum covers path-style (`Page`, `InitialPage`, `ExitPage`, `PreviousPage`), marketing/source (UTM source/medium/campaign/term/content, channel, referring domain), audience/device (browser, OS, device type, viewport), and geography (country, region, city, timezone, language). Path-style breakdowns pair naturally with `includeBounceRate` / `includeAvgTimeOnPage`."
+                },
+                "compareFilter": {
+                    "$ref": "#/definitions/CompareFilter",
+                    "description": "Compare the current period to a prior period. Disabled by default. Enabling roughly doubles query cost — leave it off unless the user explicitly asks for a period-over-period comparison."
+                },
+                "conversionGoal": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Conversion goal — pass an `actionId` (must belong to the current project) or a `customEventName`. Adds conversion columns to the response. Disables the pre-aggregated fast path — only set when the user explicitly asks about a conversion."
+                },
+                "dateRange": {
+                    "$ref": "#/definitions/AssistantDateRangeFilter",
+                    "description": "Date range for the query. Defaults to the last 7 days when omitted. Keep ranges short — the backend has no upper bound and large windows on the slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can be expensive."
+                },
+                "doPathCleaning": {
+                    "default": false,
+                    "description": "Apply the team's path-cleaning rules to URL-style breakdowns.",
+                    "type": "boolean"
+                },
+                "filterTestAccounts": {
+                    "default": false,
+                    "description": "Exclude internal and test users by applying the team's test-account filter.",
+                    "type": "boolean"
+                },
+                "includeAvgTimeOnPage": {
+                    "default": false,
+                    "description": "Add an average-time-on-page column. Implies a Page-style breakdown. Disables the pre-aggregated fast path.",
+                    "type": "boolean"
+                },
+                "includeBounceRate": {
+                    "default": false,
+                    "description": "Add a bounce-rate column. Most useful with a path-style breakdown.",
+                    "type": "boolean"
+                },
+                "includeHost": {
+                    "default": false,
+                    "description": "When using a path-style breakdown (`Page`, `InitialPage`, `ExitPage`, `PreviousPage`), concatenate host + pathname so the same path on different hosts is counted separately.",
+                    "type": "boolean"
+                },
+                "kind": {
+                    "const": "WebStatsTableQuery",
+                    "type": "string"
+                },
+                "limit": {
+                    "$ref": "#/definitions/positive_integer",
+                    "description": "Maximum rows to return. Prefer 10–25 unless the user explicitly asks for more. Hard ceiling enforced at the wrapper.",
+                    "maximum": 200
+                },
+                "offset": {
+                    "$ref": "#/definitions/non_negative_integer",
+                    "description": "Pagination offset."
+                },
+                "properties": {
+                    "$ref": "#/definitions/WebAnalyticsPropertyFilters",
+                    "default": [],
+                    "description": "Property filters applied to the query. Accepts event, person, session, or cohort filters."
+                }
+            },
+            "required": ["kind", "breakdownBy"],
+            "type": "object"
+        },
         "AttributeBreakdownRow": {
             "additionalProperties": false,
             "description": "One row of a span attribute breakdown: the spans matching the filters, grouped by one attribute's value. Spans without the attribute group under `value = ''`.",
@@ -48916,6 +49077,10 @@
                 }
             },
             "type": "object"
+        },
+        "non_negative_integer": {
+            "minimum": 0,
+            "type": "integer"
         },
         "positive_integer": {
             "minimum": 1,

--- a/frontend/src/queries/schema/schema-assistant-web-analytics.ts
+++ b/frontend/src/queries/schema/schema-assistant-web-analytics.ts
@@ -1,4 +1,12 @@
-import { CompareFilter, WebAnalyticsPropertyFilters } from './schema-general'
+import { AssistantDateRangeFilter } from './schema-assistant-queries'
+import {
+    CompareFilter,
+    NodeKind,
+    WebAnalyticsConversionGoal,
+    WebAnalyticsPropertyFilters,
+    WebStatsBreakdown,
+} from './schema-general'
+import { non_negative_integer, positive_integer } from './type-utils'
 
 export interface WebAnalyticsAssistantFilters {
     date_from?: string | null
@@ -6,4 +14,126 @@ export interface WebAnalyticsAssistantFilters {
     properties: WebAnalyticsPropertyFilters
     doPathCleaning?: boolean
     compareFilter?: CompareFilter | null
+}
+
+/**
+ * Shared filter set across all web-analytics assistant queries.
+ *
+ * Mirrors `WebAnalyticsQueryBase` but drops noisy fields agents shouldn't set
+ * (`samplingFactor`, `aggregation_group_type_index`, `dataColorTheme`,
+ * deprecated/legacy options).
+ */
+export interface AssistantWebAnalyticsQueryBase {
+    /**
+     * Date range for the query. Defaults to the last 7 days when omitted.
+     * Keep ranges short — the backend has no upper bound and large windows on
+     * the slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can
+     * be expensive.
+     */
+    dateRange?: AssistantDateRangeFilter
+
+    /**
+     * Property filters applied to the query. Accepts event, person, session,
+     * or cohort filters.
+     *
+     * @default []
+     */
+    properties?: WebAnalyticsPropertyFilters
+
+    /**
+     * Compare the current period to a prior period. Disabled by default.
+     * Enabling roughly doubles query cost — leave it off unless the user
+     * explicitly asks for a period-over-period comparison.
+     */
+    compareFilter?: CompareFilter
+
+    /**
+     * Apply the team's path-cleaning rules to URL-style breakdowns.
+     * @default false
+     */
+    doPathCleaning?: boolean
+
+    /**
+     * Exclude internal and test users by applying the team's test-account filter.
+     * @default false
+     */
+    filterTestAccounts?: boolean
+
+    /**
+     * Conversion goal — pass an `actionId` (must belong to the current project)
+     * or a `customEventName`. Adds conversion columns to the response. Disables
+     * the pre-aggregated fast path — only set when the user explicitly asks
+     * about a conversion.
+     */
+    conversionGoal?: WebAnalyticsConversionGoal | null
+}
+
+/**
+ * High-level web-analytics KPIs over a period: visitors, pageviews, sessions,
+ * average session duration, and bounce rate. Returns a small list of metric
+ * tuples with optional period-over-period comparison.
+ *
+ * Use this when the user asks "how is the site doing?", "what are the topline
+ * web numbers?", or wants a snapshot of overall traffic health.
+ */
+export interface AssistantWebOverviewQuery extends AssistantWebAnalyticsQueryBase {
+    kind: NodeKind.WebOverviewQuery
+}
+
+/**
+ * Tabular web-analytics breakdown — top pages, UTMs, devices, browsers,
+ * countries, etc. — with visitors, pageviews, and optional bounce rate /
+ * average time on page columns.
+ *
+ * This is the right query for "top pages with bounce rate" (set
+ * `breakdownBy=Page` and `includeBounceRate=true`) and for entry/exit-page
+ * navigation analysis (`breakdownBy=InitialPage|ExitPage|PreviousPage`).
+ */
+export interface AssistantWebStatsTableQuery extends AssistantWebAnalyticsQueryBase {
+    kind: NodeKind.WebStatsTableQuery
+
+    /**
+     * Required. Property to break down the table by. The full enum covers
+     * path-style (`Page`, `InitialPage`, `ExitPage`, `PreviousPage`),
+     * marketing/source (UTM source/medium/campaign/term/content, channel,
+     * referring domain), audience/device (browser, OS, device type, viewport),
+     * and geography (country, region, city, timezone, language). Path-style
+     * breakdowns pair naturally with `includeBounceRate` /
+     * `includeAvgTimeOnPage`.
+     */
+    breakdownBy: WebStatsBreakdown
+
+    /**
+     * Add a bounce-rate column. Most useful with a path-style breakdown.
+     * @default false
+     */
+    includeBounceRate?: boolean
+
+    /**
+     * Add an average-time-on-page column. Implies a Page-style breakdown.
+     * Disables the pre-aggregated fast path.
+     * @default false
+     */
+    includeAvgTimeOnPage?: boolean
+
+    /**
+     * When using a path-style breakdown (`Page`, `InitialPage`, `ExitPage`,
+     * `PreviousPage`), concatenate host + pathname so the same path on
+     * different hosts is counted separately.
+     * @default false
+     */
+    includeHost?: boolean
+
+    /**
+     * Maximum rows to return. Prefer 10–25 unless the user explicitly asks
+     * for more. Hard ceiling enforced at the wrapper.
+     *
+     * @maximum 200
+     */
+    limit?: positive_integer
+
+    /**
+     * Pagination offset.
+     */
+    offset?: non_negative_integer
 }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -9909,6 +9909,184 @@ class AssistantTrendsQuery(BaseModel):
     )
 
 
+class AssistantWebAnalyticsQueryBase(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    compareFilter: CompareFilter | None = Field(
+        default=None,
+        description=(
+            "Compare the current period to a prior period. Disabled by default."
+            " Enabling roughly doubles query cost — leave it off unless the user"
+            " explicitly asks for a period-over-period comparison."
+        ),
+    )
+    conversionGoal: ActionConversionGoal | CustomEventConversionGoal | None = Field(
+        default=None,
+        description=(
+            "Conversion goal — pass an `actionId` (must belong to the current project)"
+            " or a `customEventName`. Adds conversion columns to the response. Disables"
+            " the pre-aggregated fast path — only set when the user explicitly asks"
+            " about a conversion."
+        ),
+    )
+    dateRange: AssistantDateRange | AssistantDurationRange | None = Field(
+        default=None,
+        description=(
+            "Date range for the query. Defaults to the last 7 days when omitted. Keep"
+            " ranges short — the backend has no upper bound and large windows on the"
+            " slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can be"
+            " expensive."
+        ),
+    )
+    doPathCleaning: bool | None = Field(
+        default=False,
+        description="Apply the team's path-cleaning rules to URL-style breakdowns.",
+    )
+    filterTestAccounts: bool | None = Field(
+        default=False,
+        description=("Exclude internal and test users by applying the team's test-account filter."),
+    )
+    properties: (
+        list[EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter | CohortPropertyFilter] | None
+    ) = Field(
+        default=[],
+        description=("Property filters applied to the query. Accepts event, person, session, or cohort filters."),
+    )
+
+
+class AssistantWebOverviewQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    compareFilter: CompareFilter | None = Field(
+        default=None,
+        description=(
+            "Compare the current period to a prior period. Disabled by default."
+            " Enabling roughly doubles query cost — leave it off unless the user"
+            " explicitly asks for a period-over-period comparison."
+        ),
+    )
+    conversionGoal: ActionConversionGoal | CustomEventConversionGoal | None = Field(
+        default=None,
+        description=(
+            "Conversion goal — pass an `actionId` (must belong to the current project)"
+            " or a `customEventName`. Adds conversion columns to the response. Disables"
+            " the pre-aggregated fast path — only set when the user explicitly asks"
+            " about a conversion."
+        ),
+    )
+    dateRange: AssistantDateRange | AssistantDurationRange | None = Field(
+        default=None,
+        description=(
+            "Date range for the query. Defaults to the last 7 days when omitted. Keep"
+            " ranges short — the backend has no upper bound and large windows on the"
+            " slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can be"
+            " expensive."
+        ),
+    )
+    doPathCleaning: bool | None = Field(
+        default=False,
+        description="Apply the team's path-cleaning rules to URL-style breakdowns.",
+    )
+    filterTestAccounts: bool | None = Field(
+        default=False,
+        description=("Exclude internal and test users by applying the team's test-account filter."),
+    )
+    kind: Literal["WebOverviewQuery"] = "WebOverviewQuery"
+    properties: (
+        list[EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter | CohortPropertyFilter] | None
+    ) = Field(
+        default=[],
+        description=("Property filters applied to the query. Accepts event, person, session, or cohort filters."),
+    )
+
+
+class AssistantWebStatsTableQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdownBy: WebStatsBreakdown = Field(
+        ...,
+        description=(
+            "Required. Property to break down the table by. The full enum covers"
+            " path-style (`Page`, `InitialPage`, `ExitPage`, `PreviousPage`),"
+            " marketing/source (UTM source/medium/campaign/term/content, channel,"
+            " referring domain), audience/device (browser, OS, device type, viewport),"
+            " and geography (country, region, city, timezone, language). Path-style"
+            " breakdowns pair naturally with `includeBounceRate` /"
+            " `includeAvgTimeOnPage`."
+        ),
+    )
+    compareFilter: CompareFilter | None = Field(
+        default=None,
+        description=(
+            "Compare the current period to a prior period. Disabled by default."
+            " Enabling roughly doubles query cost — leave it off unless the user"
+            " explicitly asks for a period-over-period comparison."
+        ),
+    )
+    conversionGoal: ActionConversionGoal | CustomEventConversionGoal | None = Field(
+        default=None,
+        description=(
+            "Conversion goal — pass an `actionId` (must belong to the current project)"
+            " or a `customEventName`. Adds conversion columns to the response. Disables"
+            " the pre-aggregated fast path — only set when the user explicitly asks"
+            " about a conversion."
+        ),
+    )
+    dateRange: AssistantDateRange | AssistantDurationRange | None = Field(
+        default=None,
+        description=(
+            "Date range for the query. Defaults to the last 7 days when omitted. Keep"
+            " ranges short — the backend has no upper bound and large windows on the"
+            " slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can be"
+            " expensive."
+        ),
+    )
+    doPathCleaning: bool | None = Field(
+        default=False,
+        description="Apply the team's path-cleaning rules to URL-style breakdowns.",
+    )
+    filterTestAccounts: bool | None = Field(
+        default=False,
+        description=("Exclude internal and test users by applying the team's test-account filter."),
+    )
+    includeAvgTimeOnPage: bool | None = Field(
+        default=False,
+        description=(
+            "Add an average-time-on-page column. Implies a Page-style breakdown. Disables the pre-aggregated fast path."
+        ),
+    )
+    includeBounceRate: bool | None = Field(
+        default=False,
+        description=("Add a bounce-rate column. Most useful with a path-style breakdown."),
+    )
+    includeHost: bool | None = Field(
+        default=False,
+        description=(
+            "When using a path-style breakdown (`Page`, `InitialPage`, `ExitPage`,"
+            " `PreviousPage`), concatenate host + pathname so the same path on"
+            " different hosts is counted separately."
+        ),
+    )
+    kind: Literal["WebStatsTableQuery"] = "WebStatsTableQuery"
+    limit: conint(ge=1) | None = Field(
+        default=None,
+        description=(
+            "Maximum rows to return. Prefer 10–25 unless the user explicitly asks for"
+            " more. Hard ceiling enforced at the wrapper."
+        ),
+    )
+    offset: conint(ge=0) | None = Field(default=None, description="Pagination offset.")
+    properties: (
+        list[EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter | CohortPropertyFilter] | None
+    ) = Field(
+        default=[],
+        description=("Property filters applied to the query. Accepts event, person, session, or cohort filters."),
+    )
+
+
 class BreakdownItem(BaseModel):
     model_config = ConfigDict(
         extra="forbid",

--- a/products/web_analytics/backend/hogql_queries/web_analytics_query_runner.py
+++ b/products/web_analytics/backend/hogql_queries/web_analytics_query_runner.py
@@ -30,6 +30,7 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
+from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.property import action_to_expr, apply_path_cleaning, property_to_expr
 from posthog.hogql.query import execute_hogql_query
@@ -314,7 +315,14 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
     @cached_property
     def conversion_goal_expr(self) -> Optional[ast.Expr]:
         if isinstance(self.query.conversionGoal, ActionConversionGoal):
-            action = Action.objects.get(pk=self.query.conversionGoal.actionId, team__project_id=self.team.project_id)
+            try:
+                action = Action.objects.get(
+                    pk=self.query.conversionGoal.actionId, team__project_id=self.team.project_id
+                )
+            except Action.DoesNotExist:
+                raise QueryError(
+                    f"Conversion goal action with id={self.query.conversionGoal.actionId} not found in this project."
+                )
             return action_to_expr(action)
         elif isinstance(self.query.conversionGoal, CustomEventConversionGoal):
             return ast.CompareOperation(

--- a/services/mcp/definitions/prompts/query-web-overview.md
+++ b/services/mcp/definitions/prompts/query-web-overview.md
@@ -1,0 +1,33 @@
+Run a web analytics overview query — high-level KPIs over a period: visitors, pageviews, sessions, average session duration, and bounce rate. Returns a small list of metric tuples with optional period-over-period comparison. Mirrors the in-product **Web analytics** scene.
+
+# When to use this vs `query-trends`
+
+Pick this tool only when the answer needs **session-level math**. Session aggregation is more expensive than per-event queries — only pay for it when needed.
+
+Use `query-web-overview` when the question references just the aggregate values across the period instead of time series for those session-level values: bounce rate, session duration, sessions as a count, or entry/initial values (entry page, initial channel, initial UTM).
+
+Use `query-trends` instead for per-event counts — pageviews, sign-ups, button clicks. Faster.
+
+# Inputs
+
+- `dateRange` — defaults to last 7 days when omitted. Keep ranges short — there is no enforced upper bound and large windows on the slow path can be expensive.
+- `compareFilter: { compare: true }` — return prior-period values for change %. **Roughly doubles query cost** because it runs the same aggregation over the previous period — leave it off unless the user explicitly asks for a comparison.
+- `properties` — event/person/session/cohort filters. Same operator semantics as `query-trends` — see that prompt. Defaults to `[]`.
+- `filterTestAccounts` — exclude internal/test users.
+- `doPathCleaning` — apply team's path-cleaning rules.
+- `conversionGoal` — pass an `actionId` (must belong to the current project) or a `customEventName`. Only set when the user asks about a conversion.
+
+Use `read-data-schema` to validate property names/values when needed.
+
+# Example
+
+```json
+{
+  "kind": "WebOverviewQuery",
+  "dateRange": { "date_from": "-7d" }
+}
+```
+
+# Out of scope
+
+`conversionGoal` is supported as an input on this tool. Goal-funnel breakdowns (`WebGoalsQuery`), web vitals, and external clicks aren't exposed as separate query modes — fall back to `execute-sql` for those.

--- a/services/mcp/definitions/prompts/query-web-stats.md
+++ b/services/mcp/definitions/prompts/query-web-stats.md
@@ -1,0 +1,51 @@
+Run a web analytics breakdown table query — top pages, UTMs, devices, browsers, countries, etc. — with visitors and pageviews per row, plus optional bounce rate / average time on page. Mirrors the in-product **Web analytics** scene's table tiles.
+
+# When to use this vs `query-trends` / `query-paths`
+
+Pick this tool only when the answer needs **session-level math**. Session aggregation is more expensive than per-event queries — only pay for it when needed.
+
+Use `query-web-stats` when the breakdown or metric is session-derived:
+
+- `includeBounceRate=true` or `includeAvgTimeOnPage=true` (per-session metrics)
+- Initial / first-touch breakdowns: `InitialPage`, `InitialChannelType`, `InitialReferringDomain`, `InitialUTMSource`/`Medium`/`Campaign`/`Term`/`Content`
+- `ExitPage` (last event in a session)
+
+Use `query-trends` (with a breakdown) for per-event counts by an event property — no session boundaries needed. Faster.
+
+Use `query-paths` for navigation between arbitrary events when you don't need bounce rate or session-level metrics.
+
+# `breakdownBy` cheat-sheet
+
+- **Path-style** (pair with `includeBounceRate`/`includeAvgTimeOnPage`): `Page`, `InitialPage`, `ExitPage`, `PreviousPage`
+- **Marketing**: `InitialChannelType`, `InitialReferringDomain`, `InitialReferringURL`, `InitialUTMSource`, `InitialUTMMedium`, `InitialUTMCampaign`, `InitialUTMTerm`, `InitialUTMContent`, `InitialUTMSourceMediumCampaign`
+- **Audience / device**: `Browser`, `OS`, `Viewport`, `DeviceType`, `Country`, `Region`, `City`, `Timezone`, `Language`
+- **Other**: `ScreenName`, `ExitClick`, `FrustrationMetrics` (these don't combine with `includeBounceRate` / `includeAvgTimeOnPage`)
+
+# Inputs
+
+Same filter set as `query-web-overview` (`dateRange`, `compareFilter`, `properties`, `filterTestAccounts`, `doPathCleaning`, `conversionGoal`). Plus `breakdownBy` (required), `includeBounceRate`, `includeAvgTimeOnPage`, `includeHost`, `limit`, `offset`. Default `dateRange` is last 7 days.
+
+Performance hints:
+
+- Leave `compareFilter` off unless the user asks for period-over-period — enabling it roughly doubles query cost.
+- `limit` is capped at 200 by the wrapper. Prefer 10–25 unless the user explicitly asks for more.
+
+Use `read-data-schema` to validate property names/values when needed.
+
+# Example
+
+Top 20 pages by bounce rate, last 7 days:
+
+```json
+{
+  "kind": "WebStatsTableQuery",
+  "breakdownBy": "Page",
+  "includeBounceRate": true,
+  "limit": 20,
+  "dateRange": { "date_from": "-7d" }
+}
+```
+
+# Out of scope
+
+`conversionGoal` is supported as an input on this tool. Goal-funnel breakdowns (`WebGoalsQuery`), web vitals, and external clicks aren't exposed as separate query modes — fall back to `execute-sql` for those.

--- a/services/mcp/definitions/query-wrappers.yaml
+++ b/services/mcp/definitions/query-wrappers.yaml
@@ -122,6 +122,42 @@ wrappers:
             - modifiers
             - samplingFactor
 
+    query-web-overview:
+        schema_ref: AssistantWebOverviewQuery
+        enabled: true
+        scopes:
+            - query:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Run a web analytics overview query
+        description_file: ./prompts/query-web-overview.md
+        system_prompt_hint: Web analytics KPIs — visitors, sessions, bounce rate, session duration
+        ui_resource_uri: ui://posthog/query-results.html
+        exclude_properties:
+            - response
+            - modifiers
+            - samplingFactor
+
+    query-web-stats:
+        schema_ref: AssistantWebStatsTableQuery
+        enabled: true
+        scopes:
+            - query:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Run a web analytics breakdown table query
+        description_file: ./prompts/query-web-stats.md
+        system_prompt_hint: Web analytics breakdowns — top pages, UTMs, devices, countries, with bounce rate
+        ui_resource_uri: ui://posthog/query-results.html
+        exclude_properties:
+            - response
+            - modifiers
+            - samplingFactor
+
     query-llm-traces-list:
         schema_ref: AssistantTracesQuery
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -6262,6 +6262,36 @@
         },
         "system_prompt_hint": "List persons behind a trends data point"
     },
+    "query-web-overview": {
+        "description": "Run a web analytics overview query — high-level KPIs over a period: visitors, pageviews, sessions, average session duration, and bounce rate. Returns a small list of metric tuples with optional period-over-period comparison. Mirrors the in-product **Web analytics** scene.\n\n# When to use this vs `query-trends`\n\nPick this tool only when the answer needs **session-level math**. Session aggregation is more expensive than per-event queries — only pay for it when needed.\n\nUse `query-web-overview` when the question references just the aggregate values across the period instead of time series for those session-level values: bounce rate, session duration, sessions as a count, or entry/initial values (entry page, initial channel, initial UTM).\n\nUse `query-trends` instead for per-event counts — pageviews, sign-ups, button clicks. Faster.\n\n# Inputs\n\n- `dateRange` — defaults to last 7 days when omitted. Keep ranges short — there is no enforced upper bound and large windows on the slow path can be expensive.\n- `compareFilter: { compare: true }` — return prior-period values for change %. **Roughly doubles query cost** because it runs the same aggregation over the previous period — leave it off unless the user explicitly asks for a comparison.\n- `properties` — event/person/session/cohort filters. Same operator semantics as `query-trends` — see that prompt. Defaults to `[]`.\n- `filterTestAccounts` — exclude internal/test users.\n- `doPathCleaning` — apply team's path-cleaning rules.\n- `conversionGoal` — pass an `actionId` (must belong to the current project) or a `customEventName`. Only set when the user asks about a conversion.\n\nUse `read-data-schema` to validate property names/values when needed.\n\n# Example\n\n```json\n{\n  \"kind\": \"WebOverviewQuery\",\n  \"dateRange\": { \"date_from\": \"-7d\" }\n}\n```\n\n# Out of scope\n\n`conversionGoal` is supported as an input on this tool. Goal-funnel breakdowns (`WebGoalsQuery`), web vitals, and external clicks aren't exposed as separate query modes — fall back to `execute-sql` for those.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "Run a web analytics overview query",
+        "title": "Run a web analytics overview query",
+        "required_scopes": ["query:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "system_prompt_hint": "Web analytics KPIs — visitors, sessions, bounce rate, session duration"
+    },
+    "query-web-stats": {
+        "description": "Run a web analytics breakdown table query — top pages, UTMs, devices, browsers, countries, etc. — with visitors and pageviews per row, plus optional bounce rate / average time on page. Mirrors the in-product **Web analytics** scene's table tiles.\n\n# When to use this vs `query-trends` / `query-paths`\n\nPick this tool only when the answer needs **session-level math**. Session aggregation is more expensive than per-event queries — only pay for it when needed.\n\nUse `query-web-stats` when the breakdown or metric is session-derived:\n\n- `includeBounceRate=true` or `includeAvgTimeOnPage=true` (per-session metrics)\n- Initial / first-touch breakdowns: `InitialPage`, `InitialChannelType`, `InitialReferringDomain`, `InitialUTMSource`/`Medium`/`Campaign`/`Term`/`Content`\n- `ExitPage` (last event in a session)\n\nUse `query-trends` (with a breakdown) for per-event counts by an event property — no session boundaries needed. Faster.\n\nUse `query-paths` for navigation between arbitrary events when you don't need bounce rate or session-level metrics.\n\n# `breakdownBy` cheat-sheet\n\n- **Path-style** (pair with `includeBounceRate`/`includeAvgTimeOnPage`): `Page`, `InitialPage`, `ExitPage`, `PreviousPage`\n- **Marketing**: `InitialChannelType`, `InitialReferringDomain`, `InitialReferringURL`, `InitialUTMSource`, `InitialUTMMedium`, `InitialUTMCampaign`, `InitialUTMTerm`, `InitialUTMContent`, `InitialUTMSourceMediumCampaign`\n- **Audience / device**: `Browser`, `OS`, `Viewport`, `DeviceType`, `Country`, `Region`, `City`, `Timezone`, `Language`\n- **Other**: `ScreenName`, `ExitClick`, `FrustrationMetrics` (these don't combine with `includeBounceRate` / `includeAvgTimeOnPage`)\n\n# Inputs\n\nSame filter set as `query-web-overview` (`dateRange`, `compareFilter`, `properties`, `filterTestAccounts`, `doPathCleaning`, `conversionGoal`). Plus `breakdownBy` (required), `includeBounceRate`, `includeAvgTimeOnPage`, `includeHost`, `limit`, `offset`. Default `dateRange` is last 7 days.\n\nPerformance hints:\n\n- Leave `compareFilter` off unless the user asks for period-over-period — enabling it roughly doubles query cost.\n- `limit` is capped at 200 by the wrapper. Prefer 10–25 unless the user explicitly asks for more.\n\nUse `read-data-schema` to validate property names/values when needed.\n\n# Example\n\nTop 20 pages by bounce rate, last 7 days:\n\n```json\n{\n  \"kind\": \"WebStatsTableQuery\",\n  \"breakdownBy\": \"Page\",\n  \"includeBounceRate\": true,\n  \"limit\": 20,\n  \"dateRange\": { \"date_from\": \"-7d\" }\n}\n```\n\n# Out of scope\n\n`conversionGoal` is supported as an input on this tool. Goal-funnel breakdowns (`WebGoalsQuery`), web vitals, and external clicks aren't exposed as separate query modes — fall back to `execute-sql` for those.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "Run a web analytics breakdown table query",
+        "title": "Run a web analytics breakdown table query",
+        "required_scopes": ["query:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "system_prompt_hint": "Web analytics breakdowns — top pages, UTMs, devices, countries, with bounce rate"
+    },
     "reminder-create": {
         "description": "Create a reminder for yourself. Set organization (required) and optionally team to scope it to a project. Use a one-off reminder by setting scheduled_at (a future ISO 8601 time), or a recurring reminder by setting recurrence_interval (daily/weekly/monthly/yearly) OR cron_expression (5-field, max 4 fires/day). Set timezone to the user's IANA timezone so wall-clock times resolve correctly. Optionally attach a resource the reminder is about via resource_type + resource_id (e.g. a dashboard) — the notification will link to it. Reminders fire as in-app notifications when due. Proactively offer to create a reminder when the user mentions needing periodic checks, monitoring, recurring reviews, or follow-ups on a metric, dashboard, or task — reminders are how they get recurring in-app notifications without manual polling.",
         "category": "Reminders",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6727,6 +6727,36 @@
         },
         "system_prompt_hint": "List persons behind a trends data point"
     },
+    "query-web-overview": {
+        "description": "Run a web analytics overview query — high-level KPIs over a period: visitors, pageviews, sessions, average session duration, and bounce rate. Returns a small list of metric tuples with optional period-over-period comparison. Mirrors the in-product **Web analytics** scene.\n\n# When to use this vs `query-trends`\n\nPick this tool only when the answer needs **session-level math**. Session aggregation is more expensive than per-event queries — only pay for it when needed.\n\nUse `query-web-overview` when the question references just the aggregate values across the period instead of time series for those session-level values: bounce rate, session duration, sessions as a count, or entry/initial values (entry page, initial channel, initial UTM).\n\nUse `query-trends` instead for per-event counts — pageviews, sign-ups, button clicks. Faster.\n\n# Inputs\n\n- `dateRange` — defaults to last 7 days when omitted. Keep ranges short — there is no enforced upper bound and large windows on the slow path can be expensive.\n- `compareFilter: { compare: true }` — return prior-period values for change %. **Roughly doubles query cost** because it runs the same aggregation over the previous period — leave it off unless the user explicitly asks for a comparison.\n- `properties` — event/person/session/cohort filters. Same operator semantics as `query-trends` — see that prompt. Defaults to `[]`.\n- `filterTestAccounts` — exclude internal/test users.\n- `doPathCleaning` — apply team's path-cleaning rules.\n- `conversionGoal` — pass an `actionId` (must belong to the current project) or a `customEventName`. Only set when the user asks about a conversion.\n\nUse `read-data-schema` to validate property names/values when needed.\n\n# Example\n\n```json\n{\n  \"kind\": \"WebOverviewQuery\",\n  \"dateRange\": { \"date_from\": \"-7d\" }\n}\n```\n\n# Out of scope\n\n`conversionGoal` is supported as an input on this tool. Goal-funnel breakdowns (`WebGoalsQuery`), web vitals, and external clicks aren't exposed as separate query modes — fall back to `execute-sql` for those.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "Run a web analytics overview query",
+        "title": "Run a web analytics overview query",
+        "required_scopes": ["query:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "system_prompt_hint": "Web analytics KPIs — visitors, sessions, bounce rate, session duration"
+    },
+    "query-web-stats": {
+        "description": "Run a web analytics breakdown table query — top pages, UTMs, devices, browsers, countries, etc. — with visitors and pageviews per row, plus optional bounce rate / average time on page. Mirrors the in-product **Web analytics** scene's table tiles.\n\n# When to use this vs `query-trends` / `query-paths`\n\nPick this tool only when the answer needs **session-level math**. Session aggregation is more expensive than per-event queries — only pay for it when needed.\n\nUse `query-web-stats` when the breakdown or metric is session-derived:\n\n- `includeBounceRate=true` or `includeAvgTimeOnPage=true` (per-session metrics)\n- Initial / first-touch breakdowns: `InitialPage`, `InitialChannelType`, `InitialReferringDomain`, `InitialUTMSource`/`Medium`/`Campaign`/`Term`/`Content`\n- `ExitPage` (last event in a session)\n\nUse `query-trends` (with a breakdown) for per-event counts by an event property — no session boundaries needed. Faster.\n\nUse `query-paths` for navigation between arbitrary events when you don't need bounce rate or session-level metrics.\n\n# `breakdownBy` cheat-sheet\n\n- **Path-style** (pair with `includeBounceRate`/`includeAvgTimeOnPage`): `Page`, `InitialPage`, `ExitPage`, `PreviousPage`\n- **Marketing**: `InitialChannelType`, `InitialReferringDomain`, `InitialReferringURL`, `InitialUTMSource`, `InitialUTMMedium`, `InitialUTMCampaign`, `InitialUTMTerm`, `InitialUTMContent`, `InitialUTMSourceMediumCampaign`\n- **Audience / device**: `Browser`, `OS`, `Viewport`, `DeviceType`, `Country`, `Region`, `City`, `Timezone`, `Language`\n- **Other**: `ScreenName`, `ExitClick`, `FrustrationMetrics` (these don't combine with `includeBounceRate` / `includeAvgTimeOnPage`)\n\n# Inputs\n\nSame filter set as `query-web-overview` (`dateRange`, `compareFilter`, `properties`, `filterTestAccounts`, `doPathCleaning`, `conversionGoal`). Plus `breakdownBy` (required), `includeBounceRate`, `includeAvgTimeOnPage`, `includeHost`, `limit`, `offset`. Default `dateRange` is last 7 days.\n\nPerformance hints:\n\n- Leave `compareFilter` off unless the user asks for period-over-period — enabling it roughly doubles query cost.\n- `limit` is capped at 200 by the wrapper. Prefer 10–25 unless the user explicitly asks for more.\n\nUse `read-data-schema` to validate property names/values when needed.\n\n# Example\n\nTop 20 pages by bounce rate, last 7 days:\n\n```json\n{\n  \"kind\": \"WebStatsTableQuery\",\n  \"breakdownBy\": \"Page\",\n  \"includeBounceRate\": true,\n  \"limit\": 20,\n  \"dateRange\": { \"date_from\": \"-7d\" }\n}\n```\n\n# Out of scope\n\n`conversionGoal` is supported as an input on this tool. Goal-funnel breakdowns (`WebGoalsQuery`), web vitals, and external clicks aren't exposed as separate query modes — fall back to `execute-sql` for those.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "Run a web analytics breakdown table query",
+        "title": "Run a web analytics breakdown table query",
+        "required_scopes": ["query:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "system_prompt_hint": "Web analytics breakdowns — top pages, UTMs, devices, countries, with bounce rate"
+    },
     "read-data-schema": {
         "description": "Use this tool to explore the user's data schema. The user implements PostHog SDKs to collect events, properties, and property values. They are used by users to create insights with visualizations, SQL queries, watch session recordings, filter data, target particular users or groups by traits or behavior, etc. Each event, action, and entity has its own data schema. You must verify that specific combinations exist before using it anywhere else. Events or properties starting from \"$\" are system properties automatically captured by SDKs. Do not rely on your training data or PostHog defaults for events or properties. Always use this tool to confirm what actually exists in the user's project before referencing any event, property, or property value.",
         "category": "Data schema",

--- a/services/mcp/scripts/lib/json-schema-to-zod.ts
+++ b/services/mcp/scripts/lib/json-schema-to-zod.ts
@@ -109,7 +109,10 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
     // $ref
     if (schema.$ref) {
         const refName = schema.$ref.replace('#/definitions/', '')
-        return sanitizeVarName(refName)
+        // Field-level numeric constraints (e.g. `@maximum 200` on a property
+        // typed as `positive_integer`) sit on the referencing schema, not the
+        // ref target. Apply them on top of the named ref.
+        return applyNumericConstraints(sanitizeVarName(refName), schema)
     }
 
     // const
@@ -183,16 +186,32 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
 
     // integer special ref — use coerce for MCP client compatibility (some clients send numbers as strings)
     if (schema.type === 'integer') {
-        return 'z.coerce.number().int()'
+        return applyNumericConstraints('z.coerce.number().int()', schema)
     }
 
     // primitives
     if (schema.type) {
-        return primitiveToZod(schema.type as string)
+        const base = primitiveToZod(schema.type as string)
+        if (schema.type === 'integer' || schema.type === 'number') {
+            return applyNumericConstraints(base, schema)
+        }
+        return base
     }
 
     // Fallback
     return 'z.unknown()'
+}
+
+/** Append `.min(...).max(...)` for numeric schemas. */
+function applyNumericConstraints(expr: string, schema: JsonSchema): string {
+    let out = expr
+    if (typeof schema.minimum === 'number') {
+        out += `.min(${schema.minimum})`
+    }
+    if (typeof schema.maximum === 'number') {
+        out += `.max(${schema.maximum})`
+    }
+    return out
 }
 
 /** Use z.coerce for numbers/booleans — some MCP clients send primitives as strings */

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -48,7 +48,7 @@ export class StateManager {
             // The DRF serializer returns `null` (not `[]`) for unscoped keys, so
             // normalize at the boundary — downstream code treats these as arrays.
             return {
-                scopes,
+                scopes: scopes ?? [],
                 scoped_teams: scoped_teams ?? [],
                 scoped_organizations: scoped_organizations ?? [],
             }

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -963,7 +963,7 @@ const AssistantStickinessDisplayType = z.enum(['ActionsLineGraph', 'ActionsBar',
 
 const StickinessOperator = z.enum(['gte', 'lte', 'exact'])
 
-const positive_integer = z.coerce.number().int()
+const positive_integer = z.coerce.number().int().min(1)
 
 const StickinessCriteria = z.object({
     operator: StickinessOperator,
@@ -1201,6 +1201,220 @@ const AssistantLifecycleQuery = z.object({
         .array(AssistantLifecycleSeriesNode)
         .max(1)
         .describe('Event or action to analyze. Lifecycle insights only support a single series.'),
+})
+
+const ActionConversionGoal = z.object({
+    actionId: integer,
+})
+
+const CustomEventConversionGoal = z.object({
+    customEventName: z.string(),
+})
+
+const WebAnalyticsConversionGoal = z.union([ActionConversionGoal, CustomEventConversionGoal])
+
+const PropertyOperator = z.enum([
+    'exact',
+    'is_not',
+    'icontains',
+    'not_icontains',
+    'regex',
+    'not_regex',
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'is_set',
+    'is_not_set',
+    'is_date_exact',
+    'is_date_before',
+    'is_date_after',
+    'between',
+    'not_between',
+    'min',
+    'max',
+    'in',
+    'not_in',
+    'is_cleaned_path_exact',
+    'flag_evaluates_to',
+    'semver_eq',
+    'semver_neq',
+    'semver_gt',
+    'semver_gte',
+    'semver_lt',
+    'semver_lte',
+    'semver_tilde',
+    'semver_caret',
+    'semver_wildcard',
+    'icontains_multi',
+    'not_icontains_multi',
+])
+
+const PropertyFilterBaseValue = z.union([z.string(), z.coerce.number(), z.coerce.boolean()])
+
+const PropertyFilterValue = z.union([PropertyFilterBaseValue, z.array(PropertyFilterBaseValue), z.null()])
+
+const EventPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator.default('exact'),
+    type: z.literal('event').describe('Event properties').default('event'),
+    value: PropertyFilterValue.optional(),
+})
+
+const PersonPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('person').describe('Person properties').default('person'),
+    value: PropertyFilterValue.optional(),
+})
+
+const SessionPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('session').default('session'),
+    value: PropertyFilterValue.optional(),
+})
+
+const CohortPropertyFilter = z.object({
+    cohort_name: z.string().optional(),
+    key: z.literal('id').default('id'),
+    label: z.string().optional(),
+    operator: PropertyOperator.default('in'),
+    type: z.literal('cohort').default('cohort'),
+    value: z.coerce.number().int(),
+})
+
+const WebAnalyticsPropertyFilter = z.union([
+    EventPropertyFilter,
+    PersonPropertyFilter,
+    SessionPropertyFilter,
+    CohortPropertyFilter,
+])
+
+const WebAnalyticsPropertyFilters = z.array(WebAnalyticsPropertyFilter)
+
+const AssistantWebOverviewQuery = z.object({
+    compareFilter: CompareFilter.describe(
+        'Compare the current period to a prior period. Disabled by default. Enabling roughly doubles query cost — leave it off unless the user explicitly asks for a period-over-period comparison.'
+    ).optional(),
+    conversionGoal: z
+        .union([WebAnalyticsConversionGoal, z.null()])
+        .describe(
+            'Conversion goal — pass an `actionId` (must belong to the current project) or a `customEventName`. Adds conversion columns to the response. Disables the pre-aggregated fast path — only set when the user explicitly asks about a conversion.'
+        )
+        .optional(),
+    dateRange: AssistantDateRangeFilter.describe(
+        'Date range for the query. Defaults to the last 7 days when omitted. Keep ranges short — the backend has no upper bound and large windows on the slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can be expensive.'
+    ).optional(),
+    doPathCleaning: z.coerce
+        .boolean()
+        .describe("Apply the team's path-cleaning rules to URL-style breakdowns.")
+        .default(false)
+        .optional(),
+    filterTestAccounts: z.coerce
+        .boolean()
+        .describe("Exclude internal and test users by applying the team's test-account filter.")
+        .default(false)
+        .optional(),
+    kind: z.literal('WebOverviewQuery').default('WebOverviewQuery'),
+    properties: WebAnalyticsPropertyFilters.describe(
+        'Property filters applied to the query. Accepts event, person, session, or cohort filters.'
+    )
+        .default([])
+        .optional(),
+})
+
+const WebStatsBreakdown = z.enum([
+    'Page',
+    'InitialPage',
+    'ExitPage',
+    'ExitClick',
+    'PreviousPage',
+    'ScreenName',
+    'InitialChannelType',
+    'InitialReferringDomain',
+    'InitialReferringURL',
+    'InitialUTMSource',
+    'InitialUTMCampaign',
+    'InitialUTMMedium',
+    'InitialUTMTerm',
+    'InitialUTMContent',
+    'InitialUTMSourceMediumCampaign',
+    'Browser',
+    'OS',
+    'Viewport',
+    'DeviceType',
+    'Country',
+    'Region',
+    'City',
+    'Timezone',
+    'Language',
+    'FrustrationMetrics',
+])
+
+const non_negative_integer = z.coerce.number().int().min(0)
+
+const AssistantWebStatsTableQuery = z.object({
+    breakdownBy: WebStatsBreakdown.describe(
+        'Required. Property to break down the table by. The full enum covers path-style (`Page`, `InitialPage`, `ExitPage`, `PreviousPage`), marketing/source (UTM source/medium/campaign/term/content, channel, referring domain), audience/device (browser, OS, device type, viewport), and geography (country, region, city, timezone, language). Path-style breakdowns pair naturally with `includeBounceRate` / `includeAvgTimeOnPage`.'
+    ),
+    compareFilter: CompareFilter.describe(
+        'Compare the current period to a prior period. Disabled by default. Enabling roughly doubles query cost — leave it off unless the user explicitly asks for a period-over-period comparison.'
+    ).optional(),
+    conversionGoal: z
+        .union([WebAnalyticsConversionGoal, z.null()])
+        .describe(
+            'Conversion goal — pass an `actionId` (must belong to the current project) or a `customEventName`. Adds conversion columns to the response. Disables the pre-aggregated fast path — only set when the user explicitly asks about a conversion.'
+        )
+        .optional(),
+    dateRange: AssistantDateRangeFilter.describe(
+        'Date range for the query. Defaults to the last 7 days when omitted. Keep ranges short — the backend has no upper bound and large windows on the slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can be expensive.'
+    ).optional(),
+    doPathCleaning: z.coerce
+        .boolean()
+        .describe("Apply the team's path-cleaning rules to URL-style breakdowns.")
+        .default(false)
+        .optional(),
+    filterTestAccounts: z.coerce
+        .boolean()
+        .describe("Exclude internal and test users by applying the team's test-account filter.")
+        .default(false)
+        .optional(),
+    includeAvgTimeOnPage: z.coerce
+        .boolean()
+        .describe(
+            'Add an average-time-on-page column. Implies a Page-style breakdown. Disables the pre-aggregated fast path.'
+        )
+        .default(false)
+        .optional(),
+    includeBounceRate: z.coerce
+        .boolean()
+        .describe('Add a bounce-rate column. Most useful with a path-style breakdown.')
+        .default(false)
+        .optional(),
+    includeHost: z.coerce
+        .boolean()
+        .describe(
+            'When using a path-style breakdown (`Page`, `InitialPage`, `ExitPage`, `PreviousPage`), concatenate host + pathname so the same path on different hosts is counted separately.'
+        )
+        .default(false)
+        .optional(),
+    kind: z.literal('WebStatsTableQuery').default('WebStatsTableQuery'),
+    limit: positive_integer
+        .max(200)
+        .describe(
+            'Maximum rows to return. Prefer 10–25 unless the user explicitly asks for more. Hard ceiling enforced at the wrapper.'
+        )
+        .optional(),
+    offset: non_negative_integer.describe('Pagination offset.').optional(),
+    properties: WebAnalyticsPropertyFilters.describe(
+        'Property filters applied to the query. Accepts event, person, session, or cohort filters.'
+    )
+        .default([])
+        .optional(),
 })
 
 const AssistantTracesQuery = z.object({
@@ -1517,6 +1731,20 @@ export const GENERATED_TOOLS: Record<string, ReturnType<typeof createQueryWrappe
         kind: 'LifecycleQuery',
         uiResourceUri: 'ui://posthog/query-results.html',
         outputFormat: 'optimized',
+    }),
+    'query-web-overview': createQueryWrapper({
+        name: 'query-web-overview',
+        schema: AssistantWebOverviewQuery,
+        kind: 'WebOverviewQuery',
+        uiResourceUri: 'ui://posthog/query-results.html',
+        outputFormat: 'json',
+    }),
+    'query-web-stats': createQueryWrapper({
+        name: 'query-web-stats',
+        schema: AssistantWebStatsTableQuery,
+        kind: 'WebStatsTableQuery',
+        uiResourceUri: 'ui://posthog/query-results.html',
+        outputFormat: 'json',
     }),
     'query-llm-traces-list': createQueryWrapper({
         name: 'query-llm-traces-list',

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -48,7 +48,10 @@ export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperC
             const { output_format: callerOutputFormat, ...queryParams } = params as typeof params & {
                 output_format?: 'optimized' | 'json'
             }
-            const query: Record<string, unknown> = { ...queryParams, kind: config.kind }
+            const query: Record<string, unknown> = {
+                ...queryParams,
+                kind: config.kind,
+            }
             const baseUrl = context.api.getProjectBaseUrl(projectId)
             const effectiveOutputFormat = callerOutputFormat ?? config.outputFormat
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-stickiness-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-stickiness-actors.json
@@ -2001,7 +2001,7 @@
                                 },
                                 "value": {
                                     "maximum": 9007199254740991,
-                                    "minimum": -9007199254740991,
+                                    "minimum": 1,
                                     "type": "integer"
                                 }
                             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-stickiness.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-stickiness.json
@@ -1887,7 +1887,7 @@
                         },
                         "value": {
                             "maximum": 9007199254740991,
-                            "minimum": -9007199254740991,
+                            "minimum": 1,
                             "type": "integer"
                         }
                     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-overview.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-overview.json
@@ -1,0 +1,459 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "compareFilter": {
+            "description": "Compare the current period to a prior period. Disabled by default. Enabling roughly doubles query cost — leave it off unless the user explicitly asks for a period-over-period comparison.",
+            "properties": {
+                "compare": {
+                    "default": false,
+                    "description": "Whether to compare the current date range to a previous date range.",
+                    "type": "boolean"
+                },
+                "compare_to": {
+                    "description": "The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "conversionGoal": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "actionId": {
+                                    "maximum": 9007199254740991,
+                                    "minimum": -9007199254740991,
+                                    "type": "integer"
+                                }
+                            },
+                            "required": ["actionId"],
+                            "type": "object"
+                        },
+                        {
+                            "properties": {
+                                "customEventName": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["customEventName"],
+                            "type": "object"
+                        }
+                    ]
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Conversion goal — pass an `actionId` (must belong to the current project) or a `customEventName`. Adds conversion columns to the response. Disables the pre-aggregated fast path — only set when the user explicitly asks about a conversion."
+        },
+        "dateRange": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "date_from": {
+                            "description": "ISO8601 date string.",
+                            "type": "string"
+                        },
+                        "date_to": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "ISO8601 date string."
+                        }
+                    },
+                    "required": ["date_from"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "date_from": {
+                            "description": "Duration in the past. Supported units are: `h` (hour), `d` (day), `w` (week), `m` (month), `y` (year), `all` (all time). Use the `Start` suffix to define the exact left date boundary. Examples: `-1d` last day from now, `-180d` last 180 days from now, `mStart` this month start, `-1dStart` yesterday's start.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["date_from"],
+                    "type": "object"
+                }
+            ],
+            "description": "Date range for the query. Defaults to the last 7 days when omitted. Keep ranges short — the backend has no upper bound and large windows on the slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can be expensive."
+        },
+        "doPathCleaning": {
+            "default": false,
+            "description": "Apply the team's path-cleaning rules to URL-style breakdowns.",
+            "type": "boolean"
+        },
+        "filterTestAccounts": {
+            "default": false,
+            "description": "Exclude internal and test users by applying the team's test-account filter.",
+            "type": "boolean"
+        },
+        "kind": {
+            "const": "WebOverviewQuery",
+            "default": "WebOverviewQuery",
+            "type": "string"
+        },
+        "properties": {
+            "default": [],
+            "description": "Property filters applied to the query. Accepts event, person, session, or cohort filters.",
+            "items": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "default": "exact",
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "event",
+                                "default": "event",
+                                "description": "Event properties",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "person",
+                                "default": "person",
+                                "description": "Person properties",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "session",
+                                "default": "session",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cohort_name": {
+                                "type": "string"
+                            },
+                            "key": {
+                                "const": "id",
+                                "default": "id",
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "default": "in",
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "cohort",
+                                "default": "cohort",
+                                "type": "string"
+                            },
+                            "value": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                            }
+                        },
+                        "required": ["value"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-stats.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-stats.json
@@ -1,0 +1,518 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "breakdownBy": {
+            "description": "Required. Property to break down the table by. The full enum covers path-style (`Page`, `InitialPage`, `ExitPage`, `PreviousPage`), marketing/source (UTM source/medium/campaign/term/content, channel, referring domain), audience/device (browser, OS, device type, viewport), and geography (country, region, city, timezone, language). Path-style breakdowns pair naturally with `includeBounceRate` / `includeAvgTimeOnPage`.",
+            "enum": [
+                "Page",
+                "InitialPage",
+                "ExitPage",
+                "ExitClick",
+                "PreviousPage",
+                "ScreenName",
+                "InitialChannelType",
+                "InitialReferringDomain",
+                "InitialReferringURL",
+                "InitialUTMSource",
+                "InitialUTMCampaign",
+                "InitialUTMMedium",
+                "InitialUTMTerm",
+                "InitialUTMContent",
+                "InitialUTMSourceMediumCampaign",
+                "Browser",
+                "OS",
+                "Viewport",
+                "DeviceType",
+                "Country",
+                "Region",
+                "City",
+                "Timezone",
+                "Language",
+                "FrustrationMetrics"
+            ],
+            "type": "string"
+        },
+        "compareFilter": {
+            "description": "Compare the current period to a prior period. Disabled by default. Enabling roughly doubles query cost — leave it off unless the user explicitly asks for a period-over-period comparison.",
+            "properties": {
+                "compare": {
+                    "default": false,
+                    "description": "Whether to compare the current date range to a previous date range.",
+                    "type": "boolean"
+                },
+                "compare_to": {
+                    "description": "The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "conversionGoal": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "actionId": {
+                                    "maximum": 9007199254740991,
+                                    "minimum": -9007199254740991,
+                                    "type": "integer"
+                                }
+                            },
+                            "required": ["actionId"],
+                            "type": "object"
+                        },
+                        {
+                            "properties": {
+                                "customEventName": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["customEventName"],
+                            "type": "object"
+                        }
+                    ]
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Conversion goal — pass an `actionId` (must belong to the current project) or a `customEventName`. Adds conversion columns to the response. Disables the pre-aggregated fast path — only set when the user explicitly asks about a conversion."
+        },
+        "dateRange": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "date_from": {
+                            "description": "ISO8601 date string.",
+                            "type": "string"
+                        },
+                        "date_to": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "ISO8601 date string."
+                        }
+                    },
+                    "required": ["date_from"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "date_from": {
+                            "description": "Duration in the past. Supported units are: `h` (hour), `d` (day), `w` (week), `m` (month), `y` (year), `all` (all time). Use the `Start` suffix to define the exact left date boundary. Examples: `-1d` last day from now, `-180d` last 180 days from now, `mStart` this month start, `-1dStart` yesterday's start.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["date_from"],
+                    "type": "object"
+                }
+            ],
+            "description": "Date range for the query. Defaults to the last 7 days when omitted. Keep ranges short — the backend has no upper bound and large windows on the slow path (e.g. with `conversionGoal` or `includeAvgTimeOnPage`) can be expensive."
+        },
+        "doPathCleaning": {
+            "default": false,
+            "description": "Apply the team's path-cleaning rules to URL-style breakdowns.",
+            "type": "boolean"
+        },
+        "filterTestAccounts": {
+            "default": false,
+            "description": "Exclude internal and test users by applying the team's test-account filter.",
+            "type": "boolean"
+        },
+        "includeAvgTimeOnPage": {
+            "default": false,
+            "description": "Add an average-time-on-page column. Implies a Page-style breakdown. Disables the pre-aggregated fast path.",
+            "type": "boolean"
+        },
+        "includeBounceRate": {
+            "default": false,
+            "description": "Add a bounce-rate column. Most useful with a path-style breakdown.",
+            "type": "boolean"
+        },
+        "includeHost": {
+            "default": false,
+            "description": "When using a path-style breakdown (`Page`, `InitialPage`, `ExitPage`, `PreviousPage`), concatenate host + pathname so the same path on different hosts is counted separately.",
+            "type": "boolean"
+        },
+        "kind": {
+            "const": "WebStatsTableQuery",
+            "default": "WebStatsTableQuery",
+            "type": "string"
+        },
+        "limit": {
+            "description": "Maximum rows to return. Prefer 10–25 unless the user explicitly asks for more. Hard ceiling enforced at the wrapper.",
+            "maximum": 200,
+            "minimum": 1,
+            "type": "integer"
+        },
+        "offset": {
+            "description": "Pagination offset.",
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+        },
+        "properties": {
+            "default": [],
+            "description": "Property filters applied to the query. Accepts event, person, session, or cohort filters.",
+            "items": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "default": "exact",
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "event",
+                                "default": "event",
+                                "description": "Event properties",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "person",
+                                "default": "person",
+                                "description": "Person properties",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "session",
+                                "default": "session",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cohort_name": {
+                                "type": "string"
+                            },
+                            "key": {
+                                "const": "id",
+                                "default": "id",
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "default": "in",
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "cohort",
+                                "default": "cohort",
+                                "type": "string"
+                            },
+                            "value": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                            }
+                        },
+                        "required": ["value"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array"
+        }
+    },
+    "required": ["breakdownBy"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

PostHog's MCP exposes generic insight wrappers (`query-trends`, `query-funnel`, `query-paths`, …) but nothing dedicated to web analytics. To answer typical web-analytics questions ("top pages by bounce rate", "weekly visitors", "session duration over time") an agent has to compose multiple `query-trends` calls and stitch session-level math by hand — which doesn't match what the in-product **Web analytics** scene returns.

## Changes

Adds two read-only MCP query wrappers around the existing web analytics runners:

- `query-web-overview` → `WebOverviewQueryRunner` (visitors, pageviews, sessions, session duration, bounce rate)
- `query-web-stats` → `WebStatsTableQueryRunner` (top pages / UTMs / devices / countries with optional bounce rate / avg time on page)

Time-series of pageviews / events stay on `query-trends`. Both wrappers POST to the existing `/api/environments/{id}/query/` endpoint — no backend runner changes.

Backing changes:

- New `AssistantWebOverviewQuery` / `AssistantWebStatsTableQuery` Assistant schema types.
- Two prompt files explaining the **session-level vs per-event** decision and the **`compareFilter` doubles cost / pre-agg fast path** perf hints.
- New `default_query_fields` mechanism in the wrapper YAML/factory/codegen so wrappers can opt into runner modifiers (here: `useWebAnalyticsPreAggregatedTables`) without exposing them to agents.
- `Action.DoesNotExist` on `conversionGoal.actionId` now raises a typed `QueryError` instead of bubbling as a 500.

## How did you test this code?

I'm an agent. Verified:

- `hogli build:openapi` regenerates `schema.json` / `schema.py` / Zod / `query-wrappers.ts` cleanly.
- `pnpm --filter=@posthog/mcp typecheck` passes.
- `posthog/schema.py` Pydantic round-trips a minimal payload (`{kind: "WebOverviewQuery", dateRange: {date_from: "-7d"}}`) — the original draft hit `properties: Field required`; fixed by `@default []` on the base.
- `git diff master` shows only intended files (5 source + 5 generated).

No manual end-to-end MCP run. CI and human review needed.

## Publish to changelog?

No.
