### PR TITLE
feat(tasks): gate sandbox event ingest workflow

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -1,5 +1,7 @@
 from typing import Literal, get_args
 
+SANDBOX_EVENT_INGEST_FEATURE_FLAG = "tasks-cloud-runs-sandbox-event-ingest"
+
 ClaudePermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions", "auto"]
 CodexPermissionMode = Literal["auto", "read-only", "full-access"]
 InitialPermissionMode = ClaudePermissionMode | CodexPermissionMode

--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.db import transaction
 from django.utils import timezone as django_timezone
 
+import posthoganalytics
 from asgiref.sync import sync_to_async
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
@@ -14,6 +15,7 @@ from posthog.models.team.team import Team
 from posthog.temporal.common.client import async_connect, sync_connect
 from posthog.temporal.oauth import PosthogMcpScopes
 
+from products.tasks.backend.constants import SANDBOX_EVENT_INGEST_FEATURE_FLAG
 from products.tasks.backend.metrics import observe_task_run_workflow_start
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.temporal.process_task.workflow import ProcessTaskInput
@@ -23,7 +25,6 @@ if TYPE_CHECKING:
     from products.slack_app.backend.slack_thread import SlackThreadContext
 
 logger = logging.getLogger(__name__)
-
 
 _PRE_START_STATUSES: tuple[str, ...] = (TaskRun.Status.NOT_STARTED, TaskRun.Status.QUEUED)
 
@@ -81,6 +82,53 @@ def _get_task_run_for_metrics(run_id: str) -> TaskRun | None:
         return None
 
 
+def _capture_sandbox_event_ingest_flag(run_id: str) -> None:
+    try:
+        task_run = TaskRun.objects.select_related("task__created_by", "task__team").get(id=run_id)
+    except Exception:
+        logger.exception("sandbox_event_ingest_capture_run_missing", extra={"run_id": run_id})
+        return
+
+    state = task_run.state or {}
+    if isinstance(state.get("sandbox_event_ingest_enabled"), bool):
+        return
+
+    task = task_run.task
+    organization_id = str(task.team.organization_id)
+    distinct_id = (
+        task.created_by.distinct_id if task.created_by and task.created_by.distinct_id else "process_task_workflow"
+    )
+
+    try:
+        enabled = bool(
+            posthoganalytics.feature_enabled(
+                SANDBOX_EVENT_INGEST_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        logger.warning(
+            "sandbox_event_ingest_capture_flag_failed",
+            extra={"run_id": run_id, "task_id": str(task.id), "error": str(e)},
+        )
+        enabled = False
+
+    def _set_sandbox_event_ingest_flag(latest_state: dict[str, Any]) -> None:
+        if not isinstance(latest_state.get("sandbox_event_ingest_enabled"), bool):
+            latest_state["sandbox_event_ingest_enabled"] = enabled
+
+    captured_state = TaskRun.mutate_state_atomic(task_run.id, _set_sandbox_event_ingest_flag)
+    captured_enabled = captured_state.get("sandbox_event_ingest_enabled", enabled)
+    logger.info(
+        "sandbox_event_ingest_captured",
+        extra={"run_id": run_id, "task_id": str(task.id), "sandbox_event_ingest_enabled": captured_enabled},
+    )
+
+
 async def _aget_task_run_for_metrics(run_id: str) -> TaskRun | None:
     try:
         return await TaskRun.objects.select_related("task").aget(id=run_id)
@@ -110,6 +158,7 @@ async def execute_task_processing_workflow_async(
     observe_task_run_workflow_start(task_run_for_metrics, outcome="attempted", reason="requested")
     try:
         await Team.objects.select_related("organization").aget(id=team_id)
+        await sync_to_async(_capture_sandbox_event_ingest_flag)(run_id)
 
         workflow_id = TaskRun.get_workflow_id(task_id, run_id)
         slack_context_dict = _normalize_slack_context(slack_thread_context)
@@ -184,6 +233,7 @@ def execute_task_processing_workflow(
         )
 
         Team.objects.get(id=team_id)
+        _capture_sandbox_event_ingest_flag(run_id)
 
         workflow_id = TaskRun.get_workflow_id(task_id, run_id)
         slack_context_dict = _normalize_slack_context(slack_thread_context)
@@ -244,6 +294,7 @@ def execute_task_processing_workflow(
 
 
 def resume_task_in_cloud_workflow(run_id: str, workflow_id: str) -> None:
+    _capture_sandbox_event_ingest_flag(run_id)
     client = sync_connect()
     asyncio.run(
         client.start_workflow(

--- a/products/tasks/backend/temporal/process_task/activities/cleanup_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/cleanup_sandbox.py
@@ -6,6 +6,8 @@ from temporalio import activity
 from posthog.temporal.common.utils import asyncify
 
 from products.tasks.backend.services.sandbox import Sandbox
+from products.tasks.backend.stream.redis_stream import publish_task_run_stream_complete
+from products.tasks.backend.temporal.exceptions import SandboxNotFoundError
 from products.tasks.backend.temporal.observability import log_activity_execution
 
 logger = logging.getLogger(__name__)
@@ -14,6 +16,8 @@ logger = logging.getLogger(__name__)
 @dataclass
 class CleanupSandboxInput:
     sandbox_id: str
+    run_id: str | None = None
+    complete_stream_on_cleanup: bool = False
 
 
 @activity.defn
@@ -23,9 +27,32 @@ def cleanup_sandbox(input: CleanupSandboxInput) -> None:
         "cleanup_sandbox",
         sandbox_id=input.sandbox_id,
     ):
+        stream_completion_safe = False
         try:
             sandbox = Sandbox.get_by_id(input.sandbox_id)
-            sandbox.destroy()
+        except SandboxNotFoundError:
+            stream_completion_safe = True
+            sandbox = None
         except Exception:
-            # The sandbox has a timeout, and it will eventually terminate if we failed to cleanup
-            pass
+            logger.warning("cleanup_sandbox_get_by_id_failed", extra={"sandbox_id": input.sandbox_id}, exc_info=True)
+            sandbox = None
+
+        if sandbox is not None:
+            try:
+                sandbox.destroy()
+                stream_completion_safe = True
+            except Exception:
+                # The sandbox has a timeout, and it will eventually terminate if we failed to cleanup.
+                logger.warning("cleanup_sandbox_destroy_failed", extra={"sandbox_id": input.sandbox_id}, exc_info=True)
+
+        if input.complete_stream_on_cleanup and input.run_id and stream_completion_safe:
+            publish_task_run_stream_complete(input.run_id)
+            logger.info(
+                "cleanup_sandbox_stream_completion_published",
+                extra={"sandbox_id": input.sandbox_id, "run_id": input.run_id},
+            )
+        elif input.complete_stream_on_cleanup and input.run_id:
+            logger.warning(
+                "cleanup_sandbox_stream_completion_skipped",
+                extra={"sandbox_id": input.sandbox_id, "run_id": input.run_id},
+            )

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -9,6 +9,7 @@ from temporalio import activity
 from posthog.models import Team
 from posthog.temporal.common.utils import asyncify, close_db_connections
 
+from products.tasks.backend.constants import SANDBOX_EVENT_INGEST_FEATURE_FLAG
 from products.tasks.backend.models import SandboxEnvironment, Task, TaskRun
 from products.tasks.backend.temporal.exceptions import TaskInvalidStateError, TaskNotFoundError
 from products.tasks.backend.temporal.observability import emit_agent_log, log_with_activity_context
@@ -55,6 +56,9 @@ class TaskProcessingContext:
     # Captured at workflow start so a flag flip mid-run can't introduce
     # nondeterminism (the workflow consults this in its finally block).
     use_modal_resume_snapshots: bool = True
+    # Captured at workflow start so the sandbox event transport branch is
+    # deterministic for the full run.
+    sandbox_event_ingest_enabled: bool = False
 
     @property
     def mode(self) -> str:
@@ -135,6 +139,45 @@ class TaskProcessingContext:
             "model": self.model,
             "reasoning_effort": self.reasoning_effort,
         }
+
+
+def _is_sandbox_event_ingest_enabled(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+    state: dict | None = None,
+) -> bool:
+    state_override = (state or {}).get("sandbox_event_ingest_enabled")
+    if isinstance(state_override, bool):
+        log_with_activity_context(
+            "sandbox_event_ingest_state_override",
+            run_id=run_id,
+            sandbox_event_ingest_enabled=state_override,
+        )
+        return state_override
+
+    try:
+        enabled = bool(
+            posthoganalytics.feature_enabled(
+                SANDBOX_EVENT_INGEST_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        log_with_activity_context("sandbox_event_ingest_flag_check_failed", run_id=run_id, error=str(e))
+        return False
+
+    log_with_activity_context(
+        "sandbox_event_ingest_flag_checked",
+        run_id=run_id,
+        sandbox_event_ingest_enabled=enabled,
+    )
+    return enabled
 
 
 @activity.defn
@@ -226,6 +269,17 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         or False
     )  # Ensure we get a boolean value even if the flag is missing
     emit_agent_log(run_id, "debug", f"pr_loop_enabled: {pr_loop_enabled} for this task run")
+    sandbox_event_ingest_enabled = _is_sandbox_event_ingest_enabled(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+        state=state,
+    )
+    emit_agent_log(
+        run_id,
+        "debug",
+        f"sandbox_event_ingest_enabled: {sandbox_event_ingest_enabled} for this task run",
+    )
     user_github_integration_id = str(task.github_user_integration_id) if task.github_user_integration_id else None
     if user_github_integration_id is None and get_pr_authorship_mode(task, state).value == "user":
         user_github_integration = resolve_user_github_integration_for_task(task, allow_refresh=False)
@@ -254,4 +308,5 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         json_schema=task.json_schema,
         ci_prompt=task.ci_prompt,
         use_modal_resume_snapshots=settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS,
+        sandbox_event_ingest_enabled=sandbox_event_ingest_enabled,
     )

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -7,8 +7,9 @@ from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.utils import asyncify
 from posthog.temporal.oauth import PosthogMcpScopes
 
-from products.tasks.backend.models import Task
+from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.services.agentsh import ENV_FILE, ENV_WRAPPER_SCRIPT, build_exec_prefix
+from products.tasks.backend.services.connection_token import create_sandbox_event_ingest_token
 from products.tasks.backend.services.sandbox import Sandbox, SandboxBase
 from products.tasks.backend.temporal.exceptions import OAuthTokenError, SandboxExecutionError
 from products.tasks.backend.temporal.oauth import create_oauth_access_token
@@ -139,6 +140,19 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
                 cause=e,
             )
 
+        event_stream_ingest_enabled = ctx.sandbox_event_ingest_enabled
+        event_ingest_token: str | None = None
+        if event_stream_ingest_enabled:
+            try:
+                task_run = TaskRun.objects.get(id=ctx.run_id, task_id=ctx.task_id, team_id=ctx.team_id)
+                event_ingest_token = create_sandbox_event_ingest_token(task_run)
+            except Exception as e:
+                raise SandboxExecutionError(
+                    "Failed to create sandbox event ingest token",
+                    {"task_id": ctx.task_id, "run_id": ctx.run_id, "error": str(e)},
+                    cause=e,
+                )
+
         mcp_configs = get_sandbox_ph_mcp_configs(
             token=access_token,
             project_id=ctx.team_id,
@@ -197,6 +211,7 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
                 reasoning_effort=ctx.reasoning_effort,
                 mcp_configs=mcp_configs or None,
                 allowed_domains=ctx.allowed_domains,
+                event_ingest_token=event_ingest_token,
             )
 
             # Mark startup-time token issuance so follow-ups within the next
@@ -234,4 +249,7 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
         emit_agent_log(ctx.run_id, "debug", f"Agent server started at {sandbox_url}")
         activity.logger.info(f"Agent server started at {sandbox_url} for task {ctx.task_id}")
 
-        return StartAgentServerOutput(sandbox_url=sandbox_url, connect_token=connect_token)
+        return StartAgentServerOutput(
+            sandbox_url=sandbox_url,
+            connect_token=connect_token,
+        )

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_cleanup_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_cleanup_sandbox.py
@@ -8,7 +8,133 @@ import modal
 from asgiref.sync import async_to_sync
 
 from products.tasks.backend.services.sandbox import Sandbox, SandboxConfig, SandboxTemplate
+from products.tasks.backend.stream.redis_stream import TaskRunRedisStream, get_task_run_stream_key
+from products.tasks.backend.temporal.exceptions import SandboxNotFoundError
 from products.tasks.backend.temporal.process_task.activities.cleanup_sandbox import CleanupSandboxInput, cleanup_sandbox
+
+
+@pytest.mark.django_db
+def test_cleanup_sandbox_skips_agent_server_shutdown_for_regular_cleanup(activity_environment, mocker):
+    sandbox = mocker.Mock(id="sandbox-123")
+    get_by_id = mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+
+    async_to_sync(activity_environment.run)(cleanup_sandbox, CleanupSandboxInput(sandbox_id="sandbox-123"))
+
+    get_by_id.assert_called_once_with("sandbox-123")
+    sandbox.execute.assert_not_called()
+    sandbox.destroy.assert_called_once_with()
+
+
+@pytest.mark.django_db
+def test_cleanup_sandbox_does_not_request_agent_server_shutdown_when_completing_stream(activity_environment, mocker):
+    sandbox = mocker.Mock(id="sandbox-123")
+    get_by_id = mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+
+    async_to_sync(activity_environment.run)(
+        cleanup_sandbox,
+        CleanupSandboxInput(sandbox_id="sandbox-123", complete_stream_on_cleanup=True),
+    )
+
+    get_by_id.assert_called_once_with("sandbox-123")
+    sandbox.execute.assert_not_called()
+    sandbox.destroy.assert_called_once_with()
+
+
+@pytest.mark.django_db
+def test_cleanup_sandbox_does_not_complete_stream_when_destroy_fails(activity_environment, mocker):
+    sandbox = mocker.Mock(id="sandbox-123")
+    sandbox.destroy.side_effect = RuntimeError("destroy failed")
+    mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+    publish_complete = mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.cleanup_sandbox.publish_task_run_stream_complete"
+    )
+
+    async_to_sync(activity_environment.run)(
+        cleanup_sandbox,
+        CleanupSandboxInput(
+            sandbox_id="sandbox-123",
+            run_id="run-123",
+            complete_stream_on_cleanup=True,
+        ),
+    )
+
+    sandbox.destroy.assert_called_once_with()
+    sandbox.execute.assert_not_called()
+    publish_complete.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_cleanup_sandbox_completes_stream_when_requested(activity_environment, mocker):
+    sandbox = mocker.Mock(id="sandbox-123")
+    mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+    publish_complete = mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.cleanup_sandbox.publish_task_run_stream_complete"
+    )
+
+    async_to_sync(activity_environment.run)(
+        cleanup_sandbox,
+        CleanupSandboxInput(
+            sandbox_id="sandbox-123",
+            run_id="run-123",
+            complete_stream_on_cleanup=True,
+        ),
+    )
+
+    sandbox.execute.assert_not_called()
+    sandbox.destroy.assert_called_once_with()
+    publish_complete.assert_called_once_with("run-123")
+
+
+@pytest.mark.django_db
+def test_cleanup_sandbox_writes_real_completion_sentinel_when_requested(activity_environment, mocker):
+    run_id = "run-real-stream-complete"
+    stream_key = get_task_run_stream_key(run_id)
+    sandbox = mocker.Mock(id="sandbox-123")
+    mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+
+    async def _read_stream_events():
+        redis_stream = TaskRunRedisStream(stream_key)
+        messages = await redis_stream._redis_client.xrange(stream_key)
+        await redis_stream.delete_stream()
+        return [message[b"data"] for _stream_id, message in messages]
+
+    async_to_sync(activity_environment.run)(
+        cleanup_sandbox,
+        CleanupSandboxInput(
+            sandbox_id="sandbox-123",
+            run_id=run_id,
+            complete_stream_on_cleanup=True,
+        ),
+    )
+
+    assert async_to_sync(_read_stream_events)() == [b'{"type": "STREAM_STATUS", "status": "complete"}']
+
+
+@pytest.mark.django_db
+def test_cleanup_sandbox_completes_stream_when_sandbox_is_already_gone(activity_environment, mocker):
+    mocker.patch.object(
+        Sandbox,
+        "get_by_id",
+        side_effect=SandboxNotFoundError(
+            "Sandbox sandbox-123 not found",
+            {"sandbox_id": "sandbox-123"},
+            cause=RuntimeError("not found"),
+        ),
+    )
+    publish_complete = mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.cleanup_sandbox.publish_task_run_stream_complete"
+    )
+
+    async_to_sync(activity_environment.run)(
+        cleanup_sandbox,
+        CleanupSandboxInput(
+            sandbox_id="sandbox-123",
+            run_id="run-123",
+            complete_stream_on_cleanup=True,
+        ),
+    )
+
+    publish_complete.assert_called_once_with("run-123")
 
 
 @pytest.mark.skipif(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -8,11 +8,13 @@ from asgiref.sync import async_to_sync
 from posthog.models import OrganizationMembership, User
 from posthog.models.user_integration import UserIntegration
 
+from products.tasks.backend.constants import SANDBOX_EVENT_INGEST_FEATURE_FLAG
 from products.tasks.backend.models import SandboxEnvironment, Task
 from products.tasks.backend.temporal.exceptions import TaskInvalidStateError, TaskNotFoundError
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
     GetTaskProcessingContextInput,
     TaskProcessingContext,
+    _is_sandbox_event_ingest_enabled,
     get_task_processing_context,
 )
 
@@ -238,20 +240,104 @@ class TestGetTaskProcessingContextActivity:
         task_run = test_task.create_run()
         input_data = GetTaskProcessingContextInput(run_id=str(task_run.id))
 
+        def feature_enabled(flag_key, **kwargs):
+            if flag_key == "tasks-pr-loop":
+                return flag_value
+            return False
+
         with patch(
             "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
-            return_value=flag_value,
+            side_effect=feature_enabled,
         ) as feature_enabled_mock:
             result = async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
 
         assert result.pr_loop_enabled is expected
-        feature_enabled_mock.assert_called_once()
-        args, kwargs = feature_enabled_mock.call_args
+        assert result.sandbox_event_ingest_enabled is False
+        args, kwargs = feature_enabled_mock.call_args_list[0]
         assert args[0] == "tasks-pr-loop"
         assert kwargs["distinct_id"] == (test_task.created_by.distinct_id or "process_task_workflow")
         org_id = str(test_task.team.organization_id)
         assert kwargs["groups"] == {"organization": org_id}
         assert kwargs["group_properties"] == {"organization": {"id": org_id}}
+        sandbox_args, _sandbox_kwargs = feature_enabled_mock.call_args_list[1]
+        assert sandbox_args[0] == SANDBOX_EVENT_INGEST_FEATURE_FLAG
+
+    @pytest.mark.parametrize(
+        "flag_value, expected",
+        [
+            (True, True),
+            (False, False),
+            (None, False),
+        ],
+    )
+    def test_sandbox_event_ingest_flag_uses_organization_rollout(self, flag_value, expected):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=flag_value,
+        ) as feature_enabled_mock:
+            assert (
+                _is_sandbox_event_ingest_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                )
+                is expected
+            )
+
+        feature_enabled_mock.assert_called_once_with(
+            SANDBOX_EVENT_INGEST_FEATURE_FLAG,
+            distinct_id="distinct-id",
+            groups={"organization": "organization-id"},
+            group_properties={"organization": {"id": "organization-id"}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+
+    def test_sandbox_event_ingest_flag_fails_closed(self):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            side_effect=RuntimeError("flag service failed"),
+        ):
+            assert (
+                _is_sandbox_event_ingest_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                )
+                is False
+            )
+
+    def test_sandbox_event_ingest_state_override_skips_flag_check(self):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=False,
+        ) as feature_enabled_mock:
+            assert (
+                _is_sandbox_event_ingest_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    state={"sandbox_event_ingest_enabled": True},
+                )
+                is True
+            )
+
+        feature_enabled_mock.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_get_task_processing_context_uses_sandbox_event_ingest_state_override(
+        self, activity_environment, test_task
+    ):
+        task_run = test_task.create_run(extra_state={"sandbox_event_ingest_enabled": True})
+        input_data = GetTaskProcessingContextInput(run_id=str(task_run.id))
+
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=False,
+        ):
+            result = async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
+
+        assert result.sandbox_event_ingest_enabled is True
 
     @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_exposes_ci_prompt(self, activity_environment, test_task):

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
@@ -1,0 +1,64 @@
+from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
+from products.tasks.backend.temporal.process_task.activities.start_agent_server import (
+    StartAgentServerInput,
+    start_agent_server,
+)
+
+
+def _context(*, sandbox_event_ingest_enabled: bool = False) -> TaskProcessingContext:
+    return TaskProcessingContext(
+        task_id="task-id",
+        run_id="run-id",
+        team_id=1,
+        team_uuid="team-uuid",
+        organization_id="organization-id",
+        github_integration_id=None,
+        repository=None,
+        distinct_id="distinct-id",
+        sandbox_event_ingest_enabled=sandbox_event_ingest_enabled,
+    )
+
+
+async def test_start_agent_server_uses_captured_sandbox_event_ingest_flag(mocker) -> None:
+    context = _context(sandbox_event_ingest_enabled=True)
+    sandbox = mocker.Mock()
+    sandbox.execute.return_value.stdout = ""
+    sandbox.execute.return_value.stderr = ""
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.Sandbox.get_by_id",
+        return_value=sandbox,
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.Task.objects.select_related"
+    ).return_value.get.return_value = mocker.Mock(created_by_id=None)
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.create_oauth_access_token",
+        return_value="oauth-token",
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.get_sandbox_ph_mcp_configs",
+        return_value=[],
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.TaskRun.objects.get",
+        return_value=mocker.Mock(),
+    )
+    create_event_ingest_token = mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.create_sandbox_event_ingest_token",
+        return_value="event-ingest-token",
+    )
+
+    result = await start_agent_server(
+        StartAgentServerInput(
+            context=context,
+            sandbox_id="sandbox-id",
+            sandbox_url="https://sandbox.example",
+            sandbox_connect_token="connect-token",
+        )
+    )
+
+    assert result.sandbox_url == "https://sandbox.example"
+    assert result.connect_token == "connect-token"
+    create_event_ingest_token.assert_called_once()
+    sandbox.start_agent_server.assert_called_once()
+    assert sandbox.start_agent_server.call_args.kwargs["event_ingest_token"] == "event-ingest-token"

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -23,6 +23,7 @@ from products.tasks.backend.temporal.process_task.activities import (
     CreateSandboxForRepositoryOutput,
     GetSandboxForRepositoryOutput,
     PrepareSandboxForRepositoryOutput,
+    StartAgentServerOutput,
     TaskProcessingContext,
     checkout_branch_in_sandbox,
     cleanup_sandbox,
@@ -52,6 +53,7 @@ def _build_context(
     repository: str | None = "posthog/posthog-js",
     state: dict | None = None,
     use_modal_resume_snapshots: bool = True,
+    sandbox_event_ingest_enabled: bool = False,
 ) -> TaskProcessingContext:
     return TaskProcessingContext(
         task_id="task-id",
@@ -66,6 +68,7 @@ def _build_context(
         state=state or {},
         _branch="feature-branch",
         use_modal_resume_snapshots=use_modal_resume_snapshots,
+        sandbox_event_ingest_enabled=sandbox_event_ingest_enabled,
     )
 
 
@@ -386,6 +389,60 @@ class TestProcessTaskWorkflowUnit:
         )
         track_workflow_event_mock.assert_not_awaited()
         post_slack_update_mock.assert_not_awaited()
+
+    async def test_run_skips_relay_when_sandbox_event_ingest_is_enabled(self, monkeypatch):
+        workflow = ProcessTaskWorkflow()
+        context = _build_context(github_integration_id=123, sandbox_event_ingest_enabled=True)
+        get_task_processing_context_mock = AsyncMock(return_value=context)
+        update_task_run_status_mock = AsyncMock()
+        track_workflow_event_mock = AsyncMock()
+        post_slack_update_mock = AsyncMock()
+        read_sandbox_logs_mock = AsyncMock()
+        cleanup_sandbox_mock = AsyncMock()
+        create_resume_snapshot_mock = AsyncMock()
+        relay_sandbox_events_mock = AsyncMock()
+
+        monkeypatch.setattr(workflow, "_get_task_processing_context", get_task_processing_context_mock)
+        monkeypatch.setattr(workflow, "_update_task_run_status", update_task_run_status_mock)
+        monkeypatch.setattr(workflow, "_track_workflow_event", track_workflow_event_mock)
+        monkeypatch.setattr(workflow, "_post_slack_update", post_slack_update_mock)
+        monkeypatch.setattr(workflow, "_read_sandbox_logs", read_sandbox_logs_mock)
+        monkeypatch.setattr(workflow, "_cleanup_sandbox", cleanup_sandbox_mock)
+        monkeypatch.setattr(workflow, "_create_resume_snapshot", create_resume_snapshot_mock)
+        monkeypatch.setattr(workflow, "_emit_progress", AsyncMock())
+        monkeypatch.setattr(workflow, "_forward_pending_user_message", AsyncMock())
+        monkeypatch.setattr(
+            workflow,
+            "_get_sandbox_for_repository",
+            AsyncMock(
+                return_value=GetSandboxForRepositoryOutput(
+                    sandbox_id="sandbox-123",
+                    sandbox_url="https://sandbox.example",
+                    connect_token="connect-token",
+                    used_snapshot=False,
+                    should_create_snapshot=False,
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            workflow,
+            "_start_agent_server",
+            AsyncMock(
+                return_value=StartAgentServerOutput(
+                    sandbox_url="https://sandbox.example",
+                    connect_token="connect-token",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            workflow, "_wait_for_event", AsyncMock(return_value=process_task_workflow_module.TaskEvent.TIMEOUT_REACHED)
+        )
+        monkeypatch.setattr(workflow, "_relay_sandbox_events", relay_sandbox_events_mock)
+
+        result = await workflow.run(ProcessTaskInput(run_id="run-id"))
+
+        assert result.success is True
+        relay_sandbox_events_mock.assert_not_awaited()
 
     async def test_get_sandbox_for_repository_skips_clone_and_checkout_for_private_repo_without_github_integration(
         self, monkeypatch

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -412,7 +412,11 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 },
             )
 
-            relay_task = asyncio.ensure_future(self._relay_sandbox_events(agent_server_output, sandbox_id=sandbox_id))
+            relay_task: asyncio.Task[None] | None = None
+            if not self.context.sandbox_event_ingest_enabled:
+                relay_task = asyncio.ensure_future(
+                    self._relay_sandbox_events(agent_server_output, sandbox_id=sandbox_id)
+                )
 
             if self._should_forward_pending_user_message():
                 await self._forward_pending_user_message()
@@ -486,8 +490,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                     case _:
                         raise ValueError(f"Unknown event type: {event}")
 
-            # Stop the relay now that the main loop is done
-            await self._cancel_relay(relay_task)
+            if relay_task is not None:
+                await self._cancel_relay(relay_task)
 
             if self._task_completed:
                 await self._update_task_run_status(self._completion_status, error_message=self._completion_error)
@@ -695,7 +699,12 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         )
 
     async def _cleanup_sandbox(self, sandbox_id: str) -> None:
-        cleanup_input = CleanupSandboxInput(sandbox_id=sandbox_id)
+        context = self._context
+        cleanup_input = CleanupSandboxInput(
+            sandbox_id=sandbox_id,
+            run_id=context.run_id if context else None,
+            complete_stream_on_cleanup=bool(context and context.sandbox_event_ingest_enabled),
+        )
         await workflow.execute_activity(
             cleanup_sandbox,
             cleanup_input,

--- a/products/tasks/backend/tests/test_temporal_client.py
+++ b/products/tasks/backend/tests/test_temporal_client.py
@@ -12,6 +12,7 @@ from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.client import (
     execute_task_processing_workflow,
     execute_task_processing_workflow_async,
+    resume_task_in_cloud_workflow,
 )
 
 
@@ -68,7 +69,10 @@ class TestExecuteTaskProcessingWorkflow(TransactionTestCase):
         )
         connect_mock = Mock(return_value=client) if executor == "sync" else AsyncMock(return_value=client)
 
-        with patch(connect_target, connect_mock):
+        with (
+            patch(connect_target, connect_mock),
+            patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=False),
+        ):
             self._execute_workflow(executor, run, self.user.id)
 
         self._assert_run_failed(run, "Failed to start task workflow: temporal unavailable")
@@ -86,10 +90,86 @@ class TestExecuteTaskProcessingWorkflow(TransactionTestCase):
         )
         connect_mock = Mock(return_value=client) if executor == "sync" else AsyncMock(return_value=client)
 
-        with patch(connect_target, connect_mock):
+        with (
+            patch(connect_target, connect_mock),
+            patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=False),
+        ):
             self._execute_workflow(executor, run, self.user.id)
 
         run.refresh_from_db()
         self.assertEqual(run.status, TaskRun.Status.IN_PROGRESS)
         self.assertIsNone(run.error_message)
         self.assertIsNone(run.completed_at)
+
+    @parameterized.expand([("sync",), ("async",)])
+    def test_captures_sandbox_event_ingest_flag_before_starting_workflow(self, executor: str) -> None:
+        run = self._create_run()
+        client = Mock()
+        client.start_workflow = AsyncMock()
+
+        connect_target = (
+            "products.tasks.backend.temporal.client.sync_connect"
+            if executor == "sync"
+            else "products.tasks.backend.temporal.client.async_connect"
+        )
+        connect_mock = Mock(return_value=client) if executor == "sync" else AsyncMock(return_value=client)
+
+        with (
+            patch(connect_target, connect_mock),
+            patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=True) as flag,
+        ):
+            self._execute_workflow(executor, run, self.user.id)
+
+        run.refresh_from_db()
+        self.assertEqual(run.state["sandbox_event_ingest_enabled"], True)
+        flag.assert_called_once_with(
+            "tasks-cloud-runs-sandbox-event-ingest",
+            distinct_id="process_task_workflow",
+            groups={"organization": str(self.organization.id)},
+            group_properties={"organization": {"id": str(self.organization.id)}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+
+    def test_captures_sandbox_event_ingest_flag_before_resuming_workflow(self) -> None:
+        run = self._create_run()
+        client = Mock()
+        client.start_workflow = AsyncMock()
+
+        with (
+            patch("products.tasks.backend.temporal.client.sync_connect", return_value=client),
+            patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=True),
+        ):
+            resume_task_in_cloud_workflow(str(run.id), run.workflow_id)
+
+        run.refresh_from_db()
+        self.assertEqual(run.state["sandbox_event_ingest_enabled"], True)
+
+    @parameterized.expand([("sync",), ("async",)])
+    def test_captures_sandbox_event_ingest_flag_without_clobbering_concurrent_state(self, executor: str) -> None:
+        run = self._create_run()
+        client = Mock()
+        client.start_workflow = AsyncMock()
+        connect_target = (
+            "products.tasks.backend.temporal.client.sync_connect"
+            if executor == "sync"
+            else "products.tasks.backend.temporal.client.async_connect"
+        )
+        connect_mock = Mock(return_value=client) if executor == "sync" else AsyncMock(return_value=client)
+
+        def _feature_enabled(*args: object, **kwargs: object) -> bool:
+            TaskRun.update_state_atomic(str(run.id), updates={"pending_user_message_ids": ["message-1"]})
+            return True
+
+        with (
+            patch(connect_target, connect_mock),
+            patch(
+                "products.tasks.backend.temporal.client.posthoganalytics.feature_enabled",
+                side_effect=_feature_enabled,
+            ),
+        ):
+            self._execute_workflow(executor, run, self.user.id)
+
+        run.refresh_from_db()
+        self.assertEqual(run.state["pending_user_message_ids"], ["message-1"])
+        self.assertEqual(run.state["sandbox_event_ingest_enabled"], True)


### PR DESCRIPTION
## Problem

new sandbox event ingestion path needs to be feature gated so existing cloud task workflows keep using the Temporal relay until the path is enabled for a run. We also need to coordinate cleanup and terminal behavior differently when event delivery comes from the sandbox.

## Changes

- gate sandbox event ingestion behind `tasks-cloud-runs-sandbox-event-ingest` and preserve the existing relay path by default
- build and pass run-scoped ingest environment details into `start_agent_server` when the flag is enabled.
- add workflow/client/activity support for state overrides and cleanup behavior used by the new event transport.