### PR TITLE
chore(data-warehouse): disable temporal deadlock detector in data-imports tests

### DIFF
--- a/posthog/temporal/tests/data_imports/conftest.py
+++ b/posthog/temporal/tests/data_imports/conftest.py
@@ -168,6 +168,7 @@ async def run_external_data_job_workflow(
                 workflow_runner=UnsandboxedWorkflowRunner(),
                 activity_executor=ThreadPoolExecutor(max_workers=50),
                 max_concurrent_activities=50,
+                debug_mode=True,  # turn off sandbox/deadlock detector
             ):
                 await activity_environment.client.execute_workflow(
                     ExternalDataJobWorkflow.run,

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -633,6 +633,7 @@ async def _execute_run(workflow_id: str, inputs: ExternalDataWorkflowInputs, moc
                 workflow_runner=UnsandboxedWorkflowRunner(),
                 activity_executor=ThreadPoolExecutor(max_workers=50),
                 max_concurrent_activities=50,
+                debug_mode=True,  # turn off sandbox/deadlock detector
             ):
                 await activity_environment.client.execute_workflow(
                     ExternalDataJobWorkflow.run,


### PR DESCRIPTION
## Problem

CI shard 5/7 has been flaking on rotating tests in `posthog/temporal/tests/data_imports/` (`test_chargebee_customer`, `test_customer_io_sender_identities`, `test_zendesk_sla_policies`, `test_zendesk_groups`, …). Root cause is Temporal's deadlock detector (default 2s) tripping when synchronous Python code runs longer than 2s inside the workflow event loop. Three observed mechanisms all share that pattern:

1. `MagicMock` attribute creation for `get_data_import_finished_metric` (patched in tests, called from the workflow body in `external_data_job.py`) — `MagicMock`'s lazy child-mock machinery (`_get_child_mock` → `_mock_set_magics`) is slow under load.
2. `aiobotocore`/`aiohttp` teardown crossing event loops — sessions opened inside an activity get closed via `__aexit__` running on the workflow loop.
3. GC/weakref cleanup (`_weakrefset.py:_remove`, `contextlib.__exit__`) running during a workflow tick.

These tests already use `UnsandboxedWorkflowRunner()` so mocks are allowed in the workflow loop, but the deadlock detector is still on. Other Temporal tests in the repo (e.g. `posthog/temporal/tests/test_subscriptions_workflows.py`) handle this by adding `debug_mode=True`.

## Changes

Add `debug_mode=True` to the two `Worker(...)` call sites in the data-imports tests:

- `posthog/temporal/tests/data_imports/conftest.py`
- `posthog/temporal/tests/data_imports/test_end_to_end.py`

`debug_mode=True` disables both the sandbox and the deadlock detector, matching the pattern already used by the subscriptions team.

## How did you test this code?

I'm an agent. No manual testing performed. The change is a one-line flag addition to test scaffolding that mirrors an existing pattern in the same repo (`test_subscriptions_workflows.py:176`). It only affects test infrastructure and does not touch any production code path. CI on this PR will exercise the affected shards.

## Publish to changelog?

No.

## Docs update

n/a

## 🤖 Agent context

- Tools: PostHog Code agent (Claude Opus 4.7), used Read/Edit/Grep/Bash for codebase navigation and the patch.
- Investigation: traced rotating CI flakes to Temporal's 2s deadlock detector by mapping three failure stack traces (mock attribute creation, aiobotocore teardown, GC sweep) onto the workflow loop, and confirmed `UnsandboxedWorkflowRunner()` was active without `debug_mode=True` at both Worker sites.
- Decision: ship the minimal flag flip first because it matches a precedent already in the tree (subscriptions tests) and unblocks CI. A real fix — moving the metric increment out of the workflow body into the `update_external_data_job_model` activity — is intentionally deferred to a follow-up so this PR stays scoped to the unflake.
- Considered and rejected for this PR: rewriting the metric call site, auditing aiobotocore/aiohttp lifetimes, tightening `pytest-timeout`. All worth doing, none of them blocking the immediate flake.