### PR TITLE
fix(oauth): translate first-party client_id when switching region

### DIFF
--- a/frontend/src/scenes/authentication/RegionSelect.tsx
+++ b/frontend/src/scenes/authentication/RegionSelect.tsx
@@ -11,6 +11,8 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 import { Region } from '~/types'
 
+import { buildRegionSwitchUrl } from './crossRegionOAuth'
+
 const sections = [
     {
         title: 'US hosting',
@@ -84,7 +86,18 @@ const RegionSelect = (): JSX.Element | null => {
                             return
                         }
                         const { pathname, search, hash } = router.values.currentLocation
-                        const newUrl = `https://${CLOUD_HOSTNAMES[region]}${pathname}${search}${hash}`
+                        // For an in-flight OAuth flow (/oauth/authorize directly, or
+                        // /login?next=/oauth/authorize?...), rewrite the embedded
+                        // first-party client_id so it matches the target region's
+                        // OAuth application — otherwise the destination server
+                        // rejects the request as "Invalid client_id".
+                        const newUrl = buildRegionSwitchUrl({
+                            targetHost: CLOUD_HOSTNAMES[region],
+                            pathname,
+                            search,
+                            hash,
+                            targetRegion: region,
+                        })
                         window.location.href = newUrl
                     }}
                     value={preflight?.region}

--- a/frontend/src/scenes/authentication/crossRegionOAuth.test.ts
+++ b/frontend/src/scenes/authentication/crossRegionOAuth.test.ts
@@ -1,0 +1,92 @@
+import { Region } from '~/types'
+
+import { buildRegionSwitchUrl, translateClientIdForRegion } from './crossRegionOAuth'
+
+const POSTHOG_CODE_US_CLIENT_ID = 'HCWoE0aRFMYxIxFNTTwkOORn5LBjOt2GVDzwSw5W'
+const POSTHOG_CODE_EU_CLIENT_ID = 'AIvijgMS0dxKEmr5z6odvRd8Pkh5vts3nPTzgzU9'
+
+describe('translateClientIdForRegion', () => {
+    test('translates US → EU for known first-party clients', () => {
+        expect(translateClientIdForRegion(POSTHOG_CODE_US_CLIENT_ID, Region.EU)).toBe(POSTHOG_CODE_EU_CLIENT_ID)
+    })
+
+    test('translates EU → US for known first-party clients', () => {
+        expect(translateClientIdForRegion(POSTHOG_CODE_EU_CLIENT_ID, Region.US)).toBe(POSTHOG_CODE_US_CLIENT_ID)
+    })
+
+    test('returns the same client_id when target region matches existing region', () => {
+        expect(translateClientIdForRegion(POSTHOG_CODE_US_CLIENT_ID, Region.US)).toBe(POSTHOG_CODE_US_CLIENT_ID)
+    })
+
+    test('passes through unknown client_ids unchanged (third-party apps)', () => {
+        expect(translateClientIdForRegion('not-a-known-client', Region.EU)).toBe('not-a-known-client')
+    })
+})
+
+describe('buildRegionSwitchUrl', () => {
+    test('rewrites client_id when path is /oauth/authorize directly', () => {
+        const url = buildRegionSwitchUrl({
+            targetHost: 'eu.posthog.com',
+            pathname: '/oauth/authorize',
+            search: `?client_id=${POSTHOG_CODE_US_CLIENT_ID}&response_type=code`,
+            hash: '',
+            targetRegion: Region.EU,
+        })
+        expect(url).toBe(
+            `https://eu.posthog.com/oauth/authorize?client_id=${POSTHOG_CODE_EU_CLIENT_ID}&response_type=code`
+        )
+    })
+
+    test('rewrites client_id inside next= when bouncing through /login', () => {
+        const next = `/oauth/authorize?client_id=${POSTHOG_CODE_US_CLIENT_ID}&response_type=code&state=abc`
+        const url = buildRegionSwitchUrl({
+            targetHost: 'eu.posthog.com',
+            pathname: '/login',
+            search: `?next=${encodeURIComponent(next)}`,
+            hash: '',
+            targetRegion: Region.EU,
+        })
+        const decodedNext = new URLSearchParams(new URL(url).search).get('next')!
+        const innerParams = new URLSearchParams(decodedNext.split('?')[1])
+        expect(innerParams.get('client_id')).toBe(POSTHOG_CODE_EU_CLIENT_ID)
+        expect(innerParams.get('response_type')).toBe('code')
+        expect(innerParams.get('state')).toBe('abc')
+    })
+
+    test('leaves unrelated URLs untouched', () => {
+        const url = buildRegionSwitchUrl({
+            targetHost: 'eu.posthog.com',
+            pathname: '/dashboard',
+            search: '?foo=bar',
+            hash: '#section',
+            targetRegion: Region.EU,
+        })
+        expect(url).toBe('https://eu.posthog.com/dashboard?foo=bar#section')
+    })
+
+    test('does not rewrite unknown client_ids on /oauth/authorize', () => {
+        const url = buildRegionSwitchUrl({
+            targetHost: 'eu.posthog.com',
+            pathname: '/oauth/authorize',
+            search: '?client_id=third-party-id&response_type=code',
+            hash: '',
+            targetRegion: Region.EU,
+        })
+        expect(url).toBe('https://eu.posthog.com/oauth/authorize?client_id=third-party-id&response_type=code')
+    })
+
+    test('preserves hash and other params on /login?next=...', () => {
+        const next = `/oauth/authorize?client_id=${POSTHOG_CODE_US_CLIENT_ID}`
+        const url = buildRegionSwitchUrl({
+            targetHost: 'eu.posthog.com',
+            pathname: '/login',
+            search: `?next=${encodeURIComponent(next)}&error=some_error`,
+            hash: '#anchor',
+            targetRegion: Region.EU,
+        })
+        expect(url).toContain('https://eu.posthog.com/login?')
+        expect(url).toContain('error=some_error')
+        expect(url).toContain(encodeURIComponent(POSTHOG_CODE_EU_CLIENT_ID))
+        expect(url.endsWith('#anchor')).toBe(true)
+    })
+})

--- a/frontend/src/scenes/authentication/crossRegionOAuth.ts
+++ b/frontend/src/scenes/authentication/crossRegionOAuth.ts
@@ -1,0 +1,141 @@
+import { Region } from '~/types'
+
+/**
+ * First-party OAuth applications are registered with the same client name
+ * on both US and EU PostHog Cloud instances, but they have different
+ * client_ids in each region's database. When a user is in the middle of
+ * an OAuth flow on /login?next=/oauth/authorize?client_id=... and switches
+ * the data region with <RegionSelect />, we need to translate the
+ * region-specific client_id (and any matching redirect_uri) inside the
+ * `next` URL — otherwise the destination region's server rejects the
+ * request with "Invalid client_id".
+ *
+ * Keep these in sync with:
+ *   - apps/code/src/shared/constants/oauth.ts in posthog/code
+ *   - posthog/temporal/oauth.py
+ *   - the OAuth proxy KV mappings at oauth.posthog.com
+ *
+ * Only first-party PostHog apps belong here. Third-party clients should
+ * be re-initialized from the source app rather than rewritten.
+ */
+type CrossRegionClientMapping = {
+    [Region.US]: string
+    [Region.EU]: string
+}
+
+const CROSS_REGION_CLIENT_MAPPINGS: CrossRegionClientMapping[] = [
+    {
+        // PostHog Code (desktop app)
+        [Region.US]: 'HCWoE0aRFMYxIxFNTTwkOORn5LBjOt2GVDzwSw5W',
+        [Region.EU]: 'AIvijgMS0dxKEmr5z6odvRd8Pkh5vts3nPTzgzU9',
+    },
+]
+
+function findMappingByClientId(clientId: string): CrossRegionClientMapping | null {
+    for (const mapping of CROSS_REGION_CLIENT_MAPPINGS) {
+        if (mapping[Region.US] === clientId || mapping[Region.EU] === clientId) {
+            return mapping
+        }
+    }
+    return null
+}
+
+/**
+ * Translate a client_id from one region to another for known first-party
+ * cross-region apps. Returns the original client_id if no mapping is found
+ * (third-party clients, unknown clients, etc.).
+ */
+export function translateClientIdForRegion(clientId: string, targetRegion: Region): string {
+    const mapping = findMappingByClientId(clientId)
+    if (!mapping) {
+        return clientId
+    }
+    return mapping[targetRegion]
+}
+
+/**
+ * Given the current location (pathname + search + hash), produce a URL on
+ * the target region's host that preserves the OAuth flow. In particular,
+ * if the URL targets /oauth/authorize/ directly, or carries a
+ * `next=/oauth/authorize/...` (the typical login -> oauth chain), rewrite
+ * the embedded `client_id` to the target region's equivalent for known
+ * first-party apps.
+ *
+ * This is best-effort: any unrecognized client_id is left untouched and
+ * the user will see the upstream "Invalid client_id" error, which is
+ * already the existing behavior.
+ */
+export function buildRegionSwitchUrl({
+    targetHost,
+    pathname,
+    search,
+    hash,
+    targetRegion,
+}: {
+    targetHost: string
+    pathname: string
+    search: string
+    hash: string
+    targetRegion: Region
+}): string {
+    const rewrittenSearch = rewriteOAuthSearchParams(pathname, search, targetRegion)
+    return `https://${targetHost}${pathname}${rewrittenSearch}${hash}`
+}
+
+function rewriteOAuthSearchParams(pathname: string, search: string, targetRegion: Region): string {
+    if (!search) {
+        return search
+    }
+    const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+
+    const isOAuthAuthorize = pathname === '/oauth/authorize' || pathname === '/oauth/authorize/'
+
+    if (isOAuthAuthorize) {
+        const clientId = params.get('client_id')
+        if (clientId) {
+            const translated = translateClientIdForRegion(clientId, targetRegion)
+            if (translated !== clientId) {
+                params.set('client_id', translated)
+            }
+        }
+    }
+
+    // /login?next=/oauth/authorize?client_id=... is the most common path; the
+    // backend bounces unauthenticated users from /oauth/authorize to /login
+    // with the original URL encoded as `next`. Rewrite that too so the post-
+    // login redirect lands on a valid client_id for the new region.
+    const next = params.get('next')
+    if (next) {
+        const rewrittenNext = rewriteEmbeddedNext(next, targetRegion)
+        if (rewrittenNext !== next) {
+            params.set('next', rewrittenNext)
+        }
+    }
+
+    const rebuilt = params.toString()
+    return rebuilt ? `?${rebuilt}` : ''
+}
+
+function rewriteEmbeddedNext(nextValue: string, targetRegion: Region): string {
+    // `next` is a relative path with its own query string, e.g.
+    //   /oauth/authorize?client_id=...&redirect_uri=...
+    // Splitting by '?' is sufficient here since `next` cannot contain a host.
+    const [path, ...rest] = nextValue.split('?')
+    if (!rest.length) {
+        return nextValue
+    }
+    if (path !== '/oauth/authorize' && path !== '/oauth/authorize/') {
+        return nextValue
+    }
+    const params = new URLSearchParams(rest.join('?'))
+    const clientId = params.get('client_id')
+    if (!clientId) {
+        return nextValue
+    }
+    const translated = translateClientIdForRegion(clientId, targetRegion)
+    if (translated === clientId) {
+        return nextValue
+    }
+    params.set('client_id', translated)
+    return `${path}?${params.toString()}`
+}


### PR DESCRIPTION
## Summary

When a user is on \`/login?next=/oauth/authorize?client_id=...\` (the typical chain hit by an EU customer who installed PostHog Code with its US default and clicked "Sign in"), the existing \`<RegionSelect />\` swapped the host but kept the embedded \`client_id\` unchanged. Because first-party OAuth applications are registered with different \`client_id\`s on each regional Cloud instance, the destination server returned **"Invalid client_id"** and the flow died on a confusing error page. This is the broken EU switch reported by users.

This PR introduces \`crossRegionOAuth.ts\`, a small frontend mapping of well-known cross-region first-party \`client_id\`s (currently PostHog Code), and uses it from \`RegionSelect.tsx\` when the user changes region. We rewrite the \`client_id\` for both:

- \`/oauth/authorize?client_id=...\` directly, and
- \`/login?next=/oauth/authorize?client_id=...\` (the more common case).

Unknown / third-party \`client_id\`s pass through unchanged, so the failure mode for non-first-party clients is identical to today.

The mapping intentionally lives in a small, well-commented module; it must stay in sync with \`posthog/temporal/oauth.py\` (\`ARRAY_APP_CLIENT_ID_*\`), \`apps/code/src/shared/constants/oauth.ts\` in PostHog Code, and the OAuth proxy KV at \`oauth.posthog.com\`. Future first-party apps just append a new entry.

Companion UI prominence improvement in PostHog Code: https://github.com/PostHog/code/pull/2090

### Caveats / things to verify

- I could not run the full PostHog stack against US + EU instances locally, so the fix is reasoned from the code path (\`Login.tsx\` -> \`RegionSelect\` -> \`window.location.href\`) and the known client_id mapping in \`posthog/temporal/oauth.py\`. The unit tests in \`crossRegionOAuth.test.ts\` cover the URL rewriting logic; an end-to-end check of the actual EU consent screen on staging is still recommended before un-drafting.
- This does **not** rewrite \`redirect_uri\`. PostHog Code uses \`posthog-code://callback\` (protocol handler), which is registered the same way on both regional apps, so no per-region rewrite is needed. If a future first-party client uses different per-region redirect URIs, that handling can be added to the same module.

## Test plan

- [ ] \`pnpm --filter @posthog/frontend test crossRegionOAuth\` — unit tests pass.
- [ ] On staging US, log out, hit \`/oauth/authorize?client_id={US PostHog Code}&...\`, get bounced to \`/login?next=...\`, switch region to EU. Confirm the URL ends up on \`eu.posthog.com\` with the EU client_id, the EU login screen renders, and after logging in the OAuth consent flow completes (first-party app skips consent and redirects to \`posthog-code://callback\`).
- [ ] Repeat the inverse (EU → US).
- [ ] On a non-OAuth page (e.g. \`/dashboard\`), switching region still just swaps host (no behavior change).
- [ ] On \`/oauth/authorize\` with a third-party (e.g. DCR) client_id, switching region leaves the client_id untouched and the destination server still returns its existing error (no regression for third-party clients).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*