### PR TITLE
feat(tasks): allow editing invite code value in admin

### DIFF
--- a/products/tasks/backend/admin.py
+++ b/products/tasks/backend/admin.py
@@ -72,22 +72,16 @@ class CodeInviteAdmin(admin.ModelAdmin):
     autocomplete_fields = ("created_by",)
     inlines = []
 
-    def get_readonly_fields(self, request, obj=None):
-        if obj:
-            return ("id", "code", "redemption_count", "created_at")
-        return ("id", "redemption_count", "created_at")
-
     def get_fieldsets(self, request, obj=None):
         if obj:
-            # Show auto-generated code as readonly on existing records
             return (
                 (None, {"fields": ("id", "code", "description")}),
                 ("Limits", {"fields": ("is_active", "max_redemptions", "redemption_count", "expires_at")}),
                 ("Metadata", {"fields": ("created_by", "created_at")}),
             )
-        # On add, omit code — it will be auto-generated on save
+        # On add, code may be set manually or left blank to auto-generate on save
         return (
-            (None, {"fields": ("id", "description")}),
+            (None, {"fields": ("id", "code", "description")}),
             ("Limits", {"fields": ("is_active", "max_redemptions", "expires_at")}),
             ("Metadata", {"fields": ("created_by",)}),
         )


### PR DESCRIPTION
## Problem

In the Django admin for the tasks product's `CodeInvite` model (PostHog Code invite codes), the `code` field is auto-generated on save and was previously read-only on the change form. Admins had no way to manually set or override the value of an existing invite's code from the admin UI.

## Changes

- Remove the `code` field from `CodeInviteAdmin.get_readonly_fields` so it is editable on existing records.
- Include `code` in the add-form fieldset so admins may optionally set a value when creating an invite. Leaving it blank preserves the existing auto-generation behavior on save (`CodeInvite.save` generates an 8-character code when `code` is empty).
- Drop the now-redundant `get_readonly_fields` override (it returned the same tuple as the class attribute).

The DB-level `unique=True` constraint on `code` is unchanged, so duplicate values are still rejected.

## How did you test this code?

I'm an agent. I did not run the app or exercise the admin UI manually. The change is limited to admin form configuration; it does not alter persistence or validation behavior, and the model already supports setting `code` directly (the auto-generation path only runs when `self.code` is falsy).

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Code)
- Considered: only making the field editable on the change form (matching an alternative draft PR #58008). Chose to also expose it on the add form so admins can set the value at creation time without a follow-up edit, while preserving the auto-generate-when-blank behavior already in `CodeInvite.save`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*