### PR TITLE
feat(ingestion): make error-tracking overflow partition locality configurable

### DIFF
--- a/nodejs/src/ingestion/error-tracking/config.ts
+++ b/nodejs/src/ingestion/error-tracking/config.ts
@@ -31,12 +31,13 @@ export type ErrorTrackingConsumerConfig = {
     /** TTL in seconds for local cache entries */
     ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS: number
     /**
-     * When true, redirects to the overflow lane keep the event's original
-     * partition key. When false (default), the overflow producer emits with
-     * a null key and Kafka spreads the events across partitions. Cymbal
-     * cache locality is enforced one layer down — by team_id consistent
-     * hashing inside `CymbalClient` — so the partition key on the overflow
-     * lane doesn't affect symbolication cache hits.
+     * When true (default, matching the previous hardcoded behavior), redirects
+     * to the overflow lane keep the event's original partition key. When
+     * false, the overflow producer emits with a null key and Kafka spreads
+     * the events across partitions. Cymbal cache locality is enforced one
+     * layer down — by team_id consistent hashing inside `CymbalClient` — so
+     * the partition key on the overflow lane doesn't affect symbolication
+     * cache hits.
      */
     ERROR_TRACKING_OVERFLOW_PRESERVE_PARTITION_LOCALITY: boolean
 
@@ -77,7 +78,7 @@ export function getDefaultErrorTrackingConsumerConfig(): ErrorTrackingConsumerCo
         ERROR_TRACKING_STATEFUL_OVERFLOW_ENABLED: false,
         ERROR_TRACKING_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS: 300, // 5 minutes
         ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS: 60, // 1 minute
-        ERROR_TRACKING_OVERFLOW_PRESERVE_PARTITION_LOCALITY: false,
+        ERROR_TRACKING_OVERFLOW_PRESERVE_PARTITION_LOCALITY: true,
         ERROR_TRACKING_CYMBAL_MAX_BODY_BYTES: 1_800_000,
         ERROR_TRACKING_RATE_LIMITER_ENABLED: false,
         ERROR_TRACKING_RATE_LIMITER_REPORTING_MODE: true,

--- a/nodejs/src/ingestion/error-tracking/config.ts
+++ b/nodejs/src/ingestion/error-tracking/config.ts
@@ -30,6 +30,15 @@ export type ErrorTrackingConsumerConfig = {
     ERROR_TRACKING_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS: number
     /** TTL in seconds for local cache entries */
     ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS: number
+    /**
+     * When true, redirects to the overflow lane keep the event's original
+     * partition key. When false (default), the overflow producer emits with
+     * a null key and Kafka spreads the events across partitions. Cymbal
+     * cache locality is enforced one layer down — by team_id consistent
+     * hashing inside `CymbalClient` — so the partition key on the overflow
+     * lane doesn't affect symbolication cache hits.
+     */
+    ERROR_TRACKING_OVERFLOW_PRESERVE_PARTITION_LOCALITY: boolean
 
     /** Max HTTP body size in bytes per Cymbal API request. Used to proactively
      *  split large batches before they hit Cymbal's body limit. */
@@ -68,6 +77,7 @@ export function getDefaultErrorTrackingConsumerConfig(): ErrorTrackingConsumerCo
         ERROR_TRACKING_STATEFUL_OVERFLOW_ENABLED: false,
         ERROR_TRACKING_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS: 300, // 5 minutes
         ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS: 60, // 1 minute
+        ERROR_TRACKING_OVERFLOW_PRESERVE_PARTITION_LOCALITY: false,
         ERROR_TRACKING_CYMBAL_MAX_BODY_BYTES: 1_800_000,
         ERROR_TRACKING_RATE_LIMITER_ENABLED: false,
         ERROR_TRACKING_RATE_LIMITER_REPORTING_MODE: true,

--- a/nodejs/src/ingestion/error-tracking/config.ts
+++ b/nodejs/src/ingestion/error-tracking/config.ts
@@ -34,10 +34,10 @@ export type ErrorTrackingConsumerConfig = {
      * When true (default, matching the previous hardcoded behavior), redirects
      * to the overflow lane keep the event's original partition key. When
      * false, the overflow producer emits with a null key and Kafka spreads
-     * the events across partitions. Cymbal cache locality is enforced one
-     * layer down — by team_id consistent hashing inside `CymbalClient` — so
-     * the partition key on the overflow lane doesn't affect symbolication
-     * cache hits.
+     * events across overflow-topic partitions. Cymbal cache locality is
+     * enforced one layer down — by team_id consistent hashing inside
+     * `CymbalClient` — so the partition key on the overflow lane doesn't
+     * affect symbolication cache hits.
      */
     ERROR_TRACKING_OVERFLOW_PRESERVE_PARTITION_LOCALITY: boolean
 

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -156,6 +156,7 @@ describe('ErrorTrackingConsumer', () => {
             statefulOverflowEnabled: hub.ERROR_TRACKING_STATEFUL_OVERFLOW_ENABLED,
             statefulOverflowRedisTTLSeconds: hub.ERROR_TRACKING_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS,
             statefulOverflowLocalCacheTTLSeconds: hub.ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
+            preservePartitionLocality: hub.ERROR_TRACKING_OVERFLOW_PRESERVE_PARTITION_LOCALITY,
             pipeline: hub.INGESTION_PIPELINE ?? 'errortracking',
             rateLimiterEnabled: hub.ERROR_TRACKING_RATE_LIMITER_ENABLED,
             rateLimiterReportingMode: hub.ERROR_TRACKING_RATE_LIMITER_REPORTING_MODE,

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -53,6 +53,12 @@ export interface ErrorTrackingConsumerOptions {
     statefulOverflowEnabled: boolean
     statefulOverflowRedisTTLSeconds: number
     statefulOverflowLocalCacheTTLSeconds: number
+    /**
+     * When true, overflow redirects keep the original partition key. When
+     * false (default), the overflow producer emits with a null key. Applies
+     * to both restriction-driven force-overflow and rate-limit-to-overflow.
+     */
+    preservePartitionLocality: boolean
     pipeline: string
     rateLimiterEnabled: boolean
     rateLimiterReportingMode: boolean
@@ -259,6 +265,7 @@ export class ErrorTrackingConsumer {
             groupTypeManager: this.deps.groupTypeManager,
             eventIngestionRestrictionManager: this.eventIngestionRestrictionManager,
             overflowEnabled: this.config.overflowEnabled,
+            preservePartitionLocality: this.config.preservePartitionLocality,
             overflowRedirectService: this.overflowRedirectService,
             overflowLaneTTLRefreshService: this.overflowLaneTTLRefreshService,
             preCymbalRateLimiters: this.buildPreCymbalRateLimiterSpecs(),

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
@@ -308,6 +308,7 @@ describe('ErrorTrackingPipeline', () => {
             groupTypeManager: mockGroupTypeManager,
             eventIngestionRestrictionManager: mockEventIngestionRestrictionManager,
             overflowEnabled: false,
+            preservePartitionLocality: false,
             topHog: mockTopHog,
         }
     })

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
@@ -72,6 +72,16 @@ export interface ErrorTrackingPipelineConfig {
     groupTypeManager: GroupTypeManager
     eventIngestionRestrictionManager: EventIngestionRestrictionManager
     overflowEnabled: boolean
+    /**
+     * When true, overflow redirects (both restriction-driven force-overflow
+     * and rate-limit-to-overflow) keep the original partition key. When
+     * false, redirects emit with a null key so Kafka spreads load across
+     * overflow-topic partitions. Cymbal cache locality is enforced one layer
+     * down (team_id consistent hashing inside `CymbalClient`), so the
+     * partition key on the overflow lane doesn't affect symbolication cache
+     * hits.
+     */
+    preservePartitionLocality: boolean
     /** Service for rate limiting and redirecting to overflow (main lane only). */
     overflowRedirectService?: OverflowRedirectService
     /** Service for refreshing TTLs on overflow lane events. */
@@ -155,6 +165,7 @@ export function createErrorTrackingPipeline(
         groupTypeManager,
         eventIngestionRestrictionManager,
         overflowEnabled,
+        preservePartitionLocality,
         overflowRedirectService,
         overflowLaneTTLRefreshService,
         preCymbalRateLimiters,
@@ -180,7 +191,7 @@ export function createErrorTrackingPipeline(
                         .pipe(
                             createApplyEventRestrictionsStep(eventIngestionRestrictionManager, {
                                 overflowEnabled,
-                                preservePartitionLocality: true,
+                                preservePartitionLocality,
                             })
                         )
                         // Parse Kafka message body [REUSE]
@@ -222,7 +233,7 @@ export function createErrorTrackingPipeline(
                                     // Rate limit high-volume token:distinct_id pairs to overflow
                                     .pipeBatch(
                                         createRateLimitToOverflowStep(
-                                            true, // preservePartitionLocality
+                                            preservePartitionLocality,
                                             overflowRedirectService
                                         )
                                     )

--- a/nodejs/src/servers/error-tracking-server.ts
+++ b/nodejs/src/servers/error-tracking-server.ts
@@ -206,6 +206,7 @@ export class ErrorTrackingServer implements NodeServer {
                     statefulOverflowRedisTTLSeconds: this.config.ERROR_TRACKING_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS,
                     statefulOverflowLocalCacheTTLSeconds:
                         this.config.ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
+                    preservePartitionLocality: this.config.ERROR_TRACKING_OVERFLOW_PRESERVE_PARTITION_LOCALITY,
                     pipeline: this.config.INGESTION_PIPELINE ?? 'errortracking',
                     rateLimiterEnabled: this.config.ERROR_TRACKING_RATE_LIMITER_ENABLED,
                     rateLimiterReportingMode: this.config.ERROR_TRACKING_RATE_LIMITER_REPORTING_MODE,


### PR DESCRIPTION
## Problem

Two spots in the error-tracking pipeline hardcoded \`preservePartitionLocality: true\`:

- \`error-tracking-pipeline.ts\` — the apply-event-restrictions step (force-overflow on Django-tagged tokens)
- \`error-tracking-pipeline.ts\` — the rate-limit-to-overflow step (high-volume token:distinct_id redirects)

There was no way to opt out per environment. Symbolication cache locality is enforced one layer down: \`CymbalClient\` resolves the Cymbal headless service via DNS and routes events to a Cymbal pod by \`jumpConsistentHash(team_id, endpoints.length)\`. The Kafka partition key on the overflow lane doesn't affect Cymbal cache hit rate, so for the rate-limit-to-overflow case in particular, preserving the key just defeats the load-spreading purpose of the overflow lane. We want the option to flip it off per environment.

## Changes

- Add \`ERROR_TRACKING_OVERFLOW_PRESERVE_PARTITION_LOCALITY\` env var, defaulting to \`true\` to match the previous hardcoded behavior. **No behavior change for existing deployments.**
- Plumb it through \`ErrorTrackingConsumerOptions\` → \`ErrorTrackingPipelineConfig\` so both overflow call sites read from the same source. Keeping them in lockstep is what we want — there's no reason these two overflow paths would ever want different locality semantics.

Production behavior is pinned via a charts override; this PR only adds the knob and wires it up.

## How did you test this code?

Agent-authored. Local checks:

- \`pnpm build\` — clean
- \`pnpm lint\` — clean
- \`pnpm test -- src/ingestion/error-tracking/error-tracking-pipeline.test.ts\` — 28/28 passed
- The two test files that construct the consumer/pipeline config got a new \`preservePartitionLocality\` field; without it, TS surfaces the missing property.

No manual testing. The consumer integration test (\`error-tracking-consumer.test.ts\`) needs Postgres/Redis services running and isn't exercised in this session — it's covered by CI.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code session
- Human prompt: look into the error-tracking pipeline config — is there a way to disable preserve key on overflow? we don't need it really. then: open a PR for nodejs that allows changing the preserve partition locality using an env variable in the error tracking pipeline — both for restrictions and for overflow.
- Decision: env var with default \`true\` matching the previous hardcoded behavior. I went back and forth on this and noisy-committed; the final state matches the human's stated intent — no surprise behavior change for existing deployments, opt out per env when load spreading is wanted. Unlike the analytics consumer (which defaults to \`false\`), error tracking starts conservative and the env var is the lever for environments that want spreading.
- Decision: a single \`preservePartitionLocality\` field plumbed all the way through, feeding both the restriction step and the rate-limit-to-overflow step. There's no reason these two overflow paths would ever want different locality semantics.