### PR TITLE
feat(product-analytics): validate test account filters for mcp/api

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -372,6 +372,8 @@ export interface PaginatedProjectBackwardCompatBasicListApi {
 
 export type ProjectBackwardCompatApiGroupTypesItem = { [key: string]: unknown }
 
+export type ProjectBackwardCompatApiTestAccountFiltersItem = { [key: string]: unknown }
+
 export type ProjectBackwardCompatApiDefaultModifiers = { [key: string]: unknown }
 
 export type ProjectBackwardCompatApiProductIntentsItem = {
@@ -604,8 +606,8 @@ export interface ProjectBackwardCompatApi {
     anonymize_ips?: boolean
     completed_snippet_onboarding?: boolean
     readonly ingested_event: boolean
-    /** Filter groups that identify internal/test traffic to be excluded from insights. */
-    test_account_filters?: unknown
+    /** Property filters that identify internal/test traffic to exclude from insights. */
+    test_account_filters?: ProjectBackwardCompatApiTestAccountFiltersItem[]
     /**
      * When true, new insights default to excluding internal/test users.
      * @nullable
@@ -1355,6 +1357,8 @@ export interface ProjectBackwardCompatApi {
 
 export type PatchedProjectBackwardCompatApiGroupTypesItem = { [key: string]: unknown }
 
+export type PatchedProjectBackwardCompatApiTestAccountFiltersItem = { [key: string]: unknown }
+
 export type PatchedProjectBackwardCompatApiDefaultModifiers = { [key: string]: unknown }
 
 export type PatchedProjectBackwardCompatApiProductIntentsItem = {
@@ -1400,8 +1404,8 @@ export interface PatchedProjectBackwardCompatApi {
     anonymize_ips?: boolean
     completed_snippet_onboarding?: boolean
     readonly ingested_event?: boolean
-    /** Filter groups that identify internal/test traffic to be excluded from insights. */
-    test_account_filters?: unknown
+    /** Property filters that identify internal/test traffic to exclude from insights. */
+    test_account_filters?: PatchedProjectBackwardCompatApiTestAccountFiltersItem[]
     /**
      * When true, new insights default to excluding internal/test users.
      * @nullable

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -233,9 +233,9 @@ export const OrganizationsProjectsCreateBody = /* @__PURE__ */ zod
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal\/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()
@@ -425,9 +425,9 @@ export const OrganizationsProjectsUpdateBody = /* @__PURE__ */ zod
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal\/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()
@@ -619,9 +619,9 @@ export const OrganizationsProjectsPartialUpdateBody = /* @__PURE__ */ zod
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal\/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()
@@ -813,9 +813,9 @@ export const OrganizationsProjectsAddProductIntentPartialUpdateBody = /* @__PURE
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal\/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()
@@ -1019,9 +1019,9 @@ export const OrganizationsProjectsChangeOrganizationCreateBody = /* @__PURE__ */
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal\/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()
@@ -1221,9 +1221,9 @@ export const OrganizationsProjectsCompleteProductOnboardingPartialUpdateBody = /
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal\/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()
@@ -1437,9 +1437,9 @@ export const OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateBody = /* 
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal\/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()
@@ -1653,9 +1653,9 @@ export const OrganizationsProjectsGenerateConversationsPublicTokenCreateBody = /
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal\/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()
@@ -1867,9 +1867,9 @@ export const OrganizationsProjectsResetTokenPartialUpdateBody = /* @__PURE__ */ 
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal\/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()
@@ -2061,9 +2061,9 @@ export const OrganizationsProjectsRotateSecretTokenPartialUpdateBody = /* @__PUR
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal\/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal\/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -36839,6 +36839,40 @@
             },
             "type": "array"
         },
+        "TestAccountFilter": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/EventPropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/PersonPropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/SessionPropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/CohortPropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/FeaturePropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/GroupPropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/ElementPropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/HogQLPropertyFilter"
+                }
+            ]
+        },
+        "TestAccountFilters": {
+            "items": {
+                "$ref": "#/definitions/TestAccountFilter"
+            },
+            "type": "array"
+        },
         "TestBasicQueryResponse": {
             "additionalProperties": false,
             "deprecated": "Only exported for use in test_query_runner.py! Don't use anywhere else.",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -17,6 +17,7 @@ import {
     CohortPropertyFilter,
     CountPerActorMathType,
     DataWarehouseViewLink,
+    ElementPropertyFilter,
     EventPropertyFilter,
     EventType,
     ExperimentHoldoutType,
@@ -24,13 +25,16 @@ import {
     ExperimentMetricGoal,
     ExperimentMetricMathType,
     ExperimentStatsMethod,
+    FeaturePropertyFilter,
     FileSystemIconColor,
     FilterLogicalOperator,
     FilterType,
     FunnelConversionWindowTimeUnit,
     FunnelMathType,
     FunnelsFilterType,
+    GroupPropertyFilter,
     GroupMathType,
+    HogQLPropertyFilter,
     HogQLMathType,
     InsightShortId,
     InsightType,
@@ -2203,6 +2207,16 @@ export type WebAnalyticsPropertyFilter =
     | SessionPropertyFilter
     | CohortPropertyFilter
 export type WebAnalyticsPropertyFilters = WebAnalyticsPropertyFilter[]
+export type TestAccountFilter =
+    | EventPropertyFilter
+    | PersonPropertyFilter
+    | SessionPropertyFilter
+    | CohortPropertyFilter
+    | FeaturePropertyFilter
+    | GroupPropertyFilter
+    | ElementPropertyFilter
+    | HogQLPropertyFilter
+export type TestAccountFilters = TestAccountFilter[]
 export type ActionConversionGoal = {
     actionId: integer
 }

--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -18,6 +18,8 @@ import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
+import { ErrorBoundary } from '~/layout/ErrorBoundary'
+
 import { SearchResultGroup } from './settingsLogic'
 import { settingsLogic } from './settingsLogic'
 import { SettingId, SettingLevelId, SettingSectionId, SettingsLogicProps } from './types'
@@ -371,7 +373,7 @@ function SettingsRenderer(props: SettingsLogicProps & { handleLocally: boolean }
                             </p>
                         )}
 
-                        {x.component}
+                        <ErrorBoundary>{x.component}</ErrorBoundary>
                     </div>
                 ))
             ) : (

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -22,6 +22,7 @@ from posthog.api.team import (
     get_or_mint_live_events_token,
     handle_conversations_token_on_update,
     validate_team_attrs,
+    validate_test_account_filters,
 )
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
 from posthog.cloud_utils import get_cached_instance_license, is_cloud
@@ -90,6 +91,11 @@ class ProjectBackwardCompatSerializer(ProjectBackwardCompatBasicSerializer, User
     # These are @property attrs on Team, not Django model fields — declare explicitly so drf-spectacular can resolve them
     default_modifiers = serializers.DictField(read_only=True)  # Compat with TeamSerializer
     person_on_events_querying_enabled = serializers.BooleanField(read_only=True)  # Compat with TeamSerializer
+    test_account_filters = serializers.ListField(
+        child=serializers.DictField(),
+        required=False,
+        help_text="Property filters that identify internal/test traffic to exclude from insights.",
+    )
 
     def validate_app_urls(self, value: list[str | None] | None) -> list[str] | None:
         if value is None:
@@ -108,6 +114,10 @@ class ProjectBackwardCompatSerializer(ProjectBackwardCompatBasicSerializer, User
         if "widget_domains" in value and value["widget_domains"] is not None:
             value["widget_domains"] = [domain for domain in value["widget_domains"] if domain]
         return value
+
+    @staticmethod
+    def validate_test_account_filters(value: object) -> list[dict[str, object]]:
+        return validate_test_account_filters(value)
 
     class Meta:
         model = Project

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -232,7 +232,7 @@ def validate_test_account_filters(value: object) -> list[dict[str, object]]:
     try:
         TestAccountFilters.model_validate(value)
     except PydanticValidationError as error:
-        raise exceptions.ValidationError("Must provide an array of valid property filters.") from error
+        raise exceptions.ValidationError(f"Must provide an array of valid property filters. {error}") from error
 
     return cast(list[dict[str, object]], value)
 

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -225,8 +225,7 @@ TEAM_CONFIG_FIELDS_SET = set(TEAM_CONFIG_FIELDS)
 
 
 def validate_test_account_filters(value: object) -> list[dict[str, object]]:
-    # temporarily disable validation, until we checked all prod entities
-    if True:
+    if not settings.TEST_ACCOUNT_FILTERS_STRICT_VALIDATION_ENABLED:
         return cast(list[dict[str, object]], value)
 
     try:

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -225,6 +225,10 @@ TEAM_CONFIG_FIELDS_SET = set(TEAM_CONFIG_FIELDS)
 
 
 def validate_test_account_filters(value: object) -> list[dict[str, object]]:
+    # temporarily disable validation, until we checked all prod entities
+    if True:
+        return cast(list[dict[str, object]], value)
+
     try:
         TestAccountFilters.model_validate(value)
     except PydanticValidationError as error:

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -16,10 +16,11 @@ from django.utils.dateparse import parse_datetime
 from drf_spectacular.utils import extend_schema, extend_schema_field, extend_schema_view
 from loginas.utils import is_impersonated_session
 from opentelemetry import trace
+from pydantic_core import ValidationError as PydanticValidationError
 from rest_framework import exceptions, request, response, serializers, viewsets
 from rest_framework.permissions import BasePermission, IsAuthenticated
 
-from posthog.schema import AttributionMode, HogQLQueryModifiers
+from posthog.schema import AttributionMode, HogQLQueryModifiers, TestAccountFilters
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import TeamBasicSerializer
@@ -221,6 +222,15 @@ TEAM_CONFIG_FIELDS = (
 )
 
 TEAM_CONFIG_FIELDS_SET = set(TEAM_CONFIG_FIELDS)
+
+
+def validate_test_account_filters(value: object) -> list[dict[str, object]]:
+    try:
+        TestAccountFilters.model_validate(value)
+    except PydanticValidationError as error:
+        raise exceptions.ValidationError("Must provide an array of valid property filters.") from error
+
+    return cast(list[dict[str, object]], value)
 
 
 class TeamRevenueAnalyticsConfigSerializer(serializers.ModelSerializer, UserAccessControlSerializerMixin):
@@ -470,6 +480,11 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
     marketing_analytics_config = TeamMarketingAnalyticsConfigSerializer(required=False)
     customer_analytics_config = TeamCustomerAnalyticsConfigSerializer(required=False)
     base_currency = serializers.ChoiceField(choices=CURRENCY_CODE_CHOICES, default=DEFAULT_CURRENCY)
+    test_account_filters = serializers.ListField(
+        child=serializers.DictField(),
+        required=False,
+        help_text="Property filters that identify internal/test traffic to exclude from insights.",
+    )
 
     class Meta:
         model = Team
@@ -613,6 +628,10 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         if not serializer.is_valid():
             raise exceptions.ValidationError(_format_serializer_errors(serializer.errors))
         return serializer.validated_data
+
+    @staticmethod
+    def validate_test_account_filters(value: object) -> list[dict[str, object]]:
+        return validate_test_account_filters(value)
 
     @staticmethod
     def validate_session_recording_linked_flag(value) -> dict | None:

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -417,7 +417,7 @@ def team_api_test_factory():
 
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             self.assertEqual(response.json()["attr"], "test_account_filters")
-            self.assertEqual(response.json()["detail"], "Must provide an array of valid property filters.")
+            self.assertIn("Must provide an array of valid property filters.", response.json()["detail"])
 
             self.team.refresh_from_db()
             self.assertEqual(self.team.test_account_filters, [])

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -387,6 +387,53 @@ def team_api_test_factory():
                 [{"key": "$current_url", "value": "test"}],
             )
 
+        @parameterized.expand(
+            [
+                (
+                    "missing_key",
+                    [{"type": "person", "operator": "exact", "value": "posthog.com"}],
+                ),
+                (
+                    "invalid_type",
+                    [{"key": "email", "type": "not_a_type", "operator": "exact", "value": "posthog.com"}],
+                ),
+                (
+                    "invalid_operator",
+                    [{"key": "email", "type": "person", "operator": "not_an_operator", "value": "posthog.com"}],
+                ),
+                (
+                    "invalid_cohort_value",
+                    [{"key": "id", "type": "cohort", "operator": "in", "value": "not-a-cohort-id"}],
+                ),
+            ]
+        )
+        def test_filter_permission_rejects_invalid_filters(
+            self, _name: str, test_account_filters: list[dict[str, Any]]
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/",
+                {"test_account_filters": test_account_filters},
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(response.json()["attr"], "test_account_filters")
+            self.assertEqual(response.json()["detail"], "Must provide an array of valid property filters.")
+
+            self.team.refresh_from_db()
+            self.assertEqual(self.team.test_account_filters, [])
+
+        def test_filter_permission_allows_is_set_filters_without_value(self):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/",
+                {"test_account_filters": [{"key": "email", "type": "person", "operator": "is_set"}]},
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(
+                response.json()["test_account_filters"],
+                [{"key": "email", "type": "person", "operator": "is_set"}],
+            )
+
         @freeze_time("2022-02-08")
         def test_delete_team_activity_log(self):
             self.organization_membership.level = OrganizationMembership.Level.ADMIN

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -410,10 +410,11 @@ def team_api_test_factory():
         def test_filter_permission_rejects_invalid_filters(
             self, _name: str, test_account_filters: list[dict[str, Any]]
         ):
-            response = self.client.patch(
-                f"/api/environments/{self.team.id}/",
-                {"test_account_filters": test_account_filters},
-            )
+            with self.settings(TEST_ACCOUNT_FILTERS_STRICT_VALIDATION_ENABLED=True):
+                response = self.client.patch(
+                    f"/api/environments/{self.team.id}/",
+                    {"test_account_filters": test_account_filters},
+                )
 
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             self.assertEqual(response.json()["attr"], "test_account_filters")
@@ -423,10 +424,11 @@ def team_api_test_factory():
             self.assertEqual(self.team.test_account_filters, [])
 
         def test_filter_permission_allows_is_set_filters_without_value(self):
-            response = self.client.patch(
-                f"/api/environments/{self.team.id}/",
-                {"test_account_filters": [{"key": "email", "type": "person", "operator": "is_set"}]},
-            )
+            with self.settings(TEST_ACCOUNT_FILTERS_STRICT_VALIDATION_ENABLED=True):
+                response = self.client.patch(
+                    f"/api/environments/{self.team.id}/",
+                    {"test_account_filters": [{"key": "email", "type": "person", "operator": "is_set"}]},
+                )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(

--- a/posthog/management/commands/audit_test_account_filters.py
+++ b/posthog/management/commands/audit_test_account_filters.py
@@ -92,11 +92,11 @@ class Command(BaseCommand):
             )
             return
 
-        first_error = errors[0] if errors else {}
+        first_error_message = errors[0].get("msg", "validation failed") if errors else "validation failed"
         self.stdout.write(
             self.style.WARNING(
                 "Invalid test account filters for "
                 f"team_id={team.id}, project_id={team.project_id}, organization_id={team.organization_id}: "
-                f"{first_error.get('msg', 'validation failed')}"
+                f"{first_error_message}"
             )
         )

--- a/posthog/management/commands/audit_test_account_filters.py
+++ b/posthog/management/commands/audit_test_account_filters.py
@@ -1,0 +1,102 @@
+import json
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+
+from pydantic_core import ValidationError as PydanticValidationError
+
+from posthog.schema import TestAccountFilters
+
+from posthog.models import Team
+
+
+class Command(BaseCommand):
+    help = "Audit Team.test_account_filters values against the generated TestAccountFilters schema"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--team-id",
+            dest="team_ids",
+            action="append",
+            type=int,
+            help="Team ID to audit. Can be provided multiple times. Defaults to all teams with non-empty filters.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Maximum number of teams to audit.",
+        )
+        parser.add_argument(
+            "--format",
+            choices=["text", "jsonl"],
+            default="text",
+            help="Output format for invalid teams.",
+        )
+        parser.add_argument(
+            "--fail-on-invalid",
+            action="store_true",
+            help="Exit with a non-zero status if any invalid filters are found.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        team_ids: list[int] | None = options.get("team_ids")
+        limit: int | None = options.get("limit")
+        output_format: str = options["format"]
+        fail_on_invalid: bool = options["fail_on_invalid"]
+
+        queryset = Team.objects.only("id", "organization_id", "project_id", "test_account_filters").order_by("id")
+        if team_ids:
+            queryset = queryset.filter(id__in=team_ids)
+        else:
+            queryset = queryset.exclude(test_account_filters=[])
+
+        if limit is not None:
+            if limit < 1:
+                raise CommandError("--limit must be greater than 0.")
+            queryset = queryset[:limit]
+
+        checked_count = 0
+        invalid_count = 0
+
+        for team in queryset.iterator(chunk_size=500):
+            checked_count += 1
+            try:
+                TestAccountFilters.model_validate(team.test_account_filters)
+            except PydanticValidationError as error:
+                invalid_count += 1
+                self._write_invalid_team(team, error, output_format)
+
+        summary = f"Audited {checked_count} team(s): {invalid_count} invalid, {checked_count - invalid_count} valid."
+        if invalid_count:
+            self.stdout.write(self.style.WARNING(summary))
+        else:
+            self.stdout.write(self.style.SUCCESS(summary))
+
+        if fail_on_invalid and invalid_count:
+            raise CommandError(f"Found {invalid_count} team(s) with invalid test account filters.")
+
+    def _write_invalid_team(self, team: Team, error: PydanticValidationError, output_format: str) -> None:
+        errors = error.errors(include_url=False)
+        if output_format == "jsonl":
+            self.stdout.write(
+                json.dumps(
+                    {
+                        "team_id": team.id,
+                        "project_id": team.project_id,
+                        "organization_id": str(team.organization_id),
+                        "errors": errors,
+                        "test_account_filters": team.test_account_filters,
+                    },
+                    default=str,
+                )
+            )
+            return
+
+        first_error = errors[0] if errors else {}
+        self.stdout.write(
+            self.style.WARNING(
+                "Invalid test account filters for "
+                f"team_id={team.id}, project_id={team.project_id}, organization_id={team.organization_id}: "
+                f"{first_error.get('msg', 'validation failed')}"
+            )
+        )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8593,6 +8593,32 @@ class TeamTaxonomyItem(BaseModel):
     event: str
 
 
+class TestAccountFilters(
+    RootModel[
+        list[
+            EventPropertyFilter
+            | PersonPropertyFilter
+            | SessionPropertyFilter
+            | CohortPropertyFilter
+            | FeaturePropertyFilter
+            | GroupPropertyFilter
+            | ElementPropertyFilter
+            | HogQLPropertyFilter
+        ]
+    ]
+):
+    root: list[
+        EventPropertyFilter
+        | PersonPropertyFilter
+        | SessionPropertyFilter
+        | CohortPropertyFilter
+        | FeaturePropertyFilter
+        | GroupPropertyFilter
+        | ElementPropertyFilter
+        | HogQLPropertyFilter
+    ]
+
+
 class TestBasicQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -2,11 +2,19 @@ import os
 import json
 from contextlib import suppress
 
-from posthog.settings.utils import get_from_env, get_list
+from posthog.settings.utils import get_from_env, get_list, str_to_bool
 
 # Used mostly by the hobby install to have some feature flags enabled by default
 # NOTE: This only affects the frontend, the same FFs will still be considered disabled on the backend
 PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", ""))
+
+# Temporarily disabled until teams have been validated with
+# audit_test_account_filters.py in prod.
+TEST_ACCOUNT_FILTERS_STRICT_VALIDATION_ENABLED: bool = get_from_env(
+    "TEST_ACCOUNT_FILTERS_STRICT_VALIDATION_ENABLED",
+    False,
+    type_cast=str_to_bool,
+)
 
 # Per-team local evaluation rate limits, e.g. {"123": "1200/minute", "456": "2400/hour"}
 LOCAL_EVAL_RATE_LIMITS: dict[int, str] = {}

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26613,6 +26613,8 @@ export namespace Schemas {
 
     export type PatchedProjectBackwardCompatGroupTypesItem = { [key: string]: unknown };
 
+    export type PatchedProjectBackwardCompatTestAccountFiltersItem = { [key: string]: unknown };
+
     export type PatchedProjectBackwardCompatDefaultModifiers = { [key: string]: unknown };
 
     export type PatchedProjectBackwardCompatProductIntentsItem = {
@@ -26686,8 +26688,8 @@ export namespace Schemas {
       anonymize_ips?: boolean;
       completed_snippet_onboarding?: boolean;
       readonly ingested_event?: boolean;
-      /** Filter groups that identify internal/test traffic to be excluded from insights. */
-      test_account_filters?: unknown;
+      /** Property filters that identify internal/test traffic to exclude from insights. */
+      test_account_filters?: PatchedProjectBackwardCompatTestAccountFiltersItem[];
       /**
          * When true, new insights default to excluding internal/test users.
          * @nullable
@@ -28710,6 +28712,8 @@ export namespace Schemas {
 
     export type PatchedTeamDefaultModifiers = { [key: string]: unknown };
 
+    export type PatchedTeamTestAccountFiltersItem = { [key: string]: unknown };
+
     export type PatchedTeamGroupTypesItem = { [key: string]: unknown };
 
     export type PatchedTeamProductIntentsItem = { [key: string]: unknown };
@@ -28778,7 +28782,8 @@ export namespace Schemas {
       app_urls?: (string | null)[];
       anonymize_ips?: boolean;
       completed_snippet_onboarding?: boolean;
-      test_account_filters?: unknown;
+      /** Property filters that identify internal/test traffic to exclude from insights. */
+      test_account_filters?: PatchedTeamTestAccountFiltersItem[];
       /** @nullable */
       test_account_filters_default_checked?: boolean | null;
       path_cleaning_filters?: unknown;
@@ -29380,6 +29385,8 @@ export namespace Schemas {
 
     export type ProjectBackwardCompatGroupTypesItem = { [key: string]: unknown };
 
+    export type ProjectBackwardCompatTestAccountFiltersItem = { [key: string]: unknown };
+
     export type ProjectBackwardCompatDefaultModifiers = { [key: string]: unknown };
 
     export type ProjectBackwardCompatProductIntentsItem = {
@@ -29425,8 +29432,8 @@ export namespace Schemas {
       anonymize_ips?: boolean;
       completed_snippet_onboarding?: boolean;
       readonly ingested_event: boolean;
-      /** Filter groups that identify internal/test traffic to be excluded from insights. */
-      test_account_filters?: unknown;
+      /** Property filters that identify internal/test traffic to exclude from insights. */
+      test_account_filters?: ProjectBackwardCompatTestAccountFiltersItem[];
       /**
          * When true, new insights default to excluding internal/test users.
          * @nullable
@@ -33687,6 +33694,8 @@ export namespace Schemas {
 
     export type TeamDefaultModifiers = { [key: string]: unknown };
 
+    export type TeamTestAccountFiltersItem = { [key: string]: unknown };
+
     export type TeamGroupTypesItem = { [key: string]: unknown };
 
     export type TeamProductIntentsItem = { [key: string]: unknown };
@@ -33726,7 +33735,8 @@ export namespace Schemas {
       app_urls?: (string | null)[];
       anonymize_ips?: boolean;
       completed_snippet_onboarding?: boolean;
-      test_account_filters?: unknown;
+      /** Property filters that identify internal/test traffic to exclude from insights. */
+      test_account_filters?: TeamTestAccountFiltersItem[];
       /** @nullable */
       test_account_filters_default_checked?: boolean | null;
       path_cleaning_filters?: unknown;

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -123,9 +123,9 @@ export const OrganizationsProjectsPartialUpdateBody = /* @__PURE__ */ zod
             .describe('When true, PostHog drops the IP address from every ingested event.'),
         completed_snippet_onboarding: zod.boolean().optional(),
         test_account_filters: zod
-            .unknown()
+            .array(zod.record(zod.string(), zod.unknown()))
             .optional()
-            .describe('Filter groups that identify internal/test traffic to be excluded from insights.'),
+            .describe('Property filters that identify internal/test traffic to exclude from insights.'),
         test_account_filters_default_checked: zod
             .boolean()
             .nullish()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/project-settings-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/project-settings-update.json
@@ -370,7 +370,15 @@
             "description": "Enables displaying surveys via posthog-js on allowed origins."
         },
         "test_account_filters": {
-            "description": "Filter groups that identify internal/test traffic to be excluded from insights."
+            "description": "Property filters that identify internal/test traffic to exclude from insights.",
+            "items": {
+                "additionalProperties": {},
+                "propertyNames": {
+                    "type": "string"
+                },
+                "type": "object"
+            },
+            "type": "array"
         },
         "test_account_filters_default_checked": {
             "anyOf": [


### PR DESCRIPTION
## Problem

Since adding capabilities for changing test account filters to MCP, we see invalid configurations e.g. https://posthoghelp.zendesk.com/agent/tickets/57788. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/59139)

## Changes

This PR extends the Pydantic schema to validate structural correctness. They are temporarily disabled until I checked all prod entries with a script.

## How did you test this code?

Added a test case