### PR TITLE
fix(mcp): exec returns only formatted table in optimized mode

### DIFF
--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -6,7 +6,13 @@ import { isPostHogCodeConsumer } from '@/lib/client-detection'
 import { formatResponse } from '@/lib/response'
 
 import { TOKEN_CHAR_LIMIT, listAvailablePaths, resolveSchemaPath, summarizeSchema } from './schema-utils'
-import { POSTHOG_META_KEY, type Context, type Tool, type ZodObjectAny } from './types'
+import {
+    POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY,
+    POSTHOG_META_KEY,
+    type Context,
+    type Tool,
+    type ZodObjectAny,
+} from './types'
 
 type ExecSchema = ReturnType<typeof makeExecSchema>
 
@@ -270,7 +276,23 @@ export function createExecTool(
                         success: true,
                         output_format: useJson ? 'json' : 'text',
                     })
-                    return useJson ? JSON.stringify(result) : formatResponse(result)
+                    if (useJson) {
+                        return JSON.stringify(result)
+                    }
+                    // Optimized mode: when the handler attached a backend-formatted table
+                    // via `__formatted_results_override`, return ONLY that string. The raw
+                    // `results`/`_posthogUrl` payload would otherwise duplicate the table
+                    // and crowd it out — buildToolResultPayload makes the same choice for
+                    // the non-exec path, this keeps exec consistent.
+                    if (result !== null && typeof result === 'object') {
+                        const formattedOverride = (result as Record<string, unknown>)[
+                            POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY
+                        ]
+                        if (typeof formattedOverride === 'string') {
+                            return formattedOverride
+                        }
+                    }
+                    return formatResponse(result)
                 }
 
                 default:

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -11,7 +11,13 @@ import { SessionManager } from '@/lib/SessionManager'
 import { getToolsFromContext } from '@/tools'
 import { createExecTool, type ExecInnerCallProperties } from '@/tools/exec'
 import { getToolDefinition } from '@/tools/toolDefinitions'
-import { POSTHOG_META_KEY, type Context, type Tool, type ZodObjectAny } from '@/tools/types'
+import {
+    POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY,
+    POSTHOG_META_KEY,
+    type Context,
+    type Tool,
+    type ZodObjectAny,
+} from '@/tools/types'
 
 function makeMockTool(overrides: Partial<Tool<ZodObjectAny>> = {}): Tool<ZodObjectAny> {
     return {
@@ -71,6 +77,50 @@ describe('exec tool', () => {
             const result = await exec.handler(mockContext, { command: 'call --json mock-tool' })
             const parsed = JSON.parse(result as string)
             expect(parsed).toEqual({ id: 1, name: 'test', items: [{ a: 1 }, { a: 2 }] })
+        })
+
+        it('returns ONLY the formatted table when result has __formatted_results_override and mode is optimized', async () => {
+            const tool = makeMockTool({
+                handler: async () => ({
+                    results: [{ data: [1, 2, 3], count: 6 }],
+                    _posthogUrl: 'http://localhost:8010/insights/new#q=...',
+                    [POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]: 'Date|count\n2026-05-07|6',
+                }),
+            })
+            const exec = createExec([tool])
+            const result = await exec.handler(mockContext, { command: 'call mock-tool' })
+            expect(result).toBe('Date|count\n2026-05-07|6')
+            // Raw fields and the override key itself must not leak into optimized output
+            expect(result).not.toContain('_posthogUrl')
+            expect(result).not.toContain('results')
+            expect(result).not.toContain('__formatted_results_override')
+        })
+
+        it('still TOON-encodes when __formatted_results_override is absent', async () => {
+            const tool = makeMockTool({
+                handler: async () => ({
+                    results: [{ data: [1, 2, 3], count: 6 }],
+                    _posthogUrl: 'http://localhost:8010/insights/new#q=...',
+                }),
+            })
+            const exec = createExec([tool])
+            const result = (await exec.handler(mockContext, { command: 'call mock-tool' })) as string
+            expect(result).toContain('_posthogUrl')
+            expect(result).toContain('results')
+        })
+
+        it('returns raw JSON (with override key) when --json flag is passed even if override is present', async () => {
+            const tool = makeMockTool({
+                handler: async () => ({
+                    results: [{ data: [1, 2, 3] }],
+                    [POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]: 'Date|count\n2026-05-07|6',
+                }),
+            })
+            const exec = createExec([tool])
+            const result = await exec.handler(mockContext, { command: 'call --json mock-tool' })
+            const parsed = JSON.parse(result as string)
+            expect(parsed.results).toEqual([{ data: [1, 2, 3] }])
+            expect(parsed[POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]).toBe('Date|count\n2026-05-07|6')
         })
 
         it('throws usage error for bare call', async () => {


### PR DESCRIPTION
## Problem

The query tool regressed in the exec MCP and started to return both formatted and unformatted results, but it must return only one of them.

## Changes

- `services/mcp/src/tools/exec.ts`: in the `call` verb path, after the handler returns, when `output_format` is optimized (i.e. not `--json` / not tool-meta json) **and** the result object carries a string-typed `__formatted_results_override`, return only that string. Behavior in JSON mode and the UI-app branch is unchanged.
- `services/mcp/tests/unit/exec.test.ts`: three new tests covering (a) the optimized-mode override returns only the table, (b) absence of the override falls back to TOON-encoding the full payload, (c) `--json` still returns the full raw object including the override key.

## How did you test this code?

I'm an agent — I did not manually exercise this in a running MCP. I ran the automated test suite:

- `pnpm test -- run --project unit tests/unit/exec.test.ts tests/unit/build-tool-result.test.ts tests/unit/query-wrapper-factory.test.ts` — all pass (1149 tests across the unit + workers projects).
- `pnpm typecheck` — clean.
- `bin/hogli format:js` (via the lint-staged pre-commit hook) — clean.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7).
- The bug was reported by Georgiy Tarasov after observing both the raw structured payload and the `__formatted_results_override` field appearing simultaneously in an optimized-mode `query-trends` exec call.
- Considered also stripping the override key from `--json` output for symmetry, but kept that path unchanged: the user's report was specific to optimized mode, and JSON callers may want the override available for inspection.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*