### PR TITLE
fix(flox): restore openssl dev+out outputs for rust builds

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -20,7 +20,7 @@ nodejs = { pkg-path = "nodejs_24", pkg-group = "nodejs", version = "24.13.0" } #
 corepack = { pkg-path = "corepack_24", pkg-group = "nodejs", version = "24.13.0", priority = 4 } # Same maj.min as in Dockerfile; diverges from patch ver
 brotli = { pkg-path = "brotli", pkg-group = "nodejs" }
 zstd = { pkg-path = "zstd", pkg-group = "nodejs" }
-openssl = { pkg-path = "openssl", version = "3.4.1", pkg-group = "openssl" }
+openssl = { pkg-path = "openssl", version = "3.4.1", pkg-group = "openssl", outputs = ["bin", "man", "dev", "out"] }
 nodemon = { pkg-path = "nodemon" }
 # Rust toolchain (based on https://flox.dev/docs/cookbook/languages/rust/)
 cargo = { pkg-path = "cargo", pkg-group = "rust-toolchain", version = "1.91.1" }


### PR DESCRIPTION
## Problem

Fresh PostHog devboxes can't build any Rust service. Every `cargo build` panics in `openssl-sys`'s `expando.c` step with `Failed to find OpenSSL development headers`, taking down `capture`, `ingestion`, `feature-flags`, `personhog-router`/`replica`, `property-defs-rs`, `flags-consumer`, plus `nodejs` (via the `cyclotron-node` Rust build).

The flox manifest still points `OPENSSL_INCLUDE_DIR=$FLOX_ENV/include` and `OPENSSL_LIB_DIR=$FLOX_ENV/lib`, but those paths no longer contain openssl headers/libs because PR #57816 (the postgresql `outputs="all"` fix) also removed `outputs = "all"` from openssl. Default outputs are `bin` + `man` only — the `dev` headers and `out` libs Rust links against got dropped.

## Changes

Restore `dev` + `out` outputs for openssl explicitly rather than reverting to `outputs = "all"`, matching the precedent in PR #55150 (nodejs) — minimal, conflict-free, doesn't reintroduce the `"all"` collision class that #57816 was fixing.

```diff
-openssl = { pkg-path = "openssl", version = "3.4.1", pkg-group = "openssl" }
+openssl = { pkg-path = "openssl", version = "3.4.1", pkg-group = "openssl", outputs = ["bin", "man", "dev", "out"] }
```

## How did you test this code?

Agent-authored. Applied the change on a live devbox, ran `flox activate`, and confirmed:

- `$FLOX_ENV/include/openssl/opensslv.h` is back (the file `expando.c` panics on)
- `libssl.so` / `libcrypto.so` are linked into `$FLOX_ENV/lib`
- `openssl.pc` / `libssl.pc` / `libcrypto.pc` are in `lib/pkgconfig`

No manual Rust rebuild or full `hogli start` cycle on top of that.

## Publish to changelog?

no

## 🤖 Agent context

Claude Code session. Diagnosed by reading the panic trace, confirming `$FLOX_ENV` was missing the openssl `dev`/`out` outputs, and `git blame`-ing the openssl line to PR #57816. Validated the fix in a flox subactivation before opening the PR. Considered reverting to `outputs = "all"` but rejected — that's the pattern PR #57816 was deliberately moving away from; explicit list is the same shape PR #55150 used and keeps the resolver narrow.