### PR TITLE
feat(observability): add api/ latency histogram by source and access_method

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -426,7 +426,7 @@ class CHQueries:
             **get_mcp_properties(request),
         )
 
-        start = time.perf_counter() if is_api_request else None
+        start = time.perf_counter()
 
         try:
             response: HttpResponse = self.get_response(request)
@@ -436,10 +436,14 @@ class CHQueries:
                     "http_api_request_response",
                     tags={"id": route_id, "status_code": response.status_code},
                 )
-                assert start is not None
                 API_REQUESTS_LATENCY_SECONDS.labels(
+                    # Three-step fallback: DRF viewset name first (api:viewset-action),
+                    # Django URL name next, view function name as last resort. Bounded
+                    # by URLconf so cardinality stays safe.
                     view=route.view_name or route.url_name or route.func.__name__,
                     method=request.method or "",
+                    # Read after get_response so view code that calls tag_queries(source=...)
+                    # wins — matches access_method semantics, where DRF auth tags during dispatch.
                     source=get_query_tag_value("source") or "",
                     access_method=get_query_tag_value("access_method") or "",
                 ).observe(time.perf_counter() - start)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -447,10 +447,10 @@ class CHQueries:
         finally:
             if is_api_request:
                 API_REQUESTS_LATENCY_SECONDS.labels(
-                    # Three-step fallback: DRF viewset name first (api:viewset-action),
-                    # Django URL name next, view function name as last resort. Bounded
-                    # by URLconf so cardinality stays safe.
-                    view=route.view_name or route.url_name or route.func.__name__,
+                    # DRF viewset name (api:viewset-action) when set, view function name
+                    # otherwise. (Django builds view_name from url_name, so url_name as a
+                    # middle fallback would be unreachable.) Bounded by URLconf — safe cardinality.
+                    view=route.view_name or route.func.__name__,
                     method=request.method or "",
                     # Read after get_response so view code that calls tag_queries(source=...)
                     # wins — matches access_method semantics, where DRF auth tags during dispatch.

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -367,7 +367,10 @@ class AutoProjectMiddleware:
 API_REQUESTS_LATENCY_SECONDS = Histogram(
     "posthog_api_requests_latency_seconds",
     "Latency of api/ requests, labelled to expose agent vs browser traffic.",
-    labelnames=["view", "method", "source", "access_method"],
+    # `status_class` is "2xx" / "3xx" / "4xx" / "5xx" on a returned response,
+    # or "error" when the view raised before producing one — keeps error-path
+    # latency from polluting success buckets while still recording it.
+    labelnames=["view", "method", "source", "access_method", "status_class"],
     # Same buckets as django_prometheus' default so we line up with
     # django_http_requests_latency_seconds_by_view_method.
     buckets=(
@@ -427,15 +430,22 @@ class CHQueries:
         )
 
         start = time.perf_counter()
+        # Stays "error" if get_response raises — observed in the finally below.
+        status_class = "error"
 
         try:
             response: HttpResponse = self.get_response(request)
+            status_class = f"{response.status_code // 100}xx"
 
             if is_api_request:
                 statsd.incr(
                     "http_api_request_response",
                     tags={"id": route_id, "status_code": response.status_code},
                 )
+
+            return response
+        finally:
+            if is_api_request:
                 API_REQUESTS_LATENCY_SECONDS.labels(
                     # Three-step fallback: DRF viewset name first (api:viewset-action),
                     # Django URL name next, view function name as last resort. Bounded
@@ -446,10 +456,8 @@ class CHQueries:
                     # wins — matches access_method semantics, where DRF auth tags during dispatch.
                     source=get_query_tag_value("source") or "",
                     access_method=get_query_tag_value("access_method") or "",
+                    status_class=status_class,
                 ).observe(time.perf_counter() - start)
-
-            return response
-        finally:
             reset_query_tags()
 
     def _get_param(self, request: HttpRequest, name: str):

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -26,12 +26,13 @@ from django.utils.deprecation import MiddlewareMixin
 import structlog
 from django_prometheus.middleware import Metrics
 from loginas.utils import is_impersonated_session, restore_original_login
+from prometheus_client import Histogram
 from social_core.exceptions import AuthCanceled, AuthException, AuthFailed
 from statshog.defaults.django import statsd
 
 from posthog.api.shared import UserBasicSerializer
 from posthog.clickhouse.client.execute import clickhouse_query_counter
-from posthog.clickhouse.query_tagging import QueryCounter, reset_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import QueryCounter, get_query_tag_value, reset_query_tags, tag_queries
 from posthog.cloud_utils import is_cloud, is_dev_mode
 from posthog.constants import AUTH_BACKEND_KEYS
 from posthog.event_usage import get_event_source, get_mcp_properties
@@ -363,6 +364,34 @@ class AutoProjectMiddleware:
         return True
 
 
+API_REQUESTS_LATENCY_SECONDS = Histogram(
+    "posthog_api_requests_latency_seconds",
+    "Latency of api/ requests, labelled to expose agent vs browser traffic.",
+    labelnames=["view", "method", "source", "access_method"],
+    # Same buckets as django_prometheus' default so we line up with
+    # django_http_requests_latency_seconds_by_view_method.
+    buckets=(
+        0.01,
+        0.025,
+        0.05,
+        0.075,
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        2.5,
+        5.0,
+        7.5,
+        10.0,
+        25.0,
+        50.0,
+        75.0,
+        float("inf"),
+    ),
+)
+
+
 class CHQueries:
     def __init__(self, get_response):
         self.get_response = get_response
@@ -375,6 +404,7 @@ class CHQueries:
         """
         route = resolve(request.path)
         route_id = f"{route.route} ({route.func.__name__})"
+        is_api_request = "api/" in request.path and "capture" not in request.path
 
         user = cast(User, request.user)
 
@@ -396,14 +426,23 @@ class CHQueries:
             **get_mcp_properties(request),
         )
 
+        start = time.perf_counter() if is_api_request else None
+
         try:
             response: HttpResponse = self.get_response(request)
 
-            if "api/" in request.path and "capture" not in request.path:
+            if is_api_request:
                 statsd.incr(
                     "http_api_request_response",
                     tags={"id": route_id, "status_code": response.status_code},
                 )
+                assert start is not None
+                API_REQUESTS_LATENCY_SECONDS.labels(
+                    view=route.view_name or route.url_name or route.func.__name__,
+                    method=request.method or "",
+                    source=get_query_tag_value("source") or "",
+                    access_method=get_query_tag_value("access_method") or "",
+                ).observe(time.perf_counter() - start)
 
             return response
         finally:

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1891,7 +1891,6 @@ def test_chqueries_middleware_tags_source(user_agent, expected_source):
 
 @parameterized.expand(
     [
-        # api/ paths emit the histogram
         ("api_path_emits", "/api/projects/@current/query/", True),
         ("api_capture_excluded", "/api/projects/@current/capture/", False),
         ("non_api_path_excluded", "/login", False),
@@ -1925,10 +1924,8 @@ def test_chqueries_middleware_api_latency_histogram_scope(name, path, should_emi
 
 @parameterized.expand(
     [
-        # populates source from user-agent tagging done inside CHQueries
         ("source_mcp", "posthog/mcp-server v1", None, "mcp", ""),
         ("source_web", "Mozilla/5.0", None, "web", ""),
-        # populates access_method from auth-time tagging that happens during get_response
         ("access_method_personal_api_key", "Mozilla/5.0", "personal_api_key", "web", "personal_api_key"),
         ("access_method_oauth", "Mozilla/5.0", "oauth", "web", "oauth"),
     ]

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1889,6 +1889,85 @@ def test_chqueries_middleware_tags_source(user_agent, expected_source):
     assert captured["feature"] is None
 
 
+@parameterized.expand(
+    [
+        # api/ paths emit the histogram
+        ("api_path_emits", "/api/projects/@current/query/", True),
+        ("api_capture_excluded", "/api/projects/@current/capture/", False),
+        ("non_api_path_excluded", "/login", False),
+    ]
+)
+def test_chqueries_middleware_api_latency_histogram_scope(name, path, should_emit):
+    from django.http import HttpResponse
+    from django.test import RequestFactory
+
+    from prometheus_client import REGISTRY
+
+    from posthog.middleware import CHQueries
+
+    labels = {"view": "project_query-list", "method": "GET", "source": "web", "access_method": ""}
+
+    def sample_count() -> float:
+        return REGISTRY.get_sample_value("posthog_api_requests_latency_seconds_count", labels=labels) or 0.0
+
+    before = sample_count()
+
+    request = RequestFactory().get(path)
+    request.user = MagicMock(pk=1, is_authenticated=False)
+    request.session = MagicMock(session_key="abc123")
+
+    CHQueries(lambda r: HttpResponse("ok"))(request)
+
+    delta = sample_count() - before
+    expected = 1.0 if should_emit else 0.0
+    assert delta == expected, f"{name}: expected delta {expected}, got {delta}"
+
+
+@parameterized.expand(
+    [
+        # populates source from user-agent tagging done inside CHQueries
+        ("source_mcp", "posthog/mcp-server v1", None, "mcp", ""),
+        ("source_web", "Mozilla/5.0", None, "web", ""),
+        # populates access_method from auth-time tagging that happens during get_response
+        ("access_method_personal_api_key", "Mozilla/5.0", "personal_api_key", "web", "personal_api_key"),
+        ("access_method_oauth", "Mozilla/5.0", "oauth", "web", "oauth"),
+    ]
+)
+def test_chqueries_middleware_api_latency_labels(name, user_agent, access_method, expected_source, expected_access):
+    from django.http import HttpResponse
+    from django.test import RequestFactory
+
+    from prometheus_client import REGISTRY
+
+    from posthog.clickhouse.query_tagging import tag_queries
+    from posthog.middleware import CHQueries
+
+    labels = {
+        "view": "project_query-list",
+        "method": "GET",
+        "source": expected_source,
+        "access_method": expected_access,
+    }
+
+    def sample_count() -> float:
+        return REGISTRY.get_sample_value("posthog_api_requests_latency_seconds_count", labels=labels) or 0.0
+
+    before = sample_count()
+
+    def get_response(req):
+        if access_method is not None:
+            tag_queries(access_method=access_method)
+        return HttpResponse("ok")
+
+    request = RequestFactory().get("/api/projects/@current/query/", HTTP_USER_AGENT=user_agent)
+    request.user = MagicMock(pk=1, is_authenticated=False)
+    request.session = MagicMock(session_key="abc123")
+
+    CHQueries(get_response)(request)
+
+    assert sample_count() - before == 1.0, f"{name}: histogram not observed for labels {labels}"
+
+
 def test_query_time_counting_middleware_emits_durations_in_milliseconds() -> None:
     from posthog.middleware import QueryTimeCountingMiddleware
 

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1904,7 +1904,13 @@ def test_chqueries_middleware_api_latency_histogram_scope(name, path, should_emi
 
     from posthog.middleware import CHQueries
 
-    labels = {"view": "project_query-list", "method": "GET", "source": "web", "access_method": ""}
+    labels = {
+        "view": "project_query-list",
+        "method": "GET",
+        "source": "web",
+        "access_method": "",
+        "status_class": "2xx",
+    }
 
     def sample_count() -> float:
         return REGISTRY.get_sample_value("posthog_api_requests_latency_seconds_count", labels=labels) or 0.0
@@ -1944,6 +1950,7 @@ def test_chqueries_middleware_api_latency_labels(name, user_agent, access_method
         "method": "GET",
         "source": expected_source,
         "access_method": expected_access,
+        "status_class": "2xx",
     }
 
     def sample_count() -> float:
@@ -1963,6 +1970,77 @@ def test_chqueries_middleware_api_latency_labels(name, user_agent, access_method
     CHQueries(get_response)(request)
 
     assert sample_count() - before == 1.0, f"{name}: histogram not observed for labels {labels}"
+
+
+@parameterized.expand(
+    [
+        ("ok_2xx", 200, "2xx"),
+        ("redirect_3xx", 301, "3xx"),
+        ("client_error_4xx", 404, "4xx"),
+        ("server_error_5xx", 503, "5xx"),
+    ]
+)
+def test_chqueries_middleware_api_latency_status_class(name, status_code, expected_class):
+    from django.http import HttpResponse
+    from django.test import RequestFactory
+
+    from prometheus_client import REGISTRY
+
+    from posthog.middleware import CHQueries
+
+    labels = {
+        "view": "project_query-list",
+        "method": "GET",
+        "source": "web",
+        "access_method": "",
+        "status_class": expected_class,
+    }
+
+    def sample_count() -> float:
+        return REGISTRY.get_sample_value("posthog_api_requests_latency_seconds_count", labels=labels) or 0.0
+
+    before = sample_count()
+
+    request = RequestFactory().get("/api/projects/@current/query/")
+    request.user = MagicMock(pk=1, is_authenticated=False)
+    request.session = MagicMock(session_key="abc123")
+
+    CHQueries(lambda r: HttpResponse("body", status=status_code))(request)
+
+    assert sample_count() - before == 1.0, f"{name}: expected 1 observation at status_class={expected_class}"
+
+
+def test_chqueries_middleware_api_latency_records_on_raise():
+    from django.test import RequestFactory
+
+    from prometheus_client import REGISTRY
+
+    from posthog.middleware import CHQueries
+
+    labels = {
+        "view": "project_query-list",
+        "method": "GET",
+        "source": "web",
+        "access_method": "",
+        "status_class": "error",
+    }
+
+    def sample_count() -> float:
+        return REGISTRY.get_sample_value("posthog_api_requests_latency_seconds_count", labels=labels) or 0.0
+
+    before = sample_count()
+
+    def boom(req):
+        raise RuntimeError("view exploded")
+
+    request = RequestFactory().get("/api/projects/@current/query/")
+    request.user = MagicMock(pk=1, is_authenticated=False)
+    request.session = MagicMock(session_key="abc123")
+
+    with pytest.raises(RuntimeError, match="view exploded"):
+        CHQueries(boom)(request)
+
+    assert sample_count() - before == 1.0, "exception path must still record latency at status_class=error"
 
 
 def test_query_time_counting_middleware_emits_durations_in_milliseconds() -> None:


### PR DESCRIPTION
## Problem

We already have a per-route request-latency histogram from `django_prometheus` (`django_http_requests_latency_seconds_by_view_method`), but it's only labelled by `view` and `method`. With MCP and other agent traffic now hitting our API endpoints alongside browser sessions, we can't separate agent vs browser TTFB tail in Grafana — the dimensions we care about (`source`, `access_method`) live only in ClickHouse query tags, not in Prometheus.

We already have a long-running interest in TTFB on the HTML side; this is the same lens for API endpoints, where MCP and agents are the load that matters.

## Changes

- New `posthog_api_requests_latency_seconds` Prometheus histogram with labels `view`, `method`, `source`, `access_method`. Buckets match `django_prometheus`' default so the new metric lines up with the upstream one in dashboards.
- Observed inside `CHQueries.__call__`, only for paths under `api/` excluding `capture/` (matching the existing `http_api_request_response` statsd carve-out) so cardinality stays bounded — the upstream histogram already covers everything else.
- `source` is read from query tags (set just above by `CHQueries` from `get_event_source`); `access_method` from query tags (set during DRF auth dispatch by `PersonalAPIKeyAuthentication`/OAuth/etc.). Both are populated before `reset_query_tags()` runs in `finally`. Unset values map to empty string.
- The existing `django_http_requests_latency_seconds_by_view_method` is untouched, so existing Grafana queries keep working.

## How did you test this code?

I'm an agent (PostHog Code). I have not done manual Grafana verification.

7 new parameterized tests in `posthog/test/test_middleware.py`:

- `test_chqueries_middleware_api_latency_histogram_scope` (3 cases) — covers `api/` paths emit, `/api/.../capture/` excluded, `/login` excluded.
- `test_chqueries_middleware_api_latency_labels` (4 cases) — covers `mcp`/`web` source values and `personal_api_key`/`oauth` access methods, including the case where neither auth-time tag is set (label is empty string).

All pass; ruff clean.

## Publish to changelog?

no

## Docs update

Not needed — internal observability metric.

## 🤖 Agent context

Authored by PostHog Code on behalf of Paul. The plan was negotiated in chat:

- Considered extending the upstream `django_http_requests_latency_seconds_by_view_method` by subclassing `Metrics` + `PrometheusAfterMiddleware`. Rejected — changes upstream-owned metric, requires changes in two places (Metrics + middleware), and risks breaking dashboards that already depend on the existing label set.
- Considered observing in `PrometheusAfterMiddleware.process_response`. Workable (it runs inside `CHQueries`'s `try` block so query tags are still set), but makes the timing implicit. Chose `CHQueries.__call__` instead because the same middleware already times request lifecycle bits and emits the matching `http_api_request_response` statsd counter — keeps the agent-traffic plumbing in one place.
- Considered `view = route_id` (the verbose `route + view-func` string used by the existing statsd counter). Rejected in favour of `route.view_name` to match `django_prometheus`' convention and keep cardinality lower.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
