### PR TITLE
fix(health): link pipeline warnings to sources page on health page

### DIFF
--- a/frontend/src/scenes/health/categoryDetail/categoryDetailConfig.ts
+++ b/frontend/src/scenes/health/categoryDetail/categoryDetailConfig.ts
@@ -42,10 +42,10 @@ export const CATEGORY_DETAIL_CONFIG: Partial<Record<HealthIssueCategory, Categor
     },
     pipelines: {
         docsUrl: 'https://posthog.com/docs/cdp',
-        deepDiveUrl: urls.pipelineStatus(),
-        deepDiveLabel: 'Open pipeline status',
+        deepDiveUrl: urls.sources(),
+        deepDiveLabel: 'Open sources',
         guidance: 'Pipeline failures mean data may not be flowing to your destinations correctly.',
-        redirectUrl: urls.pipelineStatus(),
+        redirectUrl: urls.sources(),
         tableComponent: PipelineHealthTable,
     },
     data_modeling: {


### PR DESCRIPTION
## Problem
clicking into details from pipeline warnings on the health page brings you to an old/outdated CDP page (rather than the data>sources page where these warnings come from)

Slack thread: https://posthog.slack.com/archives/C0ACRAMJUAG/p1778080537542429

## Changes
Correctly link to /data-management/sources where the data warehouse sources are managed.


## How did you test this code?
Kinda locally, I don't have any warnings locally so i couldnt test end to end, but the logic looks right

## Publish to changelog?
No
