### PR TITLE
fix(surveys): remove duplicate view recording button in responses table

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -979,6 +979,7 @@ export function DataTable({
                                                   return (
                                                       <EventRowActions
                                                           event={(result as any[])[columnsInResponse.indexOf('*')]}
+                                                          hideRecordingButton={recordingColumnShown}
                                                       />
                                                   )
                                               }

--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -16,20 +16,28 @@ import { urls } from 'scenes/urls'
 import { saveActionFromEvent } from '~/models/saveAsActionDialog'
 import { EventType, SurveyEventName } from '~/types'
 
-export function EventRowActions({ event }: { event: EventType }): JSX.Element {
+export function EventRowActions({
+    event,
+    hideRecordingButton,
+}: {
+    event: EventType
+    hideRecordingButton?: boolean
+}): JSX.Element {
     return (
         <div className="flex items-center justify-end gap-1">
-            <ViewRecordingButton
-                iconOnly
-                sessionId={event.properties.$session_id}
-                recordingStatus={event.properties.$recording_status}
-                timestamp={event.timestamp}
-                hasRecording={event.properties.$has_recording as boolean | undefined}
-                openPlayerIn={RecordingPlayerType.NewTab}
-                size="xsmall"
-                type="secondary"
-                data-attr="events-table-inline-recording-button"
-            />
+            {!hideRecordingButton && (
+                <ViewRecordingButton
+                    iconOnly
+                    sessionId={event.properties.$session_id}
+                    recordingStatus={event.properties.$recording_status}
+                    timestamp={event.timestamp}
+                    hasRecording={event.properties.$has_recording as boolean | undefined}
+                    openPlayerIn={RecordingPlayerType.NewTab}
+                    size="xsmall"
+                    type="secondary"
+                    data-attr="events-table-inline-recording-button"
+                />
+            )}
             <More overlay={<EventRowActionsDropdown event={event} />} />
         </div>
     )

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2135,7 +2135,6 @@ export const surveyLogic = kea<surveyLogicType>([
                     propertiesViaUrl: true,
                     showExport: true,
                     showReload: true,
-                    showRecordingColumn: true,
                     showEventFilter: false,
                     showPropertyFilter: false,
                     showTimings: false,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2135,6 +2135,7 @@ export const surveyLogic = kea<surveyLogicType>([
                     propertiesViaUrl: true,
                     showExport: true,
                     showReload: true,
+                    showRecordingColumn: true,
                     showEventFilter: false,
                     showPropertyFilter: false,
                     showTimings: false,


### PR DESCRIPTION
## Problem

The survey responses table renders a "View recording" button twice in each row — once in a dedicated recording column and once as an inline icon button next to the row's `More` menu. Reported in support ticket #642.

Closes #642

## Changes

The dedicated recording column is the right surface for "View recording" — it's a high-intent action that warrants its own specialized column, so it stays. The duplicate inline icon-only button is what we drop, but only on tables that already render the dedicated column.

- `EventRowActions` now accepts a `hideRecordingButton` prop that suppresses the inline `ViewRecordingButton`.
- `DataTable` passes `hideRecordingButton={recordingColumnShown}` so the inline button is hidden whenever the dedicated `__recording` column is rendered. Tables that don't enable `showRecordingColumn` are unaffected and still get the inline icon button.
- The earlier attempt that dropped `showRecordingColumn: true` from the survey config has been reverted.

## How did you test this code?

I'm an agent and have not manually verified the UI. No automated tests were added or run for this change. Reviewer should:
- Check the survey responses table to confirm only the dedicated recording column is rendered (no second icon next to `More`).
- Check another events table without `showRecordingColumn` (e.g. activity / events explorer) to confirm the inline recording icon still renders next to the row actions.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) from a Slack thread reporting the duplicate button.
- First commit removed `showRecordingColumn: true` from the survey config. Reviewer pushed back: the recording button is high-intent and warrants the dedicated column, so the inline icon is the redundant one.
- Considered removing the inline icon unconditionally from `EventRowActions`, but that's shared across every events table — would silently regress the inline button on tables that rely on it.
- Settled on a scoped fix: `hideRecordingButton` prop on `EventRowActions`, driven by whether the dedicated column is shown. Behavior changes only on tables that already had the duplicate.