### PR TITLE
fix(surveys): support relative dates in guided targeting

### DIFF
--- a/frontend/src/scenes/surveys/wizard/SurveyAudienceFilters.test.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyAudienceFilters.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { BindLogic, Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { PropertyFilterType, PropertyOperator } from '~/types'
+import type { FeatureFlagFilters } from '~/types'
+
+import { surveyLogic } from '../surveyLogic'
+import { SurveyAudienceFilters } from './SurveyAudienceFilters'
+
+const mockPropertyFilters = jest.fn()
+
+jest.mock('lib/components/PropertyFilters/PropertyFilters', () => ({
+    PropertyFilters: (props: Record<string, unknown>) => {
+        mockPropertyFilters(props)
+        return <div data-attr="audience-property-filters" data-testid="audience-property-filters" />
+    },
+}))
+
+describe('SurveyAudienceFilters', () => {
+    beforeEach(() => {
+        initKeaTests()
+        useMocks({
+            get: {
+                '/api/projects/:team/surveys/': () => [200, { count: 0, results: [], next: null, previous: null }],
+                '/api/projects/:team/surveys/responses_count': () => [200, {}],
+            },
+        })
+        mockPropertyFilters.mockClear()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('enables relative date options for guided audience rules', () => {
+        const logic = surveyLogic({ id: 'new' })
+        logic.mount()
+
+        const targetingFilters: FeatureFlagFilters = {
+            groups: [
+                {
+                    properties: [
+                        {
+                            key: 'last_signed_in_at',
+                            value: '-7d',
+                            operator: PropertyOperator.IsDateBefore,
+                            type: PropertyFilterType.Person,
+                        },
+                    ],
+                    rollout_percentage: 100,
+                    variant: null,
+                },
+            ],
+            multivariate: null,
+            payloads: {},
+        }
+
+        logic.actions.setSurveyValue('targeting_flag_filters', targetingFilters)
+
+        render(
+            <Provider>
+                <BindLogic logic={surveyLogic} props={{ id: 'new' }}>
+                    <SurveyAudienceFilters />
+                </BindLogic>
+            </Provider>
+        )
+
+        expect(screen.getByTestId('audience-property-filters')).toBeInTheDocument()
+        expect(mockPropertyFilters).toHaveBeenCalledWith(
+            expect.objectContaining({
+                allowRelativeDateOptions: true,
+                propertyFilters: targetingFilters.groups[0].properties,
+            })
+        )
+    })
+})

--- a/frontend/src/scenes/surveys/wizard/SurveyAudienceFilters.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyAudienceFilters.tsx
@@ -215,6 +215,7 @@ export function SurveyAudienceFilters({ onOpenFullEditor }: { onOpenFullEditor?:
                                             TaxonomicFilterGroupType.PersonProperties,
                                             TaxonomicFilterGroupType.Cohorts,
                                         ]}
+                                        allowRelativeDateOptions
                                         buttonText="Add audience rule"
                                         buttonSize="small"
                                         openOnInsert


### PR DESCRIPTION
## Problem

Guided survey audience targeting used the shared property filter UI without enabling relative date values for DateTime person properties. The full editor already supports values like `-7d`, so users had to switch editors to configure the same targeting rule.

## Changes

Enabled relative date options for the guided survey audience rule `PropertyFilters` component, matching the full editor behavior.

Added a focused regression test that verifies the guided audience filters pass `allowRelativeDateOptions` through to the shared property filter UI.

## How did you test this code?

Agent-authored change. Automated test run:

`hogli test frontend/src/scenes/surveys/wizard/SurveyAudienceFilters.test.tsx`

## Publish to changelog?

no

## Docs update

No docs update needed. This fixes parity between the guided and full survey editors for an existing targeting capability.

## 🤖 Agent context

Authored by Codex in this workspace.

Key prompt: fix the survey guided editor so person property relative date targeting works the same way as the full editor.

Decision notes: the full editor reaches feature flag release conditions, which already enables relative date options. The guided editor uses `PropertyFilters` directly for simple audience rules, so the smallest fix is to pass `allowRelativeDateOptions` there and cover that integration with a focused Jest test.