### PR TITLE
chore(ci): skip migration risk publish on fork prs

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -877,7 +877,13 @@ jobs:
               # definitive verdict on its head SHA. Consumers can then treat
               # "no completed check yet" purely as "CI hasn't finished" and
               # don't need a fallback heuristic.
-              if: always() && github.event_name == 'pull_request'
+              #
+              # Skipped on PRs from forks: GITHUB_TOKEN is read-only for fork
+              # PRs regardless of the workflow's `permissions:` block, so the
+              # check-runs POST 403s. The analyzer itself still runs in earlier
+              # steps and fails the job on Blocked migrations; reviewers can
+              # read the verdict in the uploaded migration-analysis artifact.
+              if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   HEAD_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Problem

External-contributor PRs from forks fail the `Validate migrations and OpenAPI types` job on the final `Publish Migration risk check` step:

```
gh: Resource not accessible by integration (HTTP 403)
```

`GITHUB_TOKEN` is read-only for `pull_request` runs from forks regardless of the workflow's `permissions:` block, so the `POST /repos/.../check-runs` call always 403s. The `Migration risk` check is also published when there are zero migrations to analyze, so this hits every fork PR — not just ones touching migrations.

Maintainer "Approve and run" allows the workflow to execute but does not elevate the token's scopes.

Example: PR #53533 (external contributor, no migrations in diff).

## Changes

Gate the `Publish Migration risk check` step on `github.event.pull_request.head.repo.fork == false`. The migration risk analyzer itself runs in earlier steps and still fails the job on Blocked migrations; reviewers can read the verdict in the existing `migration-analysis` artifact upload.

Inlines the fork check rather than referencing the existing `RUNS_ON_INTERNAL_PR` env var — that var is currently only consumed by shell scripts, never in `if:` expressions, and inlining keeps the intent local to the step.

Considered a `workflow_run`-based publish workflow (would also restore the check entry on fork PRs) and a GitHub-App-token approach like `ci-backend-update-test-timing.yml` uses. Both are a heavier fix that might be worth implementing if we still want these messages on those PRs, this one is just to unblock us.

## How did you test this code?

I'm an agent. No automated test exists for this workflow gate. Verified by:

- Reading the failing job log on PR #53533 to confirm the 403 came from the `gh api .../check-runs` call in this exact step.
- Confirming `RUNS_ON_INTERNAL_PR` (defined at workflow level on line 51) evaluates `github.event.pull_request.head.repo.fork == false` for the same predicate.
- Confirming all other validation in this job (migration risk analyzer with `--fail-on-blocked`, `Check migrations`, `Check CH migrations`, `Check and update OpenAPI types`) runs in separate steps that do not need API write access — so external PRs still fail on real migration / OpenAPI issues.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Carlos via Claude Code (Opus 4.7) while debugging the failing CI on PR #53533.

- Pulled the failing job log, identified the 403 on the `check-runs` POST.
- Surveyed the repo for existing patterns to elevate permissions on fork PRs: only `ci-master-status.yml` uses `workflow_run`, and `ci-backend-update-test-timing.yml` uses an App-token pattern. Neither was a clean fit; opted for the smallest change that preserves all real validation.
- Considered using `env.RUNS_ON_INTERNAL_PR == 'true'` in the `if:` expression but inlined the underlying expression to avoid relying on `env`-context evaluation order in conditionals (no precedent in this repo for that pattern).
- Trade-off accepted: external-contributor PRs lose the inline `Migration risk` check entry. The analyzer still runs and fails the job on Blocked migrations; verdict markdown is in the uploaded artifact.

Agent-authored — requires human review.
