### PR TITLE
chore: remove codeowners from services/mcp

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,3 @@ rust/persons_migrations/** @PostHog/team-ingestion
 posthog/api/authentication.py @PostHog/team-security
 posthog/auth.py @PostHog/team-security
 ee/api/scim/auth.py @PostHog/team-security
-
-# MCP tools - owned by @PostHog/team-posthog-ai
-services/mcp/src/tools/ @PostHog/team-posthog-ai
-services/mcp/src/tools/generated/


### PR DESCRIPTION
## Problem

Codeowners on the MCP didn't work with an exclusion list, so they are slowing down the product teams.

## Changes

- Remove the MCP tools codeowner block from `.github/CODEOWNERS` (the `services/mcp/src/tools/ @PostHog/team-posthog-ai` entry plus the `services/mcp/src/tools/generated/` exclusion line and the section comment).

## How did you test this code?

I am an agent. No automated tests exercise CODEOWNERS directly; verification is by reading the resulting file. Confirmed via `git diff` that only the intended four lines (section comment, owner rule, generated exclusion, and the preceding blank line) were removed and no other entries were touched.

## Publish to changelog?

no

## Docs update

No docs changes required.

## 🤖 Agent context

- Tool: PostHog Code (Claude Code).
- Task: remove the codeowner entry covering `services/mcp` from `.github/CODEOWNERS`.
- Approach: located the only matching block (lines 51-53) and removed it along with the leading blank line so the file ends cleanly after the security auth entries. No other CODEOWNERS rules were modified.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*