### PR TITLE
fix(signals): If BOT comes to Task with repo+user id, but no team GitHub integration - allow to user user's GitHub integration

### DIFF
--- a/products/signals/backend/report_generation/select_repo.py
+++ b/products/signals/backend/report_generation/select_repo.py
@@ -47,8 +47,10 @@ def resolve_team_github_integration(team_id: int, team: Team | None = None) -> G
     """Resolve the GitHub source the agent should use for this team."""
     integration = (
         Integration.objects.filter(team_id=team_id, kind="github")
-        # Prioritize orgs vs users (alphabetically)
-        .order_by("config__account__type", "id")
+        # Skips integrations whose installation grants access to 0 repos
+        .exclude(repository_cache=[])
+        # Prioritize orgs vs users (alphabetically), then oldest first
+        .order_by("config__account__type", "created_at", "id")
         .first()
     )
     # Prefer the first GitHub integration from the team
@@ -61,7 +63,8 @@ def resolve_team_github_integration(team_id: int, team: Team | None = None) -> G
             kind=UserIntegration.IntegrationKind.GITHUB,
             user__in=team.all_users_with_access(),
         )
-        .order_by("config__account__type", "id")
+        .exclude(repository_cache=[])
+        .order_by("config__account__type", "created_at", "id")
         .first()
     )
     # If no team integration - pick the integration of the first user

--- a/products/signals/backend/report_generation/select_repo.py
+++ b/products/signals/backend/report_generation/select_repo.py
@@ -47,8 +47,8 @@ def resolve_team_github_integration(team_id: int, team: Team | None = None) -> G
     """Resolve the GitHub source the agent should use for this team."""
     integration = (
         Integration.objects.filter(team_id=team_id, kind="github")
-        # Skips integrations whose installation grants access to 0 repos
-        .exclude(repository_cache=[])
+        # Skip integrations whose installation has been synced and confirmed empty (0 repos)
+        .exclude(repository_cache=[], repository_cache_updated_at__isnull=False)
         # Prioritize orgs vs users (alphabetically), then oldest first
         .order_by("config__account__type", "created_at", "id")
         .first()
@@ -63,7 +63,7 @@ def resolve_team_github_integration(team_id: int, team: Team | None = None) -> G
             kind=UserIntegration.IntegrationKind.GITHUB,
             user__in=team.all_users_with_access(),
         )
-        .exclude(repository_cache=[])
+        .exclude(repository_cache=[], repository_cache_updated_at__isnull=False)
         .order_by("config__account__type", "created_at", "id")
         .first()
     )

--- a/products/signals/backend/test/test_resolve_team_github_integration.py
+++ b/products/signals/backend/test/test_resolve_team_github_integration.py
@@ -1,9 +1,13 @@
+import time
+import uuid
+
 import pytest
 
 from posthog.models import Organization, Team, User
 from posthog.models.integration import GitHubIntegration, Integration
 from posthog.models.organization import OrganizationMembership
 from posthog.models.user_integration import UserGitHubIntegration, UserIntegration
+from posthog.models.utils import uuid7
 
 from products.signals.backend.report_generation.select_repo import resolve_team_github_integration
 
@@ -36,14 +40,19 @@ def _create_team_integration(team: Team, *, integration_id: str = "team-1") -> I
     )
 
 
-def _create_user_integration(user: User, *, integration_id: str = "user-1") -> UserIntegration:
-    return UserIntegration.objects.create(
-        user=user,
-        kind=UserIntegration.IntegrationKind.GITHUB,
-        integration_id=integration_id,
-        config={"installation_id": integration_id},
-        sensitive_config={},
-    )
+def _create_user_integration(
+    user: User, *, integration_id: str = "user-1", id: uuid.UUID | None = None
+) -> UserIntegration:
+    kwargs: dict = {
+        "user": user,
+        "kind": UserIntegration.IntegrationKind.GITHUB,
+        "integration_id": integration_id,
+        "config": {"installation_id": integration_id},
+        "sensitive_config": {},
+    }
+    if id is not None:
+        kwargs["id"] = id
+    return UserIntegration.objects.create(**kwargs)
 
 
 @pytest.mark.django_db
@@ -78,8 +87,11 @@ def test_falls_back_to_user_integration_when_no_team_integration(organization, t
 def test_picks_first_user_integration_by_id(organization, team):
     first_user = _create_user("first@example.com", organization)
     second_user = _create_user("second@example.com", organization)
-    first_user_int = _create_user_integration(first_user, integration_id="first")
-    _create_user_integration(second_user, integration_id="second")
+    # Pin ids to distinct timestamps so sort order is deterministic — UUIDv7
+    # only sorts by creation order across millisecond boundaries.
+    now_ms = time.time_ns() // 1_000_000
+    first_user_int = _create_user_integration(first_user, integration_id="first", id=uuid7(unix_ms_time=now_ms - 1000))
+    _create_user_integration(second_user, integration_id="second", id=uuid7(unix_ms_time=now_ms))
 
     resolved = resolve_team_github_integration(team.id)
 

--- a/products/signals/backend/test/test_resolve_team_github_integration.py
+++ b/products/signals/backend/test/test_resolve_team_github_integration.py
@@ -1,5 +1,4 @@
-import time
-import uuid
+import datetime
 
 import pytest
 
@@ -7,7 +6,6 @@ from posthog.models import Organization, Team, User
 from posthog.models.integration import GitHubIntegration, Integration
 from posthog.models.organization import OrganizationMembership
 from posthog.models.user_integration import UserGitHubIntegration, UserIntegration
-from posthog.models.utils import uuid7
 
 from products.signals.backend.report_generation.select_repo import resolve_team_github_integration
 
@@ -30,29 +28,47 @@ def _create_user(email: str, organization: Organization, *, is_active: bool = Tr
     return user
 
 
-def _create_team_integration(team: Team, *, integration_id: str = "team-1") -> Integration:
+_REPO_CACHE_ENTRY = {"full_name": "PostHog/posthog", "id": 1}
+
+
+def _create_team_integration(
+    team: Team,
+    *,
+    integration_id: str = "team-1",
+    account_type: str | None = None,
+    repository_cache: list[dict] | None = None,
+) -> Integration:
+    config: dict = {"installation_id": integration_id}
+    if account_type is not None:
+        config["account"] = {"type": account_type}
     return Integration.objects.create(
         team=team,
         kind="github",
         integration_id=integration_id,
-        config={"installation_id": integration_id},
+        config=config,
         sensitive_config={},
+        repository_cache=[_REPO_CACHE_ENTRY] if repository_cache is None else repository_cache,
     )
 
 
 def _create_user_integration(
-    user: User, *, integration_id: str = "user-1", id: uuid.UUID | None = None
+    user: User,
+    *,
+    integration_id: str = "user-1",
+    account_type: str | None = None,
+    repository_cache: list[dict] | None = None,
 ) -> UserIntegration:
-    kwargs: dict = {
-        "user": user,
-        "kind": UserIntegration.IntegrationKind.GITHUB,
-        "integration_id": integration_id,
-        "config": {"installation_id": integration_id},
-        "sensitive_config": {},
-    }
-    if id is not None:
-        kwargs["id"] = id
-    return UserIntegration.objects.create(**kwargs)
+    config: dict = {"installation_id": integration_id}
+    if account_type is not None:
+        config["account"] = {"type": account_type}
+    return UserIntegration.objects.create(
+        user=user,
+        kind=UserIntegration.IntegrationKind.GITHUB,
+        integration_id=integration_id,
+        config=config,
+        sensitive_config={},
+        repository_cache=[_REPO_CACHE_ENTRY] if repository_cache is None else repository_cache,
+    )
 
 
 @pytest.mark.django_db
@@ -84,14 +100,16 @@ def test_falls_back_to_user_integration_when_no_team_integration(organization, t
 
 
 @pytest.mark.django_db
-def test_picks_first_user_integration_by_id(organization, team):
+def test_picks_oldest_user_integration_among_org_members(organization, team):
     first_user = _create_user("first@example.com", organization)
     second_user = _create_user("second@example.com", organization)
-    # Pin ids to distinct timestamps so sort order is deterministic — UUIDv7
-    # only sorts by creation order across millisecond boundaries.
-    now_ms = time.time_ns() // 1_000_000
-    first_user_int = _create_user_integration(first_user, integration_id="first", id=uuid7(unix_ms_time=now_ms - 1000))
-    _create_user_integration(second_user, integration_id="second", id=uuid7(unix_ms_time=now_ms))
+    first_user_int = _create_user_integration(first_user, integration_id="first")
+    # Backdate `first_user_int` so it sorts first by `created_at` regardless of
+    # auto_now_add resolution between the two creates.
+    UserIntegration.objects.filter(pk=first_user_int.pk).update(
+        created_at=first_user_int.created_at - datetime.timedelta(hours=1)
+    )
+    _create_user_integration(second_user, integration_id="second")
 
     resolved = resolve_team_github_integration(team.id)
 
@@ -106,3 +124,61 @@ def test_skips_user_integration_when_owner_has_no_team_access(organization, team
     _create_user_integration(outsider, integration_id="outsider-int")
 
     assert resolve_team_github_integration(team.id) is None
+
+
+@pytest.mark.django_db
+def test_skips_team_integration_with_empty_repository_cache(organization, team):
+    user = _create_user("a@example.com", organization)
+    _create_team_integration(team, integration_id="team-empty", repository_cache=[])
+    user_int = _create_user_integration(user, integration_id="user-1")
+
+    resolved = resolve_team_github_integration(team.id)
+
+    assert isinstance(resolved, UserGitHubIntegration)
+    assert resolved.integration.id == user_int.id
+
+
+@pytest.mark.django_db
+def test_skips_user_integration_with_empty_repository_cache(organization, team):
+    empty_user = _create_user("empty@example.com", organization)
+    populated_user = _create_user("populated@example.com", organization)
+    _create_user_integration(empty_user, integration_id="user-empty", repository_cache=[])
+    populated_int = _create_user_integration(populated_user, integration_id="user-populated")
+
+    resolved = resolve_team_github_integration(team.id)
+
+    assert isinstance(resolved, UserGitHubIntegration)
+    assert resolved.integration.id == populated_int.id
+
+
+@pytest.mark.django_db
+def test_returns_none_when_all_integrations_have_empty_repository_cache(organization, team):
+    user = _create_user("a@example.com", organization)
+    _create_team_integration(team, integration_id="team-empty", repository_cache=[])
+    _create_user_integration(user, integration_id="user-empty", repository_cache=[])
+
+    assert resolve_team_github_integration(team.id) is None
+
+
+@pytest.mark.django_db
+def test_prefers_org_account_over_user_account(organization, team):
+    # Org accounts sort before User accounts on `config__account__type` (alphabetical).
+    _create_team_integration(team, integration_id="user-acct", account_type="User")
+    org_int = _create_team_integration(team, integration_id="org-acct", account_type="Organization")
+
+    resolved = resolve_team_github_integration(team.id)
+
+    assert isinstance(resolved, GitHubIntegration)
+    assert resolved.integration.id == org_int.id
+
+
+@pytest.mark.django_db
+def test_prefers_oldest_among_same_account_type(organization, team):
+    older = _create_team_integration(team, integration_id="org-old", account_type="Organization")
+    Integration.objects.filter(pk=older.pk).update(created_at=older.created_at - datetime.timedelta(hours=1))
+    _create_team_integration(team, integration_id="org-new", account_type="Organization")
+
+    resolved = resolve_team_github_integration(team.id)
+
+    assert isinstance(resolved, GitHubIntegration)
+    assert resolved.integration.id == older.id

--- a/products/signals/backend/test/test_resolve_team_github_integration.py
+++ b/products/signals/backend/test/test_resolve_team_github_integration.py
@@ -2,6 +2,8 @@ import datetime
 
 import pytest
 
+from django.utils import timezone
+
 from posthog.models import Organization, Team, User
 from posthog.models.integration import GitHubIntegration, Integration
 from posthog.models.organization import OrganizationMembership
@@ -37,11 +39,12 @@ def _create_team_integration(
     integration_id: str = "team-1",
     account_type: str | None = None,
     repository_cache: list[dict] | None = None,
+    cache_synced: bool = True,
 ) -> Integration:
     config: dict = {"installation_id": integration_id}
     if account_type is not None:
         config["account"] = {"type": account_type}
-    return Integration.objects.create(
+    integration = Integration.objects.create(
         team=team,
         kind="github",
         integration_id=integration_id,
@@ -49,6 +52,10 @@ def _create_team_integration(
         sensitive_config={},
         repository_cache=[_REPO_CACHE_ENTRY] if repository_cache is None else repository_cache,
     )
+    if cache_synced:
+        Integration.objects.filter(pk=integration.pk).update(repository_cache_updated_at=timezone.now())
+        integration.refresh_from_db()
+    return integration
 
 
 def _create_user_integration(
@@ -57,11 +64,12 @@ def _create_user_integration(
     integration_id: str = "user-1",
     account_type: str | None = None,
     repository_cache: list[dict] | None = None,
+    cache_synced: bool = True,
 ) -> UserIntegration:
     config: dict = {"installation_id": integration_id}
     if account_type is not None:
         config["account"] = {"type": account_type}
-    return UserIntegration.objects.create(
+    integration = UserIntegration.objects.create(
         user=user,
         kind=UserIntegration.IntegrationKind.GITHUB,
         integration_id=integration_id,
@@ -69,6 +77,10 @@ def _create_user_integration(
         sensitive_config={},
         repository_cache=[_REPO_CACHE_ENTRY] if repository_cache is None else repository_cache,
     )
+    if cache_synced:
+        UserIntegration.objects.filter(pk=integration.pk).update(repository_cache_updated_at=timezone.now())
+        integration.refresh_from_db()
+    return integration
 
 
 @pytest.mark.django_db
@@ -158,6 +170,29 @@ def test_returns_none_when_all_integrations_have_empty_repository_cache(organiza
     _create_user_integration(user, integration_id="user-empty", repository_cache=[])
 
     assert resolve_team_github_integration(team.id) is None
+
+
+@pytest.mark.django_db
+def test_keeps_team_integration_with_empty_unsynced_repository_cache(team):
+    # Freshly installed integration: cache is empty but never synced (updated_at is NULL).
+    # We can't yet conclude "0 repos" — keep it so select_repo can lazily sync.
+    integration = _create_team_integration(team, integration_id="team-fresh", repository_cache=[], cache_synced=False)
+
+    resolved = resolve_team_github_integration(team.id)
+
+    assert isinstance(resolved, GitHubIntegration)
+    assert resolved.integration.id == integration.id
+
+
+@pytest.mark.django_db
+def test_keeps_user_integration_with_empty_unsynced_repository_cache(organization, team):
+    user = _create_user("fresh@example.com", organization)
+    integration = _create_user_integration(user, integration_id="user-fresh", repository_cache=[], cache_synced=False)
+
+    resolved = resolve_team_github_integration(team.id)
+
+    assert isinstance(resolved, UserGitHubIntegration)
+    assert resolved.integration.id == integration.id
 
 
 @pytest.mark.django_db

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -321,6 +321,16 @@ class Task(DeletedMetaFields, models.Model):
             )
             if user_github_integration_is_usable(user_github_integration):
                 github_user_integration = user_github_integration.integration if user_github_integration else None
+        elif authorship_mode == PrAuthorshipMode.BOT and github_integration is None:
+            # If BOT starts a task, provides a repo, but there's no team GitHub Integration,
+            # then use the user_id BOT provided and get user's GitHub Integration instead
+            user_github_integration = resolve_user_github_integration_for_task(
+                task_stub,
+                repository=repository,
+                allow_refresh=True,
+            )
+            if user_github_integration is not None:
+                github_user_integration = user_github_integration.integration
 
         if repository:
             if not github_integration and github_user_integration is None and not is_public_sandbox_repo(repository):

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -83,8 +83,9 @@ class SandboxConfig(BaseModel):
 
 WORKING_DIR = "/tmp/workspace"
 
-PUBLIC_SANDBOX_REPOS: frozenset[str] = frozenset({"posthog/hedgebox"})
-"""Repos the sandbox is allowed to clone unauthenticated, even when the team has no GitHub integration."""
+PUBLIC_SANDBOX_REPOS: frozenset[str] = frozenset({"posthog/hedgebox", "posthog/.github"})
+"""Repos the sandbox is allowed to clone unauthenticated, even when the team has no GitHub integration"""
+# TODO: Remove `posthog/.github` when we switch repo discovery to repo-less agent (now it works as a lightweight dummy)
 
 
 def is_public_sandbox_repo(repository: str | None) -> bool:

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -466,3 +466,60 @@ class TestGetSandboxGitHubToken(TestCase):
         result = get_sandbox_github_token(None, run_id="run-1", state={"pr_authorship_mode": "bot"})
 
         assert result is None
+
+    def test_bot_authorship_falls_back_to_user_install_token_when_team_integration_missing(self) -> None:
+        from posthog.models import Organization, Team
+        from posthog.models.user import User
+        from posthog.models.user_integration import UserIntegration
+
+        organization = Organization.objects.create(name="bot-fallback-org")
+        Team.objects.create(organization=organization, name="bot-fallback-team")
+        user = User.objects.create(email="bot-fallback@test.com")
+        user_integration = UserIntegration.objects.create(
+            user=user,
+            kind=UserIntegration.IntegrationKind.GITHUB,
+            integration_id="install-1",
+            config={},
+            sensitive_config={"access_token": "ghs_user_install"},
+        )
+
+        result = get_sandbox_github_token(
+            None,
+            run_id="run-1",
+            state={"pr_authorship_mode": "bot"},
+            github_user_integration_id=str(user_integration.id),
+        )
+
+        assert result == "ghs_user_install"
+
+    def test_bot_authorship_prefers_team_integration_over_user_install_token(self) -> None:
+        from posthog.models import Integration, Organization, Team
+        from posthog.models.user import User
+        from posthog.models.user_integration import UserIntegration
+
+        organization = Organization.objects.create(name="bot-precedence-org")
+        team = Team.objects.create(organization=organization, name="bot-precedence-team")
+        team_integration = Integration.objects.create(
+            team=team,
+            kind="github",
+            integration_id="team-install",
+            config={},
+            sensitive_config={"access_token": "ghs_team"},
+        )
+        user = User.objects.create(email="bot-precedence@test.com")
+        user_integration = UserIntegration.objects.create(
+            user=user,
+            kind=UserIntegration.IntegrationKind.GITHUB,
+            integration_id="user-install",
+            config={},
+            sensitive_config={"access_token": "ghs_user_install"},
+        )
+
+        result = get_sandbox_github_token(
+            team_integration.id,
+            run_id="run-1",
+            state={"pr_authorship_mode": "bot"},
+            github_user_integration_id=str(user_integration.id),
+        )
+
+        assert result == "ghs_team"

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -538,15 +538,14 @@ def get_sandbox_github_token(
                 )
             return get_github_token(github_integration_id)
         if github_integration_id is None:
-            # No team fallback — let the integration's raise propagate with its specific message.
-            token = user_github_integration.get_usable_user_access_token()
-            if token is None:
+            no_team_token: str | None = user_github_integration.get_usable_user_access_token()
+            if no_team_token is None:
                 raise ReauthorizationRequired(
                     f"User-authored run {run_id} requires a linked GitHub account with repo access."
                 )
-            return token
+            return no_team_token
         try:
-            token = user_github_integration.get_usable_user_access_token()
+            token: str | None = user_github_integration.get_usable_user_access_token()
         except ReauthorizationRequired:
             token = None
         if token is not None:

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -332,6 +332,15 @@ def get_github_token(github_integration_id: int) -> Optional[str]:
     return github_integration.integration.access_token or None
 
 
+def get_user_github_token(github_user_integration_id: str) -> Optional[str]:
+    """Return the installation access token from a UserIntegration, refreshing if expired."""
+    integration = UserIntegration.objects.get(id=github_user_integration_id)
+    github_integration = UserGitHubIntegration(integration)
+    if github_integration.access_token_expired():
+        github_integration.refresh_access_token()
+    return github_integration.integration.sensitive_config.get("access_token") or None
+
+
 def _normalize_repository(repository: str | None) -> str | None:
     if not repository:
         return None
@@ -527,24 +536,33 @@ def get_sandbox_github_token(
                 raise ReauthorizationRequired(
                     f"User-authored run {run_id} requires a linked GitHub account with repo access."
                 )
-        elif github_integration_id is None:
+            return get_github_token(github_integration_id)
+        if github_integration_id is None:
+            # No team fallback — let the integration's raise propagate with its specific message.
             token = user_github_integration.get_usable_user_access_token()
             if token is None:
                 raise ReauthorizationRequired(
                     f"User-authored run {run_id} requires a linked GitHub account with repo access."
                 )
             return token
-        else:
-            try:
-                token = user_github_integration.get_usable_user_access_token()
-            except ReauthorizationRequired:
-                token = None
-            if token is not None:
-                return token
-
+        try:
+            token = user_github_integration.get_usable_user_access_token()
+        except ReauthorizationRequired:
+            token = None
+        if token is not None:
+            return token
+        return get_github_token(github_integration_id)
+    elif pr_authorship_mode == PrAuthorshipMode.BOT:
+        if github_integration_id is not None:
+            return get_github_token(github_integration_id)
+        # BOT fallback for teams without an Integration row: borrow the
+        # installation access token from the UserIntegration the task was created with.
+        if github_user_integration_id:
+            return get_user_github_token(github_user_integration_id)
+        return None
+    # No authorship mode resolved (legacy callers without state and without a task).
     if github_integration_id is None:
         return None
-
     return get_github_token(github_integration_id)
 
 

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -13,7 +13,9 @@ from django.test import TestCase
 from parameterized import parameterized
 
 from posthog.models import Integration, Organization, Team
+from posthog.models.organization import OrganizationMembership
 from posthog.models.user import User
+from posthog.models.user_integration import UserIntegration
 from posthog.storage import object_storage
 
 from products.tasks.backend.models import CodeInvite, SandboxEnvironment, SandboxSnapshot, Task, TaskRun
@@ -205,6 +207,53 @@ class TestTask(TestCase):
 
         self.assertEqual(task.github_integration, integration)
         mock_execute_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_and_run_signal_report_falls_back_to_user_integration(self, mock_execute_workflow):
+        # Signal reports are BOT-authored. When the team has no Integration row but the task
+        # creator has a UserIntegration that grants access to the repo, we should accept it
+        # instead of raising "Team does not have a GitHub integration".
+        user = User.objects.create(email="signal-report@test.com")
+        OrganizationMembership.objects.create(user=user, organization=self.organization)
+        user_integration = UserIntegration.objects.create(
+            user=user,
+            kind=UserIntegration.IntegrationKind.GITHUB,
+            integration_id="install-1",
+            config={"installation_id": "install-1"},
+            sensitive_config={"access_token": "ghs_user_install"},
+            repository_cache=[{"full_name": "posthog/posthog", "id": 1}],
+        )
+
+        task = Task.create_and_run(
+            team=self.team,
+            title="Signal Report",
+            description="Research",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+            user_id=user.id,
+            repository="posthog/posthog",
+        )
+
+        self.assertIsNone(task.github_integration)
+        self.assertEqual(task.github_user_integration, user_integration)
+        mock_execute_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_and_run_signal_report_raises_when_no_integration_anywhere(self, mock_execute_workflow):
+        user = User.objects.create(email="signal-no-int@test.com")
+        OrganizationMembership.objects.create(user=user, organization=self.organization)
+
+        with self.assertRaises(ValueError) as cm:
+            Task.create_and_run(
+                team=self.team,
+                title="Signal Report",
+                description="Research",
+                origin_product=Task.OriginProduct.SIGNAL_REPORT,
+                user_id=user.id,
+                repository="posthog/posthog",
+            )
+
+        self.assertIn("does not have a GitHub integration", str(cm.exception))
+        mock_execute_workflow.assert_not_called()
 
     @parameterized.expand(
         [


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
- We allow the use of GitHub `UserIntegration` on the Signals side
- When it comes to Task - task can't find integration and fails

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Now it doesn't
- BONUS: We ignore integrations with 0 repos

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
