### PR TITLE
fix(llma): remove moved apps banner

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -1,8 +1,8 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
-import React, { useMemo } from 'react'
+import React from 'react'
 
-import { LemonBanner, LemonButton, LemonTab, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonTab, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
@@ -25,8 +25,6 @@ import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { EditCustomProductsModal } from '~/layout/panel-layout/PinnedFolder/EditCustomProductsModal'
-import { editCustomProductsModalLogic } from '~/layout/panel-layout/PinnedFolder/editCustomProductsModalLogic'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
@@ -463,7 +461,6 @@ function LLMAnalyticsSceneContent(): JSX.Element {
     const isTraceReviewEnabled = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TRACE_REVIEW]
 
     const { push } = useActions(router)
-    const { toggleProduct, openModal: openEditCustomProductsModal } = useActions(editCustomProductsModalLogic)
 
     // Tab switching shortcuts
     useAppShortcut({
@@ -591,8 +588,6 @@ function LLMAnalyticsSceneContent(): JSX.Element {
     })
 
     const isEarlyAdopter = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
-    const isPromptManagementEnabled = !!featureFlags[FEATURE_FLAGS.PROMPT_MANAGEMENT] || isEarlyAdopter
-    const isSkillsEnabled = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SKILLS]
 
     if (featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TOOLS_TAB]) {
         tabs.push({
@@ -638,61 +633,6 @@ function LLMAnalyticsSceneContent(): JSX.Element {
         })
     }
 
-    const availableItemsInSidebar = useMemo(() => {
-        return [
-            <Link
-                key="playground"
-                to={combineUrl(urls.llmAnalyticsPlayground(), searchParams).url}
-                onClick={() => toggleProduct('Playground', true)}
-            >
-                Playground
-            </Link>,
-            <Link
-                key="clusters"
-                to={combineUrl(urls.llmAnalyticsClusters(), searchParams).url}
-                onClick={() => toggleProduct('Clusters', true)}
-            >
-                clusters
-            </Link>,
-            featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_DATASETS] ? (
-                <Link
-                    key="datasets"
-                    to={combineUrl(urls.llmAnalyticsDatasets(), searchParams).url}
-                    onClick={() => toggleProduct('Datasets', true)}
-                >
-                    datasets
-                </Link>
-            ) : null,
-            featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS] ? (
-                <Link
-                    key="evaluations"
-                    to={combineUrl(urls.llmAnalyticsEvaluations(), searchParams).url}
-                    onClick={() => toggleProduct('Evaluations', true)}
-                >
-                    evaluations
-                </Link>
-            ) : null,
-            isPromptManagementEnabled ? (
-                <Link
-                    key="prompts"
-                    to={combineUrl(urls.llmAnalyticsPrompts(), searchParams).url}
-                    onClick={() => toggleProduct('Prompts', true)}
-                >
-                    prompts
-                </Link>
-            ) : null,
-            isSkillsEnabled ? (
-                <Link
-                    key="skills"
-                    to={combineUrl(urls.llmAnalyticsSkills(), searchParams).url}
-                    onClick={() => toggleProduct('Skills', true)}
-                >
-                    skills
-                </Link>
-            ) : null,
-        ].filter(Boolean) as JSX.Element[]
-    }, [featureFlags, isPromptManagementEnabled, isSkillsEnabled, searchParams, toggleProduct])
-
     if (activeTab === 'reviews' && !isTraceReviewEnabled) {
         return <NotFound object="page" />
     }
@@ -718,24 +658,6 @@ function LLMAnalyticsSceneContent(): JSX.Element {
                     </>
                 }
             />
-
-            {availableItemsInSidebar.length > 0 ? (
-                <>
-                    <LemonBanner type="info" className="mb-2" dismissKey="llm-analytics-sidebar-moved-banner">
-                        We've moved{' '}
-                        {availableItemsInSidebar.map((el, i) => (
-                            <React.Fragment key={i}>
-                                {i > 0 && ', '}
-                                {el}
-                            </React.Fragment>
-                        ))}{' '}
-                        out of LLM Analytics and into their own apps. You can access them by clicking in the links
-                        above, or by clicking "All apps" in the sidebar. You can also customize your sidebar{' '}
-                        <Link onClick={openEditCustomProductsModal}>here</Link>.
-                    </LemonBanner>
-                    <EditCustomProductsModal />
-                </>
-            ) : null}
 
             <LemonTabs activeKey={activeTab} data-attr="llm-analytics-tabs" tabs={tabs} sceneInset />
         </SceneContent>


### PR DESCRIPTION
## Problem

The LLM analytics scene still shows a moved-apps banner pointing users to standalone apps and sidebar customization, which is no longer wanted in this surface.

## Changes

- Removed the moved-apps banner from the LLM analytics scene.
- Removed the now-unused banner and sidebar customization modal wiring from that component.

## How did you test this code?

Agent-authored change. Targeted frontend lint check passed.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 Agent context

Codex handled this PR. The change is intentionally scoped to removing the informational banner from the LLM analytics scene and cleaning up imports/state that only supported that banner.
