### PR TITLE
chore(flags): mirror array-exact short-circuit refactor in IcontainsMulti

### DIFF
--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -159,21 +159,16 @@ pub fn match_property(
             if let Some(match_value) = match_value {
                 let match_string = to_string_representation(match_value).to_ascii_lowercase();
 
-                // Handle both single values and arrays
-                let search_values: Vec<String> = match value {
-                    Value::Array(arr) => arr
-                        .iter()
-                        .map(|v| to_string_representation(v).to_ascii_lowercase())
-                        .collect(),
-                    single_value => {
-                        vec![to_string_representation(single_value).to_ascii_lowercase()]
-                    }
+                // Check if any of the search values is contained in the match value.
+                // Handle both single values and arrays without materializing an
+                // intermediate Vec — short-circuits the per-element lowercase work too.
+                let any_contained = match value {
+                    Value::Array(arr) => arr.iter().any(|v| {
+                        match_string.contains(&to_string_representation(v).to_ascii_lowercase())
+                    }),
+                    single_value => match_string
+                        .contains(&to_string_representation(single_value).to_ascii_lowercase()),
                 };
-
-                // Check if any of the search values is contained in the match value
-                let any_contained = search_values
-                    .iter()
-                    .any(|search_val| match_string.contains(search_val));
 
                 if operator == OperatorType::IcontainsMulti {
                     Ok(any_contained)


### PR DESCRIPTION
## Problem

Follow-up to #58068. The `IcontainsMulti` / `NotIcontainsMulti` branch in `match_property` still builds an intermediate `Vec<String>` of every lowercased search value before scanning, even though the adjacent `Exact` branch was simplified in #58068:

```rust
let search_values: Vec<String> = match value {
    Value::Array(arr) => arr.iter().map(|v| ...lowercase()).collect(),
    single_value => vec![lower(str(single_value))],
};
let any_contained = search_values.iter().any(|s| match_string.contains(s));
```

This operator is rarely used in production (a handful of flags), so this is a code-consistency cleanup more than a perf change; it just keeps the two adjacent branches of the same function using the same idiom.

## Changes

Drop the intermediate `Vec` and fold the lowercase plus `contains` check into a single `iter().any(...)`, mirroring #58068. Same predicate, same iteration order, same behavior on empty arrays, scalar values, missing match values, and both operator directions.

## How did you test this code?

`cargo test -p feature-flags --lib property_matching` ran locally; 45 tests pass.

No new tests added; existing coverage already exercises every branch this change touches:

* `test_match_properties_icontains_multi` covers array match at index 0 and 1, array no-match, single-value match, single-value no-match, and missing-key error.
* `test_match_properties_not_icontains_multi` covers the same shape for the negated operator.
* `test_match_properties_icontains_multi_empty_values` and `test_match_properties_not_icontains_multi_empty_values` cover empty array in both directions.

## Publish to changelog?

no