### PR TITLE
chore: add flaky-test skill for triaging unrelated CI failures

### DIFF
--- a/.agents/skills/flaky-test/SKILL.md
+++ b/.agents/skills/flaky-test/SKILL.md
@@ -6,9 +6,10 @@ description: >
   run URL on their PR and asks to look at a failing test, invokes /flaky-test,
   or asks "is this CI failure mine?". Determines whether the failure is caused
   by the PR's diff (then stop and report), or unrelated (then open a draft fix
-  PR off master and identify the owning team via CODEOWNERS so the user can
-  ping them on Slack). Never posts to Slack itself — returns suggested reply
-  text the user can paste.
+  PR off master, resolve the owning team via CODEOWNERS / the feature ownership
+  handbook, and resolve the corresponding Slack sub-team handle by listing
+  user groups via the Slack MCP — never hardcoded, never guessed). Never posts
+  to Slack itself — returns suggested reply text the user can paste.
 ---
 
 # Triaging flaky / unrelated test failures on PostHog PRs
@@ -117,7 +118,20 @@ If the fix needs more than one PR (cross-cutting refactor, deeper
 investigation, ambiguous root cause), don't open a PR. Capture what you
 learned for the team handoff in step 4.
 
-### Step 4: Identify the owning team
+### Step 4: Resolve the owning team — twice
+
+You need *two* identifiers and they are not interchangeable:
+
+- a **GitHub team handle** like `@PostHog/team-product-analytics`, used in
+  PR review requests
+- a **Slack handle** for the corresponding user group, used in the Slack
+  reply
+
+A GitHub team handle pasted into Slack does not ping anyone. Always resolve
+the Slack handle separately. Do **not** hardcode a github-team-to-slack
+mapping inside this skill or guess based on naming similarity.
+
+#### 4a. GitHub team via CODEOWNERS / handbook
 
 Look up CODEOWNERS for the failing test's path:
 
@@ -126,40 +140,76 @@ grep -E '<test-path-fragment-or-parent-dir>' .github/CODEOWNERS
 ```
 
 CODEOWNERS uses longest-prefix match — start specific (the test file's
-exact path) and walk up parent directories until you find a match. Cross-
-reference with the public feature ownership handbook at
-<https://posthog.com/handbook/engineering/feature-ownership> when CODEOWNERS
-doesn't cover the path or the match is ambiguous.
+exact path) and walk up parent directories until you find a match. PostHog's
+CODEOWNERS is intentionally sparse — most paths have no explicit owner.
+When that's the case, the public feature ownership handbook at
+<https://posthog.com/handbook/engineering/feature-ownership> is the source
+of truth (`WebFetch` it, search for the directory or feature name).
 
-Note that PostHog's CODEOWNERS file is intentionally sparse — most paths
-have no explicit owner. When that's the case, the handbook's feature
-ownership table is the source of truth. If neither resolves the owner with
-confidence, say so explicitly in the suggested reply rather than guessing —
-it's better to leave a question for humans than to ping the wrong team.
+The output of this step is a *team identity* — the GitHub handle if
+CODEOWNERS gave one, otherwise the team's name as written in the handbook
+(e.g. "Product analytics", "Replay", "Pipeline"). That identity is the
+input to step 4b.
+
+#### 4b. Slack handle via the Slack MCP
+
+The harness should expose a Slack MCP server with user-group / sub-team
+listing tools (typical names: `slack_get_user_groups`,
+`slack_user_groups_list`, `list_user_groups`, `usergroups.list`). List
+all user groups, then match the team identity from 4a against:
+
+- the user group's `handle` (e.g. `team-replay`)
+- the user group's `name` / display name
+- the user group's `description`
+
+Pick the user group whose handle/name most directly corresponds to the
+GitHub team or feature-handbook entry. If the GitHub handle is
+`@PostHog/team-replay` and Slack has a user group with handle
+`team-replay` or name `Team Replay`, that's the match. If the only match
+candidates differ (e.g. handbook says "Pipeline" and Slack has both
+`team-pipeline` and `team-pipeline-ingest`), prefer the more general one
+unless the failing test path narrows it.
+
+For the actual ping, use Slack's sub-team mention syntax so the message
+pings the group:
+
+```text
+<!subteam^SXXXXXXX|team-replay>
+```
+
+`SXXXXXXX` is the user group's `id` from the list call; `team-replay` is
+its `handle`. A bare `@team-replay` in skill output text does not ping —
+only the `<!subteam^...>` form does.
+
+If no Slack MCP is available, or no user group plausibly matches, do not
+guess a handle — fall through to the "owning team unclear" reply template
+and ask the user to fill in the right handle.
 
 ### Step 5: Compose the Slack reply
 
 Return suggested reply text for the user to paste into Slack. Don't post
-it yourself. Templates:
+it yourself. Templates (substitute the resolved Slack sub-team mention into
+`<slack-team-mention>`):
 
 **Unrelated, fix PR opened:**
 
 > Failure on `<test-path>::<test-name>` looks unrelated to your PR — the
 > test exercises `<area>` which your diff doesn't touch. I opened
 > <https://github.com/PostHog/posthog/pull/><n> with a likely fix. cc
-> @PostHog/<team> — please review.
+> <slack-team-mention> — please review.
 
 **Unrelated, not a one-PR fix:**
 
 > Failure on `<test-path>::<test-name>` looks unrelated to your PR but
 > isn't a one-PR fix — root cause appears to be `<short summary>`. cc
-> @PostHog/<team> — flagging for triage.
+> <slack-team-mention> — flagging for triage.
 
-**Unrelated, owning team unclear:**
+**Unrelated, Slack handle unresolved:**
 
 > Failure on `<test-path>::<test-name>` looks unrelated to your PR. I
-> couldn't confidently identify an owning team from CODEOWNERS or the
-> feature ownership handbook — would appreciate a pointer.
+> believe the owning team is `<team identity from 4a>` (per
+> CODEOWNERS / feature-ownership handbook), but I couldn't resolve the
+> Slack handle — could you tag them?
 
 ## Safety rules
 
@@ -171,6 +221,10 @@ Inherit all safety rules from `debugging-ci-failures`. In addition:
 - Keep fix PRs minimal and scoped to the failing test's root cause. No
   drive-by cleanups, no scope creep.
 - Never post to Slack — return suggested reply text only.
+- Never hardcode or guess a Slack handle. The team-to-Slack mapping must
+  always be resolved at run time via the Slack MCP. If no Slack MCP is
+  available or no user group plausibly matches, use the "Slack handle
+  unresolved" template and let the user fill it in.
 - Do not rerun CI, accept snapshots, or modify `.github/workflows/`
   without explicit approval.
 - If you can't confidently determine PR-caused vs unrelated, say so and
@@ -186,5 +240,6 @@ Always respond with:
 3. If unrelated:
    - link to the fix PR (if you opened one), or the reason no PR is
      possible
-   - the owning team handle (or "unknown" if you couldn't determine)
+   - the GitHub team handle / feature-handbook team name (or "unknown")
+   - the resolved Slack sub-team mention (or "unresolved" — never guessed)
    - the suggested Slack reply text, ready to copy-paste

--- a/.agents/skills/flaky-test/SKILL.md
+++ b/.agents/skills/flaky-test/SKILL.md
@@ -7,10 +7,10 @@ description: >
   or asks "is this CI failure mine?". Decides whether the failure is caused by
   the PR's diff (then say so and stop) or unrelated (then identify the owning
   team via CODEOWNERS / the feature ownership handbook, resolve the Slack
-  sub-team handle by listing user groups via the Slack MCP — never hardcoded,
-  never guessed — and return suggested Slack reply text). Never opens a fix PR
-  and never posts to Slack — both require explicit follow-up authorization
-  from the user.
+  sub-team mention by listing user groups via the Slack MCP — never hardcoded,
+  never guessed — and reply with that mention inline so the team is actually
+  pinged). Never opens a fix PR; opening one requires explicit follow-up
+  authorization from the user.
 ---
 
 # Triaging flaky / unrelated test failures on PostHog PRs
@@ -33,13 +33,17 @@ After inspecting the failure, every run produces _exactly one_ of these:
 
 1. **PR-caused** — tell the user the failure is theirs, with a one-sentence
    explanation. Stop. Do not tag a team.
-2. **Unrelated** — identify the owning team and return suggested Slack reply
-   text that tags them.
+2. **Unrelated** — identify the owning team and reply with the resolved
+   Slack sub-team mention inline so the team is actually pinged.
 
-Always _return_ suggested Slack reply text — never post to Slack yourself.
+The reply is the bot's response in the calling channel — write it as the
+final message, with the real `<!subteam^...>` mention rendered inline. Do
+not return placeholder text the user has to copy, paste, or tag manually;
+that defeats the point of the skill.
+
 Never open a fix PR — opening one requires explicit follow-up authorization
-from the user, even when the cause is obvious. Stop after returning the
-reply text and let the user decide.
+from the user, even when the cause is obvious. Stop after the reply and let
+the user decide.
 
 ## Workflow
 
@@ -147,21 +151,27 @@ only the `<!subteam^...>` form does.
 
 If no Slack MCP is available, or no user group plausibly matches, do not
 guess a handle — fall through to the "Slack handle unresolved" reply
-template and ask the user to fill in the right handle.
+template below and ask the user to fill in the right handle.
 
-### Step 4: Compose the Slack reply
+### Step 4: Reply
 
-Return suggested reply text for the user to paste into Slack. Don't post
-it yourself. Templates (substitute the resolved Slack sub-team mention into
-`<slack-team-mention>`):
+This is the bot's final response. Write it directly — render the actual
+`<!subteam^...>` mention inline so the team is pinged the moment the
+message lands. Do not output a placeholder like `<slack-team-mention>` and
+do not ask the user to paste, edit, or tag manually; that defeats the
+purpose of resolving the mention.
+
+Substitute the values you resolved in steps 1–3 inline:
 
 **Unrelated, owning team resolved:**
 
 > Failure on `<test-path>::<test-name>` looks unrelated to your PR — the
 > test exercises `<area>` which your diff doesn't touch. Suspected cause:
-> `<short summary>`. cc <slack-team-mention> — flagging for triage.
+> `<short summary>`. cc <!subteam^SXXXXXXX|team-handle> — flagging for
+> triage.
 
-**Unrelated, Slack handle unresolved:**
+**Unrelated, Slack handle unresolved** (only when step 3b genuinely
+couldn't match a user group — never as a shortcut to skip the lookup):
 
 > Failure on `<test-path>::<test-name>` looks unrelated to your PR.
 > Suspected cause: `<short summary>`. I believe the owning team is
@@ -181,11 +191,14 @@ Inherit all safety rules from `debugging-ci-failures`. In addition:
   the user. Describe what the fix would look like in the suggested Slack
   reply if helpful, but stop short of making it.
 - Never push to, modify, or otherwise touch the user's PR branch.
-- Never post to Slack — return suggested reply text only.
 - Never hardcode or guess a Slack handle. The team-to-Slack mapping must
   always be resolved at run time via the Slack MCP. If no Slack MCP is
   available or no user group plausibly matches, use the "Slack handle
-  unresolved" template and let the user fill it in.
+  unresolved" template and let the user fill it in. Don't use that
+  fallback as a shortcut to skip the lookup.
+- The reply you produce is the bot's actual response in the calling
+  channel — render the resolved `<!subteam^...>` mention inline rather
+  than asking the user to paste or tag manually.
 - Do not rerun CI, accept snapshots, or modify `.github/workflows/`
   without explicit approval.
 - If you can't confidently determine PR-caused vs unrelated, say so and
@@ -201,5 +214,7 @@ Always respond with:
 3. If unrelated:
    - the suspected root cause (one short sentence)
    - the GitHub team handle / feature-handbook team name (or "unknown")
-   - the resolved Slack sub-team mention (or "unresolved" — never guessed)
-   - the suggested Slack reply text, ready to copy-paste
+   - the resolved Slack sub-team mention as `<!subteam^...>` (or
+     "unresolved" — never guessed)
+   - the reply itself, with the mention rendered inline so the team is
+     pinged when the message lands

--- a/.agents/skills/flaky-test/SKILL.md
+++ b/.agents/skills/flaky-test/SKILL.md
@@ -4,12 +4,13 @@ description: >
   Triages a single failing test on a PostHog PR's CI run when it might be flaky
   or unrelated to the user's changes. Use when the user pastes a GitHub Actions
   run URL on their PR and asks to look at a failing test, invokes /flaky-test,
-  or asks "is this CI failure mine?". Determines whether the failure is caused
-  by the PR's diff (then stop and report), or unrelated (then open a draft fix
-  PR off master, resolve the owning team via CODEOWNERS / the feature ownership
-  handbook, and resolve the corresponding Slack sub-team handle by listing
-  user groups via the Slack MCP — never hardcoded, never guessed). Never posts
-  to Slack itself — returns suggested reply text the user can paste.
+  or asks "is this CI failure mine?". Decides whether the failure is caused by
+  the PR's diff (then say so and stop) or unrelated (then identify the owning
+  team via CODEOWNERS / the feature ownership handbook, resolve the Slack
+  sub-team handle by listing user groups via the Slack MCP — never hardcoded,
+  never guessed — and return suggested Slack reply text). Never opens a fix PR
+  and never posts to Slack — both require explicit follow-up authorization
+  from the user.
 ---
 
 # Triaging flaky / unrelated test failures on PostHog PRs
@@ -31,15 +32,14 @@ ID identifies the specific failing job within the workflow run.
 After inspecting the failure, every run produces _exactly one_ of these:
 
 1. **PR-caused** — tell the user the failure is theirs, with a one-sentence
-   explanation. Stop. Do not open a fix PR. Do not tag a team.
-2. **Unrelated, fixable** — open a draft fix PR off `master` (NOT off the
-   user's branch). Identify the owning team. Return suggested Slack reply
-   text linking the fix PR and tagging the team.
-3. **Unrelated, not fixable in one PR** — don't open a PR. Identify the
-   owning team. Return suggested Slack reply text summarizing the failure
-   and tagging the team for triage.
+   explanation. Stop. Do not tag a team.
+2. **Unrelated** — identify the owning team and return suggested Slack reply
+   text that tags them.
 
 Always _return_ suggested Slack reply text — never post to Slack yourself.
+Never open a fix PR — opening one requires explicit follow-up authorization
+from the user, even when the cause is obvious. Stop after returning the
+reply text and let the user decide.
 
 ## Workflow
 
@@ -79,51 +79,15 @@ likely PR-caused — but pre-existing flakes can also surface on a single PR
 purely by chance, so weigh this signal against the diff analysis above.
 
 If PR-caused → STOP. Tell the user, point to the suspect commit / file, and
-exit without further action.
+exit without further action. Do not tag a team — pinging a team for a
+PR-caused failure is noise.
 
-### Step 3 (unrelated only): Try to fix
-
-Read the failing test and surrounding code to understand the root cause.
-Common patterns:
-
-- _Race / timing_: missing `await`, fixture ordering, time-based assertion,
-  test depending on a shared resource without isolation.
-- _State leakage_: a sibling test left state that this one depends on not
-  existing, or vice versa. Look for class-level or module-level fixtures
-  that aren't reset per-test.
-- _Snapshot drift_: visual or string snapshot that needs regenerating after
-  a legitimate change on master that the failing test forgot to keep up
-  with.
-- _Infra / runner_: no local repro is possible; treat per
-  `debugging-ci-failures` and skip to the "not fixable in one PR" branch.
-
-If the cause is clear and small, write the fix on a **new branch off
-`master`** (not off the user's PR branch — the fix is independent and
-shouldn't depend on the user's diff). Commit, push, and open as draft per
-repo conventions:
-
-```bash
-git fetch origin master
-git checkout -B posthog-code/fix-flaky-<short-name> origin/master
-# ... make the fix ...
-git push -u origin HEAD
-gh pr create --draft --base master --title "fix(<scope>): ..." --body "..."
-```
-
-Use the `posthog-code/` branch prefix and follow conventional commits per
-[CLAUDE.md](../../../CLAUDE.md). Keep the fix minimal — don't bundle
-drive-by cleanups.
-
-If the fix needs more than one PR (cross-cutting refactor, deeper
-investigation, ambiguous root cause), don't open a PR. Capture what you
-learned for the team handoff in step 4.
-
-### Step 4: Resolve the owning team — twice
+### Step 3: Resolve the owning team — twice
 
 You need _two_ identifiers and they are not interchangeable:
 
-- a **GitHub team handle** like `@PostHog/team-product-analytics`, used in
-  PR review requests
+- a **GitHub team handle** like `@PostHog/team-product-analytics`, used
+  internally to resolve ownership
 - a **Slack handle** for the corresponding user group, used in the Slack
   reply
 
@@ -131,7 +95,7 @@ A GitHub team handle pasted into Slack does not ping anyone. Always resolve
 the Slack handle separately. Do **not** hardcode a github-team-to-slack
 mapping inside this skill or guess based on naming similarity.
 
-#### 4a. GitHub team via CODEOWNERS / handbook
+#### 3a. GitHub team via CODEOWNERS / handbook
 
 Look up CODEOWNERS for the failing test's path:
 
@@ -149,14 +113,14 @@ of truth (`WebFetch` it, search for the directory or feature name).
 The output of this step is a _team identity_ — the GitHub handle if
 CODEOWNERS gave one, otherwise the team's name as written in the handbook
 (e.g. "Product analytics", "Replay", "Pipeline"). That identity is the
-input to step 4b.
+input to step 3b.
 
-#### 4b. Slack handle via the Slack MCP
+#### 3b. Slack handle via the Slack MCP
 
 The harness should expose a Slack MCP server with user-group / sub-team
 listing tools (typical names: `slack_get_user_groups`,
 `slack_user_groups_list`, `list_user_groups`, `usergroups.list`). List
-all user groups, then match the team identity from 4a against:
+all user groups, then match the team identity from 3a against:
 
 - the user group's `handle` (e.g. `team-replay`)
 - the user group's `name` / display name
@@ -182,44 +146,41 @@ its `handle`. A bare `@team-replay` in skill output text does not ping —
 only the `<!subteam^...>` form does.
 
 If no Slack MCP is available, or no user group plausibly matches, do not
-guess a handle — fall through to the "owning team unclear" reply template
-and ask the user to fill in the right handle.
+guess a handle — fall through to the "Slack handle unresolved" reply
+template and ask the user to fill in the right handle.
 
-### Step 5: Compose the Slack reply
+### Step 4: Compose the Slack reply
 
 Return suggested reply text for the user to paste into Slack. Don't post
 it yourself. Templates (substitute the resolved Slack sub-team mention into
 `<slack-team-mention>`):
 
-**Unrelated, fix PR opened:**
+**Unrelated, owning team resolved:**
 
 > Failure on `<test-path>::<test-name>` looks unrelated to your PR — the
-> test exercises `<area>` which your diff doesn't touch. I opened
-> <https://github.com/PostHog/posthog/pull/><n> with a likely fix. cc
-> <slack-team-mention> — please review.
-
-**Unrelated, not a one-PR fix:**
-
-> Failure on `<test-path>::<test-name>` looks unrelated to your PR but
-> isn't a one-PR fix — root cause appears to be `<short summary>`. cc
-> <slack-team-mention> — flagging for triage.
+> test exercises `<area>` which your diff doesn't touch. Suspected cause:
+> `<short summary>`. cc <slack-team-mention> — flagging for triage.
 
 **Unrelated, Slack handle unresolved:**
 
-> Failure on `<test-path>::<test-name>` looks unrelated to your PR. I
-> believe the owning team is `<team identity from 4a>` (per
-> CODEOWNERS / feature-ownership handbook), but I couldn't resolve the
-> Slack handle — could you tag them?
+> Failure on `<test-path>::<test-name>` looks unrelated to your PR.
+> Suspected cause: `<short summary>`. I believe the owning team is
+> `<team identity from 3a>` (per CODEOWNERS / feature-ownership handbook),
+> but I couldn't resolve the Slack handle — could you tag them?
+
+If the user later asks you to attempt a fix, defer to whichever skill or
+workflow they invoke for that next step — opening a fix PR is out of scope
+for this skill.
 
 ## Safety rules
 
 Inherit all safety rules from `debugging-ci-failures`. In addition:
 
-- Never push to or modify the user's PR branch. Fixes go on a brand-new
-  branch off `master`.
-- Always open fix PRs as **draft**.
-- Keep fix PRs minimal and scoped to the failing test's root cause. No
-  drive-by cleanups, no scope creep.
+- Never open a fix PR. Even when the root cause is obvious and the fix is
+  one line, opening a PR requires explicit follow-up authorization from
+  the user. Describe what the fix would look like in the suggested Slack
+  reply if helpful, but stop short of making it.
+- Never push to, modify, or otherwise touch the user's PR branch.
 - Never post to Slack — return suggested reply text only.
 - Never hardcode or guess a Slack handle. The team-to-Slack mapping must
   always be resolved at run time via the Slack MCP. If no Slack MCP is
@@ -228,7 +189,7 @@ Inherit all safety rules from `debugging-ci-failures`. In addition:
 - Do not rerun CI, accept snapshots, or modify `.github/workflows/`
   without explicit approval.
 - If you can't confidently determine PR-caused vs unrelated, say so and
-  ask for human input — don't guess and open a PR you're unsure about.
+  ask for human input — don't guess.
 
 ## Reporting shape
 
@@ -238,8 +199,7 @@ Always respond with:
    `debugging-ci-failures`.
 2. PR-caused decision with a one-sentence reason.
 3. If unrelated:
-   - link to the fix PR (if you opened one), or the reason no PR is
-     possible
+   - the suspected root cause (one short sentence)
    - the GitHub team handle / feature-handbook team name (or "unknown")
    - the resolved Slack sub-team mention (or "unresolved" — never guessed)
    - the suggested Slack reply text, ready to copy-paste

--- a/.agents/skills/flaky-test/SKILL.md
+++ b/.agents/skills/flaky-test/SKILL.md
@@ -204,9 +204,9 @@ Inherit all safety rules from `debugging-ci-failures`. In addition:
 - If you can't confidently determine PR-caused vs unrelated, say so and
   ask for human input — don't guess.
 
-## Reporting shape
+## Internal analysis (not the response)
 
-Always respond with:
+Before composing the reply, internally work through:
 
 1. The failing test (path + name) and classification from
    `debugging-ci-failures`.
@@ -216,5 +216,7 @@ Always respond with:
    - the GitHub team handle / feature-handbook team name (or "unknown")
    - the resolved Slack sub-team mention as `<!subteam^...>` (or
      "unresolved" — never guessed)
-   - the reply itself, with the mention rendered inline so the team is
-     pinged when the message lands
+
+Do not output these as the response. The final user-facing message is the
+reply defined in Step 4, written as a single conversational message with
+the resolved mention rendered inline.

--- a/.agents/skills/flaky-test/SKILL.md
+++ b/.agents/skills/flaky-test/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: flaky-test
+description: >
+  Triages a single failing test on a PostHog PR's CI run when it might be flaky
+  or unrelated to the user's changes. Use when the user pastes a GitHub Actions
+  run URL on their PR and asks to look at a failing test, invokes /flaky-test,
+  or asks "is this CI failure mine?". Determines whether the failure is caused
+  by the PR's diff (then stop and report), or unrelated (then open a draft fix
+  PR off master and identify the owning team via CODEOWNERS so the user can
+  ping them on Slack). Never posts to Slack itself — returns suggested reply
+  text the user can paste.
+---
+
+# Triaging flaky / unrelated test failures on PostHog PRs
+
+This skill is the *triage decision* layer on top of `debugging-ci-failures`.
+For read-only inspection, classification, and local repro guidance, use the
+`debugging-ci-failures` skill — this skill picks up after that, when the
+question is: "is this failure mine, or someone else's?".
+
+## When to invoke
+
+The user gives a GitHub Actions run URL such as
+`https://github.com/PostHog/posthog/actions/runs/<run-id>/job/<job-id>?pr=<pr>`
+and asks you to look at the failing test. The PR number is in `?pr=`; the job
+ID identifies the specific failing job within the workflow run.
+
+## The contract
+
+After inspecting the failure, every run produces *exactly one* of these:
+
+1. **PR-caused** — tell the user the failure is theirs, with a one-sentence
+   explanation. Stop. Do not open a fix PR. Do not tag a team.
+2. **Unrelated, fixable** — open a draft fix PR off `master` (NOT off the
+   user's branch). Identify the owning team. Return suggested Slack reply
+   text linking the fix PR and tagging the team.
+3. **Unrelated, not fixable in one PR** — don't open a PR. Identify the
+   owning team. Return suggested Slack reply text summarizing the failure
+   and tagging the team for triage.
+
+Always *return* suggested Slack reply text — never post to Slack yourself.
+
+## Workflow
+
+### Step 1: Inspect
+
+Use the read-only inspection commands from `debugging-ci-failures`:
+
+```bash
+gh pr view <pr> --json number,headRefName,baseRefName,files,statusCheckRollup
+gh run view <run-id> --json jobs,conclusion,name,workflowName,url
+gh run view <run-id> --log-failed
+```
+
+Extract:
+
+- failing test path and test name (e.g. `posthog/api/test/test_foo.py::TestFoo::test_bar`)
+- the workflow + job + step that failed
+- the PR's changed file list
+- the relevant diff context for the failing test's code path
+
+### Step 2: Decide if PR-caused
+
+Read the failing test source and compare to the PR's diff. The failure is
+**caused by the PR** if any of these are true:
+
+- the failing test file or files it imports are in the PR's `files` list
+- the test exercises a code path the PR changed (transitive imports, shared
+  utilities, modified models / serializers / HogQL nodes the test touches)
+- the failure mode (assertion text, snapshot diff, error message) clearly
+  maps to a behavior the PR introduced
+
+Sanity check via `master`: look at the same job's recent history with
+`gh run list --branch master --workflow <workflow> --limit 20`, and check
+whether the test has been failing on `master` independently. A test that
+passed on `master` at the PR's base SHA and only fails on this PR is more
+likely PR-caused — but pre-existing flakes can also surface on a single PR
+purely by chance, so weigh this signal against the diff analysis above.
+
+If PR-caused → STOP. Tell the user, point to the suspect commit / file, and
+exit without further action.
+
+### Step 3 (unrelated only): Try to fix
+
+Read the failing test and surrounding code to understand the root cause.
+Common patterns:
+
+- *Race / timing*: missing `await`, fixture ordering, time-based assertion,
+  test depending on a shared resource without isolation.
+- *State leakage*: a sibling test left state that this one depends on not
+  existing, or vice versa. Look for class-level or module-level fixtures
+  that aren't reset per-test.
+- *Snapshot drift*: visual or string snapshot that needs regenerating after
+  a legitimate change on master that the failing test forgot to keep up
+  with.
+- *Infra / runner*: no local repro is possible; treat per
+  `debugging-ci-failures` and skip to the "not fixable in one PR" branch.
+
+If the cause is clear and small, write the fix on a **new branch off
+`master`** (not off the user's PR branch — the fix is independent and
+shouldn't depend on the user's diff). Commit, push, and open as draft per
+repo conventions:
+
+```bash
+git fetch origin master
+git checkout -B posthog-code/fix-flaky-<short-name> origin/master
+# ... make the fix ...
+git push -u origin HEAD
+gh pr create --draft --base master --title "fix(<scope>): ..." --body "..."
+```
+
+Use the `posthog-code/` branch prefix and follow conventional commits per
+[CLAUDE.md](../../../CLAUDE.md). Keep the fix minimal — don't bundle
+drive-by cleanups.
+
+If the fix needs more than one PR (cross-cutting refactor, deeper
+investigation, ambiguous root cause), don't open a PR. Capture what you
+learned for the team handoff in step 4.
+
+### Step 4: Identify the owning team
+
+Look up CODEOWNERS for the failing test's path:
+
+```bash
+grep -E '<test-path-fragment-or-parent-dir>' .github/CODEOWNERS
+```
+
+CODEOWNERS uses longest-prefix match — start specific (the test file's
+exact path) and walk up parent directories until you find a match. Cross-
+reference with the public feature ownership handbook at
+<https://posthog.com/handbook/engineering/feature-ownership> when CODEOWNERS
+doesn't cover the path or the match is ambiguous.
+
+Note that PostHog's CODEOWNERS file is intentionally sparse — most paths
+have no explicit owner. When that's the case, the handbook's feature
+ownership table is the source of truth. If neither resolves the owner with
+confidence, say so explicitly in the suggested reply rather than guessing —
+it's better to leave a question for humans than to ping the wrong team.
+
+### Step 5: Compose the Slack reply
+
+Return suggested reply text for the user to paste into Slack. Don't post
+it yourself. Templates:
+
+**Unrelated, fix PR opened:**
+
+> Failure on `<test-path>::<test-name>` looks unrelated to your PR — the
+> test exercises `<area>` which your diff doesn't touch. I opened
+> <https://github.com/PostHog/posthog/pull/><n> with a likely fix. cc
+> @PostHog/<team> — please review.
+
+**Unrelated, not a one-PR fix:**
+
+> Failure on `<test-path>::<test-name>` looks unrelated to your PR but
+> isn't a one-PR fix — root cause appears to be `<short summary>`. cc
+> @PostHog/<team> — flagging for triage.
+
+**Unrelated, owning team unclear:**
+
+> Failure on `<test-path>::<test-name>` looks unrelated to your PR. I
+> couldn't confidently identify an owning team from CODEOWNERS or the
+> feature ownership handbook — would appreciate a pointer.
+
+## Safety rules
+
+Inherit all safety rules from `debugging-ci-failures`. In addition:
+
+- Never push to or modify the user's PR branch. Fixes go on a brand-new
+  branch off `master`.
+- Always open fix PRs as **draft**.
+- Keep fix PRs minimal and scoped to the failing test's root cause. No
+  drive-by cleanups, no scope creep.
+- Never post to Slack — return suggested reply text only.
+- Do not rerun CI, accept snapshots, or modify `.github/workflows/`
+  without explicit approval.
+- If you can't confidently determine PR-caused vs unrelated, say so and
+  ask for human input — don't guess and open a PR you're unsure about.
+
+## Reporting shape
+
+Always respond with:
+
+1. The failing test (path + name) and classification from
+   `debugging-ci-failures`.
+2. PR-caused decision with a one-sentence reason.
+3. If unrelated:
+   - link to the fix PR (if you opened one), or the reason no PR is
+     possible
+   - the owning team handle (or "unknown" if you couldn't determine)
+   - the suggested Slack reply text, ready to copy-paste

--- a/.agents/skills/flaky-test/SKILL.md
+++ b/.agents/skills/flaky-test/SKILL.md
@@ -14,7 +14,7 @@ description: >
 
 # Triaging flaky / unrelated test failures on PostHog PRs
 
-This skill is the *triage decision* layer on top of `debugging-ci-failures`.
+This skill is the _triage decision_ layer on top of `debugging-ci-failures`.
 For read-only inspection, classification, and local repro guidance, use the
 `debugging-ci-failures` skill — this skill picks up after that, when the
 question is: "is this failure mine, or someone else's?".
@@ -28,7 +28,7 @@ ID identifies the specific failing job within the workflow run.
 
 ## The contract
 
-After inspecting the failure, every run produces *exactly one* of these:
+After inspecting the failure, every run produces _exactly one_ of these:
 
 1. **PR-caused** — tell the user the failure is theirs, with a one-sentence
    explanation. Stop. Do not open a fix PR. Do not tag a team.
@@ -39,7 +39,7 @@ After inspecting the failure, every run produces *exactly one* of these:
    owning team. Return suggested Slack reply text summarizing the failure
    and tagging the team for triage.
 
-Always *return* suggested Slack reply text — never post to Slack yourself.
+Always _return_ suggested Slack reply text — never post to Slack yourself.
 
 ## Workflow
 
@@ -86,15 +86,15 @@ exit without further action.
 Read the failing test and surrounding code to understand the root cause.
 Common patterns:
 
-- *Race / timing*: missing `await`, fixture ordering, time-based assertion,
+- _Race / timing_: missing `await`, fixture ordering, time-based assertion,
   test depending on a shared resource without isolation.
-- *State leakage*: a sibling test left state that this one depends on not
+- _State leakage_: a sibling test left state that this one depends on not
   existing, or vice versa. Look for class-level or module-level fixtures
   that aren't reset per-test.
-- *Snapshot drift*: visual or string snapshot that needs regenerating after
+- _Snapshot drift_: visual or string snapshot that needs regenerating after
   a legitimate change on master that the failing test forgot to keep up
   with.
-- *Infra / runner*: no local repro is possible; treat per
+- _Infra / runner_: no local repro is possible; treat per
   `debugging-ci-failures` and skip to the "not fixable in one PR" branch.
 
 If the cause is clear and small, write the fix on a **new branch off
@@ -120,7 +120,7 @@ learned for the team handoff in step 4.
 
 ### Step 4: Resolve the owning team — twice
 
-You need *two* identifiers and they are not interchangeable:
+You need _two_ identifiers and they are not interchangeable:
 
 - a **GitHub team handle** like `@PostHog/team-product-analytics`, used in
   PR review requests
@@ -146,7 +146,7 @@ When that's the case, the public feature ownership handbook at
 <https://posthog.com/handbook/engineering/feature-ownership> is the source
 of truth (`WebFetch` it, search for the directory or feature name).
 
-The output of this step is a *team identity* — the GitHub handle if
+The output of this step is a _team identity_ — the GitHub handle if
 CODEOWNERS gave one, otherwise the team's name as written in the handbook
 (e.g. "Product analytics", "Replay", "Pipeline"). That identity is the
 input to step 4b.


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C09ADEV3AJD/p1778250606695359

I wanted a short-hand for this prompt, so I can run a posthog code instance and automatically tag the owning team

## Changes

- New skill at `.agents/skills/flaky-test/SKILL.md`.
- Sits on top of the existing `debugging-ci-failures` skill — that skill still owns read-only inspection, classification, and local repro guidance. `flaky-test` is the _triage decision_ layer that picks up after.
- Outputs exactly one of two results per run:
  1. **PR-caused** → tell the user the failure is theirs and stop. No team ping.
  2. **Unrelated** → identify the owning team (GitHub via CODEOWNERS / feature-ownership handbook, then Slack handle via the Slack MCP's user-group listing) and reply with that mention rendered inline as `<!subteam^SXXXX|team-handle>`, so the team is actually pinged when the message lands.
- The reply is the bot's own message in the calling channel — no copy-paste step. No `<placeholder>` tags in the output; the resolved subteam mention is rendered inline.
- Never opens a fix PR. Even when the root cause is one line, opening a PR requires explicit follow-up authorization from the user. The skill stops after replying.
- Never hardcodes or guesses a Slack handle; if the Slack MCP isn't available or no user group plausibly matches, falls through to a "Slack handle unresolved" template that asks the user to fill it in.

## How did you test this code?

I'm an agent — I haven't manually tested the skill end-to-end on a real CI run. Validated locally:

- Frontmatter has the required `name` and `description` fields.
- `name` matches the kebab-case format.
- `SKILL.md` stays well under the 500-line guideline.
- `pnpm exec oxfmt --check` passes on the file.
- CI's skills-lint and oxfmt jobs run on push.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Authored by PostHog Code based on a Slack request from Robbie. Iterated through review feedback in-thread:

1. Initial draft hardcoded a `@PostHog/<team>` placeholder, which is a GitHub handle and doesn't ping in Slack — fixed by splitting team resolution into two sub-steps (GitHub identity from CODEOWNERS / handbook → Slack handle from the Slack MCP's user-group list) and using `<!subteam^SXXXX|name>` mention syntax. Hardcoded mappings and naming-similarity guesses are explicitly forbidden in the safety rules.
2. Hex's review feedback narrowed the scope: the skill must never auto-open a fix PR. Even an obvious one-line fix needs explicit follow-up authorization from the user. The "unrelated, fixable" branch and all fix-PR scaffolding (branch creation, `gh pr create`, fix-PR Slack templates) were removed; safety rules explicitly forbid opening fix PRs from this skill.
3. Robbie pushed back on the "return suggested reply text the user pastes" framing — that defeats the purpose when the bot is the one replying in Slack. The reply is now framed as the bot's own message in the calling channel, with the resolved `<!subteam^...>` rendered inline rather than a placeholder.
4. Greptile flagged a contradiction between the old "never posts to Slack" framing and the new "ping inline" framing; this PR description is updated to match. Graphite flagged that the trailing "Reporting shape" section read like a structured-data response format, conflicting with the conversational reply in Step 4 — that section is now labeled as internal analysis with an explicit note that it isn't the response.

Other decisions:

- **Name:** kept as `flaky-test` (noun phrase) to match the slash-command trigger Robbie asked for, even though the writing-skills guide prefers gerund form. Noun phrases are documented as acceptable.
- **Location:** `.agents/skills/` rather than `products/*/skills/` — this is repo infrastructure, not product-specific (sibling to `debugging-ci-failures`, `qa-team`, etc).
- **Layered with `debugging-ci-failures`:** rather than duplicating inspection / classification guidance, this skill defers to it and only adds the triage decision and team-handoff layer on top.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*