### PR TITLE
chore(ingestion): rename error_tracking pipeline value to errortracking

### DIFF
--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -156,7 +156,7 @@ describe('ErrorTrackingConsumer', () => {
             statefulOverflowEnabled: hub.ERROR_TRACKING_STATEFUL_OVERFLOW_ENABLED,
             statefulOverflowRedisTTLSeconds: hub.ERROR_TRACKING_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS,
             statefulOverflowLocalCacheTTLSeconds: hub.ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
-            pipeline: hub.INGESTION_PIPELINE ?? 'error_tracking',
+            pipeline: hub.INGESTION_PIPELINE ?? 'errortracking',
             rateLimiterEnabled: hub.ERROR_TRACKING_RATE_LIMITER_ENABLED,
             rateLimiterReportingMode: hub.ERROR_TRACKING_RATE_LIMITER_REPORTING_MODE,
             rateLimiterRedisHost: hub.ERROR_TRACKING_RATE_LIMITER_REDIS_HOST,

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -145,7 +145,7 @@ export class ErrorTrackingConsumer {
         this.promiseScheduler = new PromiseScheduler()
 
         this.eventIngestionRestrictionManager = new EventIngestionRestrictionManager(deps.redisPool, {
-            pipeline: 'error_tracking',
+            pipeline: 'errortracking',
         })
 
         // Create shared Redis repository for overflow redirect services

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
@@ -937,7 +937,7 @@ describe('ErrorTrackingPipeline', () => {
 
             topHog = new TopHog({
                 outputs: tophogOutputs,
-                pipeline: 'error_tracking',
+                pipeline: 'errortracking',
                 lane: 'main',
             })
         })
@@ -1044,7 +1044,7 @@ describe('ErrorTrackingPipeline', () => {
             const messages = getTopHogMessages()
             expect(messages.length).toBeGreaterThan(0)
             for (const msg of messages) {
-                expect(msg.pipeline).toBe('error_tracking')
+                expect(msg.pipeline).toBe('errortracking')
                 expect(msg.lane).toBe('main')
             }
         })

--- a/nodejs/src/servers/error-tracking-server.ts
+++ b/nodejs/src/servers/error-tracking-server.ts
@@ -206,7 +206,7 @@ export class ErrorTrackingServer implements NodeServer {
                     statefulOverflowRedisTTLSeconds: this.config.ERROR_TRACKING_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS,
                     statefulOverflowLocalCacheTTLSeconds:
                         this.config.ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
-                    pipeline: this.config.INGESTION_PIPELINE ?? 'error_tracking',
+                    pipeline: this.config.INGESTION_PIPELINE ?? 'errortracking',
                     rateLimiterEnabled: this.config.ERROR_TRACKING_RATE_LIMITER_ENABLED,
                     rateLimiterReportingMode: this.config.ERROR_TRACKING_RATE_LIMITER_REPORTING_MODE,
                     rateLimiterRedisHost: this.config.ERROR_TRACKING_RATE_LIMITER_REDIS_HOST,

--- a/nodejs/src/utils/event-ingestion-restrictions/manager.ts
+++ b/nodejs/src/utils/event-ingestion-restrictions/manager.ts
@@ -7,7 +7,7 @@ import { logger } from '../logger'
 import { REDIS_KEY_PREFIX, RedisRestrictionArraySchema, RedisRestrictionType, toRestrictionRule } from './redis-schema'
 import { EventContext, RestrictionFilters, RestrictionMap, RestrictionRule, RestrictionType } from './rules'
 
-export type IngestionPipeline = 'analytics' | 'session_recordings' | 'error_tracking'
+export type IngestionPipeline = 'analytics' | 'session_recordings' | 'errortracking'
 
 const EMPTY_RESTRICTIONS: ReadonlySet<RestrictionType> = new Set()
 

--- a/nodejs/src/utils/event-ingestion-restrictions/redis-schema.ts
+++ b/nodejs/src/utils/event-ingestion-restrictions/redis-schema.ts
@@ -13,7 +13,7 @@ export enum RedisRestrictionType {
 export const REDIS_KEY_PREFIX = 'event_ingestion_restriction_dynamic_config'
 
 // Base schema for common fields
-const pipelinesSchema = z.array(z.enum(['analytics', 'session_recordings', 'error_tracking'])).optional()
+const pipelinesSchema = z.array(z.enum(['analytics', 'session_recordings', 'errortracking'])).optional()
 
 // Redis schema v0 (legacy) - single identifier per entry, no version field
 const RedisRestrictionItemSchemaV0 = z.object({


### PR DESCRIPTION
## Problem

Pipeline identifiers used in `EventIngestionRestrictionConfig.pipelines` (and the matching Node.js / Rust capture lookups) must not contain underscores so they can be reused as k8s identifiers. The first such identifier where this matters is the upcoming `errortracking` option being added on the Django side; today the Node.js error-tracking consumer reads `error_tracking` from Redis, which would never match the new Django value.

This PR is part one of two. It renames the value across the Node.js ingestion code so the consumer is already listening on the new name by the time Django starts emitting it.

The existing pipeline names (`analytics`, `session_recordings`) are left untouched — they predate the new convention and renaming them is a separate, larger migration.

## Changes

- Rename the `error_tracking` pipeline string to `errortracking` in:
  - `IngestionPipeline` union (`utils/event-ingestion-restrictions/manager.ts`)
  - Redis schema enum (`utils/event-ingestion-restrictions/redis-schema.ts`)
  - `ErrorTrackingConsumer` restriction manager option (`ingestion/error-tracking/error-tracking-consumer.ts`)
  - `error-tracking-server.ts` default for `INGESTION_PIPELINE` on the consumer config (the Prometheus default at line 119 was already `errortracking`; this aligns the second usage)
  - matching test fixtures in `error-tracking-pipeline.test.ts` and `error-tracking-consumer.test.ts`

No production restriction configs reference `error_tracking` today (the value isn't yet a valid Django enum entry), so this is a safe rename — there's no Redis cache to migrate.

## How did you test this code?

Agent-authored. Automated checks run locally:

- `pnpm typescript:check` — clean
- `pnpm build` — clean
- `pnpm lint` — clean
- `pnpm test -- src/ingestion/error-tracking/error-tracking-pipeline.test.ts` — pass
- `pnpm test -- src/ingestion/error-tracking/error-tracking-consumer.test.ts` — pre-existing environmental failures only (test setup needs running Postgres/Kafka via docker; not invoked from this branch). Tests that exercise the renamed `pipeline` field (assertions in `error-tracking-pipeline.test.ts`) pass.

No manual testing performed.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code session
- Human prompt: rename `error_tracking` to `errortracking` for the new no-underscore pipeline-naming convention (k8s identifiers don't allow underscores)
- Decision: rename only the new identifier, not the existing `session_recordings`. Existing values stay until they're explicitly migrated, since renaming them requires a coordinated Redis cache flip and Django + Rust capture changes that aren't in scope here.
- Decision: ship the Node.js side first so the consumer is already listening for `errortracking` before Django (PR 2) makes it a selectable option.