### PR TITLE
chore(batch-exports): require Integration for BigQuery destinations

### DIFF
--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -1373,61 +1373,23 @@ def test_creating_http_batch_export_only_allows_events_model(
         assert response.json()["detail"] == expected_error
 
 
+_S3_FILTER_TEST_CONFIG = {
+    "bucket_name": "my-s3-bucket",
+    "region": "us-east-1",
+    "prefix": "posthog-events/",
+    "aws_access_key_id": "abc123",
+    "aws_secret_access_key": "secret",
+}
+
+
 @pytest.mark.parametrize(
-    "type,filters,config,expected_status,expected_error",
+    "filters,expected_status,expected_error",
     [
+        ({"filters": {"filter_something": 123}}, status.HTTP_400_BAD_REQUEST, "should be an array"),
+        (None, status.HTTP_201_CREATED, None),
+        ([], status.HTTP_201_CREATED, None),
         (
-            "BigQuery",
-            {"filters": {"filter_something": 123}},
-            {
-                "project_id": "test",
-                "dataset_id": "test",
-                "private_key": "pkey",
-                "private_key_id": "pkey_id",
-                "token_uri": "token",
-                "client_email": "email",
-            },
-            status.HTTP_400_BAD_REQUEST,
-            "should be an array",
-        ),
-        (
-            "BigQuery",
-            None,
-            {
-                "project_id": "test",
-                "dataset_id": "test",
-                "private_key": "pkey",
-                "private_key_id": "pkey_id",
-                "token_uri": "token",
-                "client_email": "email",
-            },
-            status.HTTP_201_CREATED,
-            None,
-        ),
-        (
-            "BigQuery",
-            [],
-            {
-                "project_id": "test",
-                "dataset_id": "test",
-                "private_key": "pkey",
-                "private_key_id": "pkey_id",
-                "token_uri": "token",
-                "client_email": "email",
-            },
-            status.HTTP_201_CREATED,
-            None,
-        ),
-        (
-            "S3",
             [{"data_interval_start": "2025-01-01"}],
-            {
-                "bucket_name": "my-s3-bucket",
-                "region": "us-east-1",
-                "prefix": "posthog-events/",
-                "aws_access_key_id": "abc123",
-                "aws_secret_access_key": "secret",
-            },
             status.HTTP_400_BAD_REQUEST,
             "not 'filters'. Trigger a backfill",
         ),
@@ -1439,17 +1401,15 @@ def test_creating_batch_export_with_filters(
     organization,
     team,
     user,
-    type,
     filters,
-    config,
     expected_status,
     expected_error,
 ):
     """Test validation of the filters field when creating a batch export."""
 
     destination_data = {
-        "type": type,
-        "config": config,
+        "type": "S3",
+        "config": _S3_FILTER_TEST_CONFIG,
     }
 
     batch_export_data = {

--- a/posthog/api/test/batch_exports/test_test.py
+++ b/posthog/api/test/batch_exports/test_test.py
@@ -350,14 +350,32 @@ def bigquery_config() -> dict[str, str]:
     }
 
 
+@pytest.fixture
+def bigquery_integration(team, user):
+    """Create a Google Cloud Service Account integration for BigQuery."""
+    return Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.GOOGLE_CLOUD_SERVICE_ACCOUNT,
+        integration_id="test-bigquery-service-account",
+        config={"project_id": "project", "service_account_email": "client_email"},
+        sensitive_config={
+            "private_key": "private_key",
+            "private_key_id": "private_key_id",
+            "token_uri": "token_uri",
+        },
+        created_by=user,
+    )
+
+
 def test_can_run_bigquery_test_step_with_castable_type(
-    client: HttpClient, bigquery_config, temporal, organization, team, user
+    client: HttpClient, bigquery_config, bigquery_integration, temporal, organization, team, user
 ):
     """Test a destination test with invalid types that can be casted to required types."""
     config = {"use_json_type": "True", **bigquery_config}  # "True" (string) can be casted to True (bool)
 
     destination_data = {
         "type": "BigQuery",
+        "integration_id": bigquery_integration.id,
         "config": config,
     }
 

--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -33,6 +33,23 @@ pytestmark = [
 ]
 
 
+@pytest.fixture
+def bigquery_integration(team, user):
+    """Create a Google Cloud Service Account integration for BigQuery."""
+    return Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.GOOGLE_CLOUD_SERVICE_ACCOUNT,
+        integration_id="test-bigquery-service-account",
+        config={"project_id": "test", "service_account_email": "email"},
+        sensitive_config={
+            "private_key": "pkey",
+            "private_key_id": "pkey_id",
+            "token_uri": "token",
+        },
+        created_by=user,
+    )
+
+
 def test_can_put_config(client: HttpClient, temporal, organization, team, user):
     destination_data: dict[str, t.Any] = {
         "type": "S3",
@@ -533,6 +550,7 @@ def test_patch_different_type_resets_config(
     organization,
     team,
     user,
+    bigquery_integration,
 ):
     """Assert patching a config with a different type resets it.
 
@@ -567,10 +585,10 @@ def test_patch_different_type_resets_config(
 
     new_destination_data = {
         "type": "BigQuery",
+        "integration_id": bigquery_integration.id,
         "config": {
             "table_id": "test",
             "dataset_id": "test",
-            "project_id": "test",
         },
     }
 
@@ -587,8 +605,8 @@ def test_patch_different_type_resets_config(
     assert batch_export_data["destination"]["config"].get("bucket_name") is None
     assert batch_export_data["destination"]["config"].get("aws_secret_access_key") is None
     assert batch_export_data["destination"]["config"]["dataset_id"] == "test"
-    assert batch_export_data["destination"]["config"]["project_id"] == "test"
     assert batch_export_data["destination"]["config"]["table_id"] == "test"
+    assert batch_export_data["destination"]["integration"] == bigquery_integration.id
 
     # validate the underlying temporal schedule has been updated
     codec = EncryptionCodec(settings=settings)

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -257,6 +257,30 @@ class DatabricksDestinationConfigSerializer(serializers.Serializer):
     )
 
 
+class BigQueryDestinationConfigSerializer(serializers.Serializer):
+    """Typed configuration for a BigQuery batch-export destination.
+
+    Credentials live in the linked Integration, not in this config. Mirrors the
+    non-credential fields of `BigQueryBatchExportInputs` in
+    `products/batch_exports/backend/service.py`.
+    """
+
+    dataset_id = serializers.CharField(help_text="BigQuery dataset ID to write to.")
+    table_id = serializers.CharField(
+        required=False,
+        default="events",
+        help_text="BigQuery table ID inside the dataset.",
+    )
+    use_json_type = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text=(
+            "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type "
+            "rather than STRING. Cannot be changed after the export is created."
+        ),
+    )
+
+
 class AzureBlobDestinationConfigSerializer(serializers.Serializer):
     """Typed configuration for an Azure Blob Storage batch-export destination.
 
@@ -298,6 +322,7 @@ class AzureBlobDestinationConfigSerializer(serializers.Serializer):
         serializers={
             "Databricks": DatabricksDestinationConfigSerializer,
             "AzureBlob": AzureBlobDestinationConfigSerializer,
+            "BigQuery": BigQueryDestinationConfigSerializer,
         },
         resource_type_field_name="type",
     )
@@ -338,11 +363,24 @@ class AzureBlobDestinationRequestSerializer(serializers.Serializer):
     config = AzureBlobDestinationConfigSerializer()
 
 
+class BigQueryDestinationRequestSerializer(serializers.Serializer):
+    """Request shape for creating or updating a BigQuery batch-export destination."""
+
+    type = serializers.ChoiceField(choices=["BigQuery"])
+    integration_id = serializers.IntegerField(
+        help_text=(
+            "ID of a google-cloud-service-account-kind Integration. Use the integrations-list MCP tool to find one."
+        ),
+    )
+    config = BigQueryDestinationConfigSerializer()
+
+
 BatchExportDestinationRequest = PolymorphicProxySerializer(
     component_name="BatchExportDestinationRequest",
     serializers={
         "Databricks": DatabricksDestinationRequestSerializer,
         "AzureBlob": AzureBlobDestinationRequestSerializer,
+        "BigQuery": BigQueryDestinationRequestSerializer,
     },
     resource_type_field_name="type",
 )
@@ -352,8 +390,8 @@ BatchExportDestinationRequest = PolymorphicProxySerializer(
 class BatchExportDestinationRequestField(serializers.JSONField):
     """JSONField annotated with a polymorphic OpenAPI request schema.
 
-    Only integration-backed destinations (Databricks, AzureBlob) are exposed in the
-    schema — their integration_id is required so clients and MCP tools know up front
+    Only integration-backed destinations (Databricks, AzureBlob, BigQuery) are exposed in
+    the schema — their integration_id is required so clients and MCP tools know up front
     that these destinations need a linked Integration. Runtime validation remains
     `BatchExportDestinationSerializer.validate_destination`.
     """
@@ -413,7 +451,7 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
     """Serializer for an BatchExportDestination model.
 
     The `config` field is polymorphic and typed only for destinations that keep
-    credentials in the linked Integration (currently Databricks and AzureBlob).
+    credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
     Other destination types accept the same JSON shape but without a typed
     OpenAPI schema. Secret fields are stripped from `config` on read.
     """
@@ -421,7 +459,7 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
     config = TypedBatchExportDestinationConfigField(
         help_text=(
             "Destination-specific configuration. Fields depend on `type`. Credentials for "
-            "integration-backed destinations (Databricks, AzureBlob) are NOT stored here — "
+            "integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — "
             "they live in the linked Integration. Secret fields are stripped from responses."
         ),
     )
@@ -438,8 +476,8 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
         help_text=(
-            "ID of a team-scoped Integration providing credentials. Required for Databricks "
-            "and AzureBlob destinations; optional for BigQuery; unused for other types."
+            "ID of a team-scoped Integration providing credentials. Required for Databricks, "
+            "AzureBlob, and BigQuery destinations; unused for other types."
         ),
     )
 
@@ -974,12 +1012,14 @@ class BatchExportSerializer(serializers.ModelSerializer):
 
         if destination_type == BatchExportDestination.Destination.BIGQUERY:
             team_id = self.context["team_id"]
+
             integration = destination_attrs.get("integration")
-            if integration is not None:
-                if integration.team_id != team_id:
-                    raise serializers.ValidationError("Integration does not belong to this team.")
-                if integration.kind != Integration.IntegrationKind.GOOGLE_CLOUD_SERVICE_ACCOUNT:
-                    raise serializers.ValidationError("Integration is not a Google Cloud service account integration.")
+            if integration is None:
+                raise serializers.ValidationError("Integration is required for BigQuery batch exports")
+            if integration.team_id != team_id:
+                raise serializers.ValidationError("Integration does not belong to this team.")
+            if integration.kind != Integration.IntegrationKind.GOOGLE_CLOUD_SERVICE_ACCOUNT:
+                raise serializers.ValidationError("Integration is not a Google Cloud service account integration.")
 
         if destination_type == BatchExportDestination.Destination.AZURE_BLOB:
             team_id = self.context["team_id"]
@@ -1248,8 +1288,8 @@ def recursive_dict_merge(
 @extend_schema(tags=["batch_exports"])
 @extend_schema_view(
     # Request bodies use a polymorphic destination schema so that integration-backed types
-    # (Databricks, AzureBlob) advertise integration_id as required up front. Responses
-    # continue to use BatchExportSerializer.
+    # (Databricks, AzureBlob, BigQuery) advertise integration_id as required up front.
+    # Responses continue to use BatchExportSerializer.
     create=extend_schema(request=BatchExportRequestSerializer),
     update=extend_schema(request=BatchExportRequestSerializer),
     partial_update=extend_schema(request=BatchExportRequestSerializer),

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -152,13 +152,40 @@ export interface AzureBlobDestinationConfigApi {
     type: AzureBlobDestinationConfigApiType
 }
 
-export type BatchExportDestinationConfigApi = DatabricksDestinationConfigApi | AzureBlobDestinationConfigApi
+export type BigQueryDestinationConfigApiType =
+    (typeof BigQueryDestinationConfigApiType)[keyof typeof BigQueryDestinationConfigApiType]
+
+export const BigQueryDestinationConfigApiType = {
+    BigQuery: 'BigQuery',
+} as const
+
+/**
+ * Typed configuration for a BigQuery batch-export destination.
+
+Credentials live in the linked Integration, not in this config. Mirrors the
+non-credential fields of `BigQueryBatchExportInputs` in
+`products/batch_exports/backend/service.py`.
+ */
+export interface BigQueryDestinationConfigApi {
+    /** BigQuery dataset ID to write to. */
+    dataset_id: string
+    /** BigQuery table ID inside the dataset. */
+    table_id?: string
+    /** Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created. */
+    use_json_type?: boolean
+    type: BigQueryDestinationConfigApiType
+}
+
+export type BatchExportDestinationConfigApi =
+    | DatabricksDestinationConfigApi
+    | AzureBlobDestinationConfigApi
+    | BigQueryDestinationConfigApi
 
 /**
  * Serializer for an BatchExportDestination model.
 
 The `config` field is polymorphic and typed only for destinations that keep
-credentials in the linked Integration (currently Databricks and AzureBlob).
+credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
 Other destination types accept the same JSON shape but without a typed
 OpenAPI schema. Secret fields are stripped from `config` on read.
  */
@@ -177,7 +204,7 @@ export interface BatchExportDestinationApi {
   * `NoOp` - Noop
   * `FileDownload` - File Download */
     type: BatchExportDestinationTypeEnumApi
-    /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
+    /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
     config: BatchExportDestinationConfigApi
     /**
      * The integration for this destination.
@@ -185,7 +212,7 @@ export interface BatchExportDestinationApi {
      */
     integration?: number | null
     /**
-     * ID of a team-scoped Integration providing credentials. Required for Databricks and AzureBlob destinations; optional for BigQuery; unused for other types.
+     * ID of a team-scoped Integration providing credentials. Required for Databricks, AzureBlob, and BigQuery destinations; unused for other types.
      * @nullable
      */
     integration_id?: number | null
@@ -1027,7 +1054,27 @@ export interface AzureBlobDestinationRequestApi {
     config: AzureBlobDestinationConfigApi
 }
 
-export type BatchExportDestinationRequestApi = DatabricksDestinationRequestApi | AzureBlobDestinationRequestApi
+export type BigQueryDestinationRequestApiType =
+    (typeof BigQueryDestinationRequestApiType)[keyof typeof BigQueryDestinationRequestApiType]
+
+export const BigQueryDestinationRequestApiType = {
+    BigQuery: 'BigQuery',
+} as const
+
+/**
+ * Request shape for creating or updating a BigQuery batch-export destination.
+ */
+export interface BigQueryDestinationRequestApi {
+    type: BigQueryDestinationRequestApiType
+    /** ID of a google-cloud-service-account-kind Integration. Use the integrations-list MCP tool to find one. */
+    integration_id: number
+    config: BigQueryDestinationConfigApi
+}
+
+export type BatchExportDestinationRequestApi =
+    | DatabricksDestinationRequestApi
+    | AzureBlobDestinationRequestApi
+    | BigQueryDestinationRequestApi
 
 /**
  * Request body for create/partial_update on BatchExportViewSet.
@@ -1258,6 +1305,16 @@ export type AzureBlobDestinationRequestTypeEnumApi =
 
 export const AzureBlobDestinationRequestTypeEnumApi = {
     AzureBlob: 'AzureBlob',
+} as const
+
+/**
+ * * `BigQuery` - BigQuery
+ */
+export type BigQueryDestinationRequestTypeEnumApi =
+    (typeof BigQueryDestinationRequestTypeEnumApi)[keyof typeof BigQueryDestinationRequestTypeEnumApi]
+
+export const BigQueryDestinationRequestTypeEnumApi = {
+    BigQuery: 'BigQuery',
 } as const
 
 export type BatchExportsListParams = {

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -13,6 +13,8 @@ export const batchExportsCreateBodyDestinationOneOneConfigUseVariantTypeDefault 
 export const batchExportsCreateBodyDestinationOneOneConfigUseAutomaticSchemaEvolutionDefault = true
 export const batchExportsCreateBodyDestinationOneTwoConfigPrefixDefault = ``
 export const batchExportsCreateBodyDestinationOneTwoConfigFileFormatDefault = `JSONLines`
+export const batchExportsCreateBodyDestinationOneThreeConfigTableIdDefault = `events`
+export const batchExportsCreateBodyDestinationOneThreeConfigUseJsonTypeDefault = false
 export const batchExportsCreateBodyOffsetDayMin = 0
 export const batchExportsCreateBodyOffsetDayMax = 6
 
@@ -112,6 +114,34 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating an Azure Blob Storage batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['BigQuery']),
+                        integration_id: zod
+                            .number()
+                            .describe(
+                                'ID of a google-cloud-service-account-kind Integration. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                dataset_id: zod.string().describe('BigQuery dataset ID to write to.'),
+                                table_id: zod
+                                    .string()
+                                    .default(batchExportsCreateBodyDestinationOneThreeConfigTableIdDefault)
+                                    .describe('BigQuery table ID inside the dataset.'),
+                                use_json_type: zod
+                                    .boolean()
+                                    .default(batchExportsCreateBodyDestinationOneThreeConfigUseJsonTypeDefault)
+                                    .describe(
+                                        "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created."
+                                    ),
+                                type: zod.enum(['BigQuery']),
+                            })
+                            .describe(
+                                'Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a BigQuery batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -400,6 +430,8 @@ export const batchExportsUpdateBodyDestinationOneOneConfigUseVariantTypeDefault 
 export const batchExportsUpdateBodyDestinationOneOneConfigUseAutomaticSchemaEvolutionDefault = true
 export const batchExportsUpdateBodyDestinationOneTwoConfigPrefixDefault = ``
 export const batchExportsUpdateBodyDestinationOneTwoConfigFileFormatDefault = `JSONLines`
+export const batchExportsUpdateBodyDestinationOneThreeConfigTableIdDefault = `events`
+export const batchExportsUpdateBodyDestinationOneThreeConfigUseJsonTypeDefault = false
 export const batchExportsUpdateBodyOffsetDayMin = 0
 export const batchExportsUpdateBodyOffsetDayMax = 6
 
@@ -499,6 +531,34 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating an Azure Blob Storage batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['BigQuery']),
+                        integration_id: zod
+                            .number()
+                            .describe(
+                                'ID of a google-cloud-service-account-kind Integration. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                dataset_id: zod.string().describe('BigQuery dataset ID to write to.'),
+                                table_id: zod
+                                    .string()
+                                    .default(batchExportsUpdateBodyDestinationOneThreeConfigTableIdDefault)
+                                    .describe('BigQuery table ID inside the dataset.'),
+                                use_json_type: zod
+                                    .boolean()
+                                    .default(batchExportsUpdateBodyDestinationOneThreeConfigUseJsonTypeDefault)
+                                    .describe(
+                                        "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created."
+                                    ),
+                                type: zod.enum(['BigQuery']),
+                            })
+                            .describe(
+                                'Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a BigQuery batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -542,6 +602,8 @@ export const batchExportsPartialUpdateBodyDestinationOneOneConfigUseVariantTypeD
 export const batchExportsPartialUpdateBodyDestinationOneOneConfigUseAutomaticSchemaEvolutionDefault = true
 export const batchExportsPartialUpdateBodyDestinationOneTwoConfigPrefixDefault = ``
 export const batchExportsPartialUpdateBodyDestinationOneTwoConfigFileFormatDefault = `JSONLines`
+export const batchExportsPartialUpdateBodyDestinationOneThreeConfigTableIdDefault = `events`
+export const batchExportsPartialUpdateBodyDestinationOneThreeConfigUseJsonTypeDefault = false
 export const batchExportsPartialUpdateBodyOffsetDayMin = 0
 export const batchExportsPartialUpdateBodyOffsetDayMax = 6
 
@@ -641,6 +703,34 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating an Azure Blob Storage batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['BigQuery']),
+                        integration_id: zod
+                            .number()
+                            .describe(
+                                'ID of a google-cloud-service-account-kind Integration. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                dataset_id: zod.string().describe('BigQuery dataset ID to write to.'),
+                                table_id: zod
+                                    .string()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneThreeConfigTableIdDefault)
+                                    .describe('BigQuery table ID inside the dataset.'),
+                                use_json_type: zod
+                                    .boolean()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneThreeConfigUseJsonTypeDefault)
+                                    .describe(
+                                        "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created."
+                                    ),
+                                type: zod.enum(['BigQuery']),
+                            })
+                            .describe(
+                                'Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a BigQuery batch-export destination.'),
             ])
             .optional()
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
@@ -689,6 +779,8 @@ export const batchExportsPauseCreateBodyDestinationOneConfigOneOneUseVariantType
 export const batchExportsPauseCreateBodyDestinationOneConfigOneOneUseAutomaticSchemaEvolutionDefault = true
 export const batchExportsPauseCreateBodyDestinationOneConfigOneTwoPrefixDefault = ``
 export const batchExportsPauseCreateBodyDestinationOneConfigOneTwoFileFormatDefault = `JSONLines`
+export const batchExportsPauseCreateBodyDestinationOneConfigOneThreeTableIdDefault = `events`
+export const batchExportsPauseCreateBodyDestinationOneConfigOneThreeUseJsonTypeDefault = false
 export const batchExportsPauseCreateBodyOffsetDayMin = 0
 export const batchExportsPauseCreateBodyOffsetDayMax = 6
 
@@ -795,20 +887,38 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for an Azure Blob Storage batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors\n`AzureBlobBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                dataset_id: zod.string().describe('BigQuery dataset ID to write to.'),
+                                table_id: zod
+                                    .string()
+                                    .default(batchExportsPauseCreateBodyDestinationOneConfigOneThreeTableIdDefault)
+                                    .describe('BigQuery table ID inside the dataset.'),
+                                use_json_type: zod
+                                    .boolean()
+                                    .default(batchExportsPauseCreateBodyDestinationOneConfigOneThreeUseJsonTypeDefault)
+                                    .describe(
+                                        "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created."
+                                    ),
+                                type: zod.enum(['BigQuery']),
+                            })
+                            .describe(
+                                'Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required for Databricks and AzureBlob destinations; optional for BigQuery; unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required for Databricks, AzureBlob, and BigQuery destinations; unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks and AzureBlob).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -866,6 +976,8 @@ export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneOneUseVaria
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneOneUseAutomaticSchemaEvolutionDefault = true
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneTwoPrefixDefault = ``
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneTwoFileFormatDefault = `JSONLines`
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneThreeTableIdDefault = `events`
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneThreeUseJsonTypeDefault = false
 export const batchExportsRunTestStepCreateBodyOffsetDayMin = 0
 export const batchExportsRunTestStepCreateBodyOffsetDayMax = 6
 
@@ -976,20 +1088,42 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for an Azure Blob Storage batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors\n`AzureBlobBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                dataset_id: zod.string().describe('BigQuery dataset ID to write to.'),
+                                table_id: zod
+                                    .string()
+                                    .default(
+                                        batchExportsRunTestStepCreateBodyDestinationOneConfigOneThreeTableIdDefault
+                                    )
+                                    .describe('BigQuery table ID inside the dataset.'),
+                                use_json_type: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsRunTestStepCreateBodyDestinationOneConfigOneThreeUseJsonTypeDefault
+                                    )
+                                    .describe(
+                                        "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created."
+                                    ),
+                                type: zod.enum(['BigQuery']),
+                            })
+                            .describe(
+                                'Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required for Databricks and AzureBlob destinations; optional for BigQuery; unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required for Databricks, AzureBlob, and BigQuery destinations; unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks and AzureBlob).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -1050,6 +1184,8 @@ export const batchExportsUnpauseCreateBodyDestinationOneConfigOneOneUseVariantTy
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneOneUseAutomaticSchemaEvolutionDefault = true
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneTwoPrefixDefault = ``
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneTwoFileFormatDefault = `JSONLines`
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneThreeTableIdDefault = `events`
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneThreeUseJsonTypeDefault = false
 export const batchExportsUnpauseCreateBodyOffsetDayMin = 0
 export const batchExportsUnpauseCreateBodyOffsetDayMax = 6
 
@@ -1158,20 +1294,40 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for an Azure Blob Storage batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors\n`AzureBlobBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                dataset_id: zod.string().describe('BigQuery dataset ID to write to.'),
+                                table_id: zod
+                                    .string()
+                                    .default(batchExportsUnpauseCreateBodyDestinationOneConfigOneThreeTableIdDefault)
+                                    .describe('BigQuery table ID inside the dataset.'),
+                                use_json_type: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsUnpauseCreateBodyDestinationOneConfigOneThreeUseJsonTypeDefault
+                                    )
+                                    .describe(
+                                        "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created."
+                                    ),
+                                type: zod.enum(['BigQuery']),
+                            })
+                            .describe(
+                                'Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required for Databricks and AzureBlob destinations; optional for BigQuery; unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required for Databricks, AzureBlob, and BigQuery destinations; unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks and AzureBlob).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -1229,6 +1385,8 @@ export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneOneUseVa
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneOneUseAutomaticSchemaEvolutionDefault = true
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneTwoPrefixDefault = ``
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneTwoFileFormatDefault = `JSONLines`
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneThreeTableIdDefault = `events`
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneThreeUseJsonTypeDefault = false
 export const batchExportsRunTestStepNewCreateBodyOffsetDayMin = 0
 export const batchExportsRunTestStepNewCreateBodyOffsetDayMax = 6
 
@@ -1341,20 +1499,42 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for an Azure Blob Storage batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors\n`AzureBlobBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                dataset_id: zod.string().describe('BigQuery dataset ID to write to.'),
+                                table_id: zod
+                                    .string()
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneThreeTableIdDefault
+                                    )
+                                    .describe('BigQuery table ID inside the dataset.'),
+                                use_json_type: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneThreeUseJsonTypeDefault
+                                    )
+                                    .describe(
+                                        "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created."
+                                    ),
+                                type: zod.enum(['BigQuery']),
+                            })
+                            .describe(
+                                'Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required for Databricks and AzureBlob destinations; optional for BigQuery; unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required for Databricks, AzureBlob, and BigQuery destinations; unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks and AzureBlob).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -5082,13 +5082,37 @@ export namespace Schemas {
       type: DatabricksDestinationConfigType;
     }
 
-    export type BatchExportDestinationConfig = DatabricksDestinationConfig | AzureBlobDestinationConfig;
+    export type BigQueryDestinationConfigType = typeof BigQueryDestinationConfigType[keyof typeof BigQueryDestinationConfigType];
+
+
+    export const BigQueryDestinationConfigType = {
+      BigQuery: 'BigQuery',
+    } as const;
+
+    /**
+     * Typed configuration for a BigQuery batch-export destination.
+
+    Credentials live in the linked Integration, not in this config. Mirrors the
+    non-credential fields of `BigQueryBatchExportInputs` in
+    `products/batch_exports/backend/service.py`.
+     */
+    export interface BigQueryDestinationConfig {
+      /** BigQuery dataset ID to write to. */
+      dataset_id: string;
+      /** BigQuery table ID inside the dataset. */
+      table_id?: string;
+      /** Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created. */
+      use_json_type?: boolean;
+      type: BigQueryDestinationConfigType;
+    }
+
+    export type BatchExportDestinationConfig = DatabricksDestinationConfig | AzureBlobDestinationConfig | BigQueryDestinationConfig;
 
     /**
      * Serializer for an BatchExportDestination model.
 
     The `config` field is polymorphic and typed only for destinations that keep
-    credentials in the linked Integration (currently Databricks and AzureBlob).
+    credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
     Other destination types accept the same JSON shape but without a typed
     OpenAPI schema. Secret fields are stripped from `config` on read.
      */
@@ -5107,7 +5131,7 @@ export namespace Schemas {
       * `NoOp` - Noop
       * `FileDownload` - File Download */
       type: BatchExportDestinationTypeEnum;
-      /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
+      /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
       config: BatchExportDestinationConfig;
       /**
          * The integration for this destination.
@@ -5115,7 +5139,7 @@ export namespace Schemas {
          */
       integration?: number | null;
       /**
-         * ID of a team-scoped Integration providing credentials. Required for Databricks and AzureBlob destinations; optional for BigQuery; unused for other types.
+         * ID of a team-scoped Integration providing credentials. Required for Databricks, AzureBlob, and BigQuery destinations; unused for other types.
          * @nullable
          */
       integration_id?: number | null;
@@ -6024,7 +6048,24 @@ export namespace Schemas {
       config: DatabricksDestinationConfig;
     }
 
-    export type BatchExportDestinationRequest = DatabricksDestinationRequest | AzureBlobDestinationRequest;
+    export type BigQueryDestinationRequestType = typeof BigQueryDestinationRequestType[keyof typeof BigQueryDestinationRequestType];
+
+
+    export const BigQueryDestinationRequestType = {
+      BigQuery: 'BigQuery',
+    } as const;
+
+    /**
+     * Request shape for creating or updating a BigQuery batch-export destination.
+     */
+    export interface BigQueryDestinationRequest {
+      type: BigQueryDestinationRequestType;
+      /** ID of a google-cloud-service-account-kind Integration. Use the integrations-list MCP tool to find one. */
+      integration_id: number;
+      config: BigQueryDestinationConfig;
+    }
+
+    export type BatchExportDestinationRequest = DatabricksDestinationRequest | AzureBlobDestinationRequest | BigQueryDestinationRequest;
 
     /**
      * Request body for create/partial_update on BatchExportViewSet.
@@ -6165,6 +6206,16 @@ export namespace Schemas {
       /** Observed share of users assigned to `$multiple`, as a percentage (0-100). */
       multiple_variant_percentage: number;
     }
+
+    /**
+     * * `BigQuery` - BigQuery
+     */
+    export type BigQueryDestinationRequestTypeEnum = typeof BigQueryDestinationRequestTypeEnum[keyof typeof BigQueryDestinationRequestTypeEnum];
+
+
+    export const BigQueryDestinationRequestTypeEnum = {
+      BigQuery: 'BigQuery',
+    } as const;
 
     export interface BlastRadius {
       /** Number of users matching the filters */

--- a/services/mcp/src/generated/batch_exports/api.ts
+++ b/services/mcp/src/generated/batch_exports/api.ts
@@ -33,6 +33,8 @@ export const batchExportsCreateBodyDestinationOneOneConfigUseVariantTypeDefault 
 export const batchExportsCreateBodyDestinationOneOneConfigUseAutomaticSchemaEvolutionDefault = true
 export const batchExportsCreateBodyDestinationOneTwoConfigPrefixDefault = ``
 export const batchExportsCreateBodyDestinationOneTwoConfigFileFormatDefault = `JSONLines`
+export const batchExportsCreateBodyDestinationOneThreeConfigTableIdDefault = `events`
+export const batchExportsCreateBodyDestinationOneThreeConfigUseJsonTypeDefault = false
 export const batchExportsCreateBodyOffsetDayMin = 0
 export const batchExportsCreateBodyOffsetDayMax = 6
 
@@ -130,6 +132,33 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating an Azure Blob Storage batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['BigQuery']),
+                        integration_id: zod
+                            .number()
+                            .describe(
+                                'ID of a google-cloud-service-account-kind Integration. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                dataset_id: zod.string().describe('BigQuery dataset ID to write to.'),
+                                table_id: zod
+                                    .string()
+                                    .default(batchExportsCreateBodyDestinationOneThreeConfigTableIdDefault)
+                                    .describe('BigQuery table ID inside the dataset.'),
+                                use_json_type: zod
+                                    .boolean()
+                                    .default(batchExportsCreateBodyDestinationOneThreeConfigUseJsonTypeDefault)
+                                    .describe(
+                                        "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created."
+                                    ),
+                            })
+                            .describe(
+                                'Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products/batch_exports/backend/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a BigQuery batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -186,6 +215,8 @@ export const batchExportsPartialUpdateBodyDestinationOneOneConfigUseVariantTypeD
 export const batchExportsPartialUpdateBodyDestinationOneOneConfigUseAutomaticSchemaEvolutionDefault = true
 export const batchExportsPartialUpdateBodyDestinationOneTwoConfigPrefixDefault = ``
 export const batchExportsPartialUpdateBodyDestinationOneTwoConfigFileFormatDefault = `JSONLines`
+export const batchExportsPartialUpdateBodyDestinationOneThreeConfigTableIdDefault = `events`
+export const batchExportsPartialUpdateBodyDestinationOneThreeConfigUseJsonTypeDefault = false
 export const batchExportsPartialUpdateBodyOffsetDayMin = 0
 export const batchExportsPartialUpdateBodyOffsetDayMax = 6
 
@@ -283,6 +314,33 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating an Azure Blob Storage batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['BigQuery']),
+                        integration_id: zod
+                            .number()
+                            .describe(
+                                'ID of a google-cloud-service-account-kind Integration. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                dataset_id: zod.string().describe('BigQuery dataset ID to write to.'),
+                                table_id: zod
+                                    .string()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneThreeConfigTableIdDefault)
+                                    .describe('BigQuery table ID inside the dataset.'),
+                                use_json_type: zod
+                                    .boolean()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneThreeConfigUseJsonTypeDefault)
+                                    .describe(
+                                        "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created."
+                                    ),
+                            })
+                            .describe(
+                                'Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products/batch_exports/backend/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a BigQuery batch-export destination.'),
             ])
             .optional()
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/batch-export-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/batch-export-create.json
@@ -112,6 +112,42 @@
                     },
                     "required": ["type", "integration_id", "config"],
                     "type": "object"
+                },
+                {
+                    "description": "Request shape for creating or updating a BigQuery batch-export destination.",
+                    "properties": {
+                        "config": {
+                            "description": "Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products/batch_exports/backend/service.py`.",
+                            "properties": {
+                                "dataset_id": {
+                                    "description": "BigQuery dataset ID to write to.",
+                                    "type": "string"
+                                },
+                                "table_id": {
+                                    "default": "events",
+                                    "description": "BigQuery table ID inside the dataset.",
+                                    "type": "string"
+                                },
+                                "use_json_type": {
+                                    "default": false,
+                                    "description": "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": ["dataset_id"],
+                            "type": "object"
+                        },
+                        "integration_id": {
+                            "description": "ID of a google-cloud-service-account-kind Integration. Use the integrations-list MCP tool to find one.",
+                            "type": "number"
+                        },
+                        "type": {
+                            "enum": ["BigQuery"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "integration_id", "config"],
+                    "type": "object"
                 }
             ],
             "description": "Destination configuration. Required integration_id is enforced per destination type."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/batch-export-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/batch-export-update.json
@@ -111,6 +111,42 @@
                     },
                     "required": ["type", "integration_id", "config"],
                     "type": "object"
+                },
+                {
+                    "description": "Request shape for creating or updating a BigQuery batch-export destination.",
+                    "properties": {
+                        "config": {
+                            "description": "Typed configuration for a BigQuery batch-export destination.\n\nCredentials live in the linked Integration, not in this config. Mirrors the\nnon-credential fields of `BigQueryBatchExportInputs` in\n`products/batch_exports/backend/service.py`.",
+                            "properties": {
+                                "dataset_id": {
+                                    "description": "BigQuery dataset ID to write to.",
+                                    "type": "string"
+                                },
+                                "table_id": {
+                                    "default": "events",
+                                    "description": "BigQuery table ID inside the dataset.",
+                                    "type": "string"
+                                },
+                                "use_json_type": {
+                                    "default": false,
+                                    "description": "Whether to export 'properties', 'set', and 'set_once' fields as the BigQuery JSON type rather than STRING. Cannot be changed after the export is created.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": ["dataset_id"],
+                            "type": "object"
+                        },
+                        "integration_id": {
+                            "description": "ID of a google-cloud-service-account-kind Integration. Use the integrations-list MCP tool to find one.",
+                            "type": "number"
+                        },
+                        "type": {
+                            "enum": ["BigQuery"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "integration_id", "config"],
+                    "type": "object"
                 }
             ],
             "description": "Destination configuration. Required integration_id is enforced per destination type."


### PR DESCRIPTION
## Problem

BigQuery batch-export destinations could be created with either a linked Google Cloud Service Account Integration or inline credentials in the destination config. The frontend now only offers the integration path, but the API still accepted both.

## Changes

- `posthog/batch_exports/http.py`:
  - New typed `BigQueryDestinationConfigSerializer` (`dataset_id`, `table_id`, `use_json_type`) and `BigQueryDestinationRequestSerializer` with required `integration_id`, registered in the polymorphic config and request schemas.
  - `validate_destination` now raises `Integration is required for BigQuery batch exports` when missing — same shape as the Databricks/AzureBlob check.
  - Updated docstrings and the `integration_id` `help_text` to list the three integration-backed destinations.
- Tests: added a `bigquery_integration` fixture in `test_update.py` and `test_test.py` and updated the BigQuery cases (`test_patch_different_type_resets_config`, `test_can_run_bigquery_test_step_with_castable_type`) to pass `integration_id`.
- Regenerated frontend and MCP artifacts via `hogli build:openapi`.

## How did you test this code?

Automated tests.

## Publish to changelog?

no

## Docs update

No user-facing docs change — the UI flow already required an Integration.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.7). Mirrored the existing Databricks/AzureBlob enforcement pattern.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*