### PR TITLE
feat(insights): add TimeSeriesBarChart storybook stories

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -576,6 +576,34 @@ snapshots:
         hash: v1.k794b7964.bf6bedb1f09bacdd7008902e47f2118b353f59b59d2dfbf7abecb7ad8fa09bd1.-uNfx0wyQ72E6nc1PrqC8rHg8J7gY8-7i9nop7w4Y2M
     components-hogcharts-referenceline--vertical-reference-lines--light:
         hash: v1.k794b7964.fde30e22b2056f1e8e22850bb06c5220d2953cfc94fbfd66bfb7f7b8eeb7323f.mR0MdlvDVJmrXWFmM9o48B66Ikx9Qavg8VWdW4bYy6s
+    components-hogcharts-timeseriesbarchart--basic--dark:
+        hash: v1.k794b7964.49a1e8a1eb97155c19c31ce91b1d86e105a1b5e0f765d06c84344ace6f8f6a58.s3nR2e7gLDKDRXx9IV6TIz0Y3kOHl-PL9cjCmS-aFOY
+    components-hogcharts-timeseriesbarchart--basic--light:
+        hash: v1.k794b7964.788ae5e999b58e3ede4bd4284c28b449b26be099c4f0dde27a86b5b8e8abad58.54Hx8iTGaD5XitKExq9trODrqq1B4A93CduzMoPNkqc
+    components-hogcharts-timeseriesbarchart--date-axis--dark:
+        hash: v1.k794b7964.dfded726eace9f7b68beb9eaed0d85391cb70d9492b820d101591407cb4cffb1.lc9Flcr_sl6RknrbX4CvKt6brf40andiXr8FiEXJbFM
+    components-hogcharts-timeseriesbarchart--date-axis--light:
+        hash: v1.k794b7964.d7e563085dc3084d542e4b052dd0d8c4b9f9d4b7c0f5ec71e62bd27a7213b659.7mc0isBHvoiB12nDHqLZzG1h5RoZe_1wOsroFeVYQCo
+    components-hogcharts-timeseriesbarchart--grouped--dark:
+        hash: v1.k794b7964.2fe54f3bb728346aef94338597292c29fd27d117d4bab8b65ff5a368845a029e.FmtYOKsSQrzqo8wp_Mj-qUwoNf37DiH7ZWbNYB9qvg0
+    components-hogcharts-timeseriesbarchart--grouped--light:
+        hash: v1.k794b7964.616f2405c8f0c2669592f3544fa1bd126c10f8e71f481b759d95e0f4a2304a64.jbC7Wp68t70yxq289nossg5_8mfBpM8C3f2x4Rsl0SU
+    components-hogcharts-timeseriesbarchart--percent--dark:
+        hash: v1.k794b7964.e5f1a829ca7eebd2815ba02d569a2e5900249928ceb963111efcd8ab531ba665.noqU4LaSIE7V0tAw-1lm0ut_dsiLtS46MtEz-8KpYIU
+    components-hogcharts-timeseriesbarchart--percent--light:
+        hash: v1.k794b7964.97eeda327c290f6a218c0c5a612b6180cdcf59738c4fcc6a2dd60343050b216d.5KrJNULtEF9jDv7lrNBQDHGXvT8Ic60zJ4ASkoFn3_g
+    components-hogcharts-timeseriesbarchart--with-goal-line--dark:
+        hash: v1.k794b7964.a8afb665d437ac38f634e5a06a5489c8391d46d16a1b352920a9b11459c395e5.AZQRLWxOoK_bteNjvt4Ptt0h5Cz83fFRq06n-r-JDmw
+    components-hogcharts-timeseriesbarchart--with-goal-line--light:
+        hash: v1.k794b7964.ddfc22ac1f0f33c808eb42283eadc30095e24e90c09e68f45a330268e31613db.v_goCVyEY1X4rmmEbJ5tCKfs5bufHel67bL3vwabk-Y
+    components-hogcharts-timeseriesbarchart--with-value-labels--dark:
+        hash: v1.k794b7964.1d0b0f2ecd15593f82e3d673117538810b965e02d7460d974efc339f961e1c21.OfNaizOyso4D6O4EQJHfGCHYWVzZI-0fv8ksX6UtgH0
+    components-hogcharts-timeseriesbarchart--with-value-labels--light:
+        hash: v1.k794b7964.fad53a12e74f46bf1a8d26028935217ff279055cbb358d55f92f13c16129887e.fxKF3fI4mBYxukfGZiZlFh9syRkrNeguh2BuUdLh77Y
+    components-hogcharts-timeseriesbarchart--y-axis-formats--dark:
+        hash: v1.k794b7964.8019eb7165d9abb73ad3b595d33f099759f0940a649bdd54cfe1335b1148b851.lS2FWNLUehmWeagXowg7IvZcCjwOikNGVR8CJDlefkM
+    components-hogcharts-timeseriesbarchart--y-axis-formats--light:
+        hash: v1.k794b7964.558538f869802c296bed33a7415816188b83cbffdcd3d8bdd56d94476c2c805a.UkrVCNekCAmcO703kMoQHXcKpGb5cJ5hkiPS8Fk1Qyc
     components-hogcharts-timeserieslinechart--basic--dark:
         hash: v1.k794b7964.fd4f061f91b805ee93979a43d90e3e3857f4edb6a08b486690e88234f19a3035.HIRic-fGdwhh9laajb8jCdtPZhYBALfKkU-PD3MkNDQ
     components-hogcharts-timeserieslinechart--basic--light:

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.stories.tsx
@@ -1,0 +1,248 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { TimeSeriesBarChart } from 'lib/hog-charts'
+import type { Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
+
+import { Stage, useReactiveTheme } from '../../story-helpers'
+
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+const SERIES: Series[] = [
+    { key: 'visits', label: 'Visits', data: [20, 35, 28, 60, 45, 70, 52] },
+    { key: 'signups', label: 'Sign-ups', data: [4, 8, 6, 14, 11, 19, 13] },
+    { key: 'activations', label: 'Activations', data: [2, 5, 4, 9, 7, 12, 8] },
+]
+
+const meta: Meta = {
+    title: 'Components/HogCharts/TimeSeriesBarChart',
+    parameters: { layout: 'centered' },
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+export const Basic: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesBarChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{ yAxis: { showGrid: true } }}
+                />
+            </Stage>
+        )
+    },
+}
+
+export const Grouped: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesBarChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{ barLayout: 'grouped', yAxis: { showGrid: true } }}
+                />
+            </Stage>
+        )
+    },
+}
+
+export const Percent: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesBarChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{ barLayout: 'percent', yAxis: { showGrid: true } }}
+                />
+            </Stage>
+        )
+    },
+}
+
+const HOURLY_LABELS = Array.from({ length: 24 }, (_, i) => `2025-04-01 ${String(i).padStart(2, '0')}:00:00`)
+const HOURLY_SERIES: Series[] = [
+    {
+        key: 'visits',
+        label: 'Visits',
+        data: [12, 9, 7, 6, 8, 14, 22, 35, 48, 55, 60, 64, 62, 58, 54, 50, 46, 44, 40, 36, 30, 24, 18, 14],
+    },
+]
+
+const DAILY_LABELS = Array.from({ length: 30 }, (_, i) => {
+    const d = new Date(Date.UTC(2025, 2, 15))
+    d.setUTCDate(d.getUTCDate() + i)
+    return d.toISOString().slice(0, 10)
+})
+const DAILY_SERIES: Series[] = [
+    {
+        key: 'visits',
+        label: 'Visits',
+        data: DAILY_LABELS.map((_, i) => 40 + Math.round(20 * Math.sin(i / 4))),
+    },
+]
+
+const MONTHLY_LABELS = [
+    '2024-09-01',
+    '2024-10-01',
+    '2024-11-01',
+    '2024-12-01',
+    '2025-01-01',
+    '2025-02-01',
+    '2025-03-01',
+    '2025-04-01',
+    '2025-05-01',
+    '2025-06-01',
+    '2025-07-01',
+    '2025-08-01',
+]
+const MONTHLY_SERIES: Series[] = [
+    { key: 'visits', label: 'Visits', data: [120, 135, 150, 142, 200, 220, 245, 260, 275, 290, 310, 330] },
+]
+
+interface DateAxisCellProps {
+    title: string
+    labels: string[]
+    series: Series[]
+    interval: TimeInterval
+    timezone: string
+}
+
+function DateAxisCell({ title, labels, series, interval, timezone }: DateAxisCellProps): JSX.Element {
+    const theme = useReactiveTheme()
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span className="text-xs text-muted">{title}</span>
+            <Stage width={420} height={220}>
+                <TimeSeriesBarChart
+                    series={series}
+                    labels={labels}
+                    theme={theme}
+                    config={{
+                        xAxis: { timezone, interval },
+                        yAxis: { showGrid: true },
+                    }}
+                />
+            </Stage>
+        </div>
+    )
+}
+
+interface YFormatCellProps {
+    title: string
+    config: YAxisConfig
+    series: Series[]
+}
+
+function YFormatCell({ title, config, series }: YFormatCellProps): JSX.Element {
+    const theme = useReactiveTheme()
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span className="text-xs text-muted">{title}</span>
+            <Stage width={420} height={220}>
+                <TimeSeriesBarChart
+                    series={series}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{ yAxis: { ...config, showGrid: true } }}
+                />
+            </Stage>
+        </div>
+    )
+}
+
+const NUMERIC_SERIES: Series[] = [{ key: 'visits', label: 'Visits', data: [1200, 1350, 1280, 1600, 1450, 1700, 1520] }]
+const PERCENTAGE_SERIES: Series[] = [{ key: 'rate', label: 'Conversion', data: [12, 18, 22, 31, 28, 35, 41] }]
+const CURRENCY_SERIES: Series[] = [
+    { key: 'revenue', label: 'Revenue', data: [1200, 1450, 1390, 1820, 1675, 2100, 1990] },
+]
+const DURATION_SERIES: Series[] = [{ key: 'session', label: 'Session length', data: [45, 90, 120, 180, 240, 300, 540] }]
+
+export const YAxisFormats: Story = {
+    render: () => (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, auto)', gap: 24 }}>
+            <YFormatCell title="numeric" series={NUMERIC_SERIES} config={{ format: 'numeric' }} />
+            <YFormatCell title="short" series={NUMERIC_SERIES} config={{ format: 'short' }} />
+            <YFormatCell title="percentage" series={PERCENTAGE_SERIES} config={{ format: 'percentage' }} />
+            <YFormatCell title="currency" series={CURRENCY_SERIES} config={{ format: 'currency', currency: 'USD' }} />
+            <YFormatCell title="duration (s)" series={DURATION_SERIES} config={{ format: 'duration' }} />
+        </div>
+    ),
+}
+
+export const WithGoalLine: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesBarChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{
+                        yAxis: { showGrid: true },
+                        goalLines: [{ value: 50, label: 'Target' }],
+                    }}
+                />
+            </Stage>
+        )
+    },
+}
+
+export const WithValueLabels: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesBarChart
+                    series={[SERIES[0]]}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{ yAxis: { showGrid: true }, valueLabels: true }}
+                />
+            </Stage>
+        )
+    },
+}
+
+export const DateAxis: Story = {
+    render: () => {
+        const cells: { interval: TimeInterval; labels: string[]; series: Series[]; title: string }[] = [
+            { interval: 'hour', labels: HOURLY_LABELS, series: HOURLY_SERIES, title: 'hour' },
+            { interval: 'day', labels: DAILY_LABELS, series: DAILY_SERIES, title: 'day' },
+            { interval: 'month', labels: MONTHLY_LABELS, series: MONTHLY_SERIES, title: 'month' },
+        ]
+        return (
+            // eslint-disable-next-line react/forbid-dom-props
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, auto)', gap: 24 }}>
+                {(['UTC', 'America/New_York'] as const).map((timezone) => (
+                    // eslint-disable-next-line react/forbid-dom-props
+                    <div key={timezone} style={{ display: 'contents' }}>
+                        {cells.map(({ interval, labels, series, title }) => (
+                            <DateAxisCell
+                                key={`${timezone}-${interval}`}
+                                title={`${timezone} · ${title}`}
+                                labels={labels}
+                                series={series}
+                                interval={interval}
+                                timezone={timezone}
+                            />
+                        ))}
+                    </div>
+                ))}
+            </div>
+        )
+    },
+}

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.stories.tsx
@@ -4,14 +4,22 @@ import { TimeSeriesBarChart } from 'lib/hog-charts'
 import type { Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
 
 import { Stage, useReactiveTheme } from '../../story-helpers'
-
-const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
-
-const SERIES: Series[] = [
-    { key: 'visits', label: 'Visits', data: [20, 35, 28, 60, 45, 70, 52] },
-    { key: 'signups', label: 'Sign-ups', data: [4, 8, 6, 14, 11, 19, 13] },
-    { key: 'activations', label: 'Activations', data: [2, 5, 4, 9, 7, 12, 8] },
-]
+import {
+    CURRENCY_SERIES,
+    DAILY_LABELS,
+    DAILY_SERIES,
+    DAYS,
+    DURATION_MS_SERIES,
+    DURATION_SERIES,
+    HOURLY_LABELS,
+    HOURLY_SERIES,
+    MONTHLY_LABELS,
+    MONTHLY_SERIES,
+    NUMERIC_SERIES,
+    PERCENTAGE_SCALED_SERIES,
+    PERCENTAGE_SERIES,
+    SERIES,
+} from '../time-series-fixtures'
 
 const meta: Meta = {
     title: 'Components/HogCharts/TimeSeriesBarChart',
@@ -69,46 +77,6 @@ export const Percent: Story = {
     },
 }
 
-const HOURLY_LABELS = Array.from({ length: 24 }, (_, i) => `2025-04-01 ${String(i).padStart(2, '0')}:00:00`)
-const HOURLY_SERIES: Series[] = [
-    {
-        key: 'visits',
-        label: 'Visits',
-        data: [12, 9, 7, 6, 8, 14, 22, 35, 48, 55, 60, 64, 62, 58, 54, 50, 46, 44, 40, 36, 30, 24, 18, 14],
-    },
-]
-
-const DAILY_LABELS = Array.from({ length: 30 }, (_, i) => {
-    const d = new Date(Date.UTC(2025, 2, 15))
-    d.setUTCDate(d.getUTCDate() + i)
-    return d.toISOString().slice(0, 10)
-})
-const DAILY_SERIES: Series[] = [
-    {
-        key: 'visits',
-        label: 'Visits',
-        data: DAILY_LABELS.map((_, i) => 40 + Math.round(20 * Math.sin(i / 4))),
-    },
-]
-
-const MONTHLY_LABELS = [
-    '2024-09-01',
-    '2024-10-01',
-    '2024-11-01',
-    '2024-12-01',
-    '2025-01-01',
-    '2025-02-01',
-    '2025-03-01',
-    '2025-04-01',
-    '2025-05-01',
-    '2025-06-01',
-    '2025-07-01',
-    '2025-08-01',
-]
-const MONTHLY_SERIES: Series[] = [
-    { key: 'visits', label: 'Visits', data: [120, 135, 150, 142, 200, 220, 245, 260, 275, 290, 310, 330] },
-]
-
 interface DateAxisCellProps {
     title: string
     labels: string[]
@@ -162,22 +130,26 @@ function YFormatCell({ title, config, series }: YFormatCellProps): JSX.Element {
     )
 }
 
-const NUMERIC_SERIES: Series[] = [{ key: 'visits', label: 'Visits', data: [1200, 1350, 1280, 1600, 1450, 1700, 1520] }]
-const PERCENTAGE_SERIES: Series[] = [{ key: 'rate', label: 'Conversion', data: [12, 18, 22, 31, 28, 35, 41] }]
-const CURRENCY_SERIES: Series[] = [
-    { key: 'revenue', label: 'Revenue', data: [1200, 1450, 1390, 1820, 1675, 2100, 1990] },
-]
-const DURATION_SERIES: Series[] = [{ key: 'session', label: 'Session length', data: [45, 90, 120, 180, 240, 300, 540] }]
-
 export const YAxisFormats: Story = {
     render: () => (
         // eslint-disable-next-line react/forbid-dom-props
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, auto)', gap: 24 }}>
             <YFormatCell title="numeric" series={NUMERIC_SERIES} config={{ format: 'numeric' }} />
+            <YFormatCell
+                title="numeric · prefix + suffix"
+                series={NUMERIC_SERIES}
+                config={{ format: 'numeric', prefix: '$', suffix: ' req' }}
+            />
             <YFormatCell title="short" series={NUMERIC_SERIES} config={{ format: 'short' }} />
-            <YFormatCell title="percentage" series={PERCENTAGE_SERIES} config={{ format: 'percentage' }} />
+            <YFormatCell title="percentage (0-100)" series={PERCENTAGE_SERIES} config={{ format: 'percentage' }} />
+            <YFormatCell
+                title="percentage_scaled (0-1)"
+                series={PERCENTAGE_SCALED_SERIES}
+                config={{ format: 'percentage_scaled' }}
+            />
             <YFormatCell title="currency" series={CURRENCY_SERIES} config={{ format: 'currency', currency: 'USD' }} />
             <YFormatCell title="duration (s)" series={DURATION_SERIES} config={{ format: 'duration' }} />
+            <YFormatCell title="duration_ms" series={DURATION_MS_SERIES} config={{ format: 'duration_ms' }} />
         </div>
     ),
 }

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
@@ -5,14 +5,22 @@ import type { Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
 import { ciRanges } from 'lib/statistics'
 
 import { Stage, useReactiveTheme } from '../../story-helpers'
-
-const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
-
-const SERIES: Series[] = [
-    { key: 'visits', label: 'Visits', data: [20, 35, 28, 60, 45, 70, 52] },
-    { key: 'signups', label: 'Sign-ups', data: [4, 8, 6, 14, 11, 19, 13] },
-    { key: 'activations', label: 'Activations', data: [2, 5, 4, 9, 7, 12, 8] },
-]
+import {
+    CURRENCY_SERIES,
+    DAILY_LABELS,
+    DAILY_SERIES,
+    DAYS,
+    DURATION_MS_SERIES,
+    DURATION_SERIES,
+    HOURLY_LABELS,
+    HOURLY_SERIES,
+    MONTHLY_LABELS,
+    MONTHLY_SERIES,
+    NUMERIC_SERIES,
+    PERCENTAGE_SCALED_SERIES,
+    PERCENTAGE_SERIES,
+    SERIES,
+} from '../time-series-fixtures'
 
 const meta: Meta = {
     title: 'Components/HogCharts/TimeSeriesLineChart',
@@ -37,46 +45,6 @@ export const Basic: Story = {
         )
     },
 }
-
-const HOURLY_LABELS = Array.from({ length: 24 }, (_, i) => `2025-04-01 ${String(i).padStart(2, '0')}:00:00`)
-const HOURLY_SERIES: Series[] = [
-    {
-        key: 'visits',
-        label: 'Visits',
-        data: [12, 9, 7, 6, 8, 14, 22, 35, 48, 55, 60, 64, 62, 58, 54, 50, 46, 44, 40, 36, 30, 24, 18, 14],
-    },
-]
-
-const DAILY_LABELS = Array.from({ length: 30 }, (_, i) => {
-    const d = new Date(Date.UTC(2025, 2, 15))
-    d.setUTCDate(d.getUTCDate() + i)
-    return d.toISOString().slice(0, 10)
-})
-const DAILY_SERIES: Series[] = [
-    {
-        key: 'visits',
-        label: 'Visits',
-        data: DAILY_LABELS.map((_, i) => 40 + Math.round(20 * Math.sin(i / 4))),
-    },
-]
-
-const MONTHLY_LABELS = [
-    '2024-09-01',
-    '2024-10-01',
-    '2024-11-01',
-    '2024-12-01',
-    '2025-01-01',
-    '2025-02-01',
-    '2025-03-01',
-    '2025-04-01',
-    '2025-05-01',
-    '2025-06-01',
-    '2025-07-01',
-    '2025-08-01',
-]
-const MONTHLY_SERIES: Series[] = [
-    { key: 'visits', label: 'Visits', data: [120, 135, 150, 142, 200, 220, 245, 260, 275, 290, 310, 330] },
-]
 
 interface DateAxisCellProps {
     title: string
@@ -130,17 +98,6 @@ function YFormatCell({ title, config, series }: YFormatCellProps): JSX.Element {
         </div>
     )
 }
-
-const NUMERIC_SERIES: Series[] = [{ key: 'visits', label: 'Visits', data: [1200, 1350, 1280, 1600, 1450, 1700, 1520] }]
-const PERCENTAGE_SERIES: Series[] = [{ key: 'rate', label: 'Conversion', data: [12, 18, 22, 31, 28, 35, 41] }]
-const PERCENTAGE_SCALED_SERIES: Series[] = [
-    { key: 'rate', label: 'Conversion', data: [0.12, 0.18, 0.22, 0.31, 0.28, 0.35, 0.41] },
-]
-const CURRENCY_SERIES: Series[] = [
-    { key: 'revenue', label: 'Revenue', data: [1200, 1450, 1390, 1820, 1675, 2100, 1990] },
-]
-const DURATION_SERIES: Series[] = [{ key: 'session', label: 'Session length', data: [45, 90, 120, 180, 240, 300, 540] }]
-const DURATION_MS_SERIES: Series[] = [{ key: 'latency', label: 'Latency', data: [120, 180, 240, 320, 410, 530, 680] }]
 
 export const YAxisFormats: Story = {
     render: () => (

--- a/frontend/src/lib/hog-charts/charts/time-series-fixtures.ts
+++ b/frontend/src/lib/hog-charts/charts/time-series-fixtures.ts
@@ -1,0 +1,66 @@
+import type { Series } from '../core/types'
+
+export const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+export const SERIES: Series[] = [
+    { key: 'visits', label: 'Visits', data: [20, 35, 28, 60, 45, 70, 52] },
+    { key: 'signups', label: 'Sign-ups', data: [4, 8, 6, 14, 11, 19, 13] },
+    { key: 'activations', label: 'Activations', data: [2, 5, 4, 9, 7, 12, 8] },
+]
+
+export const HOURLY_LABELS = Array.from({ length: 24 }, (_, i) => `2025-04-01 ${String(i).padStart(2, '0')}:00:00`)
+export const HOURLY_SERIES: Series[] = [
+    {
+        key: 'visits',
+        label: 'Visits',
+        data: [12, 9, 7, 6, 8, 14, 22, 35, 48, 55, 60, 64, 62, 58, 54, 50, 46, 44, 40, 36, 30, 24, 18, 14],
+    },
+]
+
+export const DAILY_LABELS = Array.from({ length: 30 }, (_, i) => {
+    const d = new Date(Date.UTC(2025, 2, 15))
+    d.setUTCDate(d.getUTCDate() + i)
+    return d.toISOString().slice(0, 10)
+})
+export const DAILY_SERIES: Series[] = [
+    {
+        key: 'visits',
+        label: 'Visits',
+        data: DAILY_LABELS.map((_, i) => 40 + Math.round(20 * Math.sin(i / 4))),
+    },
+]
+
+export const MONTHLY_LABELS = [
+    '2024-09-01',
+    '2024-10-01',
+    '2024-11-01',
+    '2024-12-01',
+    '2025-01-01',
+    '2025-02-01',
+    '2025-03-01',
+    '2025-04-01',
+    '2025-05-01',
+    '2025-06-01',
+    '2025-07-01',
+    '2025-08-01',
+]
+export const MONTHLY_SERIES: Series[] = [
+    { key: 'visits', label: 'Visits', data: [120, 135, 150, 142, 200, 220, 245, 260, 275, 290, 310, 330] },
+]
+
+export const NUMERIC_SERIES: Series[] = [
+    { key: 'visits', label: 'Visits', data: [1200, 1350, 1280, 1600, 1450, 1700, 1520] },
+]
+export const PERCENTAGE_SERIES: Series[] = [{ key: 'rate', label: 'Conversion', data: [12, 18, 22, 31, 28, 35, 41] }]
+export const PERCENTAGE_SCALED_SERIES: Series[] = [
+    { key: 'rate', label: 'Conversion', data: [0.12, 0.18, 0.22, 0.31, 0.28, 0.35, 0.41] },
+]
+export const CURRENCY_SERIES: Series[] = [
+    { key: 'revenue', label: 'Revenue', data: [1200, 1450, 1390, 1820, 1675, 2100, 1990] },
+]
+export const DURATION_SERIES: Series[] = [
+    { key: 'session', label: 'Session length', data: [45, 90, 120, 180, 240, 300, 540] },
+]
+export const DURATION_MS_SERIES: Series[] = [
+    { key: 'latency', label: 'Latency', data: [120, 180, 240, 320, 410, 530, 680] },
+]


### PR DESCRIPTION
## Problem

`TimeSeriesBarChart` (#58026) shipped without storybook coverage. Stories are useful both for visual review and as a reference catalog for consumers picking config shapes.

## Changes

Add `TimeSeriesBarChart.stories.tsx` mirroring the `TimeSeriesLineChart` story set:

- Basic, Grouped, Percent layouts
- Y-axis format variants (numeric, short, percentage, currency, duration)
- Goal-line and value-label overlay examples
- Date-axis cells (hour / day / month) across two timezones

Stacked on #58026 — review/merge that one first.

This is the third of a series:
1. move shared helpers (#58025)
2. add `TimeSeriesBarChart` (chart + tests) (#58026)
3. **(this PR)** storybook stories
4. switch `TrendsBarChart` to `TimeSeriesBarChart`

## How did you test this code?

Agent (PostHog Code), no manual testing. Stories are visual scaffolding; correctness is covered by the test suite in #58026.

## Publish to changelog?

no

## 🤖 Agent context

Tooling: PostHog Code (Claude Opus 4.7), task `265d88d3-94f6-4f5b-93b2-5dcaa41f1eae`. Carved out of #58018 because the stories file is large enough to dominate any PR it ships with — splitting it lets the chart implementation review focus on the chart code, and the stories review focus on visual coverage.