### PR TITLE
perf(flags): short-circuit array exact match in property_matching

### DIFF
--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -666,8 +666,18 @@ mod test_match_properties {
         .is_err());
     }
 
-    #[test]
-    fn test_match_properties_exact_array_is_case_insensitive() {
+    #[rstest::rstest]
+    #[case("us", true)]
+    #[case("Us", true)]
+    #[case("US", true)]
+    #[case("ca", true)]
+    #[case("uk", true)]
+    #[case("UK", true)]
+    #[case("de", false)]
+    fn test_match_properties_exact_array_is_case_insensitive(
+        #[case] user_value: &str,
+        #[case] expected: bool,
+    ) {
         // Array Exact comparisons lowercase both sides, so a mixed-case filter
         // value must still match a lowercase user property and vice-versa.
         let property = PropertyFilter {
@@ -680,28 +690,19 @@ mod test_match_properties {
             compiled_regex: None,
         };
 
-        for user_value in ["us", "Us", "US", "ca", "uk", "UK"] {
-            assert!(
-                match_property(
-                    &property,
-                    &HashMap::from([("country".to_string(), json!(user_value))]),
-                    true
-                )
-                .expect("expected match to exist"),
-                "expected '{}' to match",
-                user_value
-            );
-        }
-
-        assert!(!match_property(
+        let actual = match_property(
             &property,
-            &HashMap::from([("country".to_string(), json!("de"))]),
-            true
+            &HashMap::from([("country".to_string(), json!(user_value))]),
+            true,
         )
-        .expect("expected match to exist"));
+        .expect("expected match to exist");
 
-        // Empty array filter never matches.
-        let property_empty = PropertyFilter {
+        assert_eq!(actual, expected, "user_value = {user_value}");
+    }
+
+    #[test]
+    fn test_match_properties_exact_empty_array_never_matches() {
+        let property = PropertyFilter {
             key: "country".to_string(),
             value: Some(json!([])),
             operator: Some(OperatorType::Exact),
@@ -711,7 +712,7 @@ mod test_match_properties {
             compiled_regex: None,
         };
         assert!(!match_property(
-            &property_empty,
+            &property,
             &HashMap::from([("country".to_string(), json!("us"))]),
             true
         )

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -107,13 +107,12 @@ pub fn match_property(
                 }
 
                 if value.is_array() {
+                    let target = to_string_representation(override_value).to_lowercase();
                     return value
                         .as_array()
                         .expect("expected array value")
                         .iter()
-                        .map(|v| to_string_representation(v).to_lowercase())
-                        .collect::<Vec<String>>()
-                        .contains(&to_string_representation(override_value).to_lowercase());
+                        .any(|v| to_string_representation(v).to_lowercase() == target);
                 }
                 to_string_representation(value).to_lowercase()
                     == to_string_representation(override_value).to_lowercase()
@@ -665,6 +664,58 @@ mod test_match_properties {
             true
         )
         .is_err());
+    }
+
+    #[test]
+    fn test_match_properties_exact_array_is_case_insensitive() {
+        // Array Exact comparisons lowercase both sides, so a mixed-case filter
+        // value must still match a lowercase user property and vice-versa.
+        let property = PropertyFilter {
+            key: "country".to_string(),
+            value: Some(json!(["US", "CA", "Uk"])),
+            operator: Some(OperatorType::Exact),
+            prop_type: PropertyType::Person,
+            group_type_index: None,
+            negation: None,
+            compiled_regex: None,
+        };
+
+        for user_value in ["us", "Us", "US", "ca", "uk", "UK"] {
+            assert!(
+                match_property(
+                    &property,
+                    &HashMap::from([("country".to_string(), json!(user_value))]),
+                    true
+                )
+                .expect("expected match to exist"),
+                "expected '{}' to match",
+                user_value
+            );
+        }
+
+        assert!(!match_property(
+            &property,
+            &HashMap::from([("country".to_string(), json!("de"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Empty array filter never matches.
+        let property_empty = PropertyFilter {
+            key: "country".to_string(),
+            value: Some(json!([])),
+            operator: Some(OperatorType::Exact),
+            prop_type: PropertyType::Person,
+            group_type_index: None,
+            negation: None,
+            compiled_regex: None,
+        };
+        assert!(!match_property(
+            &property_empty,
+            &HashMap::from([("country".to_string(), json!("us"))]),
+            true
+        )
+        .expect("expected match to exist"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The Exact / IsNot match path for array valued property filters in `match_property` materializes a `Vec<String>` of every lowercased filter entry before scanning for the user's value:

```rust
.map(|v| to_string_representation(v).to_lowercase())
.collect::<Vec<String>>()
.contains(&to_string_representation(override_value).to_lowercase());
```

The full array is allocated and lowercased on every flag evaluation regardless of where (or whether) the match occurs.

## Changes

Replace `map(...).collect::<Vec<_>>().contains(...)` with `iter().any(...)` and hoist the user value lowercase out of the loop.

* Same predicate (existence of an element whose lowercased string representation equals the lowercased override value).
* Drops the intermediate `Vec<String>` allocation.
* Short circuits the per element `to_lowercase` work on first match.
* Identical behavior for empty arrays, no match cases, and any element position.

### Distribution in production

Querying active, non deleted flags for Exact/IsNot property filters whose value is a JSON array (excluding cohort/flag types):

| array length | filters | flags |
|---|---|---|
| 1            | 29,487  | 19,862 |
| 2 to 5       | 15,502  | 13,991 |
| 6 to 20      |  6,117  |  5,642 |
| 21 to 100    |  1,499  |  1,365 |
| 101 to 1000  |    468  |    352 |
| 1000+        |    ~65  |    ~50 (max length 10,301) |

The bulk of filters are tiny and won't see a measurable change. The long tail is what motivates this: a handful of flags use array filters with thousands of entries as ad hoc allowlists, and each evaluation currently allocates and lowercases the entire list before scanning.

## How did you test this code?

I'm an agent. I ran \`cargo test -p feature-flags --lib property_matching\` locally; 38 tests passed (37 existing plus the new one below). No manual testing was performed.

Test additions:

* New \`test_match_properties_exact_array_is_case_insensitive\` covering case insensitive matching and the empty array edge case for the Exact operator (the path this PR touches).

Existing \`test_match_properties_exact_with_partial_props\` already covers match at index 0/1/2 and no match.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code assistance; Patricio drove the investigation, verified semantic equivalence, ran the production query, and reviewed the diff before commit. The change is purely allocation reduction in the hot Exact match path; behavior is preserved (same predicate, same iteration order, same case folding rules). Reviewer focus: confirm semantic equivalence between \`map+collect+contains\` and \`iter().any(==)\` patterns, and the new test's coverage choice.