### PR TITLE
feat(workflows): export opt-out lists to csv

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6107,7 +6107,7 @@ const api = {
                 })
                 .get()
         },
-        async exportMessageOptOuts(categoryKey?: string): Promise<Blob> {
+        async exportMessageOptOuts(categoryKey?: string): Promise<{ blob: Blob; filename: string }> {
             const response = await new ApiRequest()
                 .messagingPreferencesExportOptOuts()
                 .withQueryString(categoryKey ? { category_key: categoryKey } : {})
@@ -6115,7 +6115,11 @@ const api = {
             if (!response.ok) {
                 throw new Error(`Failed to export opt-outs: ${response.status}`)
             }
-            return await response.blob()
+            const blob = await response.blob()
+            const disposition = response.headers.get('Content-Disposition') || ''
+            const match = disposition.match(/filename="?([^"]+)"?/)
+            const filename = match?.[1] || 'opt-outs.csv'
+            return { blob, filename }
         },
     },
     hogFlows: {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1930,6 +1930,13 @@ export class ApiRequest {
         return this.environments().current().addPathComponent('messaging_preferences').addPathComponent('opt_outs')
     }
 
+    public messagingPreferencesExportOptOuts(): ApiRequest {
+        return this.environments()
+            .current()
+            .addPathComponent('messaging_preferences')
+            .addPathComponent('export_opt_outs')
+    }
+
     public hogFlows(): ApiRequest {
         return this.environments().current().addPathComponent('hog_flows')
     }
@@ -6099,6 +6106,16 @@ const api = {
                     page: page || 1,
                 })
                 .get()
+        },
+        async exportMessageOptOuts(categoryKey?: string): Promise<Blob> {
+            const response = await new ApiRequest()
+                .messagingPreferencesExportOptOuts()
+                .withQueryString(categoryKey ? { category_key: categoryKey } : {})
+                .getResponse()
+            if (!response.ok) {
+                throw new Error(`Failed to export opt-outs: ${response.status}`)
+            }
+            return await response.blob()
         },
     },
     hogFlows: {

--- a/products/messaging/backend/api/message_preferences.py
+++ b/products/messaging/backend/api/message_preferences.py
@@ -1,6 +1,15 @@
+import csv
+from datetime import UTC, datetime
+
+from django.db.models import QuerySet
+from django.http import HttpResponse
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.documentation import _FallbackSerializer
@@ -22,9 +31,14 @@ class OptOutsPagination(PageNumberPagination):
 
 
 class MessagePreferencesSerializer(serializers.ModelSerializer):
-    identifier = serializers.CharField()
-    updated_at = serializers.DateTimeField()
-    preferences = serializers.JSONField()
+    identifier = serializers.CharField(help_text="Recipient identifier (typically an email address).")
+    updated_at = serializers.DateTimeField(help_text="When this recipient's preferences were last updated.")
+    preferences = serializers.JSONField(
+        help_text=(
+            "Mapping of category id (or `$all` for the global marketing bucket) to one of "
+            "`OPTED_IN`, `OPTED_OUT`, or `NO_PREFERENCE`."
+        ),
+    )
 
     class Meta:
         model = MessageRecipientPreference
@@ -47,28 +61,41 @@ class MessagePreferencesViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     scope_object = "INTERNAL"
     serializer_class = _FallbackSerializer
 
-    @action(detail=False, methods=["get"])
-    def opt_outs(self, request, **kwargs):
-        """Get opt-outs filtered by category or overall opt-outs if no category specified"""
+    def _get_opt_outs_queryset(
+        self, request: Request
+    ) -> tuple[QuerySet[MessageRecipientPreference] | None, Response | None, MessageCategory | None]:
+        """Build the opt-out queryset shared by `opt_outs` and `export_opt_outs`.
+
+        Returns ``(queryset, error_response, category)``. On error (e.g. unknown
+        ``category_key``), the queryset is ``None`` and a ready-to-return DRF
+        ``Response`` is provided instead.
+        """
         category_key = request.query_params.get("category_key")
+        category: MessageCategory | None = None
 
         if category_key:
-            # Get opt-outs for a specific category
             try:
                 category = MessageCategory.objects.get(key=category_key, team_id=self.team_id)
             except MessageCategory.DoesNotExist:
-                return Response({"error": "Category not found"}, status=404)
+                return None, Response({"error": "Category not found"}, status=404), None
 
-        # Find recipients who have opted out of this specific category, or use the derived $all category if no specific category is provided
-        category_id = category.id if category_key else ALL_MESSAGE_PREFERENCE_CATEGORY_ID
-        query_filters = {}
+        # Use the specific category id if provided, otherwise the derived $all bucket
+        category_id = category.id if category else ALL_MESSAGE_PREFERENCE_CATEGORY_ID
+        query_filters = {f"preferences__{str(category_id)}": PreferenceStatus.OPTED_OUT.value}
 
-        query_filters[f"preferences__{str(category_id)}"] = PreferenceStatus.OPTED_OUT.value
-
-        opt_outs = MessageRecipientPreference.objects.filter(
+        queryset = MessageRecipientPreference.objects.filter(
             team_id=self.team_id,
             **query_filters,
-        ).order_by("-updated_at")  # Order by most recently updated first
+        ).order_by("-updated_at")
+        return queryset, None, category
+
+    @action(detail=False, methods=["get"])
+    def opt_outs(self, request, **kwargs):
+        """Get opt-outs filtered by category or overall opt-outs if no category specified"""
+        opt_outs, error, _category = self._get_opt_outs_queryset(request)
+        if error is not None:
+            return error
+        assert opt_outs is not None
 
         # Apply pagination
         paginator = OptOutsPagination()
@@ -80,6 +107,49 @@ class MessagePreferencesViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         # Fallback if pagination fails for some reason
         serializer = MessagePreferencesSerializer(opt_outs, many=True)
         return Response(serializer.data)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="category_key",
+                description=(
+                    "Optional category key. When omitted, exports recipients who opted out of all "
+                    "marketing communications (the `$all` bucket)."
+                ),
+                required=False,
+                type=str,
+            ),
+        ],
+        responses={(200, "text/csv"): OpenApiTypes.STR},
+        description=(
+            "Export opt-out recipients as CSV. Returns a `text/csv` attachment with columns "
+            "`Recipient` and `Opt-out date` (ISO-8601 UTC), filtered identically to the "
+            "`opt_outs` endpoint."
+        ),
+    )
+    @action(detail=False, methods=["get"])
+    def export_opt_outs(self, request, **kwargs):
+        """Export opt-outs as a CSV file, filtered by category if provided."""
+        opt_outs, error, category = self._get_opt_outs_queryset(request)
+        if error is not None:
+            return error
+        assert opt_outs is not None
+
+        response = HttpResponse(content_type="text/csv")
+        date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        slug = category.key if category else "marketing"
+        response["Content-Disposition"] = f'attachment; filename="opt-outs-{slug}-{date_str}.csv"'
+
+        writer = csv.writer(response)
+        writer.writerow(["Recipient", "Opt-out date"])
+        for opt_out in opt_outs.iterator():
+            writer.writerow(
+                [
+                    opt_out.identifier,
+                    opt_out.updated_at.isoformat() if opt_out.updated_at else "",
+                ]
+            )
+        return response
 
     @action(detail=False, methods=["get"])
     def webhook_url(self, request, **kwargs):

--- a/products/messaging/backend/api/test/test_message_preferences.py
+++ b/products/messaging/backend/api/test/test_message_preferences.py
@@ -1,3 +1,5 @@
+import io
+import csv
 import json
 
 from posthog.test.base import APIBaseTest, BaseTest
@@ -334,3 +336,134 @@ class TestMessagePreferencesAPIViewSet(APIBaseTest):
         self.assertEqual(data["count"], 1)
         self.assertEqual(len(data["results"]), 1)
         self.assertEqual(data["results"][0]["identifier"], "user1@example.com")
+
+    def _parse_export_csv(self, response) -> list[list[str]]:
+        return list(csv.reader(io.StringIO(response.content.decode("utf-8"))))
+
+    def test_export_opt_outs_global(self):
+        """Global opt-outs export returns a CSV attachment with header + rows for $all opt-outs."""
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="user1@example.com",
+            preferences={ALL_MESSAGE_PREFERENCE_CATEGORY_ID: PreferenceStatus.OPTED_OUT.value},
+        )
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="user2@example.com",
+            preferences={ALL_MESSAGE_PREFERENCE_CATEGORY_ID: PreferenceStatus.OPTED_OUT.value},
+        )
+        # A category-only opt-out should not appear in the global export
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="user3@example.com",
+            preferences={str(self.category.id): PreferenceStatus.OPTED_OUT.value},
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/messaging_preferences/export_opt_outs/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertTrue(response["Content-Disposition"].startswith("attachment;"))
+        self.assertIn("opt-outs-marketing-", response["Content-Disposition"])
+        self.assertTrue(response["Content-Disposition"].rstrip('"').endswith(".csv"))
+
+        rows = self._parse_export_csv(response)
+        self.assertEqual(rows[0], ["Recipient", "Opt-out date"])
+        identifiers = [r[0] for r in rows[1:]]
+        self.assertCountEqual(identifiers, ["user1@example.com", "user2@example.com"])
+
+    def test_export_opt_outs_by_category(self):
+        """`?category_key=...` returns only that category's opted-out users."""
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="user1@example.com",
+            preferences={str(self.category.id): PreferenceStatus.OPTED_OUT.value},
+        )
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="user2@example.com",
+            preferences={str(self.category2.id): PreferenceStatus.OPTED_OUT.value},
+        )
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="user3@example.com",
+            preferences={str(self.category.id): PreferenceStatus.OPTED_OUT.value},
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/messaging_preferences/export_opt_outs/",
+            {"category_key": self.category.key},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f"opt-outs-{self.category.key}-", response["Content-Disposition"])
+
+        rows = self._parse_export_csv(response)
+        self.assertEqual(rows[0], ["Recipient", "Opt-out date"])
+        identifiers = [r[0] for r in rows[1:]]
+        self.assertCountEqual(identifiers, ["user1@example.com", "user3@example.com"])
+
+    def test_export_opt_outs_team_isolation(self):
+        """Other teams' opt-outs are not in the CSV."""
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="user1@example.com",
+            preferences={ALL_MESSAGE_PREFERENCE_CATEGORY_ID: PreferenceStatus.OPTED_OUT.value},
+        )
+        other_team = self.organization.teams.create(name="Other Team")
+        MessageRecipientPreference.objects.create(
+            team=other_team,
+            identifier="leaked@example.com",
+            preferences={ALL_MESSAGE_PREFERENCE_CATEGORY_ID: PreferenceStatus.OPTED_OUT.value},
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/messaging_preferences/export_opt_outs/")
+        self.assertEqual(response.status_code, 200)
+
+        rows = self._parse_export_csv(response)
+        identifiers = [r[0] for r in rows[1:]]
+        self.assertEqual(identifiers, ["user1@example.com"])
+        self.assertNotIn("leaked@example.com", identifiers)
+
+    def test_export_opt_outs_excludes_opted_in(self):
+        """Recipients with OPTED_IN or NO_PREFERENCE for the category are excluded."""
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="opted-out@example.com",
+            preferences={str(self.category.id): PreferenceStatus.OPTED_OUT.value},
+        )
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="opted-in@example.com",
+            preferences={str(self.category.id): PreferenceStatus.OPTED_IN.value},
+        )
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="no-pref@example.com",
+            preferences={str(self.category.id): PreferenceStatus.NO_PREFERENCE.value},
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/messaging_preferences/export_opt_outs/",
+            {"category_key": self.category.key},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        rows = self._parse_export_csv(response)
+        identifiers = [r[0] for r in rows[1:]]
+        self.assertEqual(identifiers, ["opted-out@example.com"])
+
+    def test_export_opt_outs_empty(self):
+        """When no opt-outs exist, returns the header row only."""
+        response = self.client.get(f"/api/environments/{self.team.id}/messaging_preferences/export_opt_outs/")
+        self.assertEqual(response.status_code, 200)
+
+        rows = self._parse_export_csv(response)
+        self.assertEqual(rows, [["Recipient", "Opt-out date"]])
+
+    def test_export_opt_outs_unknown_category(self):
+        """An unknown `category_key` returns a 404 (matching the `opt_outs` action)."""
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/messaging_preferences/export_opt_outs/",
+            {"category_key": "nonexistent_category"},
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"], "Category not found")

--- a/products/messaging/frontend/generated/api.schemas.ts
+++ b/products/messaging/frontend/generated/api.schemas.ts
@@ -162,6 +162,13 @@ export type MessagingCategoriesListParams = {
     offset?: number
 }
 
+export type MessagingPreferencesExportOptOutsRetrieveParams = {
+    /**
+     * Optional category key. When omitted, exports recipients who opted out of all marketing communications (the `$all` bucket).
+     */
+    category_key?: string
+}
+
 export type MessagingTemplatesListParams = {
     /**
      * Number of results to return per page.

--- a/products/messaging/frontend/generated/api.ts
+++ b/products/messaging/frontend/generated/api.ts
@@ -12,6 +12,7 @@ import type {
     MessageCategoryApi,
     MessageTemplateApi,
     MessagingCategoriesListParams,
+    MessagingPreferencesExportOptOutsRetrieveParams,
     MessagingTemplatesListParams,
     PaginatedMessageCategoryListApi,
     PaginatedMessageTemplateListApi,
@@ -252,6 +253,39 @@ export const messagingCategoriesSaveWebhookConfigCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(messageCategoryApi),
+    })
+}
+
+/**
+ * Export opt-out recipients as CSV. Returns a `text/csv` attachment with columns `Recipient` and `Opt-out date` (ISO-8601 UTC), filtered identically to the `opt_outs` endpoint.
+ */
+export const getMessagingPreferencesExportOptOutsRetrieveUrl = (
+    projectId: string,
+    params?: MessagingPreferencesExportOptOutsRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/environments/${projectId}/messaging_preferences/export_opt_outs/?${stringifiedParams}`
+        : `/api/environments/${projectId}/messaging_preferences/export_opt_outs/`
+}
+
+export const messagingPreferencesExportOptOutsRetrieve = async (
+    projectId: string,
+    params?: MessagingPreferencesExportOptOutsRetrieveParams,
+    options?: RequestInit
+): Promise<string> => {
+    return apiMutator<string>(getMessagingPreferencesExportOptOutsRetrieveUrl(projectId, params), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/workflows/frontend/OptOuts/OptOutList.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutList.tsx
@@ -15,14 +15,8 @@ import type { OptOutEntry } from './types'
 
 export function OptOutList({ category }: { category?: MessageCategory }): JSX.Element {
     const logic = optOutListLogic({ category })
-    const {
-        setSelectedIdentifier,
-        openPreferencesPage,
-        loadNextPage,
-        loadPreviousPage,
-        loadOptOutPersons,
-        exportCsv,
-    } = useActions(logic)
+    const { setSelectedIdentifier, openPreferencesPage, loadNextPage, loadPreviousPage, loadOptOutPersons, exportCsv } =
+        useActions(logic)
     const {
         selectedIdentifier,
         optOutPersons,
@@ -104,7 +98,9 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
                     type="secondary"
                     onClick={exportCsv}
                     loading={csvExporting}
-                    disabledReason={optOutPersons.count === 0 ? 'No opt-outs to export' : undefined}
+                    disabledReason={
+                        !optOutPersonsLoading && optOutPersons.count === 0 ? 'No opt-outs to export' : undefined
+                    }
                 >
                     Export to CSV
                 </LemonButton>

--- a/products/workflows/frontend/OptOuts/OptOutList.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutList.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconChevronLeft, IconChevronRight, IconExternal, IconRefresh } from '@posthog/icons'
+import { IconChevronLeft, IconChevronRight, IconDownload, IconExternal, IconRefresh } from '@posthog/icons'
 import { LemonButton, LemonModal, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
@@ -15,10 +15,22 @@ import type { OptOutEntry } from './types'
 
 export function OptOutList({ category }: { category?: MessageCategory }): JSX.Element {
     const logic = optOutListLogic({ category })
-    const { setSelectedIdentifier, openPreferencesPage, loadNextPage, loadPreviousPage, loadOptOutPersons } =
-        useActions(logic)
-    const { selectedIdentifier, optOutPersons, optOutPersonsLoading, preferencesUrlLoading, currentPage } =
-        useValues(logic)
+    const {
+        setSelectedIdentifier,
+        openPreferencesPage,
+        loadNextPage,
+        loadPreviousPage,
+        loadOptOutPersons,
+        exportCsv,
+    } = useActions(logic)
+    const {
+        selectedIdentifier,
+        optOutPersons,
+        optOutPersonsLoading,
+        preferencesUrlLoading,
+        currentPage,
+        csvExporting,
+    } = useValues(logic)
 
     const handleShowPersons = (identifier: string): void => {
         setSelectedIdentifier(identifier)
@@ -85,7 +97,17 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
 
     return (
         <>
-            <div className="flex justify-end mb-2 mt-[-3rem]">
+            <div className="flex justify-end gap-2 mb-2 mt-[-3rem]">
+                <LemonButton
+                    icon={<IconDownload />}
+                    size="small"
+                    type="secondary"
+                    onClick={exportCsv}
+                    loading={csvExporting}
+                    disabledReason={optOutPersons.count === 0 ? 'No opt-outs to export' : undefined}
+                >
+                    Export to CSV
+                </LemonButton>
                 <LemonButton
                     icon={<IconRefresh />}
                     size="small"

--- a/products/workflows/frontend/OptOuts/optOutListLogic.ts
+++ b/products/workflows/frontend/OptOuts/optOutListLogic.ts
@@ -1,9 +1,11 @@
-import { actions, afterMount, connect, kea, key, path, props, reducers } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
+import { downloadBlob } from 'lib/components/ExportButton/exporter'
+import { dayjs } from 'lib/dayjs'
 
 import { MessageCategory } from './optOutCategoriesLogic'
 import type { optOutListLogicType } from './optOutListLogicType'
@@ -34,6 +36,8 @@ export const optOutListLogic = kea<optOutListLogicType>([
         setCurrentPage: (page: number) => ({ page }),
         loadNextPage: true,
         loadPreviousPage: true,
+        exportCsv: true,
+        setCsvExporting: (exporting: boolean) => ({ exporting }),
     }),
     reducers({
         personsModalOpen: [
@@ -75,6 +79,12 @@ export const optOutListLogic = kea<optOutListLogicType>([
                 loadPreviousPageSuccess: (state) => Math.max(1, state - 1),
             },
         ],
+        csvExporting: [
+            false,
+            {
+                setCsvExporting: (_, { exporting }) => exporting,
+            },
+        ],
     }),
     loaders(({ props, values }) => ({
         optOutPersons: {
@@ -107,6 +117,20 @@ export const optOutListLogic = kea<optOutListLogicType>([
                     return values.optOutPersons
                 }
             },
+        },
+    })),
+    listeners(({ props, actions }) => ({
+        exportCsv: async () => {
+            actions.setCsvExporting(true)
+            try {
+                const blob = await api.messaging.exportMessageOptOuts(props.category?.key)
+                const slug = props.category?.key ?? 'marketing'
+                downloadBlob(blob, `opt-outs-${slug}-${dayjs().format('YYYY-MM-DD')}.csv`)
+            } catch {
+                lemonToast.error('Failed to export opt-outs')
+            } finally {
+                actions.setCsvExporting(false)
+            }
         },
     })),
     afterMount(({ props, actions }) => {

--- a/products/workflows/frontend/OptOuts/optOutListLogic.ts
+++ b/products/workflows/frontend/OptOuts/optOutListLogic.ts
@@ -5,7 +5,6 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
 import { downloadBlob } from 'lib/components/ExportButton/exporter'
-import { dayjs } from 'lib/dayjs'
 
 import { MessageCategory } from './optOutCategoriesLogic'
 import type { optOutListLogicType } from './optOutListLogicType'
@@ -123,9 +122,8 @@ export const optOutListLogic = kea<optOutListLogicType>([
         exportCsv: async () => {
             actions.setCsvExporting(true)
             try {
-                const blob = await api.messaging.exportMessageOptOuts(props.category?.key)
-                const slug = props.category?.key ?? 'marketing'
-                downloadBlob(blob, `opt-outs-${slug}-${dayjs().format('YYYY-MM-DD')}.csv`)
+                const { blob, filename } = await api.messaging.exportMessageOptOuts(props.category?.key)
+                downloadBlob(blob, filename)
             } catch {
                 lemonToast.error('Failed to export opt-outs')
             } finally {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -42630,6 +42630,13 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type MessagingPreferencesExportOptOutsRetrieveParams = {
+    /**
+     * Optional category key. When omitted, exports recipients who opted out of all marketing communications (the `$all` bucket).
+     */
+    category_key?: string;
+    };
+
     export type MessagingTemplatesListParams = {
     /**
      * Number of results to return per page.


### PR DESCRIPTION
Adds an "Export to CSV" button to each opt-out list (per-category and global marketing) plus a backend export_opt_outs action that returns a text/csv attachment filtered identically to the existing opt_outs endpoint.

<img width="2682" height="1846" alt="2026-05-07 16 11 56" src="https://github.com/user-attachments/assets/35e61321-89af-4a6c-9a62-2bcc0077a0b8" />



Closes #41368

Generated-By: PostHog Code
Task-Id: bcd0c9ce-f12d-4b65-8037-dbcfec9aeb31

<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->
