### PR TITLE
chore(llma): tag gateway on cost update PRs

### DIFF
--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -138,7 +138,8 @@ jobs:
                       --base master \
                       --head chore/llma-update-ai-costs \
                       --label "automated" --label "llm-analytics" \
-                      --reviewer "PostHog/team-llm-analytics"
+                      --reviewer "PostHog/team-llm-analytics" \
+                      --reviewer "PostHog/team-llm-gateway"
                   fi
 
             - name: Alert Slack on failure


### PR DESCRIPTION
## Problem

Automated LLM cost update PRs currently request review only from Team LLM analytics. Team LLM gateway should also be tagged while ownership is shared.

## Changes

Adds `PostHog/team-llm-gateway` as an additional reviewer request in the Update AI Costs workflow-generated PRs, while keeping `PostHog/team-llm-analytics` in place.

## How did you test this code?

Agent-authored: workflow YAML formatting and diff whitespace validation passed locally. The scheduled workflow itself was not run.

## Publish to changelog?

No.

## Docs update

No docs update needed.
