### PR TITLE
Allow PostHog Code project-scoped tokens to flip org AI toggle

### DIFF
--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -327,6 +327,88 @@ class TestOrganizationAPI(APIBaseTest):
             "OIDC_RSA_PRIVATE_KEY": generate_rsa_key(),
         }
     )
+    def test_project_scoped_oauth_token_can_toggle_ai_data_processing_approval(self):
+        """
+        PostHog Code uses project-scoped OAuth tokens. The narrow exemption in
+        APIScopePermission lets such tokens flip is_ai_data_processing_approved
+        on the parent org without leaving the desktop app, while every other
+        org-level update is still blocked.
+        """
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        oauth_app = OAuthApplication.objects.create(
+            name="PostHog Code (test)",
+            client_id="test_posthog_code_client_id",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+            user=self.user,
+        )
+        access_token = OAuthAccessToken.objects.create(
+            application=oauth_app,
+            user=self.user,
+            token="test_project_scoped_token",
+            scope="organization:write",
+            expires=timezone.now() + timedelta(hours=1),
+            scoped_teams=[self.team.id],
+        )
+
+        # The narrow toggle is allowed.
+        response = self.client.patch(
+            f"/api/organizations/{self.organization.id}/",
+            {"is_ai_data_processing_approved": True},
+            headers={"authorization": f"Bearer {access_token.token}"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.organization.refresh_from_db()
+        self.assertTrue(self.organization.is_ai_data_processing_approved)
+
+        # Other org-level updates remain blocked for project-scoped tokens.
+        response = self.client.patch(
+            f"/api/organizations/{self.organization.id}/",
+            {"name": "should-not-update"},
+            headers={"authorization": f"Bearer {access_token.token}"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+        self.organization.refresh_from_db()
+        self.assertNotEqual(self.organization.name, "should-not-update")
+
+        # Mixed payloads must NOT slip through the narrow exemption either.
+        response = self.client.patch(
+            f"/api/organizations/{self.organization.id}/",
+            {"is_ai_data_processing_approved": False, "name": "should-not-update"},
+            headers={"authorization": f"Bearer {access_token.token}"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+        self.organization.refresh_from_db()
+        self.assertTrue(self.organization.is_ai_data_processing_approved)
+        self.assertNotEqual(self.organization.name, "should-not-update")
+
+        # Token scoped to a team that doesn't belong to this org must still 403.
+        other_org, _, other_team = Organization.objects.bootstrap(self.user)
+        access_token_other_org = OAuthAccessToken.objects.create(
+            application=oauth_app,
+            user=self.user,
+            token="test_project_scoped_token_other_org",
+            scope="organization:write",
+            expires=timezone.now() + timedelta(hours=1),
+            scoped_teams=[other_team.id],
+        )
+        response = self.client.patch(
+            f"/api/organizations/{self.organization.id}/",
+            {"is_ai_data_processing_approved": False},
+            headers={"authorization": f"Bearer {access_token_other_org.token}"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+
+    @override_settings(
+        OAUTH2_PROVIDER={
+            **settings.OAUTH2_PROVIDER,
+            "OIDC_RSA_PRIVATE_KEY": generate_rsa_key(),
+        }
+    )
     def test_projects_outside_oauth_scoped_organizations_causes_401(self):
         # TODO: This should filter out the organizations to the scoped organizations, but it causes a 401 due to a bug in APIScopePermission for list endpoints.
         other_org, _, _ = Organization.objects.bootstrap(self.user)

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -408,6 +408,41 @@ class TimeSensitiveActionPermission(BasePermission):
         return True
 
 
+# The single org-level field that project-scoped OAuth tokens are allowed to
+# toggle, so that PostHog Code's onboarding can flip AI data processing
+# approval inline. Anything beyond this exact key (and only in isolation) goes
+# through the normal `scoped_teams` enforcement path.
+_AI_CONSENT_TOGGLE_FIELD = "is_ai_data_processing_approved"
+
+
+def _is_narrow_ai_consent_toggle(request, view) -> bool:
+    """Whether this request is the AI data processing approval toggle on the OrganizationViewSet.
+
+    Matches a PATCH/PUT to `OrganizationViewSet` whose body contains *only*
+    the `is_ai_data_processing_approved` field. The narrowness is deliberate —
+    we don't want this exemption to silently widen if a request body grows.
+    """
+    if request.method not in ("PATCH", "PUT"):
+        return False
+
+    if getattr(view, "basename", None) != "organizations":
+        return False
+
+    action = getattr(view, "action", None)
+    if action not in ("update", "partial_update"):
+        return False
+
+    try:
+        data = request.data
+    except Exception:
+        return False
+
+    if not isinstance(data, dict):
+        return False
+
+    return set(data.keys()) == {_AI_CONSENT_TOGGLE_FIELD}
+
+
 class ScopeBasePermission(BasePermission):
     """
     Base class for shared functionality between APIScopePermission and AccessControlPermission
@@ -545,6 +580,22 @@ class APIScopePermission(ScopeBasePermission):
         else:
             raise ValueError("Unexpected authentication type")
 
+        # Narrow exemption for the AI-data-processing-approval toggle on the org
+        # viewset. PostHog Code (and other first-party clients that authenticate
+        # with project-scoped OAuth tokens) need this single org-level boolean
+        # to be flippable inline during onboarding — without this exemption,
+        # `scoped_teams` enforcement below 403s the request on a non-project
+        # endpoint and forces the user to leave the app to flip the toggle on
+        # the web. Personal API keys, broader updates, and unrelated org
+        # endpoints remain fully gated. The wider question of giving the
+        # PostHog Code OAuth client carte-blanche org access is still open.
+        # See: posthog-code/allow-code-app-org-ai-toggle.
+        if _is_narrow_ai_consent_toggle(request, view) and isinstance(
+            request.successful_authenticator, OAuthAccessTokenAuthentication
+        ):
+            self._enforce_ai_consent_toggle_team_membership(request, view, scoped_teams, scoped_organizations)
+            return
+
         if scoped_teams and not skip_team_and_org:
             # Views that aren't project-nested but still need to accept
             # scoped_teams tokens can set `dangerously_skip_scoped_team_enforcement = True`
@@ -570,6 +621,36 @@ class APIScopePermission(ScopeBasePermission):
             except ValueError:
                 # Indicates this is not an organization scoped view
                 pass
+
+    def _enforce_ai_consent_toggle_team_membership(
+        self,
+        request,
+        view,
+        scoped_teams: list[int] | None,
+        scoped_organizations: list[str] | None,
+    ) -> None:
+        """
+        For the narrow AI-consent-toggle exemption, we still verify the token
+        actually has access to the target organization — either via at least
+        one team that belongs to it, or via `scoped_organizations` directly.
+        """
+        try:
+            organization = get_organization_from_view(view)
+        except ValueError:
+            return
+
+        if scoped_organizations and str(organization.id) in scoped_organizations:
+            return
+
+        if scoped_teams:
+            if Team.objects.filter(id__in=scoped_teams, organization_id=organization.id).exists():
+                return
+            raise PermissionDenied(
+                f"API key does not have access to the requested organization: ID {organization.id}."
+            )
+
+        # Token is not project- or org-scoped, fall through to the normal
+        # admin/membership checks higher up the permission chain.
 
     def _check_organization_personal_api_key_restrictions(self, request, view) -> None:
         """

--- a/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
@@ -1144,19 +1144,6 @@
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.32
   '''
-  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
-         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
-         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
-         "posthog_teamrevenueanalyticsconfig"."events",
-         "posthog_teamrevenueanalyticsconfig"."goals",
-         "posthog_teamrevenueanalyticsconfig"."base_currency"
-  FROM "posthog_teamrevenueanalyticsconfig"
-  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.33
-  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -1189,7 +1176,7 @@
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.34
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.33
   '''
   SELECT "posthog_datawarehousetable"."created_by_id",
          "posthog_datawarehousetable"."created_at",
@@ -1245,7 +1232,7 @@
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.35
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.34
   '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
@@ -1265,6 +1252,15 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.35
+  '''
+  SELECT 1 AS "a"
+  FROM "access_control_propertyaccesscontrol"
+  WHERE ("access_control_propertyaccesscontrol"."team_id" = 99999
+         AND NOT ("access_control_propertyaccesscontrol"."property_definition_id" IS NULL))
+  LIMIT 1
+  '''
+# ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.36
   '''
   SELECT 1 AS "a"
@@ -1276,15 +1272,6 @@
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.37
   '''
-  SELECT 1 AS "a"
-  FROM "access_control_propertyaccesscontrol"
-  WHERE ("access_control_propertyaccesscontrol"."team_id" = 99999
-         AND NOT ("access_control_propertyaccesscontrol"."property_definition_id" IS NULL))
-  LIMIT 1
-  '''
-# ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.38
-  '''
   SELECT COUNT(*)
   FROM
     (SELECT DISTINCT "ee_single_session_summary"."session_id" AS "session_id"
@@ -1292,7 +1279,7 @@
      WHERE "ee_single_session_summary"."team_id" = 99999) subquery
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.39
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.38
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -1335,6 +1322,44 @@
   LIMIT 21
   '''
 # ---
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.39
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."is_active",
+         "posthog_organization"."is_not_active_reason",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."default_anonymize_ips",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."is_pending_deletion",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.4
   '''
   SELECT "posthog_organization"."id",
@@ -1374,44 +1399,6 @@
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.40
-  '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."logo_media_id",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."is_active",
-         "posthog_organization"."is_not_active_reason",
-         "posthog_organization"."session_cookie_age",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."is_ai_data_processing_approved",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."members_can_invite",
-         "posthog_organization"."members_can_use_personal_api_keys",
-         "posthog_organization"."allow_publicly_shared_resources",
-         "posthog_organization"."default_role_id",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."default_experiment_stats_method",
-         "posthog_organization"."default_anonymize_ips",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."is_pending_deletion",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."is_platform"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
-  '''
-# ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.41
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1540,7 +1527,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.42
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.41
   '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -1587,7 +1574,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.43
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.42
   '''
   SELECT "ee_accesscontrol"."id",
          "ee_accesscontrol"."team_id",
@@ -1633,7 +1620,7 @@
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.44
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.43
   '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -1678,6 +1665,17 @@
   WHERE "posthog_organizationmembership"."user_id" = 99999
   '''
 # ---
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.44
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_sessionrecordingplaylist"
+  WHERE (NOT "posthog_sessionrecordingplaylist"."deleted"
+         AND NOT "posthog_sessionrecordingplaylist"."deleted"
+         AND "posthog_sessionrecordingplaylist"."team_id" = 99999
+         AND NOT "posthog_sessionrecordingplaylist"."deleted"
+         AND NOT "posthog_sessionrecordingplaylist"."deleted")
+  '''
+# ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.45
   '''
   SELECT COUNT(*) AS "__count"
@@ -1690,17 +1688,6 @@
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.46
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_sessionrecordingplaylist"
-  WHERE (NOT "posthog_sessionrecordingplaylist"."deleted"
-         AND NOT "posthog_sessionrecordingplaylist"."deleted"
-         AND "posthog_sessionrecordingplaylist"."team_id" = 99999
-         AND NOT "posthog_sessionrecordingplaylist"."deleted"
-         AND NOT "posthog_sessionrecordingplaylist"."deleted")
-  '''
-# ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.47
   '''
   SELECT "posthog_sessionrecordingplaylist"."id",
          "posthog_sessionrecordingplaylist"."short_id",
@@ -1902,7 +1889,7 @@
   LIMIT 100
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.48
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.47
   '''
   SELECT "posthog_sessionrecordingplaylistitem"."playlist_id" AS "playlist_id",
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "c"
@@ -1919,7 +1906,7 @@
   GROUP BY 1
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.49
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.48
   '''
   SELECT "posthog_sessionrecordingplaylistitem"."playlist_id" AS "playlist_id",
          "posthog_sessionrecordingplaylistitem"."recording_id" AS "recording_id"
@@ -1931,6 +1918,15 @@
                                                                       3,
                                                                       4,
                                                                       5 /* ... */))
+  '''
+# ---
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.49
+  '''
+  SELECT "posthog_sessionrecordingviewed"."session_id" AS "session_id"
+  FROM "posthog_sessionrecordingviewed"
+  WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
+         AND "posthog_sessionrecordingviewed"."user_id" = 99999
+         AND "posthog_sessionrecordingviewed"."session_id" IN ('00000000-0000-0000-0000-000000000000'))
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.5
@@ -2064,22 +2060,13 @@
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.50
   '''
-  SELECT "posthog_sessionrecordingviewed"."session_id" AS "session_id"
-  FROM "posthog_sessionrecordingviewed"
-  WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
-         AND "posthog_sessionrecordingviewed"."user_id" = 99999
-         AND "posthog_sessionrecordingviewed"."session_id" IN ('00000000-0000-0000-0000-000000000000'))
-  '''
-# ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.51
-  '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_sessionrecordingviewed"
   WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
          AND "posthog_sessionrecordingviewed"."user_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.52
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.51
   '''
   SELECT COUNT(*)
   FROM
@@ -2091,7 +2078,7 @@
             AND NOT ("posthog_comment"."item_id" IS NULL))) subquery
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.53
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.52
   '''
   SELECT COUNT(*)
   FROM
@@ -2102,7 +2089,7 @@
             AND NOT ("posthog_sharingconfiguration"."recording_id" IS NULL))) subquery
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.54
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.53
   '''
   SELECT COUNT(*)
   FROM
@@ -2117,7 +2104,7 @@
                      AND "posthog_exportedasset"."export_context" IS NOT NULL))) subquery
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.55
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.54
   '''
   SELECT "posthog_datawarehousesavedquery"."created_by_id",
          "posthog_datawarehousesavedquery"."created_at",
@@ -2182,7 +2169,7 @@
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.56
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.55
   '''
   SELECT "posthog_datawarehousesavedquery"."created_by_id",
          "posthog_datawarehousesavedquery"."created_at",
@@ -2239,7 +2226,7 @@
                   AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.57
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.56
   '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
@@ -2273,7 +2260,7 @@
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.58
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.57
   '''
   SELECT "posthog_datawarehousetable"."created_by_id",
          "posthog_datawarehousetable"."created_at",
@@ -2329,7 +2316,7 @@
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.59
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.58
   '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
@@ -2347,6 +2334,15 @@
   WHERE ("posthog_datawarehousejoin"."team_id" = 99999
          AND NOT ("posthog_datawarehousejoin"."deleted"
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.59
+  '''
+  SELECT 1 AS "a"
+  FROM "access_control_propertyaccesscontrol"
+  WHERE ("access_control_propertyaccesscontrol"."team_id" = 99999
+         AND NOT ("access_control_propertyaccesscontrol"."property_definition_id" IS NULL))
+  LIMIT 1
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.6
@@ -2407,11 +2403,11 @@
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.61
   '''
-  SELECT 1 AS "a"
-  FROM "access_control_propertyaccesscontrol"
-  WHERE ("access_control_propertyaccesscontrol"."team_id" = 99999
-         AND NOT ("access_control_propertyaccesscontrol"."property_definition_id" IS NULL))
-  LIMIT 1
+  SELECT COUNT(*)
+  FROM
+    (SELECT DISTINCT "ee_single_session_summary"."session_id" AS "session_id"
+     FROM "ee_single_session_summary"
+     WHERE "ee_single_session_summary"."team_id" = 99999) subquery
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.62


### PR DESCRIPTION
## Summary

PostHog Code authenticates with project-scoped OAuth tokens (`scoped_teams=[team_id]`). The Inbox onboarding step requires the parent org to have AI data processing approval enabled, but flipping that boolean today is an org-level write that `APIScopePermission.check_team_and_org_permissions` blocks for any token with `scoped_teams` set, since the org viewset is not project-nested. The user has to leave the desktop app, log into PostHog web, flip the toggle, and come back.

This adds a narrow exemption to `APIScopePermission.check_team_and_org_permissions`:

- `PATCH`/`PUT` to `OrganizationViewSet`...
- ...whose body contains *only* `is_ai_data_processing_approved`...
- ...authenticated by an OAuth access token (not a personal API key)...
- ...where the token's `scoped_teams` includes a team in the target org (or `scoped_organizations` includes the target org).

In that single case, the `scoped_teams` enforcement that would normally raise `"API keys with scoped projects are only supported on project-based endpoints."` is skipped. Everything else continues to flow through the same path:

- Other org-level updates (e.g. `name`, `enforce_2fa`) remain blocked for project-scoped tokens.
- Mixed payloads (`{is_ai_data_processing_approved: true, name: "x"}`) do *not* slip through — `set(data.keys()) == {field}` is exact.
- `OrganizationAdminWritePermissions` continues to enforce admin level downstream.
- `PersonalAPIKeyAuthentication` is excluded — only OAuth tokens get the exemption.

The companion change in PostHog Code uses this to add an inline "Approve AI data processing" button to the onboarding screen so the user no longer has to leave the app.

### The wider scope question

The user's preference is to give the official PostHog Code OAuth client carte-blanche org access (so it behaves like the web app, uniquely among OAuth apps). That's a bigger change — it would need a way to identify the official client (e.g. by client_id or a flag on `OAuthApplication`) and a new code path in `APIScopePermission`. **This PR is the minimum viable fix that closes today's onboarding pain without expanding what every project-scoped OAuth client can do.** The wider scope question is still open and tracked separately.

## Test plan

- [x] New `test_project_scoped_oauth_token_can_toggle_ai_data_processing_approval` in `test_organization.py` covers:
  - Project-scoped token can flip `is_ai_data_processing_approved` on the parent org (200).
  - Project-scoped token still cannot rename the org (403).
  - Mixed payload combining the toggle and another field is rejected (403).
  - Token scoped to a team in a *different* org is rejected (403).
- [x] Existing `test_projects_outside_oauth_scoped_organizations_causes_401` and `test_ai_data_processing_consent_capture_event` continue to pass.
- [ ] Manual: PostHog Code onboarding (companion PR in PostHog/code) — flip toggle inline, no browser detour.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*