### PR TITLE
feat(mcp): enable PostHog MCP analytics SDK

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3433,6 +3433,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@posthog/mcp-analytics':
+        specifier: npm:@posthog/mcp@0.0.2
+        version: '@posthog/mcp@0.0.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(rxjs@7.8.1)'
       '@posthog/mosaic':
         specifier: workspace:*
         version: link:../../common/mosaic
@@ -8849,6 +8852,9 @@ packages:
   '@posthog/core@1.23.1':
     resolution: {integrity: sha512-GViD5mOv/mcbZcyzz3z9CS0R79JzxVaqEz4sP5Dsea178M/j3ZWe6gaHDZB9yuyGfcmIMQ/8K14yv+7QrK4sQQ==}
 
+  '@posthog/core@1.28.3':
+    resolution: {integrity: sha512-SOy0aphKawZzp8jxfeOpTcXPwi6ii0I2V6tX8YXnM+WbxKKR/R+BXLK0jS6LV8kZtW3H5YxmPAfuIbUP1UnGTw==}
+
   '@posthog/core@1.28.4':
     resolution: {integrity: sha512-wmtUYHYqA3zIAKDKvYWRNWAQsWOIBwxV08e+bWzVy0wQQzpaS/LzzRupXWRMRrLOk+1x3JKFxbqA3n0QGvpqsQ==}
 
@@ -8885,6 +8891,12 @@ packages:
       kea-router: '*'
       react: 18.3.1
       react-dom: 18.3.1
+
+  '@posthog/mcp@0.0.2':
+    resolution: {integrity: sha512-sK0/kY/wyPXzWaX14UrBjA2wTo+K9mUmRfzDBUSDFyyDeZgxEMK2JK/0CeuEI0yXdpTja6rsDlMkRZjYakTFVA==}
+    engines: {node: '>=22.22.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.29.0
 
   '@posthog/react@1.9.0':
     resolution: {integrity: sha512-lVdTsWT5+PtHBu44gSQ7QohbLjAYqHkFAIGAQ+HV8Eh9yj+OcnQ7mXCmyhaMlTBD3z7D0H1eWMp4vQaFnsIyWQ==}
@@ -8926,6 +8938,9 @@ packages:
 
   '@posthog/types@1.372.10':
     resolution: {integrity: sha512-KuT3vLu3LSFsNWCwasS4gqjH/ysAyIUcB/aJSmKyNhDd/85hAznHRz1eSSl0sMvtsDTYiQIq0I0ybduVbrpPew==}
+
+  '@posthog/types@1.372.9':
+    resolution: {integrity: sha512-B7k9S+H9WUKHXxe1HOkQWbpWtMcrBvsodm5stZaLQ3pYxf9TowtwssdzTtX4hHjzSYqgrS1IpNnJX4vs1KgBzA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -20150,6 +20165,15 @@ packages:
   posthog-node@5.25.0:
     resolution: {integrity: sha512-DFE5lZAoD6hk7RATuT8qVQ7KFgFP5YlFTJciMbU2qq6NX0A8eJxiJcmEsMnB3g30jJJ9suiwGIq4I8ESwf9bZg==}
     engines: {node: ^20.20.0 || >=22.22.0}
+
+  posthog-node@5.33.3:
+    resolution: {integrity: sha512-6BkdRtRKf/y/j6JGXLUDWpruL9Rebpe2EtbSU3EB+yaI9ukTwEGT8XJQDyM8wcsxu1HdOnvAwN7gnOOu5OgY2A==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
 
   posthtml-parser@0.11.0:
     resolution: {integrity: sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==}
@@ -32015,6 +32039,10 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
+  '@posthog/core@1.28.3':
+    dependencies:
+      '@posthog/types': 1.372.9
+
   '@posthog/core@1.28.4':
     dependencies:
       '@posthog/types': 1.372.10
@@ -32056,6 +32084,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@posthog/mcp@0.0.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(rxjs@7.8.1)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      posthog-node: 5.33.3(rxjs@7.8.1)
+    transitivePeerDependencies:
+      - rxjs
+
   '@posthog/react@1.9.0(@types/react@18.3.27)(posthog-js@1.372.10)(react@18.3.1)':
     dependencies:
       posthog-js: 1.372.10
@@ -32096,6 +32131,8 @@ snapshots:
   '@posthog/siphash@1.1.1': {}
 
   '@posthog/types@1.372.10': {}
+
+  '@posthog/types@1.372.9': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -46681,6 +46718,12 @@ snapshots:
   posthog-node@5.25.0:
     dependencies:
       '@posthog/core': 1.23.1
+
+  posthog-node@5.33.3(rxjs@7.8.1):
+    dependencies:
+      '@posthog/core': 1.28.3
+    optionalDependencies:
+      rxjs: 7.8.1
 
   posthtml-parser@0.11.0:
     dependencies:

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -36,6 +36,7 @@
     "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.0.2",
         "@posthog/mosaic": "workspace:*",
         "@toon-format/toon": "^2.1.0",
         "agents": "0.10.2",

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -14,6 +14,36 @@ import type { CloudRegion } from '@/tools/types'
 
 import { MCP, RequestProperties } from './mcp'
 
+function extendMcpServerLog(log: RequestLogger, props: RequestProperties): void {
+    const mcpServerLog: Record<string, unknown> = {
+        ...(props.mcpAnalyticsProvider ? { mcpAnalyticsProvider: props.mcpAnalyticsProvider } : {}),
+        ...(props.mcpAnalyticsFlagKey ? { mcpAnalyticsFlagKey: props.mcpAnalyticsFlagKey } : {}),
+        ...(props.mcpAnalyticsFlagEnabled !== undefined
+            ? { mcpAnalyticsFlagEnabled: props.mcpAnalyticsFlagEnabled }
+            : {}),
+        ...(props.mcpAnalyticsFlagErrorName ? { mcpAnalyticsFlagErrorName: props.mcpAnalyticsFlagErrorName } : {}),
+        ...(props.mcpAnalyticsFlagErrorMessage
+            ? { mcpAnalyticsFlagErrorMessage: props.mcpAnalyticsFlagErrorMessage }
+            : {}),
+        ...(props.posthogMcpAnalyticsInitAction
+            ? { posthogMcpAnalyticsInitAction: props.posthogMcpAnalyticsInitAction }
+            : {}),
+        ...(props.posthogMcpAnalyticsInitReason
+            ? { posthogMcpAnalyticsInitReason: props.posthogMcpAnalyticsInitReason }
+            : {}),
+        ...(props.posthogMcpAnalyticsInitErrorName
+            ? { posthogMcpAnalyticsInitErrorName: props.posthogMcpAnalyticsInitErrorName }
+            : {}),
+        ...(props.posthogMcpAnalyticsInitErrorMessage
+            ? { posthogMcpAnalyticsInitErrorMessage: props.posthogMcpAnalyticsInitErrorMessage }
+            : {}),
+    }
+
+    if (Object.keys(mcpServerLog).length > 0) {
+        log.extend(mcpServerLog)
+    }
+}
+
 // Helper to get the public-facing URL, respecting reverse proxy headers
 // This is needed for local development with ngrok/cloudflared where request.url
 // shows http://localhost but the actual URL is https://...ngrok-free.dev
@@ -371,7 +401,16 @@ const handleRequest = async (
     }
 
     if (server !== null) {
-        return server.then(onThenErrorHandler).catch((error: Error) => onCatchErrorHandler(error, log, ctx))
+        return server
+            .then(async (response) => {
+                const handledResponse = await onThenErrorHandler(response)
+                extendMcpServerLog(log, ctx.props)
+                return handledResponse
+            })
+            .catch((error: Error) => {
+                extendMcpServerLog(log, ctx.props)
+                return onCatchErrorHandler(error, log, ctx)
+            })
     }
 
     log.extend({ error: 'route_not_found' })

--- a/services/mcp/src/lib/posthog-mcp-analytics.ts
+++ b/services/mcp/src/lib/posthog-mcp-analytics.ts
@@ -143,7 +143,6 @@ export async function initPostHogMcpAnalytics(
             reportMissingEnabled: true,
         }
     } catch (error) {
-        // Observability initialization must never block MCP server startup.
         return {
             action: 'failed',
             errorName: error instanceof Error ? error.name : 'UnknownError',

--- a/services/mcp/src/lib/posthog-mcp-analytics.ts
+++ b/services/mcp/src/lib/posthog-mcp-analytics.ts
@@ -9,9 +9,25 @@ export type PostHogMcpAnalyticsOptions = {
     contextEnabled: boolean
 }
 
-function logPostHogMcpAnalytics(data: Record<string, unknown>): void {
-    console.info('[MCP]', JSON.stringify({ event: 'posthog_mcp_analytics', ...data }))
-}
+export type PostHogMcpAnalyticsInitResult =
+    | {
+          action: 'initialized'
+          contextEnabled: boolean
+          tracingEnabled: true
+          aiTracingEnabled: true
+          reportMissingEnabled: true
+      }
+    | {
+          action: 'skipped'
+          reason: 'missing_config'
+          hasApiKey: boolean
+          hasHost: boolean
+      }
+    | {
+          action: 'failed'
+          errorName: string
+          errorMessage: string
+      }
 
 async function buildEventTags(identity: PostHogMcpAnalyticsIdentityProvider): Promise<Record<string, string>> {
     const sessionUuid = await identity.getSessionUuid()
@@ -84,17 +100,16 @@ export async function initPostHogMcpAnalytics(
     server: McpServer,
     identity: PostHogMcpAnalyticsIdentityProvider,
     options: PostHogMcpAnalyticsOptions = { contextEnabled: false }
-): Promise<void> {
+): Promise<PostHogMcpAnalyticsInitResult> {
     const posthogApiKey = env.POSTHOG_ANALYTICS_API_KEY
     const posthogHost = env.POSTHOG_ANALYTICS_HOST
     if (!posthogApiKey || !posthogHost) {
-        logPostHogMcpAnalytics({
+        return {
             action: 'skipped',
             reason: 'missing_config',
             hasApiKey: !!posthogApiKey,
             hasHost: !!posthogHost,
-        })
-        return
+        }
     }
 
     try {
@@ -119,19 +134,20 @@ export async function initPostHogMcpAnalytics(
             eventProperties: async () => buildEventProperties(identity),
             redactSensitiveInformation: (text) => Promise.resolve(redactSensitiveInformation(text)),
         })
-        logPostHogMcpAnalytics({
+
+        return {
             action: 'initialized',
             contextEnabled: options.contextEnabled,
             tracingEnabled: true,
             aiTracingEnabled: true,
             reportMissingEnabled: true,
-        })
+        }
     } catch (error) {
-        logPostHogMcpAnalytics({
+        // Observability initialization must never block MCP server startup.
+        return {
             action: 'failed',
             errorName: error instanceof Error ? error.name : 'UnknownError',
             errorMessage: error instanceof Error ? error.message : String(error),
-        })
-        // Observability initialization must never block MCP server startup.
+        }
     }
 }

--- a/services/mcp/src/lib/posthog-mcp-analytics.ts
+++ b/services/mcp/src/lib/posthog-mcp-analytics.ts
@@ -1,0 +1,137 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { env } from 'cloudflare:workers'
+
+import { type McpCatIdentityProvider, redactSensitiveInformation } from '@/lib/mcpcat'
+
+export type PostHogMcpAnalyticsIdentityProvider = McpCatIdentityProvider
+
+export type PostHogMcpAnalyticsOptions = {
+    contextEnabled: boolean
+}
+
+function logPostHogMcpAnalytics(data: Record<string, unknown>): void {
+    console.info('[MCP]', JSON.stringify({ event: 'posthog_mcp_analytics', ...data }))
+}
+
+async function buildEventTags(identity: PostHogMcpAnalyticsIdentityProvider): Promise<Record<string, string>> {
+    const sessionUuid = await identity.getSessionUuid()
+    if (!sessionUuid) {
+        return {}
+    }
+
+    return {
+        $session_id: sessionUuid,
+        $ai_session_id: sessionUuid,
+    }
+}
+
+async function buildEventProperties(identity: PostHogMcpAnalyticsIdentityProvider): Promise<Record<string, unknown>> {
+    const [
+        mcpVersion,
+        clientUserAgent,
+        mcpClientName,
+        mcpClientVersion,
+        mcpProtocolVersion,
+        mcpRegion,
+        analyticsContext,
+        oauthClientName,
+        readOnly,
+        transport,
+        mcpConsumer,
+        mcpMode,
+    ] = await Promise.all([
+        identity.getMcpVersion(),
+        identity.getClientUserAgent(),
+        identity.getMcpClientName(),
+        identity.getMcpClientVersion(),
+        identity.getMcpProtocolVersion(),
+        identity.getRegion(),
+        identity.getAnalyticsContext(),
+        identity.getOAuthClientName(),
+        identity.getReadOnly(),
+        identity.getTransport(),
+        identity.getMcpConsumer(),
+        identity.getMcpMode(),
+    ])
+
+    const groups = {
+        ...(analyticsContext?.organizationId ? { organization: analyticsContext.organizationId } : {}),
+        ...(analyticsContext?.projectUuid ? { project: analyticsContext.projectUuid } : {}),
+    }
+
+    return {
+        $ai_product: 'mcp',
+        $mcp_version: mcpVersion,
+        $mcp_client_user_agent: clientUserAgent,
+        $mcp_client_name: mcpClientName,
+        $mcp_client_version: mcpClientVersion,
+        $mcp_protocol_version: mcpProtocolVersion,
+        $mcp_region: mcpRegion,
+        $mcp_organization_id: analyticsContext?.organizationId,
+        $mcp_project_id: analyticsContext?.projectId,
+        $mcp_project_uuid: analyticsContext?.projectUuid,
+        $mcp_project_name: analyticsContext?.projectName,
+        $mcp_oauth_client_name: oauthClientName,
+        $mcp_read_only: readOnly,
+        $mcp_transport: transport,
+        $mcp_consumer: mcpConsumer,
+        $mcp_mode: mcpMode,
+        ...(Object.keys(groups).length > 0 ? { $groups: groups } : {}),
+    }
+}
+
+export async function initPostHogMcpAnalytics(
+    server: McpServer,
+    identity: PostHogMcpAnalyticsIdentityProvider,
+    options: PostHogMcpAnalyticsOptions = { contextEnabled: false }
+): Promise<void> {
+    const posthogApiKey = env.POSTHOG_ANALYTICS_API_KEY
+    const posthogHost = env.POSTHOG_ANALYTICS_HOST
+    if (!posthogApiKey || !posthogHost) {
+        logPostHogMcpAnalytics({
+            action: 'skipped',
+            reason: 'missing_config',
+            hasApiKey: !!posthogApiKey,
+            hasHost: !!posthogHost,
+        })
+        return
+    }
+
+    try {
+        const { track } = await import('@posthog/mcp-analytics')
+        const distinctId = await identity.getDistinctId()
+        const identifyResult = { userId: distinctId }
+
+        track(server, {
+            apiKey: posthogApiKey,
+            context: options.contextEnabled,
+            enableAITracing: true,
+            enableTracing: true,
+            host: posthogHost,
+            identify: async () => identifyResult,
+            posthogOptions: {
+                flushAt: 1,
+                flushInterval: 0,
+                host: posthogHost,
+            },
+            reportMissing: true,
+            eventTags: async () => buildEventTags(identity),
+            eventProperties: async () => buildEventProperties(identity),
+            redactSensitiveInformation: (text) => Promise.resolve(redactSensitiveInformation(text)),
+        })
+        logPostHogMcpAnalytics({
+            action: 'initialized',
+            contextEnabled: options.contextEnabled,
+            tracingEnabled: true,
+            aiTracingEnabled: true,
+            reportMissingEnabled: true,
+        })
+    } catch (error) {
+        logPostHogMcpAnalytics({
+            action: 'failed',
+            errorName: error instanceof Error ? error.name : 'UnknownError',
+            errorMessage: error instanceof Error ? error.message : String(error),
+        })
+        // Observability initialization must never block MCP server startup.
+    }
+}

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -29,6 +29,7 @@ import { handleToolError, wrapError } from '@/lib/errors'
 import { type QueryToolInfo } from '@/lib/instructions'
 import { InstructionsFormatter } from '@/lib/instructions-formatter'
 import { initMcpCatObservability } from '@/lib/mcpcat'
+import { initPostHogMcpAnalytics } from '@/lib/posthog-mcp-analytics'
 import { SessionManager } from '@/lib/SessionManager'
 import { StateManager } from '@/lib/StateManager'
 import { formatPrompt, type McpMode, sanitizeHeaderValue } from '@/lib/utils'
@@ -41,6 +42,7 @@ import { getToolDefinition } from '@/tools/toolDefinitions'
 import { type CloudRegion, type Context, type State, type Tool } from '@/tools/types'
 
 const instructionsFormatter = new InstructionsFormatter()
+const POSTHOG_MCP_ANALYTICS_FLAG = 'mcp-posthog-analytics-sdk'
 
 export type RequestProperties = {
     userHash: string
@@ -500,6 +502,7 @@ export class MCP extends McpAgent<Env> {
         const flagPromise = this.resolveVersionFlag()
         const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion)
         const singleExecPromise = this.resolveSingleExecFlag()
+        const posthogMcpAnalyticsPromise = this.resolvePostHogMcpAnalyticsFlag()
 
         // Seed cache with header-provided IDs before any fetches
         if (organizationId) {
@@ -528,10 +531,11 @@ export class MCP extends McpAgent<Env> {
             await context.stateManager.setDefaultOrganizationAndProject()
         }
 
-        const [flagVersion, toolFeatureFlags, singleExecFlagOn] = await Promise.all([
+        const [flagVersion, toolFeatureFlags, singleExecFlagOn, posthogMcpAnalyticsOn] = await Promise.all([
             flagPromise,
             toolFlagsPromise,
             singleExecPromise,
+            posthogMcpAnalyticsPromise,
             // Trigger OAuth introspection so the OAuth client name is cached before the useSingleExec decision below
             context.stateManager.getApiKey(),
         ])
@@ -699,7 +703,7 @@ export class MCP extends McpAgent<Env> {
             }
         }
 
-        await initMcpCatObservability(this.server, {
+        const mcpAnalyticsIdentity = {
             getDistinctId: () => this.getDistinctId(),
             getSessionUuid: async () =>
                 this.requestProperties.sessionId
@@ -714,14 +718,36 @@ export class MCP extends McpAgent<Env> {
             getAnalyticsContext: async () => this.getAnalyticsContextSafe(await this.getContext()),
             getClientUserAgent: async () => this.requestProperties.clientUserAgent,
             // Server-resolved version (may differ from the client-reported one because of
-            // the `mcp-version-2` feature flag), so mcpcat events line up with ours.
+            // the `mcp-version-2` feature flag), so observability events line up with ours.
             getMcpVersion: async () => version,
             getOAuthClientName: async () => (await this.cache.get('clientName')) || undefined,
             getReadOnly: async () => readOnly,
             getTransport: async () => this.requestProperties.transport,
             getMcpConsumer: async () => this.requestProperties.mcpConsumer,
             getMcpMode: async () => this.mcpMode,
-        })
+        }
+
+        console.info(
+            '[MCP]',
+            JSON.stringify({
+                event: 'mcp_analytics_provider_selected',
+                provider: posthogMcpAnalyticsOn ? 'posthog_mcp_analytics' : 'mcpcat',
+                flagKey: POSTHOG_MCP_ANALYTICS_FLAG,
+                flagEnabled: posthogMcpAnalyticsOn,
+                mcpVersion: version,
+                mcpMode: this.mcpMode,
+                transport: this.requestProperties.transport,
+                mcpConsumer: this.requestProperties.mcpConsumer,
+            })
+        )
+
+        if (posthogMcpAnalyticsOn) {
+            await initPostHogMcpAnalytics(this.server, mcpAnalyticsIdentity, {
+                contextEnabled: true,
+            })
+        } else {
+            await initMcpCatObservability(this.server, mcpAnalyticsIdentity)
+        }
 
         const initDurationMs = this.requestProperties.requestStartTime
             ? Date.now() - this.requestProperties.requestStartTime
@@ -750,7 +776,7 @@ export class MCP extends McpAgent<Env> {
 
     /**
      * Decide single-exec mode and the protocol version for this connection,
-     * stashing both on the instance so `trackEvent` and the mcpcat identity
+     * stashing both on the instance so `trackEvent` and observability identity
      * provider can emit `mcp_mode` / `mcp_version` on every downstream event
      * without re-deriving them.
      *
@@ -801,6 +827,25 @@ export class MCP extends McpAgent<Env> {
             const distinctId = await this.getDistinctId()
             return !!(await isFeatureFlagEnabled('mcp-single-exec-tool', distinctId))
         } catch {
+            return false
+        }
+    }
+
+    private async resolvePostHogMcpAnalyticsFlag(): Promise<boolean> {
+        try {
+            const distinctId = await this.getDistinctId()
+            return !!(await isFeatureFlagEnabled(POSTHOG_MCP_ANALYTICS_FLAG, distinctId))
+        } catch (error) {
+            console.warn(
+                '[MCP]',
+                JSON.stringify({
+                    event: 'mcp_analytics_provider_flag_error',
+                    flagKey: POSTHOG_MCP_ANALYTICS_FLAG,
+                    flagEnabled: false,
+                    errorName: error instanceof Error ? error.name : 'UnknownError',
+                    errorMessage: error instanceof Error ? error.message : String(error),
+                })
+            )
             return false
         }
     }

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -29,7 +29,7 @@ import { handleToolError, wrapError } from '@/lib/errors'
 import { type QueryToolInfo } from '@/lib/instructions'
 import { InstructionsFormatter } from '@/lib/instructions-formatter'
 import { initMcpCatObservability } from '@/lib/mcpcat'
-import { initPostHogMcpAnalytics } from '@/lib/posthog-mcp-analytics'
+import { initPostHogMcpAnalytics, type PostHogMcpAnalyticsInitResult } from '@/lib/posthog-mcp-analytics'
 import { SessionManager } from '@/lib/SessionManager'
 import { StateManager } from '@/lib/StateManager'
 import { formatPrompt, type McpMode, sanitizeHeaderValue } from '@/lib/utils'
@@ -43,6 +43,12 @@ import { type CloudRegion, type Context, type State, type Tool } from '@/tools/t
 
 const instructionsFormatter = new InstructionsFormatter()
 const POSTHOG_MCP_ANALYTICS_FLAG = 'mcp-posthog-analytics-sdk'
+type McpAnalyticsProvider = 'posthog_mcp_analytics' | 'mcpcat'
+type PostHogMcpAnalyticsFlagResult = {
+    enabled: boolean
+    errorName?: string
+    errorMessage?: string
+}
 
 export type RequestProperties = {
     userHash: string
@@ -64,6 +70,15 @@ export type RequestProperties = {
     transport?: 'streamable-http' | 'sse'
     viaSseRedirect?: boolean
     requestStartTime?: number
+    mcpAnalyticsProvider?: McpAnalyticsProvider
+    mcpAnalyticsFlagKey?: string
+    mcpAnalyticsFlagEnabled?: boolean
+    mcpAnalyticsFlagErrorName?: string
+    mcpAnalyticsFlagErrorMessage?: string
+    posthogMcpAnalyticsInitAction?: PostHogMcpAnalyticsInitResult['action']
+    posthogMcpAnalyticsInitReason?: string
+    posthogMcpAnalyticsInitErrorName?: string
+    posthogMcpAnalyticsInitErrorMessage?: string
 }
 
 export class MCP extends McpAgent<Env> {
@@ -502,7 +517,7 @@ export class MCP extends McpAgent<Env> {
         const flagPromise = this.resolveVersionFlag()
         const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion)
         const singleExecPromise = this.resolveSingleExecFlag()
-        const posthogMcpAnalyticsPromise = this.resolvePostHogMcpAnalyticsFlag()
+        const posthogMcpAnalyticsFlagPromise = this.resolvePostHogMcpAnalyticsFlag()
 
         // Seed cache with header-provided IDs before any fetches
         if (organizationId) {
@@ -531,14 +546,15 @@ export class MCP extends McpAgent<Env> {
             await context.stateManager.setDefaultOrganizationAndProject()
         }
 
-        const [flagVersion, toolFeatureFlags, singleExecFlagOn, posthogMcpAnalyticsOn] = await Promise.all([
+        const [flagVersion, toolFeatureFlags, singleExecFlagOn, posthogMcpAnalyticsFlag] = await Promise.all([
             flagPromise,
             toolFlagsPromise,
             singleExecPromise,
-            posthogMcpAnalyticsPromise,
+            posthogMcpAnalyticsFlagPromise,
             // Trigger OAuth introspection so the OAuth client name is cached before the useSingleExec decision below
             context.stateManager.getApiKey(),
         ])
+        const posthogMcpAnalyticsOn = posthogMcpAnalyticsFlag.enabled
 
         const oauthClientName = (await this.cache.get('clientName')) || undefined
 
@@ -727,23 +743,35 @@ export class MCP extends McpAgent<Env> {
             getMcpMode: async () => this.mcpMode,
         }
 
-        console.info(
-            '[MCP]',
-            JSON.stringify({
-                event: 'mcp_analytics_provider_selected',
-                provider: posthogMcpAnalyticsOn ? 'posthog_mcp_analytics' : 'mcpcat',
-                flagKey: POSTHOG_MCP_ANALYTICS_FLAG,
-                flagEnabled: posthogMcpAnalyticsOn,
-                mcpVersion: version,
-                mcpMode: this.mcpMode,
-                transport: this.requestProperties.transport,
-                mcpConsumer: this.requestProperties.mcpConsumer,
-            })
-        )
+        Object.assign(this.requestProperties, {
+            mcpAnalyticsProvider: posthogMcpAnalyticsOn ? 'posthog_mcp_analytics' : 'mcpcat',
+            mcpAnalyticsFlagKey: POSTHOG_MCP_ANALYTICS_FLAG,
+            mcpAnalyticsFlagEnabled: posthogMcpAnalyticsOn,
+            ...(posthogMcpAnalyticsFlag.errorName
+                ? { mcpAnalyticsFlagErrorName: posthogMcpAnalyticsFlag.errorName }
+                : {}),
+            ...(posthogMcpAnalyticsFlag.errorMessage
+                ? { mcpAnalyticsFlagErrorMessage: posthogMcpAnalyticsFlag.errorMessage }
+                : {}),
+        })
 
+        // @posthog/mcp is based on the MCP Cat wrapper and keeps tool tracing,
+        // AI spans, context capture, and get_more_tools for flagged sessions.
+        // Avoid initializing both wrappers because both patch tool handlers and
+        // would double-capture every call.
         if (posthogMcpAnalyticsOn) {
-            await initPostHogMcpAnalytics(this.server, mcpAnalyticsIdentity, {
+            const initResult = await initPostHogMcpAnalytics(this.server, mcpAnalyticsIdentity, {
                 contextEnabled: true,
+            })
+            Object.assign(this.requestProperties, {
+                posthogMcpAnalyticsInitAction: initResult.action,
+                ...(initResult.action === 'skipped' ? { posthogMcpAnalyticsInitReason: initResult.reason } : {}),
+                ...(initResult.action === 'failed'
+                    ? {
+                          posthogMcpAnalyticsInitErrorName: initResult.errorName,
+                          posthogMcpAnalyticsInitErrorMessage: initResult.errorMessage,
+                      }
+                    : {}),
             })
         } else {
             await initMcpCatObservability(this.server, mcpAnalyticsIdentity)
@@ -831,22 +859,16 @@ export class MCP extends McpAgent<Env> {
         }
     }
 
-    private async resolvePostHogMcpAnalyticsFlag(): Promise<boolean> {
+    private async resolvePostHogMcpAnalyticsFlag(): Promise<PostHogMcpAnalyticsFlagResult> {
         try {
             const distinctId = await this.getDistinctId()
-            return !!(await isFeatureFlagEnabled(POSTHOG_MCP_ANALYTICS_FLAG, distinctId))
+            return { enabled: !!(await isFeatureFlagEnabled(POSTHOG_MCP_ANALYTICS_FLAG, distinctId)) }
         } catch (error) {
-            console.warn(
-                '[MCP]',
-                JSON.stringify({
-                    event: 'mcp_analytics_provider_flag_error',
-                    flagKey: POSTHOG_MCP_ANALYTICS_FLAG,
-                    flagEnabled: false,
-                    errorName: error instanceof Error ? error.name : 'UnknownError',
-                    errorMessage: error instanceof Error ? error.message : String(error),
-                })
-            )
-            return false
+            return {
+                enabled: false,
+                errorName: error instanceof Error ? error.name : 'UnknownError',
+                errorMessage: error instanceof Error ? error.message : String(error),
+            }
         }
     }
 

--- a/services/mcp/tests/setup.ts
+++ b/services/mcp/tests/setup.ts
@@ -10,6 +10,11 @@ vi.mock('mcpcat', () => ({
     track: vi.fn(),
 }))
 
+// Mock PostHog MCP analytics module to avoid networked analytics in tests
+vi.mock('@posthog/mcp-analytics', () => ({
+    track: vi.fn(),
+}))
+
 // Mock cloudflare:workers module for Node.js test environment
 vi.mock('cloudflare:workers', () => ({
     env: {

--- a/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
+++ b/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
@@ -60,7 +60,7 @@ describe('initPostHogMcpAnalytics', () => {
         const server = new McpServer({ name: 'test', version: '1.0.0' })
         const identity = createMockIdentity()
 
-        await initPostHogMcpAnalytics(server, identity)
+        const result = await initPostHogMcpAnalytics(server, identity)
 
         expect(track).toHaveBeenCalledWith(
             server,
@@ -81,13 +81,14 @@ describe('initPostHogMcpAnalytics', () => {
                 reportMissing: true,
             })
         )
+        expect(result).toMatchObject({ action: 'initialized', contextEnabled: false })
     })
 
     it('enables required context only when explicitly requested', async () => {
         const server = new McpServer({ name: 'test', version: '1.0.0' })
         const identity = createMockIdentity()
 
-        await initPostHogMcpAnalytics(server, identity, { contextEnabled: true })
+        const result = await initPostHogMcpAnalytics(server, identity, { contextEnabled: true })
 
         expect(track).toHaveBeenCalledWith(
             server,
@@ -97,6 +98,7 @@ describe('initPostHogMcpAnalytics', () => {
                 reportMissing: true,
             })
         )
+        expect(result).toMatchObject({ action: 'initialized', contextEnabled: true })
     })
 
     it.each(['POSTHOG_ANALYTICS_API_KEY', 'POSTHOG_ANALYTICS_HOST'] as const)(
@@ -106,9 +108,10 @@ describe('initPostHogMcpAnalytics', () => {
             const server = new McpServer({ name: 'test', version: '1.0.0' })
             const identity = createMockIdentity()
 
-            await initPostHogMcpAnalytics(server, identity)
+            const result = await initPostHogMcpAnalytics(server, identity)
 
             expect(track).not.toHaveBeenCalled()
+            expect(result).toMatchObject({ action: 'skipped', reason: 'missing_config' })
         }
     )
 
@@ -196,7 +199,7 @@ describe('initPostHogMcpAnalytics', () => {
             throw new Error('PostHog MCP analytics init failed')
         })
 
-        await expect(initPostHogMcpAnalytics(server, identity)).resolves.toBeUndefined()
+        await expect(initPostHogMcpAnalytics(server, identity)).resolves.toMatchObject({ action: 'failed' })
     })
 
     it('swallows errors if analytics identity resolution throws', async () => {
@@ -205,7 +208,7 @@ describe('initPostHogMcpAnalytics', () => {
             getDistinctId: vi.fn().mockRejectedValue(new Error('identity unavailable')),
         })
 
-        await expect(initPostHogMcpAnalytics(server, identity)).resolves.toBeUndefined()
+        await expect(initPostHogMcpAnalytics(server, identity)).resolves.toMatchObject({ action: 'failed' })
         expect(track).not.toHaveBeenCalled()
     })
 })

--- a/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
+++ b/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
@@ -1,0 +1,211 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { env } from 'cloudflare:workers'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { track } from '@posthog/mcp-analytics'
+
+import { initPostHogMcpAnalytics, type PostHogMcpAnalyticsIdentityProvider } from '@/lib/posthog-mcp-analytics'
+
+const TEST_API_KEY = 'test-api-key'
+const TEST_HOST = 'https://test.posthog.com'
+
+describe('initPostHogMcpAnalytics', () => {
+    beforeEach(() => {
+        vi.mocked(track).mockClear()
+        env.POSTHOG_ANALYTICS_API_KEY = TEST_API_KEY
+        env.POSTHOG_ANALYTICS_HOST = TEST_HOST
+    })
+
+    function createMockIdentity(
+        overrides: Partial<PostHogMcpAnalyticsIdentityProvider> = {}
+    ): PostHogMcpAnalyticsIdentityProvider {
+        return {
+            getDistinctId: vi.fn().mockResolvedValue('user-123'),
+            getSessionUuid: vi.fn().mockResolvedValue('session-uuid-456'),
+            getMcpClientName: vi.fn().mockResolvedValue('claude-code'),
+            getMcpClientVersion: vi.fn().mockResolvedValue('1.2.3'),
+            getMcpProtocolVersion: vi.fn().mockResolvedValue('2024-11-05'),
+            getRegion: vi.fn().mockResolvedValue('us'),
+            getAnalyticsContext: vi.fn().mockResolvedValue({
+                organizationId: 'org-789',
+                projectId: 'proj-101',
+                projectUuid: 'proj-uuid-101',
+                projectName: 'Project 101',
+            }),
+            getClientUserAgent: vi.fn().mockResolvedValue('test-agent/1.0'),
+            getMcpVersion: vi.fn().mockResolvedValue(2),
+            getOAuthClientName: vi.fn().mockResolvedValue('PostHog Code'),
+            getReadOnly: vi.fn().mockResolvedValue(true),
+            getTransport: vi.fn().mockResolvedValue('streamable-http'),
+            getMcpConsumer: vi.fn().mockResolvedValue('posthog-code'),
+            getMcpMode: vi.fn().mockResolvedValue('cli'),
+            ...overrides,
+        }
+    }
+
+    function getTrackOptions(): {
+        identify: () => Promise<unknown>
+        eventTags: () => Promise<Record<string, string>>
+        eventProperties: () => Promise<Record<string, unknown>>
+    } {
+        const call = vi.mocked(track).mock.calls[0]!
+        return call[1] as {
+            identify: () => Promise<unknown>
+            eventTags: () => Promise<Record<string, string>>
+            eventProperties: () => Promise<Record<string, unknown>>
+        }
+    }
+
+    it('calls PostHog MCP analytics track with safe defaults', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        await initPostHogMcpAnalytics(server, identity)
+
+        expect(track).toHaveBeenCalledWith(
+            server,
+            expect.objectContaining({
+                apiKey: TEST_API_KEY,
+                context: false,
+                enableAITracing: true,
+                enableTracing: true,
+                host: TEST_HOST,
+                identify: expect.any(Function),
+                eventTags: expect.any(Function),
+                eventProperties: expect.any(Function),
+                posthogOptions: {
+                    flushAt: 1,
+                    flushInterval: 0,
+                    host: TEST_HOST,
+                },
+                reportMissing: true,
+            })
+        )
+    })
+
+    it('enables required context only when explicitly requested', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        await initPostHogMcpAnalytics(server, identity, { contextEnabled: true })
+
+        expect(track).toHaveBeenCalledWith(
+            server,
+            expect.objectContaining({
+                context: true,
+                enableAITracing: true,
+                reportMissing: true,
+            })
+        )
+    })
+
+    it.each(['POSTHOG_ANALYTICS_API_KEY', 'POSTHOG_ANALYTICS_HOST'] as const)(
+        'skips initialization when %s is not set',
+        async (envKey) => {
+            env[envKey] = undefined as unknown as string
+            const server = new McpServer({ name: 'test', version: '1.0.0' })
+            const identity = createMockIdentity()
+
+            await initPostHogMcpAnalytics(server, identity)
+
+            expect(track).not.toHaveBeenCalled()
+        }
+    )
+
+    it('identify callback resolves identity from provider', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        await initPostHogMcpAnalytics(server, identity)
+
+        expect(await getTrackOptions().identify()).toEqual({ userId: 'user-123' })
+    })
+
+    it('eventTags callback returns $session_id and $ai_session_id when available', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        await initPostHogMcpAnalytics(server, identity)
+
+        expect(await getTrackOptions().eventTags()).toEqual({
+            $session_id: 'session-uuid-456',
+            $ai_session_id: 'session-uuid-456',
+        })
+    })
+
+    it('eventTags callback returns empty when session uuid is undefined', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity({
+            getSessionUuid: vi.fn().mockResolvedValue(undefined),
+        })
+
+        await initPostHogMcpAnalytics(server, identity)
+
+        expect(await getTrackOptions().eventTags()).toEqual({})
+    })
+
+    it('eventProperties callback returns PostHog MCP context properties', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        await initPostHogMcpAnalytics(server, identity)
+
+        expect(await getTrackOptions().eventProperties()).toEqual({
+            $ai_product: 'mcp',
+            $mcp_version: 2,
+            $mcp_client_user_agent: 'test-agent/1.0',
+            $mcp_client_name: 'claude-code',
+            $mcp_client_version: '1.2.3',
+            $mcp_protocol_version: '2024-11-05',
+            $mcp_region: 'us',
+            $mcp_organization_id: 'org-789',
+            $mcp_project_id: 'proj-101',
+            $mcp_project_uuid: 'proj-uuid-101',
+            $mcp_project_name: 'Project 101',
+            $mcp_oauth_client_name: 'PostHog Code',
+            $mcp_read_only: true,
+            $mcp_transport: 'streamable-http',
+            $mcp_consumer: 'posthog-code',
+            $mcp_mode: 'cli',
+            $groups: {
+                organization: 'org-789',
+                project: 'proj-uuid-101',
+            },
+        })
+    })
+
+    it('eventProperties callback omits $groups when analytics context is unavailable', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity({
+            getAnalyticsContext: vi.fn().mockResolvedValue(undefined),
+        })
+
+        await initPostHogMcpAnalytics(server, identity)
+
+        const properties = await getTrackOptions().eventProperties()
+        expect(properties.$groups).toBeUndefined()
+        expect(properties.$mcp_organization_id).toBeUndefined()
+        expect(properties.$mcp_project_uuid).toBeUndefined()
+    })
+
+    it('swallows errors if PostHog MCP analytics track throws', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        vi.mocked(track).mockImplementationOnce(() => {
+            throw new Error('PostHog MCP analytics init failed')
+        })
+
+        await expect(initPostHogMcpAnalytics(server, identity)).resolves.toBeUndefined()
+    })
+
+    it('swallows errors if analytics identity resolution throws', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity({
+            getDistinctId: vi.fn().mockRejectedValue(new Error('identity unavailable')),
+        })
+
+        await expect(initPostHogMcpAnalytics(server, identity)).resolves.toBeUndefined()
+        expect(track).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Problem

We want to dogfood PostHog MCP analytics in the PostHog MCP server while keeping rollout safe. The MCP server currently initializes MCP Cat for all sessions, so we need a feature-flagged path that can initialize the new PostHog MCP analytics SDK for selected users without breaking startup or existing users.

## Changes

- Add the published `@posthog/mcp` SDK as an aliased MCP service dependency, imported as `@posthog/mcp-analytics` to avoid the service package name collision.
- Add a PostHog MCP analytics initializer that:
  - enables tool-call tracing, AI tracing, required context, and `get_more_tools` support through the SDK
  - attaches MCP workspace, client, transport, mode, session, and group properties to captured events
  - redacts sensitive data using the existing MCP redaction helper
  - skips or fails closed without blocking MCP server startup
- Gate the new provider behind the `mcp-posthog-analytics-sdk` feature flag. Users without the flag keep the existing MCP Cat path.
- Add structured logs for provider flag evaluation, provider selection, and PostHog MCP analytics initialization status.
- Add unit coverage for SDK initialization, context gating, event properties, session tags, missing config, and failure handling.

## How did you test this code?

I am an agent. I ran:

- `pnpm --filter @posthog/mcp exec vitest run tests/unit/posthog-mcp-analytics.test.ts`
- `pnpm --filter @posthog/mcp typecheck`

I also verified locally through `localhost:8787/mcp` that a feature-flagged session exposed required `context` on tools, registered `get_more_tools`, and captured `mcp_tool_call` plus `$ai_span` events with `$mcp_intent`, `$mcp_tool_name`, `$ai_trace_id`, and `$ai_span_id`.

## Publish to changelog?

No.

## Docs update

No docs update needed for this internal rollout path.

## 🤖 Agent context

Implemented with Codex from Lucas's prompts to safely enable the newly published PostHog MCP SDK inside the PostHog MCP server.

Key decisions:

- Keep MCP Cat as the fallback provider for users without the rollout flag.
- Use the `mcp-posthog-analytics-sdk` feature flag to gate the PostHog SDK path and required `context` behavior.
- Import the package as `@posthog/mcp-analytics` because `services/mcp/package.json` is already named `@posthog/mcp`.
- Make analytics initialization defensive: missing config, identity failures, or SDK initialization failures should log and return instead of failing MCP startup.
- Use existing MCP redaction before passing tool data to the SDK.
