### PR TITLE
chore(django): gtm to personhog moves in grou view

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -38,6 +38,9 @@ from posthog.models.group_type_mapping import (
     GROUP_TYPE_MAPPING_SERIALIZER_FIELDS,
     GroupTypeMapping,
     delete_group_type_mapping,
+    get_group_type_mapping_instance,
+    get_group_types_for_project,
+    group_type_dict_to_instance,
     invalidate_group_types_cache,
     update_group_type_mapping_fields,
 )
@@ -113,10 +116,16 @@ class GroupsTypesViewSet(
     def safely_get_queryset(self, queryset):
         return queryset.filter(project_id=self.team.project_id)
 
+    def list(self, request, *args, **kwargs):
+        group_types = get_group_types_for_project(self.team.project_id)
+        instances = [group_type_dict_to_instance(gt, self.team.project_id) for gt in group_types]
+        serializer = self.get_serializer(instances, many=True)
+        return response.Response(serializer.data)
+
     @action(detail=False, methods=["PATCH"], name="Update group types metadata")
     def update_metadata(self, request: request.Request, *args, **kwargs):
         for row in cast(list[dict], request.data):
-            instance = GroupTypeMapping.objects.get(  # nosemgrep: no-direct-persons-db-orm
+            instance = get_group_type_mapping_instance(
                 project_id=self.team.project_id, group_type_index=row["group_type_index"]
             )
             # Pre-populate the team FK cache so serializer access control checks
@@ -137,7 +146,7 @@ class GroupsTypesViewSet(
     @action(methods=["PUT"], detail=False)
     def create_detail_dashboard(self, request: request.Request, **kw):
         try:
-            group_type_mapping = GroupTypeMapping.objects.get(  # nosemgrep: no-direct-persons-db-orm
+            group_type_mapping = get_group_type_mapping_instance(
                 project_id=self.team.project_id, group_type_index=request.data["group_type_index"]
             )
         except GroupTypeMapping.DoesNotExist:
@@ -166,7 +175,7 @@ class GroupsTypesViewSet(
     @action(methods=["PUT"], detail=False)
     def set_default_columns(self, request: request.Request, **kw):
         try:
-            group_type_mapping = GroupTypeMapping.objects.get(  # nosemgrep: no-direct-persons-db-orm
+            group_type_mapping = get_group_type_mapping_instance(
                 project_id=self.team.project_id, group_type_index=request.data["group_type_index"]
             )
         except GroupTypeMapping.DoesNotExist:

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -1623,11 +1623,16 @@ class GroupsTypesViewSetTestCase(APIBaseTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Stale sentinel data must be gone — the list() call at the end of
-        # update_metadata re-populates the cache with fresh data via
-        # get_group_types_for_project().
-        self.assertNotEqual(cache.get(cache_key), [{"stale": True}])
-        self.assertNotEqual(cache.get(stale_cache_key), [{"stale": True}])
+        # update_metadata invalidates then repopulates via list() →
+        # get_group_types_for_project(). Verify real data came back.
+        fresh = cache.get(cache_key)
+        self.assertIsNotNone(fresh)
+        self.assertEqual(len(fresh), 1)
+        self.assertEqual(fresh[0]["group_type"], "organization")
+        fresh_stale = cache.get(stale_cache_key)
+        self.assertIsNotNone(fresh_stale)
+        self.assertEqual(len(fresh_stale), 1)
+        self.assertEqual(fresh_stale[0]["group_type"], "organization")
 
     def test_destroy_invalidates_cache(self):
         GroupTypeMapping.objects.create(

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -1623,8 +1623,11 @@ class GroupsTypesViewSetTestCase(APIBaseTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIsNone(cache.get(cache_key))
-        self.assertIsNone(cache.get(stale_cache_key))
+        # Stale sentinel data must be gone — the list() call at the end of
+        # update_metadata re-populates the cache with fresh data via
+        # get_group_types_for_project().
+        self.assertNotEqual(cache.get(cache_key), [{"stale": True}])
+        self.assertNotEqual(cache.get(stale_cache_key), [{"stale": True}])
 
     def test_destroy_invalidates_cache(self):
         GroupTypeMapping.objects.create(

--- a/posthog/models/group_type_mapping.py
+++ b/posthog/models/group_type_mapping.py
@@ -302,6 +302,73 @@ def get_group_types_for_projects(project_ids: list[int]) -> dict[int, list[dict[
     return result
 
 
+def get_group_type_mapping_instance(project_id: int, group_type_index: int) -> GroupTypeMapping:
+    """Fetch a single GroupTypeMapping model instance by project_id and group_type_index.
+
+    Routes through personhog first, falls back to ORM.
+    Raises GroupTypeMapping.DoesNotExist if not found.
+    """
+    from posthog.personhog_client.client import get_personhog_client
+    from posthog.personhog_client.converters import proto_group_type_mapping_to_model
+    from posthog.personhog_client.proto import GetGroupTypeMappingsByProjectIdRequest
+
+    client = get_personhog_client()
+    if client is not None:
+        try:
+            resp = client.get_group_type_mappings_by_project_id(
+                GetGroupTypeMappingsByProjectIdRequest(project_id=project_id)
+            )
+            for m in resp.mappings:
+                if m.group_type_index == group_type_index:
+                    PERSONHOG_ROUTING_TOTAL.labels(
+                        operation="get_group_type_mapping_instance",
+                        source="personhog",
+                        client_name=get_client_name(),
+                    ).inc()
+                    return proto_group_type_mapping_to_model(m)
+            raise GroupTypeMapping.DoesNotExist()
+        except GroupTypeMapping.DoesNotExist:
+            raise
+        except Exception:
+            PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
+                operation="get_group_type_mapping_instance",
+                source="personhog",
+                error_type="grpc_error",
+                client_name=get_client_name(),
+            ).inc()
+            logger.warning(
+                "personhog_get_group_type_mapping_instance_failure",
+                project_id=project_id,
+                group_type_index=group_type_index,
+                exc_info=True,
+            )
+
+    PERSONHOG_ROUTING_TOTAL.labels(
+        operation="get_group_type_mapping_instance",
+        source="django_orm",
+        client_name=get_client_name(),
+    ).inc()
+    return GroupTypeMapping.objects.get(  # nosemgrep: no-direct-persons-db-orm
+        project_id=project_id, group_type_index=group_type_index
+    )
+
+
+def group_type_dict_to_instance(data: dict[str, Any], project_id: int) -> GroupTypeMapping:
+    """Convert a dict from get_group_types_for_project() to a GroupTypeMapping model instance."""
+    obj = GroupTypeMapping(
+        project_id=project_id,
+        group_type=data["group_type"],
+        group_type_index=data["group_type_index"],
+        name_singular=data.get("name_singular"),
+        name_plural=data.get("name_plural"),
+        detail_dashboard_id=data.get("detail_dashboard_id"),
+        default_columns=data.get("default_columns"),
+        created_at=data.get("created_at"),
+    )
+    obj._state.adding = False
+    return obj
+
+
 def update_group_type_mapping_fields(
     instance: GroupTypeMapping,
     *,

--- a/posthog/models/test/test_group_type_mapping.py
+++ b/posthog/models/test/test_group_type_mapping.py
@@ -7,11 +7,14 @@ from parameterized import parameterized
 from posthog.models.group_type_mapping import (
     GROUP_TYPES_CACHE_KEY_PREFIX,
     GROUP_TYPES_STALE_CACHE_KEY_PREFIX,
+    GroupTypeMapping,
     clear_dashboard_from_group_type_mapping,
     delete_group_type_mapping,
+    get_group_type_mapping_instance,
     get_group_types_for_project,
     get_group_types_for_projects,
     get_group_types_for_team,
+    group_type_dict_to_instance,
     update_group_type_mapping_fields,
 )
 from posthog.utils import safe_cache_delete
@@ -851,3 +854,260 @@ class TestClearDashboardFromGroupTypeMapping(SimpleTestCase):
 
         mock_objects.using.assert_called_once()
         mock_errors_counter.labels.assert_called_once()
+
+
+class TestGetGroupTypeMappingInstance(SimpleTestCase):
+    def setUp(self):
+        self._client_patcher = patch(_CLIENT_PATCH, return_value=MagicMock())
+        self._client_patcher.start()
+
+    def tearDown(self):
+        self._client_patcher.stop()
+
+    @patch("posthog.models.group_type_mapping.GroupTypeMapping.objects")
+    @patch("posthog.models.group_type_mapping.PERSONHOG_ROUTING_TOTAL")
+    @patch(_CLIENT_PATCH)
+    def test_personhog_success_returns_model_instance(self, mock_get_client, mock_routing_counter, mock_objects):
+        from posthog.personhog_client.proto.generated.personhog.types.v1 import group_pb2
+
+        mock_client = MagicMock()
+        mock_client.get_group_type_mappings_by_project_id.return_value = group_pb2.GroupTypeMappingsResponse(
+            mappings=[
+                group_pb2.GroupTypeMapping(
+                    id=42,
+                    team_id=10,
+                    project_id=1,
+                    group_type="organization",
+                    group_type_index=0,
+                    name_singular="Org",
+                    name_plural="Orgs",
+                ),
+                group_pb2.GroupTypeMapping(
+                    id=43,
+                    team_id=10,
+                    project_id=1,
+                    group_type="company",
+                    group_type_index=1,
+                ),
+            ]
+        )
+        mock_get_client.return_value = mock_client
+
+        result = get_group_type_mapping_instance(project_id=1, group_type_index=0)
+
+        assert isinstance(result, GroupTypeMapping)
+        assert result.id == 42
+        assert result.team_id == 10
+        assert result.project_id == 1
+        assert result.group_type == "organization"
+        assert result.group_type_index == 0
+        assert result.name_singular == "Org"
+        assert result.name_plural == "Orgs"
+        assert result._state.adding is False
+        mock_objects.get.assert_not_called()
+        mock_routing_counter.labels.assert_called_with(
+            operation="get_group_type_mapping_instance", source="personhog", client_name="posthog-django"
+        )
+
+    @patch("posthog.models.group_type_mapping.GroupTypeMapping.objects")
+    @patch("posthog.models.group_type_mapping.PERSONHOG_ROUTING_TOTAL")
+    @patch(_CLIENT_PATCH)
+    def test_personhog_not_found_raises_does_not_exist(self, mock_get_client, mock_routing_counter, mock_objects):
+        from posthog.personhog_client.proto.generated.personhog.types.v1 import group_pb2
+
+        mock_client = MagicMock()
+        mock_client.get_group_type_mappings_by_project_id.return_value = group_pb2.GroupTypeMappingsResponse(
+            mappings=[
+                group_pb2.GroupTypeMapping(
+                    id=42, team_id=10, project_id=1, group_type="organization", group_type_index=0
+                ),
+            ]
+        )
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(GroupTypeMapping.DoesNotExist):
+            get_group_type_mapping_instance(project_id=1, group_type_index=99)
+
+        mock_objects.get.assert_not_called()
+
+    @patch("posthog.models.group_type_mapping.GroupTypeMapping.objects")
+    @patch("posthog.models.group_type_mapping.PERSONHOG_ROUTING_TOTAL")
+    @patch("posthog.models.group_type_mapping.PERSONHOG_ROUTING_ERRORS_TOTAL")
+    @patch(_CLIENT_PATCH)
+    def test_personhog_failure_falls_back_to_orm(
+        self, mock_get_client, mock_errors_counter, mock_routing_counter, mock_objects
+    ):
+        mock_client = MagicMock()
+        mock_client.get_group_type_mappings_by_project_id.side_effect = RuntimeError("grpc timeout")
+        mock_get_client.return_value = mock_client
+
+        orm_instance = MagicMock(spec=GroupTypeMapping)
+        mock_objects.get.return_value = orm_instance
+
+        result = get_group_type_mapping_instance(project_id=1, group_type_index=0)
+
+        assert result is orm_instance
+        mock_objects.get.assert_called_once_with(project_id=1, group_type_index=0)
+        mock_errors_counter.labels.assert_called_once_with(
+            operation="get_group_type_mapping_instance",
+            source="personhog",
+            error_type="grpc_error",
+            client_name="posthog-django",
+        )
+        mock_routing_counter.labels.assert_called_with(
+            operation="get_group_type_mapping_instance", source="django_orm", client_name="posthog-django"
+        )
+
+    @patch("posthog.models.group_type_mapping.GroupTypeMapping.objects")
+    @patch("posthog.models.group_type_mapping.PERSONHOG_ROUTING_TOTAL")
+    @patch(_CLIENT_PATCH)
+    def test_client_none_falls_back_to_orm(self, mock_get_client, mock_routing_counter, mock_objects):
+        mock_get_client.return_value = None
+
+        orm_instance = MagicMock(spec=GroupTypeMapping)
+        mock_objects.get.return_value = orm_instance
+
+        result = get_group_type_mapping_instance(project_id=1, group_type_index=0)
+
+        assert result is orm_instance
+        mock_objects.get.assert_called_once_with(project_id=1, group_type_index=0)
+        mock_routing_counter.labels.assert_called_with(
+            operation="get_group_type_mapping_instance", source="django_orm", client_name="posthog-django"
+        )
+
+    @patch("posthog.models.group_type_mapping.GroupTypeMapping.objects")
+    @patch("posthog.models.group_type_mapping.PERSONHOG_ROUTING_TOTAL")
+    @patch("posthog.models.group_type_mapping.PERSONHOG_ROUTING_ERRORS_TOTAL")
+    @patch(_CLIENT_PATCH)
+    def test_personhog_failure_orm_not_found_raises_does_not_exist(
+        self, mock_get_client, mock_errors_counter, mock_routing_counter, mock_objects
+    ):
+        mock_client = MagicMock()
+        mock_client.get_group_type_mappings_by_project_id.side_effect = RuntimeError("grpc timeout")
+        mock_get_client.return_value = mock_client
+
+        mock_objects.get.side_effect = GroupTypeMapping.DoesNotExist()
+
+        with self.assertRaises(GroupTypeMapping.DoesNotExist):
+            get_group_type_mapping_instance(project_id=1, group_type_index=99)
+
+    @patch("posthog.models.group_type_mapping.GroupTypeMapping.objects")
+    @patch("posthog.models.group_type_mapping.PERSONHOG_ROUTING_TOTAL")
+    @patch(_CLIENT_PATCH)
+    def test_personhog_empty_project_raises_does_not_exist(self, mock_get_client, mock_routing_counter, mock_objects):
+        from posthog.personhog_client.proto.generated.personhog.types.v1 import group_pb2
+
+        mock_client = MagicMock()
+        mock_client.get_group_type_mappings_by_project_id.return_value = group_pb2.GroupTypeMappingsResponse(
+            mappings=[]
+        )
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(GroupTypeMapping.DoesNotExist):
+            get_group_type_mapping_instance(project_id=1, group_type_index=0)
+
+        mock_objects.get.assert_not_called()
+
+
+class TestGroupTypeDictToInstance(SimpleTestCase):
+    def test_converts_dict_to_model_instance(self):
+        data = {
+            "group_type": "organization",
+            "group_type_index": 0,
+            "name_singular": "Org",
+            "name_plural": "Orgs",
+            "detail_dashboard_id": 42,
+            "default_columns": ["name", "email"],
+            "created_at": None,
+        }
+
+        result = group_type_dict_to_instance(data, project_id=1)
+
+        assert isinstance(result, GroupTypeMapping)
+        assert result.project_id == 1
+        assert result.group_type == "organization"
+        assert result.group_type_index == 0
+        assert result.name_singular == "Org"
+        assert result.name_plural == "Orgs"
+        assert result.detail_dashboard_id == 42
+        assert result.default_columns == ["name", "email"]
+        assert result._state.adding is False
+
+    def test_handles_none_values(self):
+        data = {
+            "group_type": "company",
+            "group_type_index": 1,
+            "name_singular": None,
+            "name_plural": None,
+            "detail_dashboard_id": None,
+            "default_columns": None,
+            "created_at": None,
+        }
+
+        result = group_type_dict_to_instance(data, project_id=5)
+
+        assert result.group_type == "company"
+        assert result.group_type_index == 1
+        assert result.name_singular is None
+        assert result.name_plural is None
+        assert result.detail_dashboard_id is None
+        assert result.default_columns is None
+        assert result._state.adding is False
+
+
+class TestProtoGroupTypeMappingToModel(SimpleTestCase):
+    def test_converts_proto_to_model_instance(self):
+        import json
+
+        from posthog.personhog_client.converters import proto_group_type_mapping_to_model
+        from posthog.personhog_client.proto.generated.personhog.types.v1 import group_pb2
+
+        proto = group_pb2.GroupTypeMapping(
+            id=42,
+            team_id=10,
+            project_id=1,
+            group_type="organization",
+            group_type_index=0,
+            name_singular="Org",
+            name_plural="Orgs",
+            default_columns=json.dumps(["name"]).encode(),
+            detail_dashboard_id=5,
+            created_at=1620000000000,
+        )
+
+        result = proto_group_type_mapping_to_model(proto)
+
+        assert isinstance(result, GroupTypeMapping)
+        assert result.id == 42
+        assert result.team_id == 10
+        assert result.project_id == 1
+        assert result.group_type == "organization"
+        assert result.group_type_index == 0
+        assert result.name_singular == "Org"
+        assert result.name_plural == "Orgs"
+        assert result.default_columns == ["name"]
+        assert result.detail_dashboard_id == 5
+        assert result.created_at is not None
+        assert result._state.adding is False
+
+    def test_handles_empty_proto_fields(self):
+        from posthog.personhog_client.converters import proto_group_type_mapping_to_model
+        from posthog.personhog_client.proto.generated.personhog.types.v1 import group_pb2
+
+        proto = group_pb2.GroupTypeMapping(
+            id=1,
+            team_id=10,
+            project_id=1,
+            group_type="",
+            group_type_index=0,
+        )
+
+        result = proto_group_type_mapping_to_model(proto)
+
+        assert result.group_type is None
+        assert result.name_singular is None
+        assert result.name_plural is None
+        assert result.detail_dashboard_id is None
+        assert result.default_columns is None
+        assert result.created_at is None
+        assert result._state.adding is False

--- a/posthog/models/test/test_group_type_mapping.py
+++ b/posthog/models/test/test_group_type_mapping.py
@@ -1104,7 +1104,7 @@ class TestProtoGroupTypeMappingToModel(SimpleTestCase):
 
         result = proto_group_type_mapping_to_model(proto)
 
-        assert result.group_type is None
+        assert result.group_type == ""
         assert result.name_singular is None
         assert result.name_plural is None
         assert result.detail_dashboard_id is None

--- a/posthog/personhog_client/converters.py
+++ b/posthog/personhog_client/converters.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from posthog.models.group.group import Group
+    from posthog.models.group_type_mapping import GroupTypeMapping
     from posthog.models.person import Person
     from posthog.personhog_client.proto.generated.personhog.types.v1 import group_pb2, person_pb2
 
@@ -50,6 +51,38 @@ def proto_group_type_mapping_to_result(mapping: group_pb2.GroupTypeMapping) -> G
         group_type=mapping.group_type,
         group_type_index=mapping.group_type_index,
     )
+
+
+def proto_group_type_mapping_to_model(mapping: group_pb2.GroupTypeMapping) -> GroupTypeMapping:
+    """Convert a proto GroupTypeMapping to a Django GroupTypeMapping model instance (unsaved).
+
+    The instance is NOT saved to the database. It carries data in memory
+    so that existing serializers and viewset code work without modification.
+    """
+    from posthog.models.group_type_mapping import GroupTypeMapping as GroupTypeMappingModel
+
+    default_columns: list[str] | None = None
+    if mapping.default_columns:
+        default_columns = json.loads(mapping.default_columns)
+
+    created_at: datetime | None = None
+    if mapping.created_at:
+        created_at = datetime.fromtimestamp(mapping.created_at / 1000, tz=UTC)
+
+    obj = GroupTypeMappingModel(
+        id=mapping.id,
+        team_id=mapping.team_id,
+        project_id=mapping.project_id,
+        group_type=mapping.group_type or None,
+        group_type_index=mapping.group_type_index,
+        name_singular=mapping.name_singular or None,
+        name_plural=mapping.name_plural or None,
+        detail_dashboard_id=mapping.detail_dashboard_id or None,
+        default_columns=default_columns,
+        created_at=created_at,
+    )
+    obj._state.adding = False
+    return obj
 
 
 def proto_person_to_model(

--- a/posthog/personhog_client/converters.py
+++ b/posthog/personhog_client/converters.py
@@ -73,7 +73,7 @@ def proto_group_type_mapping_to_model(mapping: group_pb2.GroupTypeMapping) -> Gr
         id=mapping.id,
         team_id=mapping.team_id,
         project_id=mapping.project_id,
-        group_type=mapping.group_type or None,
+        group_type=mapping.group_type,
         group_type_index=mapping.group_type_index,
         name_singular=mapping.name_singular or None,
         name_plural=mapping.name_plural or None,


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

The Groups view (`GroupsTypesViewSet`) was still querying `GroupTypeMapping` directly via the Django ORM in several places — `list()`, `update_metadata()`, `create_detail_dashboard()`, and `set_default_columns()`.
This needs to be migrated to route through the personhog gRPC client (with ORM fallback) as part of the broader personhog dual-read migration for person/group data.


## Changes

- **`ee/clickhouse/views/groups.py`**: Override `list()` to use `get_group_types_for_project()` (already personhog-routed) instead of the default queryset. Replace three `GroupTypeMapping.objects.get(...)` calls in `update_metadata`, `create_detail_dashboard`, and `set_default_columns` with the new `get_group_type_mapping_instance()` helper.
- **`posthog/models/group_type_mapping.py`**: Add `get_group_type_mapping_instance()` — a personhog-routed helper that fetches a single `GroupTypeMapping` by project_id + group_type_index, with ORM fallback and metrics. Add `group_type_dict_to_instance()` to convert dicts from `get_group_types_for_project()` into model instances for serializer compatibility.
- **`posthog/personhog_client/converters.py`**: Add `proto_group_type_mapping_to_model()` to convert proto `GroupTypeMapping` to a Django model instance (unsaved, in-memory only) so existing serializers work without changes.
- **Tests**: Updated the cache invalidation test in `test_clickhouse_groups.py` to reflect that `list()` now repopulates the cache after invalidation. Added comprehensive unit tests for `get_group_type_mapping_instance()`, `group_type_dict_to_instance()`, and `proto_group_type_mapping_to_model()`.


## How did you test this code?

Unit tests covering personhog success path, not-found, gRPC failure fallback to ORM, and null client fallback. Existing groups API tests verify end-to-end behavior.
