### PR TITLE
feat(propdefs): filter posthog_eventproperty writes to type EVENT defs only

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -327,24 +327,30 @@ impl Event {
             }
 
             if !will_fit_in_postgres_column(key) {
+                let skipped = if parent_type == PropertyParentType::Event {
+                    2 // EventProperty + PropertyDefinition
+                } else {
+                    1 // PropertyDefinition only
+                };
                 metrics::counter!(
                     UPDATES_SKIPPED,
                     &[("reason", "property_name_wont_fit_in_postgres")]
                 )
-                .increment(2); // We're skipping one EventProperty, and one PropertyDefinition
+                .increment(skipped);
                 continue;
             }
 
-            // Property keys flow into posthog_eventproperty.property and
-            // posthog_propertydefinition.name — both text columns. Postgres rejects null bytes
-            // in text, so any payload with an embedded \u{0000} burns the full 3-retry cycle and
-            // is then dropped. Mirror the existing sanitize on event names (line 222 above).
-            updates.push(Update::EventProperty(EventProperty {
-                team_id: self.team_id,
-                project_id: self.project_id,
-                event: sanitize_string(&self.event),
-                property: sanitize_string(key),
-            }));
+            // posthog_eventproperty only tracks which properties appear on which events —
+            // person, group, and session properties have no meaningful event association
+            // and no read path consumes those rows.
+            if parent_type == PropertyParentType::Event {
+                updates.push(Update::EventProperty(EventProperty {
+                    team_id: self.team_id,
+                    project_id: self.project_id,
+                    event: sanitize_string(&self.event),
+                    property: sanitize_string(key),
+                }));
+            }
 
             let property_type = detect_property_type(key, value);
             let is_numerical = matches!(property_type, Some(PropertyValueType::Numeric));

--- a/rust/property-defs-rs/tests/batch_ingestion.rs
+++ b/rust/property-defs-rs/tests/batch_ingestion.rs
@@ -75,8 +75,8 @@ async fn test_group_batch_write(db: PgPool) {
     ));
     let mut updates =
         gen_test_event_updates("$groupidentify", 100, Some(PropertyParentType::Group));
-    // should decompose into 1 group event def, 100 prop defs (of group type), 100 event props
-    assert_eq!(updates.len(), 201);
+    // should decompose into 1 group event def, 100 prop defs (of group type), 0 event props
+    assert_eq!(updates.len(), 101);
 
     // TODO(eli): quick hack - until we refacor the group type hydration on AppContext,
     // we need to manually do this prior to passing to process_batch for the test
@@ -114,7 +114,7 @@ async fn test_group_batch_write(db: PgPool) {
             .fetch_one(&db)
             .await
             .unwrap();
-    assert_eq!(Some(100), event_props_count);
+    assert_eq!(Some(0), event_props_count);
 }
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
@@ -127,8 +127,8 @@ async fn test_person_batch_write(db: PgPool) {
     ));
     let updates =
         gen_test_event_updates("event_with_person", 100, Some(PropertyParentType::Person));
-    // should decompose into 1 event def, 100 event props, 100 prop defs (50 $set, 50 $set_once props)
-    assert_eq!(updates.len(), 201);
+    // should decompose into 1 event def, 0 event props, 100 prop defs (50 $set, 50 $set_once props)
+    assert_eq!(updates.len(), 101);
 
     process_batch(&config, cache, &db, updates).await;
 
@@ -151,7 +151,7 @@ async fn test_person_batch_write(db: PgPool) {
             .fetch_one(&db)
             .await
             .unwrap();
-    assert_eq!(Some(100), event_props_count);
+    assert_eq!(Some(0), event_props_count);
 }
 
 fn gen_test_event_updates(

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use property_defs_rs::types::{
     detect_property_type, get_floored_last_seen, Event, PropertyValueType, Update,
 };
-use serde_json::{Number, Value};
+use serde_json::{json, Number, Value};
 
 #[test]
 fn test_date_flooring() {
@@ -486,4 +486,153 @@ fn test_property_keys_are_sanitized_of_null_bytes() {
         saw_sanitized_property_definition,
         "expected at least one PropertyDefinition with the sanitized name: {updates:?}"
     );
+}
+
+#[test]
+fn test_event_properties_only_emitted_for_event_parent_type() {
+    let props = json!({
+        "url": "https://example.com",
+        "count": 42,
+        "$set": {
+            "email": "test@example.com",
+            "name": "Test User"
+        }
+    });
+    let event = Event {
+        team_id: 1,
+        project_id: 1,
+        event: "my_event".to_string(),
+        properties: Some(props.to_string()),
+    };
+
+    let updates = event.into_updates(1000);
+
+    let event_property_keys: Vec<&str> = updates
+        .iter()
+        .filter_map(|u| match u {
+            Update::EventProperty(ep) => Some(ep.property.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    // Only top-level event properties should produce EventProperty updates;
+    // $set is in SKIP_PROPERTIES so it's excluded from event-type processing
+    assert!(
+        event_property_keys.contains(&"url"),
+        "expected EventProperty for top-level 'url': {event_property_keys:?}"
+    );
+    assert!(
+        event_property_keys.contains(&"count"),
+        "expected EventProperty for top-level 'count': {event_property_keys:?}"
+    );
+    assert_eq!(
+        event_property_keys.len(),
+        2,
+        "expected exactly 2 EventProperty updates (url + count), got: {event_property_keys:?}"
+    );
+    // Person properties from $set must NOT produce EventProperty rows
+    assert!(
+        !event_property_keys.contains(&"email"),
+        "person property 'email' must not appear in EventProperty: {event_property_keys:?}"
+    );
+    assert!(
+        !event_property_keys.contains(&"name"),
+        "person property 'name' must not appear in EventProperty: {event_property_keys:?}"
+    );
+
+    // But person properties should still produce PropertyDefinition updates
+    let prop_def_names: Vec<&str> = updates
+        .iter()
+        .filter_map(|u| match u {
+            Update::Property(pd) => Some(pd.name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        prop_def_names.contains(&"email"),
+        "expected PropertyDefinition for person property 'email': {prop_def_names:?}"
+    );
+    assert!(
+        prop_def_names.contains(&"name"),
+        "expected PropertyDefinition for person property 'name': {prop_def_names:?}"
+    );
+}
+
+#[test]
+fn test_groupidentify_emits_zero_event_properties() {
+    let props = json!({
+        "$group_type": "company",
+        "$group_key": "posthog",
+        "$group_set": {
+            "name": "PostHog",
+            "industry": "Analytics"
+        }
+    });
+    let event = Event {
+        team_id: 1,
+        project_id: 1,
+        event: "$groupidentify".to_string(),
+        properties: Some(props.to_string()),
+    };
+
+    let updates = event.into_updates(1000);
+
+    let event_property_count = updates
+        .iter()
+        .filter(|u| matches!(u, Update::EventProperty(_)))
+        .count();
+
+    assert_eq!(
+        event_property_count, 0,
+        "expected zero EventProperty updates for $groupidentify, got {event_property_count}: {updates:?}"
+    );
+
+    // Group properties should still produce PropertyDefinition updates
+    let prop_def_names: Vec<&str> = updates
+        .iter()
+        .filter_map(|u| match u {
+            Update::Property(pd) => Some(pd.name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        prop_def_names.contains(&"name"),
+        "expected PropertyDefinition for group property 'name': {prop_def_names:?}"
+    );
+    assert!(
+        prop_def_names.contains(&"industry"),
+        "expected PropertyDefinition for group property 'industry': {prop_def_names:?}"
+    );
+}
+
+#[test]
+fn test_plain_event_properties_still_emitted() {
+    let props = json!({
+        "page": "/home",
+        "referrer": "https://google.com"
+    });
+    let event = Event {
+        team_id: 1,
+        project_id: 1,
+        event: "$pageview".to_string(),
+        properties: Some(props.to_string()),
+    };
+
+    let updates = event.into_updates(1000);
+
+    let event_property_keys: Vec<&str> = updates
+        .iter()
+        .filter_map(|u| match u {
+            Update::EventProperty(ep) => Some(ep.property.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        event_property_keys.len(),
+        2,
+        "expected exactly 2 EventProperty updates: {event_property_keys:?}"
+    );
+    assert!(event_property_keys.contains(&"page"));
+    assert!(event_property_keys.contains(&"referrer"));
 }


### PR DESCRIPTION
## Problem
After some research to confirm access patterns, I see that while we still only expect `posthog_eventproperty` rows to be written when the `posthog_propertydefinition` is of type `EVENT`, the filtering before pushing the `Update` enums into the buffer in `property-defs-rs` is only partially honoring this rule.

That means person and group props are overwriting these values for nothing. This is a no-op since the system invariant is that only ONE property key per team can be mapped to a data type across all events/prop types, it is causing undue load on the write path for this table.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Filter event property Updates (luckily, these are now split by outgoing table for batching in the v2 write path 😅  so this is possible!)
* Test updates to exercise this is working
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Small change.

Research confirmed all access paths respect and expect this behavior and due to overlapping prop names/classifications, aren't aware its not already this way. The effect is on the write vol from this bug.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
I thunk it, Claude wrotes it, I reviews it 🧠 
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
