### PR TITLE
feat(tasks): allow editing PostHog Code invite code value in admin

### DIFF
--- a/products/tasks/backend/admin.py
+++ b/products/tasks/backend/admin.py
@@ -73,13 +73,10 @@ class CodeInviteAdmin(admin.ModelAdmin):
     inlines = []
 
     def get_readonly_fields(self, request, obj=None):
-        if obj:
-            return ("id", "code", "redemption_count", "created_at")
         return ("id", "redemption_count", "created_at")
 
     def get_fieldsets(self, request, obj=None):
         if obj:
-            # Show auto-generated code as readonly on existing records
             return (
                 (None, {"fields": ("id", "code", "description")}),
                 ("Limits", {"fields": ("is_active", "max_redemptions", "redemption_count", "expires_at")}),

--- a/products/tasks/backend/admin.py
+++ b/products/tasks/backend/admin.py
@@ -72,9 +72,6 @@ class CodeInviteAdmin(admin.ModelAdmin):
     autocomplete_fields = ("created_by",)
     inlines = []
 
-    def get_readonly_fields(self, request, obj=None):
-        return ("id", "redemption_count", "created_at")
-
     def get_fieldsets(self, request, obj=None):
         if obj:
             return (


### PR DESCRIPTION
## Problem

PostHog Code invite codes live in separate US and EU databases, so the auto-generated code value differs per region. That makes it awkward to publish a single shareable invite code (e.g. on the YC Bookface deal page) — admins have no way to align the value across regions today because the `code` field is locked to readonly on existing records in Django admin.

## Changes

Drop the `code`-is-readonly-after-creation rule on `CodeInviteAdmin` so admins can edit the auto-generated invite code value on an existing `CodeInvite`. The model's DB-level `unique=True` constraint still prevents collisions, and the redemption lookup is `code__iexact` so case still doesn't matter at redeem time.

- `products/tasks/backend/admin.py`: `get_readonly_fields` no longer adds `code` when editing an existing record. Fieldset on add/edit is unchanged.

No model, migration, or API changes — purely an admin-UI affordance.

## How did you test this code?

I'm an agent (PostHog Code). I did not run the test suite or manually exercise the admin UI. The change is a 3-line edit to `CodeInviteAdmin` and I relied on reading the surrounding code: the `code` field is `unique=True, db_index=True` on the model, redemption lookups use `code__iexact`, and `CodeInviteRedemption` references invites by FK (id), so editing the code value on an existing invite does not orphan existing redemptions — it only invalidates the previous string for future redemption attempts.

A human reviewer should sanity-check the admin form behavior and confirm there are no other readers of `CodeInvite.code` that assume immutability.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) on behalf of Josh Snyder, in response to a Slack thread about YC Code invite distribution. The original ask: make the invite code editable in admin so US and EU codes can be manually aligned to a single shareable value.
- Considered: (a) auto-syncing codes across regions — rejected, much larger scope, and the regional DB segmentation is intentional. (b) adding a "set code" admin action with explicit confirmation — rejected as overkill; admins already have full mutation rights on this model and the form's \`unique\` validator catches the only meaningful failure mode (collision).
- Did not add tests; the change is purely an admin form configuration tweak with no business logic.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*