### PR TITLE
fix(web-vitals): ship web-vitals-with-attribution.js bundle to frontend/dist/

### DIFF
--- a/frontend/bin/copy-posthog-js
+++ b/frontend/bin/copy-posthog-js
@@ -11,6 +11,7 @@ cp node_modules/posthog-js/dist/surveys.js* dist/
 cp node_modules/posthog-js/dist/logs.js* dist/
 cp node_modules/posthog-js/dist/exception-autocapture.js* dist/
 cp node_modules/posthog-js/dist/web-vitals.js* dist/
+cp node_modules/posthog-js/dist/web-vitals-with-attribution.js* dist/
 cp node_modules/posthog-js/dist/tracing-headers.js* dist/
 cp node_modules/posthog-js/dist/dead-clicks-autocapture.js* dist/
 cp node_modules/posthog-js/dist/customizations.full.js* dist/

--- a/frontend/plugins/vite-posthog-js-plugin.ts
+++ b/frontend/plugins/vite-posthog-js-plugin.ts
@@ -46,6 +46,8 @@ function copyPostHogJsFiles(): void {
         'exception-autocapture.js.map',
         'web-vitals.js',
         'web-vitals.js.map',
+        'web-vitals-with-attribution.js',
+        'web-vitals-with-attribution.js.map',
         'tracing-headers.js',
         'tracing-headers.js.map',
         'dead-clicks-autocapture.js',


### PR DESCRIPTION
## Problem

posthog-js builds and publishes both `web-vitals.js` and `web-vitals-with-attribution.js` in its npm `dist/`. This repo only copies `web-vitals.js` into `frontend/dist/`, so the attribution bundle is missing from the PostHog CDN — both self-hosted and Cloud.

When the SDK is configured with `capture_performance: { web_vitals_attribution: true }` (or just `web_vitals_attribution: true`), posthog-js dynamically loads `/static/web-vitals-with-attribution.js?v=<version>` instead of `/static/web-vitals.js`. The fetch result on a current self-hosted instance:

```
$ curl -I 'https://<self-hosted>/static/web-vitals-with-attribution.js?v=1.372.3'
HTTP/2 200
content-type: text/html; charset=utf-8
via: 1.1 Caddy
```

Django falls through to the SPA catch-all and returns the app shell HTML. The browser refuses to execute it (`Refused to execute script ... because its MIME type ('text/html') is not executable`) and the web-vitals callbacks never register — so no `$web_vitals` events are sent at all.

Same behavior on PostHog Cloud: `us-assets.i.posthog.com/static/web-vitals-with-attribution.js` returns `302 /login`.

The fix is to copy the bundle into `frontend/dist/` alongside `web-vitals.js`.

## Changes

Add `web-vitals-with-attribution.js` (and its `.map`) to both copy paths used by the build:

- `frontend/bin/copy-posthog-js` — used by the main webpack/CI build (matches the surrounding `cp` lines for other bundles).
- `frontend/plugins/vite-posthog-js-plugin.ts` — used by the Storybook Vite build, which copies a static allowlist (matches the surrounding `web-vitals.js{,.map}` entries).

3 inserted lines, no removals, no reordering.

## How did you test this code?

Verified the build copy-script picks up the new file end-to-end on a clean checkout of this branch:

```sh
cd frontend
mkdir -p test-copy && cd test-copy
mkdir -p node_modules/posthog-js dist
curl -sSL https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.10.tgz \
  | tar -xz -C node_modules/posthog-js --strip-components=1

# Confirm the source file ships in npm:
ls node_modules/posthog-js/dist/ | grep -E '^web-vitals'
# → web-vitals-with-attribution.js
# → web-vitals-with-attribution.js.map
# → web-vitals.js
# → web-vitals.js.map

sh ../bin/copy-posthog-js

ls dist/ | grep -E '^web-vitals'
# → web-vitals-with-attribution.js
# → web-vitals-with-attribution.js.map
# → web-vitals.js
# → web-vitals.js.map
```

Pre-fix, `dist/` only contained `web-vitals.js{,.map}`. Post-fix it contains all four files.

For the Vite plugin, the change is a purely additive entry in the static `filesToCopy` allowlist — same shape as the surrounding entries — so the runtime path is identical to how `web-vitals.js` is already handled.

`posthog-js@1.372.10` (the version pinned in this repo's pnpm catalog) ships the bundle, as do all recent releases — `unpkg.com/posthog-js@latest/dist/web-vitals-with-attribution.js` returns `200 text/javascript`.

## Publish to changelog?

no — internal build script fix.

## Docs update

Not needed.

## 🤖 Agent context

This PR was authored by Aleksandr Kozhevnikov with Claude Code (Anthropic) assistance.

The bug surfaced when our team enabled `capture_performance.web_vitals_attribution: true` in our front-end (posthog-js@1.372.3) and `$web_vitals` events stopped flowing entirely on our self-hosted PostHog. We narrowed it down by:

1. Reproducing the broken bundle response (`text/html` for `/static/web-vitals-with-attribution.js`) directly via curl on both our self-hosted instance and `us-assets.i.posthog.com`.
2. Reading `posthog-js`: `WebVitalsAutocapture` switches the lazy-script kind to `web-vitals-with-attribution` when the attribution flag is set, and `RequestRouter.endpointFor('assets', ...)` builds the `/static/<file>?v=<ver>` URL.
3. Searching this repo for `web-vitals-with-attribution` (zero hits across `frontend/`) and inspecting `frontend/bin/copy-posthog-js` / `frontend/plugins/vite-posthog-js-plugin.ts` to confirm the explicit allowlists exclude the file.
4. Verifying the npm package ships the bundle (`unpkg.com/posthog-js@latest/...` → 200 text/javascript) so the only missing step is the copy in this repo.

The change matches the existing convention for every other bundle in both files and keeps the diff minimal — no refactor, no rename, no reordering. Ready for normal review.

Closes the gap that prevents Web Vitals attribution data (LCP target selector, CLS shift target, INP interaction target) from reaching `$web_vitals` events on every self-hosted and Cloud instance today.