### PR TITLE
feat(usage-reports): Use pre-agg MV for event-based usage reporting

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -69,6 +69,18 @@ logger.setLevel(logging.INFO)
 # Changes to the AIEventType enum will impact usage reporting
 AI_EVENTS = [event.value for event in AIEventType]
 
+# Events excluded from billable event counts. AI events are billed
+# separately via `ai_event_count_in_period`; `$exception` is excluded
+# during the beta; survey/feature-flag bookkeeping events are not billable.
+BILLABLE_EXCLUDED_EVENTS: list[str] = [
+    "$feature_flag_called",
+    "survey sent",
+    "survey shown",
+    "survey dismissed",
+    "$exception",
+    *AI_EVENTS,
+]
+
 
 class Period(TypedDict):
     start_inclusive: str
@@ -529,17 +541,6 @@ def get_teams_with_billable_event_count_in_period(
     else:
         distinct_expression = "1"
 
-    # We are excluding $exception events during the beta
-    # We also exclude AI events as they are billed separately through ai_event_count_in_period
-    excluded_events = [
-        "$feature_flag_called",
-        "survey sent",
-        "survey shown",
-        "survey dismissed",
-        "$exception",
-        *AI_EVENTS,
-    ]
-
     query_template = f"""
         SELECT team_id, count({distinct_expression}) as count
         FROM events
@@ -549,7 +550,9 @@ def get_teams_with_billable_event_count_in_period(
     """
 
     with tags_context(product=Product.PRODUCT_ANALYTICS, feature=Feature.USAGE_REPORT):
-        return _execute_split_query(begin, end, query_template, {"excluded_events": excluded_events}, num_splits=12)
+        return _execute_split_query(
+            begin, end, query_template, {"excluded_events": BILLABLE_EXCLUDED_EVENTS}, num_splits=12
+        )
 
 
 @timed_log()
@@ -568,16 +571,6 @@ def get_teams_with_billable_enhanced_persons_event_count_in_period(
     else:
         distinct_expression = "1"
 
-    # We exclude AI events as they are billed separately through ai_event_count_in_period
-    excluded_events = [
-        "$feature_flag_called",
-        "survey sent",
-        "survey shown",
-        "survey dismissed",
-        "$exception",
-        *AI_EVENTS,
-    ]
-
     query_template = f"""
         SELECT team_id, count({distinct_expression}) as count
         FROM events
@@ -588,7 +581,9 @@ def get_teams_with_billable_enhanced_persons_event_count_in_period(
     """
 
     with tags_context(product=Product.PRODUCT_ANALYTICS, feature=Feature.USAGE_REPORT):
-        return _execute_split_query(begin, end, query_template, {"excluded_events": excluded_events}, num_splits=12)
+        return _execute_split_query(
+            begin, end, query_template, {"excluded_events": BILLABLE_EXCLUDED_EVENTS}, num_splits=12
+        )
 
 
 @timed_log()

--- a/posthog/temporal/tests/usage_report/test_preagg_queries.py
+++ b/posthog/temporal/tests/usage_report/test_preagg_queries.py
@@ -1,0 +1,332 @@
+"""Functional tests for the preagg-table versions of the usage-report
+event-count queries. The tests insert rows directly into the writable
+preagg table — constructing aggregate states the same way the
+materialized view does — and then call the helpers under test.
+
+The legacy versions in `posthog/tasks/usage_report.py` already have
+their own coverage in `posthog/tasks/test/test_usage_report.py`; these
+tests prove the preagg helpers produce equivalent results from
+pre-aggregated rows.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models.usage_report_events_preagg.sql import (
+    DISTRIBUTED_USAGE_REPORT_EVENTS_PREAGG_TABLE_SQL,
+    SHARDED_USAGE_REPORT_EVENTS_PREAGG_TABLE,
+    SHARDED_USAGE_REPORT_EVENTS_PREAGG_TABLE_SQL,
+    WRITABLE_USAGE_REPORT_EVENTS_PREAGG_TABLE,
+    WRITABLE_USAGE_REPORT_EVENTS_PREAGG_TABLE_SQL,
+)
+from posthog.temporal.usage_report.preagg_queries import (
+    get_all_event_metrics_in_period_from_preagg,
+    get_teams_with_billable_enhanced_persons_event_count_in_period_from_preagg,
+    get_teams_with_billable_event_count_in_period_from_preagg,
+)
+
+# Picked far above any seeded test team so leftover rows from other
+# tests sharing the dev/test ClickHouse don't bleed into our queries.
+_TEAM_A = 9_900_001
+_TEAM_B = 9_900_002
+
+# Match production semantics: `get_previous_day` returns
+# `(start_of_day, end_of_day at 23:59:59.999999)` — both within the same
+# calendar day. The preagg helpers must include the end day.
+_BEGIN = datetime(2026, 5, 4, 0, 0, 0)
+_END = datetime(2026, 5, 4, 23, 59, 59, 999999)
+_DAY = "2026-05-04"
+
+
+def _evt(
+    *,
+    team_id: int,
+    event: str,
+    distinct_id: str,
+    uuid: str,
+    person_mode: str = "full",
+    lib: str = "web",
+    day: str = _DAY,
+) -> dict[str, Any]:
+    return {
+        "date": day,
+        "team_id": team_id,
+        "person_mode": person_mode,
+        "lib": lib,
+        "event": event,
+        "distinct_id": distinct_id,
+        "uuid": uuid,
+    }
+
+
+def _as_dict(rows: Any) -> dict[int, int]:
+    return {int(team_id): int(count) for team_id, count in rows}
+
+
+class _PreaggQueriesBase(ClickhouseTestMixin, BaseTest):
+    """Shared setup. Migrations target AUX/INGESTION clusters which
+    aren't always present in the local test cluster, so we recreate the
+    tables our queries touch the same way `test_usage_report_events_preagg_mv`
+    does — that's the established pattern for testing this MV.
+    """
+
+    def setUp(self) -> None:
+        sync_execute(SHARDED_USAGE_REPORT_EVENTS_PREAGG_TABLE_SQL())
+        sync_execute(DISTRIBUTED_USAGE_REPORT_EVENTS_PREAGG_TABLE_SQL())
+        sync_execute(WRITABLE_USAGE_REPORT_EVENTS_PREAGG_TABLE_SQL())
+        # TRUNCATE rather than DELETE: lightweight DELETE is async and
+        # was racing inserts inside individual test methods, so a
+        # date-sensitive assertion (`test_period_filter_is_half_open`)
+        # would see no rows. The preagg table is dedicated to this
+        # workflow, so wiping the whole thing between tests is safe.
+        sync_execute(f"TRUNCATE TABLE {SHARDED_USAGE_REPORT_EVENTS_PREAGG_TABLE}")
+        super().setUp()
+
+    def _insert_preagg_events(self, events: list[dict[str, Any]]) -> None:
+        """Insert raw billable-event tuples into the writable preagg
+        table, aggregating them into the same `distinct_events_unique` /
+        `event_count` states the MV would produce.
+
+        Each item in `events` is a single occurrence:
+            {date, team_id, person_mode, lib, event, distinct_id, uuid}
+
+        The UNION ALL is grouped by (date, team_id, person_mode, lib,
+        event) so collisions on the unique tuple inside one bucket
+        dedupe via `uniqExactState`, exactly mirroring the MV's
+        behavior.
+        """
+        if not events:
+            return
+
+        union_parts: list[str] = []
+        params: dict[str, Any] = {}
+        for i, e in enumerate(events):
+            union_parts.append(
+                f"""
+                SELECT
+                    toDate(%(date_{i})s) AS date,
+                    toInt64(%(team_id_{i})s) AS team_id,
+                    %(person_mode_{i})s AS person_mode,
+                    %(lib_{i})s AS lib,
+                    %(event_{i})s AS event,
+                    %(distinct_id_{i})s AS distinct_id,
+                    %(uuid_{i})s AS uuid
+                """
+            )
+            params[f"date_{i}"] = e["date"]
+            params[f"team_id_{i}"] = e["team_id"]
+            params[f"person_mode_{i}"] = e["person_mode"]
+            params[f"lib_{i}"] = e["lib"]
+            params[f"event_{i}"] = e["event"]
+            params[f"distinct_id_{i}"] = e["distinct_id"]
+            params[f"uuid_{i}"] = e["uuid"]
+
+        union_sql = " UNION ALL ".join(union_parts)
+
+        sync_execute(
+            f"""
+            INSERT INTO {WRITABLE_USAGE_REPORT_EVENTS_PREAGG_TABLE}
+            SELECT
+                date,
+                team_id,
+                person_mode,
+                lib,
+                event,
+                uniqExactState((cityHash64(distinct_id), cityHash64(uuid), cityHash64(event)))
+                    AS distinct_events_unique,
+                sumState(toUInt64(1)) AS event_count
+            FROM ({union_sql})
+            GROUP BY date, team_id, person_mode, lib, event
+            """,
+            params,
+        )
+
+
+class TestBillableEventCountFromPreagg(_PreaggQueriesBase):
+    def test_counts_distinct_events_per_team(self) -> None:
+        self._insert_preagg_events(
+            [
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u1", uuid="a-1"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u2", uuid="a-2"),
+                _evt(team_id=_TEAM_A, event="click", distinct_id="u1", uuid="a-3"),
+                _evt(team_id=_TEAM_B, event="pageview", distinct_id="u3", uuid="b-1"),
+            ]
+        )
+
+        result = _as_dict(get_teams_with_billable_event_count_in_period_from_preagg(_BEGIN, _END))
+
+        self.assertEqual(result, {_TEAM_A: 3, _TEAM_B: 1})
+
+    def test_replayed_events_dedupe_within_a_day(self) -> None:
+        # Same (distinct_id, uuid, event) twice on the same day should
+        # collapse to 1 — that's the whole reason `uniqExactState` is
+        # used over a plain count.
+        self._insert_preagg_events(
+            [
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u1", uuid="a-1"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u1", uuid="a-1"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u2", uuid="a-2"),
+            ]
+        )
+
+        result = _as_dict(get_teams_with_billable_event_count_in_period_from_preagg(_BEGIN, _END))
+
+        self.assertEqual(result, {_TEAM_A: 2})
+
+    def test_excludes_billing_blocklist(self) -> None:
+        # The legacy query excludes feature-flag bookkeeping, survey
+        # bookkeeping, and `$exception`. The preagg version must too —
+        # otherwise customers get double-billed for events also covered
+        # by other meters.
+        self._insert_preagg_events(
+            [
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u1", uuid="a-1"),
+                _evt(team_id=_TEAM_A, event="$feature_flag_called", distinct_id="u1", uuid="a-2"),
+                _evt(team_id=_TEAM_A, event="survey sent", distinct_id="u1", uuid="a-3"),
+                _evt(team_id=_TEAM_A, event="survey shown", distinct_id="u1", uuid="a-4"),
+                _evt(team_id=_TEAM_A, event="survey dismissed", distinct_id="u1", uuid="a-5"),
+                _evt(team_id=_TEAM_A, event="$exception", distinct_id="u1", uuid="a-6"),
+                _evt(team_id=_TEAM_A, event="$ai_generation", distinct_id="u1", uuid="a-7"),
+            ]
+        )
+
+        result = _as_dict(get_teams_with_billable_event_count_in_period_from_preagg(_BEGIN, _END))
+
+        self.assertEqual(result, {_TEAM_A: 1})
+
+    def test_filters_to_single_day(self) -> None:
+        # Helper is single-day only: only events whose `date` matches
+        # `toDate(begin)` are counted. Events on neighboring days must
+        # not bleed in, so the daily workflow can chain without
+        # double-counting boundaries.
+        self._insert_preagg_events(
+            [
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u1", uuid="a-1", day="2026-05-03"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u2", uuid="a-2", day="2026-05-04"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u3", uuid="a-3", day="2026-05-05"),
+            ]
+        )
+
+        result = _as_dict(get_teams_with_billable_event_count_in_period_from_preagg(_BEGIN, _END))
+
+        self.assertEqual(result, {_TEAM_A: 1})
+
+
+class TestEnhancedPersonsEventCountFromPreagg(_PreaggQueriesBase):
+    def test_filters_to_full_and_force_upgrade_modes(self) -> None:
+        self._insert_preagg_events(
+            [
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u1", uuid="a-1", person_mode="full"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u2", uuid="a-2", person_mode="propertyless"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u3", uuid="a-3", person_mode="force_upgrade"),
+            ]
+        )
+
+        result = _as_dict(get_teams_with_billable_enhanced_persons_event_count_in_period_from_preagg(_BEGIN, _END))
+
+        # `full` and `force_upgrade` count, `propertyless` doesn't.
+        self.assertEqual(result, {_TEAM_A: 2})
+
+    def test_excludes_billing_blocklist(self) -> None:
+        self._insert_preagg_events(
+            [
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u1", uuid="a-1"),
+                _evt(team_id=_TEAM_A, event="$ai_generation", distinct_id="u1", uuid="a-2"),
+                _evt(team_id=_TEAM_A, event="$exception", distinct_id="u1", uuid="a-3"),
+            ]
+        )
+
+        result = _as_dict(get_teams_with_billable_enhanced_persons_event_count_in_period_from_preagg(_BEGIN, _END))
+
+        self.assertEqual(result, {_TEAM_A: 1})
+
+
+class TestAllEventMetricsFromPreagg(_PreaggQueriesBase):
+    def test_buckets_by_event_prefix_and_lib(self) -> None:
+        self._insert_preagg_events(
+            [
+                _evt(team_id=_TEAM_A, event="helicone_request", distinct_id="u1", uuid="a-1", lib="web"),
+                _evt(team_id=_TEAM_A, event="langfuse_trace", distinct_id="u2", uuid="a-2", lib="web"),
+                _evt(team_id=_TEAM_A, event="keywords_ai_event", distinct_id="u3", uuid="a-3", lib="web"),
+                _evt(team_id=_TEAM_A, event="traceloop_span", distinct_id="u4", uuid="a-4", lib="web"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u5", uuid="a-5", lib="web"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u6", uuid="a-6", lib="js"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u7", uuid="a-7", lib="posthog-node"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u8", uuid="a-8", lib="posthog-android"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u9", uuid="a-9", lib="posthog-ios"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u10", uuid="a-10", lib="posthog-server"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u11", uuid="a-11", lib="posthog-rs"),
+                # Unknown lib — should be bucketed `other` and dropped.
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u12", uuid="a-12", lib="some-mystery"),
+            ]
+        )
+
+        result = get_all_event_metrics_in_period_from_preagg(_BEGIN, _END)
+
+        # Each provider/library-prefix bucket has exactly one event.
+        self.assertEqual(_as_dict(result["helicone_events"]), {_TEAM_A: 1})
+        self.assertEqual(_as_dict(result["langfuse_events"]), {_TEAM_A: 1})
+        self.assertEqual(_as_dict(result["keywords_ai_events"]), {_TEAM_A: 1})
+        self.assertEqual(_as_dict(result["traceloop_events"]), {_TEAM_A: 1})
+        self.assertEqual(_as_dict(result["web_events"]), {_TEAM_A: 1})
+        self.assertEqual(_as_dict(result["web_lite_events"]), {_TEAM_A: 1})
+        self.assertEqual(_as_dict(result["node_events"]), {_TEAM_A: 1})
+        self.assertEqual(_as_dict(result["android_events"]), {_TEAM_A: 1})
+        self.assertEqual(_as_dict(result["ios_events"]), {_TEAM_A: 1})
+        self.assertEqual(_as_dict(result["rust_events"]), {_TEAM_A: 1})
+        # `posthog-server` collapses into `java_events` per the
+        # legacy bucketing.
+        self.assertEqual(_as_dict(result["java_events"]), {_TEAM_A: 1})
+
+    def test_metric_returns_total_count_not_distinct(self) -> None:
+        # `event_count` is a `sumState` of one-per-row, so two rows for
+        # the same (distinct_id, uuid) on the same day still sum to 2.
+        # The legacy version uses `count(1)`, so this matches.
+        self._insert_preagg_events(
+            [
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u1", uuid="a-1", lib="web"),
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u1", uuid="a-1", lib="web"),
+            ]
+        )
+
+        result = get_all_event_metrics_in_period_from_preagg(_BEGIN, _END)
+
+        self.assertEqual(_as_dict(result["web_events"]), {_TEAM_A: 2})
+
+    def test_returns_empty_lists_for_unused_buckets(self) -> None:
+        self._insert_preagg_events(
+            [
+                _evt(team_id=_TEAM_A, event="pageview", distinct_id="u1", uuid="a-1", lib="web"),
+            ]
+        )
+
+        result = get_all_event_metrics_in_period_from_preagg(_BEGIN, _END)
+
+        # Every metric key must be present even if empty — the
+        # aggregator iterates over the multi-keys mapping and would
+        # KeyError otherwise.
+        for key in (
+            "helicone_events",
+            "langfuse_events",
+            "keywords_ai_events",
+            "traceloop_events",
+            "node_events",
+            "android_events",
+            "ios_events",
+            "flutter_events",
+            "go_events",
+            "java_events",
+            "react_native_events",
+            "ruby_events",
+            "python_events",
+            "php_events",
+            "dotnet_events",
+            "elixir_events",
+            "unity_events",
+            "rust_events",
+            "web_lite_events",
+        ):
+            self.assertEqual(result[key], [])

--- a/posthog/temporal/usage_report/preagg_queries.py
+++ b/posthog/temporal/usage_report/preagg_queries.py
@@ -1,0 +1,196 @@
+"""Preagg-table versions of the heavy event-count usage-report queries.
+
+These read from `usage_report_events_preagg` — a daily aggregate
+materialized view fed off `KAFKA_EVENTS_JSON` — instead of the raw
+`events` table. The legacy versions in `posthog/tasks/usage_report.py`
+scan billions of rows and routinely take 10–20 minutes per run; the
+preagg versions read tens-to-hundreds of pre-aggregated rows per
+`(date, team_id)` and complete in seconds.
+
+**Single-day only.** The usage-report workflow runs daily for the
+previous calendar day (`get_previous_day` → start-of-day to
+end-of-day, both within the same date), so these helpers filter on
+``date = toDate(begin)`` and ignore ``end``. The legacy signatures
+accept ``(begin, end)``, so we keep both args for parity, but the
+preagg versions are documented as single-day only — multi-day callers
+would silently get only the begin day.
+
+The preagg keeps a 14-day TTL; the workflow's previous-day window is
+well inside it.
+
+Equivalence to the legacy versions:
+
+* ``get_teams_with_billable_event_count_in_period_from_preagg`` — same
+  excluded-events filter and the same
+  ``count(distinct event, cityHash64(distinct_id), cityHash64(uuid))``
+  math (no ``toDate(timestamp)`` term needed since we're already on a
+  single date), computed via ``uniqExactMerge`` per ``team_id``.
+* ``get_teams_with_billable_enhanced_persons_event_count_in_period_from_preagg``
+  — same as above, additionally restricted to
+  ``person_mode IN ('full', 'force_upgrade')``.
+* ``get_all_event_metrics_in_period_from_preagg`` — same SDK-bucketing
+  ``multiIf`` as the legacy version, but reads the materialized ``lib``
+  column directly instead of parsing ``properties.$lib`` per row.
+
+Note on hashing: the legacy query hashes ``cityHash64(uuid)`` directly
+on the UUID column, while the MV stores
+``cityHash64(toString(uuid))``. The hash values differ but the
+distinctness property is preserved, so the resulting counts match.
+"""
+
+from collections.abc import Sequence
+from datetime import datetime
+
+from retry import retry
+
+from posthog.schema import AIEventType
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.logging.timing import timed_log
+from posthog.models.usage_report_events_preagg.sql import USAGE_REPORT_EVENTS_PREAGG_TABLE
+from posthog.tasks.usage_report import CH_BILLING_SETTINGS, QUERY_RETRIES, QUERY_RETRY_BACKOFF, QUERY_RETRY_DELAY
+
+# Mirrored from `posthog.tasks.usage_report.AI_EVENTS` so the preagg
+# versions stay in lockstep with the legacy filter without depending on
+# private module state.
+_AI_EVENTS: list[str] = [event.value for event in AIEventType]
+
+# Same exclusion list as the legacy
+# `get_teams_with_billable_*_event_count_in_period` queries — keep the
+# two in sync. AI events are billed separately via
+# `teams_with_ai_event_count_in_period`; `$exception` is excluded during
+# the beta; survey/feature-flag bookkeeping events are not billable.
+_BILLABLE_EXCLUDED_EVENTS: list[str] = [
+    "$feature_flag_called",
+    "survey sent",
+    "survey shown",
+    "survey dismissed",
+    "$exception",
+    *_AI_EVENTS,
+]
+
+# Source-key list for the multi-output `all_event_metrics` spec. Order
+# is irrelevant; the dict keys are looked up by name.
+_ALL_EVENT_METRIC_KEYS: tuple[str, ...] = (
+    "helicone_events",
+    "langfuse_events",
+    "keywords_ai_events",
+    "traceloop_events",
+    "web_events",
+    "web_lite_events",
+    "node_events",
+    "android_events",
+    "flutter_events",
+    "ios_events",
+    "go_events",
+    "java_events",
+    "react_native_events",
+    "ruby_events",
+    "python_events",
+    "php_events",
+    "dotnet_events",
+    "elixir_events",
+    "unity_events",
+    "rust_events",
+)
+
+
+def _billable_count_query(extra_where: str = "") -> str:
+    # Usage reports run daily for the previous calendar day, so we filter
+    # to a single date. `end` is accepted for API parity with the legacy
+    # signature but unused here — the helper is documented as single-day
+    # only.
+    return f"""
+        SELECT team_id, toUInt64(uniqExactMerge(distinct_events_unique)) AS count
+        FROM {USAGE_REPORT_EVENTS_PREAGG_TABLE}
+        WHERE date = toDate(%(begin)s)
+            AND event NOT IN %(excluded_events)s
+            {extra_where}
+        GROUP BY team_id
+    """
+
+
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_teams_with_billable_event_count_in_period_from_preagg(
+    begin: datetime, end: datetime
+) -> Sequence[tuple[int, int]]:
+    with tags_context(product=Product.PRODUCT_ANALYTICS, feature=Feature.USAGE_REPORT):
+        return sync_execute(
+            _billable_count_query(),
+            {"begin": begin, "end": end, "excluded_events": _BILLABLE_EXCLUDED_EVENTS},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
+
+
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_teams_with_billable_enhanced_persons_event_count_in_period_from_preagg(
+    begin: datetime, end: datetime
+) -> Sequence[tuple[int, int]]:
+    with tags_context(product=Product.PRODUCT_ANALYTICS, feature=Feature.USAGE_REPORT):
+        return sync_execute(
+            _billable_count_query("AND person_mode IN ('full', 'force_upgrade')"),
+            {"begin": begin, "end": end, "excluded_events": _BILLABLE_EXCLUDED_EVENTS},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
+
+
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_all_event_metrics_in_period_from_preagg(begin: datetime, end: datetime) -> dict[str, list[tuple[int, int]]]:
+    # `lib` is a materialized column on the preagg, so unlike the legacy
+    # version we don't need `get_property_string_expr` to dig $lib out
+    # of `properties` per row.
+    query = f"""
+        SELECT
+            team_id,
+            multiIf(
+                event LIKE 'helicone%%', 'helicone_events',
+                event LIKE 'langfuse%%', 'langfuse_events',
+                event LIKE 'keywords_ai%%', 'keywords_ai_events',
+                event LIKE 'traceloop%%', 'traceloop_events',
+                lib = 'web', 'web_events',
+                lib = 'js', 'web_lite_events',
+                lib = 'posthog-node', 'node_events',
+                lib = 'posthog-android', 'android_events',
+                lib = 'posthog-flutter', 'flutter_events',
+                lib = 'posthog-ios', 'ios_events',
+                lib = 'posthog-go', 'go_events',
+                lib = 'posthog-java', 'java_events',
+                lib = 'posthog-server', 'java_events',
+                lib = 'posthog-react-native', 'react_native_events',
+                lib = 'posthog-ruby', 'ruby_events',
+                lib = 'posthog-python', 'python_events',
+                lib = 'posthog-php', 'php_events',
+                lib = 'posthog-dotnet', 'dotnet_events',
+                lib = 'posthog-elixir', 'elixir_events',
+                lib = 'posthog-unity', 'unity_events',
+                lib = 'posthog-rs', 'rust_events',
+                'other'
+            ) AS metric,
+            toUInt64(sumMerge(event_count)) AS count
+        FROM {USAGE_REPORT_EVENTS_PREAGG_TABLE}
+        WHERE date = toDate(%(begin)s)
+        GROUP BY team_id, metric
+        HAVING metric != 'other'
+    """
+
+    with tags_context(product=Product.PRODUCT_ANALYTICS, feature=Feature.USAGE_REPORT):
+        rows = sync_execute(
+            query,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
+
+    out: dict[str, list[tuple[int, int]]] = {key: [] for key in _ALL_EVENT_METRIC_KEYS}
+    for team_id, metric, count in rows:
+        bucket = out.get(metric)
+        if bucket is not None:
+            bucket.append((int(team_id), int(count)))
+    return out

--- a/posthog/temporal/usage_report/preagg_queries.py
+++ b/posthog/temporal/usage_report/preagg_queries.py
@@ -43,33 +43,18 @@ from datetime import datetime
 
 from retry import retry
 
-from posthog.schema import AIEventType
-
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.logging.timing import timed_log
 from posthog.models.usage_report_events_preagg.sql import USAGE_REPORT_EVENTS_PREAGG_TABLE
-from posthog.tasks.usage_report import CH_BILLING_SETTINGS, QUERY_RETRIES, QUERY_RETRY_BACKOFF, QUERY_RETRY_DELAY
-
-# Mirrored from `posthog.tasks.usage_report.AI_EVENTS` so the preagg
-# versions stay in lockstep with the legacy filter without depending on
-# private module state.
-_AI_EVENTS: list[str] = [event.value for event in AIEventType]
-
-# Same exclusion list as the legacy
-# `get_teams_with_billable_*_event_count_in_period` queries — keep the
-# two in sync. AI events are billed separately via
-# `teams_with_ai_event_count_in_period`; `$exception` is excluded during
-# the beta; survey/feature-flag bookkeeping events are not billable.
-_BILLABLE_EXCLUDED_EVENTS: list[str] = [
-    "$feature_flag_called",
-    "survey sent",
-    "survey shown",
-    "survey dismissed",
-    "$exception",
-    *_AI_EVENTS,
-]
+from posthog.tasks.usage_report import (
+    BILLABLE_EXCLUDED_EVENTS,
+    CH_BILLING_SETTINGS,
+    QUERY_RETRIES,
+    QUERY_RETRY_BACKOFF,
+    QUERY_RETRY_DELAY,
+)
 
 # Source-key list for the multi-output `all_event_metrics` spec. Order
 # is irrelevant; the dict keys are looked up by name.
@@ -120,7 +105,7 @@ def get_teams_with_billable_event_count_in_period_from_preagg(
     with tags_context(product=Product.PRODUCT_ANALYTICS, feature=Feature.USAGE_REPORT):
         return sync_execute(
             _billable_count_query(),
-            {"begin": begin, "end": end, "excluded_events": _BILLABLE_EXCLUDED_EVENTS},
+            {"begin": begin, "end": end, "excluded_events": BILLABLE_EXCLUDED_EVENTS},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
         )
@@ -134,7 +119,7 @@ def get_teams_with_billable_enhanced_persons_event_count_in_period_from_preagg(
     with tags_context(product=Product.PRODUCT_ANALYTICS, feature=Feature.USAGE_REPORT):
         return sync_execute(
             _billable_count_query("AND person_mode IN ('full', 'force_upgrade')"),
-            {"begin": begin, "end": end, "excluded_events": _BILLABLE_EXCLUDED_EVENTS},
+            {"begin": begin, "end": end, "excluded_events": BILLABLE_EXCLUDED_EVENTS},
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
         )

--- a/posthog/temporal/usage_report/queries.py
+++ b/posthog/temporal/usage_report/queries.py
@@ -49,7 +49,6 @@ from posthog.constants import FlagRequestType
 from posthog.models import GroupTypeMapping
 from posthog.models.feature_flag import FeatureFlag
 from posthog.tasks.usage_report import (
-    get_all_event_metrics_in_period,
     get_teams_with_active_batch_exports_in_period,
     get_teams_with_active_external_data_schemas_in_period,
     get_teams_with_active_hog_destinations_in_period,
@@ -57,8 +56,6 @@ from posthog.tasks.usage_report import (
     get_teams_with_ai_credits_used_in_period,
     get_teams_with_ai_event_count_in_period,
     get_teams_with_api_queries_metrics,
-    get_teams_with_billable_enhanced_persons_event_count_in_period,
-    get_teams_with_billable_event_count_in_period,
     get_teams_with_cdp_billable_invocations_in_period,
     get_teams_with_dwh_mat_views_storage_in_s3,
     get_teams_with_dwh_tables_storage_in_s3,
@@ -83,6 +80,11 @@ from posthog.tasks.usage_report import (
     get_teams_with_workflow_push_sent_in_period,
     get_teams_with_workflow_sms_sent_in_period,
     get_teams_with_zero_duration_recording_count_in_period,
+)
+from posthog.temporal.usage_report.preagg_queries import (
+    get_all_event_metrics_in_period_from_preagg,
+    get_teams_with_billable_enhanced_persons_event_count_in_period_from_preagg,
+    get_teams_with_billable_event_count_in_period_from_preagg,
 )
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -203,15 +205,21 @@ class QuerySpec:
 
 QUERIES: list[QuerySpec] = [
     # ---- ClickHouse: events --------------------------------------------------
+    # The three event-count specs below read from `usage_report_events_preagg`,
+    # a daily aggregate MV. They previously each scanned the raw `events`
+    # table for ~30 minutes; the preagg versions complete in seconds, so
+    # the activity timeout drops to match the other ClickHouse specs.
+    # See `posthog/temporal/usage_report/preagg_queries.py` for parity
+    # notes vs. the legacy implementations.
     QuerySpec(
         name="teams_with_event_count_in_period",
-        fn=lambda b, e: get_teams_with_billable_event_count_in_period(b, e, count_distinct=True),
-        timeout_minutes=30,
+        fn=get_teams_with_billable_event_count_in_period_from_preagg,
+        timeout_minutes=5,
     ),
     QuerySpec(
         name="teams_with_enhanced_persons_event_count_in_period",
-        fn=lambda b, e: get_teams_with_billable_enhanced_persons_event_count_in_period(b, e, count_distinct=True),
-        timeout_minutes=30,
+        fn=get_teams_with_billable_enhanced_persons_event_count_in_period_from_preagg,
+        timeout_minutes=5,
     ),
     QuerySpec(
         name="teams_with_event_count_with_groups_in_period",
@@ -219,7 +227,7 @@ QUERIES: list[QuerySpec] = [
     ),
     QuerySpec(
         name="all_event_metrics",
-        fn=get_all_event_metrics_in_period,
+        fn=get_all_event_metrics_in_period_from_preagg,
         output="multi",
         multi_keys_mapping={
             "helicone_events": "teams_with_event_count_from_helicone_in_period",
@@ -243,7 +251,7 @@ QUERIES: list[QuerySpec] = [
             "unity_events": "teams_with_unity_events_count_in_period",
             "rust_events": "teams_with_rust_events_count_in_period",
         },
-        timeout_minutes=30,
+        timeout_minutes=5,
     ),
     # ---- ClickHouse: recordings ----------------------------------------------
     QuerySpec(


### PR DESCRIPTION
This PR integrates the new temporal usage reporting workflow with the events pre-agg MV to speed up usage reporting.