### PR TITLE
fix(django): tests failing  due to refactor of dashboard consts

### DIFF
--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -1109,7 +1109,7 @@ class TestSharedInsightsExecutionMode(BaseTest):
     def test_shared_force_blocking_min_age_matches_frontend_auto_refresh_interval(self) -> None:
         """Backend throttle must match frontend auto-refresh interval — drift would silently throttle periodic refreshes."""
         frontend_file = (
-            Path(__file__).resolve().parents[3] / "frontend" / "src" / "scenes" / "dashboard" / "dashboardUtils.ts"
+            Path(__file__).resolve().parents[3] / "frontend" / "src" / "scenes" / "dashboard" / "dashboardConstants.ts"
         )
         source = frontend_file.read_text()
 


### PR DESCRIPTION
## Problem

backend test was failing after a refactor of some util/const file

## Changes

change the frontend files that the be test looks for some consts in

## How did you test this code?

if CI passes its good

