### PR TITLE
feat(schema): share dashboard auto-refresh interval via generated schema

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11170,6 +11170,10 @@
             "required": ["status", "proposalId", "toolName", "preview", "payload"],
             "type": "object"
         },
+        "DashboardAutoRefreshInterval": {
+            "const": 1800,
+            "type": "number"
+        },
         "DashboardFilter": {
             "additionalProperties": false,
             "properties": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5979,6 +5979,10 @@ export enum InfinityValue {
     NEGATIVE_INFINITY_VALUE = -999999,
 }
 
+export enum DashboardAutoRefreshInterval {
+    SECONDS = 1800,
+}
+
 export type UsageMetricFormat = 'numeric' | 'currency'
 
 export type UsageMetricDisplay = 'number' | 'sparkline'

--- a/frontend/src/scenes/dashboard/dashboardConstants.ts
+++ b/frontend/src/scenes/dashboard/dashboardConstants.ts
@@ -1,4 +1,6 @@
-export const AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 1800
+import { DashboardAutoRefreshInterval } from '~/queries/schema/schema-general'
+
+export const AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = DashboardAutoRefreshInterval.SECONDS
 
 /**
  * Cold-start one-shot threshold: if data is older than this when a shared dashboard loads,

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -18,6 +18,7 @@ from posthog.schema import (
     CacheMissResponse,
     CalendarHeatmapQuery,
     ChartDisplayType,
+    DashboardAutoRefreshInterval,
     DashboardFilter,
     DateRange,
     EndpointsUsageOverviewQuery,
@@ -194,10 +195,10 @@ def execution_mode_from_refresh(refresh_requested: bool | str | None) -> Executi
     return ExecutionMode.CACHE_ONLY_NEVER_CALCULATE
 
 
-# Minimum age before a shared insight may honor `?refresh=force_blocking`. Must match the
-# frontend `AUTO_REFRESH_INITIAL_INTERVAL_SECONDS` (1800s) — drift would silently drop
-# periodic refresh ticks. Best-effort throttle, not a hard rate limit.
-SHARED_FORCE_BLOCKING_MIN_AGE = timedelta(minutes=30)
+# Minimum age before a shared insight may honor `?refresh=force_blocking`.
+# Sourced from the same generated schema as the frontend's auto-refresh interval so the
+# two cannot drift. Best-effort throttle, not a hard rate limit.
+SHARED_FORCE_BLOCKING_MIN_AGE = timedelta(seconds=DashboardAutoRefreshInterval().root)
 
 
 _SHARED_MODE_WHITELIST = {

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -1,6 +1,4 @@
-import re
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from typing import Any, Literal, Optional
 from zoneinfo import ZoneInfo
 
@@ -43,7 +41,6 @@ from posthog.hogql.constants import LimitContext
 
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.hogql_queries.query_runner import (
-    SHARED_FORCE_BLOCKING_MIN_AGE,
     ExecutionMode,
     QueryRunner,
     get_query_runner,
@@ -1105,33 +1102,3 @@ class TestSharedInsightsExecutionMode(BaseTest):
         last_refresh = None if last_refresh_offset is None else datetime.now(UTC) - last_refresh_offset
         result = shared_insights_execution_mode(execution_mode, last_refresh=last_refresh)
         self.assertEqual(result, expected_mode)
-
-    def test_shared_force_blocking_min_age_matches_frontend_auto_refresh_interval(self) -> None:
-        """Backend throttle must match frontend auto-refresh interval — drift would silently throttle periodic refreshes."""
-        frontend_file = (
-            Path(__file__).resolve().parents[3] / "frontend" / "src" / "scenes" / "dashboard" / "dashboardConstants.ts"
-        )
-        source = frontend_file.read_text()
-
-        interval_match = re.search(
-            r"export\s+const\s+AUTO_REFRESH_INITIAL_INTERVAL_SECONDS\s*=\s*(\d+)\s*",
-            source,
-        )
-        assert interval_match, f"Could not find AUTO_REFRESH_INITIAL_INTERVAL_SECONDS in {frontend_file}"
-        frontend_interval_minutes = int(interval_match.group(1)) // 60
-
-        stale_match = re.search(
-            r"export\s+const\s+SHARED_DASHBOARD_AUTO_FORCE_IF_STALE_MINUTES\s*=\s*AUTO_REFRESH_INITIAL_INTERVAL_SECONDS\s*/\s*60",
-            source,
-        )
-        assert stale_match, (
-            f"SHARED_DASHBOARD_AUTO_FORCE_IF_STALE_MINUTES must be derived from "
-            f"AUTO_REFRESH_INITIAL_INTERVAL_SECONDS / 60 in {frontend_file}."
-        )
-
-        backend_minutes = int(SHARED_FORCE_BLOCKING_MIN_AGE.total_seconds() // 60)
-        self.assertEqual(
-            backend_minutes,
-            frontend_interval_minutes,
-            f"Backend ({backend_minutes}m) must equal frontend ({frontend_interval_minutes}m).",
-        )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1287,6 +1287,10 @@ class DangerousOperationResponse(BaseModel):
     toolName: str
 
 
+class DashboardAutoRefreshInterval(RootModel[Literal[1800]]):
+    root: Literal[1800] = 1800
+
+
 class DataColorToken(StrEnum):
     PRESET_1 = "preset-1"
     PRESET_2 = "preset-2"


### PR DESCRIPTION
## TL;DR

Move the dashboard auto-refresh interval constant into the shared generated schema so both frontend and backend source the same value automatically, eliminating manual synchronization and drift risk.

## Problem

The dashboard auto-refresh interval was hardcoded separately in TypeScript (`dashboardConstants.ts`) and Python (`query_runner.py`), requiring manual synchronization. This created a drift risk where periodic refresh ticks could silently drop if the values diverged.

## Changes

- **Added `DashboardAutoRefreshInterval` to shared schema**: New constant defined in both `schema.json` and `schema-general.ts` with a value of 1800 seconds
- **Updated frontend dashboard constants**: Changed `AUTO_REFRESH_INITIAL_INTERVAL_SECONDS` to reference the generated schema enum instead of a hardcoded value
- **Updated backend query runner**: Changed `SHARED_FORCE_BLOCKING_MIN_AGE` to source from the generated schema's `DashboardAutoRefreshInterval` class
- **Removed manual test**: Deleted the regex-based validation test that checked frontend/backend interval alignment, as it's now unnecessary with shared schema sourcing

## How did you test this code?

As an agent, I have verified the changes match the diff:
- Schema constants added to both `schema.json` and TypeScript type definitions
- Both frontend and backend now import and reference the shared constant
- Removed manual synchronization test that is no longer needed with schema-driven constants

The changes ensure automatic synchronization through the existing schema generation system, making manual drift checks obsolete.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*