### PR TITLE
fix(mcp): Apply string-int casting to further MCP tools

### DIFF
--- a/products/actions/mcp/tools.yaml
+++ b/products/actions/mcp/tools.yaml
@@ -69,6 +69,9 @@ tools:
         description: >
             Get a specific action by ID. Returns the action configuration including all steps and their trigger
             conditions.
+        param_overrides:
+            id:
+                cast: string-int
         ui_app: action
     action-update:
         operation: actions_partial_update

--- a/products/annotations/mcp/tools.yaml
+++ b/products/annotations/mcp/tools.yaml
@@ -54,6 +54,9 @@ tools:
         description: >
             Retrieve a single annotation by ID from the current project. Use this when you already know the annotation
             ID and want complete details.
+        param_overrides:
+            id:
+                cast: string-int
     annotations-list:
         operation: annotations_list
         enabled: true

--- a/products/cohorts/mcp/tools.yaml
+++ b/products/cohorts/mcp/tools.yaml
@@ -87,6 +87,11 @@ tools:
             to get full details including filters, calculation status,
 
             and query definition.
+        param_overrides:
+            limit:
+                cast: string-int
+            offset:
+                cast: string-int
         ui_app: cohort-list
         response:
             include:
@@ -122,6 +127,9 @@ tools:
             - last_error_message
             - count
             - experiment_set
+        param_overrides:
+            id:
+                cast: string-int
         ui_app: cohort
     cohorts-persons-retrieve:
         operation: cohorts_persons_retrieve
@@ -140,6 +148,9 @@ tools:
         description: >
             Get a specific cohort by ID. Returns the cohort name, description, filters (for dynamic cohorts), count of
             matching users, and calculation status.
+        param_overrides:
+            id:
+                cast: string-int
         ui_app: cohort
     cohorts-rm-person-from-static-cohort-partial-update:
         operation: cohorts_remove_person_from_static_cohort_partial_update

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -87,6 +87,9 @@ tools:
         title: Delete dashboard
         description: |
             Delete a dashboard by ID. The dashboard will be soft-deleted and no longer appear in lists.
+        param_overrides:
+            id:
+                cast: string-int
         soft_delete: true
     dashboard-get:
         operation: dashboards_retrieve
@@ -106,6 +109,9 @@ tools:
             insight-query for a single insight. Supports variables_override and filters_override query params; on this
             endpoint they affect only the merged `filters` and `variables` fields in the response (preview). To execute
             insights with the same overrides, pass the same query params to dashboard-insights-run.
+        param_overrides:
+            id:
+                cast: string-int
         response:
             exclude:
                 - effective_restriction_level
@@ -159,6 +165,9 @@ tools:
             refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or
             'json' for raw query results. Supports variables_override and filters_override query params to run insights
             with one-off overrides without persisting; see the parameter descriptions for the exact JSON shape required.
+        param_overrides:
+            id:
+                cast: string-int
     dashboard-reorder-tiles:
         operation: dashboards_reorder_tiles_create
         enabled: true
@@ -213,6 +222,9 @@ tools:
             - persisted_filters
             - persisted_variables
             - _create_in_folder
+        param_overrides:
+            id:
+                cast: string-int
         response:
             exclude:
                 - effective_restriction_level
@@ -294,6 +306,11 @@ tools:
             filters by tag and pinned status are also supported. Returns name, description, pinned status, tags, and
             creation metadata. Tiles and insights are not included — use dashboard-get to fetch a dashboard's tiles,
             then dashboard-insights-run to fetch the actual data for each insight.
+        param_overrides:
+            limit:
+                cast: string-int
+            offset:
+                cast: string-int
     dashboards-move-tile-partial-update:
         operation: dashboards_move_tile_partial_update
         enabled: false

--- a/products/feature_flags/mcp/tools.yaml
+++ b/products/feature_flags/mcp/tools.yaml
@@ -50,6 +50,9 @@ tools:
         title: Delete feature flag
         description: |
             Soft-delete a feature flag by ID in the current project.
+        param_overrides:
+            id:
+                cast: string-int
         soft_delete: true
     feature-flag-get-all:
         operation: feature_flags_list
@@ -71,6 +74,10 @@ tools:
                 description:
                     Search by feature flag key or name (case-insensitive). Use this to find the flag ID for get/update/delete
                     tools.
+            limit:
+                cast: string-int
+            offset:
+                cast: string-int
         response:
             include:
                 - id
@@ -92,6 +99,9 @@ tools:
         title: Get feature flag definition
         description: |
             Get a feature flag by ID.
+        param_overrides:
+            id:
+                cast: string-int
     feature-flags-activity-retrieve:
         operation: feature_flags_activity_retrieve
         enabled: true
@@ -105,6 +115,9 @@ tools:
         description: >
             Get the audit trail for a specific feature flag by ID. Returns a paginated list of changes including who
             made changes, what was changed, and when. Use limit and page query params for pagination.
+        param_overrides:
+            id:
+                cast: string-int
     feature-flags-all-activity-retrieve:
         operation: feature_flags_all_activity_retrieve
         enabled: false
@@ -150,6 +163,9 @@ tools:
         description: >
             Get other active feature flags that depend on this flag. Use this to understand flag dependency chains
             before making changes to a flag's rollout conditions or disabling it.
+        param_overrides:
+            id:
+                cast: string-int
     feature-flags-enrich-usage-dashboard-create:
         operation: feature_flags_enrich_usage_dashboard_create
         enabled: false
@@ -192,6 +208,9 @@ tools:
         description: >
             Check the health and evaluation status of a feature flag by ID. Returns a status (active, stale, deleted, or
             unknown) and a human-readable reason explaining the status.
+        param_overrides:
+            id:
+                cast: string-int
     feature-flags-test-evaluation-create:
         operation: feature_flags_test_evaluation_create
         enabled: false
@@ -318,3 +337,6 @@ tools:
             - active
             - tags
             - evaluation_contexts
+        param_overrides:
+            id:
+                cast: string-int

--- a/products/persons/mcp/tools.yaml
+++ b/products/persons/mcp/tools.yaml
@@ -91,6 +91,11 @@ tools:
         exclude_params:
             - format
             - properties
+        param_overrides:
+            limit:
+                cast: string-int
+            offset:
+                cast: string-int
         response:
             include:
                 - id

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -26,6 +26,9 @@ tools:
         param_overrides:
             page_size:
                 default: 10
+                cast: string-int
+            page:
+                cast: string-int
         url_prefix: /activity
         response:
             include:

--- a/products/product_analytics/mcp/tools.yaml
+++ b/products/product_analytics/mcp/tools.yaml
@@ -257,6 +257,11 @@ tools:
             - basic
             - format
             - refresh
+        param_overrides:
+            limit:
+                cast: string-int
+            offset:
+                cast: string-int
         response:
             include:
                 - id

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -449,6 +449,7 @@ tools:
         param_overrides:
             id:
                 description: Project ID, or `@current` to fetch the caller's active project.
+                cast: string-int
         response:
             exclude:
                 - secret_api_token
@@ -510,6 +511,7 @@ tools:
         param_overrides:
             id:
                 description: Project ID, or `@current` to target the caller's active project.
+                cast: string-int
     projects-create:
         operation: organizations_projects_create
         enabled: false

--- a/services/mcp/src/tools/generated/actions.ts
+++ b/services/mcp/src/tools/generated/actions.ts
@@ -11,6 +11,7 @@ import {
     ActionsRetrieveParams,
 } from '@/generated/actions/api'
 import { withUiApp } from '@/resources/ui-apps'
+import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
@@ -71,7 +72,9 @@ const actionDelete = (): ToolBase<typeof ActionDeleteSchema, Schemas.Action> => 
     },
 })
 
-const ActionGetSchema = ActionsRetrieveParams.omit({ project_id: true })
+const ActionGetSchema = ActionsRetrieveParams.omit({ project_id: true }).extend({
+    id: z.preprocess(castStringToInt, ActionsRetrieveParams.shape['id']),
+})
 
 const actionGet = (): ToolBase<typeof ActionGetSchema, WithPostHogUrl<Schemas.Action>> =>
     withUiApp('action', {

--- a/services/mcp/src/tools/generated/annotations.ts
+++ b/services/mcp/src/tools/generated/annotations.ts
@@ -10,6 +10,7 @@ import {
     AnnotationsPartialUpdateParams,
     AnnotationsRetrieveParams,
 } from '@/generated/annotations/api'
+import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
@@ -60,7 +61,9 @@ const annotationDelete = (): ToolBase<typeof AnnotationDeleteSchema, Schemas.Ann
     },
 })
 
-const AnnotationRetrieveSchema = AnnotationsRetrieveParams.omit({ project_id: true })
+const AnnotationRetrieveSchema = AnnotationsRetrieveParams.omit({ project_id: true }).extend({
+    id: z.preprocess(castStringToInt, AnnotationsRetrieveParams.shape['id']),
+})
 
 const annotationRetrieve = (): ToolBase<typeof AnnotationRetrieveSchema, Schemas.Annotation> => ({
     name: 'annotation-retrieve',

--- a/services/mcp/src/tools/generated/cohorts.ts
+++ b/services/mcp/src/tools/generated/cohorts.ts
@@ -14,6 +14,7 @@ import {
     CohortsRetrieveParams,
 } from '@/generated/cohorts/api'
 import { withUiApp } from '@/resources/ui-apps'
+import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
@@ -78,7 +79,10 @@ const cohortsCreate = (): ToolBase<typeof CohortsCreateSchema, WithPostHogUrl<Sc
         },
     })
 
-const CohortsListSchema = CohortsListQueryParams
+const CohortsListSchema = CohortsListQueryParams.extend({
+    limit: z.preprocess(castStringToInt, CohortsListQueryParams.shape['limit']).optional(),
+    offset: z.preprocess(castStringToInt, CohortsListQueryParams.shape['offset']).optional(),
+})
 
 const cohortsList = (): ToolBase<typeof CohortsListSchema, WithPostHogUrl<Schemas.PaginatedCohortList>> =>
     withUiApp('cohort-list', {
@@ -113,9 +117,9 @@ const cohortsList = (): ToolBase<typeof CohortsListSchema, WithPostHogUrl<Schema
         },
     })
 
-const CohortsPartialUpdateSchema = CohortsPartialUpdateParams.omit({ project_id: true }).extend(
-    CohortsPartialUpdateBody.omit({ _create_in_folder: true, _create_static_person_ids: true }).shape
-)
+const CohortsPartialUpdateSchema = CohortsPartialUpdateParams.omit({ project_id: true })
+    .extend(CohortsPartialUpdateBody.omit({ _create_in_folder: true, _create_static_person_ids: true }).shape)
+    .extend({ id: z.preprocess(castStringToInt, CohortsPartialUpdateParams.shape['id']) })
 
 const cohortsPartialUpdate = (): ToolBase<typeof CohortsPartialUpdateSchema, WithPostHogUrl<Schemas.Cohort>> =>
     withUiApp('cohort', {
@@ -154,7 +158,9 @@ const cohortsPartialUpdate = (): ToolBase<typeof CohortsPartialUpdateSchema, Wit
         },
     })
 
-const CohortsRetrieveSchema = CohortsRetrieveParams.omit({ project_id: true })
+const CohortsRetrieveSchema = CohortsRetrieveParams.omit({ project_id: true }).extend({
+    id: z.preprocess(castStringToInt, CohortsRetrieveParams.shape['id']),
+})
 
 const cohortsRetrieve = (): ToolBase<typeof CohortsRetrieveSchema, WithPostHogUrl<Schemas.Cohort>> =>
     withUiApp('cohort', {

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -19,12 +19,16 @@ import {
     UsersPartialUpdateParams,
     UsersRetrieveParams,
 } from '@/generated/core/api'
+import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ProjectGetSchema = OrganizationsProjectsRetrieveParams.omit({ organization_id: true }).extend({
-    id: OrganizationsProjectsRetrieveParams.shape['id'].describe(
-        "Project ID, or `@current` to fetch the caller's active project."
+    id: z.preprocess(
+        castStringToInt,
+        OrganizationsProjectsRetrieveParams.shape['id'].describe(
+            "Project ID, or `@current` to fetch the caller's active project."
+        )
     ),
 })
 
@@ -50,8 +54,11 @@ const projectGet = (): ToolBase<typeof ProjectGetSchema, Schemas.ProjectBackward
 const ProjectSettingsUpdateSchema = OrganizationsProjectsPartialUpdateParams.omit({ organization_id: true })
     .extend(OrganizationsProjectsPartialUpdateBody.shape)
     .extend({
-        id: OrganizationsProjectsPartialUpdateParams.shape['id'].describe(
-            "Project ID, or `@current` to target the caller's active project."
+        id: z.preprocess(
+            castStringToInt,
+            OrganizationsProjectsPartialUpdateParams.shape['id'].describe(
+                "Project ID, or `@current` to target the caller's active project."
+            )
         ),
     })
 

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -15,6 +15,7 @@ import {
     DashboardsRunInsightsRetrieveParams,
     DashboardsRunInsightsRetrieveQueryParams,
 } from '@/generated/dashboards/api'
+import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
@@ -107,7 +108,9 @@ const dashboardCreate = (): ToolBase<typeof DashboardCreateSchema, WithPostHogUr
     },
 })
 
-const DashboardDeleteSchema = DashboardsDestroyParams.omit({ project_id: true })
+const DashboardDeleteSchema = DashboardsDestroyParams.omit({ project_id: true }).extend({
+    id: z.preprocess(castStringToInt, DashboardsDestroyParams.shape['id']),
+})
 
 const dashboardDelete = (): ToolBase<typeof DashboardDeleteSchema, Schemas.Dashboard> => ({
     name: 'dashboard-delete',
@@ -125,6 +128,7 @@ const dashboardDelete = (): ToolBase<typeof DashboardDeleteSchema, Schemas.Dashb
 
 const DashboardGetSchema = DashboardsRetrieveParams.omit({ project_id: true })
     .extend(DashboardsRetrieveQueryParams.omit({ format: true }).shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsRetrieveParams.shape['id']) })
     .extend({
         filters_override: z
             .union([z.string(), z.record(z.string(), z.unknown())])
@@ -196,6 +200,7 @@ const dashboardGet = (): ToolBase<typeof DashboardGetSchema, WithPostHogUrl<Sche
 
 const DashboardInsightsRunSchema = DashboardsRunInsightsRetrieveParams.omit({ project_id: true })
     .extend(DashboardsRunInsightsRetrieveQueryParams.omit({ format: true }).shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsRunInsightsRetrieveParams.shape['id']) })
     .extend({
         filters_override: z
             .union([z.string(), z.record(z.string(), z.unknown())])
@@ -255,9 +260,9 @@ const dashboardReorderTiles = (): ToolBase<typeof DashboardReorderTilesSchema, W
     },
 })
 
-const DashboardUpdateSchema = DashboardsPartialUpdateParams.omit({ project_id: true }).extend(
-    DashboardsPartialUpdateBody.shape
-)
+const DashboardUpdateSchema = DashboardsPartialUpdateParams.omit({ project_id: true })
+    .extend(DashboardsPartialUpdateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsPartialUpdateParams.shape['id']) })
 
 const dashboardUpdate = (): ToolBase<typeof DashboardUpdateSchema, WithPostHogUrl<Schemas.Dashboard>> => ({
     name: 'dashboard-update',
@@ -344,7 +349,10 @@ const dashboardUpdate = (): ToolBase<typeof DashboardUpdateSchema, WithPostHogUr
     },
 })
 
-const DashboardsGetAllSchema = DashboardsListQueryParams.omit({ format: true })
+const DashboardsGetAllSchema = DashboardsListQueryParams.omit({ format: true }).extend({
+    limit: z.preprocess(castStringToInt, DashboardsListQueryParams.shape['limit']).optional(),
+    offset: z.preprocess(castStringToInt, DashboardsListQueryParams.shape['offset']).optional(),
+})
 
 const dashboardsGetAll = (): ToolBase<
     typeof DashboardsGetAllSchema,

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -23,6 +23,7 @@ import {
     ScheduledChangesPartialUpdateParams,
     ScheduledChangesRetrieveParams,
 } from '@/generated/feature_flags/api'
+import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
@@ -61,7 +62,9 @@ const createFeatureFlag = (): ToolBase<typeof CreateFeatureFlagSchema, WithPostH
     },
 })
 
-const DeleteFeatureFlagSchema = FeatureFlagsDestroyParams.omit({ project_id: true })
+const DeleteFeatureFlagSchema = FeatureFlagsDestroyParams.omit({ project_id: true }).extend({
+    id: z.preprocess(castStringToInt, FeatureFlagsDestroyParams.shape['id']),
+})
 
 const deleteFeatureFlag = (): ToolBase<typeof DeleteFeatureFlagSchema, Schemas.FeatureFlag> => ({
     name: 'delete-feature-flag',
@@ -81,6 +84,8 @@ const FeatureFlagGetAllSchema = FeatureFlagsListQueryParams.extend({
     search: FeatureFlagsListQueryParams.shape['search'].describe(
         'Search by feature flag key or name (case-insensitive). Use this to find the flag ID for get/update/delete tools.'
     ),
+    limit: z.preprocess(castStringToInt, FeatureFlagsListQueryParams.shape['limit']).optional(),
+    offset: z.preprocess(castStringToInt, FeatureFlagsListQueryParams.shape['offset']).optional(),
 })
 
 const featureFlagGetAll = (): ToolBase<
@@ -126,7 +131,9 @@ const featureFlagGetAll = (): ToolBase<
     },
 })
 
-const FeatureFlagGetDefinitionSchema = FeatureFlagsRetrieveParams.omit({ project_id: true })
+const FeatureFlagGetDefinitionSchema = FeatureFlagsRetrieveParams.omit({ project_id: true }).extend({
+    id: z.preprocess(castStringToInt, FeatureFlagsRetrieveParams.shape['id']),
+})
 
 const featureFlagGetDefinition = (): ToolBase<
     typeof FeatureFlagGetDefinitionSchema,
@@ -144,9 +151,9 @@ const featureFlagGetDefinition = (): ToolBase<
     },
 })
 
-const FeatureFlagsActivityRetrieveSchema = FeatureFlagsActivityRetrieveParams.omit({ project_id: true }).extend(
-    FeatureFlagsActivityRetrieveQueryParams.shape
-)
+const FeatureFlagsActivityRetrieveSchema = FeatureFlagsActivityRetrieveParams.omit({ project_id: true })
+    .extend(FeatureFlagsActivityRetrieveQueryParams.shape)
+    .extend({ id: z.preprocess(castStringToInt, FeatureFlagsActivityRetrieveParams.shape['id']) })
 
 const featureFlagsActivityRetrieve = (): ToolBase<
     typeof FeatureFlagsActivityRetrieveSchema,
@@ -203,7 +210,9 @@ const featureFlagsCopyFlagsCreate = (): ToolBase<
     },
 })
 
-const FeatureFlagsDependentFlagsRetrieveSchema = FeatureFlagsDependentFlagsListParams.omit({ project_id: true })
+const FeatureFlagsDependentFlagsRetrieveSchema = FeatureFlagsDependentFlagsListParams.omit({ project_id: true }).extend(
+    { id: z.preprocess(castStringToInt, FeatureFlagsDependentFlagsListParams.shape['id']) }
+)
 
 const featureFlagsDependentFlagsRetrieve = (): ToolBase<
     typeof FeatureFlagsDependentFlagsRetrieveSchema,
@@ -243,7 +252,9 @@ const featureFlagsEvaluationReasonsRetrieve = (): ToolBase<
     },
 })
 
-const FeatureFlagsStatusRetrieveSchema = FeatureFlagsStatusRetrieveParams.omit({ project_id: true })
+const FeatureFlagsStatusRetrieveSchema = FeatureFlagsStatusRetrieveParams.omit({ project_id: true }).extend({
+    id: z.preprocess(castStringToInt, FeatureFlagsStatusRetrieveParams.shape['id']),
+})
 
 const featureFlagsStatusRetrieve = (): ToolBase<
     typeof FeatureFlagsStatusRetrieveSchema,
@@ -432,9 +443,9 @@ const scheduledChangesUpdate = (): ToolBase<typeof ScheduledChangesUpdateSchema,
     },
 })
 
-const UpdateFeatureFlagSchema = FeatureFlagsPartialUpdateParams.omit({ project_id: true }).extend(
-    FeatureFlagsPartialUpdateBody.shape
-)
+const UpdateFeatureFlagSchema = FeatureFlagsPartialUpdateParams.omit({ project_id: true })
+    .extend(FeatureFlagsPartialUpdateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, FeatureFlagsPartialUpdateParams.shape['id']) })
 
 const updateFeatureFlag = (): ToolBase<typeof UpdateFeatureFlagSchema, WithPostHogUrl<Schemas.FeatureFlag>> => ({
     name: 'update-feature-flag',

--- a/services/mcp/src/tools/generated/persons.ts
+++ b/services/mcp/src/tools/generated/persons.ts
@@ -13,6 +13,7 @@ import {
     PersonsUpdatePropertyCreateParams,
     PersonsValuesRetrieveQueryParams,
 } from '@/generated/persons/api'
+import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
@@ -66,7 +67,10 @@ const personsCohortsRetrieve = (): ToolBase<typeof PersonsCohortsRetrieveSchema,
     },
 })
 
-const PersonsListSchema = PersonsListQueryParams.omit({ format: true, properties: true })
+const PersonsListSchema = PersonsListQueryParams.omit({ format: true, properties: true }).extend({
+    limit: z.preprocess(castStringToInt, PersonsListQueryParams.shape['limit']).optional(),
+    offset: z.preprocess(castStringToInt, PersonsListQueryParams.shape['offset']).optional(),
+})
 
 const personsList = (): ToolBase<typeof PersonsListSchema, WithPostHogUrl<Schemas.PaginatedPersonRecordList>> => ({
     name: 'persons-list',

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -23,11 +23,15 @@ import {
     UserHomeSettingsPartialUpdateParams,
     UserHomeSettingsRetrieveParams,
 } from '@/generated/platform_features/api'
+import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ActivityLogListSchema = ActivityLogListQueryParams.extend({
-    page_size: ActivityLogListQueryParams.shape['page_size'].default(10).optional(),
+    page_size: z
+        .preprocess(castStringToInt, ActivityLogListQueryParams.shape['page_size'].default(10).optional())
+        .optional(),
+    page: z.preprocess(castStringToInt, ActivityLogListQueryParams.shape['page']).optional(),
 })
 
 const activityLogList = (): ToolBase<
@@ -120,7 +124,6 @@ const advancedActivityLogsList = (): ToolBase<
                 scopes: params.scopes,
                 search_text: params.search_text,
                 start_date: params.start_date,
-                team_ids: params.team_ids,
                 users: params.users,
                 was_impersonated: params.was_impersonated,
             },

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -124,6 +124,7 @@ const advancedActivityLogsList = (): ToolBase<
                 scopes: params.scopes,
                 search_text: params.search_text,
                 start_date: params.start_date,
+                team_ids: params.team_ids,
                 users: params.users,
                 was_impersonated: params.was_impersonated,
             },

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -15,6 +15,7 @@ import {
     InsightsRetrieveQueryParams,
     InsightsTrendingRetrieveQueryParams,
 } from '@/generated/product_analytics/api'
+import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
@@ -363,7 +364,10 @@ const insightsAllActivityRetrieve = (): ToolBase<
     },
 })
 
-const InsightsListSchema = InsightsListQueryParams.omit({ format: true, basic: true, refresh: true })
+const InsightsListSchema = InsightsListQueryParams.omit({ format: true, basic: true, refresh: true }).extend({
+    limit: z.preprocess(castStringToInt, InsightsListQueryParams.shape['limit']).optional(),
+    offset: z.preprocess(castStringToInt, InsightsListQueryParams.shape['offset']).optional(),
+})
 
 const insightsList = (): ToolBase<typeof InsightsListSchema, WithPostHogUrl<Schemas.PaginatedInsightList>> => ({
     name: 'insights-list',


### PR DESCRIPTION
## Problem

See https://github.com/PostHog/posthog/pull/57806 and https://posthog.slack.com/archives/C09KTRWD3HD/p1778159384978519 for context.

Production traces show the same zod `expected number, received string` rejection on top-level integer fields across other MCP tools. This PR expands the same fix to them.

## Changes

- Extends the `cast: string-int` fix, applied via YAML, no code changes.
- Affected fields (24 across 9 YAMLs): `id` on get/update/delete tools and `limit`/`offset`/`page`/`page_size` on list tools. Generated files regenerated via `pnpm --filter=@posthog/mcp run generate-tools`.


## How did you test this code?

- `pnpm --filter=@posthog/mcp test` passes (1164/1165 locally; the one failure is an unrelated TLS error fetching the manifest from GitHub releases)
- Spot-check one regenerated tool schema wraps the field with `z.preprocess(castStringToInt, …)` and preserves `.optional()`

## Publish to changelog?

No

## 🤖 Agent context

- **Tool**: Claude Opus 4.7 (1M context) via Claude Code in VS Code.
- **Scope decision**: limited to fields where the production error is exactly `expected: number, received: string` (the case the cast handles). Excluded: `expected: object, received: string` rows (JSON-stringified bodies — different fix), `received: undefined` rows (missing field — different bug), nested numeric fields (cast doesn't reach), hand-written tools (`switch-project`, `event-definitions-list`, `properties-list`, `switch-organization`, `get-llm-total-costs-for-project` — not YAML-driven), and `error-tracking-issues-list` (currently `enabled: false`).
- **Companion fields**: for list tools where only `limit` had errors, also added cast to `offset` (or `page` alongside `page_size`) to match the experiments YAML pattern from #57806.
- **No new mechanism**: the `cast: string-int` keyword and `castStringToInt` helper already exist; this PR is purely additional YAML usage plus regenerated files.
