### PR TITLE
chore(dags): assign personsOnEventsMode and sessions backfills to team-query-performance

### DIFF
--- a/posthog/dags/backfill_persons_on_events_mode.py
+++ b/posthog/dags/backfill_persons_on_events_mode.py
@@ -211,7 +211,7 @@ def aggregate_persons_on_events_mode_results_op(
         "evaluation. Eliminates query-cache_key fragmentation. "
         "Set ops.persist_persons_on_events_mode_op.config.dry_run=True to preview."
     ),
-    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value},
+    tags={"owner": JobOwners.TEAM_QUERY_PERFORMANCE.value},
 )
 def backfill_persons_on_events_mode_job():
     team_ids = get_all_team_ids_op()

--- a/posthog/dags/common/owners.py
+++ b/posthog/dags/common/owners.py
@@ -16,6 +16,7 @@ class JobOwners(str, Enum):
     TEAM_LLM_ANALYTICS = "team-llm-analytics"
     TEAM_MANAGED_WAREHOUSE = "team-managed-warehouse"
     TEAM_POSTHOG_AI = "team-posthog-ai"
+    TEAM_QUERY_PERFORMANCE = "team-query-performance"
     TEAM_REVENUE_ANALYTICS = "team-revenue-analytics"
     TEAM_WAREHOUSE_SOURCES = "team-warehouse-sources"
     TEAM_WEB_ANALYTICS = "team-web-analytics"

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -257,7 +257,7 @@ def wait_for_parts_to_merge(
     partitions_def=daily_partitions,
     name="sessions_v3_backfill",
     backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
-    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **CONCURRENCY_TAG},
+    tags={"owner": JobOwners.TEAM_QUERY_PERFORMANCE.value, **CONCURRENCY_TAG},
 )
 def sessions_v3_backfill(context: AssetExecutionContext, config: SessionsBackfillConfig) -> None:
     _do_backfill(
@@ -269,7 +269,7 @@ def sessions_v3_backfill(context: AssetExecutionContext, config: SessionsBackfil
     partitions_def=daily_partitions,
     name="sessions_v3_replay_backfill",
     backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
-    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **CONCURRENCY_TAG},
+    tags={"owner": JobOwners.TEAM_QUERY_PERFORMANCE.value, **CONCURRENCY_TAG},
 )
 def sessions_v3_backfill_replay(context: AssetExecutionContext, config: SessionsBackfillConfig) -> None:
     _do_backfill(
@@ -290,7 +290,7 @@ sessions_backfill_job = define_asset_job(
     name="sessions_v3_backfill_job",
     selection=["sessions_v3_backfill", "sessions_v3_replay_backfill"],
     config=sessions_backfill_partitioned_config,
-    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **CONCURRENCY_TAG},
+    tags={"owner": JobOwners.TEAM_QUERY_PERFORMANCE.value, **CONCURRENCY_TAG},
 )
 
 
@@ -414,7 +414,7 @@ EXPERIMENTAL_CONCURRENCY_TAG = {
     partitions_def=daily_partitions,
     name="experimental_sessions_v3_backfill",
     backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
-    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **EXPERIMENTAL_CONCURRENCY_TAG},
+    tags={"owner": JobOwners.TEAM_QUERY_PERFORMANCE.value, **EXPERIMENTAL_CONCURRENCY_TAG},
 )
 def experimental_sessions_v3_backfill(
     context: AssetExecutionContext, config: ExperimentalSessionsBackfillConfig
@@ -428,7 +428,7 @@ experimental_sessions_backfill_job = define_asset_job(
     name="experimental_sessions_v3_backfill_job",
     selection=["experimental_sessions_v3_backfill"],
     config=sessions_backfill_partitioned_config,
-    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **EXPERIMENTAL_CONCURRENCY_TAG},
+    tags={"owner": JobOwners.TEAM_QUERY_PERFORMANCE.value, **EXPERIMENTAL_CONCURRENCY_TAG},
 )
 
 

--- a/posthog/dags/slack_alerts.py
+++ b/posthog/dags/slack_alerts.py
@@ -22,6 +22,7 @@ notification_channel_per_team = {
     JobOwners.TEAM_INGESTION.value: "#alerts-ingestion",
     JobOwners.TEAM_LOGS.value: "#alerts-logs-prod",
     JobOwners.TEAM_POSTHOG_AI.value: "#alerts-max-ai",
+    JobOwners.TEAM_QUERY_PERFORMANCE.value: "#alerts-query-performance",
     JobOwners.TEAM_REVENUE_ANALYTICS.value: "#alerts-growth",
     JobOwners.TEAM_WAREHOUSE_SOURCES.value: "#alerts-warehouse-sources",
     JobOwners.TEAM_WEB_ANALYTICS.value: "#alerts-web-analytics",


### PR DESCRIPTION
## Problem

The Query performance team owns the dagster jobs that populate sessions and the personsOnEventsMode modifier. They're currently tagged `JobOwners.TEAM_ANALYTICS_PLATFORM`, so failures page analytics-platform instead of the team that owns the data and the alerts.

## Changes

- `posthog/dags/common/owners.py`: add `TEAM_QUERY_PERFORMANCE = "team-query-performance"` to the `JobOwners` enum.
- `posthog/dags/slack_alerts.py`: route that owner's failures to `#alerts-query-performance`, matching the `#alerts-*` convention used by every other team in the table.
- `posthog/dags/backfill_persons_on_events_mode.py`: change the job's `owner` tag from `TEAM_ANALYTICS_PLATFORM` to `TEAM_QUERY_PERFORMANCE`.
- `posthog/dags/sessions.py`: same retag on all sessions v3 backfill assets and their asset jobs — `sessions_v3_backfill`, `sessions_v3_replay_backfill`, `sessions_v3_backfill_job`, `experimental_sessions_v3_backfill`, `experimental_sessions_v3_backfill_job`.

`sessions_v1_cleanup` and `backfill_internal_test_users_cohort` were intentionally not retagged — the user asked specifically about sessions backfills, and the cleanup/cohort jobs aren't sessions backfills.

## How did you test this code?

I'm an agent. No automated tests run for this PR — the change is config-only (enum entry, dict entry, tag string) and there are no tests covering the alert-routing table or job tags. Pre-commit hooks (ruff, ty) ran clean on each commit.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Opus 4.7). The user named the team and Slack channel; the agent verified the existing `#alerts-<team>` convention and asked which form they wanted before committing — first attempt used `#team-query-performance` verbatim, user corrected to `#alerts-query-performance`.

The personsOnEventsMode retag was originally drafted as a stack on top of #58035 (which had not yet merged when the agent started). #58035 merged mid-session, so the branch was rebased onto master and the PR base changed to master. The user then asked to expand the scope to also cover the sessions backfill DAGs.