### PR TITLE
fix: redis token bucket lua bug (v3 lua script)

### DIFF
--- a/nodejs/src/common/redis/redis-token-bucket.lua.test.ts
+++ b/nodejs/src/common/redis/redis-token-bucket.lua.test.ts
@@ -87,23 +87,26 @@ describe('redis-token-bucket lua', () => {
             const key = `@posthog-test/lua-bucket/${command}/team-1`
             await deleteKeysWithPrefix(redis, key)
 
-            const [, drained] = await callRateLimit({ command, key, cost: 101, poolMax: 100, fillRate: 1.5 })
-            // V3 doesn't charge denied requests, so a cost > poolMax leaves the
-            // bucket untouched. V1/V2 charge speculatively and clamp to -1.
-            const expectedDrained = command === 'checkRateLimitV3' ? 100 : -1
-            expect(drained).toBe(expectedDrained)
+            const [, tokensAfterFirstCall] = await callRateLimit({
+                command,
+                key,
+                cost: 100,
+                poolMax: 100,
+                fillRate: 1.5,
+            })
+            expect(tokensAfterFirstCall).toBe(0)
 
-            let lastTokens = drained
+            let tokensAfter = tokensAfterFirstCall
             for (let i = 0; i < 10; i++) {
                 advanceTime(1000)
-                const [, tokens] = await callRateLimit({ command, key, cost: 1, poolMax: 100, fillRate: 1.5 })
-                lastTokens = tokens
+                const [, tokensAfterTemp] = await callRateLimit({ command, key, cost: 1, poolMax: 100, fillRate: 1.5 })
+                tokensAfter = tokensAfterTemp
             }
 
             if (expectsRecovery) {
-                expect(lastTokens).toBeGreaterThan(0)
+                expect(tokensAfter).toBeGreaterThan(0)
             } else {
-                expect(lastTokens).toBe(-1)
+                expect(tokensAfter).toBe(-1)
             }
         })
     })

--- a/nodejs/src/common/redis/redis-token-bucket.lua.test.ts
+++ b/nodejs/src/common/redis/redis-token-bucket.lua.test.ts
@@ -46,13 +46,19 @@ describe('redis-token-bucket lua', () => {
         jest.clearAllMocks()
     })
 
-    const callRateLimit = async (
-        command: CommandName,
-        key: string,
-        cost: number,
-        poolMax: number,
+    const callRateLimit = async ({
+        command,
+        key,
+        cost,
+        poolMax,
+        fillRate,
+    }: {
+        command: CommandName
+        key: string
+        cost: number
+        poolMax: number
         fillRate: number
-    ): Promise<[number, number]> => {
+    }): Promise<[number, number]> => {
         const result = await redis.useClient({ name: 'lua-test' }, async (client) => {
             // V1's typing claims `Promise<number>` but the underlying Lua is identical
             // to V2 and returns [tokensBefore, tokensAfter]. V3 returns strings to
@@ -81,7 +87,7 @@ describe('redis-token-bucket lua', () => {
             const key = `@posthog-test/lua-bucket/${command}/team-1`
             await deleteKeysWithPrefix(redis, key)
 
-            const [, drained] = await callRateLimit(command, key, 101, 100, 1.5)
+            const [, drained] = await callRateLimit({ command, key, cost: 101, poolMax: 100, fillRate: 1.5 })
             // V3 doesn't charge denied requests, so a cost > poolMax leaves the
             // bucket untouched. V1/V2 charge speculatively and clamp to -1.
             const expectedDrained = command === 'checkRateLimitV3' ? 100 : -1
@@ -90,7 +96,7 @@ describe('redis-token-bucket lua', () => {
             let lastTokens = drained
             for (let i = 0; i < 10; i++) {
                 advanceTime(1000)
-                const [, tokens] = await callRateLimit(command, key, 1, 100, 1.5)
+                const [, tokens] = await callRateLimit({ command, key, cost: 1, poolMax: 100, fillRate: 1.5 })
                 lastTokens = tokens
             }
 

--- a/nodejs/src/common/redis/redis-token-bucket.lua.test.ts
+++ b/nodejs/src/common/redis/redis-token-bucket.lua.test.ts
@@ -6,8 +6,6 @@ import { deleteKeysWithPrefix } from '../../cdp/_tests/redis'
 
 const mockNow: jest.SpyInstance = jest.spyOn(Date, 'now')
 
-// All three commands share the same arg shape; the only thing that varies is
-// the Lua body. We test each by name so a regression in any version is loud.
 type CommandName = 'checkRateLimit' | 'checkRateLimitV2' | 'checkRateLimitV3'
 
 describe('redis-token-bucket lua', () => {
@@ -60,9 +58,6 @@ describe('redis-token-bucket lua', () => {
         fillRate: number
     }): Promise<[number, number]> => {
         const result = await redis.useClient({ name: 'lua-test' }, async (client) => {
-            // V1's typing claims `Promise<number>` but the underlying Lua is identical
-            // to V2 and returns [tokensBefore, tokensAfter]. V3 returns strings to
-            // preserve fractional balances. Normalise both to numbers.
             return (await (client[command] as any)(key, nowSeconds(), cost, poolMax, fillRate, 60)) as
                 | [number, number]
                 | [string, string]
@@ -79,34 +74,49 @@ describe('redis-token-bucket lua', () => {
         { command: 'checkRateLimitV3', expectsRecovery: true },
     ])('$command', ({ command, expectsRecovery }) => {
         it('refill=1.5/s cost=1 1req/s starting in overdraft — recovers (V3) or stays denied (V1/V2)', async () => {
-            // Each tick we earn 1.5 tokens and spend 1 → net +0.5/tick.
-            // V1/V2 (charge-first) clamp every overdraft to -1 and throw the +0.5
-            // away each tick → wedged forever.
-            // V3 (check-first) refuses the initial cost=101 request without
-            // charging, so the bucket stays at 100 and serves cost=1 every tick.
             const key = `@posthog-test/lua-bucket/${command}/team-1`
             await deleteKeysWithPrefix(redis, key)
 
-            const [, tokensAfterFirstCall] = await callRateLimit({
-                command,
-                key,
-                cost: 100,
-                poolMax: 100,
-                fillRate: 1.5,
-            })
-            expect(tokensAfterFirstCall).toBe(0)
+            let tokensAfterA = 0
+            // here we are putting the bucket in overdraft. We send 100 requests with cost 1 to a 10 token bucket
+            // after this, bucket reaches its "minimum state"
+            for (let i = 0; i < 100; i++) {
+                const [, tokensAfterTemp] = await callRateLimit({
+                    command,
+                    key,
+                    cost: 1,
+                    poolMax: 10,
+                    fillRate: 1.5,
+                })
+                tokensAfterA = tokensAfterTemp
+            }
 
-            let tokensAfter = tokensAfterFirstCall
+            // v1/v2 and v3 have different minimum states
+            if (expectsRecovery) {
+                // v3 never goes below 0
+                expect(tokensAfterA).toBe(0)
+            } else {
+                // v1/v2 goes below 0
+                expect(tokensAfterA).toBe(-1)
+            }
+
+            let tokensAfterB = 0
+
+            // here we are simulating a sustained traffic pattern
+            // 1 request with cost 1 every second to a 1.5 token refill rate bucket
+            // in theory it should recover
             for (let i = 0; i < 10; i++) {
                 advanceTime(1000)
-                const [, tokensAfterTemp] = await callRateLimit({ command, key, cost: 1, poolMax: 100, fillRate: 1.5 })
-                tokensAfter = tokensAfterTemp
+                const [, tokensAfterTemp] = await callRateLimit({ command, key, cost: 1, poolMax: 10, fillRate: 1.5 })
+                tokensAfterB = tokensAfterTemp
             }
 
             if (expectsRecovery) {
-                expect(tokensAfter).toBeGreaterThan(0)
+                // and v3 does recover
+                expect(tokensAfterB).toBeGreaterThan(0)
             } else {
-                expect(tokensAfter).toBe(-1)
+                // but v1/v2 doesn't recover
+                expect(tokensAfterB).toBe(-1)
             }
         })
     })

--- a/nodejs/src/common/redis/redis-token-bucket.lua.test.ts
+++ b/nodejs/src/common/redis/redis-token-bucket.lua.test.ts
@@ -1,0 +1,99 @@
+import { RedisV2, createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
+import { Hub } from '~/types'
+import { closeHub, createHub } from '~/utils/db/hub'
+
+import { deleteKeysWithPrefix } from '../../cdp/_tests/redis'
+
+const mockNow: jest.SpyInstance = jest.spyOn(Date, 'now')
+
+// All three commands share the same arg shape; the only thing that varies is
+// the Lua body. We test each by name so a regression in any version is loud.
+type CommandName = 'checkRateLimit' | 'checkRateLimitV2' | 'checkRateLimitV3'
+
+describe('redis-token-bucket lua', () => {
+    jest.retryTimes(3)
+
+    let now: number
+    let hub: Hub
+    let redis: RedisV2
+
+    const advanceTime = (ms: number) => {
+        now += ms
+        mockNow.mockReturnValue(now)
+    }
+
+    const nowSeconds = () => Math.round(Date.now() / 1000)
+
+    beforeEach(async () => {
+        hub = await createHub()
+        now = 1720000000000
+        mockNow.mockReturnValue(now)
+
+        redis = createRedisV2PoolFromConfig({
+            connection: hub.CDP_REDIS_HOST
+                ? {
+                      url: hub.CDP_REDIS_HOST,
+                      options: { port: hub.CDP_REDIS_PORT, password: hub.CDP_REDIS_PASSWORD },
+                  }
+                : { url: hub.REDIS_URL },
+            poolMinSize: hub.REDIS_POOL_MIN_SIZE,
+            poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
+        })
+    })
+
+    afterEach(async () => {
+        await closeHub(hub)
+        jest.clearAllMocks()
+    })
+
+    const callRateLimit = async (
+        command: CommandName,
+        key: string,
+        cost: number,
+        poolMax: number,
+        fillRate: number
+    ): Promise<[number, number]> => {
+        const result = await redis.useClient({ name: 'lua-test' }, async (client) => {
+            // V1's typing claims `Promise<number>` but the underlying Lua is identical
+            // to V2 and returns [tokensBefore, tokensAfter]. V3 returns strings to
+            // preserve fractional balances. Normalise both to numbers.
+            return (await (client[command] as any)(key, nowSeconds(), cost, poolMax, fillRate, 60)) as
+                | [number, number]
+                | [string, string]
+        })
+        if (!result) {
+            throw new Error(`expected ${command} result`)
+        }
+        return [Number(result[0]), Number(result[1])]
+    }
+
+    describe.each<{ command: CommandName; expectsRecovery: boolean }>([
+        { command: 'checkRateLimit', expectsRecovery: false },
+        { command: 'checkRateLimitV2', expectsRecovery: false },
+        { command: 'checkRateLimitV3', expectsRecovery: true },
+    ])('$command', ({ command, expectsRecovery }) => {
+        it('refill=1.5/s cost=1 1req/s starting in overdraft — recovers (V3) or stays denied (V1/V2)', async () => {
+            // Each tick we earn 1.5 tokens and spend 1 → net +0.5/tick.
+            // V3 banks the 0.5 across ticks and crosses zero after a few seconds.
+            // V1/V2 clamp every overdraft to -1 and throw the +0.5 away each tick.
+            const key = `@posthog-test/lua-bucket/${command}/team-1`
+            await deleteKeysWithPrefix(redis, key)
+
+            const [, drained] = await callRateLimit(command, key, 101, 100, 1.5)
+            expect(drained).toBe(-1)
+
+            let lastTokens = drained
+            for (let i = 0; i < 10; i++) {
+                advanceTime(1000)
+                const [, tokens] = await callRateLimit(command, key, 1, 100, 1.5)
+                lastTokens = tokens
+            }
+
+            if (expectsRecovery) {
+                expect(lastTokens).toBeGreaterThan(0)
+            } else {
+                expect(lastTokens).toBe(-1)
+            }
+        })
+    })
+})

--- a/nodejs/src/common/redis/redis-token-bucket.lua.test.ts
+++ b/nodejs/src/common/redis/redis-token-bucket.lua.test.ts
@@ -74,13 +74,18 @@ describe('redis-token-bucket lua', () => {
     ])('$command', ({ command, expectsRecovery }) => {
         it('refill=1.5/s cost=1 1req/s starting in overdraft — recovers (V3) or stays denied (V1/V2)', async () => {
             // Each tick we earn 1.5 tokens and spend 1 → net +0.5/tick.
-            // V3 banks the 0.5 across ticks and crosses zero after a few seconds.
-            // V1/V2 clamp every overdraft to -1 and throw the +0.5 away each tick.
+            // V1/V2 (charge-first) clamp every overdraft to -1 and throw the +0.5
+            // away each tick → wedged forever.
+            // V3 (check-first) refuses the initial cost=101 request without
+            // charging, so the bucket stays at 100 and serves cost=1 every tick.
             const key = `@posthog-test/lua-bucket/${command}/team-1`
             await deleteKeysWithPrefix(redis, key)
 
             const [, drained] = await callRateLimit(command, key, 101, 100, 1.5)
-            expect(drained).toBe(-1)
+            // V3 doesn't charge denied requests, so a cost > poolMax leaves the
+            // bucket untouched. V1/V2 charge speculatively and clamp to -1.
+            const expectedDrained = command === 'checkRateLimitV3' ? 100 : -1
+            expect(drained).toBe(expectedDrained)
 
             let lastTokens = drained
             for (let i = 0; i < 10; i++) {

--- a/nodejs/src/common/redis/redis-token-bucket.lua.ts
+++ b/nodejs/src/common/redis/redis-token-bucket.lua.ts
@@ -62,12 +62,13 @@ redis.call('expire', key, expiry)
 return {tokensBefore, tokensAfter}
 `
 
-// V3: fixes the "wedged at -1 under sustained traffic" bug in V2 (see
-// keyed-rate-limiter.service.test.ts). Two changes vs V2:
-//   1. Real negative balance is preserved instead of clamped to -1, so a partial
-//      refill that didn't quite cover the cost still accumulates across calls.
-//   2. The negative side is floored at -poolMax (symmetric with the positive cap)
-//      so a single oversized cost can't wedge recovery for hours.
+// V3: canonical check-first token bucket. Denied requests don't charge cost,
+// so the balance can never go negative. Fixes V2's "wedge under sustained
+// traffic" bug at the root: V2 charged on denial and clamped to -1, throwing
+// away partial refills. V3 simply doesn't charge if it can't afford the cost,
+// so partial refills accumulate cleanly toward the next allowed request.
+// Callers derive `isRateLimited` from `tokensBefore < cost` rather than
+// looking at the sign of `tokensAfter`.
 const LUA_TOKEN_BUCKET_V3 = `
 local key = KEYS[1]
 local now = tonumber(ARGV[1])
@@ -78,7 +79,12 @@ local expiry = ARGV[5]
 local before = redis.call('hget', key, 'ts')
 
 if before == false then
-  local tokensAfter = math.max(poolMax - cost, -poolMax)
+  local tokensAfter
+  if poolMax >= cost then
+    tokensAfter = poolMax - cost
+  else
+    tokensAfter = poolMax
+  end
   redis.call('hset', key, 'ts', now)
   redis.call('hset', key, 'pool', tokensAfter)
   redis.call('expire', key, expiry)
@@ -100,14 +106,15 @@ if currentTokens == false then
   currentTokens = poolMax
 end
 
-currentTokens = currentTokens + owedTokens
+currentTokens = math.min(currentTokens + owedTokens, poolMax)
 local tokensBefore = currentTokens
 
--- Symmetric clamp: cap the positive side at poolMax (otherwise idle gaps
--- compound credit forever), floor the negative side at -poolMax (otherwise
--- one giant cost makes recovery take eternity). Crucially, we do NOT clamp
--- to -1 on overdraft — that's what wedged V2 under sustained traffic.
-local tokensAfter = math.max(math.min(currentTokens - cost, poolMax), -poolMax)
+local tokensAfter
+if currentTokens >= cost then
+  tokensAfter = currentTokens - cost
+else
+  tokensAfter = currentTokens
+end
 
 redis.call('hset', key, 'pool', tokensAfter)
 redis.call('expire', key, expiry)

--- a/nodejs/src/common/redis/redis-token-bucket.lua.ts
+++ b/nodejs/src/common/redis/redis-token-bucket.lua.ts
@@ -62,6 +62,60 @@ redis.call('expire', key, expiry)
 return {tokensBefore, tokensAfter}
 `
 
+// V3: fixes the "wedged at -1 under sustained traffic" bug in V2 (see
+// keyed-rate-limiter.service.test.ts). Two changes vs V2:
+//   1. Real negative balance is preserved instead of clamped to -1, so a partial
+//      refill that didn't quite cover the cost still accumulates across calls.
+//   2. The negative side is floored at -poolMax (symmetric with the positive cap)
+//      so a single oversized cost can't wedge recovery for hours.
+const LUA_TOKEN_BUCKET_V3 = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local cost = tonumber(ARGV[2])
+local poolMax = tonumber(ARGV[3])
+local fillRate = tonumber(ARGV[4])
+local expiry = ARGV[5]
+local before = redis.call('hget', key, 'ts')
+
+if before == false then
+  local tokensAfter = math.max(poolMax - cost, -poolMax)
+  redis.call('hset', key, 'ts', now)
+  redis.call('hset', key, 'pool', tokensAfter)
+  redis.call('expire', key, expiry)
+  -- Return as strings: Redis truncates Lua numbers to integers over the wire,
+  -- which would destroy fractional balances. Callers must parseFloat.
+  return {tostring(poolMax), tostring(tokensAfter)}
+end
+
+local timeDiffSeconds = now - before
+if timeDiffSeconds > 0 then
+  redis.call('hset', key, 'ts', now)
+else
+  timeDiffSeconds = 0
+end
+
+local owedTokens = timeDiffSeconds * fillRate
+local currentTokens = redis.call('hget', key, 'pool')
+if currentTokens == false then
+  currentTokens = poolMax
+end
+
+currentTokens = currentTokens + owedTokens
+local tokensBefore = currentTokens
+
+-- Symmetric clamp: cap the positive side at poolMax (otherwise idle gaps
+-- compound credit forever), floor the negative side at -poolMax (otherwise
+-- one giant cost makes recovery take eternity). Crucially, we do NOT clamp
+-- to -1 on overdraft — that's what wedged V2 under sustained traffic.
+local tokensAfter = math.max(math.min(currentTokens - cost, poolMax), -poolMax)
+
+redis.call('hset', key, 'pool', tokensAfter)
+redis.call('expire', key, expiry)
+
+-- Stringify so fractional values survive (Redis ints over the wire otherwise).
+return {tostring(tokensBefore), tostring(tokensAfter)}
+`
+
 export const defineLuaTokenBucket = (client: Redis) => {
     // NOTE: We removed the original command and both checks point at the new one
     // Once deployed, we can follow up to use the non-v2 caller
@@ -73,5 +127,10 @@ export const defineLuaTokenBucket = (client: Redis) => {
     client.defineCommand('checkRateLimitV2', {
         numberOfKeys: 1,
         lua: LUA_TOKEN_BUCKET,
+    })
+
+    client.defineCommand('checkRateLimitV3', {
+        numberOfKeys: 1,
+        lua: LUA_TOKEN_BUCKET_V3,
     })
 }

--- a/nodejs/src/common/redis/redis-v2.ts
+++ b/nodejs/src/common/redis/redis-v2.ts
@@ -7,15 +7,21 @@ import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
 import { defineLuaTokenBucket } from './redis-token-bucket.lua'
 
-type WithCheckRateLimit<T, TV2> = {
+type WithCheckRateLimit<T, TV2, TV3> = {
     checkRateLimit: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => T
     checkRateLimitV2: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => TV2
+    /**
+     * V3 returns balances as strings (`[tokensBefore, tokensAfter]`) so fractional
+     * tokens survive — Redis truncates Lua numbers to integers on the wire. Callers
+     * must `parseFloat` the values.
+     */
+    checkRateLimitV3: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => TV3
 }
 
-export type RedisClientPipeline = Pipeline & WithCheckRateLimit<number, [number, number]>
+export type RedisClientPipeline = Pipeline & WithCheckRateLimit<number, [number, number], [string, string]>
 
 export type RedisClient = Omit<Redis, 'pipeline'> &
-    WithCheckRateLimit<Promise<number>, Promise<[number, number]>> & {
+    WithCheckRateLimit<Promise<number>, Promise<[number, number]>, Promise<[string, string]>> & {
         pipeline: () => RedisClientPipeline
     }
 

--- a/nodejs/src/common/redis/redis-v2.ts
+++ b/nodejs/src/common/redis/redis-v2.ts
@@ -13,7 +13,7 @@ type WithCheckRateLimit<T, TV2, TV3> = {
     /**
      * V3 returns balances as strings (`[tokensBefore, tokensAfter]`) so fractional
      * tokens survive — Redis truncates Lua numbers to integers on the wire. Callers
-     * must `parseFloat` the values.
+     * should convert the values with `Number(...)` or `parseFloat(...)`.
      */
     checkRateLimitV3: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => TV3
 }

--- a/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
@@ -69,7 +69,7 @@ describe('KeyedRateLimiterService', () => {
         expect(res[0][1]).toEqual({ tokens: 1, isRateLimited: false })
 
         res = await limiter.rateLimitMany([{ id: 'team-1', cost: 1 }])
-        expect(res[0][1]).toEqual({ tokens: 0, isRateLimited: true })
+        expect(res[0][1]).toEqual({ tokens: 0, isRateLimited: false })
 
         res = await limiter.rateLimitMany([{ id: 'team-1', cost: 20 }])
         expect(res[0][1].isRateLimited).toBe(true)

--- a/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
@@ -150,6 +150,35 @@ describe('KeyedRateLimiterService', () => {
         ])
     })
 
+    it('BUG: sustained traffic at exactly refillRate cannot recover from a -1 overdraft', async () => {
+        // The Lua bucket clamps stored `pool` to -1 on overdraft AND advances `ts` to `now`
+        // on every call. Sustained traffic at >= cost/refillRate therefore zeros out each
+        // fractional refill before it accrues, wedging the bucket at -1 indefinitely.
+        const limiter = buildLimiter('test-stuck-at-minus-one', { bucketSize: 100, refillRate: 1 })
+        await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
+
+        // Overdraft by 1: true balance -1.
+        const drained = await limiter.rateLimitMany([{ id: 'team-1', cost: 101 }])
+        expect(drained[0][1]).toEqual({ tokens: -1, isRateLimited: true })
+
+        // 300s at exactly the refill rate (1 call/s, cost=1, refill=1/s). The buggy bucket
+        // stays pinned at exactly -1 the whole time — every call zeros out the fractional
+        // refill it just earned via the clamp + ts-reset, so the negative balance never moves.
+        for (let i = 0; i < 300; i++) {
+            advanceTime(1000)
+            const res = await limiter.rateLimitMany([{ id: 'team-1', cost: 1 }])
+            expect(res[0][1]).toEqual({ tokens: -1, isRateLimited: true })
+        }
+
+        // The actual signal: once traffic stops, the same key recovers given enough wall
+        // time. So the wedge above is specifically caused by sustained traffic resetting
+        // `ts` against the -1 sentinel, not by the bucket math being unrecoverable.
+        advanceTime(200_000)
+        const afterIdle = await limiter.rateLimitMany([{ id: 'team-1', cost: 1 }])
+        expect(afterIdle[0][1].isRateLimited).toBe(false)
+        expect(afterIdle[0][1].tokens).toBeGreaterThan(0)
+    })
+
     it('honours per-call bucketSize and refillRate overrides', async () => {
         const limiter = buildLimiter('test-per-call', { bucketSize: 100, refillRate: 10 })
         await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())

--- a/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
@@ -150,35 +150,6 @@ describe('KeyedRateLimiterService', () => {
         ])
     })
 
-    it('BUG: sustained traffic at exactly refillRate cannot recover from a -1 overdraft', async () => {
-        // The Lua bucket clamps stored `pool` to -1 on overdraft AND advances `ts` to `now`
-        // on every call. Sustained traffic at >= cost/refillRate therefore zeros out each
-        // fractional refill before it accrues, wedging the bucket at -1 indefinitely.
-        const limiter = buildLimiter('test-stuck-at-minus-one', { bucketSize: 100, refillRate: 1 })
-        await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
-
-        // Overdraft by 1: true balance -1.
-        const drained = await limiter.rateLimitMany([{ id: 'team-1', cost: 101 }])
-        expect(drained[0][1]).toEqual({ tokens: -1, isRateLimited: true })
-
-        // 300s at exactly the refill rate (1 call/s, cost=1, refill=1/s). The buggy bucket
-        // stays pinned at exactly -1 the whole time — every call zeros out the fractional
-        // refill it just earned via the clamp + ts-reset, so the negative balance never moves.
-        for (let i = 0; i < 300; i++) {
-            advanceTime(1000)
-            const res = await limiter.rateLimitMany([{ id: 'team-1', cost: 1 }])
-            expect(res[0][1]).toEqual({ tokens: -1, isRateLimited: true })
-        }
-
-        // The actual signal: once traffic stops, the same key recovers given enough wall
-        // time. So the wedge above is specifically caused by sustained traffic resetting
-        // `ts` against the -1 sentinel, not by the bucket math being unrecoverable.
-        advanceTime(200_000)
-        const afterIdle = await limiter.rateLimitMany([{ id: 'team-1', cost: 1 }])
-        expect(afterIdle[0][1].isRateLimited).toBe(false)
-        expect(afterIdle[0][1].tokens).toBeGreaterThan(0)
-    })
-
     it('honours per-call bucketSize and refillRate overrides', async () => {
         const limiter = buildLimiter('test-per-call', { bucketSize: 100, refillRate: 10 })
         await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())

--- a/nodejs/src/common/services/keyed-rate-limiter.service.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.ts
@@ -5,8 +5,8 @@ import { RedisV2, getRedisPipelineResults } from '~/common/redis/redis-v2'
  *
  * The Redis key prefix is configurable so multiple independent limiters
  * (e.g. error tracking, future per-event-name limits) can share a Redis
- * without colliding. Built on the same `checkRateLimitV2` Lua command that
- * powers `HogRateLimiterService`.
+ * without colliding. Built on the `checkRateLimitV3` Lua command, which
+ * uses canonical check-first semantics (denied requests don't charge).
  *
  * Per-call bucket params (bucketSize / refillRate / ttlSeconds on the request)
  * are supported so the same service instance can run different limits for
@@ -95,7 +95,7 @@ export class KeyedRateLimiterService {
             { name: `keyed-rate-limiter:${this.config.name}`, failOpen: true },
             (pipeline) => {
                 requests.forEach((req) => {
-                    pipeline.checkRateLimitV2(...this.rateLimitArgs(req))
+                    pipeline.checkRateLimitV3(...this.rateLimitArgs(req))
                 })
             }
         )
@@ -109,12 +109,13 @@ export class KeyedRateLimiterService {
 
         return requests.map((req, index) => {
             const [tokenRes] = getRedisPipelineResults(res, index, 1)
-            const tokensAfter = tokenRes[1]?.[1] ?? bucketSizes[index]
+            const tokensBefore = Number(tokenRes[1]?.[0] ?? bucketSizes[index])
+            const tokensAfter = Number(tokenRes[1]?.[1] ?? bucketSizes[index])
             return [
                 req.id,
                 {
-                    tokens: Number(tokensAfter),
-                    isRateLimited: Number(tokensAfter) <= 0,
+                    tokens: tokensAfter,
+                    isRateLimited: tokensBefore < req.cost,
                 },
             ]
         })


### PR DESCRIPTION
Current version of rate limiting lua script has a bug where it can't recover under continuous load (every second calls) with refill rates `(1,2)`. Works fine for refill rates `[2, inf)`

If you set it to let's say `1.1` and then call it every `1` second with cost `1` (after already draining the pool), you would expect it to slowly recover and just work. It never recovers. The `pool` parameter is stuck at `-1` indefinitely. 

This PR adds a test which proves that and adds v3 of the lua script which fixes it. It also kinda changes how rate limiting works. Previously we first subtracted the cost and then checked if we can afford it. So pool could go negative. New V3 implementation first checks if we can afford the call and then subtracts. Pool never goes below zero.