### PR TITLE
fix(workflows): Add frontend warning if the loading of blast radius fails

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -11,6 +11,7 @@ import {
     IconPeople,
     IconPlusSmall,
     IconTarget,
+    IconWarning,
     IconWebhooks,
 } from '@posthog/icons'
 import {
@@ -489,10 +490,28 @@ function StepTriggerConfigurationManual(): JSX.Element {
 
 function StepTriggerAffectedUsers({ actionId, filters }: { actionId: string; filters: any }): JSX.Element | null {
     const logic = batchTriggerLogic({ id: actionId, filters })
-    const { blastRadiusLoading, blastRadius } = useValues(logic)
+    const { blastRadiusLoading, blastRadius, blastRadiusError } = useValues(logic)
 
     if (blastRadiusLoading) {
         return <Spinner className="mt-1" />
+    }
+
+    if (blastRadiusError) {
+        return (
+            <div className="text-warning text-xs flex items-start gap-1 mt-1">
+                <IconWarning className="text-base shrink-0 mt-0.5" />
+                <div>
+                    <div className="font-semibold">
+                        Couldn't validate audience size — this batch will likely fail to run.
+                    </div>
+                    <div>
+                        Your filters could not be evaluated against the audience. Review and adjust them before saving,
+                        otherwise the batch is likely to error when it executes.
+                    </div>
+                    <div className="mt-1 text-muted">Details: {blastRadiusError}</div>
+                </div>
+            </div>
+        )
     }
 
     if (!blastRadius) {

--- a/products/workflows/frontend/Workflows/hogflows/steps/batchTriggerLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/batchTriggerLogic.ts
@@ -1,7 +1,7 @@
-import { actions, afterMount, kea, key, path, props, propsChanged, reducers } from 'kea'
+import { actions, afterMount, kea, key, listeners, path, props, propsChanged, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import api from 'lib/api'
+import api, { ApiError } from 'lib/api'
 import { objectsEqual } from 'lib/utils'
 
 import { BlastRadiusApi } from 'products/workflows/frontend/generated/api.schemas'
@@ -22,11 +22,19 @@ export const batchTriggerLogic = kea<batchTriggerLogicType>([
     key(({ id }) => `batch-trigger-logic-${id || 'new'}`),
     actions({
         loadBlastRadius: true,
+        setBlastRadiusError: (error: string | null) => ({ error }),
     }),
     reducers(() => ({
         filters: {
             setFilters: (_, { filters }) => filters,
         },
+        blastRadiusError: [
+            null as string | null,
+            {
+                loadBlastRadius: () => null,
+                setBlastRadiusError: (_, { error }) => error,
+            },
+        ],
     })),
     loaders(({ props }) => ({
         blastRadius: [
@@ -40,6 +48,16 @@ export const batchTriggerLogic = kea<batchTriggerLogicType>([
                 },
             },
         ],
+    })),
+    listeners(({ actions }) => ({
+        loadBlastRadiusFailure: ({ errorObject }) => {
+            const apiError = errorObject as ApiError | undefined
+            const message =
+                apiError?.detail ||
+                (errorObject as Error | undefined)?.message ||
+                "Couldn't validate audience size. Your filters may not be supported."
+            actions.setBlastRadiusError(message)
+        },
     })),
     propsChanged(({ actions, props }, oldProps) => {
         if (!oldProps || !objectsEqual(props.filters, oldProps.filters)) {


### PR DESCRIPTION
## Problem

Some cohorts are not supported due to the blast radius - this adds a warning when that happens 

## Changes

As it says

## How did you test this code?

N/A

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No