### PR TITLE
fix(data-warehouse): align managed warehouse provisioning

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -101,7 +101,6 @@ import {
     DataWarehouseSavedQueryDraft,
     DataWarehouseSavedQueryFolder,
     DataWarehouseSavedQueryRunHistory,
-    DataWarehouseProvisioningStatus,
     DataWarehouseSourceRowCount,
     DataWarehouseTable,
     DataWarehouseViewLink,
@@ -211,6 +210,7 @@ import {
 } from '~/types'
 
 import type { CustomerJourneyApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+import type { WarehouseStatusResponseApi } from 'products/data_warehouse/frontend/generated/api.schemas'
 import type {
     ErrorTrackingRule,
     ErrorTrackingRuleType,
@@ -5571,7 +5571,7 @@ const api = {
                 .create(options as any)
         },
 
-        async warehouseStatus(options?: ApiMethodOptions): Promise<DataWarehouseProvisioningStatus> {
+        async warehouseStatus(options?: ApiMethodOptions): Promise<WarehouseStatusResponseApi> {
             return await new ApiRequest().dataWarehouse().withAction('warehouse_status').get(options)
         },
 
@@ -5586,7 +5586,7 @@ const api = {
         async resetPassword(): Promise<{ username: string; password: string }> {
             return await new ApiRequest()
                 .dataWarehouse()
-                .withAction('reset_password')
+                .withAction('reset-password')
                 .create({} as any)
         },
     },

--- a/frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx
@@ -11,11 +11,14 @@ import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 
-import { DataWarehouseProvisioningConnection, DataWarehouseProvisioningState } from '~/types'
+import type {
+    WarehouseStatusConnectionApi,
+    WarehouseStatusResponseApi,
+} from 'products/data_warehouse/frontend/generated/api.schemas'
 
-import { warehouseProvisioningLogic } from './warehouseProvisioningLogic'
+import { isValidManagedWarehouseDatabaseName, warehouseProvisioningLogic } from './warehouseProvisioningLogic'
 
-function stateToTagType(state: DataWarehouseProvisioningState): 'success' | 'warning' | 'danger' | 'default' {
+function stateToTagType(state: WarehouseStatusResponseApi['state']): 'success' | 'warning' | 'danger' | 'default' {
     switch (state) {
         case 'ready':
             return 'success'
@@ -31,7 +34,7 @@ function stateToTagType(state: DataWarehouseProvisioningState): 'success' | 'war
     }
 }
 
-function ConnectionDetails({ connection }: { connection: DataWarehouseProvisioningConnection }): JSX.Element {
+function ConnectionDetails({ connection }: { connection: WarehouseStatusConnectionApi }): JSX.Element {
     const { host, port, database, username } = connection
     const psqlCmd = `psql "host=${host} port=${port} dbname=${database} user=${username} sslmode=require"`
 
@@ -97,7 +100,7 @@ export function SettingsTab(): JSX.Element {
     const isReady = warehouseStatus?.state === 'ready'
     const isFailed = warehouseStatus?.state === 'failed'
     const showProvisionForm = !hasWarehouse || isFailed
-    const canRetryProvision = !!retryDatabaseName && /^[a-z][a-z0-9_-]{2,62}$/.test(retryDatabaseName)
+    const canRetryProvision = !!retryDatabaseName && isValidManagedWarehouseDatabaseName(retryDatabaseName)
 
     return (
         <div className="mt-4 space-y-4 max-w-160">
@@ -166,8 +169,8 @@ export function SettingsTab(): JSX.Element {
                             )}
                         {databaseName && !isValidDatabaseName && (
                             <p className="text-danger text-xs mt-1">
-                                Must be 3-63 characters, start with a lowercase letter, and contain only lowercase
-                                letters, numbers, hyphens, or underscores.
+                                Must be 3-63 characters, start with a lowercase letter, end with a lowercase letter or
+                                number, and contain only lowercase letters, numbers, or hyphens.
                             </p>
                         )}
                         {(!databaseName ||

--- a/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts
+++ b/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts
@@ -1,16 +1,36 @@
 import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { DataWarehouseProvisioningStatus } from '~/types'
+import {
+    dataWarehouseCheckDatabaseNameRetrieve,
+    dataWarehouseDeprovisionCreate,
+    dataWarehouseProvisionCreate,
+    dataWarehouseResetPasswordCreate,
+    dataWarehouseWarehouseStatusRetrieve,
+} from 'products/data_warehouse/frontend/generated/api'
+import type { WarehouseStatusResponseApi } from 'products/data_warehouse/frontend/generated/api.schemas'
 
 import type { warehouseProvisioningLogicType } from './warehouseProvisioningLogicType'
 
+export const MANAGED_WAREHOUSE_DATABASE_NAME_REGEX = /^[a-z](?:[a-z0-9-]{1,61}[a-z0-9])$/
+
+export function isValidManagedWarehouseDatabaseName(name: string): boolean {
+    return MANAGED_WAREHOUSE_DATABASE_NAME_REGEX.test(name)
+}
+
 const databaseNameStorageKey = (teamId: number | null): string =>
     `warehouse-provisioning-database-name-${teamId ?? 'unknown'}`
+
+const currentProjectId = (): string => {
+    const teamId = teamLogic.values.currentTeamId
+    if (!teamId) {
+        throw new Error('Current project is unavailable')
+    }
+    return String(teamId)
+}
 
 export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
     path(['scenes', 'data-warehouse', 'scene', 'warehouseProvisioningLogic']),
@@ -35,11 +55,11 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
 
     loaders({
         warehouseStatus: [
-            null as DataWarehouseProvisioningStatus | null,
+            null as WarehouseStatusResponseApi | null,
             {
                 loadWarehouseStatus: async () => {
                     try {
-                        return await api.dataWarehouse.warehouseStatus()
+                        return await dataWarehouseWarehouseStatusRetrieve(currentProjectId())
                     } catch (e: any) {
                         if (e.status === 404) {
                             return null
@@ -137,7 +157,7 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                 return status.state === 'pending' || status.state === 'provisioning' || status.state === 'deleting'
             },
         ],
-        isValidDatabaseName: [(s) => [s.databaseName], (name): boolean => /^[a-z][a-z0-9_-]{2,62}$/.test(name)],
+        isValidDatabaseName: [(s) => [s.databaseName], (name): boolean => isValidManagedWarehouseDatabaseName(name)],
         retryDatabaseName: [
             (s) => [s.databaseName, s.lastRequestedDatabaseName],
             (databaseName, lastRequestedDatabaseName): string => databaseName || lastRequestedDatabaseName || '',
@@ -156,7 +176,7 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                 if (debounceTimer) {
                     clearTimeout(debounceTimer)
                 }
-                if (/^[a-z][a-z0-9_-]{2,62}$/.test(name)) {
+                if (isValidManagedWarehouseDatabaseName(name)) {
                     actions.setDatabaseNameChecking(true)
                     debounceTimer = setTimeout(() => {
                         actions.checkDatabaseName(name)
@@ -166,7 +186,7 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
 
             checkDatabaseName: async ({ name }) => {
                 try {
-                    const result = await api.dataWarehouse.checkDatabaseName(name)
+                    const result = await dataWarehouseCheckDatabaseNameRetrieve(currentProjectId(), { name })
                     if (values.databaseName === name) {
                         actions.setDatabaseNameAvailable(result.available)
                     }
@@ -180,7 +200,9 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                 actions.setLastRequestedDatabaseName(databaseName)
                 window.localStorage.setItem(databaseNameStorageKey(teamLogic.values.currentTeamId), databaseName)
                 try {
-                    const result = await api.dataWarehouse.provisionWarehouse(databaseName)
+                    const result = await dataWarehouseProvisionCreate(currentProjectId(), {
+                        database_name: databaseName,
+                    })
                     if (result.password) {
                         actions.setInitialPassword(result.password)
                     }
@@ -195,7 +217,7 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
 
             resetPassword: async () => {
                 try {
-                    const result = await api.dataWarehouse.resetPassword()
+                    const result = await dataWarehouseResetPasswordCreate(currentProjectId())
                     if (result.password) {
                         actions.setInitialPassword(result.password)
                     }
@@ -209,7 +231,7 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
             deprovisionWarehouse: async () => {
                 window.localStorage.removeItem(databaseNameStorageKey(teamLogic.values.currentTeamId))
                 try {
-                    await api.dataWarehouse.deprovisionWarehouse()
+                    await dataWarehouseDeprovisionCreate(currentProjectId())
                     lemonToast.success('Warehouse deprovisioning started')
                     actions.loadWarehouseStatus()
                     actions.pollStatus()

--- a/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts
+++ b/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts
@@ -203,9 +203,7 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                     const result = await dataWarehouseProvisionCreate(currentProjectId(), {
                         database_name: databaseName,
                     })
-                    if (result.password) {
-                        actions.setInitialPassword(result.password)
-                    }
+                    actions.setInitialPassword(result.password)
                     lemonToast.success('Warehouse provisioning started')
                     actions.loadWarehouseStatus()
                     actions.pollStatus()
@@ -218,9 +216,7 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
             resetPassword: async () => {
                 try {
                     const result = await dataWarehouseResetPasswordCreate(currentProjectId())
-                    if (result.password) {
-                        actions.setInitialPassword(result.password)
-                    }
+                    actions.setInitialPassword(result.password)
                     lemonToast.success('Password has been reset')
                 } catch (e: any) {
                     lemonToast.error(`Failed to reset password: ${e.message || 'Unknown error'}`)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7032,28 +7032,6 @@ export interface DataWarehouseActivityRecord {
     origin?: DataWarehouseSavedQueryOrigin | null
 }
 
-export type DataWarehouseProvisioningState = 'pending' | 'provisioning' | 'ready' | 'failed' | 'deleting' | 'deleted'
-
-export interface DataWarehouseProvisioningConnection {
-    host: string
-    port: number
-    database: string
-    username: string
-}
-
-export interface DataWarehouseProvisioningStatus {
-    org_id: string
-    state: DataWarehouseProvisioningState
-    status_message: string
-    s3_state: DataWarehouseProvisioningState
-    metadata_store_state: DataWarehouseProvisioningState
-    identity_state: DataWarehouseProvisioningState
-    secrets_state: DataWarehouseProvisioningState
-    ready_at: string | null
-    failed_at: string | null
-    connection: DataWarehouseProvisioningConnection | null
-}
-
 export type HeatmapType = 'screenshot' | 'iframe' | 'recording'
 export type HeatmapStatus = 'processing' | 'completed' | 'failed'
 

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -55,6 +55,7 @@ DUCKGRES_API_URL: str | None = get_from_env("DUCKGRES_API_URL", optional=True)
 DUCKGRES_INTERNAL_SECRET: str | None = get_from_env("DUCKGRES_INTERNAL_SECRET", optional=True)
 DUCKGRES_PG_URL: str | None = get_from_env("DUCKGRES_PG_URL", optional=True)
 DUCKGRES_PG_PORT: int = get_from_env("DUCKGRES_PG_PORT", 5432, type_cast=int)
+DUCKGRES_PG_HOST_SUFFIX: str | None = get_from_env("DUCKGRES_PG_HOST_SUFFIX", optional=True)
 
 # Bulk deletion operations can be disabled during database migrations
 DISABLE_BULK_DELETES: bool = get_from_env("DISABLE_BULK_DELETES", False, type_cast=str_to_bool)

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timedelta
 from typing import cast
 from zoneinfo import ZoneInfo
@@ -43,6 +44,12 @@ from ee.billing.billing_manager import BillingManager
 
 logger = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
+
+MANAGED_WAREHOUSE_DATABASE_NAME_REGEX = re.compile(r"^[a-z](?:[a-z0-9-]{1,61}[a-z0-9])$")
+
+
+def _is_valid_managed_warehouse_database_name(database_name: str) -> bool:
+    return bool(MANAGED_WAREHOUSE_DATABASE_NAME_REGEX.fullmatch(database_name))
 
 
 class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
@@ -885,17 +892,39 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             body = {"error": resp.text[:500]}
         return Response(body, status=resp.status_code)
 
+    def _public_managed_warehouse_host(self, database_name: str) -> str | None:
+        host_suffix = getattr(django_settings, "DUCKGRES_PG_HOST_SUFFIX", None)
+        if host_suffix:
+            return f"{database_name}.{host_suffix.lstrip('.')}"
+
+        return getattr(django_settings, "DUCKGRES_PG_URL", None)
+
     @extend_schema(
         request=inline_serializer(
             "ProvisionWarehouseRequest",
-            fields={"database_name": serializers.CharField(help_text="Name for the new database")},
+            fields={
+                "database_name": serializers.RegexField(
+                    regex=MANAGED_WAREHOUSE_DATABASE_NAME_REGEX,
+                    min_length=3,
+                    max_length=63,
+                    help_text=(
+                        "DNS-safe name for the new database. Must be 3-63 characters, start with a lowercase "
+                        "letter, end with a lowercase letter or number, and contain only lowercase letters, "
+                        "numbers, or hyphens."
+                    ),
+                )
+            },
         ),
         responses={
-            200: inline_serializer(
+            202: inline_serializer(
                 "ProvisionWarehouseResponse",
                 fields={
-                    "status": serializers.CharField(),
-                    "team": serializers.CharField(),
+                    "status": serializers.CharField(help_text="Provisioning request status from duckgres."),
+                    "org": serializers.CharField(help_text="Duckgres organization identifier."),
+                    "username": serializers.CharField(help_text="Initial warehouse username."),
+                    "password": serializers.CharField(
+                        help_text="Initial warehouse password. Returned once and not stored in plaintext."
+                    ),
                 },
             )
         },
@@ -906,6 +935,16 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         database_name = request.data.get("database_name")
         if not database_name:
             return Response({"error": "database_name is required"}, status=status.HTTP_400_BAD_REQUEST)
+        if not isinstance(database_name, str) or not _is_valid_managed_warehouse_database_name(database_name):
+            return Response(
+                {
+                    "error": (
+                        "database_name must be 3-63 characters, start with a lowercase letter, end with a "
+                        "lowercase letter or number, and contain only lowercase letters, numbers, or hyphens"
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         return self._provisioning_request(
             "POST",
             "/provision",
@@ -917,11 +956,11 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
 
     @extend_schema(
         responses={
-            200: inline_serializer(
+            202: inline_serializer(
                 "DeprovisionWarehouseResponse",
                 fields={
-                    "status": serializers.CharField(),
-                    "team": serializers.CharField(),
+                    "status": serializers.CharField(help_text="Deprovisioning request status from duckgres."),
+                    "org": serializers.CharField(help_text="Duckgres organization identifier."),
                 },
             )
         },
@@ -936,13 +975,34 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             200: inline_serializer(
                 "WarehouseStatusResponse",
                 fields={
-                    "team_name": serializers.CharField(),
-                    "state": serializers.ChoiceField(
-                        choices=["pending", "provisioning", "ready", "failed", "deleting", "deleted"]
+                    "org_id": serializers.CharField(help_text="Duckgres organization identifier."),
+                    "state": serializers.CharField(help_text="Overall managed warehouse provisioning state."),
+                    "status_message": serializers.CharField(
+                        allow_blank=True, help_text="Human-readable provisioning status message."
                     ),
-                    "status_message": serializers.CharField(),
-                    "ready_at": serializers.DateTimeField(allow_null=True),
-                    "failed_at": serializers.DateTimeField(allow_null=True),
+                    "s3_state": serializers.CharField(help_text="Object storage provisioning state."),
+                    "metadata_store_state": serializers.CharField(
+                        help_text="DuckLake metadata store provisioning state."
+                    ),
+                    "identity_state": serializers.CharField(help_text="Warehouse identity and IAM provisioning state."),
+                    "secrets_state": serializers.CharField(help_text="Warehouse secret provisioning state."),
+                    "ready_at": serializers.DateTimeField(
+                        allow_null=True, required=False, help_text="Timestamp when provisioning completed."
+                    ),
+                    "failed_at": serializers.DateTimeField(
+                        allow_null=True, required=False, help_text="Timestamp when provisioning failed."
+                    ),
+                    "connection": inline_serializer(
+                        "WarehouseStatusConnection",
+                        fields={
+                            "host": serializers.CharField(help_text="Public DNS hostname for PostgreSQL clients."),
+                            "port": serializers.IntegerField(help_text="Public PostgreSQL port."),
+                            "database": serializers.CharField(help_text="Database name to use in client connections."),
+                            "username": serializers.CharField(help_text="Username to use in client connections."),
+                        },
+                        required=False,
+                        allow_null=True,
+                    ),
                 },
             )
         },
@@ -951,12 +1011,12 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     def warehouse_status(self, request: Request, **kwargs) -> Response:
         """Get the current provisioning status of the managed warehouse."""
         resp = self._provisioning_request("GET", "/warehouse/status")
-        # Override connection host/port with the public-facing duckgres PG endpoint
+        # Override connection host/port with the customer-facing duckgres PG endpoint.
         if resp.status_code == 200 and isinstance(resp.data, dict) and resp.data.get("connection"):
-            pg_url = getattr(django_settings, "DUCKGRES_PG_URL", None)
+            public_host = self._public_managed_warehouse_host(resp.data["connection"]["database"])
             pg_port = getattr(django_settings, "DUCKGRES_PG_PORT", 5432)
-            if pg_url:
-                resp.data["connection"]["host"] = pg_url
+            if public_host:
+                resp.data["connection"]["host"] = public_host
                 resp.data["connection"]["port"] = pg_port
         return resp
 
@@ -980,7 +1040,18 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         parameters=[
             inline_serializer(
                 "CheckDatabaseNameRequest",
-                fields={"name": serializers.CharField(help_text="Database name to check")},
+                fields={
+                    "name": serializers.RegexField(
+                        regex=MANAGED_WAREHOUSE_DATABASE_NAME_REGEX,
+                        min_length=3,
+                        max_length=63,
+                        help_text=(
+                            "DNS-safe database name to check. Must be 3-63 characters, start with a lowercase "
+                            "letter, end with a lowercase letter or number, and contain only lowercase letters, "
+                            "numbers, or hyphens."
+                        ),
+                    )
+                },
             )
         ],
         responses={
@@ -999,5 +1070,15 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         name = request.query_params.get("name")
         if not name:
             return Response({"error": "name query parameter is required"}, status=status.HTTP_400_BAD_REQUEST)
+        if not _is_valid_managed_warehouse_database_name(name):
+            return Response(
+                {
+                    "error": (
+                        "name must be 3-63 characters, start with a lowercase letter, end with a lowercase letter "
+                        "or number, and contain only lowercase letters, numbers, or hyphens"
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         return self._provisioning_request("GET", "database-name/check", params={"name": name}, timeout=10)

--- a/products/data_warehouse/backend/api/test/test_data_warehouse.py
+++ b/products/data_warehouse/backend/api/test/test_data_warehouse.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.test import override_settings
 from django.utils import timezone
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -16,6 +17,16 @@ from products.data_warehouse.backend.models import (
 )
 from products.data_warehouse.backend.models.data_modeling_job import DataModelingJob
 from products.data_warehouse.backend.models.team_data_warehouse_config import TeamDataWarehouseConfig
+
+
+class MockProvisioningResponse:
+    def __init__(self, status_code: int, body: dict[str, object]) -> None:
+        self.status_code = status_code
+        self.body = body
+        self.text = str(body)
+
+    def json(self) -> dict[str, object]:
+        return self.body
 
 
 class TestDataWarehouseAPI(APIBaseTest):
@@ -584,6 +595,113 @@ class TestDataWarehouseAPI(APIBaseTest):
 
         response = self.client.get(f"{endpoint}?cutoff_days=invalid")
         self.assertEqual(response.status_code, 400)
+
+    @patch("products.data_warehouse.backend.api.data_warehouse._internal_requests.request")
+    def test_check_database_name_rejects_dns_unsafe_name(self, mock_request):
+        response = self.client.get(f"/api/projects/{self.team.id}/data_warehouse/check-database-name/?name=my_db")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("hyphens", response.json()["error"])
+        mock_request.assert_not_called()
+
+    @patch("products.data_warehouse.backend.api.data_warehouse._internal_requests.request")
+    def test_provision_rejects_dns_unsafe_database_name(self, mock_request):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/data_warehouse/provision/",
+            data={"database_name": "my_db"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("hyphens", response.json()["error"])
+        mock_request.assert_not_called()
+
+    @override_settings(DUCKGRES_API_URL="http://duckgres-api", DUCKGRES_INTERNAL_SECRET="secret")
+    @patch("products.data_warehouse.backend.api.data_warehouse.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.data_warehouse.backend.api.data_warehouse._internal_requests.request")
+    def test_provision_returns_initial_credentials(self, mock_request, _mock_feature_enabled):
+        mock_request.return_value = MockProvisioningResponse(
+            202,
+            {
+                "status": "provisioning started",
+                "org": str(self.team.id),
+                "username": "root",
+                "password": "initial-password",
+            },
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/data_warehouse/provision/",
+            data={"database_name": "my-warehouse"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(
+            response.json(),
+            {
+                "status": "provisioning started",
+                "org": str(self.team.id),
+                "username": "root",
+                "password": "initial-password",
+            },
+        )
+
+    @override_settings(DUCKGRES_API_URL="http://duckgres-api", DUCKGRES_INTERNAL_SECRET="secret")
+    @patch("products.data_warehouse.backend.api.data_warehouse.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.data_warehouse.backend.api.data_warehouse._internal_requests.request")
+    def test_reset_password_proxies_to_hyphenated_duckgres_path(self, mock_request, _mock_feature_enabled):
+        mock_request.return_value = MockProvisioningResponse(
+            200,
+            {
+                "username": "root",
+                "password": "new-password",
+            },
+        )
+
+        response = self.client.post(f"/api/projects/{self.team.id}/data_warehouse/reset-password/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["password"], "new-password")
+        self.assertEqual(
+            mock_request.call_args.args[1],
+            f"http://duckgres-api/api/v1/orgs/{self.team.id}/reset-password",
+        )
+
+    @override_settings(
+        DUCKGRES_API_URL="http://duckgres-api",
+        DUCKGRES_INTERNAL_SECRET="secret",
+        DUCKGRES_PG_HOST_SUFFIX="dw.us.postwh.com",
+    )
+    @patch("products.data_warehouse.backend.api.data_warehouse.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.data_warehouse.backend.api.data_warehouse._internal_requests.request")
+    def test_warehouse_status_uses_managed_hostname(self, mock_request, _mock_feature_enabled):
+        mock_request.return_value = MockProvisioningResponse(
+            200,
+            {
+                "org_id": str(self.team.id),
+                "state": "ready",
+                "status_message": "",
+                "s3_state": "ready",
+                "metadata_store_state": "ready",
+                "identity_state": "ready",
+                "secrets_state": "ready",
+                "ready_at": None,
+                "failed_at": None,
+                "connection": {
+                    "host": "internal.duckgres",
+                    "port": 5432,
+                    "database": "my-warehouse",
+                    "username": "root",
+                },
+            },
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/data_warehouse/warehouse_status/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["connection"]["host"], "my-warehouse.dw.us.postwh.com")
+        self.assertEqual(response.json()["connection"]["port"], 5432)
 
     def test_data_ops_dashboard_creates_dashboard_on_first_call(self):
         endpoint = f"/api/projects/{self.team.pk}/data_warehouse/data_ops_dashboard"

--- a/products/data_warehouse/backend/api/test/test_data_warehouse.py
+++ b/products/data_warehouse/backend/api/test/test_data_warehouse.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 from django.test import override_settings
 from django.utils import timezone
 
+from parameterized import parameterized
+
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.data_warehouse.backend.models import (
@@ -596,19 +598,41 @@ class TestDataWarehouseAPI(APIBaseTest):
         response = self.client.get(f"{endpoint}?cutoff_days=invalid")
         self.assertEqual(response.status_code, 400)
 
+    @parameterized.expand(
+        [
+            ("contains_underscore", "my_db"),
+            ("starts_with_digit", "1starts-with-digit"),
+            ("ends_with_hyphen", "ends-with-hyphen-"),
+            ("contains_uppercase", "AB"),
+            ("too_short", "ab"),
+            ("too_long", "a" * 64),
+        ]
+    )
     @patch("products.data_warehouse.backend.api.data_warehouse._internal_requests.request")
-    def test_check_database_name_rejects_dns_unsafe_name(self, mock_request):
-        response = self.client.get(f"/api/projects/{self.team.id}/data_warehouse/check-database-name/?name=my_db")
+    def test_check_database_name_rejects_dns_unsafe_name(self, _case_name, database_name, mock_request):
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/data_warehouse/check-database-name/?name={database_name}"
+        )
 
         self.assertEqual(response.status_code, 400)
         self.assertIn("hyphens", response.json()["error"])
         mock_request.assert_not_called()
 
+    @parameterized.expand(
+        [
+            ("contains_underscore", "my_db"),
+            ("starts_with_digit", "1starts-with-digit"),
+            ("ends_with_hyphen", "ends-with-hyphen-"),
+            ("contains_uppercase", "AB"),
+            ("too_short", "ab"),
+            ("too_long", "a" * 64),
+        ]
+    )
     @patch("products.data_warehouse.backend.api.data_warehouse._internal_requests.request")
-    def test_provision_rejects_dns_unsafe_database_name(self, mock_request):
+    def test_provision_rejects_dns_unsafe_database_name(self, _case_name, database_name, mock_request):
         response = self.client.post(
             f"/api/projects/{self.team.id}/data_warehouse/provision/",
-            data={"database_name": "my_db"},
+            data={"database_name": database_name},
             content_type="application/json",
         )
 

--- a/products/data_warehouse/frontend/generated/api.schemas.ts
+++ b/products/data_warehouse/frontend/generated/api.schemas.ts
@@ -105,18 +105,31 @@ export interface CheckDatabaseNameResponseApi {
 }
 
 export interface DeprovisionWarehouseResponseApi {
+    /** Deprovisioning request status from duckgres. */
     status: string
-    team: string
+    /** Duckgres organization identifier. */
+    org: string
 }
 
 export interface ProvisionWarehouseRequestApi {
-    /** Name for the new database */
+    /**
+     * DNS-safe name for the new database. Must be 3-63 characters, start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, or hyphens.
+     * @minLength 3
+     * @maxLength 63
+     * @pattern ^[a-z](?:[a-z0-9-]{1,61}[a-z0-9])$
+     */
     database_name: string
 }
 
 export interface ProvisionWarehouseResponseApi {
+    /** Provisioning request status from duckgres. */
     status: string
-    team: string
+    /** Duckgres organization identifier. */
+    org: string
+    /** Initial warehouse username. */
+    username: string
+    /** Initial warehouse password. Returned once and not stored in plaintext. */
+    password: string
 }
 
 export interface ResetPasswordResponseApi {
@@ -124,34 +137,43 @@ export interface ResetPasswordResponseApi {
     password: string
 }
 
-/**
- * * `pending` - pending
- * `provisioning` - provisioning
- * `ready` - ready
- * `failed` - failed
- * `deleting` - deleting
- * `deleted` - deleted
- */
-export type WarehouseStatusResponseStateEnumApi =
-    (typeof WarehouseStatusResponseStateEnumApi)[keyof typeof WarehouseStatusResponseStateEnumApi]
-
-export const WarehouseStatusResponseStateEnumApi = {
-    Pending: 'pending',
-    Provisioning: 'provisioning',
-    Ready: 'ready',
-    Failed: 'failed',
-    Deleting: 'deleting',
-    Deleted: 'deleted',
-} as const
+export interface WarehouseStatusConnectionApi {
+    /** Public DNS hostname for PostgreSQL clients. */
+    host: string
+    /** Public PostgreSQL port. */
+    port: number
+    /** Database name to use in client connections. */
+    database: string
+    /** Username to use in client connections. */
+    username: string
+}
 
 export interface WarehouseStatusResponseApi {
-    team_name: string
-    state: WarehouseStatusResponseStateEnumApi
+    /** Duckgres organization identifier. */
+    org_id: string
+    /** Overall managed warehouse provisioning state. */
+    state: string
+    /** Human-readable provisioning status message. */
     status_message: string
-    /** @nullable */
-    ready_at: string | null
-    /** @nullable */
-    failed_at: string | null
+    /** Object storage provisioning state. */
+    s3_state: string
+    /** DuckLake metadata store provisioning state. */
+    metadata_store_state: string
+    /** Warehouse identity and IAM provisioning state. */
+    identity_state: string
+    /** Warehouse secret provisioning state. */
+    secrets_state: string
+    /**
+     * Timestamp when provisioning completed.
+     * @nullable
+     */
+    ready_at?: string | null
+    /**
+     * Timestamp when provisioning failed.
+     * @nullable
+     */
+    failed_at?: string | null
+    connection?: WarehouseStatusConnectionApi | null
 }
 
 /**
@@ -1920,8 +1942,10 @@ export type DataModelingJobsListParams = {
 
 export type DataWarehouseCheckDatabaseNameRetrieveParams = {
     /**
-     * Database name to check
-     * @minLength 1
+     * DNS-safe database name to check. Must be 3-63 characters, start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, or hyphens.
+     * @minLength 3
+     * @maxLength 63
+     * @pattern ^[a-z](?:[a-z0-9-]{1,61}[a-z0-9])$
      */
     name: string
 }

--- a/products/data_warehouse/frontend/generated/api.zod.ts
+++ b/products/data_warehouse/frontend/generated/api.zod.ts
@@ -51,8 +51,20 @@ export const WarehouseSavedQueryDraftsPartialUpdateBody = /* @__PURE__ */ zod.ob
 /**
  * Start provisioning a managed warehouse for this team.
  */
+export const dataWarehouseProvisionCreateBodyDatabaseNameMin = 3
+export const dataWarehouseProvisionCreateBodyDatabaseNameMax = 63
+
+export const dataWarehouseProvisionCreateBodyDatabaseNameRegExp = new RegExp('^[a-z](?:[a-z0-9-]{1,61}[a-z0-9])$')
+
 export const DataWarehouseProvisionCreateBody = /* @__PURE__ */ zod.object({
-    database_name: zod.string().describe('Name for the new database'),
+    database_name: zod
+        .string()
+        .min(dataWarehouseProvisionCreateBodyDatabaseNameMin)
+        .max(dataWarehouseProvisionCreateBodyDatabaseNameMax)
+        .regex(dataWarehouseProvisionCreateBodyDatabaseNameRegExp)
+        .describe(
+            'DNS-safe name for the new database. Must be 3-63 characters, start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, or hyphens.'
+        ),
 })
 
 export const ExternalDataSchemasCreateBody = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14990,8 +14990,10 @@ export namespace Schemas {
     }
 
     export interface DeprovisionWarehouseResponse {
+      /** Deprovisioning request status from duckgres. */
       status: string;
-      team: string;
+      /** Duckgres organization identifier. */
+      org: string;
     }
 
     /**
@@ -33796,13 +33798,24 @@ export namespace Schemas {
     }
 
     export interface ProvisionWarehouseRequest {
-      /** Name for the new database */
+      /**
+       * DNS-safe name for the new database. Must be 3-63 characters, start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, or hyphens.
+       * @minLength 3
+       * @maxLength 63
+       * @pattern ^[a-z](?:[a-z0-9-]{1,61}[a-z0-9])$
+       */
       database_name: string;
     }
 
     export interface ProvisionWarehouseResponse {
+      /** Provisioning request status from duckgres. */
       status: string;
-      team: string;
+      /** Duckgres organization identifier. */
+      org: string;
+      /** Initial warehouse username. */
+      username: string;
+      /** Initial warehouse password. Returned once and not stored in plaintext. */
+      password: string;
     }
 
     /**
@@ -38694,34 +38707,43 @@ export namespace Schemas {
       source_table_key: string;
     }
 
-    /**
-     * * `pending` - pending
-    * `provisioning` - provisioning
-    * `ready` - ready
-    * `failed` - failed
-    * `deleting` - deleting
-    * `deleted` - deleted
-     */
-    export type WarehouseStatusResponseStateEnum = typeof WarehouseStatusResponseStateEnum[keyof typeof WarehouseStatusResponseStateEnum];
-
-
-    export const WarehouseStatusResponseStateEnum = {
-      Pending: 'pending',
-      Provisioning: 'provisioning',
-      Ready: 'ready',
-      Failed: 'failed',
-      Deleting: 'deleting',
-      Deleted: 'deleted',
-    } as const;
+    export interface WarehouseStatusConnection {
+      /** Public DNS hostname for PostgreSQL clients. */
+      host: string;
+      /** Public PostgreSQL port. */
+      port: number;
+      /** Database name to use in client connections. */
+      database: string;
+      /** Username to use in client connections. */
+      username: string;
+    }
 
     export interface WarehouseStatusResponse {
-      team_name: string;
-      state: WarehouseStatusResponseStateEnum;
+      /** Duckgres organization identifier. */
+      org_id: string;
+      /** Overall managed warehouse provisioning state. */
+      state: string;
+      /** Human-readable provisioning status message. */
       status_message: string;
-      /** @nullable */
-      ready_at: string | null;
-      /** @nullable */
-      failed_at: string | null;
+      /** Object storage provisioning state. */
+      s3_state: string;
+      /** DuckLake metadata store provisioning state. */
+      metadata_store_state: string;
+      /** Warehouse identity and IAM provisioning state. */
+      identity_state: string;
+      /** Warehouse secret provisioning state. */
+      secrets_state: string;
+      /**
+       * Timestamp when provisioning completed.
+       * @nullable
+       */
+      ready_at?: string | null;
+      /**
+       * Timestamp when provisioning failed.
+       * @nullable
+       */
+      failed_at?: string | null;
+      connection?: WarehouseStatusConnection | null;
     }
 
     export interface WeeklyDigestResponse {
@@ -39719,8 +39741,10 @@ export namespace Schemas {
 
     export type EnvironmentsDataWarehouseCheckDatabaseNameRetrieveParams = {
     /**
-     * Database name to check
-     * @minLength 1
+     * DNS-safe database name to check. Must be 3-63 characters, start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, or hyphens.
+     * @minLength 3
+     * @maxLength 63
+     * @pattern ^[a-z](?:[a-z0-9-]{1,61}[a-z0-9])$
      */
     name: string;
     };
@@ -44137,8 +44161,10 @@ export namespace Schemas {
 
     export type DataWarehouseCheckDatabaseNameRetrieveParams = {
     /**
-     * Database name to check
-     * @minLength 1
+     * DNS-safe database name to check. Must be 3-63 characters, start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, or hyphens.
+     * @minLength 3
+     * @maxLength 63
+     * @pattern ^[a-z](?:[a-z0-9-]{1,61}[a-z0-9])$
      */
     name: string;
     };


### PR DESCRIPTION
## Problem

Managed warehouse provisioning exposed a few mismatches between the data ops settings page, the PostHog API contract, and the Duckgres/charts configuration. The UI could show the internal load balancer host, accept database names that are not valid DNS labels, and call a reset password path that did not match the DRF route.

## Changes

- Use a customer-facing managed warehouse hostname derived from the provisioned database name and `DUCKGRES_PG_HOST_SUFFIX`, falling back to `DUCKGRES_PG_URL` when the suffix is not configured.
- Validate managed warehouse database names as DNS-safe labels in both the API and the settings page.
- Align provision, deprovision, and status OpenAPI schemas with the Duckgres response shapes, then regenerate frontend and MCP API types.
- Move the settings page provisioning logic to generated API functions and generated response types.
- Fix the legacy reset password wrapper to call `reset-password`.
- Add focused API tests for DNS validation, initial credential passthrough, reset password routing, and public host rewriting.

## How did you test this code?

Agent-tested with:

- `OPT_OUT_CAPTURE=1 flox activate -- bash -c "bin/hogli build:openapi"`
- `flox activate -- bash -c "ruff format products/data_warehouse/backend/api/data_warehouse.py products/data_warehouse/backend/api/test/test_data_warehouse.py posthog/settings/base_variables.py && ruff check products/data_warehouse/backend/api/data_warehouse.py products/data_warehouse/backend/api/test/test_data_warehouse.py posthog/settings/base_variables.py --fix"`
- `pnpm exec oxlint frontend/src/lib/api.ts frontend/src/types.ts frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts products/data_warehouse/frontend/generated/api.schemas.ts products/data_warehouse/frontend/generated/api.zod.ts services/mcp/src/api/generated.ts`
- `git diff --check`

Could not complete the focused backend test run locally because the worktree cannot resolve the local PostHog service hostname `db`; updating `/etc/hosts` requires an interactive sudo password in this environment.

Full frontend `typescript:check` was also blocked locally by unrelated missing package declarations for `@posthog/hogvm` and `@posthog/quill` after generating Kea types and increasing Node heap.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed. This fixes internal managed warehouse provisioning wiring and generated API contracts.

## 🤖 Agent context

This PR was authored by Codex. I compared the data ops managed warehouse settings flow against the Duckgres API shape and the managed warehouse charts configuration, then chose to derive the public connection host from the provisioned database name plus a configurable DNS suffix. I kept `DUCKGRES_PG_URL` as a fallback so environments without the new suffix continue to behave as before.

I also switched the settings page logic to generated API functions/types so the frontend follows the OpenAPI contract instead of hand-maintained response types. The response state fields are modeled as strings in OpenAPI to avoid generated enum naming collisions from repeated provisioning state fields.
