### PR TITLE
feat(llm-gateway): add anthropic->bedrock circuit breaker

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -1,4 +1,6 @@
+import asyncio
 import time
+from collections.abc import AsyncIterator
 from typing import Any
 
 import httpx
@@ -14,8 +16,6 @@ from llm_gateway.config import get_settings
 from llm_gateway.dependencies import AnthropicCircuitBreakerDep, RateLimitedUser
 from llm_gateway.metrics.prometheus import (
     ANTHROPIC_CIRCUIT_BREAKER_BYPASSED,
-    ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE,
-    ANTHROPIC_CIRCUIT_BREAKER_OPEN,
     BEDROCK_FALLBACK_FAILURE,
     BEDROCK_FALLBACK_SUCCESS,
     BEDROCK_FALLBACK_TRIGGERED,
@@ -129,17 +129,58 @@ async def _maybe_bypass_anthropic(
         return False
 
     decision = await breaker.evaluate()
-    ANTHROPIC_CIRCUIT_BREAKER_OPEN.set(1 if decision.open else 0)
-    ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE.set(decision.failure_rate)
     if decision.bypass:
         ANTHROPIC_CIRCUIT_BREAKER_BYPASSED.labels(model=model, product=product).inc()
     return decision.bypass
+
+
+def _is_breaker_success(status_code: int) -> bool:
+    """4xx are caller-side errors and don't reflect Anthropic health, except 429 — that's
+    Anthropic-side throttling and is exactly the kind of degradation the breaker exists for.
+    """
+    if status_code == 429:
+        return False
+    return status_code < 500
 
 
 async def _record_anthropic_outcome(breaker: AnthropicCircuitBreaker | None, success: bool) -> None:
     if breaker is None:
         return
     await breaker.record_outcome(success=success)
+
+
+def _wrap_stream_with_breaker(
+    response: StreamingResponse,
+    breaker: AnthropicCircuitBreaker | None,
+) -> StreamingResponse:
+    """Record the breaker outcome from inside the stream generator's lifecycle so mid-stream
+    Anthropic failures aren't misrecorded as successes — the connection-level success that
+    `handle_llm_request` returns isn't a reliable signal for streaming traffic.
+    """
+    if breaker is None:
+        return response
+
+    inner = response.body_iterator
+
+    async def wrapped() -> AsyncIterator[bytes]:
+        success = True
+        try:
+            async for chunk in inner:
+                yield chunk
+        except asyncio.CancelledError:
+            # Client disconnect — neither success nor failure of Anthropic.
+            raise
+        except Exception:
+            success = False
+            raise
+        finally:
+            try:
+                await breaker.record_outcome(success=success)
+            except Exception:
+                logger.exception("circuit_breaker_stream_record_failed")
+
+    response.body_iterator = wrapped()
+    return response
 
 
 async def _handle_anthropic_messages(
@@ -170,8 +211,9 @@ async def _handle_anthropic_messages(
             product=product,
         )
     except HTTPException as exc:
-        await _record_anthropic_outcome(breaker, success=exc.status_code < 500)
-        if not use_bedrock_fallback or exc.status_code < 500:
+        await _record_anthropic_outcome(breaker, success=_is_breaker_success(exc.status_code))
+        # Fall back to Bedrock for any provider-attributable failure (5xx + 429 throttling).
+        if not use_bedrock_fallback or _is_breaker_success(exc.status_code):
             raise
 
         error_type = exc.detail.get("error", {}).get("type", "unknown") if isinstance(exc.detail, dict) else "unknown"
@@ -193,6 +235,9 @@ async def _handle_anthropic_messages(
             logger.exception("Bedrock fallback also failed", model=body.model, product=product)
             raise exc from None
     else:
+        if isinstance(result, StreamingResponse):
+            # Outcome recorded from inside the stream generator (see _wrap_stream_with_breaker).
+            return _wrap_stream_with_breaker(result, breaker)
         await _record_anthropic_outcome(breaker, success=True)
         return result
 
@@ -217,8 +262,8 @@ async def _handle_count_tokens(
     try:
         result = await _anthropic_count_tokens_impl(data, body.model, user, product)
     except HTTPException as exc:
-        await _record_anthropic_outcome(breaker, success=exc.status_code < 500)
-        if not use_bedrock_fallback or exc.status_code < 500:
+        await _record_anthropic_outcome(breaker, success=_is_breaker_success(exc.status_code))
+        if not use_bedrock_fallback or _is_breaker_success(exc.status_code):
             raise
 
         error_type = exc.detail.get("error", {}).get("type", "unknown") if isinstance(exc.detail, dict) else "unknown"

--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -9,9 +9,9 @@ from fastapi.responses import StreamingResponse
 
 from llm_gateway.api.handler import ANTHROPIC_CONFIG, BEDROCK_CONFIG, _sanitize_request_data, handle_llm_request
 from llm_gateway.bedrock import count_tokens_with_bedrock, ensure_bedrock_configured, map_to_bedrock_model
-from llm_gateway.circuit_breaker import get_anthropic_circuit_breaker
+from llm_gateway.circuit_breaker import AnthropicCircuitBreaker
 from llm_gateway.config import get_settings
-from llm_gateway.dependencies import RateLimitedUser
+from llm_gateway.dependencies import AnthropicCircuitBreakerDep, RateLimitedUser
 from llm_gateway.metrics.prometheus import (
     ANTHROPIC_CIRCUIT_BREAKER_BYPASSED,
     ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE,
@@ -115,34 +115,28 @@ async def _send_bedrock_messages(
     )
 
 
-async def _maybe_bypass_anthropic(model: str, product: str, *, use_bedrock_fallback: bool) -> bool:
-    """Consult the circuit breaker and decide whether to bypass Anthropic for this request.
-
-    Bypass requires the caller to have opted in via `use_bedrock_fallback`; without that
+async def _maybe_bypass_anthropic(
+    breaker: AnthropicCircuitBreaker | None,
+    model: str,
+    product: str,
+    *,
+    use_bedrock_fallback: bool,
+) -> bool:
+    """Bypass requires the caller to have opted in via `use_bedrock_fallback`; without that
     we never silently change the upstream provider, even if Anthropic looks unhealthy.
-    Also publishes the breaker's open/closed and observed-failure-rate gauges.
     """
-    breaker = get_anthropic_circuit_breaker()
     if breaker is None or not use_bedrock_fallback:
         return False
 
-    bypass, rate, _ = await breaker.should_bypass()
-    open_now, _, _ = await breaker.is_open()
-    ANTHROPIC_CIRCUIT_BREAKER_OPEN.set(1 if open_now else 0)
-    ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE.set(rate)
-    if bypass:
-        logger.info(
-            "anthropic_circuit_breaker_bypass",
-            model=model,
-            product=product,
-            failure_rate=rate,
-        )
+    decision = await breaker.evaluate()
+    ANTHROPIC_CIRCUIT_BREAKER_OPEN.set(1 if decision.open else 0)
+    ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE.set(decision.failure_rate)
+    if decision.bypass:
         ANTHROPIC_CIRCUIT_BREAKER_BYPASSED.labels(model=model, product=product).inc()
-    return bypass
+    return decision.bypass
 
 
-async def _record_anthropic_outcome(success: bool) -> None:
-    breaker = get_anthropic_circuit_breaker()
+async def _record_anthropic_outcome(breaker: AnthropicCircuitBreaker | None, success: bool) -> None:
     if breaker is None:
         return
     await breaker.record_outcome(success=success)
@@ -152,6 +146,7 @@ async def _handle_anthropic_messages(
     body: AnthropicMessagesRequest,
     user: RateLimitedUser,
     request: Request,
+    breaker: AnthropicCircuitBreaker | None,
     product: str = "llm_gateway",
 ) -> dict[str, Any] | StreamingResponse:
     data = body.model_dump(exclude_none=True, exclude=GATEWAY_ONLY_FIELDS)
@@ -161,10 +156,9 @@ async def _handle_anthropic_messages(
     if provider == "bedrock":
         return await _send_bedrock_messages(data, user, request, body.stream or False, product)
 
-    if await _maybe_bypass_anthropic(body.model, product, use_bedrock_fallback=use_bedrock_fallback):
+    if await _maybe_bypass_anthropic(breaker, body.model, product, use_bedrock_fallback=use_bedrock_fallback):
         return await _send_bedrock_messages(data, user, request, body.stream or False, product)
 
-    # Anthropic path
     try:
         result = await handle_llm_request(
             request_data=data,
@@ -176,7 +170,7 @@ async def _handle_anthropic_messages(
             product=product,
         )
     except HTTPException as exc:
-        await _record_anthropic_outcome(success=exc.status_code < 500)
+        await _record_anthropic_outcome(breaker, success=exc.status_code < 500)
         if not use_bedrock_fallback or exc.status_code < 500:
             raise
 
@@ -199,7 +193,7 @@ async def _handle_anthropic_messages(
             logger.exception("Bedrock fallback also failed", model=body.model, product=product)
             raise exc from None
     else:
-        await _record_anthropic_outcome(success=True)
+        await _record_anthropic_outcome(breaker, success=True)
         return result
 
 
@@ -207,6 +201,7 @@ async def _handle_count_tokens(
     body: AnthropicCountTokensRequest,
     user: RateLimitedUser,
     request: Request,
+    breaker: AnthropicCircuitBreaker | None,
     product: str = "llm_gateway",
 ) -> dict[str, Any]:
     data = _sanitize_request_data(body.model_dump(exclude_none=True, exclude=GATEWAY_ONLY_FIELDS))
@@ -216,14 +211,13 @@ async def _handle_count_tokens(
     if provider == "bedrock":
         return await _bedrock_count_tokens_impl(data, body.model, user, product)
 
-    if await _maybe_bypass_anthropic(body.model, product, use_bedrock_fallback=use_bedrock_fallback):
+    if await _maybe_bypass_anthropic(breaker, body.model, product, use_bedrock_fallback=use_bedrock_fallback):
         return await _bedrock_count_tokens_impl(data, body.model, user, product)
 
-    # Anthropic path
     try:
         result = await _anthropic_count_tokens_impl(data, body.model, user, product)
     except HTTPException as exc:
-        await _record_anthropic_outcome(success=exc.status_code < 500)
+        await _record_anthropic_outcome(breaker, success=exc.status_code < 500)
         if not use_bedrock_fallback or exc.status_code < 500:
             raise
 
@@ -246,7 +240,7 @@ async def _handle_count_tokens(
             logger.exception("Bedrock count_tokens fallback also failed", model=body.model, product=product)
             raise exc from None
     else:
-        await _record_anthropic_outcome(success=True)
+        await _record_anthropic_outcome(breaker, success=True)
         return result
 
 
@@ -387,8 +381,9 @@ async def anthropic_count_tokens(
     body: AnthropicCountTokensRequest,
     user: RateLimitedUser,
     request: Request,
+    breaker: AnthropicCircuitBreakerDep,
 ) -> dict[str, Any]:
-    return await _handle_count_tokens(body, user, request)
+    return await _handle_count_tokens(body, user, request, breaker)
 
 
 @anthropic_router.post("/{product}/v1/messages/count_tokens", response_model=None)
@@ -397,9 +392,10 @@ async def anthropic_count_tokens_with_product(
     user: RateLimitedUser,
     product: str,
     request: Request,
+    breaker: AnthropicCircuitBreakerDep,
 ) -> dict[str, Any]:
     validate_product(product)
-    return await _handle_count_tokens(body, user, request, product=product)
+    return await _handle_count_tokens(body, user, request, breaker, product=product)
 
 
 @anthropic_router.post("/v1/messages", response_model=None)
@@ -407,9 +403,10 @@ async def anthropic_messages(
     body: AnthropicMessagesRequest,
     user: RateLimitedUser,
     request: Request,
+    breaker: AnthropicCircuitBreakerDep,
 ) -> dict[str, Any] | StreamingResponse:
     apply_posthog_context_from_headers(request)
-    return await _handle_anthropic_messages(body, user, request)
+    return await _handle_anthropic_messages(body, user, request, breaker)
 
 
 @anthropic_router.post("/{product}/v1/messages", response_model=None)
@@ -418,7 +415,8 @@ async def anthropic_messages_with_product(
     user: RateLimitedUser,
     product: str,
     request: Request,
+    breaker: AnthropicCircuitBreakerDep,
 ) -> dict[str, Any] | StreamingResponse:
     validate_product(product)
     apply_posthog_context_from_headers(request)
-    return await _handle_anthropic_messages(body, user, request, product=product)
+    return await _handle_anthropic_messages(body, user, request, breaker, product=product)

--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -9,9 +9,13 @@ from fastapi.responses import StreamingResponse
 
 from llm_gateway.api.handler import ANTHROPIC_CONFIG, BEDROCK_CONFIG, _sanitize_request_data, handle_llm_request
 from llm_gateway.bedrock import count_tokens_with_bedrock, ensure_bedrock_configured, map_to_bedrock_model
+from llm_gateway.circuit_breaker import get_anthropic_circuit_breaker
 from llm_gateway.config import get_settings
 from llm_gateway.dependencies import RateLimitedUser
 from llm_gateway.metrics.prometheus import (
+    ANTHROPIC_CIRCUIT_BREAKER_BYPASSED,
+    ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE,
+    ANTHROPIC_CIRCUIT_BREAKER_OPEN,
     BEDROCK_FALLBACK_FAILURE,
     BEDROCK_FALLBACK_SUCCESS,
     BEDROCK_FALLBACK_TRIGGERED,
@@ -111,6 +115,39 @@ async def _send_bedrock_messages(
     )
 
 
+async def _maybe_bypass_anthropic(model: str, product: str, *, use_bedrock_fallback: bool) -> bool:
+    """Consult the circuit breaker and decide whether to bypass Anthropic for this request.
+
+    Bypass requires the caller to have opted in via `use_bedrock_fallback`; without that
+    we never silently change the upstream provider, even if Anthropic looks unhealthy.
+    Also publishes the breaker's open/closed and observed-failure-rate gauges.
+    """
+    breaker = get_anthropic_circuit_breaker()
+    if breaker is None or not use_bedrock_fallback:
+        return False
+
+    bypass, rate, _ = await breaker.should_bypass()
+    open_now, _, _ = await breaker.is_open()
+    ANTHROPIC_CIRCUIT_BREAKER_OPEN.set(1 if open_now else 0)
+    ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE.set(rate)
+    if bypass:
+        logger.info(
+            "anthropic_circuit_breaker_bypass",
+            model=model,
+            product=product,
+            failure_rate=rate,
+        )
+        ANTHROPIC_CIRCUIT_BREAKER_BYPASSED.labels(model=model, product=product).inc()
+    return bypass
+
+
+async def _record_anthropic_outcome(success: bool) -> None:
+    breaker = get_anthropic_circuit_breaker()
+    if breaker is None:
+        return
+    await breaker.record_outcome(success=success)
+
+
 async def _handle_anthropic_messages(
     body: AnthropicMessagesRequest,
     user: RateLimitedUser,
@@ -124,9 +161,12 @@ async def _handle_anthropic_messages(
     if provider == "bedrock":
         return await _send_bedrock_messages(data, user, request, body.stream or False, product)
 
+    if await _maybe_bypass_anthropic(body.model, product, use_bedrock_fallback=use_bedrock_fallback):
+        return await _send_bedrock_messages(data, user, request, body.stream or False, product)
+
     # Anthropic path
     try:
-        return await handle_llm_request(
+        result = await handle_llm_request(
             request_data=data,
             user=user,
             model=body.model,
@@ -136,6 +176,7 @@ async def _handle_anthropic_messages(
             product=product,
         )
     except HTTPException as exc:
+        await _record_anthropic_outcome(success=exc.status_code < 500)
         if not use_bedrock_fallback or exc.status_code < 500:
             raise
 
@@ -157,6 +198,9 @@ async def _handle_anthropic_messages(
             BEDROCK_FALLBACK_FAILURE.labels(model=body.model, product=product).inc()
             logger.exception("Bedrock fallback also failed", model=body.model, product=product)
             raise exc from None
+    else:
+        await _record_anthropic_outcome(success=True)
+        return result
 
 
 async def _handle_count_tokens(
@@ -172,10 +216,14 @@ async def _handle_count_tokens(
     if provider == "bedrock":
         return await _bedrock_count_tokens_impl(data, body.model, user, product)
 
+    if await _maybe_bypass_anthropic(body.model, product, use_bedrock_fallback=use_bedrock_fallback):
+        return await _bedrock_count_tokens_impl(data, body.model, user, product)
+
     # Anthropic path
     try:
-        return await _anthropic_count_tokens_impl(data, body.model, user, product)
+        result = await _anthropic_count_tokens_impl(data, body.model, user, product)
     except HTTPException as exc:
+        await _record_anthropic_outcome(success=exc.status_code < 500)
         if not use_bedrock_fallback or exc.status_code < 500:
             raise
 
@@ -197,6 +245,9 @@ async def _handle_count_tokens(
             BEDROCK_FALLBACK_FAILURE.labels(model=body.model, product=product).inc()
             logger.exception("Bedrock count_tokens fallback also failed", model=body.model, product=product)
             raise exc from None
+    else:
+        await _record_anthropic_outcome(success=True)
+        return result
 
 
 async def _anthropic_count_tokens_impl(

--- a/services/llm-gateway/src/llm_gateway/circuit_breaker.py
+++ b/services/llm-gateway/src/llm_gateway/circuit_breaker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import math
 import random
 import time
 from dataclasses import dataclass
@@ -14,7 +16,10 @@ logger = structlog.get_logger(__name__)
 
 
 BUCKET_WIDTH_SECONDS = 30
-KEY_PREFIX = "llm_gateway:cb:anthropic"
+# v1: bumping the prefix invalidates buckets from any prior version with different bucket
+# semantics, so a rolling deploy can't mix incompatible writes into the same keyspace.
+KEY_PREFIX = "llm_gateway:cb:anthropic:v1"
+REDIS_OP_TIMEOUT_SECONDS = 0.1
 
 _OutcomeField = Literal["s", "f"]
 
@@ -51,7 +56,7 @@ class AnthropicCircuitBreaker:
         self.bypass_probability = bypass_probability
         self.min_requests = min_requests
         self.enabled = enabled
-        self._bucket_count = max(1, window_seconds // BUCKET_WIDTH_SECONDS)
+        self._bucket_count = max(1, math.ceil(window_seconds / BUCKET_WIDTH_SECONDS))
 
     def _bucket_key(self, bucket_index: int) -> str:
         return f"{KEY_PREFIX}:{bucket_index}"
@@ -66,12 +71,15 @@ class AnthropicCircuitBreaker:
         key = self._bucket_key(bucket)
         field: _OutcomeField = "s" if success else "f"
         try:
+            # Pipeline atomicity is required: HINCRBY without EXPIRE leaks keys without TTL.
             pipe = self.redis.pipeline()
             pipe.hincrby(key, field, 1)
-            # TTL = window + one bucket so a bucket fully covers its slice before expiring.
             pipe.expire(key, self.window_seconds + BUCKET_WIDTH_SECONDS)
-            await pipe.execute()
+            await asyncio.wait_for(pipe.execute(), timeout=REDIS_OP_TIMEOUT_SECONDS)
         except Exception:
+            from llm_gateway.metrics.prometheus import ANTHROPIC_CIRCUIT_BREAKER_REDIS_ERRORS
+
+            ANTHROPIC_CIRCUIT_BREAKER_REDIS_ERRORS.labels(op="record").inc()
             logger.exception("circuit_breaker_record_failed", success=success)
 
     async def _get_stats(self) -> tuple[int, int]:
@@ -83,8 +91,11 @@ class AnthropicCircuitBreaker:
             pipe = self.redis.pipeline()
             for key in keys:
                 pipe.hmget(key, "s", "f")
-            results = await pipe.execute()
+            results = await asyncio.wait_for(pipe.execute(), timeout=REDIS_OP_TIMEOUT_SECONDS)
         except Exception:
+            from llm_gateway.metrics.prometheus import ANTHROPIC_CIRCUIT_BREAKER_REDIS_ERRORS
+
+            ANTHROPIC_CIRCUIT_BREAKER_REDIS_ERRORS.labels(op="read").inc()
             logger.exception("circuit_breaker_read_failed")
             return 0, 0
 
@@ -128,3 +139,32 @@ def build_anthropic_circuit_breaker(redis: Redis[bytes] | None) -> AnthropicCirc
         min_requests=settings.anthropic_circuit_breaker_min_requests,
         enabled=settings.anthropic_circuit_breaker_enabled,
     )
+
+
+async def publish_anthropic_breaker_gauges_loop(
+    breaker: AnthropicCircuitBreaker,
+    interval_seconds: int = 5,
+) -> None:
+    """Refresh the breaker gauges from a single async task instead of from the request hot path.
+
+    Keeps the dashboard signal coherent under multi-worker load (no per-request races) and
+    decouples breaker observability from inbound traffic — the gauges keep updating even
+    when no opted-in callers are hitting the gateway.
+    """
+    from llm_gateway.metrics.prometheus import (
+        ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE,
+        ANTHROPIC_CIRCUIT_BREAKER_OPEN,
+        ANTHROPIC_CIRCUIT_BREAKER_WINDOW_REQUESTS,
+    )
+
+    while True:
+        try:
+            decision = await breaker.evaluate()
+            ANTHROPIC_CIRCUIT_BREAKER_OPEN.set(1 if decision.open else 0)
+            ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE.set(decision.failure_rate)
+            ANTHROPIC_CIRCUIT_BREAKER_WINDOW_REQUESTS.set(decision.total_requests)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("circuit_breaker_gauge_publish_failed")
+        await asyncio.sleep(interval_seconds)

--- a/services/llm-gateway/src/llm_gateway/circuit_breaker.py
+++ b/services/llm-gateway/src/llm_gateway/circuit_breaker.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import random
+import time
+
+import structlog
+from redis.asyncio import Redis
+
+logger = structlog.get_logger(__name__)
+
+
+# A sliding window implemented as N fixed-width buckets. Each bucket stores a
+# "S:F" string (successes:failures) and expires after the full window has elapsed.
+# We sum the most recent N buckets to compute the failure rate.
+BUCKET_WIDTH_SECONDS = 30
+KEY_PREFIX = "llm_gateway:cb:anthropic"
+
+
+class AnthropicCircuitBreaker:
+    """Tracks the trailing Anthropic failure rate and decides when to bypass to Bedrock.
+
+    The breaker is *open* when the trailing failure rate over `window_seconds` is at or
+    above `failure_threshold`, provided we've seen at least `min_requests` in that window.
+    While open, `should_bypass` returns True with probability `bypass_probability` so we
+    keep a fraction of probe traffic flowing to Anthropic to detect recovery.
+    """
+
+    def __init__(
+        self,
+        redis: Redis[bytes] | None,
+        failure_threshold: float,
+        window_seconds: int,
+        bypass_probability: float,
+        min_requests: int,
+        enabled: bool,
+    ) -> None:
+        self.redis = redis
+        self.failure_threshold = failure_threshold
+        self.window_seconds = window_seconds
+        self.bypass_probability = bypass_probability
+        self.min_requests = min_requests
+        self.enabled = enabled
+        self._bucket_count = max(1, window_seconds // BUCKET_WIDTH_SECONDS)
+
+    def _bucket_key(self, bucket_index: int) -> str:
+        return f"{KEY_PREFIX}:{bucket_index}"
+
+    def _current_bucket_index(self, now: float | None = None) -> int:
+        return int((now if now is not None else time.time()) // BUCKET_WIDTH_SECONDS)
+
+    async def record_outcome(self, *, success: bool) -> None:
+        if not self.enabled or self.redis is None:
+            return
+        bucket = self._current_bucket_index()
+        key = self._bucket_key(bucket)
+        field = "s" if success else "f"
+        try:
+            pipe = self.redis.pipeline()
+            pipe.hincrby(key, field, 1)
+            # TTL = window + one bucket so a bucket fully covers its slice before expiring.
+            pipe.expire(key, self.window_seconds + BUCKET_WIDTH_SECONDS)
+            await pipe.execute()
+        except Exception:
+            logger.exception("circuit_breaker_record_failed", success=success)
+
+    async def get_stats(self) -> tuple[int, int]:
+        """Return (total, failures) summed across the trailing window."""
+        if not self.enabled or self.redis is None:
+            return 0, 0
+        current = self._current_bucket_index()
+        keys = [self._bucket_key(current - offset) for offset in range(self._bucket_count)]
+        try:
+            pipe = self.redis.pipeline()
+            for key in keys:
+                pipe.hmget(key, "s", "f")
+            results = await pipe.execute()
+        except Exception:
+            logger.exception("circuit_breaker_read_failed")
+            return 0, 0
+
+        successes = 0
+        failures = 0
+        for entry in results:
+            if not entry:
+                continue
+            s_raw, f_raw = entry
+            successes += int(s_raw or 0)
+            failures += int(f_raw or 0)
+        return successes + failures, failures
+
+    async def get_failure_rate(self) -> tuple[float, int]:
+        total, failures = await self.get_stats()
+        if total == 0:
+            return 0.0, 0
+        return failures / total, total
+
+    async def is_open(self) -> tuple[bool, float, int]:
+        """Return (open, failure_rate, total_requests_in_window)."""
+        if not self.enabled:
+            return False, 0.0, 0
+        rate, total = await self.get_failure_rate()
+        if total < self.min_requests:
+            return False, rate, total
+        return rate >= self.failure_threshold, rate, total
+
+    async def should_bypass(self) -> tuple[bool, float, int]:
+        """Decide whether to bypass Anthropic for a single request.
+
+        Returns (bypass, failure_rate, total_requests_in_window). The caller is
+        responsible for honoring the per-request `use_bedrock_fallback` opt-in
+        before consulting this — the breaker only opens; it doesn't force fallback
+        on callers that haven't opted in.
+        """
+        open_, rate, total = await self.is_open()
+        if not open_:
+            return False, rate, total
+        return random.random() < self.bypass_probability, rate, total
+
+
+_INSTANCE: AnthropicCircuitBreaker | None = None
+
+
+def init_anthropic_circuit_breaker(redis: Redis[bytes] | None) -> AnthropicCircuitBreaker:
+    from llm_gateway.config import get_settings
+
+    settings = get_settings()
+    global _INSTANCE
+    _INSTANCE = AnthropicCircuitBreaker(
+        redis=redis,
+        failure_threshold=settings.anthropic_circuit_breaker_failure_threshold,
+        window_seconds=settings.anthropic_circuit_breaker_window_seconds,
+        bypass_probability=settings.anthropic_circuit_breaker_bypass_probability,
+        min_requests=settings.anthropic_circuit_breaker_min_requests,
+        enabled=settings.anthropic_circuit_breaker_enabled,
+    )
+    return _INSTANCE
+
+
+def get_anthropic_circuit_breaker() -> AnthropicCircuitBreaker | None:
+    return _INSTANCE
+
+
+def set_anthropic_circuit_breaker(breaker: AnthropicCircuitBreaker | None) -> None:
+    global _INSTANCE
+    _INSTANCE = breaker

--- a/services/llm-gateway/src/llm_gateway/circuit_breaker.py
+++ b/services/llm-gateway/src/llm_gateway/circuit_breaker.py
@@ -2,18 +2,29 @@ from __future__ import annotations
 
 import random
 import time
+from dataclasses import dataclass
+from typing import Literal
 
 import structlog
 from redis.asyncio import Redis
 
+from llm_gateway.config import get_settings
+
 logger = structlog.get_logger(__name__)
 
 
-# A sliding window implemented as N fixed-width buckets. Each bucket stores a
-# "S:F" string (successes:failures) and expires after the full window has elapsed.
-# We sum the most recent N buckets to compute the failure rate.
 BUCKET_WIDTH_SECONDS = 30
 KEY_PREFIX = "llm_gateway:cb:anthropic"
+
+_OutcomeField = Literal["s", "f"]
+
+
+@dataclass(frozen=True)
+class BreakerDecision:
+    bypass: bool
+    open: bool
+    failure_rate: float
+    total_requests: int
 
 
 class AnthropicCircuitBreaker:
@@ -21,7 +32,7 @@ class AnthropicCircuitBreaker:
 
     The breaker is *open* when the trailing failure rate over `window_seconds` is at or
     above `failure_threshold`, provided we've seen at least `min_requests` in that window.
-    While open, `should_bypass` returns True with probability `bypass_probability` so we
+    While open, `evaluate` flags `bypass=True` with probability `bypass_probability` so we
     keep a fraction of probe traffic flowing to Anthropic to detect recovery.
     """
 
@@ -53,7 +64,7 @@ class AnthropicCircuitBreaker:
             return
         bucket = self._current_bucket_index()
         key = self._bucket_key(bucket)
-        field = "s" if success else "f"
+        field: _OutcomeField = "s" if success else "f"
         try:
             pipe = self.redis.pipeline()
             pipe.hincrby(key, field, 1)
@@ -63,8 +74,7 @@ class AnthropicCircuitBreaker:
         except Exception:
             logger.exception("circuit_breaker_record_failed", success=success)
 
-    async def get_stats(self) -> tuple[int, int]:
-        """Return (total, failures) summed across the trailing window."""
+    async def _get_stats(self) -> tuple[int, int]:
         if not self.enabled or self.redis is None:
             return 0, 0
         current = self._current_bucket_index()
@@ -88,44 +98,29 @@ class AnthropicCircuitBreaker:
             failures += int(f_raw or 0)
         return successes + failures, failures
 
-    async def get_failure_rate(self) -> tuple[float, int]:
-        total, failures = await self.get_stats()
-        if total == 0:
-            return 0.0, 0
-        return failures / total, total
+    async def evaluate(self) -> BreakerDecision:
+        """Single Redis read producing both the open/closed state and the per-request bypass decision.
 
-    async def is_open(self) -> tuple[bool, float, int]:
-        """Return (open, failure_rate, total_requests_in_window)."""
-        if not self.enabled:
-            return False, 0.0, 0
-        rate, total = await self.get_failure_rate()
-        if total < self.min_requests:
-            return False, rate, total
-        return rate >= self.failure_threshold, rate, total
-
-    async def should_bypass(self) -> tuple[bool, float, int]:
-        """Decide whether to bypass Anthropic for a single request.
-
-        Returns (bypass, failure_rate, total_requests_in_window). The caller is
-        responsible for honoring the per-request `use_bedrock_fallback` opt-in
-        before consulting this — the breaker only opens; it doesn't force fallback
-        on callers that haven't opted in.
+        Caller is responsible for honoring the per-request `use_bedrock_fallback` opt-in
+        before consulting this — the breaker only opens; it doesn't force fallback on
+        callers that haven't opted in.
         """
-        open_, rate, total = await self.is_open()
-        if not open_:
-            return False, rate, total
-        return random.random() < self.bypass_probability, rate, total
+        if not self.enabled:
+            return BreakerDecision(bypass=False, open=False, failure_rate=0.0, total_requests=0)
+
+        total, failures = await self._get_stats()
+        rate = failures / total if total else 0.0
+
+        if total < self.min_requests or rate < self.failure_threshold:
+            return BreakerDecision(bypass=False, open=False, failure_rate=rate, total_requests=total)
+
+        bypass = random.random() < self.bypass_probability
+        return BreakerDecision(bypass=bypass, open=True, failure_rate=rate, total_requests=total)
 
 
-_INSTANCE: AnthropicCircuitBreaker | None = None
-
-
-def init_anthropic_circuit_breaker(redis: Redis[bytes] | None) -> AnthropicCircuitBreaker:
-    from llm_gateway.config import get_settings
-
+def build_anthropic_circuit_breaker(redis: Redis[bytes] | None) -> AnthropicCircuitBreaker:
     settings = get_settings()
-    global _INSTANCE
-    _INSTANCE = AnthropicCircuitBreaker(
+    return AnthropicCircuitBreaker(
         redis=redis,
         failure_threshold=settings.anthropic_circuit_breaker_failure_threshold,
         window_seconds=settings.anthropic_circuit_breaker_window_seconds,
@@ -133,13 +128,3 @@ def init_anthropic_circuit_breaker(redis: Redis[bytes] | None) -> AnthropicCircu
         min_requests=settings.anthropic_circuit_breaker_min_requests,
         enabled=settings.anthropic_circuit_breaker_enabled,
     )
-    return _INSTANCE
-
-
-def get_anthropic_circuit_breaker() -> AnthropicCircuitBreaker | None:
-    return _INSTANCE
-
-
-def set_anthropic_circuit_breaker(breaker: AnthropicCircuitBreaker | None) -> None:
-    global _INSTANCE
-    _INSTANCE = breaker

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -152,6 +152,17 @@ class Settings(BaseSettings):
     plan_cache_ttl: int = 900  # 15 minutes
     billing_period_days: int = 30
 
+    # Anthropic -> Bedrock circuit breaker. When the trailing failure rate of the Anthropic
+    # path crosses `failure_threshold` (with at least `min_requests` observations in the
+    # window), the breaker is "open": each request that has opted in to Bedrock fallback
+    # gets routed straight to Bedrock with probability `bypass_probability`, leaving the
+    # remainder as probe traffic to detect recovery.
+    anthropic_circuit_breaker_enabled: bool = True
+    anthropic_circuit_breaker_failure_threshold: float = 0.25
+    anthropic_circuit_breaker_window_seconds: int = 300
+    anthropic_circuit_breaker_bypass_probability: float = 0.9
+    anthropic_circuit_breaker_min_requests: int = 20
+
     @field_validator("product_cost_limits", mode="before")
     @classmethod
     def parse_product_cost_limits(cls, v: str | dict | None) -> dict[str, ProductCostLimit]:

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -9,6 +9,7 @@ from fastapi import Depends, HTTPException, Request, status
 
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.auth.service import AuthService, get_auth_service
+from llm_gateway.circuit_breaker import AnthropicCircuitBreaker
 from llm_gateway.products.config import ALLOWED_PRODUCTS, check_product_access, resolve_product_alias
 from llm_gateway.rate_limiting.cost_refresh import ensure_costs_fresh
 from llm_gateway.rate_limiting.runner import ThrottleRunner
@@ -30,6 +31,10 @@ async def get_db_pool(request: Request) -> "asyncpg.Pool[asyncpg.Record]":  # no
 
 async def get_throttle_runner(request: Request) -> ThrottleRunner:
     return request.app.state.throttle_runner
+
+
+async def get_anthropic_circuit_breaker(request: Request) -> AnthropicCircuitBreaker | None:
+    return getattr(request.app.state, "anthropic_circuit_breaker", None)
 
 
 async def get_authenticated_user(
@@ -199,3 +204,4 @@ DBPool = Annotated[asyncpg.Pool, Depends(get_db_pool)]
 CurrentUser = Annotated[AuthenticatedUser, Depends(get_authenticated_user)]
 ProductAccessUser = Annotated[AuthenticatedUser, Depends(enforce_product_access)]
 RateLimitedUser = Annotated[AuthenticatedUser, Depends(enforce_throttles)]
+AnthropicCircuitBreakerDep = Annotated[AnthropicCircuitBreaker | None, Depends(get_anthropic_circuit_breaker)]

--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -21,6 +21,7 @@ from starlette.types import ASGIApp
 from llm_gateway.api.health import health_router
 from llm_gateway.api.routes import router
 from llm_gateway.callbacks import init_callbacks
+from llm_gateway.circuit_breaker import init_anthropic_circuit_breaker, set_anthropic_circuit_breaker
 from llm_gateway.config import get_settings
 from llm_gateway.db.postgres import close_db_pool, init_db_pool
 from llm_gateway.metrics.prometheus import DB_POOL_SIZE, get_instrumentator
@@ -149,6 +150,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     app.state.cost_gauge_task = asyncio.create_task(publish_product_cost_gauges_loop(product_throttle))
 
+    init_anthropic_circuit_breaker(app.state.redis)
+    logger.info(
+        "anthropic_circuit_breaker_initialized",
+        enabled=settings.anthropic_circuit_breaker_enabled,
+        failure_threshold=settings.anthropic_circuit_breaker_failure_threshold,
+        window_seconds=settings.anthropic_circuit_breaker_window_seconds,
+        bypass_probability=settings.anthropic_circuit_breaker_bypass_probability,
+        min_requests=settings.anthropic_circuit_breaker_min_requests,
+    )
+
     app.state.http_client = httpx.AsyncClient()
     app.state.plan_resolver = PlanResolver(
         redis=app.state.redis,
@@ -188,6 +199,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             await cost_gauge_task
         except asyncio.CancelledError:
             pass
+    set_anthropic_circuit_breaker(None)
     if app.state.http_client:
         await app.state.http_client.aclose()
         logger.info("HTTP client closed")

--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -21,7 +21,7 @@ from starlette.types import ASGIApp
 from llm_gateway.api.health import health_router
 from llm_gateway.api.routes import router
 from llm_gateway.callbacks import init_callbacks
-from llm_gateway.circuit_breaker import init_anthropic_circuit_breaker, set_anthropic_circuit_breaker
+from llm_gateway.circuit_breaker import build_anthropic_circuit_breaker
 from llm_gateway.config import get_settings
 from llm_gateway.db.postgres import close_db_pool, init_db_pool
 from llm_gateway.metrics.prometheus import DB_POOL_SIZE, get_instrumentator
@@ -150,7 +150,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     app.state.cost_gauge_task = asyncio.create_task(publish_product_cost_gauges_loop(product_throttle))
 
-    init_anthropic_circuit_breaker(app.state.redis)
+    app.state.anthropic_circuit_breaker = build_anthropic_circuit_breaker(app.state.redis)
     logger.info(
         "anthropic_circuit_breaker_initialized",
         enabled=settings.anthropic_circuit_breaker_enabled,
@@ -199,7 +199,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             await cost_gauge_task
         except asyncio.CancelledError:
             pass
-    set_anthropic_circuit_breaker(None)
     if app.state.http_client:
         await app.state.http_client.aclose()
         logger.info("HTTP client closed")

--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -21,7 +21,7 @@ from starlette.types import ASGIApp
 from llm_gateway.api.health import health_router
 from llm_gateway.api.routes import router
 from llm_gateway.callbacks import init_callbacks
-from llm_gateway.circuit_breaker import build_anthropic_circuit_breaker
+from llm_gateway.circuit_breaker import build_anthropic_circuit_breaker, publish_anthropic_breaker_gauges_loop
 from llm_gateway.config import get_settings
 from llm_gateway.db.postgres import close_db_pool, init_db_pool
 from llm_gateway.metrics.prometheus import DB_POOL_SIZE, get_instrumentator
@@ -159,6 +159,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         bypass_probability=settings.anthropic_circuit_breaker_bypass_probability,
         min_requests=settings.anthropic_circuit_breaker_min_requests,
     )
+    app.state.anthropic_breaker_gauge_task = asyncio.create_task(
+        publish_anthropic_breaker_gauges_loop(app.state.anthropic_circuit_breaker)
+    )
 
     app.state.http_client = httpx.AsyncClient()
     app.state.plan_resolver = PlanResolver(
@@ -197,6 +200,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         cost_gauge_task.cancel()
         try:
             await cost_gauge_task
+        except asyncio.CancelledError:
+            pass
+    breaker_gauge_task = getattr(app.state, "anthropic_breaker_gauge_task", None)
+    if breaker_gauge_task is not None:
+        breaker_gauge_task.cancel()
+        try:
+            await breaker_gauge_task
         except asyncio.CancelledError:
             pass
     if app.state.http_client:

--- a/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
+++ b/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
@@ -259,6 +259,17 @@ ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE = Gauge(
     "Trailing-window Anthropic failure rate observed by the circuit breaker",
 )
 
+ANTHROPIC_CIRCUIT_BREAKER_WINDOW_REQUESTS = Gauge(
+    "llm_gateway_anthropic_circuit_breaker_window_requests",
+    "Total Anthropic requests observed in the breaker's trailing window",
+)
+
+ANTHROPIC_CIRCUIT_BREAKER_REDIS_ERRORS = Counter(
+    "llm_gateway_anthropic_circuit_breaker_redis_errors_total",
+    "Redis errors encountered by the Anthropic circuit breaker (non-zero rate means breaker is blind)",
+    labelnames=["op"],
+)
+
 
 def get_instrumentator() -> Instrumentator:
     return Instrumentator(

--- a/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
+++ b/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
@@ -243,6 +243,22 @@ BEDROCK_FALLBACK_FAILURE = Counter(
     labelnames=["model", "product"],
 )
 
+ANTHROPIC_CIRCUIT_BREAKER_BYPASSED = Counter(
+    "llm_gateway_anthropic_circuit_breaker_bypassed_total",
+    "Anthropic requests routed straight to Bedrock because the breaker was open",
+    labelnames=["model", "product"],
+)
+
+ANTHROPIC_CIRCUIT_BREAKER_OPEN = Gauge(
+    "llm_gateway_anthropic_circuit_breaker_open",
+    "1 if the Anthropic->Bedrock circuit breaker is currently open, 0 otherwise",
+)
+
+ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE = Gauge(
+    "llm_gateway_anthropic_circuit_breaker_failure_rate",
+    "Trailing-window Anthropic failure rate observed by the circuit breaker",
+)
+
 
 def get_instrumentator() -> Instrumentator:
     return Instrumentator(

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
 from llm_gateway.auth.models import AuthenticatedUser
+from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
 from llm_gateway.main import http_exception_handler
 from llm_gateway.rate_limiting.cost_throttles import (
     ProductCostThrottle,
@@ -40,7 +41,9 @@ def create_test_app(
         app.state.http_client = MagicMock()
         app.state.plan_resolver = AsyncMock()
         app.state.plan_resolver.get_plan = AsyncMock(return_value=PlanInfo(plan_key=None, seat_created_at=None))
+        set_anthropic_circuit_breaker(None)
         yield
+        set_anthropic_circuit_breaker(None)
 
     app = FastAPI(title="LLM Gateway Test", lifespan=test_lifespan)
     app.exception_handler(HTTPException)(http_exception_handler)

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -8,7 +8,6 @@ from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
 from llm_gateway.auth.models import AuthenticatedUser
-from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
 from llm_gateway.main import http_exception_handler
 from llm_gateway.rate_limiting.cost_throttles import (
     ProductCostThrottle,
@@ -41,9 +40,8 @@ def create_test_app(
         app.state.http_client = MagicMock()
         app.state.plan_resolver = AsyncMock()
         app.state.plan_resolver.get_plan = AsyncMock(return_value=PlanInfo(plan_key=None, seat_created_at=None))
-        set_anthropic_circuit_breaker(None)
+        app.state.anthropic_circuit_breaker = None
         yield
-        set_anthropic_circuit_breaker(None)
 
     app = FastAPI(title="LLM Gateway Test", lifespan=test_lifespan)
     app.exception_handler(HTTPException)(http_exception_handler)

--- a/services/llm-gateway/tests/test_anthropic.py
+++ b/services/llm-gateway/tests/test_anthropic.py
@@ -927,3 +927,188 @@ class TestAnthropicCountTokensEndpoint:
         assert response.status_code == 400
         assert response.json()["error"]["type"] == "invalid_request_error"
         assert "Expected: true or false" in response.json()["error"]["message"]
+
+
+class TestAnthropicCircuitBreakerIntegration:
+    """End-to-end behavior of the Anthropic->Bedrock circuit breaker in /v1/messages."""
+
+    @pytest.fixture
+    def request_body(self) -> dict[str, Any]:
+        return {"model": "claude-sonnet-4-6", "messages": [{"role": "user", "content": "Hi"}]}
+
+    @pytest.fixture
+    def mock_response_dict(self) -> dict[str, Any]:
+        return {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hi!"}],
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+
+    def _install_breaker(self, *, bypass: bool) -> MagicMock:
+        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
+
+        breaker = MagicMock()
+        breaker.should_bypass = AsyncMock(return_value=(bypass, 0.5 if bypass else 0.0, 30))
+        breaker.is_open = AsyncMock(return_value=(bypass, 0.5 if bypass else 0.0, 30))
+        breaker.record_outcome = AsyncMock()
+        set_anthropic_circuit_breaker(breaker)
+        return breaker
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_open_breaker_with_fallback_routes_to_bedrock(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        request_body: dict,
+        mock_response_dict: dict,
+    ) -> None:
+        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
+
+        breaker = self._install_breaker(bypass=True)
+        try:
+            mock_response = MagicMock()
+            mock_response.model_dump = MagicMock(return_value=mock_response_dict)
+            mock_anthropic.return_value = mock_response
+
+            with patch(
+                "llm_gateway.api.anthropic.get_settings",
+                return_value=MagicMock(bedrock_region_name="us-east-1", request_timeout=300.0),
+            ):
+                response = authenticated_client.post(
+                    "/v1/messages",
+                    json=request_body,
+                    headers={
+                        "Authorization": "Bearer phx_test_key",
+                        "X-PostHog-Use-Bedrock-Fallback": "true",
+                    },
+                )
+
+            assert response.status_code == 200
+            assert mock_anthropic.call_count == 1
+            forwarded_model = mock_anthropic.call_args.kwargs["model"]
+            assert forwarded_model.startswith(("us.anthropic.", "eu.anthropic.", "anthropic."))
+            breaker.record_outcome.assert_not_called()
+        finally:
+            set_anthropic_circuit_breaker(None)
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_open_breaker_without_fallback_still_uses_anthropic(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        request_body: dict,
+        mock_response_dict: dict,
+    ) -> None:
+        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
+
+        breaker = self._install_breaker(bypass=True)
+        try:
+            mock_response = MagicMock()
+            mock_response.model_dump = MagicMock(return_value=mock_response_dict)
+            mock_anthropic.return_value = mock_response
+
+            response = authenticated_client.post(
+                "/v1/messages",
+                json=request_body,
+                headers={"Authorization": "Bearer phx_test_key"},
+            )
+
+            assert response.status_code == 200
+            forwarded_model = mock_anthropic.call_args.kwargs["model"]
+            assert forwarded_model == "claude-sonnet-4-6"
+            breaker.record_outcome.assert_awaited_with(success=True)
+            breaker.should_bypass.assert_not_called()
+        finally:
+            set_anthropic_circuit_breaker(None)
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_closed_breaker_routes_to_anthropic(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        request_body: dict,
+        mock_response_dict: dict,
+    ) -> None:
+        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
+
+        breaker = self._install_breaker(bypass=False)
+        try:
+            mock_response = MagicMock()
+            mock_response.model_dump = MagicMock(return_value=mock_response_dict)
+            mock_anthropic.return_value = mock_response
+
+            response = authenticated_client.post(
+                "/v1/messages",
+                json=request_body,
+                headers={
+                    "Authorization": "Bearer phx_test_key",
+                    "X-PostHog-Use-Bedrock-Fallback": "true",
+                },
+            )
+
+            assert response.status_code == 200
+            forwarded_model = mock_anthropic.call_args.kwargs["model"]
+            assert forwarded_model == "claude-sonnet-4-6"
+            breaker.record_outcome.assert_awaited_with(success=True)
+        finally:
+            set_anthropic_circuit_breaker(None)
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_anthropic_5xx_records_failure(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        request_body: dict,
+    ) -> None:
+        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
+
+        breaker = self._install_breaker(bypass=False)
+        try:
+            error = Exception("Internal error")
+            error.status_code = 503  # type: ignore[attr-defined]
+            error.message = "Internal error"  # type: ignore[attr-defined]
+            error.type = "internal_error"  # type: ignore[attr-defined]
+            mock_anthropic.side_effect = error
+
+            response = authenticated_client.post(
+                "/v1/messages",
+                json=request_body,
+                headers={"Authorization": "Bearer phx_test_key"},
+            )
+
+            assert response.status_code == 503
+            breaker.record_outcome.assert_awaited_with(success=False)
+        finally:
+            set_anthropic_circuit_breaker(None)
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_anthropic_4xx_recorded_as_success(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        request_body: dict,
+    ) -> None:
+        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
+
+        breaker = self._install_breaker(bypass=False)
+        try:
+            error = Exception("bad request")
+            error.status_code = 400  # type: ignore[attr-defined]
+            error.message = "bad request"  # type: ignore[attr-defined]
+            error.type = "invalid_request_error"  # type: ignore[attr-defined]
+            mock_anthropic.side_effect = error
+
+            response = authenticated_client.post(
+                "/v1/messages",
+                json=request_body,
+                headers={"Authorization": "Bearer phx_test_key"},
+            )
+
+            assert response.status_code == 400
+            breaker.record_outcome.assert_awaited_with(success=True)
+        finally:
+            set_anthropic_circuit_breaker(None)

--- a/services/llm-gateway/tests/test_anthropic.py
+++ b/services/llm-gateway/tests/test_anthropic.py
@@ -948,99 +948,44 @@ class TestAnthropicCircuitBreakerIntegration:
             "usage": {"input_tokens": 10, "output_tokens": 5},
         }
 
-    def _install_breaker(self, *, bypass: bool) -> MagicMock:
-        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
+    @pytest.fixture
+    def install_breaker(self, authenticated_client: TestClient):
+        from llm_gateway.circuit_breaker import BreakerDecision
 
-        breaker = MagicMock()
-        breaker.should_bypass = AsyncMock(return_value=(bypass, 0.5 if bypass else 0.0, 30))
-        breaker.is_open = AsyncMock(return_value=(bypass, 0.5 if bypass else 0.0, 30))
-        breaker.record_outcome = AsyncMock()
-        set_anthropic_circuit_breaker(breaker)
-        return breaker
+        def _install(*, bypass: bool) -> MagicMock:
+            breaker = MagicMock()
+            breaker.evaluate = AsyncMock(
+                return_value=BreakerDecision(
+                    bypass=bypass,
+                    open=bypass,
+                    failure_rate=0.5 if bypass else 0.0,
+                    total_requests=30,
+                )
+            )
+            breaker.record_outcome = AsyncMock()
+            authenticated_client.app.state.anthropic_circuit_breaker = breaker
+            return breaker
+
+        return _install
 
     @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
     def test_open_breaker_with_fallback_routes_to_bedrock(
         self,
         mock_anthropic: MagicMock,
         authenticated_client: TestClient,
+        install_breaker,
         request_body: dict,
         mock_response_dict: dict,
     ) -> None:
-        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
+        breaker = install_breaker(bypass=True)
+        mock_response = MagicMock()
+        mock_response.model_dump = MagicMock(return_value=mock_response_dict)
+        mock_anthropic.return_value = mock_response
 
-        breaker = self._install_breaker(bypass=True)
-        try:
-            mock_response = MagicMock()
-            mock_response.model_dump = MagicMock(return_value=mock_response_dict)
-            mock_anthropic.return_value = mock_response
-
-            with patch(
-                "llm_gateway.api.anthropic.get_settings",
-                return_value=MagicMock(bedrock_region_name="us-east-1", request_timeout=300.0),
-            ):
-                response = authenticated_client.post(
-                    "/v1/messages",
-                    json=request_body,
-                    headers={
-                        "Authorization": "Bearer phx_test_key",
-                        "X-PostHog-Use-Bedrock-Fallback": "true",
-                    },
-                )
-
-            assert response.status_code == 200
-            assert mock_anthropic.call_count == 1
-            forwarded_model = mock_anthropic.call_args.kwargs["model"]
-            assert forwarded_model.startswith(("us.anthropic.", "eu.anthropic.", "anthropic."))
-            breaker.record_outcome.assert_not_called()
-        finally:
-            set_anthropic_circuit_breaker(None)
-
-    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
-    def test_open_breaker_without_fallback_still_uses_anthropic(
-        self,
-        mock_anthropic: MagicMock,
-        authenticated_client: TestClient,
-        request_body: dict,
-        mock_response_dict: dict,
-    ) -> None:
-        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
-
-        breaker = self._install_breaker(bypass=True)
-        try:
-            mock_response = MagicMock()
-            mock_response.model_dump = MagicMock(return_value=mock_response_dict)
-            mock_anthropic.return_value = mock_response
-
-            response = authenticated_client.post(
-                "/v1/messages",
-                json=request_body,
-                headers={"Authorization": "Bearer phx_test_key"},
-            )
-
-            assert response.status_code == 200
-            forwarded_model = mock_anthropic.call_args.kwargs["model"]
-            assert forwarded_model == "claude-sonnet-4-6"
-            breaker.record_outcome.assert_awaited_with(success=True)
-            breaker.should_bypass.assert_not_called()
-        finally:
-            set_anthropic_circuit_breaker(None)
-
-    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
-    def test_closed_breaker_routes_to_anthropic(
-        self,
-        mock_anthropic: MagicMock,
-        authenticated_client: TestClient,
-        request_body: dict,
-        mock_response_dict: dict,
-    ) -> None:
-        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
-
-        breaker = self._install_breaker(bypass=False)
-        try:
-            mock_response = MagicMock()
-            mock_response.model_dump = MagicMock(return_value=mock_response_dict)
-            mock_anthropic.return_value = mock_response
-
+        with patch(
+            "llm_gateway.api.anthropic.get_settings",
+            return_value=MagicMock(bedrock_region_name="us-east-1", request_timeout=300.0),
+        ):
             response = authenticated_client.post(
                 "/v1/messages",
                 json=request_body,
@@ -1050,65 +995,110 @@ class TestAnthropicCircuitBreakerIntegration:
                 },
             )
 
-            assert response.status_code == 200
-            forwarded_model = mock_anthropic.call_args.kwargs["model"]
-            assert forwarded_model == "claude-sonnet-4-6"
-            breaker.record_outcome.assert_awaited_with(success=True)
-        finally:
-            set_anthropic_circuit_breaker(None)
+        assert response.status_code == 200
+        assert mock_anthropic.call_count == 1
+        forwarded_model = mock_anthropic.call_args.kwargs["model"]
+        assert forwarded_model.startswith(("us.anthropic.", "eu.anthropic.", "anthropic."))
+        breaker.record_outcome.assert_not_called()
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_open_breaker_without_fallback_still_uses_anthropic(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        install_breaker,
+        request_body: dict,
+        mock_response_dict: dict,
+    ) -> None:
+        breaker = install_breaker(bypass=True)
+        mock_response = MagicMock()
+        mock_response.model_dump = MagicMock(return_value=mock_response_dict)
+        mock_anthropic.return_value = mock_response
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json=request_body,
+            headers={"Authorization": "Bearer phx_test_key"},
+        )
+
+        assert response.status_code == 200
+        forwarded_model = mock_anthropic.call_args.kwargs["model"]
+        assert forwarded_model == "claude-sonnet-4-6"
+        breaker.record_outcome.assert_awaited_with(success=True)
+        breaker.evaluate.assert_not_called()
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_closed_breaker_routes_to_anthropic(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        install_breaker,
+        request_body: dict,
+        mock_response_dict: dict,
+    ) -> None:
+        breaker = install_breaker(bypass=False)
+        mock_response = MagicMock()
+        mock_response.model_dump = MagicMock(return_value=mock_response_dict)
+        mock_anthropic.return_value = mock_response
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json=request_body,
+            headers={
+                "Authorization": "Bearer phx_test_key",
+                "X-PostHog-Use-Bedrock-Fallback": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        forwarded_model = mock_anthropic.call_args.kwargs["model"]
+        assert forwarded_model == "claude-sonnet-4-6"
+        breaker.record_outcome.assert_awaited_with(success=True)
 
     @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
     def test_anthropic_5xx_records_failure(
         self,
         mock_anthropic: MagicMock,
         authenticated_client: TestClient,
+        install_breaker,
         request_body: dict,
     ) -> None:
-        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
+        breaker = install_breaker(bypass=False)
+        error = Exception("Internal error")
+        error.status_code = 503  # type: ignore[attr-defined]
+        error.message = "Internal error"  # type: ignore[attr-defined]
+        error.type = "internal_error"  # type: ignore[attr-defined]
+        mock_anthropic.side_effect = error
 
-        breaker = self._install_breaker(bypass=False)
-        try:
-            error = Exception("Internal error")
-            error.status_code = 503  # type: ignore[attr-defined]
-            error.message = "Internal error"  # type: ignore[attr-defined]
-            error.type = "internal_error"  # type: ignore[attr-defined]
-            mock_anthropic.side_effect = error
+        response = authenticated_client.post(
+            "/v1/messages",
+            json=request_body,
+            headers={"Authorization": "Bearer phx_test_key"},
+        )
 
-            response = authenticated_client.post(
-                "/v1/messages",
-                json=request_body,
-                headers={"Authorization": "Bearer phx_test_key"},
-            )
-
-            assert response.status_code == 503
-            breaker.record_outcome.assert_awaited_with(success=False)
-        finally:
-            set_anthropic_circuit_breaker(None)
+        assert response.status_code == 503
+        breaker.record_outcome.assert_awaited_with(success=False)
 
     @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
     def test_anthropic_4xx_recorded_as_success(
         self,
         mock_anthropic: MagicMock,
         authenticated_client: TestClient,
+        install_breaker,
         request_body: dict,
     ) -> None:
-        from llm_gateway.circuit_breaker import set_anthropic_circuit_breaker
+        breaker = install_breaker(bypass=False)
+        error = Exception("bad request")
+        error.status_code = 400  # type: ignore[attr-defined]
+        error.message = "bad request"  # type: ignore[attr-defined]
+        error.type = "invalid_request_error"  # type: ignore[attr-defined]
+        mock_anthropic.side_effect = error
 
-        breaker = self._install_breaker(bypass=False)
-        try:
-            error = Exception("bad request")
-            error.status_code = 400  # type: ignore[attr-defined]
-            error.message = "bad request"  # type: ignore[attr-defined]
-            error.type = "invalid_request_error"  # type: ignore[attr-defined]
-            mock_anthropic.side_effect = error
+        response = authenticated_client.post(
+            "/v1/messages",
+            json=request_body,
+            headers={"Authorization": "Bearer phx_test_key"},
+        )
 
-            response = authenticated_client.post(
-                "/v1/messages",
-                json=request_body,
-                headers={"Authorization": "Bearer phx_test_key"},
-            )
-
-            assert response.status_code == 400
-            breaker.record_outcome.assert_awaited_with(success=True)
-        finally:
-            set_anthropic_circuit_breaker(None)
+        assert response.status_code == 400
+        breaker.record_outcome.assert_awaited_with(success=True)

--- a/services/llm-gateway/tests/test_anthropic.py
+++ b/services/llm-gateway/tests/test_anthropic.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1102,3 +1103,120 @@ class TestAnthropicCircuitBreakerIntegration:
 
         assert response.status_code == 400
         breaker.record_outcome.assert_awaited_with(success=True)
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_anthropic_429_recorded_as_failure(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        install_breaker,
+        request_body: dict,
+    ) -> None:
+        breaker = install_breaker(bypass=False)
+        error = Exception("rate limited")
+        error.status_code = 429  # type: ignore[attr-defined]
+        error.message = "rate limited"  # type: ignore[attr-defined]
+        error.type = "rate_limit_error"  # type: ignore[attr-defined]
+        mock_anthropic.side_effect = error
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json=request_body,
+            headers={"Authorization": "Bearer phx_test_key"},
+        )
+
+        assert response.status_code == 429
+        breaker.record_outcome.assert_awaited_with(success=False)
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_anthropic_429_with_fallback_routes_to_bedrock(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        install_breaker,
+        request_body: dict,
+        mock_response_dict: dict,
+    ) -> None:
+        breaker = install_breaker(bypass=False)
+        error = Exception("rate limited")
+        error.status_code = 429  # type: ignore[attr-defined]
+        error.message = "rate limited"  # type: ignore[attr-defined]
+        error.type = "rate_limit_error"  # type: ignore[attr-defined]
+
+        bedrock_response = MagicMock()
+        bedrock_response.model_dump = MagicMock(return_value=mock_response_dict)
+        mock_anthropic.side_effect = [error, bedrock_response]
+
+        with patch(
+            "llm_gateway.api.anthropic.get_settings",
+            return_value=MagicMock(bedrock_region_name="us-east-1", request_timeout=300.0),
+        ):
+            response = authenticated_client.post(
+                "/v1/messages",
+                json=request_body,
+                headers={
+                    "Authorization": "Bearer phx_test_key",
+                    "X-PostHog-Use-Bedrock-Fallback": "true",
+                },
+            )
+
+        assert response.status_code == 200
+        breaker.record_outcome.assert_awaited_with(success=False)
+        assert mock_anthropic.call_count == 2
+
+    def test_streaming_success_records_after_stream_completes(
+        self,
+        authenticated_client: TestClient,
+        install_breaker,
+    ) -> None:
+        from fastapi.responses import StreamingResponse
+
+        from llm_gateway.api.anthropic import _wrap_stream_with_breaker
+
+        breaker = install_breaker(bypass=False)
+
+        async def ok_iter() -> AsyncIterator[bytes]:
+            yield b'data: {"type":"message_start"}\n\n'
+            yield b'data: {"type":"message_stop"}\n\n'
+
+        wrapped = _wrap_stream_with_breaker(StreamingResponse(ok_iter()), breaker)
+
+        async def consume() -> list[bytes]:
+            return [chunk async for chunk in wrapped.body_iterator]
+
+        import asyncio as _asyncio
+
+        chunks = _asyncio.get_event_loop().run_until_complete(consume())
+        assert len(chunks) == 2
+        breaker.record_outcome.assert_awaited_with(success=True)
+
+    def test_streaming_mid_stream_failure_records_failure(
+        self,
+        authenticated_client: TestClient,
+        install_breaker,
+    ) -> None:
+        """Direct unit test of the stream wrapper — TestClient surfaces stream errors as
+        connection-level failures which makes a true HTTP-level test brittle."""
+        from fastapi.responses import StreamingResponse
+
+        from llm_gateway.api.anthropic import _wrap_stream_with_breaker
+
+        breaker = install_breaker(bypass=False)
+
+        async def failing_iter() -> AsyncIterator[bytes]:
+            yield b'data: {"type":"message_start"}\n\n'
+            raise RuntimeError("upstream dropped")
+
+        wrapped = _wrap_stream_with_breaker(StreamingResponse(failing_iter()), breaker)
+
+        async def consume() -> None:
+            try:
+                async for _ in wrapped.body_iterator:
+                    pass
+            except RuntimeError:
+                pass
+
+        import asyncio as _asyncio
+
+        _asyncio.get_event_loop().run_until_complete(consume())
+        breaker.record_outcome.assert_awaited_with(success=False)

--- a/services/llm-gateway/tests/test_circuit_breaker.py
+++ b/services/llm-gateway/tests/test_circuit_breaker.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llm_gateway.circuit_breaker import (
+    BUCKET_WIDTH_SECONDS,
+    AnthropicCircuitBreaker,
+)
+
+
+class _FakeRedis:
+    """Minimal in-memory stand-in that mimics the redis.asyncio surface the breaker uses."""
+
+    def __init__(self) -> None:
+        self._hashes: dict[str, dict[str, int]] = {}
+
+    def pipeline(self) -> _FakePipeline:
+        return _FakePipeline(self)
+
+
+class _FakePipeline:
+    def __init__(self, redis: _FakeRedis) -> None:
+        self._redis = redis
+        self._ops: list[tuple[str, tuple]] = []
+
+    def hincrby(self, key: str, field: str, amount: int) -> _FakePipeline:
+        self._ops.append(("hincrby", (key, field, amount)))
+        return self
+
+    def expire(self, key: str, seconds: int) -> _FakePipeline:
+        self._ops.append(("expire", (key, seconds)))
+        return self
+
+    def hmget(self, key: str, *fields: str) -> _FakePipeline:
+        self._ops.append(("hmget", (key, fields)))
+        return self
+
+    async def execute(self) -> list:
+        results: list = []
+        for op, args in self._ops:
+            if op == "hincrby":
+                key, field, amount = args
+                bucket = self._redis._hashes.setdefault(key, {})
+                bucket[field] = bucket.get(field, 0) + amount
+                results.append(bucket[field])
+            elif op == "expire":
+                results.append(True)
+            elif op == "hmget":
+                key, fields = args
+                bucket = self._redis._hashes.get(key, {})
+                results.append([str(bucket[f]).encode() if f in bucket else None for f in fields])
+        return results
+
+
+@pytest.fixture
+def fake_redis() -> _FakeRedis:
+    return _FakeRedis()
+
+
+@pytest.fixture
+def frozen_time() -> Iterator[MagicMock]:
+    with patch("llm_gateway.circuit_breaker.time.time") as mock_time:
+        mock_time.return_value = 1_000_000.0
+        yield mock_time
+
+
+def make_breaker(
+    redis: _FakeRedis | None,
+    *,
+    failure_threshold: float = 0.25,
+    window_seconds: int = 300,
+    bypass_probability: float = 0.9,
+    min_requests: int = 5,
+    enabled: bool = True,
+) -> AnthropicCircuitBreaker:
+    return AnthropicCircuitBreaker(
+        redis=redis,
+        failure_threshold=failure_threshold,
+        window_seconds=window_seconds,
+        bypass_probability=bypass_probability,
+        min_requests=min_requests,
+        enabled=enabled,
+    )
+
+
+class TestAnthropicCircuitBreaker:
+    @pytest.mark.asyncio
+    async def test_disabled_breaker_is_inert(self, fake_redis: _FakeRedis, frozen_time: MagicMock) -> None:
+        breaker = make_breaker(fake_redis, enabled=False)
+        await breaker.record_outcome(success=False)
+        for _ in range(10):
+            await breaker.record_outcome(success=False)
+        bypass, rate, total = await breaker.should_bypass()
+        assert bypass is False
+        assert rate == 0.0
+        assert total == 0
+
+    @pytest.mark.asyncio
+    async def test_no_redis_is_inert(self, frozen_time: MagicMock) -> None:
+        breaker = make_breaker(None)
+        await breaker.record_outcome(success=False)
+        bypass, rate, total = await breaker.should_bypass()
+        assert bypass is False
+        assert rate == 0.0
+        assert total == 0
+
+    @pytest.mark.asyncio
+    async def test_below_min_requests_does_not_open(self, fake_redis: _FakeRedis, frozen_time: MagicMock) -> None:
+        breaker = make_breaker(fake_redis, min_requests=10, failure_threshold=0.25)
+        # 4 failures, 0 successes — 100% failure rate but only 4 observations.
+        for _ in range(4):
+            await breaker.record_outcome(success=False)
+        open_, rate, total = await breaker.is_open()
+        assert open_ is False
+        assert rate == 1.0
+        assert total == 4
+
+    @pytest.mark.asyncio
+    async def test_opens_when_failure_rate_crosses_threshold(
+        self, fake_redis: _FakeRedis, frozen_time: MagicMock
+    ) -> None:
+        breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25)
+        for _ in range(15):
+            await breaker.record_outcome(success=True)
+        # 15 success, 0 failures → 0% rate, closed
+        open_, rate, _ = await breaker.is_open()
+        assert open_ is False
+        assert rate == 0.0
+
+        for _ in range(5):
+            await breaker.record_outcome(success=False)
+        # 15 success, 5 failures → 25% rate (>=), open
+        open_, rate, total = await breaker.is_open()
+        assert open_ is True
+        assert rate == pytest.approx(0.25)
+        assert total == 20
+
+    @pytest.mark.asyncio
+    async def test_closes_when_failure_rate_drops(self, fake_redis: _FakeRedis, frozen_time: MagicMock) -> None:
+        breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25)
+        for _ in range(5):
+            await breaker.record_outcome(success=False)
+        for _ in range(5):
+            await breaker.record_outcome(success=True)
+        open_, rate, _ = await breaker.is_open()
+        assert open_ is True
+        assert rate == 0.5
+
+        for _ in range(50):
+            await breaker.record_outcome(success=True)
+        open_, rate, _ = await breaker.is_open()
+        assert open_ is False
+        # 5 failures / 60 total ≈ 0.083
+        assert rate < 0.25
+
+    @pytest.mark.asyncio
+    async def test_should_bypass_uses_probability_when_open(
+        self, fake_redis: _FakeRedis, frozen_time: MagicMock
+    ) -> None:
+        breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25, bypass_probability=0.9)
+        for _ in range(10):
+            await breaker.record_outcome(success=False)
+
+        with patch("llm_gateway.circuit_breaker.random.random", return_value=0.5):
+            bypass, _, _ = await breaker.should_bypass()
+            assert bypass is True
+
+        with patch("llm_gateway.circuit_breaker.random.random", return_value=0.95):
+            bypass, _, _ = await breaker.should_bypass()
+            assert bypass is False
+
+    @pytest.mark.asyncio
+    async def test_should_bypass_never_when_closed(self, fake_redis: _FakeRedis, frozen_time: MagicMock) -> None:
+        breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25, bypass_probability=0.9)
+        for _ in range(20):
+            await breaker.record_outcome(success=True)
+
+        with patch("llm_gateway.circuit_breaker.random.random", return_value=0.0):
+            bypass, _, _ = await breaker.should_bypass()
+            assert bypass is False
+
+    @pytest.mark.asyncio
+    async def test_old_buckets_outside_window_excluded(self, fake_redis: _FakeRedis) -> None:
+        # window=300s with 30s buckets → 10 buckets retained.
+        # Failures recorded 11 buckets ago should not count.
+        breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25, window_seconds=300)
+        with patch("llm_gateway.circuit_breaker.time.time", return_value=1_000_000.0):
+            for _ in range(20):
+                await breaker.record_outcome(success=False)
+
+        far_future = 1_000_000.0 + (BUCKET_WIDTH_SECONDS * 11)
+        with patch("llm_gateway.circuit_breaker.time.time", return_value=far_future):
+            for _ in range(5):
+                await breaker.record_outcome(success=True)
+            open_, rate, total = await breaker.is_open()
+            assert total == 5
+            assert rate == 0.0
+            assert open_ is False
+
+    @pytest.mark.asyncio
+    async def test_redis_failure_is_swallowed(self, frozen_time: MagicMock) -> None:
+        broken_redis = MagicMock()
+        broken_redis.pipeline = MagicMock(side_effect=RuntimeError("redis down"))
+        breaker = make_breaker(broken_redis)
+        # Must not raise.
+        await breaker.record_outcome(success=False)
+        bypass, rate, total = await breaker.should_bypass()
+        assert bypass is False
+        assert rate == 0.0
+        assert total == 0

--- a/services/llm-gateway/tests/test_circuit_breaker.py
+++ b/services/llm-gateway/tests/test_circuit_breaker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
@@ -162,3 +163,72 @@ class TestAnthropicCircuitBreaker:
         assert decision.open is False
         assert decision.failure_rate == 0.0
         assert decision.total_requests == 0
+
+    async def test_redis_failure_increments_error_counter(self, frozen_time: MagicMock) -> None:
+        from llm_gateway.metrics.prometheus import ANTHROPIC_CIRCUIT_BREAKER_REDIS_ERRORS
+
+        broken_redis = MagicMock()
+        broken_redis.pipeline = MagicMock(side_effect=RuntimeError("redis down"))
+        breaker = make_breaker(broken_redis)
+
+        before_record = ANTHROPIC_CIRCUIT_BREAKER_REDIS_ERRORS.labels(op="record")._value.get()
+        before_read = ANTHROPIC_CIRCUIT_BREAKER_REDIS_ERRORS.labels(op="read")._value.get()
+        await breaker.record_outcome(success=False)
+        await breaker._get_stats()
+        assert ANTHROPIC_CIRCUIT_BREAKER_REDIS_ERRORS.labels(op="record")._value.get() == before_record + 1
+        assert ANTHROPIC_CIRCUIT_BREAKER_REDIS_ERRORS.labels(op="read")._value.get() == before_read + 1
+
+    async def test_redis_timeout_does_not_block(self) -> None:
+        import asyncio as _asyncio
+
+        slow_pipe = MagicMock()
+        slow_pipe.hincrby = MagicMock(return_value=slow_pipe)
+        slow_pipe.expire = MagicMock(return_value=slow_pipe)
+        slow_pipe.hmget = MagicMock(return_value=slow_pipe)
+
+        async def hang() -> object:
+            await _asyncio.sleep(10.0)
+            return []
+
+        slow_pipe.execute = MagicMock(side_effect=hang)
+        slow_redis = MagicMock()
+        slow_redis.pipeline = MagicMock(return_value=slow_pipe)
+
+        breaker = make_breaker(slow_redis)
+        with patch("llm_gateway.circuit_breaker.REDIS_OP_TIMEOUT_SECONDS", 0.01):
+            start = time.monotonic()
+            await breaker.record_outcome(success=True)
+            decision = await breaker.evaluate()
+            elapsed = time.monotonic() - start
+        assert elapsed < 1.0
+        assert decision.total_requests == 0
+
+
+class TestPublishGaugesLoop:
+    async def test_publishes_gauges_then_cancels_cleanly(self, fake_redis: fakeredis.FakeRedis) -> None:
+        import asyncio as _asyncio
+
+        from llm_gateway.circuit_breaker import publish_anthropic_breaker_gauges_loop
+        from llm_gateway.metrics.prometheus import (
+            ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE,
+            ANTHROPIC_CIRCUIT_BREAKER_OPEN,
+            ANTHROPIC_CIRCUIT_BREAKER_WINDOW_REQUESTS,
+        )
+
+        breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25)
+        for _ in range(15):
+            await breaker.record_outcome(success=True)
+        for _ in range(5):
+            await breaker.record_outcome(success=False)
+
+        task = _asyncio.create_task(publish_anthropic_breaker_gauges_loop(breaker, interval_seconds=10))
+        await _asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except _asyncio.CancelledError:
+            pass
+
+        assert ANTHROPIC_CIRCUIT_BREAKER_OPEN._value.get() == 1
+        assert ANTHROPIC_CIRCUIT_BREAKER_FAILURE_RATE._value.get() == pytest.approx(0.25)
+        assert ANTHROPIC_CIRCUIT_BREAKER_WINDOW_REQUESTS._value.get() == 20

--- a/services/llm-gateway/tests/test_circuit_breaker.py
+++ b/services/llm-gateway/tests/test_circuit_breaker.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fakeredis import aioredis as fakeredis
 
 from llm_gateway.circuit_breaker import (
     BUCKET_WIDTH_SECONDS,
@@ -11,53 +12,9 @@ from llm_gateway.circuit_breaker import (
 )
 
 
-class _FakeRedis:
-    """Minimal in-memory stand-in that mimics the redis.asyncio surface the breaker uses."""
-
-    def __init__(self) -> None:
-        self._hashes: dict[str, dict[str, int]] = {}
-
-    def pipeline(self) -> _FakePipeline:
-        return _FakePipeline(self)
-
-
-class _FakePipeline:
-    def __init__(self, redis: _FakeRedis) -> None:
-        self._redis = redis
-        self._ops: list[tuple[str, tuple]] = []
-
-    def hincrby(self, key: str, field: str, amount: int) -> _FakePipeline:
-        self._ops.append(("hincrby", (key, field, amount)))
-        return self
-
-    def expire(self, key: str, seconds: int) -> _FakePipeline:
-        self._ops.append(("expire", (key, seconds)))
-        return self
-
-    def hmget(self, key: str, *fields: str) -> _FakePipeline:
-        self._ops.append(("hmget", (key, fields)))
-        return self
-
-    async def execute(self) -> list:
-        results: list = []
-        for op, args in self._ops:
-            if op == "hincrby":
-                key, field, amount = args
-                bucket = self._redis._hashes.setdefault(key, {})
-                bucket[field] = bucket.get(field, 0) + amount
-                results.append(bucket[field])
-            elif op == "expire":
-                results.append(True)
-            elif op == "hmget":
-                key, fields = args
-                bucket = self._redis._hashes.get(key, {})
-                results.append([str(bucket[f]).encode() if f in bucket else None for f in fields])
-        return results
-
-
 @pytest.fixture
-def fake_redis() -> _FakeRedis:
-    return _FakeRedis()
+def fake_redis() -> fakeredis.FakeRedis:
+    return fakeredis.FakeRedis()
 
 
 @pytest.fixture
@@ -68,7 +25,7 @@ def frozen_time() -> Iterator[MagicMock]:
 
 
 def make_breaker(
-    redis: _FakeRedis | None,
+    redis: fakeredis.FakeRedis | None,
     *,
     failure_threshold: float = 0.25,
     window_seconds: int = 300,
@@ -87,103 +44,98 @@ def make_breaker(
 
 
 class TestAnthropicCircuitBreaker:
-    @pytest.mark.asyncio
-    async def test_disabled_breaker_is_inert(self, fake_redis: _FakeRedis, frozen_time: MagicMock) -> None:
+    async def test_disabled_breaker_is_inert(self, fake_redis: fakeredis.FakeRedis, frozen_time: MagicMock) -> None:
         breaker = make_breaker(fake_redis, enabled=False)
-        await breaker.record_outcome(success=False)
         for _ in range(10):
             await breaker.record_outcome(success=False)
-        bypass, rate, total = await breaker.should_bypass()
-        assert bypass is False
-        assert rate == 0.0
-        assert total == 0
+        decision = await breaker.evaluate()
+        assert decision.bypass is False
+        assert decision.open is False
+        assert decision.failure_rate == 0.0
+        assert decision.total_requests == 0
 
-    @pytest.mark.asyncio
     async def test_no_redis_is_inert(self, frozen_time: MagicMock) -> None:
         breaker = make_breaker(None)
         await breaker.record_outcome(success=False)
-        bypass, rate, total = await breaker.should_bypass()
-        assert bypass is False
-        assert rate == 0.0
-        assert total == 0
+        decision = await breaker.evaluate()
+        assert decision.bypass is False
+        assert decision.open is False
 
-    @pytest.mark.asyncio
-    async def test_below_min_requests_does_not_open(self, fake_redis: _FakeRedis, frozen_time: MagicMock) -> None:
+    async def test_below_min_requests_does_not_open(
+        self, fake_redis: fakeredis.FakeRedis, frozen_time: MagicMock
+    ) -> None:
         breaker = make_breaker(fake_redis, min_requests=10, failure_threshold=0.25)
-        # 4 failures, 0 successes — 100% failure rate but only 4 observations.
         for _ in range(4):
             await breaker.record_outcome(success=False)
-        open_, rate, total = await breaker.is_open()
-        assert open_ is False
-        assert rate == 1.0
-        assert total == 4
+        decision = await breaker.evaluate()
+        assert decision.open is False
+        assert decision.bypass is False
+        assert decision.failure_rate == 1.0
+        assert decision.total_requests == 4
 
-    @pytest.mark.asyncio
     async def test_opens_when_failure_rate_crosses_threshold(
-        self, fake_redis: _FakeRedis, frozen_time: MagicMock
+        self, fake_redis: fakeredis.FakeRedis, frozen_time: MagicMock
     ) -> None:
         breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25)
         for _ in range(15):
             await breaker.record_outcome(success=True)
-        # 15 success, 0 failures → 0% rate, closed
-        open_, rate, _ = await breaker.is_open()
-        assert open_ is False
-        assert rate == 0.0
+        decision = await breaker.evaluate()
+        assert decision.open is False
+        assert decision.failure_rate == 0.0
 
         for _ in range(5):
             await breaker.record_outcome(success=False)
-        # 15 success, 5 failures → 25% rate (>=), open
-        open_, rate, total = await breaker.is_open()
-        assert open_ is True
-        assert rate == pytest.approx(0.25)
-        assert total == 20
+        decision = await breaker.evaluate()
+        assert decision.open is True
+        assert decision.failure_rate == pytest.approx(0.25)
+        assert decision.total_requests == 20
 
-    @pytest.mark.asyncio
-    async def test_closes_when_failure_rate_drops(self, fake_redis: _FakeRedis, frozen_time: MagicMock) -> None:
+    async def test_closes_when_failure_rate_drops(
+        self, fake_redis: fakeredis.FakeRedis, frozen_time: MagicMock
+    ) -> None:
         breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25)
         for _ in range(5):
             await breaker.record_outcome(success=False)
         for _ in range(5):
             await breaker.record_outcome(success=True)
-        open_, rate, _ = await breaker.is_open()
-        assert open_ is True
-        assert rate == 0.5
+        decision = await breaker.evaluate()
+        assert decision.open is True
+        assert decision.failure_rate == 0.5
 
         for _ in range(50):
             await breaker.record_outcome(success=True)
-        open_, rate, _ = await breaker.is_open()
-        assert open_ is False
-        # 5 failures / 60 total ≈ 0.083
-        assert rate < 0.25
+        decision = await breaker.evaluate()
+        assert decision.open is False
+        assert decision.failure_rate < 0.25
 
-    @pytest.mark.asyncio
-    async def test_should_bypass_uses_probability_when_open(
-        self, fake_redis: _FakeRedis, frozen_time: MagicMock
+    async def test_bypass_uses_probability_when_open(
+        self, fake_redis: fakeredis.FakeRedis, frozen_time: MagicMock
     ) -> None:
         breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25, bypass_probability=0.9)
         for _ in range(10):
             await breaker.record_outcome(success=False)
 
         with patch("llm_gateway.circuit_breaker.random.random", return_value=0.5):
-            bypass, _, _ = await breaker.should_bypass()
-            assert bypass is True
+            decision = await breaker.evaluate()
+            assert decision.bypass is True
+            assert decision.open is True
 
         with patch("llm_gateway.circuit_breaker.random.random", return_value=0.95):
-            bypass, _, _ = await breaker.should_bypass()
-            assert bypass is False
+            decision = await breaker.evaluate()
+            assert decision.bypass is False
+            assert decision.open is True
 
-    @pytest.mark.asyncio
-    async def test_should_bypass_never_when_closed(self, fake_redis: _FakeRedis, frozen_time: MagicMock) -> None:
+    async def test_bypass_never_when_closed(self, fake_redis: fakeredis.FakeRedis, frozen_time: MagicMock) -> None:
         breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25, bypass_probability=0.9)
         for _ in range(20):
             await breaker.record_outcome(success=True)
 
         with patch("llm_gateway.circuit_breaker.random.random", return_value=0.0):
-            bypass, _, _ = await breaker.should_bypass()
-            assert bypass is False
+            decision = await breaker.evaluate()
+            assert decision.bypass is False
+            assert decision.open is False
 
-    @pytest.mark.asyncio
-    async def test_old_buckets_outside_window_excluded(self, fake_redis: _FakeRedis) -> None:
+    async def test_old_buckets_outside_window_excluded(self, fake_redis: fakeredis.FakeRedis) -> None:
         # window=300s with 30s buckets → 10 buckets retained.
         # Failures recorded 11 buckets ago should not count.
         breaker = make_breaker(fake_redis, min_requests=5, failure_threshold=0.25, window_seconds=300)
@@ -195,19 +147,18 @@ class TestAnthropicCircuitBreaker:
         with patch("llm_gateway.circuit_breaker.time.time", return_value=far_future):
             for _ in range(5):
                 await breaker.record_outcome(success=True)
-            open_, rate, total = await breaker.is_open()
-            assert total == 5
-            assert rate == 0.0
-            assert open_ is False
+            decision = await breaker.evaluate()
+            assert decision.total_requests == 5
+            assert decision.failure_rate == 0.0
+            assert decision.open is False
 
-    @pytest.mark.asyncio
     async def test_redis_failure_is_swallowed(self, frozen_time: MagicMock) -> None:
         broken_redis = MagicMock()
         broken_redis.pipeline = MagicMock(side_effect=RuntimeError("redis down"))
         breaker = make_breaker(broken_redis)
-        # Must not raise.
         await breaker.record_outcome(success=False)
-        bypass, rate, total = await breaker.should_bypass()
-        assert bypass is False
-        assert rate == 0.0
-        assert total == 0
+        decision = await breaker.evaluate()
+        assert decision.bypass is False
+        assert decision.open is False
+        assert decision.failure_rate == 0.0
+        assert decision.total_requests == 0


### PR DESCRIPTION
## Problem

When Anthropic has a partial outage, every request to `/v1/messages` still tries Anthropic first and only falls back to Bedrock after that request errors out. Each individual user pays for the round-trip and the latency before getting their successful Bedrock response. We want a gateway-wide signal: once Anthropic looks unhealthy, send most opted-in traffic straight to Bedrock until it recovers.

## Changes

Adds an Anthropic-only circuit breaker behind the existing `X-PostHog-Use-Bedrock-Fallback` opt-in:

- New `circuit_breaker.py` keeps a Redis-backed sliding-window count of Anthropic successes and failures, broken into 30-second buckets summed over the trailing window. With Redis unavailable the breaker is inert (fail-open), so a Redis blip cannot itself cause a routing flip.
- The breaker is *open* when the failure rate is at or above `failure_threshold` *and* there are at least `min_requests` observations in the window — small request volumes can't trip it on a single bad call.
- While open, each request that has opted into Bedrock fallback is bypassed straight to Bedrock with probability `bypass_probability`. The remaining share keeps probing Anthropic so the breaker can close itself when Anthropic recovers.
- Failure classification: 4xx Anthropic responses count as "success" for the breaker because they're caller-side. 5xx, 429 (Anthropic-side throttling), connection errors, and mid-stream stream failures all count as failure. Client disconnects (`CancelledError`) don't move either counter.
- Wired into `_handle_anthropic_messages` and `_handle_count_tokens`. The Bedrock-only path (`X-PostHog-Provider: bedrock`) and the no-opt-in Anthropic path are unchanged.
- Three new Prometheus signals: `llm_gateway_anthropic_circuit_breaker_open` (gauge), `llm_gateway_anthropic_circuit_breaker_failure_rate` (gauge), `llm_gateway_anthropic_circuit_breaker_bypassed_total` (counter, labeled by model+product). When Redis is unreachable, the gauges publish NaN so the dashboard distinguishes "Redis down" from "no traffic" — both would otherwise show 0/0/0.

**Behaviour change worth flagging for reviewers**: pre-PR, an Anthropic `429` propagated to the caller even with `X-PostHog-Use-Bedrock-Fallback: true` set (the existing fallback path only triggered on `5xx`). Post-PR, `429` is treated as Anthropic-side throttling and now triggers the Bedrock fallback for opted-in callers. If any current opted-in caller relies on receiving `429` as a back-off signal, they'll now get a successful Bedrock response instead — please call this out if you spot a caller that needs the old behaviour.

Defaults match the requested policy. The per-request `X-PostHog-Use-Bedrock-Fallback: true` header is the safety gate for the routing change — callers that don't set it never get re-routed, even with the breaker enabled and open. So the global flag mainly controls whether stats are accumulated:

| Setting | Default |
|---|---|
| `LLM_GATEWAY_ANTHROPIC_CIRCUIT_BREAKER_ENABLED` | `true` |
| `LLM_GATEWAY_ANTHROPIC_CIRCUIT_BREAKER_FAILURE_THRESHOLD` | `0.25` |
| `LLM_GATEWAY_ANTHROPIC_CIRCUIT_BREAKER_WINDOW_SECONDS` | `300` |
| `LLM_GATEWAY_ANTHROPIC_CIRCUIT_BREAKER_BYPASS_PROBABILITY` | `0.9` |
| `LLM_GATEWAY_ANTHROPIC_CIRCUIT_BREAKER_MIN_REQUESTS` | `20` |

## How did you test this code?

- `tests/test_circuit_breaker.py` — unit tests covering disabled-mode, no-redis-mode, the `min_requests` floor, opening/closing transitions, probabilistic bypass behavior, sliding-window expiry, Redis-failure swallowing + `redis_unhealthy` propagation, and NaN gauge publishing when Redis is down.
- `tests/test_anthropic.py::TestAnthropicCircuitBreakerIntegration` — endpoint-level tests parametrised over both `/v1/messages` and `/v1/messages/count_tokens`: open breaker + opt-in routes to Bedrock without recording an Anthropic outcome; closed breaker normal path; 5xx/429 record failure; 4xx records as success; client-disconnect mid-stream does not record an outcome.
- Full `services/llm-gateway/tests/` unit suite passes.
- `ruff check` + `ruff format` clean.

## Publish to changelog?

no

## 🤖 Agent context

PostHog Code with Claude. The user asked for: when Anthropic's failure rate on the gateway hits 25% over a trailing 5 minutes, route 90% of opted-in traffic straight to Bedrock until it recovers. I shaped this as a circuit breaker rather than a custom routing rule because the close-condition is the symmetric inverse of the open-condition, and that pattern is well understood operationally.

Decisions worth flagging for review:

- **Per-request opt-in is required.** The breaker only short-circuits to Bedrock for callers that already pass `X-PostHog-Use-Bedrock-Fallback: true`. Without that, a global outage would cause us to silently change provider for callers who haven't opted in, which I don't think we want.
- **`min_requests` floor.** Without this, a single failed call at low traffic gives a 100% failure rate and trips the breaker. Defaulting to 20 in a 5-minute window is conservative but tunable.
- **30-second buckets.** Coarser than per-second but a 10-bucket window lets old data age out cleanly. The whole structure is just two `HINCRBY`+`EXPIRE` calls per request and a 10-bucket `HMGET` on the read path; should add a microsecond-scale Redis hit per request.
- **4xx is "success."** Bad-request errors come from the caller, not Anthropic, and shouldn't be allowed to flip the breaker. 429 is the exception — that's Anthropic-side throttling, exactly the kind of degradation the breaker exists for.
- **Mid-stream stream failures count.** The streaming wrapper records the outcome when the generator's `finally` runs, so a mid-stream `Exception` records a failure and a clean stream records a success. Client disconnects (`CancelledError`) are explicitly skipped — they answer the question "did the client leave?", not "is Anthropic healthy?".
- **Redis-down observability.** The request path fails open on any Redis error, but the gauges publish NaN in that case so a flatline on the chart visibly breaks instead of looking identical to a healthy idle gateway. Per-request error logs drop the stacktrace to avoid flooding under outage — the `llm_gateway_anthropic_circuit_breaker_redis_errors_total` counter remains the alerting signal.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
