### PR TITLE
feat(signals): Add `repository` filter to signal reports list endpoint

### DIFF
--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -547,19 +547,14 @@ class TestSignalReportListAPI(APIBaseTest):
 
     @parameterized.expand(
         [
-            # Single match — only the report whose repo_selection matches comes back.
-            ("single_match", "posthog/posthog", {"a"}, {"b"}),
-            # Multiple repos in the filter — both matching reports come back.
-            ("multiple_repos", "posthog/posthog,posthog/posthog-js", {"a", "b"}, set()),
-            # Mixed-case query against lower-case stored repo names.
-            ("case_insensitive_query", "PostHog/PostHog", {"a"}, {"b"}),
-            # Lower-case query against (hypothetically) mixed-case stored repo names.
-            # Stored values from the agentic flow are lower-case in practice, but the
-            # backend still lower-cases both sides defensively.
-            ("case_insensitive_storage", "posthog/posthog-js", {"b"}, {"a"}),
+            ("single_match", "posthog/posthog", {"a"}),
+            ("multiple_repos", "posthog/posthog,posthog/posthog-js", {"a", "b"}),
+            # Mixed-case query against lower-case stored repo names — the input is
+            # lower-cased before matching, so this still hits "posthog/posthog".
+            ("case_insensitive_query", "PostHog/PostHog", {"a"}),
         ]
     )
-    def test_repository_filter_matches_repos(self, _name, repo_query, expected_titles, excluded_titles):
+    def test_repository_filter_matches_repos(self, _name, repo_query, expected_titles):
         reports_by_title = {
             "a": self._create_report(title="A"),
             "b": self._create_report(title="B"),
@@ -570,21 +565,17 @@ class TestSignalReportListAPI(APIBaseTest):
         response = self.client.get(self._list_url(repository=repo_query))
         assert response.status_code == status.HTTP_200_OK
         result_ids = {r["id"] for r in response.json()["results"]}
-        for title in expected_titles:
-            assert str(reports_by_title[title].id) in result_ids
-        for title in excluded_titles:
-            assert str(reports_by_title[title].id) not in result_ids
+        assert result_ids == {str(reports_by_title[t].id) for t in expected_titles}
 
     def test_repository_filter_excludes_reports_without_repo_selection_artefact(self):
         report_with_repo = self._create_report(title="A")
-        report_without_repo = self._create_report(title="B")
+        self._create_report(title="B")
         self._repo_selection_artefact(report_with_repo, repository="posthog/posthog")
 
         response = self.client.get(self._list_url(repository="posthog/posthog"))
         assert response.status_code == status.HTTP_200_OK
-        ids = {r["id"] for r in response.json()["results"]}
-        assert str(report_with_repo.id) in ids
-        assert str(report_without_repo.id) not in ids
+        result_ids = {r["id"] for r in response.json()["results"]}
+        assert result_ids == {str(report_with_repo.id)}
 
     def test_repository_filter_empty_returns_all(self):
         report = self._create_report(title="A")
@@ -592,8 +583,8 @@ class TestSignalReportListAPI(APIBaseTest):
 
         response = self.client.get(self._list_url())
         assert response.status_code == status.HTTP_200_OK
-        ids = {r["id"] for r in response.json()["results"]}
-        assert str(report.id) in ids
+        result_ids = {r["id"] for r in response.json()["results"]}
+        assert result_ids == {str(report.id)}
 
     # --- legacy choice removal ---
 

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -545,42 +545,35 @@ class TestSignalReportListAPI(APIBaseTest):
             content=json.dumps({"repository": repository, "reason": "test"}),
         )
 
-    def test_repository_filter_keeps_only_matching_repo(self):
-        report_a = self._create_report(title="A")
-        report_b = self._create_report(title="B")
-        self._repo_selection_artefact(report_a, repository="posthog/posthog")
-        self._repo_selection_artefact(report_b, repository="posthog/posthog-js")
+    @parameterized.expand(
+        [
+            # Single match — only the report whose repo_selection matches comes back.
+            ("single_match", "posthog/posthog", {"a"}, {"b"}),
+            # Multiple repos in the filter — both matching reports come back.
+            ("multiple_repos", "posthog/posthog,posthog/posthog-js", {"a", "b"}, set()),
+            # Mixed-case query against lower-case stored repo names.
+            ("case_insensitive_query", "PostHog/PostHog", {"a"}, {"b"}),
+            # Lower-case query against (hypothetically) mixed-case stored repo names.
+            # Stored values from the agentic flow are lower-case in practice, but the
+            # backend still lower-cases both sides defensively.
+            ("case_insensitive_storage", "posthog/posthog-js", {"b"}, {"a"}),
+        ]
+    )
+    def test_repository_filter_matches_repos(self, _name, repo_query, expected_titles, excluded_titles):
+        reports_by_title = {
+            "a": self._create_report(title="A"),
+            "b": self._create_report(title="B"),
+        }
+        self._repo_selection_artefact(reports_by_title["a"], repository="posthog/posthog")
+        self._repo_selection_artefact(reports_by_title["b"], repository="posthog/posthog-js")
 
-        response = self.client.get(self._list_url(repository="posthog/posthog"))
+        response = self.client.get(self._list_url(repository=repo_query))
         assert response.status_code == status.HTTP_200_OK
-        ids = {r["id"] for r in response.json()["results"]}
-        assert str(report_a.id) in ids
-        assert str(report_b.id) not in ids
-
-    def test_repository_filter_accepts_multiple_repos(self):
-        report_a = self._create_report(title="A")
-        report_b = self._create_report(title="B")
-        report_c = self._create_report(title="C")
-        self._repo_selection_artefact(report_a, repository="posthog/posthog")
-        self._repo_selection_artefact(report_b, repository="posthog/posthog-js")
-        self._repo_selection_artefact(report_c, repository="posthog/other")
-
-        response = self.client.get(
-            self._list_url(repository="posthog/posthog,posthog/posthog-js"),
-        )
-        assert response.status_code == status.HTTP_200_OK
-        ids = {r["id"] for r in response.json()["results"]}
-        assert {str(report_a.id), str(report_b.id)}.issubset(ids)
-        assert str(report_c.id) not in ids
-
-    def test_repository_filter_is_case_insensitive(self):
-        report = self._create_report(title="A")
-        self._repo_selection_artefact(report, repository="posthog/posthog")
-
-        response = self.client.get(self._list_url(repository="PostHog/PostHog"))
-        assert response.status_code == status.HTTP_200_OK
-        ids = {r["id"] for r in response.json()["results"]}
-        assert str(report.id) in ids
+        result_ids = {r["id"] for r in response.json()["results"]}
+        for title in expected_titles:
+            assert str(reports_by_title[title].id) in result_ids
+        for title in excluded_titles:
+            assert str(reports_by_title[title].id) not in result_ids
 
     def test_repository_filter_excludes_reports_without_repo_selection_artefact(self):
         report_with_repo = self._create_report(title="A")

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -535,6 +535,73 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["source_products"] == []
 
+    # --- repository filter ---
+
+    def _repo_selection_artefact(self, report: SignalReport, *, repository: str | None) -> SignalReportArtefact:
+        return SignalReportArtefact.objects.create(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.REPO_SELECTION,
+            content=json.dumps({"repository": repository, "reason": "test"}),
+        )
+
+    def test_repository_filter_keeps_only_matching_repo(self):
+        report_a = self._create_report(title="A")
+        report_b = self._create_report(title="B")
+        self._repo_selection_artefact(report_a, repository="posthog/posthog")
+        self._repo_selection_artefact(report_b, repository="posthog/posthog-js")
+
+        response = self.client.get(self._list_url(repository="posthog/posthog"))
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert str(report_a.id) in ids
+        assert str(report_b.id) not in ids
+
+    def test_repository_filter_accepts_multiple_repos(self):
+        report_a = self._create_report(title="A")
+        report_b = self._create_report(title="B")
+        report_c = self._create_report(title="C")
+        self._repo_selection_artefact(report_a, repository="posthog/posthog")
+        self._repo_selection_artefact(report_b, repository="posthog/posthog-js")
+        self._repo_selection_artefact(report_c, repository="posthog/other")
+
+        response = self.client.get(
+            self._list_url(repository="posthog/posthog,posthog/posthog-js"),
+        )
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert {str(report_a.id), str(report_b.id)}.issubset(ids)
+        assert str(report_c.id) not in ids
+
+    def test_repository_filter_is_case_insensitive(self):
+        report = self._create_report(title="A")
+        self._repo_selection_artefact(report, repository="posthog/posthog")
+
+        response = self.client.get(self._list_url(repository="PostHog/PostHog"))
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert str(report.id) in ids
+
+    def test_repository_filter_excludes_reports_without_repo_selection_artefact(self):
+        report_with_repo = self._create_report(title="A")
+        report_without_repo = self._create_report(title="B")
+        self._repo_selection_artefact(report_with_repo, repository="posthog/posthog")
+
+        response = self.client.get(self._list_url(repository="posthog/posthog"))
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert str(report_with_repo.id) in ids
+        assert str(report_without_repo.id) not in ids
+
+    def test_repository_filter_empty_returns_all(self):
+        report = self._create_report(title="A")
+        self._repo_selection_artefact(report, repository="posthog/posthog")
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert str(report.id) in ids
+
     # --- legacy choice removal ---
 
     def test_actionability_null_for_legacy_choice_artefact(self):

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -439,13 +439,11 @@ class SignalReportViewSet(
         if not repository_filter:
             return queryset
 
-        # Repos are matched case-insensitively against the `repository` field of any
-        # `repo_selection` artefact's JSON content (e.g. `{"repository": "owner/repo", ...}`).
-        # Matches *any* such artefact rather than only the latest — the same shape as
-        # `_apply_signal_report_suggested_reviewer_filter`. In practice each report has
-        # at most one `repo_selection` artefact (`select_repository_activity` reuses the
-        # previous one when present), so any-vs-latest doesn't matter today; if that ever
-        # changes, switch this to a Subquery on the latest by `created_at`.
+        # Matches *any* `repo_selection` artefact rather than only the latest — same
+        # shape as `_apply_signal_report_suggested_reviewer_filter`. Each report has at
+        # most one repo_selection artefact today (`select_repository_activity` reuses the
+        # previous one), so any-vs-latest doesn't matter; if that changes, switch to a
+        # Subquery on the latest by `created_at`.
         repositories = [s.strip().lower() for s in repository_filter.split(",") if s.strip()]
         if not repositories:
             return queryset

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -348,6 +348,7 @@ class SignalReportViewSet(
         qs = self._apply_signal_report_search_filter(qs)
         qs = self._apply_signal_report_source_product_filter(qs)
         qs = self._apply_signal_report_suggested_reviewer_filter(qs)
+        qs = self._apply_signal_report_repository_filter(qs)
         qs = self._annotate_latest_actionability_value(qs)
         qs = self._annotate_signal_report_status_rank(qs)
         qs = self._annotate_signal_report_priority(qs)
@@ -429,6 +430,31 @@ class SignalReportViewSet(
                 ).extra(
                     where=[reviewer_where],
                     params=reviewer_json_filters,
+                )
+            )
+        )
+
+    def _apply_signal_report_repository_filter(self, queryset):
+        repository_filter = self.request.query_params.get("repository")
+        if not repository_filter:
+            return queryset
+
+        # Repos are matched case-insensitively against the `repository` field of the
+        # latest `repo_selection` artefact's JSON content (e.g. `{"repository": "owner/repo", ...}`).
+        repositories = [s.strip().lower() for s in repository_filter.split(",") if s.strip()]
+        if not repositories:
+            return queryset
+
+        repo_where_clause = "LOWER(content::jsonb->>'repository') = ANY(%s)"
+        return queryset.filter(
+            Exists(
+                # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (parameterized via params)
+                SignalReportArtefact.objects.filter(
+                    report_id=OuterRef("id"),
+                    type=SignalReportArtefact.ArtefactType.REPO_SELECTION,
+                ).extra(
+                    where=[repo_where_clause],
+                    params=[repositories],
                 )
             )
         )
@@ -672,6 +698,17 @@ class SignalReportViewSet(
                 description=(
                     "Comma-separated list of PostHog user UUIDs. Reports are kept if their suggested reviewers "
                     "include any of the given users."
+                ),
+            ),
+            OpenApiParameter(
+                name="repository",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description=(
+                    "Comma-separated list of repositories in `owner/repo` form. Reports are kept if their "
+                    "selected repository (from the `repo_selection` artefact) matches any of the given "
+                    "repositories. Matching is case-insensitive."
                 ),
             ),
             OpenApiParameter(

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -439,8 +439,13 @@ class SignalReportViewSet(
         if not repository_filter:
             return queryset
 
-        # Repos are matched case-insensitively against the `repository` field of the
-        # latest `repo_selection` artefact's JSON content (e.g. `{"repository": "owner/repo", ...}`).
+        # Repos are matched case-insensitively against the `repository` field of any
+        # `repo_selection` artefact's JSON content (e.g. `{"repository": "owner/repo", ...}`).
+        # Matches *any* such artefact rather than only the latest — the same shape as
+        # `_apply_signal_report_suggested_reviewer_filter`. In practice each report has
+        # at most one `repo_selection` artefact (`select_repository_activity` reuses the
+        # previous one when present), so any-vs-latest doesn't matter today; if that ever
+        # changes, switch this to a Subquery on the latest by `created_at`.
         repositories = [s.strip().lower() for s in repository_filter.split(",") if s.strip()]
         if not repositories:
             return queryset

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -252,6 +252,10 @@ export type SignalsReportsListParams = {
      */
     ordering?: string
     /**
+     * Comma-separated list of repositories in `owner/repo` form. Reports are kept if their selected repository (from the `repo_selection` artefact) matches any of the given repositories. Matching is case-insensitive.
+     */
+    repository?: string
+    /**
      * Case-insensitive substring match against report title and summary.
      */
     search?: string

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -46828,6 +46828,10 @@ export namespace Schemas {
      */
     ordering?: string;
     /**
+     * Comma-separated list of repositories in `owner/repo` form. Reports are kept if their selected repository (from the `repo_selection` artefact) matches any of the given repositories. Matching is case-insensitive.
+     */
+    repository?: string;
+    /**
      * Case-insensitive substring match against report title and summary.
      */
     search?: string;

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -25,6 +25,12 @@ export const SignalsReportsListQueryParams = /* @__PURE__ */ zod.object({
         .describe(
             "Comma-separated ordering clauses. Each clause is a field name optionally prefixed with '-' for descending. Allowed fields: status, is_suggested_reviewer, signal_count, total_weight, priority, created_at, updated_at, id. Defaults to '-is_suggested_reviewer,status,-updated_at'."
         ),
+    repository: zod
+        .string()
+        .optional()
+        .describe(
+            'Comma-separated list of repositories in `owner/repo` form. Reports are kept if their selected repository (from the `repo_selection` artefact) matches any of the given repositories. Matching is case-insensitive.'
+        ),
     search: zod.string().optional().describe('Case-insensitive substring match against report title and summary.'),
     source_product: zod
         .string()

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -28,6 +28,7 @@ const inboxReportsList = (): ToolBase<
                 limit: params.limit,
                 offset: params.offset,
                 ordering: params.ordering,
+                repository: params.repository,
                 search: params.search,
                 source_product: params.source_product,
                 status: params.status,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/inbox-reports-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/inbox-reports-list.json
@@ -13,6 +13,10 @@
             "description": "Comma-separated ordering clauses. Each clause is a field name optionally prefixed with '-' for descending. Allowed fields: status, is_suggested_reviewer, signal_count, total_weight, priority, created_at, updated_at, id. Defaults to '-is_suggested_reviewer,status,-updated_at'.",
             "type": "string"
         },
+        "repository": {
+            "description": "Comma-separated list of repositories in `owner/repo` form. Reports are kept if their selected repository (from the `repo_selection` artefact) matches any of the given repositories. Matching is case-insensitive.",
+            "type": "string"
+        },
         "search": {
             "description": "Case-insensitive substring match against report title and summary.",
             "type": "string"


### PR DESCRIPTION
## Problem

Some want to filter by the relevant repo on reports, which I think will matter more as we focus on pull requests.

Adds a `repository` query param (comma-separated `owner/repo`) to `GET /api/projects/{team}/signals/reports/`.

Mirrors the shape of the existing `source_product` and `suggested_reviewers` filters.

This is the backend half of https://github.com/PostHog/code/pull/2089.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*