### PR TITLE
fix(tasks): switch remaining asyncify tests to transaction=True

### DIFF
--- a/products/tasks/backend/temporal/create_snapshot/activities/tests/test_create_snapshot.py
+++ b/products/tasks/backend/temporal/create_snapshot/activities/tests/test_create_snapshot.py
@@ -37,7 +37,7 @@ class TestCreateSnapshotActivity:
             team_id=github_integration.team_id,
         )
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_create_snapshot_success(self, activity_environment, github_integration):
         config = SandboxConfig(
             name="test-create-snapshot",
@@ -74,7 +74,7 @@ class TestCreateSnapshotActivity:
             if created_snapshot_external_id:
                 Sandbox.delete_snapshot(created_snapshot_external_id)
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_create_snapshot_contains_only_current_repo(self, activity_environment, github_integration):
         """Verify that snapshots only contain the current repository, not accumulated repos from base."""
         base_snapshot = SandboxSnapshot.objects.create(
@@ -115,7 +115,7 @@ class TestCreateSnapshotActivity:
             if created_snapshot_external_id:
                 Sandbox.delete_snapshot(created_snapshot_external_id)
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_create_snapshot_sandbox_not_found(self, activity_environment, github_integration):
         context = self._create_context(github_integration, "test-owner/test-repo")
         input_data = CreateSnapshotInput(context=context, sandbox_id="non-existent-sandbox-id")

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_sandbox_for_repository.py
@@ -32,7 +32,7 @@ class TestGetSandboxForRepositoryActivity:
             task_created_by_id=test_task.created_by_id,
         )
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_sandbox_with_existing_snapshot(
         self, activity_environment, github_integration, test_task, test_task_run
     ):
@@ -65,7 +65,7 @@ class TestGetSandboxForRepositoryActivity:
                 except Exception:
                     pass
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_sandbox_without_snapshot_returns_should_create_snapshot(
         self, activity_environment, github_integration, test_task, test_task_run
     ):
@@ -90,7 +90,7 @@ class TestGetSandboxForRepositoryActivity:
                 except Exception:
                     pass
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_sandbox_creates_sandbox_from_base_when_no_snapshot(
         self, activity_environment, github_integration, test_task, test_task_run
     ):
@@ -118,7 +118,7 @@ class TestGetSandboxForRepositoryActivity:
                 except Exception:
                     pass
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_sandbox_includes_environment_variables(
         self, activity_environment, github_integration, test_task, test_task_run
     ):


### PR DESCRIPTION
## Problem

After #57839 switched \`asyncify\` to \`sync_to_async(thread_sensitive=False)\`, asyncified activities run on a worker thread with their own DB connection. That connection can't see rows created inside a test's \`@pytest.mark.django_db\` transaction, so activity lookups raise \`TaskNotFoundError\` and FK-bearing inserts raise \`IntegrityError\`.

The follow-up commit on that PR converted most affected tests to \`@pytest.mark.django_db(transaction=True)\` (which actually commits setup data), but missed two files:

- \`products/tasks/backend/temporal/create_snapshot/activities/tests/test_create_snapshot.py\`
- \`products/tasks/backend/temporal/process_task/activities/tests/test_get_sandbox_for_repository.py\`

Both files are gated by \`MODAL_TOKEN_ID\`/\`MODAL_TOKEN_SECRET\`, so the breakage only surfaced on the Temporal CI shard, where 6 tests fail consistently:

- \`test_create_snapshot_success\` — FK violation on \`posthog_sandbox_snapshot.integration_id\`
- \`test_create_snapshot_contains_only_current_repo\` — same FK violation
- \`test_get_sandbox_with_existing_snapshot\` — \`TaskNotFoundError\`
- \`test_get_sandbox_without_snapshot_returns_should_create_snapshot\` — \`TaskNotFoundError\`
- \`test_get_sandbox_creates_sandbox_from_base_when_no_snapshot\` — \`TaskNotFoundError\`
- \`test_get_sandbox_includes_environment_variables\` — \`TaskNotFoundError\`

## Changes

Switch every \`@pytest.mark.django_db\` to \`@pytest.mark.django_db(transaction=True)\` in the two missed files, mirroring the pattern already applied to the sibling test files. This keeps test behavior aligned with the prod threading model rather than papering over the cross-thread visibility issue.

## How did you test this code?

Agent-authored. I reproduced the failure mode locally by reverting one already-converted test (\`test_get_task_processing_context_success\`) back to plain \`@pytest.mark.django_db\` and observing the same \`TaskNotFoundError\` that fires in CI on the unconverted files. The change in this PR is mechanical and matches the convention used in the rest of the asyncified-activity test tree. The target tests themselves are skipped without \`MODAL_TOKEN_*\` secrets, so they cannot be run locally — verification will come from the Temporal shard in CI.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Investigation: pulled the failing CI run on the merged predecessor PR, identified the two files the prior fix had skipped, reproduced the cross-thread visibility failure on a converted test by reverting its decorator, then applied the same \`transaction=True\` conversion to the two missed files. Considered an alternative — making \`asyncify\` keep \`thread_sensitive=True\` under \`settings.TEST\` — but rejected it because keeping tests aligned with prod threading was the explicit request.