### PR TITLE
fix(scoping): set default_manager_name = "all_teams" on ProductTeamModel

### DIFF
--- a/posthog/models/scoping/README.md
+++ b/posthog/models/scoping/README.md
@@ -105,6 +105,9 @@ The two are deliberately not the same name. A future contributor autocompleting 
 
 ## Known limitations
 
-- **`_base_manager`**: Django uses `_base_manager` (not `objects`) for related-object access like `repo.runs.all()`. This bypasses the scoped manager. Related-object traversal is still safe because the FK constrains the result set — but the `team_id` filter is not applied.
+- **Django framework managers (`_default_manager` and `_base_manager`)**: admin queryset, `ForeignKeyRawIdWidget` label rendering, related-object access (e.g. `repo.runs.all()`), generic relations, `prefetch_related`, and DRF default querysets all go through these.
+  Per Django's contract they expect an unfiltered manager — `TeamScopedManager` would raise on missing context.
+  `ProductTeamModel.Meta.default_manager_name = "all_teams"` redirects `_default_manager` (and `_base_manager`, which inherits from `_default_manager` when `base_manager_name` is unset) to the unscoped `all_teams` manager so the framework just works.
+  `Model.objects` (the explicit attribute) stays bound to `TeamScopedManager` — user code that types it explicitly stays fail-closed.
+  The `team_id` filter is not applied on these framework paths; related-object traversal stays correct because the FK already constrains the result set, but anything reading through `_default_manager` is genuinely cross-team.
 - **Raw SQL**: `cursor.execute()` and `QuerySet.raw()` bypass managers entirely.
-- **Django admin**: Uses `_default_manager`. Since `objects` is declared first on `ProductTeamModel`, admin goes through the scoped manager and would raise without context — use `Model.all_teams` in admin classes.

--- a/posthog/models/scoping/manager.py
+++ b/posthog/models/scoping/manager.py
@@ -6,9 +6,14 @@ explicitly opted out via .unscoped(). This forces every code path to
 declare its team context — there is no silent "return everything" mode.
 
 This is a defense-in-depth convenience layer, not a complete security
-boundary. Django's _base_manager bypasses custom managers for related-
-object access, and raw SQL bypasses the ORM entirely. Use this alongside
-explicit team checks at the API layer.
+boundary. Django's `_default_manager` / `_base_manager` (used for admin
+querysets, related-object access like `repo.runs.all()`, generic
+relations, `prefetch_related`, DRF default querysets) intentionally
+route through the unscoped sibling manager via
+`ProductTeamModel.Meta.default_manager_name = "all_teams"` — the
+framework expects an unfiltered manager and a fail-closed default would
+raise on framework code that has no team context. Raw SQL bypasses the
+ORM entirely. Use this alongside explicit team checks at the API layer.
 """
 
 from typing import TypeVar, cast

--- a/posthog/models/scoping/product_mixin.py
+++ b/posthog/models/scoping/product_mixin.py
@@ -45,15 +45,23 @@ class ProductTeamModel(models.Model):
     and reads agree on where data lives — same convention as
     RootTeamMixin for main-DB models.
 
-    Two managers:
+    Two managers, with `default_manager_name = "all_teams"` set in `Meta`
+    so Django's framework reads through the unscoped sibling:
     - `objects` (TeamScopedManager): fail-closed, auto-scopes by context.
-      Raises TeamScopeError when no context is set. This is the manager
-      Django admin / Model.objects / `_default_manager` resolves to.
-    - `all_teams` (plain Manager): bypass for admin / migrations / contexts
-      that genuinely need cross-team access. Named distinctly from the
-      queryset method `Model.objects.unscoped()` to avoid the autocomplete
-      footgun where `Model.unscoped.filter(...)` looks like "I'm being
-      explicit about scoping" but actually returns every team's rows.
+      Raises TeamScopeError when no context is set. This is what user
+      code reaches for explicitly — `Model.objects.filter(...)` stays
+      fail-closed.
+    - `all_teams` (plain Manager): bypass for admin, migrations, and any
+      Django framework internal that uses `_default_manager` /
+      `_base_manager` (admin widgets, related-object access, generic
+      relations, `prefetch_related`, DRF default querysets). Per Django's
+      contract those framework managers shouldn't filter, so they're
+      pointed at `all_teams` rather than the scoped manager.
+
+      Named distinctly from the queryset method `Model.objects.unscoped()`
+      to avoid the autocomplete footgun where `Model.unscoped.filter(...)`
+      looks like "I'm being explicit about scoping" but actually returns
+      every team's rows.
     """
 
     team_id = models.BigIntegerField(db_index=True)
@@ -63,6 +71,17 @@ class ProductTeamModel(models.Model):
 
     class Meta:
         abstract = True
+
+        # Django framework internals (admin widgets, related-object access,
+        # generic relations, prefetch_related, DRF default querysets, ...)
+        # use `_default_manager`. Per Django's contract those internals
+        # expect an unfiltered manager. The `objects = TeamScopedManager()`
+        # above is what user code reaches for explicitly (`Repo.objects.all()`)
+        # and stays fail-closed; the framework reads through `all_teams` so
+        # an admin change-page or a `repo.runs.all()` traversal doesn't have
+        # to know about scoping. `Model._base_manager` defaults to
+        # `_default_manager` so it picks up the same setting.
+        default_manager_name = "all_teams"
 
     def save(self, *args: Any, **kwargs: Any) -> None:
         # Rewrite child team_ids to canonical on insert / when team_id is

--- a/products/visual_review/backend/migrations/0011_alter_artifact_managers_and_more.py
+++ b/products/visual_review/backend/migrations/0011_alter_artifact_managers_and_more.py
@@ -1,0 +1,86 @@
+# Generated for the `default_manager_name = "all_teams"` change on
+# `ProductTeamModel.Meta`. State-only — no SQL emitted. Records the
+# manager configuration in migration state so future migrations stay
+# consistent with the model definitions.
+
+from django.db import migrations, models
+
+import posthog.models.scoping.manager
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("visual_review", "0010_backfill_change_kind_and_ssim"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="artifact",
+            options={"default_manager_name": "all_teams"},
+        ),
+        migrations.AlterModelOptions(
+            name="quarantinedidentifier",
+            options={"default_manager_name": "all_teams"},
+        ),
+        migrations.AlterModelOptions(
+            name="repo",
+            options={"default_manager_name": "all_teams"},
+        ),
+        migrations.AlterModelOptions(
+            name="run",
+            options={
+                "default_manager_name": "all_teams",
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="runsnapshot",
+            options={"default_manager_name": "all_teams"},
+        ),
+        migrations.AlterModelOptions(
+            name="toleratedhash",
+            options={"default_manager_name": "all_teams"},
+        ),
+        migrations.AlterModelManagers(
+            name="artifact",
+            managers=[
+                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
+                ("all_teams", models.Manager()),
+            ],
+        ),
+        migrations.AlterModelManagers(
+            name="quarantinedidentifier",
+            managers=[
+                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
+                ("all_teams", models.Manager()),
+            ],
+        ),
+        migrations.AlterModelManagers(
+            name="repo",
+            managers=[
+                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
+                ("all_teams", models.Manager()),
+            ],
+        ),
+        migrations.AlterModelManagers(
+            name="run",
+            managers=[
+                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
+                ("all_teams", models.Manager()),
+            ],
+        ),
+        migrations.AlterModelManagers(
+            name="runsnapshot",
+            managers=[
+                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
+                ("all_teams", models.Manager()),
+            ],
+        ),
+        migrations.AlterModelManagers(
+            name="toleratedhash",
+            managers=[
+                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
+                ("all_teams", models.Manager()),
+            ],
+        ),
+    ]

--- a/products/visual_review/backend/migrations/0011_alter_artifact_managers_and_more.py
+++ b/products/visual_review/backend/migrations/0011_alter_artifact_managers_and_more.py
@@ -1,11 +1,11 @@
-# Generated for the `default_manager_name = "all_teams"` change on
-# `ProductTeamModel.Meta`. State-only — no SQL emitted. Records the
-# manager configuration in migration state so future migrations stay
-# consistent with the model definitions.
+# State-only — records the new `all_teams` manager on each
+# `ProductTeamModel`-backed model. No SQL emitted; just keeps Django's
+# migration state in sync with the model definitions after
+# `posthog/models/scoping/product_mixin.py` started exposing a sibling
+# unscoped manager alongside `objects`.
 
-from django.db import migrations, models
-
-import posthog.models.scoping.manager
+import django.db.models.manager
+from django.db import migrations
 
 
 class Migration(migrations.Migration):
@@ -14,73 +14,40 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterModelOptions(
-            name="artifact",
-            options={"default_manager_name": "all_teams"},
-        ),
-        migrations.AlterModelOptions(
-            name="quarantinedidentifier",
-            options={"default_manager_name": "all_teams"},
-        ),
-        migrations.AlterModelOptions(
-            name="repo",
-            options={"default_manager_name": "all_teams"},
-        ),
-        migrations.AlterModelOptions(
-            name="run",
-            options={
-                "default_manager_name": "all_teams",
-                "ordering": ["-created_at"],
-            },
-        ),
-        migrations.AlterModelOptions(
-            name="runsnapshot",
-            options={"default_manager_name": "all_teams"},
-        ),
-        migrations.AlterModelOptions(
-            name="toleratedhash",
-            options={"default_manager_name": "all_teams"},
-        ),
         migrations.AlterModelManagers(
             name="artifact",
             managers=[
-                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
-                ("all_teams", models.Manager()),
+                ("all_teams", django.db.models.manager.Manager()),
             ],
         ),
         migrations.AlterModelManagers(
             name="quarantinedidentifier",
             managers=[
-                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
-                ("all_teams", models.Manager()),
+                ("all_teams", django.db.models.manager.Manager()),
             ],
         ),
         migrations.AlterModelManagers(
             name="repo",
             managers=[
-                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
-                ("all_teams", models.Manager()),
+                ("all_teams", django.db.models.manager.Manager()),
             ],
         ),
         migrations.AlterModelManagers(
             name="run",
             managers=[
-                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
-                ("all_teams", models.Manager()),
+                ("all_teams", django.db.models.manager.Manager()),
             ],
         ),
         migrations.AlterModelManagers(
             name="runsnapshot",
             managers=[
-                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
-                ("all_teams", models.Manager()),
+                ("all_teams", django.db.models.manager.Manager()),
             ],
         ),
         migrations.AlterModelManagers(
             name="toleratedhash",
             managers=[
-                ("objects", posthog.models.scoping.manager.TeamScopedManager()),
-                ("all_teams", models.Manager()),
+                ("all_teams", django.db.models.manager.Manager()),
             ],
         ),
     ]

--- a/products/visual_review/backend/migrations/max_migration.txt
+++ b/products/visual_review/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0010_backfill_change_kind_and_ssim
+0011_alter_artifact_managers_and_more


### PR DESCRIPTION
## Problem

`ProductTeamModel` declared `objects = TeamScopedManager()` first, which made it the `_default_manager`. Django framework internals (admin queryset, FK widget label rendering, related-object access, generic relations, `prefetch_related`, DRF default querysets) all read through `_default_manager` and expect an unfiltered manager — they'd raise `TeamScopeError` in any context without `team_scope` set (admin, shell, management commands, etc.).

## Changes

Set `Meta.default_manager_name = "all_teams"` on `ProductTeamModel` so `_default_manager` and `_base_manager` point at the unscoped plain `Manager`. Explicit `Model.objects.filter(...)` still resolves to `TeamScopedManager` and stays fail-closed.

Includes a state-only migration (no SQL) for visual_review models to record the new manager config in migration state.

Extracted from #57879 so the scoping fix can land independently of the admin work.

## How did you test this code?

Verified in local admin that `ProductTeamModel`-backed models no longer raise `TeamScopeError` on list/change views, FK widget rendering, and inline formsets. The migration is state-only — `sqlmigrate` emits no SQL.

## 🤖 Agent context

Extracted the `ProductTeamModel.Meta.default_manager_name` change, README update, and state-only migration from the visual_review admin PR (#57879) into a standalone prep PR. No admin classes, no semgrep rules, no skill changes — just the scoping fix.