### PR TITLE
feat(exporter): split exporter shared chunk via anchors and dynamic hogql parser

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -79,7 +79,10 @@ await buildInParallel(
         },
         {
             name: 'Exporter',
-            entryPoints: { exporter: 'src/exporter/index.tsx' },
+            entryPoints: {
+                exporter: 'src/exporter/index.tsx',
+                exporterSharedChunkAnchors: 'src/sharedChunkAnchors.ts',
+            },
             splitting: true,
             format: 'esm',
             outdir: path.resolve(__dirname, 'dist'),

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -125,6 +125,9 @@ await buildInParallel(
             }
 
             if (config.name === 'Exporter') {
+                if (!isDev) {
+                    reportTopChunks(buildResponse.outputs, { label: 'Exporter chunks' })
+                }
                 writeExporterHtml(chunks, entrypoints)
             }
 

--- a/frontend/src/scenes/data-warehouse/editor/hogqlParserSingleton.ts
+++ b/frontend/src/scenes/data-warehouse/editor/hogqlParserSingleton.ts
@@ -1,14 +1,16 @@
-import createHogQLParser, { type HogQLParser } from '@posthog/hogql-parser'
+import type { HogQLParser } from '@posthog/hogql-parser'
 
 let parserPromise: Promise<HogQLParser> | null = null
 
 function getParser(): Promise<HogQLParser> {
     if (!parserPromise) {
-        parserPromise = createHogQLParser().catch((error) => {
-            // Reset so next call retries initialization
-            parserPromise = null
-            throw error
-        })
+        parserPromise = import('@posthog/hogql-parser')
+            .then((mod) => mod.default())
+            .catch((error) => {
+                // Reset so next call retries initialization
+                parserPromise = null
+                throw error
+            })
     }
     return parserPromise
 }


### PR DESCRIPTION
## Problem

The exporter pulls in `sceneLogic`, which transitively pulls in the auto-generated `frontend/src/products.tsx` (75 dynamic `import()`s) and `frontend/src/scenes/appScenes.ts` (126 more). Once esbuild's splitter sees 200+ lazy entries, every dep used by 2+ of them gets coalesced into a single shared chunk.

After the recent exporter split (#57853) that chunk had grown to ~12 MB — uncomfortably close to (and previously over) the 10 MB CloudFront object limit — and a single failure of one giant file blocks every shared/embedded view.

## Changes

Two small, low-risk knobs:

1. **`hogqlParserSingleton.ts` switched to a dynamic import.** The 1.5 MB WASM bridge is now only fetched when SQL editor / data warehouse code actually parses something — never during a normal exporter render.
2. **Added `src/sharedChunkAnchors.ts` as a second entry in the Exporter build.** Same pattern the main App build already uses. esbuild peels rrweb, posthog-icons, posthog-js, chart.js, tiptap, etc. out into their own ~2.65 MB anchor chunk.

Local result: largest exporter chunk drops from **12.36 MB to 8.23 MB**, plus a 2.65 MB anchor chunk and a 1.52 MB hogql-parser chunk that the exporter never loads in normal use.

```
before:
  12.36 MB chunk-XXXX.js  (one giant shared chunk)

after:
   8.23 MB chunk-XXXX.js
   2.65 MB chunk-XXXX.js   (anchor: rrweb + icons + posthog-js + chart.js + tiptap …)
   1.52 MB hogql_parser_wasm_browser-XXXX.js   (lazy, exporter never loads this)
```

## How did you test this code?

I'm a coding agent. I ran a local production build (`pnpm build:esbuild`) and inspected the generated metafile + `dist/exporter.html` to confirm:
- the exporter entry is still `exporter.js` (entry naming preserved by using object form for `entryPoints`),
- the new anchor chunk is in the eager `index` chunks list so it loads alongside the exporter,
- the hogql-parser WASM is now its own dynamic chunk and is *not* in the eager list.

I did not click through shared dashboards/recordings/notebooks manually — Playwright coverage from #57853 should catch regressions there.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7).

Investigation flow:
- Built the frontend locally and used the esbuild metafile to confirm the 12 MB chunk and its top contributors (hogql-parser WASM, rrweb, posthog-icons, posthog-js, chart.js, taxonomy JSON, validators).
- Considered the structural fix (decouple the exporter from `sceneLogic` / `products.tsx` / `appScenes.ts`) but it's a much bigger change. Chose the smaller, safer fixes first so we can assess local size before deciding whether to go further.
- Picked the two leaf wins with the cleanest blast radius: hogql-parser is already promise-based so a dynamic import is a one-liner; the shared-chunk-anchor pattern is already proven in the main App build.
- Skipped chart.js for now (it's used as a synchronous class in `lib/Chart.ts`, would need broader refactoring) and skipped rrweb (only `@posthog/rrweb` is anchored — recording-specific lazy split is a follow-up if needed).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*