### PR TITLE
fix(stamphog): drop broad backfill/migrate deny patterns

### DIFF
--- a/tools/pr-approval-agent/gates.py
+++ b/tools/pr-approval-agent/gates.py
@@ -69,10 +69,10 @@ _DENY_PATTERN_DEFS: dict[str, dict[str, list[str]]] = {
         ],
     },
     "migrations": {
+        # `migrations/` substring is load-bearing — also catches rust
+        # *_migrations/ dirs applied by sqlx at deploy.
         "paths": [
             "migrations/",
-            "migrate",
-            "backfill",
             "schema_change",
         ],
     },

--- a/tools/pr-approval-agent/test_gates.py
+++ b/tools/pr-approval-agent/test_gates.py
@@ -44,6 +44,26 @@ from gates import detect_deny_categories
             "fix: routing logic for dashboard",
             id="routing-logic-not-infra",
         ),
+        pytest.param(
+            ["products/signals/backend/temporal/backfill_error_tracking.py"],
+            "chore(sig): scopes and tags for exception capture",
+            id="temporal-backfill-workflow-not-migration",
+        ),
+        pytest.param(
+            ["posthog/management/commands/backfill_distinct_id_overrides.py"],
+            "feat: backfill distinct id overrides",
+            id="backfill-management-command-not-migration",
+        ),
+        pytest.param(
+            ["posthog/dags/backfill_materialized_column.py"],
+            "fix: dagster backfill dag",
+            id="dagster-backfill-dag-not-migration",
+        ),
+        pytest.param(
+            ["posthog/management/commands/migrate_team.py"],
+            "fix: team migration command",
+            id="migrate-operator-command-not-migration",
+        ),
     ],
 )
 def test_no_false_positive(files: list[str], subject: str) -> None:
@@ -109,6 +129,12 @@ def test_no_false_positive(files: list[str], subject: str) -> None:
             "feat: add new column",
             "migrations",
             id="migration-file",
+        ),
+        pytest.param(
+            ["rust/persons_migrations/20260206000001_add_last_seen_at.sql"],
+            "feat: add last_seen_at to persons",
+            "migrations",
+            id="rust-sqlx-migration",
         ),
         pytest.param(
             [".github/workflows/ci.yml"],


### PR DESCRIPTION
## Problem

Stamphog's `migrations` deny-list contained two word-match patterns — `backfill` and `migrate` — that fired on any path containing those substrings. False-positive surface: ~30 files (Temporal workflows, Dagster DAGs, management commands, admin pages). All denied as `T2-never` with no bypass route, since the analyzer added in #55998 only classifies Django migrations.

Concrete hit: stamphog blocked the signals-pipeline observability PR #57927 because one file is named `backfill_error_tracking.py` (a Temporal workflow, not a schema change).

## Changes

Drop `backfill` and `migrate` from the deny-list. Keep `migrations/` (substring is load-bearing — also catches `rust/*_migrations/` sqlx dirs that auto-apply at deploy) and `schema_change`.

Principle: gate code that mutates production state *as a side effect of merge*. Operator-run scripts mutate state when an operator runs them later — separately supervised, not the merge moment.

## How did you test this code?

`test_gates.py`: 4 new FP cases (Temporal backfill workflow, backfill management command, Dagster DAG, `migrate_team`), 1 new TP case (rust sqlx migration) locking in the load-bearing substring coverage. 26/26 pass.

## 🤖 Agent context

Authored with Claude Code (Opus 4.7).