### PR TITLE
(feat) Add cluster to evaluation draft flow

### DIFF
--- a/products/llm_analytics/backend/api/evaluations.py
+++ b/products/llm_analytics/backend/api/evaluations.py
@@ -1,6 +1,8 @@
 import json
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Q, QuerySet
 
@@ -8,7 +10,7 @@ import structlog
 import django_filters
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_field
-from rest_framework import serializers, viewsets
+from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -24,6 +26,7 @@ from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.temporal.llm_analytics.message_utils import extract_text_from_messages
 from posthog.temporal.llm_analytics.run_evaluation import extract_event_io, run_hog_eval
 
+from ..models.clustering_job import ClusteringJob
 from ..models.evaluation_config import EvaluationConfig
 from ..models.evaluation_configs import validate_evaluation_configs
 from ..models.evaluation_reports import EvaluationReport
@@ -343,6 +346,203 @@ class EvaluationListSerializer(EvaluationSerializer):
         read_only_fields = [f for f in EvaluationSerializer.Meta.read_only_fields if f != "created_by"]
 
 
+class CreateEvaluationFromClusterRequestSerializer(serializers.Serializer):
+    run_id = serializers.CharField(required=True, min_length=1)
+    cluster_id = serializers.IntegerField(required=True)
+    evaluation_goal = serializers.CharField(required=False, allow_blank=True, max_length=1000)
+    evaluation_prompt = serializers.CharField(required=False, allow_blank=True, max_length=2000)
+
+    def validate(self, attrs):
+        evaluation_prompt = attrs.get("evaluation_prompt")
+        if evaluation_prompt is not None and not evaluation_prompt.strip():
+            raise serializers.ValidationError({"evaluation_prompt": "Prompt cannot be empty."})
+        return attrs
+
+
+def _cluster_run_timestamp_bounds(run_id: str) -> tuple[str, str]:
+    """Return UTC day bounds for a clustering run id.
+
+    Run IDs are emitted as `<team_id>_<level>_<YYYYMMDD>_<HHMMSS>...`. Matching the frontend's
+    day-bounded query keeps the lookup cheap while still tolerating older or malformed IDs.
+    """
+    parts = run_id.split("_")
+    clickhouse_format = "%Y-%m-%d %H:%M:%S.%f"
+    if len(parts) >= 4:
+        try:
+            parsed = datetime.strptime(f"{parts[2]}_{parts[3]}", "%Y%m%d_%H%M%S").replace(tzinfo=UTC)
+            start = parsed.replace(hour=0, minute=0, second=0, microsecond=0)
+            end = start + timedelta(days=1) - timedelta(microseconds=1)
+            return start.strftime(clickhouse_format), end.strftime(clickhouse_format)
+        except ValueError:
+            pass
+
+    end = datetime.now(tz=UTC)
+    start = end - timedelta(days=7)
+    return start.strftime(clickhouse_format), end.strftime(clickhouse_format)
+
+
+def _parse_cluster_payload(raw_clusters: Any) -> list[dict[str, Any]]:
+    if isinstance(raw_clusters, str):
+        try:
+            raw_clusters = json.loads(raw_clusters or "[]")
+        except json.JSONDecodeError:
+            return []
+
+    if not isinstance(raw_clusters, list):
+        return []
+
+    return [cluster for cluster in raw_clusters if isinstance(cluster, dict)]
+
+
+def _fetch_cluster_run_for_evaluation(team, run_id: str) -> dict[str, Any] | None:
+    from posthog.hogql import ast
+    from posthog.hogql.parser import parse_select
+    from posthog.hogql.query import execute_hogql_query
+
+    from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+
+    day_start, day_end = _cluster_run_timestamp_bounds(run_id)
+    query = parse_select(
+        """
+        SELECT
+            JSONExtractString(properties, '$ai_clustering_run_id') as run_id,
+            JSONExtractString(properties, '$ai_clustering_level') as level,
+            JSONExtractString(properties, '$ai_clustering_job_id') as job_id,
+            JSONExtractString(properties, '$ai_clustering_job_name') as job_name,
+            JSONExtractString(properties, '$ai_window_start') as window_start,
+            JSONExtractString(properties, '$ai_window_end') as window_end,
+            JSONExtractRaw(properties, '$ai_clusters') as clusters
+        FROM events
+        WHERE event IN ('$ai_trace_clusters', '$ai_generation_clusters', '$ai_evaluation_clusters')
+            AND timestamp >= {day_start}
+            AND timestamp <= {day_end}
+            AND JSONExtractString(properties, '$ai_clustering_run_id') = {run_id}
+        ORDER BY timestamp DESC
+        LIMIT 1
+        """
+    )
+
+    tag_queries(product=Product.LLM_ANALYTICS, feature=Feature.QUERY)
+    response = execute_hogql_query(
+        query=query,
+        placeholders={
+            "day_start": ast.Constant(value=day_start),
+            "day_end": ast.Constant(value=day_end),
+            "run_id": ast.Constant(value=run_id),
+        },
+        team=team,
+        limit_context=None,
+    )
+
+    if not response.results:
+        return None
+
+    row = response.results[0]
+    return {
+        "run_id": row[0],
+        "level": row[1],
+        "job_id": row[2] or None,
+        "job_name": row[3] or None,
+        "window_start": row[4],
+        "window_end": row[5],
+        "clusters": _parse_cluster_payload(row[6]),
+    }
+
+
+def _find_cluster_for_evaluation(cluster_run: dict[str, Any], cluster_id: int) -> dict[str, Any] | None:
+    for cluster in cluster_run.get("clusters") or []:
+        if cluster.get("cluster_id") == cluster_id:
+            return cluster
+    return None
+
+
+def _truncate(value: str, max_length: int) -> str:
+    if len(value) <= max_length:
+        return value
+    if max_length <= 3:
+        return value[:max_length]
+    return value[: max_length - 3].rstrip() + "..."
+
+
+def _cluster_title(cluster: dict[str, Any], cluster_id: int) -> str:
+    title = cluster.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    return f"Cluster {cluster_id}"
+
+
+def _cluster_summary(cluster: dict[str, Any]) -> str:
+    description = cluster.get("description")
+    if isinstance(description, str) and description.strip():
+        return description.strip()
+    return "No cluster summary was available."
+
+
+def _default_cluster_evaluation_goal(cluster: dict[str, Any], cluster_id: int) -> str:
+    return (
+        f'Detect whether the generation or its trace context shows the "{_cluster_title(cluster, cluster_id)}" pattern.'
+    )
+
+
+def _build_cluster_evaluation_prompt(
+    cluster: dict[str, Any], cluster_id: int, evaluation_goal: str | None = None
+) -> str:
+    goal = evaluation_goal.strip() if evaluation_goal else _default_cluster_evaluation_goal(cluster, cluster_id)
+    return f"""You are judging whether an LLM generation shows a reusable pattern from an LLM Analytics cluster.
+
+Evaluation goal:
+{goal}
+
+Cluster title:
+{_cluster_title(cluster, cluster_id)}
+
+Cluster summary:
+{_cluster_summary(cluster)}
+
+Use the generation input, output, metadata, and any available trace context to decide.
+
+Return true when the generation clearly shows the evaluation goal.
+Return false when the generation clearly does not show the evaluation goal.
+Return N/A when there is not enough information to decide.
+
+Focus on the evaluation goal, cluster title, and cluster summary only. Ignore source run counts, costs, latencies, token counts, and other metrics."""
+
+
+def _build_cluster_evaluation_description(
+    cluster_run: dict[str, Any], cluster: dict[str, Any], cluster_id: int, evaluation_goal: str | None = None
+) -> str:
+    title = _cluster_title(cluster, cluster_id)
+    parts = [
+        f'Disabled draft evaluation generated from LLM Analytics cluster "{title}".',
+        f"Source run: {cluster_run.get('run_id')}",
+        f"Cluster id: {cluster_id}",
+    ]
+
+    if cluster_run.get("window_start") and cluster_run.get("window_end"):
+        parts.append(f"Window: {cluster_run['window_start']} to {cluster_run['window_end']}")
+
+    if evaluation_goal:
+        parts.append(f"Evaluation goal:\n{evaluation_goal}")
+
+    summary = _cluster_summary(cluster)
+    if summary:
+        parts.append(f"Cluster summary:\n{summary}")
+
+    return _truncate("\n\n".join(parts), 500)
+
+
+def _clustering_job_filters(team_id: int, job_id: str | None) -> list[dict[str, Any]]:
+    if not job_id:
+        return []
+
+    try:
+        job = ClusteringJob.objects.get(id=job_id, team_id=team_id)
+    except (ClusteringJob.DoesNotExist, ValidationError, ValueError):
+        return []
+
+    return job.event_filters if isinstance(job.event_filters, list) else []
+
+
 class TestHogRequestSerializer(serializers.Serializer):
     source = serializers.CharField(
         required=True,
@@ -563,6 +763,71 @@ class EvaluationViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbi
     @monitor(feature=None, endpoint="llma_evaluations_create", method="POST")
     def create(self, request, *args, **kwargs):
         return super().create(request, *args, **kwargs)
+
+    @extend_schema(request=CreateEvaluationFromClusterRequestSerializer, responses=EvaluationSerializer)
+    @action(detail=False, methods=["post"], url_path="create_from_cluster", required_scopes=["evaluation:write"])
+    @llma_track_latency("llma_evaluations_create_from_cluster")
+    @monitor(feature=None, endpoint="llma_evaluations_create_from_cluster", method="POST")
+    def create_from_cluster(self, request: Request, **kwargs) -> Response:
+        """Create a disabled LLM-judge evaluation draft from a cluster card summary."""
+        request_serializer = CreateEvaluationFromClusterRequestSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+
+        run_id = request_serializer.validated_data["run_id"]
+        cluster_id = request_serializer.validated_data["cluster_id"]
+        cluster_run = _fetch_cluster_run_for_evaluation(self.team, run_id)
+        if not cluster_run:
+            return Response({"detail": "Clustering run not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        cluster = _find_cluster_for_evaluation(cluster_run, cluster_id)
+        if not cluster:
+            return Response({"detail": "Cluster not found in clustering run."}, status=status.HTTP_404_NOT_FOUND)
+
+        title = _cluster_title(cluster, cluster_id)
+        evaluation_goal = (request_serializer.validated_data.get("evaluation_goal") or "").strip()
+        evaluation_prompt = (request_serializer.validated_data.get("evaluation_prompt") or "").strip()
+        if not evaluation_prompt:
+            evaluation_prompt = _build_cluster_evaluation_prompt(cluster, cluster_id, evaluation_goal or None)
+        event_filters = _clustering_job_filters(self.team_id, cluster_run.get("job_id"))
+        payload = {
+            "name": _truncate(f"Cluster: {title}", 400),
+            "description": _build_cluster_evaluation_description(
+                cluster_run, cluster, cluster_id, evaluation_goal or None
+            ),
+            "enabled": False,
+            "evaluation_type": "llm_judge",
+            "evaluation_config": {"prompt": evaluation_prompt},
+            "output_type": "boolean",
+            "output_config": {"allows_na": True},
+            "conditions": [{"id": f"cluster-{cluster_id}", "rollout_percentage": 100, "properties": event_filters}],
+        }
+
+        serializer = self.get_serializer(data=payload)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+
+        instance = serializer.instance
+        report_user_action(
+            request.user,
+            "llma evaluation created from cluster",
+            {
+                "evaluation_id": str(instance.id),
+                "evaluation_name": instance.name,
+                "cluster_id": cluster_id,
+                "cluster_title": title,
+                "clustering_run_id": run_id,
+                "clustering_level": cluster_run.get("level"),
+                "clustering_job_id": cluster_run.get("job_id"),
+                "condition_property_count": len(event_filters),
+                "has_evaluation_goal": bool(evaluation_goal),
+                "has_prompt_override": bool(request_serializer.validated_data.get("evaluation_prompt")),
+            },
+            team=self.team,
+            request=self.request,
+        )
+
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
     @llma_track_latency("llma_evaluations_update")
     @monitor(feature=None, endpoint="llma_evaluations_update", method="PUT")

--- a/products/llm_analytics/backend/api/test/test_evaluations.py
+++ b/products/llm_analytics/backend/api/test/test_evaluations.py
@@ -7,6 +7,7 @@ from rest_framework import status
 
 from posthog.models import Organization, Project, Team, User
 
+from products.llm_analytics.backend.models.clustering_job import ClusteringJob
 from products.llm_analytics.backend.models.evaluation_config import EvaluationConfig
 from products.llm_analytics.backend.models.evaluation_reports import EvaluationReport
 from products.llm_analytics.backend.models.evaluations import Evaluation
@@ -85,6 +86,144 @@ class TestEvaluationConfigsApi(APIBaseTest):
         self.assertTrue(report.enabled)
         self.assertFalse(report.deleted)
         self.assertEqual(report.delivery_targets, [])
+
+    @patch("products.llm_analytics.backend.api.evaluations._fetch_cluster_run_for_evaluation")
+    def test_can_create_disabled_llm_judge_evaluation_from_cluster(self, mock_fetch_cluster_run):
+        event_filters = [
+            {"key": "$ai_model", "value": "gpt-4.1", "operator": "exact", "type": "event"},
+        ]
+        job = ClusteringJob.objects.create(
+            team=self.team,
+            name="PostHog AI traces",
+            analysis_level="trace",
+            event_filters=event_filters,
+        )
+        mock_fetch_cluster_run.return_value = {
+            "run_id": "997_trace_20260506_120000",
+            "level": "trace",
+            "job_id": str(job.id),
+            "job_name": job.name,
+            "window_start": "2026-05-06T00:00:00Z",
+            "window_end": "2026-05-06T12:00:00Z",
+            "clusters": [
+                {
+                    "cluster_id": 3,
+                    "title": "Outliers & Misc Data Analysis",
+                    "description": "- Mixed traces that do not fit a single dominant workflow\n- Broad one-off analyses, discrepancy investigations, and ad hoc data questions\n- Includes varied upload, cohort, retention, and business metric explorations",
+                    "size": 373,
+                    "metrics": {
+                        "avg_latency": 19.17,
+                        "avg_cost": 0.134,
+                        "total_cost": 49.8555,
+                    },
+                }
+            ],
+        }
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/evaluations/create_from_cluster/",
+            {"run_id": "997_trace_20260506_120000", "cluster_id": 3},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        evaluation = Evaluation.objects.get(name="Cluster: Outliers & Misc Data Analysis")
+        self.assertEqual(response.data["id"], str(evaluation.id))
+        self.assertFalse(evaluation.enabled)
+        self.assertEqual(evaluation.evaluation_type, "llm_judge")
+        self.assertEqual(evaluation.output_type, "boolean")
+        self.assertEqual(evaluation.output_config, {"allows_na": True})
+        self.assertEqual(len(evaluation.conditions), 1)
+        condition = evaluation.conditions[0]
+        self.assertEqual(condition["id"], "cluster-3")
+        self.assertEqual(condition["rollout_percentage"], 100)
+        self.assertEqual(condition["properties"], event_filters)
+
+        prompt = evaluation.evaluation_config["prompt"]
+        self.assertIn(
+            'Detect whether the generation or its trace context shows the "Outliers & Misc Data Analysis" pattern.',
+            prompt,
+        )
+        self.assertIn("Outliers & Misc Data Analysis", prompt)
+        self.assertIn("Mixed traces that do not fit a single dominant workflow", prompt)
+        self.assertIn("Broad one-off analyses, discrepancy investigations, and ad hoc data questions", prompt)
+        self.assertIn("Includes varied upload, cohort, retention, and business metric explorations", prompt)
+        self.assertIn("Return true when the generation clearly shows the evaluation goal.", prompt)
+        self.assertNotIn("19.17", prompt)
+        self.assertNotIn("49.8555", prompt)
+
+        self.assertEqual(EvaluationReport.objects.filter(evaluation=evaluation).count(), 1)
+
+    @patch("products.llm_analytics.backend.api.evaluations._fetch_cluster_run_for_evaluation")
+    def test_create_from_cluster_accepts_editable_prompt_context(self, mock_fetch_cluster_run):
+        mock_fetch_cluster_run.return_value = {
+            "run_id": "997_trace_20260506_120000",
+            "level": "trace",
+            "job_id": None,
+            "job_name": None,
+            "window_start": "2026-05-06T00:00:00Z",
+            "window_end": "2026-05-06T12:00:00Z",
+            "clusters": [
+                {
+                    "cluster_id": 3,
+                    "title": "Event Tracking Troubleshooting",
+                    "description": "- Debugging missing, mismatched, or filtered events",
+                    "size": 126,
+                }
+            ],
+        }
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/evaluations/create_from_cluster/",
+            {
+                "run_id": "997_trace_20260506_120000",
+                "cluster_id": 3,
+                "evaluation_goal": "Detect whether the user is struggling with event tracking.",
+                "evaluation_prompt": "Return true when the user is struggling with event tracking setup.",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        evaluation = Evaluation.objects.get(name="Cluster: Event Tracking Troubleshooting")
+        self.assertEqual(
+            evaluation.evaluation_config["prompt"],
+            "Return true when the user is struggling with event tracking setup.",
+        )
+        self.assertIn(
+            "Evaluation goal:\nDetect whether the user is struggling with event tracking.", evaluation.description
+        )
+        self.assertLessEqual(len(evaluation.description), 500)
+
+    @patch("products.llm_analytics.backend.api.evaluations._fetch_cluster_run_for_evaluation")
+    def test_create_from_cluster_returns_404_when_run_missing(self, mock_fetch_cluster_run):
+        mock_fetch_cluster_run.return_value = None
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/evaluations/create_from_cluster/",
+            {"run_id": "missing-run", "cluster_id": 3},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(Evaluation.objects.count(), 0)
+
+    @patch("products.llm_analytics.backend.api.evaluations._fetch_cluster_run_for_evaluation")
+    def test_create_from_cluster_returns_404_when_cluster_missing(self, mock_fetch_cluster_run):
+        mock_fetch_cluster_run.return_value = {
+            "run_id": "997_trace_20260506_120000",
+            "level": "trace",
+            "job_id": None,
+            "job_name": None,
+            "window_start": "2026-05-06T00:00:00Z",
+            "window_end": "2026-05-06T12:00:00Z",
+            "clusters": [{"cluster_id": 2, "title": "Different cluster", "description": ""}],
+        }
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/evaluations/create_from_cluster/",
+            {"run_id": "997_trace_20260506_120000", "cluster_id": 3},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(Evaluation.objects.count(), 0)
 
     def test_evaluation_rollback_when_auto_report_fails(self):
         """

--- a/products/llm_analytics/frontend/clusters/ClusterCard.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterCard.tsx
@@ -1,7 +1,8 @@
-import { IconChevronDown, IconChevronRight } from '@posthog/icons'
+import { IconChevronDown, IconChevronRight, IconPlus } from '@posthog/icons'
 import { LemonButton, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { getSeriesColor } from 'lib/colors'
+import { More } from 'lib/lemon-ui/LemonButton/More'
 import { urls } from 'scenes/urls'
 
 import { formatErrorRate, formatLLMCost, formatLLMLatency, formatTokens } from '../utils'
@@ -21,6 +22,8 @@ interface ClusterCardProps {
     clusteringLevel?: ClusteringLevel
     metrics?: ClusterMetrics
     metricsLoading?: boolean
+    onCreateEvaluation?: (cluster: Cluster) => void
+    creatingEvaluation?: boolean
 }
 
 export function ClusterCard({
@@ -34,6 +37,8 @@ export function ClusterCard({
     clusteringLevel = 'trace',
     metrics,
     metricsLoading,
+    onCreateEvaluation,
+    creatingEvaluation,
 }: ClusterCardProps): JSX.Element {
     const percentage = totalTraces > 0 ? Math.round((cluster.size / totalTraces) * 100) : 0
     const isOutlierCluster = cluster.cluster_id === NOISE_CLUSTER_ID
@@ -211,15 +216,33 @@ export function ClusterCard({
                             </div>
                         )}
                     </div>
-                    <LemonButton
-                        size="small"
-                        noPadding
-                        icon={isExpanded ? <IconChevronDown /> : <IconChevronRight />}
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            onToggleExpand()
-                        }}
-                    />
+                    <div className="flex items-center gap-1 shrink-0" onClick={(e) => e.stopPropagation()}>
+                        {onCreateEvaluation && (
+                            <More
+                                data-attr="clusters-card-more"
+                                overlay={
+                                    <LemonButton
+                                        fullWidth
+                                        icon={<IconPlus />}
+                                        loading={creatingEvaluation}
+                                        data-attr="clusters-create-evaluation-button"
+                                        onClick={() => onCreateEvaluation(cluster)}
+                                    >
+                                        Create evaluation
+                                    </LemonButton>
+                                }
+                            />
+                        )}
+                        <LemonButton
+                            size="small"
+                            noPadding
+                            icon={isExpanded ? <IconChevronDown /> : <IconChevronRight />}
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                onToggleExpand()
+                            }}
+                        />
+                    </div>
                 </div>
             </div>
 

--- a/products/llm_analytics/frontend/clusters/ClusterEvaluationModal.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterEvaluationModal.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useState } from 'react'
+
+import { LemonButton, LemonModal, LemonTag, LemonTextArea } from '@posthog/lemon-ui'
+
+import { LemonModalContent, LemonModalFooter, LemonModalHeader } from 'lib/lemon-ui/LemonModal/LemonModal'
+
+import { EvaluationTemplateChoice, EvaluationTemplatePicker } from '../evaluations/EvaluationTemplates'
+import { defaultEvaluationTemplates, LLMJudgeTemplate } from '../evaluations/templates'
+import {
+    CLUSTER_EVALUATION_PROMPT_MAX_LENGTH,
+    buildClusterEvaluationGoal,
+    buildClusterEvaluationPrompt,
+    buildClusterTemplateEvaluationPrompt,
+} from './clusterEvaluationPrompt'
+import { Cluster } from './types'
+
+const clusterEvaluationTemplates = defaultEvaluationTemplates.filter(
+    (template): template is LLMJudgeTemplate => template.evaluation_type === 'llm_judge'
+)
+
+interface ClusterEvaluationModalProps {
+    cluster: Cluster | null
+    isOpen: boolean
+    creating: boolean
+    onClose: () => void
+    onCreate: (cluster: Cluster, evaluationGoal: string, evaluationPrompt: string) => void
+}
+
+export function ClusterEvaluationModal({
+    cluster,
+    isOpen,
+    creating,
+    onClose,
+    onCreate,
+}: ClusterEvaluationModalProps): JSX.Element | null {
+    const [evaluationGoal, setEvaluationGoal] = useState('')
+    const [evaluationPrompt, setEvaluationPrompt] = useState('')
+    const [promptEdited, setPromptEdited] = useState(false)
+    const [selectedTemplate, setSelectedTemplate] = useState<EvaluationTemplateChoice | null>(null)
+
+    useEffect(() => {
+        if (!cluster || !isOpen) {
+            return
+        }
+
+        setSelectedTemplate(null)
+        setEvaluationGoal('')
+        setEvaluationPrompt('')
+        setPromptEdited(false)
+    }, [cluster, isOpen])
+
+    if (!cluster) {
+        return null
+    }
+
+    const clusterTitle = cluster.title || `Cluster ${cluster.cluster_id}`
+    const selectedTemplateName = selectedTemplate === 'blank' ? 'Create from scratch' : selectedTemplate?.name
+
+    const buildPromptForTemplate = (
+        template: EvaluationTemplateChoice,
+        cluster: Cluster,
+        nextEvaluationGoal: string
+    ): string => {
+        if (template === 'blank') {
+            return buildClusterEvaluationPrompt(cluster, nextEvaluationGoal)
+        }
+
+        return buildClusterTemplateEvaluationPrompt(template as LLMJudgeTemplate, cluster, nextEvaluationGoal)
+    }
+
+    const selectTemplate = (template: EvaluationTemplateChoice): void => {
+        const nextEvaluationGoal = template === 'blank' ? buildClusterEvaluationGoal(cluster) : ''
+
+        setSelectedTemplate(template)
+        setEvaluationGoal(nextEvaluationGoal)
+        setEvaluationPrompt(buildPromptForTemplate(template, cluster, nextEvaluationGoal))
+        setPromptEdited(false)
+    }
+
+    const updateGoal = (value: string): void => {
+        setEvaluationGoal(value)
+        if (!promptEdited && selectedTemplate) {
+            setEvaluationPrompt(buildPromptForTemplate(selectedTemplate, cluster, value))
+        }
+    }
+
+    const promptDisabledReason = !selectedTemplate
+        ? 'Choose an evaluation template'
+        : !evaluationPrompt.trim()
+          ? 'Evaluation prompt is required'
+          : evaluationPrompt.length > CLUSTER_EVALUATION_PROMPT_MAX_LENGTH
+            ? `Evaluation prompt must be ${CLUSTER_EVALUATION_PROMPT_MAX_LENGTH} characters or fewer`
+            : undefined
+
+    return (
+        <LemonModal
+            isOpen={isOpen}
+            onClose={onClose}
+            simple
+            maxWidth={selectedTemplate ? '44rem' : '68rem'}
+            className="w-full"
+            data-attr="clusters-create-evaluation-modal"
+        >
+            {!selectedTemplate ? (
+                <LemonModalContent className="max-h-[80vh] overflow-y-auto">
+                    <EvaluationTemplatePicker
+                        title={`Create evaluation from "${clusterTitle}"`}
+                        description="Choose a template. We'll use this cluster's summary to draft the evaluation."
+                        minHeight="auto"
+                        templates={clusterEvaluationTemplates}
+                        blankDescription="Build a custom LLM judge evaluation from this cluster"
+                        onSelectTemplate={selectTemplate}
+                    />
+                </LemonModalContent>
+            ) : (
+                <>
+                    <LemonModalHeader>Create draft evaluation</LemonModalHeader>
+                    <LemonModalContent className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">
+                        <div className="rounded border bg-surface-secondary p-3 space-y-2">
+                            <div className="flex items-center gap-2 flex-wrap">
+                                <div className="font-semibold">Template</div>
+                                <LemonTag type={selectedTemplate === 'blank' ? 'muted' : 'caution'}>
+                                    {selectedTemplateName}
+                                </LemonTag>
+                            </div>
+                            <div className="text-sm text-muted">
+                                {selectedTemplate === 'blank'
+                                    ? 'Draft a boolean LLM-as-judge evaluation from this cluster.'
+                                    : 'The selected template prompt is preserved, with cluster context appended at the bottom.'}
+                            </div>
+                        </div>
+
+                        <div className="space-y-2">
+                            <div className="text-sm font-medium">
+                                {selectedTemplate === 'blank'
+                                    ? 'What should this evaluation detect?'
+                                    : 'Additional context'}
+                            </div>
+                            <LemonTextArea
+                                value={evaluationGoal}
+                                onChange={updateGoal}
+                                rows={3}
+                                maxLength={1000}
+                                placeholder={
+                                    selectedTemplate === 'blank'
+                                        ? 'Detect whether the user is struggling with event tracking setup or debugging.'
+                                        : 'Optional. Add anything specific you want this template to pay attention to.'
+                                }
+                                data-attr="clusters-create-evaluation-goal"
+                            />
+                            <div className="text-xs text-muted">
+                                {selectedTemplate === 'blank'
+                                    ? 'This becomes the positive case for a boolean LLM-as-judge evaluation.'
+                                    : 'This is added inside the cluster context section at the bottom of the prompt.'}
+                            </div>
+                        </div>
+
+                        <div className="space-y-2">
+                            <div className="flex items-center justify-between gap-2">
+                                <div className="text-sm font-medium">Evaluation prompt</div>
+                                <div className="text-xs text-muted">
+                                    {evaluationPrompt.length}/{CLUSTER_EVALUATION_PROMPT_MAX_LENGTH}
+                                </div>
+                            </div>
+                            <LemonTextArea
+                                value={evaluationPrompt}
+                                onChange={(value) => {
+                                    setEvaluationPrompt(value)
+                                    setPromptEdited(true)
+                                }}
+                                rows={7}
+                                maxLength={CLUSTER_EVALUATION_PROMPT_MAX_LENGTH}
+                                className="font-mono text-sm"
+                                data-attr="clusters-create-evaluation-prompt"
+                            />
+                            <div className="text-xs text-muted">
+                                The draft evaluation stays disabled, so you can review it again before enabling.
+                            </div>
+                        </div>
+                    </LemonModalContent>
+                    <LemonModalFooter>
+                        <LemonButton
+                            type="secondary"
+                            onClick={() => {
+                                setSelectedTemplate(null)
+                                setEvaluationGoal('')
+                                setEvaluationPrompt('')
+                                setPromptEdited(false)
+                            }}
+                            disabled={creating}
+                            data-attr="clusters-create-evaluation-back"
+                        >
+                            Back
+                        </LemonButton>
+                        <LemonButton
+                            type="secondary"
+                            onClick={onClose}
+                            disabled={creating}
+                            data-attr="clusters-create-evaluation-cancel"
+                        >
+                            Cancel
+                        </LemonButton>
+                        <LemonButton
+                            type="primary"
+                            onClick={() => onCreate(cluster, evaluationGoal, evaluationPrompt)}
+                            loading={creating}
+                            disabledReason={promptDisabledReason}
+                            data-attr="clusters-create-evaluation-submit"
+                        >
+                            Create draft evaluation
+                        </LemonButton>
+                    </LemonModalFooter>
+                </>
+            )}
+        </LemonModal>
+    )
+}

--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 
 import { IconChevronDown, IconChevronRight, IconGear, IconInfo, IconQuestion, IconStack } from '@posthog/icons'
 import { LemonButton, LemonSegmentedButton, LemonSelect, Spinner, Tooltip } from '@posthog/lemon-ui'
@@ -16,6 +17,7 @@ import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { ClusterCard } from './ClusterCard'
 import { ClusterDistributionBar } from './ClusterDistributionBar'
+import { ClusterEvaluationModal } from './ClusterEvaluationModal'
 import { ClusteringAdminModal } from './ClusteringAdminModal'
 import { clusteringJobsLogic } from './clusteringJobsLogic'
 import { ClusteringJobsPanel } from './ClusteringJobsPanel'
@@ -27,6 +29,7 @@ import { EvaluationFilterBar } from './EvaluationFilterBar'
 import { Cluster, ClusteringLevel, getJobIdFromRunId } from './types'
 
 export function ClustersView(): JSX.Element {
+    const [clusterEvaluationModalCluster, setClusterEvaluationModalCluster] = useState<Cluster | null>(null)
     const {
         clusteringLevel,
         clusteringRuns,
@@ -45,9 +48,15 @@ export function ClustersView(): JSX.Element {
         propertyFilters,
         shouldFilterTestAccounts,
         propertyFilteredItemIdsLoading,
+        creatingEvaluationFromClusterIds,
     } = useValues(clustersLogic)
-    const { setClusteringLevel, setSelectedRunId, toggleClusterExpanded, toggleScatterPlotExpanded } =
-        useActions(clustersLogic)
+    const {
+        setClusteringLevel,
+        setSelectedRunId,
+        toggleClusterExpanded,
+        toggleScatterPlotExpanded,
+        createEvaluationFromCluster,
+    } = useActions(clustersLogic)
     const { setPropertyFilters, setShouldFilterTestAccounts } = useActions(clustersLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -391,6 +400,8 @@ export function ClustersView(): JSX.Element {
                             clusteringLevel={clusteringLevel}
                             metrics={clusterMetrics[cluster.cluster_id]}
                             metricsLoading={clusterMetricsLoading}
+                            onCreateEvaluation={setClusterEvaluationModalCluster}
+                            creatingEvaluation={creatingEvaluationFromClusterIds.has(cluster.cluster_id)}
                         />
                     ))}
                 </div>
@@ -418,6 +429,21 @@ export function ClustersView(): JSX.Element {
 
             {/* Admin Modal */}
             {showAdminPanel && <ClusteringAdminModal />}
+
+            <ClusterEvaluationModal
+                cluster={clusterEvaluationModalCluster}
+                isOpen={!!clusterEvaluationModalCluster}
+                creating={
+                    clusterEvaluationModalCluster
+                        ? creatingEvaluationFromClusterIds.has(clusterEvaluationModalCluster.cluster_id)
+                        : false
+                }
+                onClose={() => setClusterEvaluationModalCluster(null)}
+                onCreate={(cluster, evaluationGoal, evaluationPrompt) => {
+                    createEvaluationFromCluster(cluster, evaluationGoal, evaluationPrompt)
+                    setClusterEvaluationModalCluster(null)
+                }}
+            />
         </div>
     )
 }

--- a/products/llm_analytics/frontend/clusters/clusterEvaluationPrompt.test.ts
+++ b/products/llm_analytics/frontend/clusters/clusterEvaluationPrompt.test.ts
@@ -1,0 +1,38 @@
+import { defaultEvaluationTemplates, LLMJudgeTemplate } from '../evaluations/templates'
+import { buildClusterTemplateEvaluationPrompt } from './clusterEvaluationPrompt'
+import { Cluster } from './types'
+
+const eventTrackingCluster: Cluster = {
+    cluster_id: 2,
+    size: 126,
+    title: 'Event Tracking Troubleshooting',
+    description:
+        '- Debugging missing, mismatched, or filtered events\n- Includes webhook configuration, initialization, and instrumentation issues\n- Focused on why tracking data is not appearing as expected',
+    traces: {},
+    centroid: [],
+    centroid_x: 0,
+    centroid_y: 0,
+}
+
+describe('clusterEvaluationPrompt', () => {
+    it('keeps the selected LLM judge template prompt and appends cluster context at the bottom', () => {
+        const helpfulnessTemplate = defaultEvaluationTemplates.find(
+            (template): template is LLMJudgeTemplate =>
+                template.key === 'helpfulness' && template.evaluation_type === 'llm_judge'
+        )
+
+        if (!helpfulnessTemplate) {
+            throw new Error('Expected helpfulness template to exist')
+        }
+
+        const prompt = buildClusterTemplateEvaluationPrompt(helpfulnessTemplate, eventTrackingCluster)
+
+        expect(prompt.startsWith(helpfulnessTemplate.prompt)).toBe(true)
+        expect(prompt).toContain('## Cluster context added from LLM Analytics')
+        expect(prompt).toContain('Source cluster: Event Tracking Troubleshooting')
+        expect(prompt).toContain('Debugging missing, mismatched, or filtered events')
+        expect(prompt.indexOf('## Cluster context added from LLM Analytics')).toBeGreaterThan(
+            helpfulnessTemplate.prompt.length
+        )
+    })
+})

--- a/products/llm_analytics/frontend/clusters/clusterEvaluationPrompt.ts
+++ b/products/llm_analytics/frontend/clusters/clusterEvaluationPrompt.ts
@@ -1,0 +1,63 @@
+import { LLMJudgeTemplate } from '../evaluations/templates'
+import { Cluster } from './types'
+
+export const CLUSTER_EVALUATION_PROMPT_MAX_LENGTH = 2000
+
+function clusterTitle(cluster: Cluster): string {
+    return cluster.title?.trim() || `Cluster ${cluster.cluster_id}`
+}
+
+function clusterSummary(cluster: Cluster): string {
+    return cluster.description?.trim() || 'No cluster summary was available.'
+}
+
+function buildClusterContextSection(cluster: Cluster, additionalContext?: string): string {
+    const trimmedAdditionalContext = additionalContext?.trim()
+
+    return `## Cluster context added from LLM Analytics
+The context below was added because this draft evaluation was created from a cluster. Edit or remove it before creating the draft if it does not match what you want to detect.
+
+Source cluster: ${clusterTitle(cluster)}
+
+Cluster summary:
+${clusterSummary(cluster)}
+${trimmedAdditionalContext ? `\nAdditional context:\n${trimmedAdditionalContext}\n` : ''}
+Use the generation input, output, metadata, and any available trace context to decide how this context should affect the evaluation.
+
+Ignore source run counts, costs, latencies, token counts, and other metrics.`
+}
+
+export function buildClusterEvaluationGoal(cluster: Cluster): string {
+    return `Detect whether the generation or its trace context shows the "${clusterTitle(cluster)}" pattern. Use the cluster summary as the positive case.`
+}
+
+export function buildClusterEvaluationPrompt(cluster: Cluster, evaluationGoal: string): string {
+    return `You are judging whether an LLM generation shows a reusable pattern from an LLM Analytics cluster.
+
+Evaluation goal:
+${evaluationGoal.trim() || buildClusterEvaluationGoal(cluster)}
+
+Cluster title:
+${clusterTitle(cluster)}
+
+Cluster summary:
+${clusterSummary(cluster)}
+
+Use the generation input, output, metadata, and any available trace context to decide.
+
+Return true when the generation clearly shows the evaluation goal.
+Return false when the generation clearly does not show the evaluation goal.
+Return N/A when there is not enough information to decide.
+
+Focus on the evaluation goal, cluster title, and cluster summary only. Ignore source run counts, costs, latencies, token counts, and other metrics.`
+}
+
+export function buildClusterTemplateEvaluationPrompt(
+    template: LLMJudgeTemplate,
+    cluster: Cluster,
+    additionalContext?: string
+): string {
+    return `${template.prompt.trim()}
+
+${buildClusterContextSection(cluster, additionalContext)}`
+}

--- a/products/llm_analytics/frontend/clusters/clustersLogic.test.ts
+++ b/products/llm_analytics/frontend/clusters/clustersLogic.test.ts
@@ -1,5 +1,8 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { clustersLogic } from './clustersLogic'
@@ -18,6 +21,7 @@ describe('clustersLogic', () => {
 
     afterEach(() => {
         logic.unmount()
+        jest.restoreAllMocks()
     })
 
     describe('reducers', () => {
@@ -221,6 +225,66 @@ describe('clustersLogic', () => {
                     clusterMetricsLoading: false,
                 })
             })
+        })
+    })
+
+    describe('listeners', () => {
+        it('creates a draft evaluation from the active clustering run and cluster', async () => {
+            let createPayload: Record<string, unknown> | null = null
+            useMocks({
+                post: {
+                    '/api/environments/:team_id/query/': () => [200, { results: [] }],
+                    '/api/environments/:team_id/evaluations/create_from_cluster/': async (req) => {
+                        createPayload = await req.json()
+                        return [201, { id: 'eval-123' }]
+                    },
+                },
+            })
+            const toastSpy = jest.spyOn(lemonToast, 'success').mockImplementation(() => undefined as any)
+            const cluster: Cluster = {
+                cluster_id: 3,
+                size: 373,
+                title: 'Outliers & Misc Data Analysis',
+                description: '- Mixed traces that do not fit a single dominant workflow',
+                traces: {},
+                centroid: [],
+                centroid_x: 0,
+                centroid_y: 0,
+            }
+
+            logic.actions.loadClusteringRunsSuccess([
+                {
+                    runId: '997_trace_20260506_120000',
+                    windowEnd: '2026-05-06T12:00:00Z',
+                    label: 'May 6, 2026 12:00 PM',
+                },
+            ])
+
+            await expectLogic(logic, () => {
+                logic.actions.createEvaluationFromCluster(
+                    cluster,
+                    'Detect whether the user is struggling with event tracking.',
+                    'Return true when the user is struggling with event tracking setup.'
+                )
+            }).toDispatchActions([
+                'createEvaluationFromCluster',
+                'setCreatingEvaluationFromCluster',
+                'setCreatingEvaluationFromCluster',
+            ])
+
+            expect(createPayload).toEqual({
+                run_id: '997_trace_20260506_120000',
+                cluster_id: 3,
+                evaluation_goal: 'Detect whether the user is struggling with event tracking.',
+                evaluation_prompt: 'Return true when the user is struggling with event tracking setup.',
+            })
+            expect(logic.values.creatingEvaluationFromClusterIds.has(3)).toBe(false)
+            expect(toastSpy).toHaveBeenCalledWith(
+                'Evaluation created',
+                expect.objectContaining({
+                    button: expect.objectContaining({ label: 'View' }),
+                })
+            )
         })
     })
 

--- a/products/llm_analytics/frontend/clusters/clustersLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clustersLogic.ts
@@ -9,6 +9,7 @@ import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { EventsQuery, NodeKind, ProductKey } from '~/queries/schema/schema-general'
@@ -96,7 +97,12 @@ export const clustersLogic = kea<clustersLogicType>([
     key((props) => props.tabId ?? 'default'),
 
     connect((props: ClustersLogicProps) => ({
-        values: [llmAnalyticsSharedLogic({ tabId: props.tabId }), ['propertyFilters', 'shouldFilterTestAccounts']],
+        values: [
+            llmAnalyticsSharedLogic({ tabId: props.tabId }),
+            ['propertyFilters', 'shouldFilterTestAccounts'],
+            teamLogic,
+            ['currentTeamIdStrict'],
+        ],
         actions: [
             llmAnalyticsSharedLogic({ tabId: props.tabId }),
             ['setPropertyFilters', 'setShouldFilterTestAccounts', 'applyUrlState'],
@@ -124,6 +130,12 @@ export const clustersLogic = kea<clustersLogicType>([
         setEvalEvaluatorNamesFilter: (names: string[]) => ({ names }),
         setEvalVerdictsFilter: (verdicts: EvaluationVerdict[]) => ({ verdicts }),
         clearEvalFilters: true,
+        createEvaluationFromCluster: (cluster: Cluster, evaluationGoal?: string, evaluationPrompt?: string) => ({
+            cluster,
+            evaluationGoal,
+            evaluationPrompt,
+        }),
+        setCreatingEvaluationFromCluster: (clusterId: number, creating: boolean) => ({ clusterId, creating }),
     }),
 
     reducers({
@@ -219,6 +231,20 @@ export const clustersLogic = kea<clustersLogicType>([
                 clearEvalFilters: () => [],
                 setClusteringLevel: () => [],
                 setSelectedRunId: () => [],
+            },
+        ],
+        creatingEvaluationFromClusterIds: [
+            new Set<number>() as Set<number>,
+            {
+                setCreatingEvaluationFromCluster: (state, { clusterId, creating }) => {
+                    const next = new Set(state)
+                    if (creating) {
+                        next.add(clusterId)
+                    } else {
+                        next.delete(clusterId)
+                    }
+                    return next
+                },
             },
         ],
     }),
@@ -812,6 +838,43 @@ export const clustersLogic = kea<clustersLogicType>([
                         actions.setTraceSummariesLoading(false)
                     }
                 }
+            }
+        },
+
+        createEvaluationFromCluster: async ({ cluster, evaluationGoal, evaluationPrompt }) => {
+            const runId = values.currentRun?.runId || values.effectiveRunId
+            if (!runId) {
+                lemonToast.error('No clustering run selected')
+                return
+            }
+
+            actions.setCreatingEvaluationFromCluster(cluster.cluster_id, true)
+            try {
+                // nosemgrep: prefer-codegen-api
+                const created = await api.create<{ id: string }>(
+                    `/api/environments/${values.currentTeamIdStrict}/evaluations/create_from_cluster/`,
+                    {
+                        run_id: runId,
+                        cluster_id: cluster.cluster_id,
+                        ...(evaluationGoal?.trim() ? { evaluation_goal: evaluationGoal.trim() } : {}),
+                        ...(evaluationPrompt?.trim() ? { evaluation_prompt: evaluationPrompt.trim() } : {}),
+                    }
+                )
+                posthog.capture('llma cluster saved as evaluation', {
+                    run_id: runId,
+                    cluster_id: cluster.cluster_id,
+                    evaluation_id: created.id,
+                })
+                lemonToast.success('Evaluation created', {
+                    button: {
+                        label: 'View',
+                        action: () => router.actions.push(urls.llmAnalyticsEvaluation(created.id)),
+                    },
+                })
+            } catch {
+                lemonToast.error('Failed to create evaluation')
+            } finally {
+                actions.setCreatingEvaluationFromCluster(cluster.cluster_id, false)
             }
         },
 

--- a/products/llm_analytics/frontend/evaluations/EvaluationTemplates.tsx
+++ b/products/llm_analytics/frontend/evaluations/EvaluationTemplates.tsx
@@ -15,8 +15,12 @@ export const scene: SceneExport = {
     component: EvaluationTemplatesScene,
 }
 
+export type EvaluationTemplateChoice = EvaluationTemplate | 'blank'
+
 interface TemplateCardProps {
-    template: EvaluationTemplate | 'blank'
+    template: EvaluationTemplateChoice
+    blankDescription?: string
+    onSelectTemplate?: (template: EvaluationTemplateChoice) => void
 }
 
 function getTemplateIcon(icon: EvaluationTemplate['icon']): JSX.Element {
@@ -39,7 +43,7 @@ function getTemplateIcon(icon: EvaluationTemplate['icon']): JSX.Element {
     }
 }
 
-function TemplateCard({ template }: TemplateCardProps): JSX.Element {
+function TemplateCard({ template, blankDescription, onSelectTemplate }: TemplateCardProps): JSX.Element {
     const isBlank = template === 'blank'
     const { searchParams } = useValues(router)
 
@@ -47,6 +51,11 @@ function TemplateCard({ template }: TemplateCardProps): JSX.Element {
         posthog.capture('llm evaluation template selected', {
             template_key: isBlank ? 'blank' : template.key,
         })
+
+        if (onSelectTemplate) {
+            onSelectTemplate(template)
+            return
+        }
 
         if (isBlank) {
             router.actions.push(combineUrl(urls.llmAnalyticsEvaluation('new'), searchParams).url)
@@ -79,7 +88,7 @@ function TemplateCard({ template }: TemplateCardProps): JSX.Element {
                     </div>
                     <p className="text-sm text-secondary leading-relaxed">
                         {isBlank
-                            ? 'Build a custom evaluation with your own prompt and configuration'
+                            ? blankDescription || 'Build a custom evaluation with your own prompt and configuration'
                             : template.description}
                     </p>
                 </div>
@@ -88,25 +97,32 @@ function TemplateCard({ template }: TemplateCardProps): JSX.Element {
     )
 }
 
-interface TemplateGridProps {
+interface EvaluationTemplatePickerProps {
     title: string
     description: string
     showBackButton?: boolean
     learnMoreUrl?: string
-    minHeight?: '60vh' | '80vh'
+    minHeight?: '60vh' | '80vh' | 'auto'
+    templates?: readonly EvaluationTemplate[]
+    blankDescription?: string
+    onSelectTemplate?: (template: EvaluationTemplateChoice) => void
 }
 
-function TemplateGrid({
+export function EvaluationTemplatePicker({
     title,
     description,
     showBackButton = false,
     learnMoreUrl,
     minHeight = '60vh',
-}: TemplateGridProps): JSX.Element {
+    templates = defaultEvaluationTemplates,
+    blankDescription,
+    onSelectTemplate,
+}: EvaluationTemplatePickerProps): JSX.Element {
     const { searchParams } = useValues(router)
+    const minHeightStyle = minHeight === 'auto' ? undefined : { minHeight }
 
     return (
-        <div className="flex flex-col items-center justify-center py-8" style={{ minHeight }}>
+        <div className="flex flex-col items-center justify-center py-8" style={minHeightStyle}>
             <div className="w-full max-w-5xl px-4">
                 {showBackButton && (
                     <div className="mb-6">
@@ -142,9 +158,13 @@ function TemplateGrid({
                     </div>
 
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        <TemplateCard template="blank" />
-                        {defaultEvaluationTemplates.map((template) => (
-                            <TemplateCard key={template.key} template={template} />
+                        <TemplateCard
+                            template="blank"
+                            blankDescription={blankDescription}
+                            onSelectTemplate={onSelectTemplate}
+                        />
+                        {templates.map((template) => (
+                            <TemplateCard key={template.key} template={template} onSelectTemplate={onSelectTemplate} />
                         ))}
                     </div>
                 </div>
@@ -155,7 +175,7 @@ function TemplateGrid({
 
 export function EvaluationTemplatesScene(): JSX.Element {
     return (
-        <TemplateGrid
+        <EvaluationTemplatePicker
             title="Choose an evaluation template"
             description="Select a pre-configured template to get started quickly, or create your own from scratch"
             showBackButton
@@ -166,7 +186,7 @@ export function EvaluationTemplatesScene(): JSX.Element {
 
 export function EvaluationTemplatesEmptyState(): JSX.Element {
     return (
-        <TemplateGrid
+        <EvaluationTemplatePicker
             title="Create your first evaluation"
             description="Select a pre-configured template to get started quickly, or create your own from scratch."
             showBackButton={false}

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -297,6 +297,16 @@ export interface PatchedEvaluationApi {
     deleted?: boolean
 }
 
+export interface CreateEvaluationFromClusterRequestApi {
+    /** @minLength 1 */
+    run_id: string
+    cluster_id: number
+    /** @maxLength 1000 */
+    evaluation_goal?: string
+    /** @maxLength 2000 */
+    evaluation_prompt?: string
+}
+
 export type TestHogRequestApiConditionsItem = { [key: string]: unknown }
 
 export interface TestHogRequestApi {

--- a/products/llm_analytics/frontend/generated/api.ts
+++ b/products/llm_analytics/frontend/generated/api.ts
@@ -13,6 +13,7 @@ import type {
     BatchCheckResponseApi,
     ClusteringJobApi,
     ClusteringRunRequestApi,
+    CreateEvaluationFromClusterRequestApi,
     DatasetApi,
     DatasetItemApi,
     DatasetItemsListParams,
@@ -256,6 +257,26 @@ export const evaluationsDestroy = async (projectId: string, id: string, options?
     return apiMutator<unknown>(getEvaluationsDestroyUrl(projectId, id), {
         ...options,
         method: 'DELETE',
+    })
+}
+
+/**
+ * Create a disabled LLM-judge evaluation draft from a cluster card summary.
+ */
+export const getEvaluationsCreateFromClusterCreateUrl = (projectId: string) => {
+    return `/api/environments/${projectId}/evaluations/create_from_cluster/`
+}
+
+export const evaluationsCreateFromClusterCreate = async (
+    projectId: string,
+    createEvaluationFromClusterRequestApi: CreateEvaluationFromClusterRequestApi,
+    options?: RequestInit
+): Promise<EvaluationApi> => {
+    return apiMutator<EvaluationApi>(getEvaluationsCreateFromClusterCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(createEvaluationFromClusterRequestApi),
     })
 }
 

--- a/products/llm_analytics/frontend/generated/api.zod.ts
+++ b/products/llm_analytics/frontend/generated/api.zod.ts
@@ -243,6 +243,21 @@ export const EvaluationsPartialUpdateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Create a disabled LLM-judge evaluation draft from a cluster card summary.
+ */
+
+export const evaluationsCreateFromClusterCreateBodyEvaluationGoalMax = 1000
+
+export const evaluationsCreateFromClusterCreateBodyEvaluationPromptMax = 2000
+
+export const EvaluationsCreateFromClusterCreateBody = /* @__PURE__ */ zod.object({
+    run_id: zod.string().min(1),
+    cluster_id: zod.number(),
+    evaluation_goal: zod.string().max(evaluationsCreateFromClusterCreateBodyEvaluationGoalMax).optional(),
+    evaluation_prompt: zod.string().max(evaluationsCreateFromClusterCreateBodyEvaluationPromptMax).optional(),
+})
+
+/**
  * Test Hog evaluation code against sample events without saving.
  */
 

--- a/products/llm_analytics/mcp/tools.yaml
+++ b/products/llm_analytics/mcp/tools.yaml
@@ -147,6 +147,22 @@ tools:
             (provider + model). For 'hog' type, provide evaluation_config.source (Hog code returning a boolean). When
             enabled, the evaluation runs automatically on new $ai_generation events. Results appear as '$ai_evaluation'
             events.
+    llma-evaluation-create-from-cluster:
+        operation: evaluations_create_from_cluster_create
+        enabled: true
+        scopes:
+            - evaluation:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create evaluation from cluster
+        description: >
+            Create a disabled LLM-judge evaluation draft from an LLM Analytics cluster. Pass the clustering run_id and
+            cluster_id. Optionally pass evaluation_goal to steer the generated boolean signal, or evaluation_prompt to
+            provide the exact prompt to save. The default prompt is built from the cluster card title and summary,
+            ignoring metrics like counts, cost, latency, and tokens. The evaluation stays disabled so a user or agent
+            can review it before enabling.
     llma-evaluation-delete:
         operation: evaluations_destroy
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2448,6 +2448,21 @@
             "readOnlyHint": false
         }
     },
+    "llma-evaluation-create-from-cluster": {
+        "description": "Create a disabled LLM-judge evaluation draft from an LLM Analytics cluster. Pass the clustering run_id and cluster_id. Optionally pass evaluation_goal to steer the generated boolean signal, or evaluation_prompt to provide the exact prompt to save. The default prompt is built from the cluster card title and summary, ignoring metrics like counts, cost, latency, and tokens. The evaluation stays disabled so a user or agent can review it before enabling.",
+        "category": "LLM analytics",
+        "feature": "llm_analytics",
+        "summary": "Create evaluation from cluster",
+        "title": "Create evaluation from cluster",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "llma-evaluation-delete": {
         "description": "Soft-delete an LLM evaluation. The evaluation stops running and is hidden from list views. Historical evaluation results ($ai_evaluation events) are preserved.",
         "category": "LLM analytics",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2761,6 +2761,21 @@
             "readOnlyHint": false
         }
     },
+    "llma-evaluation-create-from-cluster": {
+        "description": "Create a disabled LLM-judge evaluation draft from an LLM Analytics cluster. Pass the clustering run_id and cluster_id. Optionally pass evaluation_goal to steer the generated boolean signal, or evaluation_prompt to provide the exact prompt to save. The default prompt is built from the cluster card title and summary, ignoring metrics like counts, cost, latency, and tokens. The evaluation stays disabled so a user or agent can review it before enabling.",
+        "category": "LLM analytics",
+        "feature": "llm_analytics",
+        "summary": "Create evaluation from cluster",
+        "title": "Create evaluation from cluster",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "llma-evaluation-delete": {
         "description": "Soft-delete an LLM evaluation. The evaluation stops running and is hidden from list views. Historical evaluation results ($ai_evaluation events) are preserved.",
         "category": "LLM analytics",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -9735,6 +9735,16 @@ export namespace Schemas {
       readonly updated_at: string;
     }
 
+    export interface CreateEvaluationFromClusterRequest {
+      /** @minLength 1 */
+      run_id: string;
+      cluster_id: number;
+      /** @maxLength 1000 */
+      evaluation_goal?: string;
+      /** @maxLength 2000 */
+      evaluation_prompt?: string;
+    }
+
     export interface CreateGroup {
       /**
        * @minimum -2147483648

--- a/services/mcp/src/generated/llm_analytics/api.ts
+++ b/services/mcp/src/generated/llm_analytics/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 56 enabled ops
+ * PostHog API - MCP 57 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -237,6 +237,28 @@ export const EvaluationsDestroyParams = /* @__PURE__ */ zod.object({
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
+})
+
+/**
+ * Create a disabled LLM-judge evaluation draft from a cluster card summary.
+ */
+export const EvaluationsCreateFromClusterCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const evaluationsCreateFromClusterCreateBodyEvaluationGoalMax = 1000
+
+export const evaluationsCreateFromClusterCreateBodyEvaluationPromptMax = 2000
+
+export const EvaluationsCreateFromClusterCreateBody = /* @__PURE__ */ zod.object({
+    run_id: zod.string().min(1),
+    cluster_id: zod.number(),
+    evaluation_goal: zod.string().max(evaluationsCreateFromClusterCreateBodyEvaluationGoalMax).optional(),
+    evaluation_prompt: zod.string().max(evaluationsCreateFromClusterCreateBodyEvaluationPromptMax).optional(),
 })
 
 /**

--- a/services/mcp/src/tools/generated/llm_analytics.ts
+++ b/services/mcp/src/tools/generated/llm_analytics.ts
@@ -5,6 +5,7 @@ import type { Schemas } from '@/api/generated'
 import {
     EvaluationRunsCreateBody,
     EvaluationsCreateBody,
+    EvaluationsCreateFromClusterCreateBody,
     EvaluationsDestroyParams,
     EvaluationsListQueryParams,
     EvaluationsPartialUpdateBody,
@@ -194,6 +195,38 @@ const llmaEvaluationCreate = (): ToolBase<typeof LlmaEvaluationCreateSchema, Sch
         const result = await context.api.request<Schemas.Evaluation>({
             method: 'POST',
             path: `/api/environments/${encodeURIComponent(String(projectId))}/evaluations/`,
+            body,
+        })
+        return result
+    },
+})
+
+const LlmaEvaluationCreateFromClusterSchema = EvaluationsCreateFromClusterCreateBody
+
+const llmaEvaluationCreateFromCluster = (): ToolBase<
+    typeof LlmaEvaluationCreateFromClusterSchema,
+    Schemas.Evaluation
+> => ({
+    name: 'llma-evaluation-create-from-cluster',
+    schema: LlmaEvaluationCreateFromClusterSchema,
+    handler: async (context: Context, params: z.infer<typeof LlmaEvaluationCreateFromClusterSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.run_id !== undefined) {
+            body['run_id'] = params.run_id
+        }
+        if (params.cluster_id !== undefined) {
+            body['cluster_id'] = params.cluster_id
+        }
+        if (params.evaluation_goal !== undefined) {
+            body['evaluation_goal'] = params.evaluation_goal
+        }
+        if (params.evaluation_prompt !== undefined) {
+            body['evaluation_prompt'] = params.evaluation_prompt
+        }
+        const result = await context.api.request<Schemas.Evaluation>({
+            method: 'POST',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/evaluations/create_from_cluster/`,
             body,
         })
         return result
@@ -1586,6 +1619,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'llma-evaluation-config-get': llmaEvaluationConfigGet,
     'llma-evaluation-config-set-active-key': llmaEvaluationConfigSetActiveKey,
     'llma-evaluation-create': llmaEvaluationCreate,
+    'llma-evaluation-create-from-cluster': llmaEvaluationCreateFromCluster,
     'llma-evaluation-delete': llmaEvaluationDelete,
     'llma-evaluation-get': llmaEvaluationGet,
     'llma-evaluation-judge-models': llmaEvaluationJudgeModels,


### PR DESCRIPTION
## Summary

- Add a cluster-card create evaluation flow that opens the evaluation template picker inside a modal.
- Preserve the selected LLM judge template prompt and append editable cluster context at the bottom.
- Add the backend create-from-cluster endpoint, tests, and MCP tool definition for the same flow.

## Testing

- verified the cluster card → template chooser → draft eval → created eval UI flow.
<img width="1979" height="1155" alt="Screenshot 2026-05-07 at 10 46 32 AM" src="https://github.com/user-attachments/assets/190816de-4c70-4088-8351-fbae6f83105c" />
<img width="1942" height="1133" alt="Screenshot 2026-05-07 at 10 46 38 AM" src="https://github.com/user-attachments/assets/524b7d46-7618-401e-95a3-5673517e08f9" />
<img width="1939" height="1136" alt="Screenshot 2026-05-07 at 10 46 43 AM" src="https://github.com/user-attachments/assets/d157e935-1c5a-4239-9f24-a467fca87e72" />
<img width="1952" height="1132" alt="Screenshot 2026-05-07 at 10 46 47 AM" src="https://github.com/user-attachments/assets/b2491fa0-6d82-44bb-b596-529e48fc4329" />
