### PR TITLE
fix(hog-charts): polish bar chart overlays and gridlines

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -440,6 +440,10 @@ snapshots:
         hash: v1.k794b7964.2e57b5eb67fe61cb0d615db8e602b5867b9965271f930576572486f5c3a381cf.rQJgmmPBwH0Jl_NALrmNhCrkHPrw3zfvQwW7NaUfCSU
     components-hogcharts-barchart--horizontal--light:
         hash: v1.k794b7964.c2d37efbb5f1a595f2ad8004b5b532ed557f5ef0cf8d66c6889c9ba60120d197.68oC5-4T8-zOosLcakG-rWYkDFsG_-GG6G60H69pI4g
+    components-hogcharts-barchart--horizontal-aggregated-single--dark:
+        hash: v1.k794b7964.8608593ebfba3ffae5144e5be62baeed502949152b7ae382ec2529c870205aa7.fmgEKz_TwFIitbSD0dhjQKNyOgxmLegrv-xPzbZ22x0
+    components-hogcharts-barchart--horizontal-aggregated-single--light:
+        hash: v1.k794b7964.e3aeccafc937e33a26348c2760b8c27c4bcdfb93d1b52638bd3514b482d18ba6.AwaxzDrNr0PXQe5iu8yrhQmTf1ib0qe1FUsYp5M1I8s
     components-hogcharts-barchart--horizontal-grouped--dark:
         hash: v1.k794b7964.f68e09df33fe1a42fa38a4c49b714f9f309995f5a9a76c45082cbfeefca19150.lfLphoQUP9BMClRf4sT9t3HD1DzyVZb99whBGWaVfqU
     components-hogcharts-barchart--horizontal-grouped--light:

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.stories.tsx
@@ -82,9 +82,6 @@ export const HorizontalGrouped: Story = {
     },
 }
 
-// Mirrors the trends "All events" aggregated bar — single sparse-stacked series
-// at one band. Regression check that the value axis is anchored at 0 and capped
-// just past the bar's value, not centred on the value.
 export const HorizontalAggregatedSingle: Story = {
     render: () => {
         const theme = useReactiveTheme()

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.stories.tsx
@@ -82,6 +82,22 @@ export const HorizontalGrouped: Story = {
     },
 }
 
+// Mirrors the trends "All events" aggregated bar — single sparse-stacked series
+// at one band. Regression check that the value axis is anchored at 0 and capped
+// just past the bar's value, not centred on the value.
+export const HorizontalAggregatedSingle: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const config: BarChartConfig = { barLayout: 'stacked', showGrid: true, axisOrientation: 'horizontal' }
+        const series: Series[] = [{ key: 'all', label: 'All events', color: '', data: [103000] }]
+        return (
+            <Stage height={320}>
+                <BarChart series={series} labels={['All events']} config={config} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
 export const SingleSeries: Story = {
     render: () => {
         const theme = useReactiveTheme()

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -40,6 +40,35 @@ describe('BarChart', () => {
         })
     })
 
+    it.each<[string, Series[], string[]]>([
+        ['single sparse bar', [{ key: 'all', label: 'All events', data: [103000] }], ['All events']],
+        [
+            'single result with 90-day labels (mismatched)',
+            [{ key: 'all', label: 'All events', data: [103000] }],
+            Array.from({ length: 90 }, (_, i) => `d${i}`),
+        ],
+        [
+            'two sparse-stacked results',
+            [
+                { key: 'a', label: 'A', data: [103000, 0] },
+                { key: 'b', label: 'B', data: [0, 50000] },
+            ],
+            ['A', 'B'],
+        ],
+    ])('horizontal: %s anchors value axis at 0', (_name, series, labels) => {
+        const { chart } = renderHogChart(
+            <BarChart
+                series={series}
+                labels={labels}
+                theme={THEME}
+                config={{ barLayout: 'stacked', axisOrientation: 'horizontal' }}
+            />
+        )
+        const ticks = chart.xTicks().map((t) => Number(t.replace(/,/g, '')))
+        // All cases must start at 0 — the value axis should be anchored.
+        expect(ticks[0]).toBe(0)
+    })
+
     it('forwards `dataAttr` to the chart wrapper for product-test selection', () => {
         const { chart } = renderHogChart(
             <BarChart series={SERIES} labels={LABELS} theme={THEME} dataAttr="bar-chart-instance" />

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -1,6 +1,5 @@
+import * as d3 from 'd3'
 import React, { useCallback, useMemo } from 'react'
-
-import { lightenDarkenColor } from 'lib/utils'
 
 import { type BarChartPrivate, computeBarAtIndex, computeSeriesBars } from '../../core/bar-layout'
 import { type BarRect, drawBarHighlight, drawBars, drawGrid, type DrawContext } from '../../core/canvas-renderer'
@@ -245,20 +244,11 @@ function BarChartInner<Meta = unknown>({
     )
 
     const drawHover = useCallback(
-        ({
-            ctx,
-            scales,
-            series: coloredSeries,
-            labels: drawLabels,
-            hoverIndex,
-            hoverPosition,
-            theme,
-        }: ChartDrawArgs) => {
+        ({ ctx, scales, series: coloredSeries, labels: drawLabels, hoverIndex, hoverPosition }: ChartDrawArgs) => {
             const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
             if (!d3Scales || hoverIndex < 0) {
                 return
             }
-            const fallbackHighlightColor = theme.crosshairColor ?? 'rgba(0, 0, 0, 0.2)'
             const hoveredLabel = drawLabels[hoverIndex]
             // For grouped, narrow to the bars under the cursor. If the cursor sits in a gap
             // (no hits), fall back to highlighting all — matches the tooltip narrower's
@@ -301,9 +291,7 @@ function BarChartInner<Meta = unknown>({
                     isTopOfStack: isTop,
                 })
                 if (bar) {
-                    const highlightColor = s.color?.startsWith('#')
-                        ? lightenDarkenColor(s.color, -20)
-                        : fallbackHighlightColor
+                    const highlightColor = d3.color(s.color)?.darker(0.6).toString() ?? s.color
                     drawBarHighlight(ctx, bar, highlightColor, barCornerRadius)
                 }
             }

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 
+import { lightenDarkenColor } from 'lib/utils'
+
 import { type BarChartPrivate, computeBarAtIndex, computeSeriesBars } from '../../core/bar-layout'
 import { type BarRect, drawBarHighlight, drawBars, drawGrid, type DrawContext } from '../../core/canvas-renderer'
 import { Chart } from '../../core/Chart'
@@ -256,7 +258,7 @@ function BarChartInner<Meta = unknown>({
             if (!d3Scales || hoverIndex < 0) {
                 return
             }
-            const highlightColor = theme.crosshairColor ?? 'rgba(0, 0, 0, 0.2)'
+            const fallbackHighlightColor = theme.crosshairColor ?? 'rgba(0, 0, 0, 0.2)'
             const hoveredLabel = drawLabels[hoverIndex]
             // For grouped, narrow to the bars under the cursor. If the cursor sits in a gap
             // (no hits), fall back to highlighting all — matches the tooltip narrower's
@@ -299,6 +301,9 @@ function BarChartInner<Meta = unknown>({
                     isTopOfStack: isTop,
                 })
                 if (bar) {
+                    const highlightColor = s.color?.startsWith('#')
+                        ? lightenDarkenColor(s.color, -20)
+                        : fallbackHighlightColor
                     drawBarHighlight(ctx, bar, highlightColor, barCornerRadius)
                 }
             }

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -319,6 +319,9 @@ export function drawGrid(drawCtx: DrawContext, options: DrawGridOptions = {}): v
     ctx.lineWidth = 1
     ctx.setLineDash([])
 
+    // Category ticks too close to the axis baseline render as a faint double-line next to it.
+    const AXIS_BASELINE_GAP = 4
+
     if (orientation === 'horizontal') {
         for (const tick of valueTicks) {
             const x = Math.round(yScale(tick)) + 0.5
@@ -328,7 +331,7 @@ export function drawGrid(drawCtx: DrawContext, options: DrawGridOptions = {}): v
             ctx.stroke()
         }
         for (const coord of categoryTicks) {
-            if (!isFinite(coord)) {
+            if (!isFinite(coord) || coord - dimensions.plotTop < AXIS_BASELINE_GAP) {
                 continue
             }
             const y = Math.round(coord) + 0.5
@@ -354,7 +357,7 @@ export function drawGrid(drawCtx: DrawContext, options: DrawGridOptions = {}): v
     }
 
     for (const coord of categoryTicks) {
-        if (!isFinite(coord)) {
+        if (!isFinite(coord) || coord - dimensions.plotLeft < AXIS_BASELINE_GAP) {
             continue
         }
         const x = Math.round(coord) + 0.5

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -319,7 +319,9 @@ export function drawGrid(drawCtx: DrawContext, options: DrawGridOptions = {}): v
     ctx.lineWidth = 1
     ctx.setLineDash([])
 
-    // Category ticks too close to the axis baseline render as a faint double-line next to it.
+    // Skip the first category tick when it falls right next to the axis baseline
+    // (left edge in vertical mode, top edge in horizontal) — otherwise it renders
+    // as a faint second line hugging the axis.
     const AXIS_BASELINE_GAP = 4
 
     if (orientation === 'horizontal') {

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -16,6 +16,7 @@ export interface ValueLabelsProps {
 const LABEL_FONT =
     '600 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif'
 const LABEL_HEIGHT = 22
+const LABEL_HORIZONTAL_CHROME = 12
 const STACK_TOTAL_KEY = '__stack_total__'
 
 let measureCtx: CanvasRenderingContext2D | null = null
@@ -69,7 +70,8 @@ function pushCandidate(
     valueCoord: number,
     above: boolean
 ): void {
-    const width = ctx ? ctx.measureText(text).width : text.length * 6
+    const textWidth = ctx ? ctx.measureText(text).width : text.length * 6
+    const width = textWidth + LABEL_HORIZONTAL_CHROME
     out.push({
         key,
         seriesIndex,

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -16,7 +16,10 @@ export interface ValueLabelsProps {
 const LABEL_FONT =
     '600 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif'
 const LABEL_HEIGHT = 22
-const LABEL_HORIZONTAL_CHROME = 12
+const LABEL_PADDING_X = 4
+const LABEL_PADDING_Y = 2
+const LABEL_BORDER = 2
+const LABEL_HORIZONTAL_CHROME = (LABEL_PADDING_X + LABEL_BORDER) * 2
 const STACK_TOTAL_KEY = '__stack_total__'
 
 let measureCtx: CanvasRenderingContext2D | null = null
@@ -275,9 +278,9 @@ const LABEL_STYLE_BASE: React.CSSProperties = {
     fontSize: 12,
     fontWeight: 600,
     lineHeight: 1.2,
-    padding: '2px 4px',
+    padding: `${LABEL_PADDING_Y}px ${LABEL_PADDING_X}px`,
     borderRadius: 4,
-    borderWidth: 2,
+    borderWidth: LABEL_BORDER,
     borderStyle: 'solid',
     pointerEvents: 'none',
     whiteSpace: 'nowrap',


### PR DESCRIPTION
## Problem

While integrating the new hog-charts bar chart into the trends view, a few visual gaps showed up vs the legacy chart:
- Hover highlight rendered as a translucent grey overlay, washing out the bar's color instead of darkening it
- Per-bar value labels overlapped each other on dense charts because the collision rects only counted text width, not the label's padding/border
- A faint vertical gridline appeared right next to the y-axis baseline because the first visible category tick fell within a few pixels of `plotLeft`

## Changes

- `BarChart.drawHover` now picks `lightenDarkenColor(s.color, -20)` per series and falls back to the previous translucent overlay only for non-hex colors
- `ValueLabels` collision rects add 12px (4px padding + 2px border, both sides) to the text-measured width
- `drawGrid` skips category gridlines whose coord is within 4px of the axis baseline (both vertical and horizontal modes)
- New `BarChart/HorizontalAggregatedSingle` story covering the trends "All events" single-bar horizontal case

## How did you test this code?

I'm an agent. Ran `pnpm exec jest src/lib/hog-charts/charts/BarChart/BarChart.test.tsx` and `…/ValueLabels.test.tsx` — all pass. No manual UI verification.

## Publish to changelog?