### PR TITLE
fix(dags): raise on partial FF responses in PoE backfill

### DIFF
--- a/posthog/dags/backfill_persons_on_events_mode.py
+++ b/posthog/dags/backfill_persons_on_events_mode.py
@@ -60,6 +60,14 @@ def _resolve_persons_on_events_mode(team: Team, client: Client) -> PersonsOnEven
     Encoding their result into `team.modifiers` would freeze the override into
     DB state, so unsetting the env var wouldn't restore each team's intended
     flag-driven mode.
+
+    Hard transport failures (network errors, 5xx, 4xx, quota limits) already
+    propagate as exceptions out of `get_flags_decision`. The two soft-failure
+    cases — a 200 with `errorsWhileComputingFlags=true`, or a 200 missing one
+    of the requested flag keys — are NOT exceptional from the SDK's point of
+    view but are indistinguishable from "flag genuinely returned False" once
+    they reach the resolver. Treat them as errors so the team is counted as
+    `skipped_errored` rather than silently frozen onto the v2 fallback.
     """
     decision = client.get_flags_decision(
         distinct_id=str(team.uuid),
@@ -80,17 +88,27 @@ def _resolve_persons_on_events_mode(team: Team, client: Client) -> PersonsOnEven
         },
         flag_keys_to_evaluate=[POE_V2_FLAG, POE_V1_FLAG],
     )
-    flags = decision.get("flags", {}) or {}
 
-    v2_flag = flags.get(POE_V2_FLAG)
-    if v2_flag and v2_flag.enabled:
+    if decision.get("errorsWhileComputingFlags"):
+        raise RuntimeError("FF service returned errorsWhileComputingFlags=true")
+
+    flags = decision.get("flags", {}) or {}
+    missing = [key for key in (POE_V2_FLAG, POE_V1_FLAG) if key not in flags]
+    if missing:
+        raise RuntimeError(f"FF response missing required flag(s): {missing}")
+
+    v2_flag = flags[POE_V2_FLAG]
+    if v2_flag.enabled:
         return PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
 
-    v1_flag = flags.get(POE_V1_FLAG)
-    if v1_flag and v1_flag.enabled:
+    v1_flag = flags[POE_V1_FLAG]
+    if v1_flag.enabled:
         return PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
 
-    # Fallback: v2 (current platform default since the 2024-06-14 100% rollout).
+    # Both flags returned False — fall back to v2 (current platform default
+    # since the 2024-06-14 100% rollout). This branch is reached only when the
+    # FF service explicitly answered False for both keys, never when it failed
+    # to answer.
     return PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
 
 

--- a/posthog/dags/tests/test_backfill_persons_on_events_mode.py
+++ b/posthog/dags/tests/test_backfill_persons_on_events_mode.py
@@ -1,5 +1,6 @@
 """Tests for the persons-on-events-mode backfill job."""
 
+import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
@@ -58,16 +59,6 @@ class TestResolvePersonsOnEventsMode(BaseTest):
                 {POE_V2_FLAG: _make_flag(POE_V2_FLAG, False), POE_V1_FLAG: _make_flag(POE_V1_FLAG, False)},
                 PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
             ),
-            (
-                "fallback_when_flags_absent_from_response",
-                {},
-                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
-            ),
-            (
-                "v1_when_v2_absent_and_v1_enabled",
-                {POE_V1_FLAG: _make_flag(POE_V1_FLAG, True)},
-                PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS,
-            ),
         ]
     )
     def test_resolves_mode_from_flag_decision(
@@ -91,6 +82,67 @@ class TestResolvePersonsOnEventsMode(BaseTest):
             "organization": str(self.team.organization_id),
             "project": str(self.team.id),
         }
+
+    @parameterized.expand(
+        [
+            (
+                "errors_while_computing_flags_with_full_response",
+                # The FF service can return both keys *and* set the error flag
+                # if it partially failed (e.g. one cohort lookup timed out).
+                # Even with seemingly-complete data, treat the whole answer
+                # as untrusted so the team isn't frozen onto a wrong value.
+                {
+                    "flags": {
+                        POE_V2_FLAG: _make_flag(POE_V2_FLAG, False),
+                        POE_V1_FLAG: _make_flag(POE_V1_FLAG, True),
+                    },
+                    "errorsWhileComputingFlags": True,
+                    "requestId": "test",
+                },
+                "errorsWhileComputingFlags",
+            ),
+            (
+                "errors_while_computing_flags_with_empty_flags",
+                {"flags": {}, "errorsWhileComputingFlags": True, "requestId": "test"},
+                "errorsWhileComputingFlags",
+            ),
+            (
+                "v2_flag_missing_from_response",
+                {"flags": {POE_V1_FLAG: _make_flag(POE_V1_FLAG, True)}, "requestId": "test"},
+                "missing required flag",
+            ),
+            (
+                "v1_flag_missing_from_response",
+                {"flags": {POE_V2_FLAG: _make_flag(POE_V2_FLAG, False)}, "requestId": "test"},
+                "missing required flag",
+            ),
+            (
+                "both_flags_missing_from_response",
+                {"flags": {}, "requestId": "test"},
+                "missing required flag",
+            ),
+            (
+                "no_flags_key_at_all",
+                {"requestId": "test"},
+                "missing required flag",
+            ),
+        ]
+    )
+    def test_raises_on_partial_or_incomplete_response(
+        self,
+        _name: str,
+        decision: dict,
+        expected_substring: str,
+    ):
+        """Soft failures (200 OK with partial/error data) must raise so the
+        per-team try/except in `persist_persons_on_events_mode_op` counts the
+        team as `skipped_errored` rather than silently writing the v2 fallback.
+        """
+        client = MagicMock()
+        client.get_flags_decision.return_value = decision
+
+        with pytest.raises(RuntimeError, match=expected_substring):
+            _resolve_persons_on_events_mode(self.team, client)
 
 
 class TestBackfillPersonsOnEventsMode(BaseTest):


### PR DESCRIPTION
## Problem

Follow-up to #58035. Vasco asked on that PR whether the `posthoganalytics` client raises an exception when the FF service is unreachable, or whether it can silently swallow errors and lead to misclassification. Hard transport failures (network errors, 5xx, 4xx, quota limits) propagate as exceptions out of `Client.get_flags_decision` and are caught by the existing per-team `try/except` in `persist_persons_on_events_mode_op`, counting the team as `skipped_errored`. So far so good.

There are three soft-failure cases where the FF service returns HTTP 200 but the answer isn't trustworthy:

1. **`errorsWhileComputingFlags: true`** — the FF service indicates it couldn't compute one or more of the requested flags (e.g. a cohort lookup timed out). The response may include partial flag data alongside the error signal. The SDK does not raise on this; the caller is expected to inspect the field. See `posthoganalytics/test/test_feature_flag_result.py:465` for the contract.
2. **Either flag key absent from `decision["flags"]`** — the SDK explicitly handles "flag not in response" as a non-error condition (cf. `posthoganalytics/test/test_feature_flag_result.py:511`); `dict.get(...)` returns `None`.
3. **HTTP 200 with empty body** — `normalize_flags_response` synthesises `{"flags": {}, "requestId": None}`.

In all three cases, both `flags.get(POE_V2_FLAG)` and `flags.get(POE_V1_FLAG)` are falsy, the resolver falls through to the "both False/None → v2 fallback" branch, and the team is persisted onto v2 — silently — even when the FF service didn't actually answer. For a team that should be on v1, that's a wrong DB write that's then frozen until someone explicitly resets the modifier. The pre-2024-06-14 ~17% cohort the original PR description called out is exactly the population most likely to hit this.

## Changes

- `_resolve_persons_on_events_mode` now raises `RuntimeError` if `decision["errorsWhileComputingFlags"]` is truthy, or if either of the two requested flag keys is missing from `decision["flags"]`. The existing `except Exception` in `persist_persons_on_events_mode_op` catches both, so the team becomes `skipped_errored` and keeps a null modifier; a re-run after the FF service recovers picks it up (the job is idempotent).
- The "both flags returned False → v2 fallback" branch is preserved as-is. That path is now reachable only when the FF service explicitly answered False for both keys, never when it failed to answer.
- Tests: removed the two parameterized cases that previously asserted silent fallback (`fallback_when_flags_absent_from_response`, `v1_when_v2_absent_and_v1_enabled`) and added six new parameterized cases covering `errorsWhileComputingFlags=true` (with full and partial flag dicts), individual missing keys, both keys missing, and a response with no `flags` key at all.

## How did you test this code?

I'm an agent. I ran:

- `hogli test posthog/dags/tests/test_backfill_persons_on_events_mode.py` → 17 passed (was 11; +6 new cases, –2 inverted cases).
- `ruff check` and `ruff format --check` → clean.
- Pre-commit (lint-staged + ty) → passed.

I did not run the job against any environment.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Robbie asked me to investigate the question Vasco raised on #58035 about whether the FF SDK raises on transport failures. After tracing through `posthoganalytics/client.py`, `posthoganalytics/request.py`, and `posthoganalytics/types.py:normalize_flags_response`, the answer is "yes for hard failures, no for soft failures". This PR closes the soft-failure gap.

Decisions:

- **Why fail-closed instead of retrying inside the resolver?** Retries belong at the HTTP layer (`urllib3.Retry` already does `total=2, connect=2, read=2` with backoff for 5xx and connection failures inside `_get_flags_session`). A 200 with `errorsWhileComputingFlags=true` is a partial-success signal from the application layer — retrying the same call is unlikely to fix a flag whose evaluation server-side is timing out, and the job's idempotency means a fresh run later is the correct retry strategy.
- **Why `RuntimeError` and not a custom exception class?** The caller catches `except Exception` and bumps `skipped_errored`. A custom subclass would only matter if some upstream code wanted to distinguish soft from hard failures, which it doesn't today.
- **Why drop the `v1_when_v2_absent_and_v1_enabled` test case?** It encoded the (now-removed) behaviour where a single returned flag could short-circuit the resolver. After this change, both keys are required for the resolver to return a non-error result; that test case is no longer reachable through any code path.

Out of scope (separate work):

- Auditing other `posthoganalytics.feature_enabled` / `get_flags_decision` callsites in PostHog for similar fail-open patterns.
- Surfacing the per-mode breakdown at the job-aggregate level (Greptile comment on the original PR).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*