### PR TITLE
feat(cdp): Add valkey mirror for remaining services

### DIFF
--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -22,6 +22,7 @@ import { createCdpOutputsRegistry } from './outputs/registry'
 import { CapturedEventsService } from './services/captured-events/captured-events.service'
 import { HogExecutorService } from './services/hog-executor.service'
 import { HogInputsService } from './services/hog-inputs.service'
+import { HogFlowDuplicateObserverService } from './services/hogflows/hogflow-duplicate-observer.service'
 import { HogFlowExecutorService } from './services/hogflows/hogflow-executor.service'
 import { HogFlowFunctionsService } from './services/hogflows/hogflow-functions.service'
 import { HogFlowManagerService } from './services/hogflows/hogflow-manager.service'
@@ -401,7 +402,13 @@ export function createCdpCoreServices(
 
     const recipientsManager = new RecipientsManagerService(deps.postgres)
     const recipientPreferencesService = new RecipientPreferencesService(recipientsManager)
-    const hogFlowExecutor = new HogFlowExecutorService(hogFlowFunctionsService, recipientPreferencesService, redis)
+    // Observer mirrors writes to Valkey (load-only); only the primary path drives metrics.
+    const hogFlowDuplicateObserver = new HogFlowDuplicateObserverService(redis, valkeyShadow?.writer ?? null)
+    const hogFlowExecutor = new HogFlowExecutorService(
+        hogFlowFunctionsService,
+        recipientPreferencesService,
+        hogFlowDuplicateObserver
+    )
 
     const outputs = createCdpOutputsRegistry().build(deps.cdpProducerRegistry, config)
 

--- a/nodejs/src/cdp/consumers/cdp-base.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-base.consumer.ts
@@ -103,7 +103,7 @@ export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = Cd
         this.outputs = services.outputs
 
         // Base-only services
-        this.hogMasker = new HogMaskerService(services.redis)
+        this.hogMasker = new HogMaskerService(services.redis, services.valkeyShadow?.writer ?? null)
         this.personsManager = new PersonsManagerService(deps.teamManager, deps.personRepository, config.SITE_URL)
         this.groupsManager = new GroupsManagerService(deps.teamManager, deps.groupRepository)
         this.pluginDestinationExecutorService = new LegacyPluginExecutorService(deps.postgres, deps.geoipService)

--- a/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.test.ts
@@ -1,0 +1,127 @@
+import { register } from 'prom-client'
+
+import { RedisV2, createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
+import { Hub } from '~/types'
+import { closeHub, createHub } from '~/utils/db/hub'
+
+import { deleteKeysWithPrefix } from '../../_tests/redis'
+import { CyclotronJobInvocationHogFlow } from '../../types'
+import { HogFlowDuplicateObserverService } from './hogflow-duplicate-observer.service'
+
+const KEY_PREFIX = 'hogflow:observe:'
+
+const buildInvocation = (overrides: { id?: string; functionId?: string; eventUuid?: string | null } = {}) =>
+    ({
+        id: overrides.id ?? 'invocation-1',
+        functionId: overrides.functionId ?? 'workflow-1',
+        state: { event: overrides.eventUuid === null ? undefined : { uuid: overrides.eventUuid ?? 'event-1' } },
+    }) as unknown as CyclotronJobInvocationHogFlow
+
+const buildAction = (id: string) => ({ id, type: 'function' }) as any
+
+const dupCounterValue = async (workflowId: string): Promise<number> => {
+    const metric = register.getSingleMetric('hogflow_duplicate_invocation_detected_total') as any
+    const data = await metric.get()
+    const found = data.values.find((v: any) => v.labels.workflow_id === workflowId)
+    return found?.value ?? 0
+}
+
+describe('HogFlowDuplicateObserverService', () => {
+    jest.retryTimes(3)
+
+    let hub: Hub
+    let redis: RedisV2
+
+    beforeAll(async () => {
+        hub = await createHub()
+        redis = createRedisV2PoolFromConfig({
+            connection: hub.CDP_REDIS_HOST
+                ? {
+                      url: hub.CDP_REDIS_HOST,
+                      options: { port: hub.CDP_REDIS_PORT, password: hub.CDP_REDIS_PASSWORD },
+                  }
+                : { url: hub.REDIS_URL },
+            poolMinSize: hub.REDIS_POOL_MIN_SIZE,
+            poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
+        })
+    })
+
+    afterAll(async () => {
+        await closeHub(hub)
+    })
+
+    beforeEach(async () => {
+        await deleteKeysWithPrefix(redis, KEY_PREFIX)
+        register.resetMetrics()
+    })
+
+    const readKey = async (key: string): Promise<string | null> =>
+        (await redis.useClient({ name: 'read' }, (client) => client.get(key))) ?? null
+
+    it('is a no-op when redis is null', async () => {
+        const observer = new HogFlowDuplicateObserverService(null)
+        await observer.observe(buildInvocation(), buildAction('action-1'))
+        // Nothing to assert beyond not throwing — verifies the early return.
+    })
+
+    it('is a no-op when invocation has no eventUuid', async () => {
+        const observer = new HogFlowDuplicateObserverService(redis)
+        await observer.observe(buildInvocation({ eventUuid: null }), buildAction('action-1'))
+        const keys = await redis.useClient({ name: 'keys' }, (client) => client.keys(`${KEY_PREFIX}*`))
+        expect(keys ?? []).toHaveLength(0)
+    })
+
+    it('writes the key on first observation and does not flag a duplicate', async () => {
+        const observer = new HogFlowDuplicateObserverService(redis)
+        await observer.observe(buildInvocation({ id: 'inv-A' }), buildAction('action-1'))
+
+        const stored = await readKey('hogflow:observe:workflow-1:event-1:action-1')
+        expect(stored).toBe('inv-A')
+        expect(await dupCounterValue('workflow-1')).toBe(0)
+    })
+
+    it('does not flag a duplicate when the same invocation re-observes', async () => {
+        const observer = new HogFlowDuplicateObserverService(redis)
+        const inv = buildInvocation({ id: 'inv-A' })
+        await observer.observe(inv, buildAction('action-1'))
+        await observer.observe(inv, buildAction('action-1'))
+
+        expect(await dupCounterValue('workflow-1')).toBe(0)
+    })
+
+    it('flags a duplicate when a different invocation hits the same key', async () => {
+        const observer = new HogFlowDuplicateObserverService(redis)
+        await observer.observe(buildInvocation({ id: 'inv-A' }), buildAction('action-1'))
+        await observer.observe(buildInvocation({ id: 'inv-B' }), buildAction('action-1'))
+
+        // The second observation must NOT overwrite the first (NX) — verifies single-call atomicity.
+        expect(await readKey('hogflow:observe:workflow-1:event-1:action-1')).toBe('inv-A')
+        expect(await dupCounterValue('workflow-1')).toBe(1)
+    })
+
+    it('writes to the mirror in parallel with the primary', async () => {
+        const mirror = {
+            useClient: jest.fn().mockResolvedValue('OK'),
+        } as unknown as RedisV2
+
+        const observer = new HogFlowDuplicateObserverService(redis, mirror)
+        await observer.observe(buildInvocation({ id: 'inv-A' }), buildAction('action-1'))
+
+        expect(mirror.useClient).toHaveBeenCalledTimes(1)
+        expect((mirror.useClient as jest.Mock).mock.calls[0][0]).toMatchObject({
+            name: 'hogflow-observe-mirror',
+            failOpen: true,
+        })
+    })
+
+    it('does not break the primary when the mirror throws', async () => {
+        const mirror = {
+            useClient: jest.fn().mockRejectedValue(new Error('mirror exploded')),
+        } as unknown as RedisV2
+
+        const observer = new HogFlowDuplicateObserverService(redis, mirror)
+        await observer.observe(buildInvocation({ id: 'inv-A' }), buildAction('action-1'))
+
+        expect(await readKey('hogflow:observe:workflow-1:event-1:action-1')).toBe('inv-A')
+    })
+})

--- a/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.ts
@@ -1,6 +1,6 @@
 import { Counter } from 'prom-client'
 
-import { RedisV2 } from '~/common/redis/redis-v2'
+import { RedisClient, RedisV2 } from '~/common/redis/redis-v2'
 
 import { HogFlowAction } from '../../../schema/hogflow'
 import { logger } from '../../../utils/logger'
@@ -27,42 +27,39 @@ export class HogFlowDuplicateObserverService {
         private readonly redisMirror: RedisV2 | null = null
     ) {}
 
-    public async observe(invocation: CyclotronJobInvocationHogFlow, currentAction: HogFlowAction): Promise<void> {
+    public async observe(
+        invocation: CyclotronJobInvocationHogFlow,
+        currentAction: HogFlowAction
+    ): Promise<{ duplicate: boolean }> {
         const eventUuid = invocation.state?.event?.uuid
         if (!this.redis || !eventUuid) {
-            return
+            return { duplicate: false }
         }
         const key = `hogflow:observe:${invocation.functionId}:${eventUuid}:${currentAction.id}`
 
+        // SET ... NX GET (Redis 7+ / Valkey 7.2+) sets the key when absent and returns the
+        // existing value when present — one round-trip instead of GET-then-SETNX. ioredis 4.x
+        // types only describe 'OK' | null for the return, so we cast to the actual GET payload.
+        const setNxGet = (client: RedisClient): Promise<string | null> =>
+            client.set(key, invocation.id, ['EX', String(DUPLICATE_OBSERVATION_TTL_SECONDS), 'NX', 'GET']) as Promise<
+                string | null
+            >
+
+        let duplicate = false
         try {
-            await Promise.all([
-                this.redis.useClient({ name: 'hogflow-observe', failOpen: true }, async (client) => {
-                    const wasSet = await client.set(key, invocation.id, 'EX', DUPLICATE_OBSERVATION_TTL_SECONDS, 'NX')
-                    if (wasSet) {
-                        return
-                    }
-                    const existingId = await client.get(key)
-                    if (existingId && existingId !== invocation.id) {
-                        hogflowDuplicateInvocationDetectedTotal.inc({ workflow_id: invocation.functionId })
-                    }
-                }),
+            const [existingId] = await Promise.all([
+                this.redis.useClient({ name: 'hogflow-observe', failOpen: true }, setNxGet),
                 mirrorCall('hog-flow-duplicate-observer.observe', () =>
-                    this.redisMirror?.useClient({ name: 'hogflow-observe-mirror', failOpen: true }, async (client) => {
-                        const wasSet = await client.set(
-                            key,
-                            invocation.id,
-                            'EX',
-                            DUPLICATE_OBSERVATION_TTL_SECONDS,
-                            'NX'
-                        )
-                        if (!wasSet) {
-                            await client.get(key)
-                        }
-                    })
+                    this.redisMirror?.useClient({ name: 'hogflow-observe-mirror', failOpen: true }, setNxGet)
                 ),
             ])
+            if (existingId && existingId !== invocation.id) {
+                duplicate = true
+                hogflowDuplicateInvocationDetectedTotal.inc({ workflow_id: invocation.functionId })
+            }
         } catch (error) {
             logger.debug('🦔', '[HogFlowDuplicateObserver] failed', { error: String(error) })
         }
+        return { duplicate }
     }
 }

--- a/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.ts
@@ -1,0 +1,68 @@
+import { Counter } from 'prom-client'
+
+import { RedisV2 } from '~/common/redis/redis-v2'
+
+import { HogFlowAction } from '../../../schema/hogflow'
+import { logger } from '../../../utils/logger'
+import { CyclotronJobInvocationHogFlow } from '../../types'
+import { mirrorCall } from '../../utils/mirror-call'
+
+const DUPLICATE_OBSERVATION_TTL_SECONDS = 15 * 60
+
+const hogflowDuplicateInvocationDetectedTotal = new Counter({
+    name: 'hogflow_duplicate_invocation_detected_total',
+    help: 'Fired once per action reached by a duplicate invocation of the same (workflow, event). Inflated by N actions per duplicate pair - treat as trend signal, not exact count.',
+    labelNames: ['workflow_id'],
+})
+
+/**
+ * Detects duplicate workflow invocations via a Redis SET-NX key per
+ * (workflow, event, action). When `redisMirror` is set, every observation also
+ * fires against the mirror in parallel — load is realised on the mirror; only
+ * the primary drives the duplicate-detected metric.
+ */
+export class HogFlowDuplicateObserverService {
+    constructor(
+        private readonly redis: RedisV2 | null,
+        private readonly redisMirror: RedisV2 | null = null
+    ) {}
+
+    public async observe(invocation: CyclotronJobInvocationHogFlow, currentAction: HogFlowAction): Promise<void> {
+        const eventUuid = invocation.state?.event?.uuid
+        if (!this.redis || !eventUuid) {
+            return
+        }
+        const key = `hogflow:observe:${invocation.functionId}:${eventUuid}:${currentAction.id}`
+
+        try {
+            await Promise.all([
+                this.redis.useClient({ name: 'hogflow-observe', failOpen: true }, async (client) => {
+                    const wasSet = await client.set(key, invocation.id, 'EX', DUPLICATE_OBSERVATION_TTL_SECONDS, 'NX')
+                    if (wasSet) {
+                        return
+                    }
+                    const existingId = await client.get(key)
+                    if (existingId && existingId !== invocation.id) {
+                        hogflowDuplicateInvocationDetectedTotal.inc({ workflow_id: invocation.functionId })
+                    }
+                }),
+                mirrorCall('hog-flow-duplicate-observer.observe', () =>
+                    this.redisMirror?.useClient({ name: 'hogflow-observe-mirror', failOpen: true }, async (client) => {
+                        const wasSet = await client.set(
+                            key,
+                            invocation.id,
+                            'EX',
+                            DUPLICATE_OBSERVATION_TTL_SECONDS,
+                            'NX'
+                        )
+                        if (!wasSet) {
+                            await client.get(key)
+                        }
+                    })
+                ),
+            ])
+        } catch (error) {
+            logger.debug('🦔', '[HogFlowDuplicateObserver] failed', { error: String(error) })
+        }
+    }
+}

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -1,8 +1,5 @@
 import { get } from 'lodash'
 import { DateTime } from 'luxon'
-import { Counter } from 'prom-client'
-
-import { RedisV2 } from '~/common/redis/redis-v2'
 
 import { HogFlow, HogFlowAction } from '../../../schema/hogflow'
 import { logger } from '../../../utils/logger'
@@ -31,6 +28,7 @@ import { HogFunctionHandler } from './actions/hog_function'
 import { RandomCohortBranchHandler } from './actions/random_cohort_branch'
 import { TriggerHandler } from './actions/trigger.handler'
 import { WaitUntilTimeWindowHandler } from './actions/wait_until_time_window'
+import { HogFlowDuplicateObserverService } from './hogflow-duplicate-observer.service'
 import { HogFlowFunctionsService } from './hogflow-functions.service'
 import {
     actionIdForLogging,
@@ -41,14 +39,6 @@ import {
 } from './hogflow-utils'
 
 export const MAX_ACTION_STEPS_HARD_LIMIT = 1000
-
-const DUPLICATE_OBSERVATION_TTL_SECONDS = 15 * 60
-
-const hogflowDuplicateInvocationDetectedTotal = new Counter({
-    name: 'hogflow_duplicate_invocation_detected_total',
-    help: 'Fired once per action reached by a duplicate invocation of the same (workflow, event). Inflated by N actions per duplicate pair - treat as trend signal, not exact count.',
-    labelNames: ['workflow_id'],
-})
 
 export function createHogFlowInvocation(
     globals: HogFunctionInvocationGlobals,
@@ -89,14 +79,14 @@ export function createHogFlowInvocation(
 
 export class HogFlowExecutorService {
     private readonly actionHandlers: Record<HogFlowAction['type'], ActionHandler>
-    private readonly redis: RedisV2 | null
+    private readonly duplicateObserver: HogFlowDuplicateObserverService | null
 
     constructor(
         hogFlowFunctionsService: HogFlowFunctionsService,
         recipientPreferencesService: RecipientPreferencesService,
-        redis?: RedisV2
+        duplicateObserver?: HogFlowDuplicateObserverService
     ) {
-        this.redis = redis ?? null
+        this.duplicateObserver = duplicateObserver ?? null
         const hogFunctionHandler = new HogFunctionHandler(hogFlowFunctionsService, recipientPreferencesService, 'fetch')
         const hogFunctionEmailHandler = new HogFunctionHandler(
             hogFlowFunctionsService,
@@ -166,25 +156,7 @@ export class HogFlowExecutorService {
         invocation: CyclotronJobInvocationHogFlow,
         currentAction: HogFlowAction
     ): Promise<void> {
-        const eventUuid = invocation.state?.event?.uuid
-        if (!this.redis || !eventUuid) {
-            return
-        }
-        const key = `hogflow:observe:${invocation.functionId}:${eventUuid}:${currentAction.id}`
-        try {
-            await this.redis.useClient({ name: 'hogflow-observe', failOpen: true }, async (client) => {
-                const wasSet = await client.set(key, invocation.id, 'EX', DUPLICATE_OBSERVATION_TTL_SECONDS, 'NX')
-                if (wasSet) {
-                    return
-                }
-                const existingId = await client.get(key)
-                if (existingId && existingId !== invocation.id) {
-                    hogflowDuplicateInvocationDetectedTotal.inc({ workflow_id: invocation.functionId })
-                }
-            })
-        } catch (error) {
-            logger.debug('🦔', '[HogFlowExecutor] Duplicate observer failed', { error: String(error) })
-        }
+        await this.duplicateObserver?.observe(invocation, currentAction)
     }
 
     async execute(

--- a/nodejs/src/cdp/services/monitoring/hog-masker.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-masker.service.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto'
 
-import { RedisV2 } from '~/common/redis/redis-v2'
+import { RedisClientPipeline, RedisV2 } from '~/common/redis/redis-v2'
 
 import {
     CyclotronJobInvocation,
@@ -9,6 +9,7 @@ import {
     HogFunctionMasking,
 } from '../../types'
 import { execHog } from '../../utils/hog-exec'
+import { mirrorCall } from '../../utils/mirror-call'
 
 export const BASE_REDIS_KEY = process.env.NODE_ENV == 'test' ? '@posthog-test/hog-masker' : '@posthog/hog-masker'
 const REDIS_KEY_TOKENS = `${BASE_REDIS_KEY}/mask`
@@ -91,7 +92,10 @@ function getTtl(invocation: CyclotronJobInvocation, maskingConfig: HogFunctionMa
 
 // Hog masker is meant to be done per batch
 export class HogMaskerService {
-    constructor(private redis: RedisV2) {}
+    constructor(
+        private redis: RedisV2,
+        private redisMirror: RedisV2 | null = null
+    ) {}
 
     public async filterByMasking<T extends CyclotronJobInvocation>(
         invocations: T[]
@@ -142,13 +146,20 @@ export class HogMaskerService {
             return { masked: [], notMasked: invocations }
         }
 
-        const result = await this.redis.usePipeline({ name: 'masker', failOpen: true }, (pipeline) => {
+        const buildPipeline = (pipeline: RedisClientPipeline): void => {
             Object.values(masks).forEach(({ hogFunctionId, hash, increment, ttl }) => {
                 pipeline.incrby(`${REDIS_KEY_TOKENS}/${hogFunctionId}/${hash}`, increment)
                 // @ts-expect-error - NX is not typed in ioredis
                 pipeline.expire(`${REDIS_KEY_TOKENS}/${hogFunctionId}/${hash}`, ttl, 'NX')
             })
-        })
+        }
+
+        const [result] = await Promise.all([
+            this.redis.usePipeline({ name: 'masker', failOpen: true }, buildPipeline),
+            mirrorCall('hog-masker.filterByMasking', () =>
+                this.redisMirror?.usePipeline({ name: 'masker-mirror', failOpen: true }, buildPipeline)
+            ),
+        ])
 
         Object.values(masks).forEach((masker, index) => {
             const newValue: number | null = result ? result[index * 2][1] : null


### PR DESCRIPTION
## Problem

A couple of things left for full mirroring to the other redis/valkey.

## Changes

-  Pulls the hogflow observer out and turns on dual writing
- Same for hog masker
Hog masker will need migration effort but this way we start warming it already

## How did you test this code?

Tests 

## Publish to changelog?

No