### PR TITLE
feat(settings): wrap settings components in error boundary

### DIFF
--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -18,6 +18,8 @@ import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
+import { ErrorBoundary } from '~/layout/ErrorBoundary'
+
 import { SearchResultGroup } from './settingsLogic'
 import { settingsLogic } from './settingsLogic'
 import { SettingId, SettingLevelId, SettingSectionId, SettingsLogicProps } from './types'
@@ -371,7 +373,7 @@ function SettingsRenderer(props: SettingsLogicProps & { handleLocally: boolean }
                             </p>
                         )}
 
-                        {x.component}
+                        <ErrorBoundary>{x.component}</ErrorBoundary>
                     </div>
                 ))
             ) : (


### PR DESCRIPTION
## Problem

The settings page crashes, even if just a single settings throws a javascript error.

## Changes

Wraps individual settings components in a react error boundary.

## How did you test this code?

Tested with an invalid test account filter setting