### PR TITLE
ci: don't run backend ci on hogli changes

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -107,8 +107,6 @@ jobs:
                         # but makes it always match because the checked file always isn't `ee/frontend/**` 🙈
                         - 'ee/**/*'
                         - 'common/__init__.py'
-                        - 'tools/hogli/**'
-                        - 'tools/hogli-commands/**'
                         - 'common/hogql_parser/**'
                         - 'common/hogvm/**'
                         - 'common/ingestion/**'
@@ -154,8 +152,6 @@ jobs:
                         # Everything from backend: EXCEPT products/**/backend/**/*
                         - 'ee/**/*'
                         - 'common/__init__.py'
-                        - 'tools/hogli/**'
-                        - 'tools/hogli-commands/**'
                         - 'common/hogql_parser/**'
                         - 'common/hogvm/**'
                         - 'common/ingestion/**'


### PR DESCRIPTION
## Problem

Edits under `tools/hogli/**` and `tools/hogli-commands/**` currently match the `backend:` and `legacy:` path filters in `ci-backend.yml` and trigger the full Backend CI suite — including the ~10-minute "Validate migrations and OpenAPI types" job. That job's only signal for hogli changes is the OpenAPI check (which invokes `hogli build:openapi`); the migration steps go through `manage.py` directly.

`ci-python.yml` already exercises hogli end-to-end on those paths: `./bin/hogli meta:check` plus the pytest suites under `tools/hogli/tests` and `tools/hogli-commands/hogli_commands/tests`. That covers the framework + command wiring without the 10-minute Postgres/Django stack.

## Changes

Drop the two hogli path entries from both the `backend:` and `legacy:` filters (4 lines).

## How did you test this code?

I'm an agent (Claude Code). No manual testing — validation by inspection: hogli still gated by the `python:` filter in `ci-python.yml` (lines 62-63) and tested in `code-quality` (lines 179-192). Other `hogli` mentions in `ci-backend.yml` are runtime CLI calls in unrelated jobs and stay put.

## Publish to changelog?

no

## 🤖 Agent context

Created by Claude Opus 4.7