### PR TITLE
chore: remove dead AI_ONLY_MODE feature-flag code

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -228,7 +228,6 @@ export const FEATURE_FLAGS = {
     ACTION_REFERENCE_COUNT: 'action-reference-count', // owner: @andyzzhao #team-product-analytics, gates bulk action reference counting on actions list
     ADVANCE_MARKETING_ANALYTICS_SETTINGS: 'advance-marketing-analytics-settings', // owner: @jabahamondes  #team-web-analytics
     AI_EVENTS_TABLE_ROLLOUT: 'ai-events-table-rollout', // owner: #team-llm-analytics, gates reads off the dedicated ai_events table
-    AI_ONLY_MODE: 'ai-only-mode', // owner: #team-posthog-ai
     ALERTS_ANOMALY_DETECTION: 'alerts-anomaly-detection', // owner: @andrewm4894
     /** Alert edit modal: check history chart + chart/table toggle (table remains when off). */
     ALERTS_HISTORY_CHART: 'alerts-history-chart', // owner: #team-analytics-platform
@@ -511,9 +510,7 @@ export const FEATURE_FLAGS = {
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 
-export const STORYBOOK_FEATURE_FLAGS = Object.values(FEATURE_FLAGS).filter(
-    (flag) => flag !== FEATURE_FLAGS.AI_ONLY_MODE
-)
+export const STORYBOOK_FEATURE_FLAGS = Object.values(FEATURE_FLAGS)
 
 export const INSIGHT_VISUAL_ORDER = {
     trends: 10,

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -27,8 +27,6 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { ImpersonationNotice } from '~/layout/navigation/ImpersonationNotice'
 
-import { MaxInstance } from './max/Max'
-
 window.process = MOCK_NODE_PROCESS
 
 /**
@@ -87,7 +85,7 @@ function AppScene(): JSX.Element | null {
         activeSceneLogicPropsWithTabId,
         sceneConfig,
     } = useValues(sceneLogic)
-    const { showingDelayedSpinner, hasExitedAIOnlyMode } = useValues(appLogic)
+    const { showingDelayedSpinner } = useValues(appLogic)
 
     const { featureFlags } = useValues(featureFlagLogic)
     const { isDarkModeOn } = useValues(themeLogic)
@@ -104,23 +102,6 @@ function AppScene(): JSX.Element | null {
             theme={isDarkModeOn ? 'dark' : 'light'}
         />
     )
-
-    if (featureFlags[FEATURE_FLAGS.AI_ONLY_MODE] && !hasExitedAIOnlyMode) {
-        return (
-            <>
-                <div
-                    className="fixed inset-0 bg-surface-secondary flex flex-col overflow-auto"
-                    ref={() => {
-                        // HACK: Normally DebugNotice removes the HTML-level debug bar, but in this case we don't have the nav rendering DebugNotice
-                        document.getElementById('bottom-notice')?.remove()
-                    }}
-                >
-                    <MaxInstance tabId="ai-only-mode" sidePanel isAIOnlyMode />
-                </div>
-                {toastContainer}
-            </>
-        )
-    }
 
     let sceneElement: JSX.Element
     if (activeExportedScene?.component) {

--- a/frontend/src/scenes/appLogic.tsx
+++ b/frontend/src/scenes/appLogic.tsx
@@ -14,7 +14,6 @@ export const appLogic = kea<appLogicType>([
 
     connect([teamLogic, organizationLogic, preflightLogic]),
     actions({
-        exitAIOnlyMode: true,
         enableDelayedSpinner: true,
         ignoreFeatureFlags: true,
         showDevTools: true,
@@ -23,7 +22,6 @@ export const appLogic = kea<appLogicType>([
         showingDelayedSpinner: [false, { enableDelayedSpinner: () => true }],
         featureFlagsTimedOut: [false, { ignoreFeatureFlags: () => true }],
         showingDevTools: [false, { showDevTools: () => true }],
-        hasExitedAIOnlyMode: [false, { exitAIOnlyMode: () => true }],
     }),
     selectors({
         showApp: [

--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -16,7 +16,6 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { cn } from 'lib/utils/css-classes'
-import { appLogic } from 'scenes/appLogic'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -78,14 +77,9 @@ export function Max({ tabId }: { tabId?: string }): JSX.Element {
 export interface MaxInstanceProps {
     sidePanel?: boolean
     tabId: string
-    isAIOnlyMode?: boolean
 }
 
-export const MaxInstance = React.memo(function MaxInstance({
-    sidePanel,
-    tabId,
-    isAIOnlyMode,
-}: MaxInstanceProps): JSX.Element {
+export const MaxInstance = React.memo(function MaxInstance({ sidePanel, tabId }: MaxInstanceProps): JSX.Element {
     const {
         threadVisible,
         conversationHistoryVisible,
@@ -98,7 +92,6 @@ export const MaxInstance = React.memo(function MaxInstance({
     const { startNewConversation, goBack } = useActions(maxLogic({ tabId }))
     const { openSidePanelMax } = useActions(maxGlobalLogic)
     const { closeTabId } = useActions(sceneLogic)
-    const { exitAIOnlyMode } = useActions(appLogic)
 
     const threadProps: MaxThreadLogicProps = {
         tabId,
@@ -156,14 +149,7 @@ export const MaxInstance = React.memo(function MaxInstance({
         </BindLogic>
     )
     const header = (
-        <SidePanelPaneHeader
-            className="transition-all duration-200"
-            onClose={() => {
-                exitAIOnlyMode()
-                startNewConversation()
-            }}
-            showCloseButton={false}
-        >
+        <SidePanelPaneHeader className="transition-all duration-200" showCloseButton={false}>
             <div className="flex flex-1 min-w-0 overflow-hidden">
                 <div className="flex items-center flex-1 min-w-0">
                     <AnimatedBackButton in={!backButtonDisabled}>
@@ -182,7 +168,7 @@ export const MaxInstance = React.memo(function MaxInstance({
                         <h3 className="flex-1 font-semibold mb-0 truncate text-sm ml-2">{chatTitle || 'PostHog AI'}</h3>
                     </Tooltip>
                 </div>
-                {conversationId && !conversationHistoryVisible && !threadVisible && !isAIOnlyMode && (
+                {conversationId && !conversationHistoryVisible && !threadVisible && (
                     <LemonButton
                         size="small"
                         icon={<IconPlus />}

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -25,7 +25,6 @@ INACTIVE_FLAGS = [
     "webhooks-denylist",
     "insight-horizontal-controls",
     "flagged-feature-indicator",
-    "ai-only-mode",
 ]
 
 


### PR DESCRIPTION
## Problem

The `ai-only-mode` feature flag has been deleted in production (no flag with that key exists in any environment), but the frontend still ships an entire AI-only-mode overlay code path gated on `featureFlags[FEATURE_FLAGS.AI_ONLY_MODE]`. Because the flag never resolves truthy, this is dead code: the overlay branch in `App.tsx`, the `appLogic` exit action/reducer, the `MaxInstance.isAIOnlyMode` prop, the `FEATURE_FLAGS.AI_ONLY_MODE` constant (and the `STORYBOOK_FEATURE_FLAGS` filter that excluded it), and the `sync_feature_flags` INACTIVE_FLAGS entry.

## Changes

Removed:

- `FEATURE_FLAGS.AI_ONLY_MODE` from `frontend/src/lib/constants.tsx`. Simplified `STORYBOOK_FEATURE_FLAGS` to `Object.values(FEATURE_FLAGS)` since the only excluded flag is gone.
- `exitAIOnlyMode` action and `hasExitedAIOnlyMode` reducer from `frontend/src/scenes/appLogic.tsx`.
- The AI-only-mode overlay branch and `hasExitedAIOnlyMode` value usage from `frontend/src/scenes/App.tsx`. Dropped the now-unused `MaxInstance` import.
- `isAIOnlyMode?: boolean` prop from `MaxInstance` in `frontend/src/scenes/max/Max.tsx`. Dropped the `appLogic` import and the dead `onClose` handler on the side-panel header (the header had `showCloseButton={false}` so the handler was unreachable anyway).
- `"ai-only-mode"` entry from `INACTIVE_FLAGS` in `posthog/management/commands/sync_feature_flags.py`.

No remaining references to `AI_ONLY_MODE`, `exitAIOnlyMode`, `isAIOnlyMode`, `hasExitedAIOnlyMode`, or the `ai-only-mode` flag key anywhere in the repo.

## How did you test this code?

I'm an agent; I did not exercise the UI manually. Verified:

- Ran `pnpm --filter=@posthog/frontend typegen:write` after the kea changes — clean.
- Ran `tsc --noEmit` against the frontend — no new TS errors. The 7 errors that surface (`@posthog/hogvm`, `@posthog/quill` module-not-found) are pre-existing and unrelated.
- Confirmed via PostHog MCP that the `ai-only-mode` flag returns 0 hits in the live project, so the deleted code path was already unreachable in production.

## Publish to changelog?

no

## 🤖 Agent context

PostHog Code (Claude Opus 4.7) authored this PR.

The user asked whether `appLogic.exitAIOnlyMode` and `MaxInstance.isAIOnlyMode` were dead in trunk. I initially said no because the symbols were still wired up, but the user pointed out the gating flag had been deleted. Confirmed via PostHog MCP that the `ai-only-mode` flag is gone, then removed every symbol gated on the flag.

Trade-off considered: I simplified `STORYBOOK_FEATURE_FLAGS` to just `Object.values(FEATURE_FLAGS)` rather than leave a no-op filter as a placeholder for "flags Storybook shouldn't enable". The export retains the same shape, so consumers (a handful of `*.stories.tsx` files) need no change. If a future flag needs the same exclusion, the filter can come back at that point.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*