### PR TITLE
chore(frontend): use WrappingLoadingSkeleton for Suspense fallbacks

### DIFF
--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -10,6 +10,7 @@ import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { useThemedHtml } from 'lib/hooks/useThemedHtml'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { Link } from 'lib/lemon-ui/Link'
+import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { humanFriendlyDuration } from 'lib/utils'
 import { AUTO_REFRESH_INITIAL_INTERVAL_SECONDS } from 'scenes/dashboard/dashboardConstants'
 import { teamLogic } from 'scenes/teamLogic'
@@ -24,6 +25,14 @@ const LazyHeatmapScene = lazy(() => import('./scenes/ExporterHeatmapScene'))
 const LazyInsightScene = lazy(() => import('./scenes/ExporterInsightScene'))
 const LazyNotebookScene = lazy(() => import('./scenes/ExporterNotebookScene'))
 const LazyRecordingScene = lazy(() => import('./scenes/ExporterRecordingScene'))
+
+function ExportedSceneSkeleton(): JSX.Element {
+    return (
+        <WrappingLoadingSkeleton fullWidth>
+            <span className="block w-full h-screen" />
+        </WrappingLoadingSkeleton>
+    )
+}
 
 function resolveForcedTheme(theme?: 'light' | 'dark' | 'system'): 'light' | 'dark' | null {
     if (theme === 'light' || theme === 'dark') {
@@ -149,7 +158,7 @@ export function Exporter(props: ExportedData): JSX.Element {
                                 </div>
                             </div>
                         )}
-                        <Suspense fallback={null}>
+                        <Suspense fallback={<ExportedSceneSkeleton />}>
                             <LazyNotebookScene
                                 notebook={notebook}
                                 insights={insights}
@@ -158,15 +167,15 @@ export function Exporter(props: ExportedData): JSX.Element {
                         </Suspense>
                     </div>
                 ) : insight ? (
-                    <Suspense fallback={null}>
+                    <Suspense fallback={<ExportedSceneSkeleton />}>
                         <LazyInsightScene insight={insight} themes={themes!} exportOptions={exportOptions} />
                     </Suspense>
                 ) : dashboard ? (
-                    <Suspense fallback={null}>
+                    <Suspense fallback={<ExportedSceneSkeleton />}>
                         <LazyDashboardScene dashboard={dashboard} type={type} themes={themes} />
                     </Suspense>
                 ) : recording ? (
-                    <Suspense fallback={null}>
+                    <Suspense fallback={<ExportedSceneSkeleton />}>
                         <LazyRecordingScene
                             recording={recording}
                             mode={props.mode}
@@ -177,7 +186,7 @@ export function Exporter(props: ExportedData): JSX.Element {
                         />
                     </Suspense>
                 ) : type === ExportType.Heatmap ? (
-                    <Suspense fallback={null}>
+                    <Suspense fallback={<ExportedSceneSkeleton />}>
                         <LazyHeatmapScene />
                     </Suspense>
                 ) : (

--- a/frontend/src/lib/components/HighlightedJSONViewer.tsx
+++ b/frontend/src/lib/components/HighlightedJSONViewer.tsx
@@ -6,7 +6,7 @@ import {
     HighlightedContentWrapper,
 } from 'products/llm_analytics/frontend/ConversationDisplay/HighlightedContentWrapper'
 
-import { JSONViewerInner } from './JSONViewer'
+import { JSONViewerInner, JSONViewerSkeleton } from './JSONViewer'
 
 interface HighlightedJSONViewerProps extends ReactJsonViewProps {
     searchQuery?: string
@@ -63,7 +63,7 @@ export function HighlightedJSONViewer({ searchQuery, ...props }: HighlightedJSON
         : props.collapsed
 
     return (
-        <Suspense fallback={null}>
+        <Suspense fallback={<JSONViewerSkeleton />}>
             <HighlightedContentWrapper searchQuery={searchQuery} expandSelectors={jsonExpandSelectors} delay={50}>
                 <JSONViewerInner {...props} collapsed={effectiveCollapsed} />
             </HighlightedContentWrapper>

--- a/frontend/src/lib/components/JSONViewer.tsx
+++ b/frontend/src/lib/components/JSONViewer.tsx
@@ -4,6 +4,8 @@ import type { ReactJsonViewProps } from '@microlink/react-json-view'
 import { useValues } from 'kea'
 import { Suspense, lazy } from 'react'
 
+import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
+
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 const ReactJson = lazy(() => import('@microlink/react-json-view'))
@@ -42,9 +44,22 @@ export function JSONViewerInner({
     )
 }
 
+export function JSONViewerSkeleton(): JSX.Element {
+    return (
+        <WrappingLoadingSkeleton fullWidth>
+            <span className="block font-mono text-xs leading-5">
+                <span className="block">{'{'}</span>
+                <span className="block pl-4">"loading": "json content",</span>
+                <span className="block pl-4">"please": "wait"</span>
+                <span className="block">{'}'}</span>
+            </span>
+        </WrappingLoadingSkeleton>
+    )
+}
+
 export function JSONViewer(props: ReactJsonViewProps): JSX.Element {
     return (
-        <Suspense fallback={null}>
+        <Suspense fallback={<JSONViewerSkeleton />}>
             <JSONViewerInner {...props} />
         </Suspense>
     )

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -5,6 +5,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { BoldNumber } from 'scenes/insights/views/BoldNumber'
 import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable'
@@ -124,7 +125,15 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
         <>
             {series && (
                 <div className={embedded ? 'InsightCard__viz' : `TrendsInsight TrendsInsight--${display}`}>
-                    <Suspense fallback={null}>{renderViz()}</Suspense>
+                    <Suspense
+                        fallback={
+                            <WrappingLoadingSkeleton fullWidth>
+                                <span className="block w-full h-72" />
+                            </WrappingLoadingSkeleton>
+                        }
+                    >
+                        {renderViz()}
+                    </Suspense>
                 </div>
             )}
             {!embedded &&


### PR DESCRIPTION
## Problem

Four `<Suspense fallback={null}>` boundaries in lazy-loaded scenes (JSON viewers, Trends viz, and shared Exporter scenes) collapse their layout to zero height while the chunk loads, then jank back into place when the real content resolves. On viewports where the surrounding layout depends on the suspended child's intrinsic size, this is a visible flash and content shift.

## Changes

Replace `fallback={null}` with `WrappingLoadingSkeleton` whose children mimic the post-resolve shape:

- `JSONViewer.tsx` and `HighlightedJSONViewer.tsx`: shared `JSONViewerSkeleton` rendering a small faux JSON tree (font-mono, indented braces).
- `Trends.tsx`: chart-area block (`h-72 w-full`) — generic across all lazy chart types (TrendsLineChart, TrendsBarChart, WorldMap, RegionMap, TrendsCalendarHeatMap, BoxPlotChart).
- `Exporter.tsx`: shared `ExportedSceneSkeleton` (`w-full h-screen`) used at all five scene-level Suspense boundaries (notebook, insight, dashboard, recording, heatmap).

The skeleton hides its children with `opacity-0` and shimmers — children only contribute layout dimensions, so the surrounding page reserves the right space.

## How did you test this code?

I'm an agent. I did not manually verify this in a browser. The lint suite (`bin/hogli format:js`) ran via the pre-commit hook against all four files and passed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude). The convention came from a design engineer's guidance — use `WrappingLoadingSkeleton` with layout-faithful dummy children rather than `null` fallbacks, since `null` collapses the layout and causes jank across viewport sizes.

Decisions:

- **Shared `JSONViewerSkeleton`**: exported from `JSONViewer.tsx` and reused in `HighlightedJSONViewer.tsx` to avoid duplication — both wrap the same `JSONViewerInner`, so the resolved shape is identical.
- **Trends skeleton is generic, not display-type-specific**: the lazy chart components all render full-width chart rectangles, so a single `h-72 w-full` block is good enough. A per-display-type skeleton would add complexity for marginal layout fidelity.
- **`ExportedSceneSkeleton` is one-size-fits-all**: each Exporter scene fills the page, so a single `w-full h-screen` block fits all five boundaries.
- **Scope**: PR #58095 introduces another `fallback={null}` site — left untouched per author's instruction; will follow up after that lands.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*