### PR TITLE
fix(llma): tag runs list shows empty when data exists

### DIFF
--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts
@@ -523,5 +523,70 @@ describe('llmTaggerLogic', () => {
                     ],
                 })
         })
+
+        // Regression: combining `values: { tagger_id }` with `{filters}` made the
+        // backend's parse_select throw, the loader's catch silently returned [],
+        // and the runs tab rendered empty even when matching events existed.
+        // Lock in that the request inlines the id into the query string and
+        // does not send a `values` dict.
+        it('inlines the tagger id rather than passing it via values', async () => {
+            const capturedQueries: { query: string; values?: unknown }[] = []
+            useMocks({
+                post: {
+                    '/api/environments/:team_id/query/:kind': async (req, res, ctx) => {
+                        const body = (await req.json()) as { query?: { query?: string; values?: unknown } }
+                        if (body.query?.query?.includes('$ai_tagger_id')) {
+                            capturedQueries.push({
+                                query: body.query.query,
+                                values: body.query.values,
+                            })
+                        }
+                        return res(ctx.json({ results: [] }))
+                    },
+                },
+            })
+
+            logic = llmTaggerLogic({ id: 'tagger-abc' })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['loadTagRunsSuccess'])
+
+            expect(capturedQueries).toHaveLength(1)
+            const sent = capturedQueries[0]
+            expect(sent.query).toContain("properties.$ai_tagger_id = 'tagger-abc'")
+            expect(sent.query).toContain('{filters}')
+            expect(sent.query).not.toContain('{tagger_id}')
+            expect(sent.values).toBeUndefined()
+        })
+
+        it('escapes single quotes in the tagger id', async () => {
+            const capturedQueries: string[] = []
+            useMocks({
+                post: {
+                    '/api/environments/:team_id/query/:kind': async (req, res, ctx) => {
+                        const body = (await req.json()) as { query?: { query?: string } }
+                        if (body.query?.query?.includes('$ai_tagger_id')) {
+                            capturedQueries.push(body.query.query)
+                        }
+                        return res(ctx.json({ results: [] }))
+                    },
+                },
+            })
+
+            // Override the tagger fetch so the page can mount with this id
+            useMocks({
+                get: {
+                    "/api/environments/:team_id/taggers/o'malley/": mockTagger,
+                },
+            })
+
+            logic = llmTaggerLogic({ id: "o'malley" })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['loadTagRunsSuccess'])
+
+            expect(capturedQueries).toHaveLength(1)
+            expect(capturedQueries[0]).toContain("properties.$ai_tagger_id = 'o''malley'")
+        })
     })
 })

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts
@@ -531,7 +531,8 @@ describe('llmTaggerLogic', () => {
         // string and does not send a `values` dict.
         it.each([
             ['plain id', 'tagger-abc', "properties.$ai_tagger_id = 'tagger-abc'"],
-            ['id with single quote', "o'malley", "properties.$ai_tagger_id = 'o''malley'"],
+            ['id with single quote', "o'malley", "properties.$ai_tagger_id = 'o\\'malley'"],
+            ['id with backslash', 'tagger\\abc', "properties.$ai_tagger_id = 'tagger\\\\abc'"],
         ])('inlines the tagger id without a values dict (%s)', async (_label, taggerId, expectedSnippet) => {
             const capturedQueries: { query: string; values?: unknown }[] = []
             useMocks({

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts
@@ -527,11 +527,17 @@ describe('llmTaggerLogic', () => {
         // Regression: combining `values: { tagger_id }` with `{filters}` made the
         // backend's parse_select throw, the loader's catch silently returned [],
         // and the runs tab rendered empty even when matching events existed.
-        // Lock in that the request inlines the id into the query string and
-        // does not send a `values` dict.
-        it('inlines the tagger id rather than passing it via values', async () => {
+        // Lock in that the request inlines (and escapes) the id into the query
+        // string and does not send a `values` dict.
+        it.each([
+            ['plain id', 'tagger-abc', "properties.$ai_tagger_id = 'tagger-abc'"],
+            ['id with single quote', "o'malley", "properties.$ai_tagger_id = 'o''malley'"],
+        ])('inlines the tagger id without a values dict (%s)', async (_label, taggerId, expectedSnippet) => {
             const capturedQueries: { query: string; values?: unknown }[] = []
             useMocks({
+                get: {
+                    [`/api/environments/:team_id/taggers/${taggerId}/`]: mockTagger,
+                },
                 post: {
                     '/api/environments/:team_id/query/:kind': async (req, res, ctx) => {
                         const body = (await req.json()) as { query?: { query?: string; values?: unknown } }
@@ -546,47 +552,17 @@ describe('llmTaggerLogic', () => {
                 },
             })
 
-            logic = llmTaggerLogic({ id: 'tagger-abc' })
+            logic = llmTaggerLogic({ id: taggerId })
             logic.mount()
 
             await expectLogic(logic).toDispatchActions(['loadTagRunsSuccess'])
 
             expect(capturedQueries).toHaveLength(1)
             const sent = capturedQueries[0]
-            expect(sent.query).toContain("properties.$ai_tagger_id = 'tagger-abc'")
+            expect(sent.query).toContain(expectedSnippet)
             expect(sent.query).toContain('{filters}')
             expect(sent.query).not.toContain('{tagger_id}')
             expect(sent.values).toBeUndefined()
-        })
-
-        it('escapes single quotes in the tagger id', async () => {
-            const capturedQueries: string[] = []
-            useMocks({
-                post: {
-                    '/api/environments/:team_id/query/:kind': async (req, res, ctx) => {
-                        const body = (await req.json()) as { query?: { query?: string } }
-                        if (body.query?.query?.includes('$ai_tagger_id')) {
-                            capturedQueries.push(body.query.query)
-                        }
-                        return res(ctx.json({ results: [] }))
-                    },
-                },
-            })
-
-            // Override the tagger fetch so the page can mount with this id
-            useMocks({
-                get: {
-                    "/api/environments/:team_id/taggers/o'malley/": mockTagger,
-                },
-            })
-
-            logic = llmTaggerLogic({ id: "o'malley" })
-            logic.mount()
-
-            await expectLogic(logic).toDispatchActions(['loadTagRunsSuccess'])
-
-            expect(capturedQueries).toHaveLength(1)
-            expect(capturedQueries[0]).toContain("properties.$ai_tagger_id = 'o''malley'")
         })
     })
 })

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
@@ -13,6 +13,7 @@ import { ChartDisplayType, PropertyFilterType, PropertyOperator } from '~/types'
 import { llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
 import { parseTrialProviderKeyId } from '../ModelPicker'
 import { LLMProviderKey, llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
+import { escapeHogqlString } from '../utils'
 import type { llmTaggerLogicType } from './llmTaggerLogicType'
 import { llmTaggersLogic } from './llmTaggersLogic'
 import {
@@ -317,9 +318,8 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
             // find_placeholders runs, which means combining `{tagger_id}` with
             // `{filters}` fails — `{filters}` is missing from `values` and the
             // whole query errors out, leaving the runs list silently empty.
-            // The id is escaped via escapeHogqlString as defense in depth (it
-            // comes from the URL path).
-            const escapedTaggerId = props.id.replace(/\\/g, '\\\\').replace(/'/g, "''")
+            // Escape as defense in depth (the id comes from the URL path).
+            const escapedTaggerId = escapeHogqlString(props.id)
             const query: HogQLQuery = {
                 kind: NodeKind.HogQLQuery,
                 query: `

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
@@ -8,12 +8,12 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { HogQLQuery, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { escapeHogQLString } from '~/queries/utils'
 import { ChartDisplayType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
 import { parseTrialProviderKeyId } from '../ModelPicker'
 import { LLMProviderKey, llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
-import { escapeHogqlString } from '../utils'
 import type { llmTaggerLogicType } from './llmTaggerLogicType'
 import { llmTaggersLogic } from './llmTaggersLogic'
 import {
@@ -318,8 +318,8 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
             // find_placeholders runs, which means combining `{tagger_id}` with
             // `{filters}` fails — `{filters}` is missing from `values` and the
             // whole query errors out, leaving the runs list silently empty.
-            // Escape as defense in depth (the id comes from the URL path).
-            const escapedTaggerId = escapeHogqlString(props.id)
+            // escapeHogQLString returns the value already wrapped in single quotes.
+            const escapedTaggerId = escapeHogQLString(props.id)
             const query: HogQLQuery = {
                 kind: NodeKind.HogQLQuery,
                 query: `
@@ -333,7 +333,7 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
                         properties.$ai_tagger_name as tagger_name
                     FROM events
                     WHERE event = '$ai_tag'
-                      AND properties.$ai_tagger_id = '${escapedTaggerId}'
+                      AND properties.$ai_tagger_id = ${escapedTaggerId}
                       AND {filters}
                     ORDER BY timestamp DESC
                     LIMIT 100

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
@@ -312,9 +312,14 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
             }
             const dateFrom = values.dateFilter?.dateFrom || '-24h'
             const dateTo = values.dateFilter?.dateTo || null
-            // Use a HogQL parameter placeholder rather than string interpolation —
-            // props.id comes from the URL path, so interpolating it directly into
-            // the query text would open an injection vector.
+            // Inline the tagger_id rather than using a `values` dict: parse_select
+            // eagerly resolves all placeholders against `values` before
+            // find_placeholders runs, which means combining `{tagger_id}` with
+            // `{filters}` fails — `{filters}` is missing from `values` and the
+            // whole query errors out, leaving the runs list silently empty.
+            // The id is escaped via escapeHogqlString as defense in depth (it
+            // comes from the URL path).
+            const escapedTaggerId = props.id.replace(/\\/g, '\\\\').replace(/'/g, "''")
             const query: HogQLQuery = {
                 kind: NodeKind.HogQLQuery,
                 query: `
@@ -328,12 +333,11 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
                         properties.$ai_tagger_name as tagger_name
                     FROM events
                     WHERE event = '$ai_tag'
-                      AND properties.$ai_tagger_id = {tagger_id}
+                      AND properties.$ai_tagger_id = '${escapedTaggerId}'
                       AND {filters}
                     ORDER BY timestamp DESC
                     LIMIT 100
                 `,
-                values: { tagger_id: props.id },
                 filters: {
                     dateRange: {
                         date_from: dateFrom,

--- a/products/llm_analytics/frontend/traceMessagesLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/traceMessagesLazyLoaderLogic.ts
@@ -5,7 +5,7 @@ import api from 'lib/api'
 import { HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
 
 import type { traceMessagesLazyLoaderLogicType } from './traceMessagesLazyLoaderLogicType'
-import { parsePartialJSON } from './utils'
+import { escapeHogqlString, parsePartialJSON } from './utils'
 
 export interface TraceMessages {
     firstInput: unknown
@@ -36,11 +36,6 @@ function chunk<T>(arr: T[], size: number): T[][] {
         chunks.push(arr.slice(i, i + size))
     }
     return chunks
-}
-
-// Escape a trace ID for safe inlining into a single-quoted HogQL string.
-function escapeHogqlString(value: string): string {
-    return value.replace(/\\/g, '\\\\').replace(/'/g, "''")
 }
 
 // "2026-04-11T19:20:55.828Z" → "2026-04-11 19:20:55" (ClickHouse toDateTime format, UTC).

--- a/products/llm_analytics/frontend/traceMessagesLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/traceMessagesLazyLoaderLogic.ts
@@ -3,9 +3,10 @@ import { actions, events, kea, listeners, path, reducers, selectors } from 'kea'
 import api from 'lib/api'
 
 import { HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
+import { escapeHogQLString } from '~/queries/utils'
 
 import type { traceMessagesLazyLoaderLogicType } from './traceMessagesLazyLoaderLogicType'
-import { escapeHogqlString, parsePartialJSON } from './utils'
+import { parsePartialJSON } from './utils'
 
 export interface TraceMessages {
     firstInput: unknown
@@ -187,9 +188,9 @@ export const traceMessagesLazyLoaderLogic = kea<traceMessagesLazyLoaderLogicType
                             // Inlining IDs + timestamps rather than using a values dict: we
                             // can't combine `{values}` with `{filters}`-style placeholders
                             // because parse_select eagerly resolves all placeholders against
-                            // the values dict before find_placeholders runs. Each ID is
-                            // escaped via escapeHogqlString.
-                            const idList = safe.map((s) => `'${escapeHogqlString(s.id)}'`).join(',')
+                            // the values dict before find_placeholders runs.
+                            // escapeHogQLString returns the value already wrapped in single quotes.
+                            const idList = safe.map((s) => escapeHogQLString(s.id)).join(',')
                             const query: HogQLQuery = {
                                 kind: NodeKind.HogQLQuery,
                                 query: `

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -1440,6 +1440,14 @@ export function safeStringify(value: unknown, indent: number = 2): string {
     }
 }
 
+// Escape a value for safe inlining into a single-quoted HogQL string.
+// Use when a `values` dict can't be combined with a `{filters}` placeholder —
+// `parse_select` resolves all placeholders against `values` before
+// `find_placeholders` runs, so the two cannot coexist.
+export function escapeHogqlString(value: string): string {
+    return value.replace(/\\/g, '\\\\').replace(/'/g, "''")
+}
+
 export function removeMilliseconds(timestamp: string): string {
     return dayjs(timestamp).utc().format('YYYY-MM-DDTHH:mm:ss[Z]')
 }

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -1440,10 +1440,11 @@ export function safeStringify(value: unknown, indent: number = 2): string {
     }
 }
 
-// Escape a value for safe inlining into a single-quoted HogQL string.
-// Use when a `values` dict can't be combined with a `{filters}` placeholder —
-// `parse_select` resolves all placeholders against `values` before
-// `find_placeholders` runs, so the two cannot coexist.
+// Escape a value for safe inlining into a single-quoted HogQL string literal.
+// One common reason to inline is that a `values` dict can't be combined with a
+// `{filters}` placeholder — `parse_select` resolves all placeholders against
+// `values` before `find_placeholders` runs, so the two cannot coexist — but
+// the helper is general and applies to any single-quoted HogQL string.
 export function escapeHogqlString(value: string): string {
     return value.replace(/\\/g, '\\\\').replace(/'/g, "''")
 }

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -1440,15 +1440,6 @@ export function safeStringify(value: unknown, indent: number = 2): string {
     }
 }
 
-// Escape a value for safe inlining into a single-quoted HogQL string literal.
-// One common reason to inline is that a `values` dict can't be combined with a
-// `{filters}` placeholder — `parse_select` resolves all placeholders against
-// `values` before `find_placeholders` runs, so the two cannot coexist — but
-// the helper is general and applies to any single-quoted HogQL string.
-export function escapeHogqlString(value: string): string {
-    return value.replace(/\\/g, '\\\\').replace(/'/g, "''")
-}
-
 export function removeMilliseconds(timestamp: string): string {
     return dayjs(timestamp).utc().format('YYYY-MM-DDTHH:mm:ss[Z]')
 }


### PR DESCRIPTION
## Problem

The runs tab on individual taggers in LLM analytics renders an empty list even when `$ai_tag` events for that tagger exist in `events`. Reported in support ticket #685 against `https://us.posthog.com/project/2/llm-analytics/tags/019df8a3-7ede-0000-e1d6-a14caa61964e?date_from=-7d`, where 13k+ matching events exist but none surface in the UI.

## Changes

`loadTagRuns` in `llmTaggerLogic.ts` built a `HogQLQuery` that combined two placeholder shapes:

- `{tagger_id}` resolved from the `values` dict, and
- `{filters}` resolved later by `replace_filters` against the query's `filters` field.

`parse_select` eagerly resolves *all* placeholders against `values` before `find_placeholders` decides which are filter placeholders. Because `filters` is missing from `values`, the parse step throws, the loader's `catch` swallows it, and the runs list is silently set to `[]`.

Same gotcha is already documented in `products/llm_analytics/frontend/traceMessagesLazyLoaderLogic.ts:192-197`, which solves it by inlining ids with HogQL string escaping. This PR mirrors that approach for the tagger id (a UUID from the URL path, escaped as defense in depth).

## How did you test this code?

I'm an agent. Automated only:

- `pnpm exec jest --testPathPattern=llmTaggerLogic.test` — 33/33 pass, including the existing `loadTagRuns › parses query results into TagRun objects` case which exercises the rebuilt query path.

I verified the data exists via PostHog MCP: the same SELECT (with the tagger_id inlined) returns 13289 matching rows over 7 days for the reported tagger. No manual UI verification was performed.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code agent.
- Investigation path: read `loadTagRuns`, confirmed event data via `execute-sql` against `events.$ai_tag`, then traced placeholder handling in `posthog/hogql/placeholders.py` and `posthog/hogql_queries/hogql_query_runner.py`. The `traceMessagesLazyLoaderLogic.ts` comment already names this exact failure mode, which made the fix mechanical.
- Considered (rejected) extending `parse_select` to skip the `{filters}` placeholder during eager resolution — broader blast radius and unrelated to the user-facing bug.
- The escape helper is duplicated locally rather than extracted to a shared module to keep the diff minimal; happy to factor it out if reviewers prefer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*