### PR TITLE
fix(mcp): map actual runtime kinds for trends-actors and llm traces

### DIFF
--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -17,47 +17,54 @@ import { isShortId } from '@/tools/insights/utils'
 import type { Schemas } from './generated.js'
 import { globalRateLimiter } from './rate-limiter.js'
 
-// Maps query kinds to the productKey used by `_infer_query_tags` on the Python side.
-// Values mirror the frontend `ProductKey` enum (e.g. `session_replay`, not `replay`)
-// so attribution stays consistent with queries originating from the web app.
+// Subset of the frontend `ProductKey` enum (frontend/src/queries/schema/schema-general.ts)
+// that MCP query kinds map to. Typing the map values against this union catches typos
+// like `replay` vs `session_replay` at the TS build, and keeps attribution consistent
+// with queries originating from the web app.
+//
+// A drift guard test parses the canonical enum and asserts every value here exists there
+// — see services/mcp/tests/unit/inject-product-key.test.ts.
+export type MappedProductKey =
+    | 'product_analytics'
+    | 'error_tracking'
+    | 'llm_analytics'
+    | 'session_replay'
+    | 'experiments'
+
+// Maps the runtime `kind` string sent in the query body to the productKey consumed by
+// `_infer_query_tags` on the Python side. The keys here MUST be the runtime `kind`
+// literal — interface names like `AssistantTrendsActorsQuery` (which has runtime kind
+// `InsightActorsQuery`) silently miss and attribute to MCP. The coverage test in
+// inject-product-key.test.ts cross-references this against `query-wrappers.ts` so a
+// new `kind:` registration without a map entry fails CI.
 //
 // `null` means the kind is intentionally untagged — it falls through to the backend
-// `product=mcp` default. New product-specific query kinds must be added here; an entry
-// missing from this map silently attributes to MCP rather than the owning product.
-const QUERY_KIND_TO_PRODUCT_KEY: Record<string, string | null> = {
+// `product=mcp` default.
+export const QUERY_KIND_TO_PRODUCT_KEY: Record<string, MappedProductKey | null> = {
     // Product analytics
     TrendsQuery: 'product_analytics',
-    AssistantTrendsQuery: 'product_analytics',
-    AssistantTrendsActorsQuery: 'product_analytics',
     FunnelsQuery: 'product_analytics',
-    AssistantFunnelsQuery: 'product_analytics',
     RetentionQuery: 'product_analytics',
-    AssistantRetentionQuery: 'product_analytics',
     LifecycleQuery: 'product_analytics',
-    AssistantLifecycleQuery: 'product_analytics',
     PathsQuery: 'product_analytics',
-    AssistantPathsQuery: 'product_analytics',
     StickinessQuery: 'product_analytics',
-    AssistantStickinessQuery: 'product_analytics',
+    InsightActorsQuery: 'product_analytics',
     // Error tracking
     ErrorTrackingQuery: 'error_tracking',
     // LLM analytics
-    LLMTracesQuery: 'llm_analytics',
-    AssistantTracesQuery: 'llm_analytics',
-    AssistantTraceQuery: 'llm_analytics',
+    TracesQuery: 'llm_analytics',
+    TraceQuery: 'llm_analytics',
     // Session replay
     RecordingsQuery: 'session_replay',
-    SessionRecordingListQuery: 'session_replay',
     // Experiments
     ExperimentQuery: 'experiments',
     ExperimentExposureQuery: 'experiments',
     // Raw HogQL — no product tag; backend MCP default applies
     HogQLQuery: null,
     HogQLMetadata: null,
-    HogQLAstQuery: null,
 }
 
-function injectProductKey(query: Record<string, unknown>): Record<string, unknown> {
+export function injectProductKey(query: Record<string, unknown>): Record<string, unknown> {
     const kind = query?.kind as string | undefined
     if (!kind) {
         return query

--- a/services/mcp/tests/unit/inject-product-key.test.ts
+++ b/services/mcp/tests/unit/inject-product-key.test.ts
@@ -1,0 +1,172 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ApiClient, type MappedProductKey, QUERY_KIND_TO_PRODUCT_KEY, injectProductKey } from '@/api/client'
+
+const REPO_ROOT = resolve(__dirname, '../../../..')
+const SCHEMA_GENERAL_PATH = resolve(REPO_ROOT, 'frontend/src/queries/schema/schema-general.ts')
+const QUERY_WRAPPERS_PATH = resolve(REPO_ROOT, 'services/mcp/src/tools/generated/query-wrappers.ts')
+
+// Parse `export enum ProductKey { ... }` block from schema-general.ts and extract the
+// string values. Reading the source file (rather than importing the module) avoids
+// pulling the entire frontend graph into the MCP test bundle.
+function parseFrontendProductKeys(): Set<string> {
+    const source = readFileSync(SCHEMA_GENERAL_PATH, 'utf8')
+    const match = /export enum ProductKey \{([\s\S]*?)\n\}/.exec(source)
+    if (!match) {
+        throw new Error(`Could not locate ProductKey enum in ${SCHEMA_GENERAL_PATH}`)
+    }
+    const values = new Set<string>()
+    for (const line of match[1]!.split('\n')) {
+        const valueMatch = /^\s*[A-Z0-9_]+\s*=\s*'([^']+)'/.exec(line)
+        if (valueMatch) {
+            values.add(valueMatch[1]!)
+        }
+    }
+    return values
+}
+
+// Extract every `kind: '...'` literal registered under `GENERATED_TOOLS` in
+// query-wrappers.ts. These are the runtime kinds MCP actually sends to /query/,
+// so any kind in this set that isn't covered by QUERY_KIND_TO_PRODUCT_KEY would
+// silently attribute to product=mcp.
+function parseGeneratedToolKinds(): Set<string> {
+    const source = readFileSync(QUERY_WRAPPERS_PATH, 'utf8')
+    const generatedToolsMatch = /export const GENERATED_TOOLS[\s\S]*?\n\}\n/.exec(source)
+    if (!generatedToolsMatch) {
+        throw new Error(`Could not locate GENERATED_TOOLS block in ${QUERY_WRAPPERS_PATH}`)
+    }
+    const kinds = new Set<string>()
+    const re = /kind:\s*'([A-Z][A-Za-z0-9]*Query)'/g
+    let m: RegExpExecArray | null
+    while ((m = re.exec(generatedToolsMatch[0])) !== null) {
+        kinds.add(m[1]!)
+    }
+    return kinds
+}
+
+describe('injectProductKey', () => {
+    const taggedEntries = Object.entries(QUERY_KIND_TO_PRODUCT_KEY).filter(
+        (entry): entry is [string, MappedProductKey] => entry[1] !== null
+    )
+    const untaggedEntries = Object.entries(QUERY_KIND_TO_PRODUCT_KEY).filter(([, v]) => v === null)
+
+    it.each(taggedEntries)('tags %s with productKey=%s', (kind, expected) => {
+        const result = injectProductKey({ kind })
+        expect(result).toEqual({ kind, tags: { productKey: expected } })
+    })
+
+    it.each(untaggedEntries)('leaves %s untagged (null entry)', (kind) => {
+        expect(injectProductKey({ kind })).toEqual({ kind })
+    })
+
+    it('returns the query unchanged when kind is missing', () => {
+        const query = { foo: 'bar' }
+        expect(injectProductKey(query)).toBe(query)
+    })
+
+    it('returns the query unchanged for an unknown kind', () => {
+        const query = { kind: 'TotallyMadeUpQuery' }
+        expect(injectProductKey(query)).toBe(query)
+    })
+
+    it('preserves a caller-supplied productKey instead of overwriting it', () => {
+        const query = { kind: 'TrendsQuery', tags: { productKey: 'web_analytics', scene: 'WebAnalytics' } }
+        expect(injectProductKey(query)).toBe(query)
+    })
+
+    it('merges into existing tags when productKey is absent', () => {
+        const result = injectProductKey({ kind: 'TrendsQuery', tags: { scene: 'Insight' } })
+        expect(result).toEqual({
+            kind: 'TrendsQuery',
+            tags: { scene: 'Insight', productKey: 'product_analytics' },
+        })
+    })
+
+    it.each([[[]], [['scene']], [42], ['nope'], [true]] as const)(
+        'leaves the query untouched when tags is a non-object shape: %p',
+        (tags) => {
+            const query = { kind: 'TrendsQuery', tags }
+            expect(injectProductKey(query)).toBe(query)
+        }
+    )
+})
+
+describe('ActorsQuery wrapper top-level tags propagation', () => {
+    it('propagates the source productKey to the wrapped ActorsQuery so the backend tags it', async () => {
+        const fetchSpy = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ results: [], hasMore: false, offset: 0 }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        )
+        vi.stubGlobal('fetch', fetchSpy)
+
+        try {
+            const client = new ApiClient({ apiToken: 'token', baseUrl: 'https://example.com' })
+            await client.query({ projectId: '1' }).trendsActors({
+                query: { kind: 'InsightActorsQuery', source: { kind: 'TrendsQuery' } },
+            })
+
+            expect(fetchSpy).toHaveBeenCalledOnce()
+            const [, options] = fetchSpy.mock.calls[0]!
+            const body = JSON.parse(options.body as string)
+            expect(body.query.kind).toBe('ActorsQuery')
+            // Top-level tags so `_infer_query_tags` (which only inspects the outer query) finds it.
+            expect(body.query.tags).toEqual({ productKey: 'product_analytics' })
+            // Source is also tagged so any nested runner that re-reads the source still sees it.
+            expect(body.query.source.tags).toEqual({ productKey: 'product_analytics' })
+        } finally {
+            vi.unstubAllGlobals()
+        }
+    })
+
+    it('omits top-level tags when the source kind is unmapped (no silent attribution)', async () => {
+        const fetchSpy = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ results: [], hasMore: false, offset: 0 }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        )
+        vi.stubGlobal('fetch', fetchSpy)
+
+        try {
+            const client = new ApiClient({ apiToken: 'token', baseUrl: 'https://example.com' })
+            await client.query({ projectId: '1' }).trendsActors({
+                query: { kind: 'TotallyUnknownActorsSource' },
+            })
+
+            const [, options] = fetchSpy.mock.calls[0]!
+            const body = JSON.parse(options.body as string)
+            expect(body.query.tags).toBeUndefined()
+        } finally {
+            vi.unstubAllGlobals()
+        }
+    })
+})
+
+describe('QUERY_KIND_TO_PRODUCT_KEY drift guards', () => {
+    it('every mapped productKey exists in the canonical frontend ProductKey enum', () => {
+        const canonical = parseFrontendProductKeys()
+        // Sanity check the parser: if this fires, the enum format changed, not the map.
+        expect(canonical.size).toBeGreaterThan(20)
+
+        const offenders: Array<[string, string]> = []
+        for (const [kind, productKey] of Object.entries(QUERY_KIND_TO_PRODUCT_KEY)) {
+            if (productKey !== null && !canonical.has(productKey)) {
+                offenders.push([kind, productKey])
+            }
+        }
+        expect(offenders).toEqual([])
+    })
+
+    it('every kind registered in GENERATED_TOOLS is covered by the map', () => {
+        const generatedKinds = parseGeneratedToolKinds()
+        // Sanity check the parser: catches a refactor that moves/renames GENERATED_TOOLS.
+        expect(generatedKinds.size).toBeGreaterThan(5)
+
+        const missing = [...generatedKinds].filter((kind) => !(kind in QUERY_KIND_TO_PRODUCT_KEY))
+        expect(missing).toEqual([])
+    })
+})


### PR DESCRIPTION
## Problem

`QUERY_KIND_TO_PRODUCT_KEY` (services/mcp/src/api/client.ts) keyed several entries off the TS interface name rather than the runtime `kind` literal that MCP actually sends. Those entries were dead code:

- `AssistantTrendsActorsQuery` → runtime `kind` is `InsightActorsQuery`
- `LLMTracesQuery` / `AssistantTracesQuery` → runtime `kind` is `TracesQuery`
- `AssistantTraceQuery` → runtime `kind` is `TraceQuery`
- `Assistant{Trends,Funnels,Retention,Lifecycle,Paths,Stickiness}Query` → share runtime `kind` with the non-Assistant counterparts already in the map
- `SessionRecordingListQuery`, `HogQLAstQuery` → never existed as runtime kinds

The lookups never hit, so `query-trends-actors`, `query-llm-traces-list`, and `query-llm-trace` silently attributed to `product=mcp` instead of `product_analytics` / `llm_analytics`. Stacked on top of #56985.

## Changes

Two parts: fix the bugs, then lock the map down so this can't recur silently.

- Replace the dead entries with the runtime kinds GENERATED_TOOLS actually emits (`InsightActorsQuery`, `TracesQuery`, `TraceQuery`); drop entries that never had a matching runtime kind.
- Type the map values as `MappedProductKey | null` — a string-literal union of the five productKeys MCP attributes to. A typo like `replay` vs `session_replay` now fails the TS build.
- Add `services/mcp/tests/unit/inject-product-key.test.ts` covering each map entry, the edge cases of `injectProductKey` (missing/unknown kind, caller-set productKey, non-object tags), and the `ActorsQuery` wrapper top-level tag propagation.
- Two drift guards in the same file: every mapped value is checked against the canonical `ProductKey` enum in `frontend/src/queries/schema/schema-general.ts` (parsed from source — no cross-package import), and every `kind:` registered in `GENERATED_TOOLS` must have a map entry. A future `MarketingTrendsQuery` registered without coverage will now fail CI rather than appear in dashboards as MCP traffic.

## How did you test this code?

Author is an agent. Did not perform manual testing. Automated checks:

- `pnpm test --run inject-product-key` — 28/28 pass, including the drift guards parsed against the live schema and query-wrappers files.
- `pnpm typecheck` — clean against the strengthened map type.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

PostHog Code (Claude Opus 4.7). Built on top of `claude/tag-mcp-by-product-c9VMt` to address review feedback noting that the map was hand-maintained with no test coverage and had already needed an after-the-fact patch. While writing the coverage tests it became clear the after-the-fact patch (`AssistantTrendsActorsQuery`) was itself the wrong key — the runtime kind is `InsightActorsQuery` — so the tests double as a fix that surfaces the silent miss. Same diagnosis for the LLM trace kinds.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*