### PR TITLE
fix(llma): trace input/output preview from ai_events

### DIFF
--- a/products/llm_analytics/frontend/traceMessagesLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/traceMessagesLazyLoaderLogic.ts
@@ -199,34 +199,34 @@ export const traceMessagesLazyLoaderLogic = kea<traceMessagesLazyLoaderLogicType
                                 kind: NodeKind.HogQLQuery,
                                 query: `
                                     SELECT
-                                        properties.$ai_trace_id AS trace_id,
+                                        trace_id,
                                         anyIf(
-                                            substring(toString(properties.$ai_input_state), 1, ${FIELD_TRUNCATE_CHARS}),
+                                            substring(input_state, 1, ${FIELD_TRUNCATE_CHARS}),
                                             event = '$ai_trace'
-                                                AND length(toString(properties.$ai_input_state)) > 0
+                                                AND length(input_state) > 0
                                         ) AS first_input,
                                         anyIf(
-                                            substring(toString(properties.$ai_output_state), 1, ${FIELD_TRUNCATE_CHARS}),
+                                            substring(output_state, 1, ${FIELD_TRUNCATE_CHARS}),
                                             event = '$ai_trace'
-                                                AND length(toString(properties.$ai_output_state)) > 0
+                                                AND length(output_state) > 0
                                         ) AS last_output,
                                         argMinIf(
-                                            substring(toString(properties.$ai_input), 1, ${FIELD_TRUNCATE_CHARS}),
+                                            substring(input, 1, ${FIELD_TRUNCATE_CHARS}),
                                             timestamp,
                                             event = '$ai_generation'
-                                                AND length(toString(properties.$ai_input)) > 0
+                                                AND length(input) > 0
                                         ) AS first_input_fallback,
                                         argMaxIf(
-                                            substring(toString(properties.$ai_output_choices), 1, ${FIELD_TRUNCATE_CHARS}),
+                                            substring(output_choices, 1, ${FIELD_TRUNCATE_CHARS}),
                                             timestamp,
                                             event = '$ai_generation'
-                                                AND length(toString(properties.$ai_output_choices)) > 0
+                                                AND length(output_choices) > 0
                                         ) AS last_output_fallback
-                                    FROM events
+                                    FROM posthog.ai_events AS ai_events
                                     WHERE event IN ('$ai_trace', '$ai_generation')
                                       AND timestamp >= toDateTime('${fromStr}', 'UTC')
                                       AND timestamp <= toDateTime('${toStr}', 'UTC')
-                                      AND properties.$ai_trace_id IN (${idList})
+                                      AND trace_id IN (${idList})
                                     GROUP BY trace_id
                                 `,
                             }


### PR DESCRIPTION
## Problem

The trace list's optional **Input message** / **Output message** columns build their previews via `traceMessagesLazyLoaderLogic.ts`, which queries `events` directly for `properties.$ai_input_state`, `$ai_output_state`, `$ai_input`, and `$ai_output_choices`. Those four fields are part of the heavy AI-property set that is now stripped from `events.properties` for teams in `INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS` (currently 385921, 148051, 2 — see [PostHog/charts#10936](https://github.com/PostHog/charts/pull/10936)). For those teams the lazy loader returns empty strings and the columns render as "–".

## Changes

Switch the lazy loader's HogQL query from `events` to `ai_events` and use the dedicated columns (`trace_id`, `input_state`, `output_state`, `input`, `output_choices`) directly. Heavy columns are `Nullable(String)` on `ai_events`, so `length(col) > 0` and `substring(col, 1, N)` work without `toString(...)` wrappers — same end-state semantics as the previous `length(toString(col)) > 0` check.

No changes to batching, debounce, truncation, response shape, or the renderer's three-tier fallback. Non-stripped teams keep working because they've been double-writing to `ai_events` for the whole rollout.

## Note on scope

This is intentionally a minimal fix. It works because the columns are only toggleable for users with the `LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT` feature flag enabled — currently PostHog-only — and those users coincide with the strip allowlist where `ai_events` reads are guaranteed to work. No fallback logic since it's only internal.

## How did you test this code?

Validated the column mapping against `posthog/hogql/database/schema/ai_events.py` and confirmed the same patterns (`length(input)`, `substring(input, 1, N)`) are used in production by `posthog/temporal/llm_analytics/sentiment/constants.py`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7, 1M context) during a sanity-check session for the strip-heavy rollout to teams 385921, 148051, 2 in [PostHog/charts#10936](https://github.com/PostHog/charts/pull/10936). The session traced the rollout end-to-end (argocd config, pod restarts, dual-write verification on `events` and `ai_events`, error log review, reader migration coverage) and surfaced this lazy loader as the one remaining read path still hitting `events` for heavy props. Carlos clarified that the affected columns are gated behind `LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT` and are only opt-in inside PostHog, so the minimal frontend swap is sufficient for now; a server-side runner with `execute_with_ai_events_fallback` was discussed and deferred until the columns roll out more broadly.
