### PR TITLE
chore(groups): django group list view to personhog

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -1,9 +1,10 @@
+import json as _json
+import base64
 from collections import defaultdict
 from typing import Any, Optional, cast
+from urllib.parse import urlencode
 
 from django.db import IntegrityError, transaction
-from django.db.models import Q
-from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
 import structlog
@@ -33,7 +34,7 @@ from posthog.models.activity_logging.activity_log import Change, Detail, load_ac
 from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.filters.utils import GroupTypeIndex
 from posthog.models.group import Group
-from posthog.models.group.util import create_group, raw_create_group_ch, save_group
+from posthog.models.group.util import create_group, get_group_by_key, list_groups, raw_create_group_ch, save_group
 from posthog.models.group_type_mapping import (
     GROUP_TYPE_MAPPING_SERIALIZER_FIELDS,
     GroupTypeMapping,
@@ -59,6 +60,18 @@ from ee.clickhouse.views.exceptions import TriggerGroupIdentifyException
 
 logger = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
+
+
+def _encode_groups_cursor(created_at_ms: int, group_id: int) -> str:
+    return base64.urlsafe_b64encode(_json.dumps({"c": created_at_ms, "i": group_id}).encode()).decode()
+
+
+def _decode_groups_cursor(cursor: str) -> tuple[int, int]:
+    try:
+        data = _json.loads(base64.urlsafe_b64decode(cursor))
+        return int(data.get("c", 0)), int(data.get("i", 0))
+    except Exception:
+        return 0, 0
 
 
 def detect_group_property_type(value):
@@ -244,13 +257,10 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
 
     def safely_get_object(self, queryset):
         group_type_index, group_key = self._safely_get_query_params(require_group_key=True)
-
-        queryset = queryset.filter(
-            group_type_index=group_type_index,
-            group_key=group_key,
-        )
-
-        return get_object_or_404(queryset)
+        group = get_group_by_key(self.team.pk, int(group_type_index), group_key)
+        if group is None:
+            raise NotFound()
+        return group
 
     def get_group_type_mapping_or_404(self, group_type_index: GroupTypeIndex) -> GroupTypeMappingResult:
         from posthog.models.group_type_mapping import get_group_types_for_project
@@ -308,7 +318,13 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
                 "search",
                 OpenApiTypes.STR,
                 description="Search the group name",
-                required=True,
+                required=False,
+            ),
+            OpenApiParameter(
+                "cursor",
+                OpenApiTypes.STR,
+                description="Pagination cursor returned in the `next` URL of a previous response",
+                required=False,
             ),
         ]
     )
@@ -316,7 +332,8 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
         """
         List all groups of a specific group type. You must pass ?group_type_index= in the URL. To get a list of valid group types, call /api/:project_id/groups_types/
         """
-        if not self.request.GET.get("group_type_index"):
+        group_type_index_str = self.request.GET.get("group_type_index")
+        if not group_type_index_str:
             raise ValidationError(
                 {
                     "group_type_index": [
@@ -324,19 +341,43 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
                     ]
                 }
             )
-        queryset = self.filter_queryset(self.get_queryset())
+        try:
+            group_type_index = int(group_type_index_str)
+        except ValueError:
+            raise ValidationError({"group_type_index": ["A valid integer is required."]})
 
-        group_search = self.request.GET.get("search")
-        if group_search is not None:
-            queryset = queryset.filter(Q(group_properties__icontains=group_search) | Q(group_key__iexact=group_search))
+        group_search = self.request.GET.get("search", "")
+        group_key = self.request.GET.get("group_key", "")
 
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
+        cursor_created_at_ms = 0
+        cursor_id = 0
+        cursor_param = self.request.GET.get("cursor")
+        if cursor_param:
+            cursor_created_at_ms, cursor_id = _decode_groups_cursor(cursor_param)
 
-        serializer = self.get_serializer(queryset, many=True)
-        return response.Response(serializer.data)
+        result = list_groups(
+            team_id=self.team.pk,
+            group_type_index=group_type_index,
+            group_key_contains=group_key,
+            search=group_search,
+            cursor_created_at_ms=cursor_created_at_ms,
+            cursor_id=cursor_id,
+        )
+
+        serializer = self.get_serializer(result.groups, many=True)
+
+        next_url = None
+        if result.has_more and result.groups:
+            last = result.groups[-1]
+            cursor = _encode_groups_cursor(int(last.created_at.timestamp() * 1000), last.id)
+            params: dict[str, str | int] = {"group_type_index": group_type_index, "cursor": cursor}
+            if group_search:
+                params["search"] = group_search
+            if group_key:
+                params["group_key"] = group_key
+            next_url = request.build_absolute_uri(f"{request.path}?{urlencode(params)}")
+
+        return response.Response({"next": next_url, "previous": None, "results": serializer.data})
 
     @extend_schema(request=CreateGroupSerializer, responses={status.HTTP_201_CREATED: serializer_classes["default"]})
     def create(self, request, *args, **kwargs):
@@ -418,28 +459,27 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
     )
     @action(methods=["GET"], detail=False, required_scopes=["group:read"])
     def find(self, request: request.Request, **kw) -> response.Response:
-        _, group_key = self._safely_get_query_params(require_group_key=True)
-        try:
-            group = self.get_queryset().get(group_key=group_key)
-            if (
-                self._is_crm_enabled(cast(User, request.user))
-                and not ResourceNotebook.objects.filter(group=group.id).exists()
-            ):
-                try:
-                    self._create_notebook_for_group(group=group)
-                except IntegrityError as e:
-                    logger.exception(
-                        "Group notebook creation failed",
-                        group_key=group.group_key,
-                        group_type_index=group.group_type_index,
-                        team_id=self.team.pk,
-                        error=e,
-                    )
-
-            data = self.get_serializer(group).data
-            return response.Response(data)
-        except Group.DoesNotExist:
+        group_type_index, group_key = self._safely_get_query_params(require_group_key=True)
+        group = get_group_by_key(self.team.pk, int(group_type_index), group_key)
+        if group is None:
             raise NotFound()
+        if (
+            self._is_crm_enabled(cast(User, request.user))
+            and not ResourceNotebook.objects.filter(group=group.id).exists()
+        ):
+            try:
+                self._create_notebook_for_group(group=group)
+            except IntegrityError as e:
+                logger.exception(
+                    "Group notebook creation failed",
+                    group_key=group.group_key,
+                    group_type_index=group.group_type_index,
+                    team_id=self.team.pk,
+                    error=e,
+                )
+
+        data = self.get_serializer(group).data
+        return response.Response(data)
 
     @extend_schema(
         parameters=[

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -16,7 +16,6 @@ from opentelemetry import trace
 from requests import HTTPError
 from rest_framework import mixins, request, response, serializers, status, viewsets
 from rest_framework.exceptions import NotFound, ValidationError
-from rest_framework.pagination import CursorPagination
 
 from posthog.schema import ProductKey
 
@@ -199,11 +198,6 @@ class GroupsTypesViewSet(
         return response.Response(self.get_serializer(group_type_mapping).data)
 
 
-class GroupCursorPagination(CursorPagination):
-    ordering = "-created_at"
-    page_size = 100
-
-
 class GroupSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Group
@@ -234,7 +228,7 @@ class CreateGroupSerializer(serializers.ModelSerializer):
 class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.CreateModelMixin, viewsets.GenericViewSet):
     scope_object = "group"
     queryset = Group.objects.all()  # nosemgrep: no-direct-persons-db-orm
-    pagination_class = GroupCursorPagination
+    pagination_class = None
     serializer_classes = {
         "find": FindGroupSerializer,
         "default": GroupSerializer,
@@ -346,7 +340,11 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
     )
     def list(self, request, *args, **kwargs):
         """
-        List all groups of a specific group type. You must pass ?group_type_index= in the URL. To get a list of valid group types, call /api/:project_id/groups_types/
+        List all groups of a specific group type. You must pass ?group_type_index= in the URL.
+        To get a list of valid group types, call /api/:project_id/groups_types/.
+
+        Uses forward-only keyset pagination via the `cursor` parameter.
+        The `previous` field in the response envelope is always null.
         """
         group_type_index_str = self.request.GET.get("group_type_index")
         if not group_type_index_str:

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -365,18 +365,18 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
         group_search = self.request.GET.get("search", "")
         group_key = self.request.GET.get("group_key", "")
 
-        cursor_created_at_ms = 0
+        cursor_created_at_us = 0
         cursor_id = 0
         cursor_param = self.request.GET.get("cursor")
         if cursor_param:
-            cursor_created_at_ms, cursor_id = _decode_groups_cursor(cursor_param)
+            cursor_created_at_us, cursor_id = _decode_groups_cursor(cursor_param)
 
         result = list_groups(
             team_id=self.team.pk,
             group_type_index=group_type_index,
             group_key_contains=group_key,
             search=group_search,
-            cursor_created_at_ms=cursor_created_at_ms,
+            cursor_created_at_us=cursor_created_at_us,
             cursor_id=cursor_id,
         )
 

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -1,7 +1,7 @@
 import json as _json
 import base64
 from collections import defaultdict
-from typing import Any, Optional, cast
+from typing import Any, Literal, Optional, cast, overload
 from urllib.parse import urlencode
 
 from django.db import IntegrityError, transaction
@@ -62,14 +62,18 @@ logger = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
 
 
-def _encode_groups_cursor(created_at_ms: int, group_id: int) -> str:
-    return base64.urlsafe_b64encode(_json.dumps({"c": created_at_ms, "i": group_id}).encode()).decode()
+def _encode_groups_cursor(created_at_us: int, group_id: int) -> str:
+    return base64.urlsafe_b64encode(_json.dumps({"c": created_at_us, "i": group_id}).encode()).decode()
 
 
 def _decode_groups_cursor(cursor: str) -> tuple[int, int]:
     try:
         data = _json.loads(base64.urlsafe_b64decode(cursor))
-        return int(data.get("c", 0)), int(data.get("i", 0))
+        raw_ts = int(data.get("c", 0))
+        group_id = int(data.get("i", 0))
+        if 0 < raw_ts < 1e15:
+            raw_ts *= 1000
+        return raw_ts, group_id
     except Exception:
         return 0, 0
 
@@ -239,6 +243,12 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
     def get_serializer_class(self):
         return self.serializer_classes.get(self.action, self.serializer_classes["default"])
 
+    @overload
+    def _safely_get_query_params(self, require_group_key: Literal[True]) -> tuple[str, str]: ...
+
+    @overload
+    def _safely_get_query_params(self, require_group_key: bool = ...) -> tuple[str, str | None]: ...
+
     def _safely_get_query_params(self, require_group_key: bool = False) -> tuple[str, str | None]:
         group_type_index = self.request.GET.get("group_type_index")
         if not group_type_index:
@@ -326,6 +336,12 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
                 description="Pagination cursor returned in the `next` URL of a previous response",
                 required=False,
             ),
+            OpenApiParameter(
+                "group_key",
+                OpenApiTypes.STR,
+                description="Filter groups whose key contains this string (case-insensitive)",
+                required=False,
+            ),
         ]
     )
     def list(self, request, *args, **kwargs):
@@ -369,7 +385,7 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
         next_url = None
         if result.has_more and result.groups:
             last = result.groups[-1]
-            cursor = _encode_groups_cursor(int(last.created_at.timestamp() * 1000), last.id)
+            cursor = _encode_groups_cursor(int(last.created_at.timestamp() * 1_000_000), last.id)
             params: dict[str, str | int] = {"group_type_index": group_type_index, "cursor": cursor}
             if group_search:
                 params["search"] = group_search

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -2320,7 +2320,7 @@ class TestListGroupsFunction(ClickhouseTestMixin, APIBaseTest):
         page2 = list_groups(
             team_id=self.team.pk,
             group_type_index=0,
-            cursor_created_at_ms=int(last.created_at.timestamp() * 1_000_000),
+            cursor_created_at_us=int(last.created_at.timestamp() * 1_000_000),
             cursor_id=last.id,
             limit=2,
         )

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -2622,3 +2622,187 @@ class TestGroupsListAPIContract(ClickhouseTestMixin, APIBaseTest):
         assert len(response_data["results"]) == 1
         assert response_data["results"][0]["group_key"] == "org:fallback"
         assert response_data["results"][0]["group_properties"] == {"name": "Fallback Org"}
+
+
+class TestGroupsListPersonhogORMParity(ClickhouseTestMixin, APIBaseTest):
+    """Verify the personhog path and ORM fallback path produce identical API responses.
+
+    Each test creates data in the DB, then compares the serialized `results` array
+    from both paths to ensure field names, types, ordering, and values match exactly.
+    """
+
+    def _build_proto_from_group(self, group):
+        from posthog.personhog_client.proto.generated.personhog.types.v1.group_pb2 import Group as ProtoGroup
+
+        return ProtoGroup(
+            id=group.id,
+            team_id=group.team_id,
+            group_type_index=group.group_type_index,
+            group_key=group.group_key,
+            group_properties=json.dumps(group.group_properties).encode(),
+            created_at=int(group.created_at.timestamp() * 1000),
+            version=group.version if group.version is not None else 0,
+        )
+
+    def _get_orm_response(self, url: str) -> dict:
+        with patch("posthog.personhog_client.client.get_personhog_client", return_value=None):
+            return self.client.get(url).json()
+
+    def _get_personhog_response(self, url: str, groups: list, has_more: bool = False) -> dict:
+        from posthog.personhog_client.proto import ListGroupsResponse
+
+        proto_groups = [self._build_proto_from_group(g) for g in groups]
+        mock_response = ListGroupsResponse(groups=proto_groups, has_more=has_more)
+        mock_client = MagicMock()
+        mock_client.list_groups.return_value = mock_response
+        with patch("posthog.personhog_client.client.get_personhog_client", return_value=mock_client):
+            return self.client.get(url).json()
+
+    @freeze_time("2021-05-02")
+    def test_single_group_field_parity(self):
+        group = create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:parity",
+            properties={"name": "Parity Test", "count": 42},
+        )
+
+        url = f"/api/projects/{self.team.id}/groups?group_type_index=0"
+        orm_response = self._get_orm_response(url)
+        phog_response = self._get_personhog_response(url, [group])
+
+        assert orm_response.keys() == phog_response.keys(), "Top-level response keys must match"
+        assert len(orm_response["results"]) == len(phog_response["results"]) == 1
+
+        orm_item = orm_response["results"][0]
+        phog_item = phog_response["results"][0]
+
+        assert set(orm_item.keys()) == set(phog_item.keys()), (
+            f"Result field names must match: ORM={set(orm_item.keys())}, personhog={set(phog_item.keys())}"
+        )
+        for key in orm_item:
+            assert orm_item[key] == phog_item[key], (
+                f"Field '{key}' differs: ORM={orm_item[key]!r}, personhog={phog_item[key]!r}"
+            )
+
+    @freeze_time("2021-05-03")
+    def test_multiple_groups_ordering_parity(self):
+        with freeze_time("2021-05-01"):
+            g1 = create_group(
+                team_id=self.team.pk, group_type_index=0, group_key="org:oldest", properties={"name": "Oldest"}
+            )
+        with freeze_time("2021-05-02"):
+            g2 = create_group(
+                team_id=self.team.pk, group_type_index=0, group_key="org:middle", properties={"name": "Middle"}
+            )
+        with freeze_time("2021-05-03"):
+            g3 = create_group(
+                team_id=self.team.pk, group_type_index=0, group_key="org:newest", properties={"name": "Newest"}
+            )
+
+        url = f"/api/projects/{self.team.id}/groups?group_type_index=0"
+        orm_response = self._get_orm_response(url)
+        phog_response = self._get_personhog_response(url, [g3, g2, g1])
+
+        orm_keys = [r["group_key"] for r in orm_response["results"]]
+        phog_keys = [r["group_key"] for r in phog_response["results"]]
+        assert orm_keys == phog_keys, f"Ordering must match: ORM={orm_keys}, personhog={phog_keys}"
+
+        for orm_item, phog_item in zip(orm_response["results"], phog_response["results"]):
+            for key in orm_item:
+                assert orm_item[key] == phog_item[key], (
+                    f"Field '{key}' differs for group_key={orm_item['group_key']}: "
+                    f"ORM={orm_item[key]!r}, personhog={phog_item[key]!r}"
+                )
+
+    @freeze_time("2021-05-02")
+    def test_empty_properties_parity(self):
+        group = create_group(team_id=self.team.pk, group_type_index=0, group_key="org:empty", properties={})
+
+        url = f"/api/projects/{self.team.id}/groups?group_type_index=0"
+        orm_response = self._get_orm_response(url)
+        phog_response = self._get_personhog_response(url, [group])
+
+        assert orm_response["results"][0]["group_properties"] == phog_response["results"][0]["group_properties"] == {}
+
+    @freeze_time("2021-05-02")
+    def test_created_at_serialization_parity(self):
+        group = create_group(team_id=self.team.pk, group_type_index=0, group_key="org:ts", properties={})
+
+        url = f"/api/projects/{self.team.id}/groups?group_type_index=0"
+        orm_response = self._get_orm_response(url)
+        phog_response = self._get_personhog_response(url, [group])
+
+        orm_ts = orm_response["results"][0]["created_at"]
+        phog_ts = phog_response["results"][0]["created_at"]
+        assert orm_ts == phog_ts, f"created_at serialization must match: ORM={orm_ts!r}, personhog={phog_ts!r}"
+
+    @freeze_time("2021-05-02")
+    def test_search_results_parity(self):
+        g1 = create_group(
+            team_id=self.team.pk, group_type_index=0, group_key="org:match", properties={"name": "Matching Org"}
+        )
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:other", properties={"name": "Other Org"})
+
+        url = f"/api/projects/{self.team.id}/groups?group_type_index=0&search=Matching"
+        orm_response = self._get_orm_response(url)
+        phog_response = self._get_personhog_response(url, [g1])
+
+        assert len(orm_response["results"]) == len(phog_response["results"]) == 1
+        assert orm_response["results"][0]["group_key"] == phog_response["results"][0]["group_key"] == "org:match"
+
+    @freeze_time("2021-05-02")
+    def test_pagination_next_url_parity(self):
+        groups = []
+        for i in range(3):
+            with freeze_time(f"2021-05-0{i + 1}"):
+                groups.append(
+                    create_group(
+                        team_id=self.team.pk,
+                        group_type_index=0,
+                        group_key=f"org:{i}",
+                        properties={},
+                    )
+                )
+
+        url = f"/api/projects/{self.team.id}/groups?group_type_index=0"
+
+        orm_response = self._get_orm_response(url)
+        assert orm_response["next"] is None, "ORM: all groups fit in one page"
+
+        phog_response = self._get_personhog_response(url, list(reversed(groups)), has_more=True)
+        assert phog_response["next"] is not None, "personhog: has_more=True should produce next URL"
+        assert "cursor=" in phog_response["next"]
+        assert "group_type_index=0" in phog_response["next"]
+
+    @freeze_time("2021-05-02")
+    def test_response_envelope_keys_match(self):
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:1", properties={})
+
+        url = f"/api/projects/{self.team.id}/groups?group_type_index=0"
+        orm_response = self._get_orm_response(url)
+
+        expected_keys = {"next", "previous", "results"}
+        assert set(orm_response.keys()) == expected_keys, f"Response keys must be exactly {expected_keys}"
+
+        result_keys = {"group_type_index", "group_key", "group_properties", "created_at"}
+        assert set(orm_response["results"][0].keys()) == result_keys, f"Result item keys must be exactly {result_keys}"
+
+    @freeze_time("2021-05-02")
+    def test_result_field_types(self):
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:types",
+            properties={"key": "val"},
+        )
+
+        url = f"/api/projects/{self.team.id}/groups?group_type_index=0"
+        orm_response = self._get_orm_response(url)
+        result = orm_response["results"][0]
+
+        assert isinstance(result["group_type_index"], int)
+        assert isinstance(result["group_key"], str)
+        assert isinstance(result["group_properties"], dict)
+        assert isinstance(result["created_at"], str)
+        assert result["created_at"].endswith("Z"), "created_at must be UTC ISO format ending with Z"

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -6,7 +6,7 @@ import pytest
 from freezegun.api import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, snapshot_clickhouse_queries
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
 from django.db import IntegrityError
@@ -21,7 +21,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
 from posthog.models import GroupTypeMapping, GroupUsageMetric, Person, PropertyDefinition
 from posthog.models.filters.utils import GroupTypeIndex
-from posthog.models.group.util import create_group
+from posthog.models.group.util import create_group, list_groups
 from posthog.models.group_type_mapping import GROUP_TYPES_CACHE_KEY_PREFIX, GROUP_TYPES_STALE_CACHE_KEY_PREFIX
 from posthog.models.organization import Organization
 from posthog.models.sharing_configuration import SharingConfiguration
@@ -29,6 +29,8 @@ from posthog.models.team.team import Team
 from posthog.test.test_utils import create_group_type_mapping_without_created_at
 
 from products.notebooks.backend.models import Notebook, ResourceNotebook
+
+from ee.clickhouse.views.groups import _decode_groups_cursor, _encode_groups_cursor
 
 PATH = "ee.clickhouse.views.groups"
 
@@ -2270,3 +2272,353 @@ class GroupPropertyDefinitionsTestCase(ClickhouseTestMixin, APIBaseTest):
             team=self.team, name="test_prop", type=PropertyDefinition.Type.GROUP, group_type_index=1
         )
         self.assertEqual(prop_def.group_type_index, 1)
+
+
+class TestListGroupsFunction(ClickhouseTestMixin, APIBaseTest):
+    @freeze_time("2021-05-03")
+    def test_returns_groups_ordered_by_created_at_desc(self):
+        with freeze_time("2021-05-01"):
+            create_group(team_id=self.team.pk, group_type_index=0, group_key="org:1", properties={})
+        with freeze_time("2021-05-02"):
+            create_group(team_id=self.team.pk, group_type_index=0, group_key="org:2", properties={})
+
+        result = list_groups(team_id=self.team.pk, group_type_index=0)
+
+        assert len(result.groups) == 2
+        assert result.groups[0].group_key == "org:2"
+        assert result.groups[1].group_key == "org:1"
+        assert result.has_more is False
+
+    @freeze_time("2021-05-04")
+    def test_pagination_with_limit(self):
+        with freeze_time("2021-05-01"):
+            create_group(team_id=self.team.pk, group_type_index=0, group_key="org:1", properties={})
+        with freeze_time("2021-05-02"):
+            create_group(team_id=self.team.pk, group_type_index=0, group_key="org:2", properties={})
+        with freeze_time("2021-05-03"):
+            create_group(team_id=self.team.pk, group_type_index=0, group_key="org:3", properties={})
+
+        result = list_groups(team_id=self.team.pk, group_type_index=0, limit=2)
+
+        assert len(result.groups) == 2
+        assert result.groups[0].group_key == "org:3"
+        assert result.groups[1].group_key == "org:2"
+        assert result.has_more is True
+
+    @freeze_time("2021-05-04")
+    def test_pagination_cursor_returns_next_page(self):
+        with freeze_time("2021-05-01"):
+            create_group(team_id=self.team.pk, group_type_index=0, group_key="org:1", properties={})
+        with freeze_time("2021-05-02"):
+            create_group(team_id=self.team.pk, group_type_index=0, group_key="org:2", properties={})
+        with freeze_time("2021-05-03"):
+            create_group(team_id=self.team.pk, group_type_index=0, group_key="org:3", properties={})
+
+        page1 = list_groups(team_id=self.team.pk, group_type_index=0, limit=2)
+        last = page1.groups[-1]
+
+        page2 = list_groups(
+            team_id=self.team.pk,
+            group_type_index=0,
+            cursor_created_at_ms=int(last.created_at.timestamp() * 1000),
+            cursor_id=last.id,
+            limit=2,
+        )
+
+        assert len(page2.groups) == 1
+        assert page2.groups[0].group_key == "org:1"
+        assert page2.has_more is False
+
+    @freeze_time("2021-05-03")
+    def test_search_filters_by_properties(self):
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:1", properties={"name": "Acme Corp"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:2", properties={"name": "Beta Inc"})
+
+        result = list_groups(team_id=self.team.pk, group_type_index=0, search="Acme")
+
+        assert len(result.groups) == 1
+        assert result.groups[0].group_key == "org:1"
+
+    @freeze_time("2021-05-03")
+    def test_search_matches_group_key_exact(self):
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:alpha", properties={"name": "Alpha"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:beta", properties={"name": "Beta"})
+
+        result = list_groups(team_id=self.team.pk, group_type_index=0, search="org:alpha")
+
+        assert len(result.groups) == 1
+        assert result.groups[0].group_key == "org:alpha"
+
+    @freeze_time("2021-05-03")
+    def test_group_key_contains_filter(self):
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:alpha", properties={})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:beta", properties={})
+
+        result = list_groups(team_id=self.team.pk, group_type_index=0, group_key_contains="alpha")
+
+        assert len(result.groups) == 1
+        assert result.groups[0].group_key == "org:alpha"
+
+    @freeze_time("2021-05-03")
+    def test_filters_by_group_type_index(self):
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:1", properties={})
+        create_group(team_id=self.team.pk, group_type_index=1, group_key="company:1", properties={})
+
+        result = list_groups(team_id=self.team.pk, group_type_index=0)
+
+        assert len(result.groups) == 1
+        assert result.groups[0].group_key == "org:1"
+
+    @freeze_time("2021-05-03")
+    def test_empty_result(self):
+        result = list_groups(team_id=self.team.pk, group_type_index=0)
+
+        assert len(result.groups) == 0
+        assert result.has_more is False
+
+    @freeze_time("2021-05-03")
+    def test_personhog_fallback_on_error(self):
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:1", properties={"name": "Test"})
+
+        mock_client = MagicMock()
+        mock_client.list_groups.side_effect = Exception("gRPC error")
+        with patch("posthog.personhog_client.client.get_personhog_client", return_value=mock_client):
+            result = list_groups(team_id=self.team.pk, group_type_index=0)
+
+        assert len(result.groups) == 1
+        assert result.groups[0].group_key == "org:1"
+        mock_client.list_groups.assert_called_once()
+
+    @freeze_time("2021-05-03")
+    @patch("posthog.personhog_client.client.get_personhog_client")
+    def test_personhog_success_path(self, mock_get_client):
+        from posthog.personhog_client.proto import ListGroupsResponse
+        from posthog.personhog_client.proto.generated.personhog.types.v1.group_pb2 import Group as ProtoGroup
+
+        proto_group = ProtoGroup(
+            id=1,
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:1",
+            group_properties=b'{"name": "Test Org"}',
+            created_at=1620000000000,
+            version=0,
+        )
+        mock_response = ListGroupsResponse(groups=[proto_group], has_more=False)
+        mock_client = MagicMock()
+        mock_client.list_groups.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        result = list_groups(team_id=self.team.pk, group_type_index=0)
+
+        assert len(result.groups) == 1
+        assert result.groups[0].group_key == "org:1"
+        assert result.groups[0].group_properties == {"name": "Test Org"}
+        assert result.has_more is False
+        mock_client.list_groups.assert_called_once()
+
+    @freeze_time("2021-05-03")
+    @patch("posthog.personhog_client.client.get_personhog_client")
+    def test_personhog_pagination_has_more(self, mock_get_client):
+        from posthog.personhog_client.proto import ListGroupsResponse
+        from posthog.personhog_client.proto.generated.personhog.types.v1.group_pb2 import Group as ProtoGroup
+
+        proto_groups = [
+            ProtoGroup(
+                id=2,
+                team_id=self.team.pk,
+                group_type_index=0,
+                group_key="org:2",
+                group_properties=b"{}",
+                created_at=1620086400000,
+                version=0,
+            ),
+            ProtoGroup(
+                id=1,
+                team_id=self.team.pk,
+                group_type_index=0,
+                group_key="org:1",
+                group_properties=b"{}",
+                created_at=1620000000000,
+                version=0,
+            ),
+        ]
+        mock_response = ListGroupsResponse(groups=proto_groups, has_more=True)
+        mock_client = MagicMock()
+        mock_client.list_groups.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        result = list_groups(team_id=self.team.pk, group_type_index=0, limit=2)
+
+        assert len(result.groups) == 2
+        assert result.has_more is True
+        assert result.groups[0].group_key == "org:2"
+        assert result.groups[1].group_key == "org:1"
+
+
+class TestGroupsListAPIContract(ClickhouseTestMixin, APIBaseTest):
+    @freeze_time("2021-05-02")
+    def test_response_format_matches_contract(self):
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:1",
+            properties={"name": "Test"},
+        )
+
+        response_data = self.client.get(f"/api/projects/{self.team.id}/groups?group_type_index=0").json()
+
+        assert "next" in response_data
+        assert "previous" in response_data
+        assert "results" in response_data
+        assert response_data["next"] is None
+        assert response_data["previous"] is None
+        assert len(response_data["results"]) == 1
+        result = response_data["results"][0]
+        assert result["group_key"] == "org:1"
+        assert result["group_type_index"] == 0
+        assert result["group_properties"] == {"name": "Test"}
+        assert "created_at" in result
+
+    @freeze_time("2021-05-02")
+    def test_invalid_group_type_index_returns_400(self):
+        response = self.client.get(f"/api/projects/{self.team.id}/groups?group_type_index=abc")
+        assert response.status_code == 400
+
+    @freeze_time("2021-05-02")
+    def test_cursor_pagination_via_api(self):
+        for i in range(3):
+            with freeze_time(f"2021-05-0{i + 1}"):
+                create_group(
+                    team_id=self.team.pk,
+                    group_type_index=0,
+                    group_key=f"org:{i}",
+                    properties={},
+                )
+
+        page1 = self.client.get(f"/api/projects/{self.team.id}/groups?group_type_index=0").json()
+
+        assert page1["next"] is None
+        assert len(page1["results"]) == 3
+        assert page1["results"][0]["group_key"] == "org:2"
+        assert page1["results"][-1]["group_key"] == "org:0"
+
+    @freeze_time("2021-05-02")
+    def test_cursor_roundtrip(self):
+        cursor = _encode_groups_cursor(1620000000000, 42)
+        created_at_ms, group_id = _decode_groups_cursor(cursor)
+
+        assert created_at_ms == 1620000000000
+        assert group_id == 42
+
+    @freeze_time("2021-05-02")
+    def test_invalid_cursor_is_ignored(self):
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:1",
+            properties={},
+        )
+
+        response_data = self.client.get(
+            f"/api/projects/{self.team.id}/groups?group_type_index=0&cursor=invalid_cursor"
+        ).json()
+
+        assert len(response_data["results"]) == 1
+
+    @freeze_time("2021-05-02")
+    def test_find_uses_personhog_routed_lookup(self):
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:1",
+            properties={"name": "Test"},
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/groups/find?group_type_index=0&group_key=org:1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["group_key"] == "org:1"
+        assert data["group_properties"] == {"name": "Test"}
+
+    @freeze_time("2021-05-02")
+    def test_find_nonexistent_returns_404(self):
+        response = self.client.get(f"/api/projects/{self.team.id}/groups/find?group_type_index=0&group_key=nonexistent")
+        assert response.status_code == 404
+
+    @freeze_time("2021-05-02")
+    @patch("posthog.personhog_client.client.get_personhog_client")
+    def test_list_api_with_personhog(self, mock_get_client):
+        from posthog.personhog_client.proto import ListGroupsResponse
+        from posthog.personhog_client.proto.generated.personhog.types.v1.group_pb2 import Group as ProtoGroup
+
+        proto_group = ProtoGroup(
+            id=99,
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:phog",
+            group_properties=b'{"name": "PersonHog Org"}',
+            created_at=1620000000000,
+            version=0,
+        )
+        mock_response = ListGroupsResponse(groups=[proto_group], has_more=False)
+        mock_client = MagicMock()
+        mock_client.list_groups.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        response_data = self.client.get(f"/api/projects/{self.team.id}/groups?group_type_index=0").json()
+
+        assert response_data["next"] is None
+        assert response_data["previous"] is None
+        assert len(response_data["results"]) == 1
+        assert response_data["results"][0]["group_key"] == "org:phog"
+        assert response_data["results"][0]["group_properties"] == {"name": "PersonHog Org"}
+
+    @freeze_time("2021-05-02")
+    @patch("posthog.personhog_client.client.get_personhog_client")
+    def test_list_api_with_personhog_has_more_produces_next_url(self, mock_get_client):
+        from posthog.personhog_client.proto import ListGroupsResponse
+        from posthog.personhog_client.proto.generated.personhog.types.v1.group_pb2 import Group as ProtoGroup
+
+        proto_groups = [
+            ProtoGroup(
+                id=i,
+                team_id=self.team.pk,
+                group_type_index=0,
+                group_key=f"org:{i}",
+                group_properties=b"{}",
+                created_at=1620000000000 + i * 1000,
+                version=0,
+            )
+            for i in range(100)
+        ]
+        mock_response = ListGroupsResponse(groups=proto_groups, has_more=True)
+        mock_client = MagicMock()
+        mock_client.list_groups.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        response_data = self.client.get(f"/api/projects/{self.team.id}/groups?group_type_index=0").json()
+
+        assert response_data["next"] is not None
+        assert "cursor=" in response_data["next"]
+        assert "group_type_index=0" in response_data["next"]
+        assert len(response_data["results"]) == 100
+
+    @freeze_time("2021-05-02")
+    def test_list_api_fallback_on_personhog_error(self):
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:fallback",
+            properties={"name": "Fallback Org"},
+        )
+
+        mock_client = MagicMock()
+        mock_client.list_groups.side_effect = Exception("gRPC unavailable")
+        with patch("posthog.personhog_client.client.get_personhog_client", return_value=mock_client):
+            response_data = self.client.get(f"/api/projects/{self.team.id}/groups?group_type_index=0").json()
+
+        assert len(response_data["results"]) == 1
+        assert response_data["results"][0]["group_key"] == "org:fallback"
+        assert response_data["results"][0]["group_properties"] == {"name": "Fallback Org"}

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -2320,7 +2320,7 @@ class TestListGroupsFunction(ClickhouseTestMixin, APIBaseTest):
         page2 = list_groups(
             team_id=self.team.pk,
             group_type_index=0,
-            cursor_created_at_ms=int(last.created_at.timestamp() * 1000),
+            cursor_created_at_ms=int(last.created_at.timestamp() * 1_000_000),
             cursor_id=last.id,
             limit=2,
         )
@@ -2505,10 +2505,18 @@ class TestGroupsListAPIContract(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     def test_cursor_roundtrip(self):
-        cursor = _encode_groups_cursor(1620000000000, 42)
-        created_at_ms, group_id = _decode_groups_cursor(cursor)
+        cursor = _encode_groups_cursor(1620000000000_000, 42)
+        created_at_us, group_id = _decode_groups_cursor(cursor)
 
-        assert created_at_ms == 1620000000000
+        assert created_at_us == 1620000000000_000
+        assert group_id == 42
+
+    @freeze_time("2021-05-02")
+    def test_cursor_backward_compat_ms(self):
+        cursor = _encode_groups_cursor(1620000000000, 42)
+        created_at_us, group_id = _decode_groups_cursor(cursor)
+
+        assert created_at_us == 1620000000000_000
         assert group_id == 42
 
     @freeze_time("2021-05-02")

--- a/posthog/models/group/util.py
+++ b/posthog/models/group/util.py
@@ -369,7 +369,7 @@ def list_groups(
                     group_type_index=group_type_index,
                     group_key_contains=group_key_contains,
                     search=search,
-                    cursor_created_at_ms=cursor_created_at_ms,
+                    cursor_created_at_ms=cursor_created_at_ms // 1000,
                     cursor_id=cursor_id,
                     limit=limit,
                 )
@@ -405,11 +405,8 @@ def list_groups(
         qs = qs.filter(Q(group_properties__icontains=search) | Q(group_key__iexact=search))
     qs = qs.order_by("-created_at", "-id")
     if cursor_created_at_ms > 0:
-        cursor_dt = datetime.datetime.fromtimestamp(cursor_created_at_ms / 1000, tz=datetime.UTC)
-        cursor_dt_upper = cursor_dt + datetime.timedelta(milliseconds=1)
-        qs = qs.filter(
-            Q(created_at__lt=cursor_dt) | Q(created_at__gte=cursor_dt, created_at__lt=cursor_dt_upper, id__lt=cursor_id)
-        )
+        cursor_dt = datetime.datetime.fromtimestamp(cursor_created_at_ms / 1_000_000, tz=datetime.UTC)
+        qs = qs.filter(Q(created_at__lt=cursor_dt) | Q(created_at=cursor_dt, id__lt=cursor_id))
     groups = list(qs[: limit + 1])
     has_more = len(groups) > limit
     if has_more:

--- a/posthog/models/group/util.py
+++ b/posthog/models/group/util.py
@@ -1,9 +1,11 @@
 import json
 import datetime
+from dataclasses import dataclass
 from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
 from django.db import DatabaseError
+from django.db.models import Q
 from django.utils.timezone import now
 
 import structlog
@@ -335,3 +337,81 @@ def get_aggregation_target_field(
         return f'{event_table_alias}."$group_{aggregation_group_type_index}"'
     else:
         return default
+
+
+@dataclass
+class ListGroupsResult:
+    groups: list[Group]
+    has_more: bool
+
+
+def list_groups(
+    team_id: int,
+    group_type_index: int,
+    *,
+    group_key_contains: str = "",
+    search: str = "",
+    cursor_created_at_ms: int = 0,
+    cursor_id: int = 0,
+    limit: int = 100,
+) -> ListGroupsResult:
+    """List groups with cursor pagination, routing through personhog with ORM fallback."""
+    from posthog.personhog_client.client import get_personhog_client
+    from posthog.personhog_client.converters import proto_group_to_model
+    from posthog.personhog_client.proto import ListGroupsRequest
+
+    client = get_personhog_client()
+    if client is not None:
+        try:
+            resp = client.list_groups(
+                ListGroupsRequest(
+                    team_id=team_id,
+                    group_type_index=group_type_index,
+                    group_key_contains=group_key_contains,
+                    search=search,
+                    cursor_created_at_ms=cursor_created_at_ms,
+                    cursor_id=cursor_id,
+                    limit=limit,
+                )
+            )
+            PERSONHOG_ROUTING_TOTAL.labels(
+                operation="list_groups", source="personhog", client_name=get_client_name()
+            ).inc()
+            return ListGroupsResult(
+                groups=[proto_group_to_model(g) for g in resp.groups],
+                has_more=resp.has_more,
+            )
+        except Exception:
+            PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
+                operation="list_groups",
+                source="personhog",
+                error_type="grpc_error",
+                client_name=get_client_name(),
+            ).inc()
+            logger.warning(
+                "personhog_list_groups_failure",
+                team_id=team_id,
+                group_type_index=group_type_index,
+                exc_info=True,
+            )
+
+    PERSONHOG_ROUTING_TOTAL.labels(operation="list_groups", source="django_orm", client_name=get_client_name()).inc()
+    qs = Group.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+        team_id=team_id, group_type_index=group_type_index
+    )
+    if group_key_contains:
+        qs = qs.filter(group_key__icontains=group_key_contains)
+    if search:
+        qs = qs.filter(Q(group_properties__icontains=search) | Q(group_key__iexact=search))
+    qs = qs.order_by("-created_at", "-id")
+    if cursor_created_at_ms > 0:
+        cursor_dt = datetime.datetime.fromtimestamp(cursor_created_at_ms / 1000, tz=datetime.UTC)
+        cursor_dt_upper = cursor_dt + datetime.timedelta(milliseconds=1)
+        qs = qs.filter(
+            Q(created_at__lt=cursor_dt) | Q(created_at__gte=cursor_dt, created_at__lt=cursor_dt_upper, id__lt=cursor_id)
+        )
+    groups = list(qs[: limit + 1])
+    has_more = len(groups) > limit
+    if has_more:
+        groups = groups[:limit]
+    return ListGroupsResult(groups=groups, has_more=has_more)

--- a/posthog/models/group/util.py
+++ b/posthog/models/group/util.py
@@ -396,19 +396,28 @@ def list_groups(
             )
 
     PERSONHOG_ROUTING_TOTAL.labels(operation="list_groups", source="django_orm", client_name=get_client_name()).inc()
-    qs = Group.objects.filter(  # nosemgrep: no-direct-persons-db-orm
-        team_id=team_id, group_type_index=group_type_index
-    )
-    if group_key_contains:
-        qs = qs.filter(group_key__icontains=group_key_contains)
-    if search:
-        qs = qs.filter(Q(group_properties__icontains=search) | Q(group_key__iexact=search))
-    qs = qs.order_by("-created_at", "-id")
-    if cursor_created_at_us > 0:
-        cursor_dt = datetime.datetime.fromtimestamp(cursor_created_at_us / 1_000_000, tz=datetime.UTC)
-        qs = qs.filter(Q(created_at__lt=cursor_dt) | Q(created_at=cursor_dt, id__lt=cursor_id))
-    groups = list(qs[: limit + 1])
-    has_more = len(groups) > limit
-    if has_more:
-        groups = groups[:limit]
-    return ListGroupsResult(groups=groups, has_more=has_more)
+    try:
+        qs = Group.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+            team_id=team_id, group_type_index=group_type_index
+        )
+        if group_key_contains:
+            qs = qs.filter(group_key__icontains=group_key_contains)
+        if search:
+            qs = qs.filter(Q(group_properties__icontains=search) | Q(group_key__iexact=search))
+        qs = qs.order_by("-created_at", "-id")
+        if cursor_created_at_us > 0:
+            cursor_dt = datetime.datetime.fromtimestamp(cursor_created_at_us / 1_000_000, tz=datetime.UTC)
+            qs = qs.filter(Q(created_at__lt=cursor_dt) | Q(created_at=cursor_dt, id__lt=cursor_id))
+        groups = list(qs[: limit + 1])
+        has_more = len(groups) > limit
+        if has_more:
+            groups = groups[:limit]
+        return ListGroupsResult(groups=groups, has_more=has_more)
+    except DatabaseError:
+        logger.warning(
+            "persons_db_list_groups_failure",
+            team_id=team_id,
+            group_type_index=group_type_index,
+            exc_info=True,
+        )
+        return ListGroupsResult(groups=[], has_more=False)

--- a/posthog/models/group/util.py
+++ b/posthog/models/group/util.py
@@ -351,7 +351,7 @@ def list_groups(
     *,
     group_key_contains: str = "",
     search: str = "",
-    cursor_created_at_ms: int = 0,
+    cursor_created_at_us: int = 0,
     cursor_id: int = 0,
     limit: int = 100,
 ) -> ListGroupsResult:
@@ -369,7 +369,7 @@ def list_groups(
                     group_type_index=group_type_index,
                     group_key_contains=group_key_contains,
                     search=search,
-                    cursor_created_at_ms=cursor_created_at_ms // 1000,
+                    cursor_created_at_ms=cursor_created_at_us // 1000,
                     cursor_id=cursor_id,
                     limit=limit,
                 )
@@ -404,8 +404,8 @@ def list_groups(
     if search:
         qs = qs.filter(Q(group_properties__icontains=search) | Q(group_key__iexact=search))
     qs = qs.order_by("-created_at", "-id")
-    if cursor_created_at_ms > 0:
-        cursor_dt = datetime.datetime.fromtimestamp(cursor_created_at_ms / 1_000_000, tz=datetime.UTC)
+    if cursor_created_at_us > 0:
+        cursor_dt = datetime.datetime.fromtimestamp(cursor_created_at_us / 1_000_000, tz=datetime.UTC)
         qs = qs.filter(Q(created_at__lt=cursor_dt) | Q(created_at=cursor_dt, id__lt=cursor_id))
     groups = list(qs[: limit + 1])
     has_more = len(groups) > limit

--- a/products/groups/frontend/generated/api.schemas.ts
+++ b/products/groups/frontend/generated/api.schemas.ts
@@ -40,7 +40,7 @@ export interface CreateGroupApi {
 
 export type GroupsListParams = {
     /**
-     * The pagination cursor value.
+     * Pagination cursor returned in the `next` URL of a previous response
      */
     cursor?: string
     /**
@@ -50,7 +50,7 @@ export type GroupsListParams = {
     /**
      * Search the group name
      */
-    search: string
+    search?: string
 }
 
 export type GroupsActivityRetrieveParams = {

--- a/products/groups/frontend/generated/api.schemas.ts
+++ b/products/groups/frontend/generated/api.schemas.ts
@@ -19,14 +19,6 @@ export interface GroupApi {
     readonly created_at: string
 }
 
-export interface PaginatedGroupListApi {
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: GroupApi[]
-}
-
 export interface CreateGroupApi {
     /**
      * @minimum -2147483648
@@ -43,6 +35,10 @@ export type GroupsListParams = {
      * Pagination cursor returned in the `next` URL of a previous response
      */
     cursor?: string
+    /**
+     * Filter groups whose key contains this string (case-insensitive)
+     */
+    group_key?: string
     /**
      * Specify the group type to list
      */

--- a/products/groups/frontend/generated/api.ts
+++ b/products/groups/frontend/generated/api.ts
@@ -17,7 +17,6 @@ import type {
     GroupsListParams,
     GroupsRelatedRetrieveParams,
     GroupsUpdatePropertyCreateParams,
-    PaginatedGroupListApi,
 } from './api.schemas'
 
 // https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
@@ -38,7 +37,11 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
     : DistributeReadOnlyOverUnions<T>
 
 /**
- * List all groups of a specific group type. You must pass ?group_type_index= in the URL. To get a list of valid group types, call /api/:project_id/groups_types/
+ * List all groups of a specific group type. You must pass ?group_type_index= in the URL.
+To get a list of valid group types, call /api/:project_id/groups_types/.
+
+Uses forward-only keyset pagination via the `cursor` parameter.
+The `previous` field in the response envelope is always null.
  */
 export const getGroupsListUrl = (projectId: string, params: GroupsListParams) => {
     const normalizedParams = new URLSearchParams()
@@ -60,8 +63,8 @@ export const groupsList = async (
     projectId: string,
     params: GroupsListParams,
     options?: RequestInit
-): Promise<PaginatedGroupListApi> => {
-    return apiMutator<PaginatedGroupListApi>(getGroupsListUrl(projectId, params), {
+): Promise<GroupApi[]> => {
+    return apiMutator<GroupApi[]>(getGroupsListUrl(projectId, params), {
         ...options,
         method: 'GET',
     })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -25003,14 +25003,6 @@ export namespace Schemas {
       results: FileSystemShortcut[];
     }
 
-    export interface PaginatedGroupList {
-      /** @nullable */
-      next?: string | null;
-      /** @nullable */
-      previous?: string | null;
-      results: Group[];
-    }
-
     export interface PaginatedGroupUsageMetricList {
       count: number;
       /** @nullable */
@@ -40682,6 +40674,10 @@ export namespace Schemas {
      */
     cursor?: string;
     /**
+     * Filter groups whose key contains this string (case-insensitive)
+     */
+    group_key?: string;
+    /**
      * Specify the group type to list
      */
     group_type_index: number;
@@ -45385,6 +45381,10 @@ export namespace Schemas {
      * Pagination cursor returned in the `next` URL of a previous response
      */
     cursor?: string;
+    /**
+     * Filter groups whose key contains this string (case-insensitive)
+     */
+    group_key?: string;
     /**
      * Specify the group type to list
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -40678,7 +40678,7 @@ export namespace Schemas {
 
     export type EnvironmentsGroupsListParams = {
     /**
-     * The pagination cursor value.
+     * Pagination cursor returned in the `next` URL of a previous response
      */
     cursor?: string;
     /**
@@ -40688,7 +40688,7 @@ export namespace Schemas {
     /**
      * Search the group name
      */
-    search: string;
+    search?: string;
     };
 
     export type EnvironmentsGroupsActivityRetrieveParams = {
@@ -45382,7 +45382,7 @@ export namespace Schemas {
 
     export type GroupsListParams = {
     /**
-     * The pagination cursor value.
+     * Pagination cursor returned in the `next` URL of a previous response
      */
     cursor?: string;
     /**
@@ -45392,7 +45392,7 @@ export namespace Schemas {
     /**
      * Search the group name
      */
-    search: string;
+    search?: string;
     };
 
     export type GroupsActivityRetrieveParams = {


### PR DESCRIPTION
 ## Problem

The groups list and find endpoints (`/api/projects/:id/groups/` and `/groups/find`) read directly from the Django ORM against the persons database.
As part of the personhog migration, all person/group data access should route through the personhog gRPC client so we can eventually decommission direct ORM reads against the persons DB tables.


## Changes

- **`list_groups()` helper** (`posthog/models/group/util.py`): new function that routes through the personhog gRPC `ListGroups` RPC with ORM fallback, following the same pattern as `get_group_by_key` and `get_groups_by_identifiers`. Includes `DatabaseError` handling on the ORM fallback for resilience when the persons DB is unreachable.
- **Groups list endpoint** (`ee/clickhouse/views/groups.py`): replaced DRF's built-in `CursorPagination` with custom keyset cursor pagination backed by `list_groups()`. The cursor encodes `(created_at_us, group_id)` in base64 JSON, with backward-compatible decoding for millisecond-precision cursors. Pagination is forward-only — the `previous` field in the response envelope is always `null`.
- **`safely_get_object` and `find` action**: now route through `get_group_by_key()` (personhog-routed) instead of direct ORM queries.
- **Cleanup**: removed the now-dead `GroupCursorPagination` class and `CursorPagination` import; set `pagination_class = None` on the viewset.
- **Schema fix**: `search` parameter changed from `required: true` to `required: false` in the OpenAPI spec, matching the actual endpoint behavior.
- **New `group_key` filter parameter**: supports case-insensitive substring filtering on group keys via the API.


## How did you test this code?

- **`TestListGroupsFunction`** (11 tests): unit tests for the `list_groups()` helper covering ordering, pagination with limit, cursor continuation, search by properties, exact group key match, `group_key_contains` filter, group type index filtering, empty results, personhog gRPC fallback on error, personhog success path, and personhog pagination with `has_more`.
- **`TestGroupsListAPIContract`** (11 tests): end-to-end API tests covering response envelope shape (`next`/`previous`/`results`), invalid `group_type_index` validation, cursor pagination via the API, cursor encode/decode roundtrip, backward-compatible millisecond cursor decoding, invalid cursor graceful handling, `find` endpoint with personhog routing, `find` 404 for nonexistent groups, full API flow with mocked personhog, `has_more` producing a `next` URL, and ORM fallback on personhog error.
- **`TestGroupsListPersonhogORMParity`** (8 tests): field-by-field comparison between the personhog path and ORM fallback path to verify identical serialized output — covers single group field parity, multiple group ordering parity, empty properties, `created_at` serialization, search results, pagination `next` URL structure, response envelope keys, and result field types.
