### PR TITLE
refactor(hog-charts): dedupe helpers and tighten overlay rendering

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -6,6 +6,7 @@ import { type BarRect, drawBarHighlight, drawBars, drawGrid, type DrawContext } 
 import { Chart } from '../../core/Chart'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
 import {
+    buildStackedResolveValue,
     computePercentStackData,
     computeStackData,
     createBarScales,
@@ -299,20 +300,7 @@ function BarChartInner<Meta = unknown>({
         [stackedData, barLayout, isHorizontal, topStackedKeyByAxis, barCornerRadius]
     )
 
-    const resolveValue = useMemo(() => {
-        if (!stackedData) {
-            return undefined
-        }
-        // Return the stacked top so the tooltip anchor lands at the visual top of each segment, not the raw series value.
-        return (s: Series, dataIndex: number): number => {
-            const stacked = stackedData.get(s.key)?.top[dataIndex]
-            if (stacked != null && Number.isFinite(stacked)) {
-                return stacked
-            }
-            const raw = s.data[dataIndex]
-            return typeof raw === 'number' && Number.isFinite(raw) ? raw : 0
-        }
-    }, [stackedData])
+    const resolveValue = useMemo(() => buildStackedResolveValue(stackedData), [stackedData])
 
     return (
         <Chart

--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -9,10 +9,11 @@ import {
     computePercentStackData,
     computeStackData,
     createScales as createLineScales,
+    resolveYScaleForSeries,
     yTickCountForHeight,
 } from '../core/scales'
 import type { ScaleSet, StackedBand } from '../core/scales'
-import { DEFAULT_Y_AXIS_ID, resolveYScaleForSeries } from '../core/types'
+import { DEFAULT_Y_AXIS_ID } from '../core/types'
 import type {
     ChartDimensions,
     ChartDrawArgs,

--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -5,13 +5,14 @@ import type { DrawContext } from '../core/canvas-renderer'
 import { Chart } from '../core/Chart'
 import { ChartErrorBoundary } from '../core/ChartErrorBoundary'
 import {
+    buildStackedResolveValue,
     computePercentStackData,
     computeStackData,
     createScales as createLineScales,
     yTickCountForHeight,
 } from '../core/scales'
 import type { ScaleSet, StackedBand } from '../core/scales'
-import { DEFAULT_Y_AXIS_ID } from '../core/types'
+import { DEFAULT_Y_AXIS_ID, resolveYScaleForSeries } from '../core/types'
 import type {
     ChartDimensions,
     ChartDrawArgs,
@@ -205,10 +206,6 @@ function LineChartInner<Meta = unknown>({
             if (hoverIndex < 0) {
                 return
             }
-            const resolveChartYScale = (s: ResolvedSeries): ((value: number) => number) => {
-                const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
-                return scales.yAxes?.[axisId]?.scale ?? scales.y
-            }
             for (const s of coloredSeries) {
                 if (s.visibility?.excluded || s.fill?.lowerData) {
                     continue
@@ -221,7 +218,7 @@ function LineChartInner<Meta = unknown>({
                 }
                 const data = stackedData?.get(s.key)?.top ?? s.data
                 const x = scales.x(drawLabels[hoverIndex])
-                const y = resolveChartYScale(s)(data[hoverIndex])
+                const y = resolveYScaleForSeries(scales, s)(data[hoverIndex])
                 if (x != null && isFinite(y)) {
                     drawHighlightPoint(ctx, x, y, s.color, theme.backgroundColor ?? '#ffffff')
                 }
@@ -230,19 +227,7 @@ function LineChartInner<Meta = unknown>({
         [stackedData]
     )
 
-    const resolveValue = useMemo(() => {
-        if (!stackedData) {
-            return undefined
-        }
-        return (s: Series, dataIndex: number): number => {
-            const stacked = stackedData.get(s.key)?.top[dataIndex]
-            if (stacked != null && Number.isFinite(stacked)) {
-                return stacked
-            }
-            const raw = s.data[dataIndex]
-            return typeof raw === 'number' && Number.isFinite(raw) ? raw : 0
-        }
-    }, [stackedData])
+    const resolveValue = useMemo(() => buildStackedResolveValue(stackedData), [stackedData])
 
     return (
         <Chart

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -24,8 +24,6 @@ import {
     type ValueLabelsConfig,
 } from '../utils/use-value-labels'
 
-export type { ValueLabelsConfig }
-
 export interface TimeSeriesBarChartConfig {
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -17,12 +17,12 @@ import {
     type XAxisConfig,
     type YAxisConfig,
 } from '../../utils/use-axis-formatters'
+import { BarChart } from '../BarChart/BarChart'
 import {
     resolveValueLabelsConfig,
     useSeriesWithValueLabelAllowlist,
     type ValueLabelsConfig,
 } from '../utils/use-value-labels'
-import { BarChart } from '../BarChart/BarChart'
 
 export type { ValueLabelsConfig }
 

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -17,12 +17,14 @@ import {
     type XAxisConfig,
     type YAxisConfig,
 } from '../../utils/use-axis-formatters'
+import {
+    resolveValueLabelsConfig,
+    useSeriesWithValueLabelAllowlist,
+    type ValueLabelsConfig,
+} from '../utils/use-value-labels'
 import { BarChart } from '../BarChart/BarChart'
 
-export interface ValueLabelsConfig {
-    seriesKeys?: string[]
-    formatter?: (value: number) => string
-}
+export type { ValueLabelsConfig }
 
 export interface TimeSeriesBarChartConfig {
     xAxis?: XAxisConfig
@@ -54,16 +56,6 @@ export interface TimeSeriesBarChartProps<Meta = unknown> {
     onError?: (error: Error, info: React.ErrorInfo) => void
 }
 
-function resolveValueLabelsConfig(valueLabels: TimeSeriesBarChartConfig['valueLabels']): ValueLabelsConfig | null {
-    if (valueLabels === undefined || valueLabels === false) {
-        return null
-    }
-    if (valueLabels === true) {
-        return {}
-    }
-    return valueLabels
-}
-
 export function TimeSeriesBarChart<Meta = unknown>({
     series,
     labels,
@@ -91,21 +83,7 @@ export function TimeSeriesBarChart<Meta = unknown>({
     const yTickFormatter = useYTickFormatter(yAxis)
 
     const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
-
-    // Stable primitive key so callers can pass `valueLabels: { seriesKeys: ['a'] }` inline
-    // without re-running the transform on every render.
-    const seriesKeysSignature = valueLabelsConfig?.seriesKeys?.join(' ')
-    const seriesAfterValueLabels = useMemo(() => {
-        const seriesKeys = valueLabelsConfig?.seriesKeys
-        if (!seriesKeys) {
-            return series
-        }
-        const allowed = new Set(seriesKeys)
-        return series.map((s) =>
-            allowed.has(s.key) ? s : { ...s, visibility: { ...s.visibility, valueLabel: false } }
-        )
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [series, seriesKeysSignature])
+    const seriesAfterValueLabels = useSeriesWithValueLabelAllowlist(series, valueLabelsConfig?.seriesKeys)
 
     const valueLabelFormatter = valueLabelsConfig ? (valueLabelsConfig.formatter ?? yTickFormatter) : undefined
 

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -17,12 +17,12 @@ import {
     type XAxisConfig,
     type YAxisConfig,
 } from '../../utils/use-axis-formatters'
+import { LineChart } from '../LineChart'
 import {
     resolveValueLabelsConfig,
     useSeriesWithValueLabelAllowlist,
     type ValueLabelsConfig,
 } from '../utils/use-value-labels'
-import { LineChart } from '../LineChart'
 import {
     useDerivedSeries,
     type ConfidenceIntervalConfig,

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -30,7 +30,6 @@ import {
     type TrendLineConfig,
 } from './utils/use-derived-series'
 
-export type { ValueLabelsConfig }
 export type { ConfidenceIntervalConfig, MovingAverageConfig, TrendLineConfig }
 
 export interface TimeSeriesLineChartConfig {

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -17,6 +17,11 @@ import {
     type XAxisConfig,
     type YAxisConfig,
 } from '../../utils/use-axis-formatters'
+import {
+    resolveValueLabelsConfig,
+    useSeriesWithValueLabelAllowlist,
+    type ValueLabelsConfig,
+} from '../utils/use-value-labels'
 import { LineChart } from '../LineChart'
 import {
     useDerivedSeries,
@@ -25,11 +30,7 @@ import {
     type TrendLineConfig,
 } from './utils/use-derived-series'
 
-export interface ValueLabelsConfig {
-    seriesKeys?: string[]
-    formatter?: (value: number) => string
-}
-
+export type { ValueLabelsConfig }
 export type { ConfidenceIntervalConfig, MovingAverageConfig, TrendLineConfig }
 
 export interface TimeSeriesLineChartConfig {
@@ -63,16 +64,6 @@ export interface TimeSeriesLineChartProps<Meta = unknown> {
     onError?: (error: Error, info: React.ErrorInfo) => void
 }
 
-function resolveValueLabelsConfig(valueLabels: TimeSeriesLineChartConfig['valueLabels']): ValueLabelsConfig | null {
-    if (valueLabels === undefined || valueLabels === false) {
-        return null
-    }
-    if (valueLabels === true) {
-        return {}
-    }
-    return valueLabels
-}
-
 export function TimeSeriesLineChart<Meta = unknown>({
     series,
     labels,
@@ -102,21 +93,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
     const yTickFormatter = useYTickFormatter(yAxis)
 
     const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
-
-    // Stable primitive key so callers can pass `valueLabels: { seriesKeys: ['a'] }` inline
-    // without re-running the transform on every render.
-    const seriesKeysSignature = valueLabelsConfig?.seriesKeys?.join(' ')
-    const seriesAfterValueLabels = useMemo(() => {
-        const seriesKeys = valueLabelsConfig?.seriesKeys
-        if (!seriesKeys) {
-            return series
-        }
-        const allowed = new Set(seriesKeys)
-        return series.map((s) =>
-            allowed.has(s.key) ? s : { ...s, visibility: { ...s.visibility, valueLabel: false } }
-        )
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [series, seriesKeysSignature])
+    const seriesAfterValueLabels = useSeriesWithValueLabelAllowlist(series, valueLabelsConfig?.seriesKeys)
 
     const finalSeries = useDerivedSeries(seriesAfterValueLabels, {
         confidenceIntervals,

--- a/frontend/src/lib/hog-charts/charts/utils/use-value-labels.ts
+++ b/frontend/src/lib/hog-charts/charts/utils/use-value-labels.ts
@@ -3,19 +3,11 @@ import { useMemo } from 'react'
 import type { Series } from '../../core/types'
 
 export interface ValueLabelsConfig {
-    /** Restricts the labels to these series keys. Series outside the set keep rendering
-     *  but have `visibility.valueLabel` flipped off so the {@link ValueLabels} overlay
-     *  skips them. Omit (or pass `undefined`) to label every series. */
     seriesKeys?: string[]
-    /** Custom value formatter. Falls back to the chart's resolved y-axis formatter when omitted. */
     formatter?: (value: number) => string
 }
 
-/** Normalizes the public `valueLabels` prop to a config (or `null` when value labels
- *  are disabled). `true` becomes `{}` so callers can opt in without supplying options. */
-export function resolveValueLabelsConfig(
-    input: boolean | ValueLabelsConfig | undefined
-): ValueLabelsConfig | null {
+export function resolveValueLabelsConfig(input: boolean | ValueLabelsConfig | undefined): ValueLabelsConfig | null {
     if (input === undefined || input === false) {
         return null
     }
@@ -25,8 +17,6 @@ export function resolveValueLabelsConfig(
     return input
 }
 
-/** Restrict value-label visibility to a given series-key allowlist. Returns the input
- *  series untouched when no allowlist is set. */
 export function useSeriesWithValueLabelAllowlist<Meta>(
     series: Series<Meta>[],
     seriesKeys: string[] | undefined

--- a/frontend/src/lib/hog-charts/charts/utils/use-value-labels.ts
+++ b/frontend/src/lib/hog-charts/charts/utils/use-value-labels.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react'
+
+import type { Series } from '../../core/types'
+
+export interface ValueLabelsConfig {
+    /** Restricts the labels to these series keys. Series outside the set keep rendering
+     *  but have `visibility.valueLabel` flipped off so the {@link ValueLabels} overlay
+     *  skips them. Omit (or pass `undefined`) to label every series. */
+    seriesKeys?: string[]
+    /** Custom value formatter. Falls back to the chart's resolved y-axis formatter when omitted. */
+    formatter?: (value: number) => string
+}
+
+export type ValueLabelsConfigInput = boolean | ValueLabelsConfig | undefined
+
+/** Normalizes the public `valueLabels` prop to a config (or `null` when value labels
+ *  are disabled). `true` becomes `{}` so callers can opt in without supplying options. */
+export function resolveValueLabelsConfig(input: ValueLabelsConfigInput): ValueLabelsConfig | null {
+    if (input === undefined || input === false) {
+        return null
+    }
+    if (input === true) {
+        return {}
+    }
+    return input
+}
+
+/** Restrict value-label visibility to a given series-key allowlist. Returns the input
+ *  series untouched when no allowlist is set. */
+export function useSeriesWithValueLabelAllowlist<Meta>(
+    series: Series<Meta>[],
+    seriesKeys: string[] | undefined
+): Series<Meta>[] {
+    // Stable primitive key so callers can pass `valueLabels: { seriesKeys: ['a'] }` inline
+    // without re-running the transform on every render.
+    const seriesKeysSignature = seriesKeys?.join(' ')
+    return useMemo(() => {
+        if (!seriesKeys) {
+            return series
+        }
+        const allowed = new Set(seriesKeys)
+        return series.map((s) =>
+            allowed.has(s.key) ? s : { ...s, visibility: { ...s.visibility, valueLabel: false } }
+        )
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [series, seriesKeysSignature])
+}

--- a/frontend/src/lib/hog-charts/charts/utils/use-value-labels.ts
+++ b/frontend/src/lib/hog-charts/charts/utils/use-value-labels.ts
@@ -11,11 +11,11 @@ export interface ValueLabelsConfig {
     formatter?: (value: number) => string
 }
 
-export type ValueLabelsConfigInput = boolean | ValueLabelsConfig | undefined
-
 /** Normalizes the public `valueLabels` prop to a config (or `null` when value labels
  *  are disabled). `true` becomes `{}` so callers can opt in without supplying options. */
-export function resolveValueLabelsConfig(input: ValueLabelsConfigInput): ValueLabelsConfig | null {
+export function resolveValueLabelsConfig(
+    input: boolean | ValueLabelsConfig | undefined
+): ValueLabelsConfig | null {
     if (input === undefined || input === false) {
         return null
     }
@@ -32,8 +32,10 @@ export function useSeriesWithValueLabelAllowlist<Meta>(
     seriesKeys: string[] | undefined
 ): Series<Meta>[] {
     // Stable primitive key so callers can pass `valueLabels: { seriesKeys: ['a'] }` inline
-    // without re-running the transform on every render.
-    const seriesKeysSignature = seriesKeys?.join(' ')
+    // without re-running the transform on every render. JSON.stringify (rather than
+    // `join(' ')`) so a key that contains a space doesn't collide with two keys split on
+    // it (`['a b']` vs `['a','b']`).
+    const seriesKeysSignature = JSON.stringify(seriesKeys ?? null)
     return useMemo(() => {
         if (!seriesKeys) {
             return series

--- a/frontend/src/lib/hog-charts/core/hooks/useChartMargins.test.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartMargins.test.ts
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react'
 import type { Series } from '../types'
 import { DEFAULT_MARGINS, useChartMargins } from './useChartMargins'
 
-jest.mock('../../overlays/AxisLabels', () => ({
+jest.mock('../../utils/text-measure', () => ({
     measureLabelWidth: (text: string) => text.length * 10,
 }))
 

--- a/frontend/src/lib/hog-charts/core/hooks/useChartMargins.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartMargins.ts
@@ -1,7 +1,7 @@
 import * as d3 from 'd3'
 import { useMemo } from 'react'
 
-import { measureLabelWidth } from '../../overlays/AxisLabels'
+import { measureLabelWidth } from '../../utils/text-measure'
 import { autoFormatterFor, seriesValueRange } from '../scales'
 import { DEFAULT_Y_AXIS_ID } from '../types'
 import type { ChartMargins, Series } from '../types'

--- a/frontend/src/lib/hog-charts/core/scales.test.ts
+++ b/frontend/src/lib/hog-charts/core/scales.test.ts
@@ -1,13 +1,16 @@
 import { dimensions, makeSeries } from '../testing'
 import {
     autoFormatYTick,
+    buildStackedResolveValue,
     computePercentStackData,
     computeStackData,
     createScales,
     createXScale,
     createYScale,
+    niceLogDomain,
     yTickCountForHeight,
 } from './scales'
+import type { StackedBand } from './scales'
 import { DEFAULT_Y_AXIS_ID } from './types'
 
 describe('hog-charts scales', () => {
@@ -491,6 +494,62 @@ describe('hog-charts scales', () => {
 
         it('formats negative values correctly', () => {
             expect(autoFormatYTick(-5, 10)).toBe('-5')
+        })
+    })
+
+    describe('niceLogDomain', () => {
+        it.each([
+            { minPositive: 740, max: 4200, expected: [100, 5000] },
+            { minPositive: 1, max: 100, expected: [0.1, 100] },
+            { minPositive: 0.5, max: 9, expected: [0.1, 9] },
+            { minPositive: 25, max: 25, expected: [10, 30] },
+            { minPositive: 1000, max: 9999, expected: [100, 10000] },
+        ])('rounds [$minPositive, $max] to $expected', ({ minPositive, max, expected }) => {
+            const [niceMin, niceMax] = niceLogDomain(minPositive, max)
+            expect(niceMin).toBeCloseTo(expected[0], 5)
+            expect(niceMax).toBeCloseTo(expected[1], 5)
+        })
+
+        it('always rounds minPositive down past it (next decade lower)', () => {
+            const [niceMin] = niceLogDomain(50, 1000)
+            expect(niceMin).toBeLessThanOrEqual(50)
+        })
+    })
+
+    describe('buildStackedResolveValue', () => {
+        const series = makeSeries({ key: 'a', data: [10, 20, 30] })
+
+        it('returns undefined when stackedData is undefined', () => {
+            expect(buildStackedResolveValue(undefined)).toBeUndefined()
+        })
+
+        it('returns the stacked top when present and finite', () => {
+            const stacked = new Map<string, StackedBand>([['a', { top: [100, 200, 300], bottom: [0, 0, 0] }]])
+            const resolve = buildStackedResolveValue(stacked)!
+            expect(resolve(series, 0)).toBe(100)
+            expect(resolve(series, 2)).toBe(300)
+        })
+
+        it('falls back to the raw value when the series is not in the stack', () => {
+            const stacked = new Map<string, StackedBand>()
+            const resolve = buildStackedResolveValue(stacked)!
+            expect(resolve(series, 1)).toBe(20)
+        })
+
+        it('falls back to the raw value when the stacked top is non-finite', () => {
+            const stacked = new Map<string, StackedBand>([['a', { top: [NaN, Infinity, 50], bottom: [0, 0, 0] }]])
+            const resolve = buildStackedResolveValue(stacked)!
+            expect(resolve(series, 0)).toBe(10)
+            expect(resolve(series, 1)).toBe(20)
+            expect(resolve(series, 2)).toBe(50)
+        })
+
+        it('returns 0 when both stacked top and raw value are non-finite', () => {
+            const nanSeries = makeSeries({ key: 'a', data: [NaN, Infinity, 0] })
+            const stacked = new Map<string, StackedBand>([['a', { top: [NaN, NaN, 0], bottom: [0, 0, 0] }]])
+            const resolve = buildStackedResolveValue(stacked)!
+            expect(resolve(nanSeries, 0)).toBe(0)
+            expect(resolve(nanSeries, 1)).toBe(0)
         })
     })
 })

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -1,6 +1,6 @@
 import * as d3 from 'd3'
 
-import type { ChartDimensions, ResolveValueFn, Series } from './types'
+import type { ChartDimensions, ChartScales, ResolveValueFn, Series } from './types'
 import { DEFAULT_Y_AXIS_ID } from './types'
 
 type D3YScale = d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>
@@ -57,10 +57,8 @@ export function seriesValueRange(series: Series[]): SeriesValueRange {
     return { min, max, minPositive, count }
 }
 
-/** Nice log-scale domain: round `minPositive` down to the previous decade and `max` up
- *  to the next "round" multiple of its top decade (e.g. 740 → 800, 4200 → 5000). Used by
- *  both linear-axis and bar-axis log scales — the math is identical, only the resulting
- *  d3 scale's range differs. */
+/** Round `minPositive` down to the previous decade, `max` up to the next round multiple
+ *  of its top decade (e.g. 740 → 800, 4200 → 5000). */
 export function niceLogDomain(minPositive: number, max: number): [number, number] {
     const niceMin = Math.pow(10, Math.ceil(Math.log10(minPositive)) - 1)
     const maxDecade = Math.pow(10, Math.floor(Math.log10(max)))
@@ -250,11 +248,9 @@ export function computePercentStackData(series: Series[], labels: string[]): Map
     return buildStackData(series, labels, d3.stackOffsetExpand)
 }
 
-/** Builds a {@link ResolveValueFn} that returns the stacked top of each series so the
- *  tooltip anchor lands at the visual top of each segment, not the raw series value.
- *  Falls back to the raw value when the series isn't part of the stack (e.g. trend-line
- *  overlays, CI bands). Returns `undefined` when there is no stacked data — callers can
- *  pass that straight through and the chart will use its default resolver. */
+/** Returns the stacked top of each series so the tooltip anchor lands at the visual
+ *  top of each segment, not the raw series value. Falls back to the raw value when the
+ *  series isn't part of the stack (e.g. trend-line overlays, CI bands). */
 export function buildStackedResolveValue(
     stackedData: Map<string, StackedBand> | undefined
 ): ResolveValueFn | undefined {
@@ -367,4 +363,11 @@ export function autoFormatYTick(value: number, domainMax: number): string {
 export function autoFormatterFor(ticks: number[]): (value: number) => string {
     const domainMax = ticks.length > 0 ? Math.max(...ticks.map((t) => Math.abs(t))) : 1
     return (v) => autoFormatYTick(v, domainMax)
+}
+
+export function resolveYScaleForSeries(
+    scales: Pick<ChartScales, 'y' | 'yAxes'>,
+    series: Pick<Series, 'yAxisId'>
+): (value: number) => number {
+    return scales.yAxes?.[series.yAxisId ?? DEFAULT_Y_AXIS_ID]?.scale ?? scales.y
 }

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -1,6 +1,6 @@
 import * as d3 from 'd3'
 
-import type { ChartDimensions, Series } from './types'
+import type { ChartDimensions, ResolveValueFn, Series } from './types'
 import { DEFAULT_Y_AXIS_ID } from './types'
 
 type D3YScale = d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>
@@ -57,6 +57,17 @@ export function seriesValueRange(series: Series[]): SeriesValueRange {
     return { min, max, minPositive, count }
 }
 
+/** Nice log-scale domain: round `minPositive` down to the previous decade and `max` up
+ *  to the next "round" multiple of its top decade (e.g. 740 → 800, 4200 → 5000). Used by
+ *  both linear-axis and bar-axis log scales — the math is identical, only the resulting
+ *  d3 scale's range differs. */
+export function niceLogDomain(minPositive: number, max: number): [number, number] {
+    const niceMin = Math.pow(10, Math.ceil(Math.log10(minPositive)) - 1)
+    const maxDecade = Math.pow(10, Math.floor(Math.log10(max)))
+    const niceMax = Math.ceil(max / maxDecade) * maxDecade
+    return [niceMin, niceMax]
+}
+
 export function createXScale(labels: string[], dimensions: ChartDimensions): d3.ScalePoint<string> {
     return d3
         .scalePoint<string>()
@@ -107,12 +118,9 @@ export function createYScale(
                 .nice(tickCount)
                 .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
         }
-        const niceMin = Math.pow(10, Math.ceil(Math.log10(range.minPositive)) - 1)
-        const maxDecade = Math.pow(10, Math.floor(Math.log10(max)))
-        const niceMax = Math.ceil(max / maxDecade) * maxDecade
         return d3
             .scaleLog()
-            .domain([niceMin, niceMax])
+            .domain(niceLogDomain(range.minPositive, max))
             .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
             .clamp(true)
     }
@@ -242,6 +250,27 @@ export function computePercentStackData(series: Series[], labels: string[]): Map
     return buildStackData(series, labels, d3.stackOffsetExpand)
 }
 
+/** Builds a {@link ResolveValueFn} that returns the stacked top of each series so the
+ *  tooltip anchor lands at the visual top of each segment, not the raw series value.
+ *  Falls back to the raw value when the series isn't part of the stack (e.g. trend-line
+ *  overlays, CI bands). Returns `undefined` when there is no stacked data — callers can
+ *  pass that straight through and the chart will use its default resolver. */
+export function buildStackedResolveValue(
+    stackedData: Map<string, StackedBand> | undefined
+): ResolveValueFn | undefined {
+    if (!stackedData) {
+        return undefined
+    }
+    return (s, dataIndex) => {
+        const stacked = stackedData.get(s.key)?.top[dataIndex]
+        if (stacked != null && Number.isFinite(stacked)) {
+            return stacked
+        }
+        const raw = s.data[dataIndex]
+        return typeof raw === 'number' && Number.isFinite(raw) ? raw : 0
+    }
+}
+
 export interface BarScaleSet {
     band: d3.ScaleBand<string>
     value: D3YScale
@@ -320,10 +349,7 @@ function buildBarValueScale(
     const min = range.min > 0 ? 0 : range.min
     const max = range.max < 0 ? 0 : range.max
     if (scaleType === 'log' && isFinite(range.minPositive)) {
-        const niceMin = Math.pow(10, Math.ceil(Math.log10(range.minPositive)) - 1)
-        const maxDecade = Math.pow(10, Math.floor(Math.log10(max)))
-        const niceMax = Math.ceil(max / maxDecade) * maxDecade
-        return d3.scaleLog().domain([niceMin, niceMax]).range(valueRange).clamp(true)
+        return d3.scaleLog().domain(niceLogDomain(range.minPositive, max)).range(valueRange).clamp(true)
     }
     return d3.scaleLinear().domain([min, max]).nice(tickCount).range(valueRange)
 }

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -257,14 +257,3 @@ export interface ChartScales {
      *  Typed as `unknown` so d3-style types don't leak through the public surface. */
     _private?: unknown
 }
-
-/** Returns the y-axis scale a given series maps onto — its declared `yAxisId` when set
- *  and present in `scales.yAxes`, otherwise the default (left) axis. Use this anywhere
- *  you need to convert a series value to a y-pixel; inlining the same fallback in every
- *  chart type and overlay is how subtle drift creeps in. */
-export function resolveYScaleForSeries(
-    scales: Pick<ChartScales, 'y' | 'yAxes'>,
-    series: Pick<Series, 'yAxisId'>
-): (value: number) => number {
-    return scales.yAxes?.[series.yAxisId ?? DEFAULT_Y_AXIS_ID]?.scale ?? scales.y
-}

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -257,3 +257,14 @@ export interface ChartScales {
      *  Typed as `unknown` so d3-style types don't leak through the public surface. */
     _private?: unknown
 }
+
+/** Returns the y-axis scale a given series maps onto — its declared `yAxisId` when set
+ *  and present in `scales.yAxes`, otherwise the default (left) axis. Use this anywhere
+ *  you need to convert a series value to a y-pixel; inlining the same fallback in every
+ *  chart type and overlay is how subtle drift creeps in. */
+export function resolveYScaleForSeries(
+    scales: Pick<ChartScales, 'y' | 'yAxes'>,
+    series: Pick<Series, 'yAxisId'>
+): (value: number) => number {
+    return scales.yAxes?.[series.yAxisId ?? DEFAULT_Y_AXIS_ID]?.scale ?? scales.y
+}

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -10,8 +10,8 @@ export type {
     TimeSeriesLineChartConfig,
     TimeSeriesLineChartProps,
     TrendLineConfig,
-    ValueLabelsConfig,
 } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'
+export type { ValueLabelsConfig } from './charts/utils/use-value-labels'
 export { TimeSeriesBarChart } from './charts/TimeSeriesBarChart/TimeSeriesBarChart'
 export type { TimeSeriesBarChartConfig, TimeSeriesBarChartProps } from './charts/TimeSeriesBarChart/TimeSeriesBarChart'
 

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 
 import { useChartLayout } from '../core/chart-context'
+import { getTextMeasureCtx, LABEL_FONT } from '../utils/text-measure'
 
 interface AxisLabelsProps {
     xTickFormatter?: (value: string, index: number) => string | null
@@ -16,26 +17,7 @@ interface AxisLabelsProps {
     labelToCoord?: (label: string) => number | undefined
 }
 
-export const LABEL_FONT =
-    '12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif'
 const LABEL_PADDING = 20
-
-let measureCtx: CanvasRenderingContext2D | null = null
-function getMeasureCtx(): CanvasRenderingContext2D | null {
-    if (!measureCtx) {
-        measureCtx = document.createElement('canvas').getContext('2d')
-    }
-    return measureCtx
-}
-
-export function measureLabelWidth(text: string, font: string = LABEL_FONT): number {
-    const ctx = getMeasureCtx()
-    if (!ctx) {
-        return text.length * 7
-    }
-    ctx.font = font
-    return ctx.measureText(text).width
-}
 
 export function computeVisibleXLabels(
     labels: string[],
@@ -59,7 +41,7 @@ export function computeVisibleXLabels(
         return []
     }
 
-    const ctx = getMeasureCtx()
+    const ctx = getTextMeasureCtx()
     if (!ctx) {
         return candidates
     }
@@ -88,6 +70,78 @@ const TICK_STYLE_BASE: React.CSSProperties = {
     fontSize: 12,
     pointerEvents: 'none',
     whiteSpace: 'nowrap',
+}
+
+/** Distance in CSS pixels between the plot edge and the start of the tick label. */
+const TICK_GAP = 8
+
+interface ChartBox {
+    width: number
+    plotLeft: number
+    plotTop: number
+    plotWidth: number
+    plotHeight: number
+}
+
+/** Tick label sitting alongside a y-axis. `side` picks which axis: `left` anchors to the
+ *  right of the plot's left edge; `right` anchors to the left of the plot's right edge. */
+function YTickLabel({
+    y,
+    side,
+    box,
+    text,
+    color,
+    dataAttr,
+}: {
+    y: number
+    side: 'left' | 'right'
+    box: ChartBox
+    text: string
+    color: string
+    dataAttr: string
+}): React.ReactElement {
+    const edge =
+        side === 'left'
+            ? { right: box.width - box.plotLeft + TICK_GAP }
+            : { left: box.plotLeft + box.plotWidth + TICK_GAP }
+    return (
+        <div
+            data-attr={dataAttr}
+            style={{ ...TICK_STYLE_BASE, ...edge, top: y, transform: 'translateY(-50%)', color }}
+        >
+            {text}
+        </div>
+    )
+}
+
+/** Tick label sitting under the x-axis (the chart's bottom edge). */
+function XTickLabel({
+    x,
+    box,
+    text,
+    color,
+    dataAttr,
+}: {
+    x: number
+    box: ChartBox
+    text: string
+    color: string
+    dataAttr: string
+}): React.ReactElement {
+    return (
+        <div
+            data-attr={dataAttr}
+            style={{
+                ...TICK_STYLE_BASE,
+                left: x,
+                top: box.plotTop + box.plotHeight + TICK_GAP,
+                transform: 'translateX(-50%)',
+                color,
+            }}
+        >
+            {text}
+        </div>
+    )
 }
 
 export function AxisLabels({
@@ -136,19 +190,15 @@ export function AxisLabels({
                             return null
                         }
                         return (
-                            <div
+                            <YTickLabel
                                 key={`y-cat-${i}`}
-                                data-attr="hog-chart-axis-tick-y"
-                                style={{
-                                    ...TICK_STYLE_BASE,
-                                    right: dimensions.width - dimensions.plotLeft + 8,
-                                    top: y,
-                                    transform: 'translateY(-50%)',
-                                    color: axisColor,
-                                }}
-                            >
-                                {text}
-                            </div>
+                                y={y}
+                                side="left"
+                                box={dimensions}
+                                text={text}
+                                color={axisColor}
+                                dataAttr="hog-chart-axis-tick-y"
+                            />
                         )
                     })}
                 {!hideXAxis &&
@@ -159,19 +209,14 @@ export function AxisLabels({
                         }
                         const label = yTickFormatter ? yTickFormatter(tick) : String(tick)
                         return (
-                            <div
+                            <XTickLabel
                                 key={`x-val-${tick}`}
-                                data-attr="hog-chart-axis-tick-x"
-                                style={{
-                                    ...TICK_STYLE_BASE,
-                                    left: x,
-                                    top: dimensions.plotTop + dimensions.plotHeight + 8,
-                                    transform: 'translateX(-50%)',
-                                    color: axisColor,
-                                }}
-                            >
-                                {label}
-                            </div>
+                                x={x}
+                                box={dimensions}
+                                text={label}
+                                color={axisColor}
+                                dataAttr="hog-chart-axis-tick-x"
+                            />
                         )
                     })}
             </>
@@ -188,19 +233,15 @@ export function AxisLabels({
                     }
                     const label = yTickFormatter ? yTickFormatter(tick) : String(tick)
                     return (
-                        <div
+                        <YTickLabel
                             key={`y-${tick}`}
-                            data-attr="hog-chart-axis-tick-y"
-                            style={{
-                                ...TICK_STYLE_BASE,
-                                right: dimensions.width - dimensions.plotLeft + 8,
-                                top: y,
-                                transform: 'translateY(-50%)',
-                                color: axisColor,
-                            }}
-                        >
-                            {label}
-                        </div>
+                            y={y}
+                            side="left"
+                            box={dimensions}
+                            text={label}
+                            color={axisColor}
+                            dataAttr="hog-chart-axis-tick-y"
+                        />
                     )
                 })}
 
@@ -213,36 +254,27 @@ export function AxisLabels({
                     }
                     const label = rightFormatter ? rightFormatter(tick) : String(tick)
                     return (
-                        <div
+                        <YTickLabel
                             key={`yr-${tick}`}
-                            data-attr="hog-chart-axis-tick-yr"
-                            style={{
-                                ...TICK_STYLE_BASE,
-                                left: dimensions.plotLeft + dimensions.plotWidth + 8,
-                                top: y,
-                                transform: 'translateY(-50%)',
-                                color: axisColor,
-                            }}
-                        >
-                            {label}
-                        </div>
+                            y={y}
+                            side="right"
+                            box={dimensions}
+                            text={label}
+                            color={axisColor}
+                            dataAttr="hog-chart-axis-tick-yr"
+                        />
                     )
                 })}
 
             {visibleXLabels.map(({ index, text, x }) => (
-                <div
+                <XTickLabel
                     key={`x-${index}`}
-                    data-attr="hog-chart-axis-tick-x"
-                    style={{
-                        ...TICK_STYLE_BASE,
-                        left: x,
-                        top: dimensions.plotTop + dimensions.plotHeight + 8,
-                        transform: 'translateX(-50%)',
-                        color: axisColor,
-                    }}
-                >
-                    {text}
-                </div>
+                    x={x}
+                    box={dimensions}
+                    text={text}
+                    color={axisColor}
+                    dataAttr="hog-chart-axis-tick-x"
+                />
             ))}
         </>
     )

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -105,10 +105,7 @@ function YTickLabel({
             ? { right: box.width - box.plotLeft + TICK_GAP }
             : { left: box.plotLeft + box.plotWidth + TICK_GAP }
     return (
-        <div
-            data-attr={dataAttr}
-            style={{ ...TICK_STYLE_BASE, ...edge, top: y, transform: 'translateY(-50%)', color }}
-        >
+        <div data-attr={dataAttr} style={{ ...TICK_STYLE_BASE, ...edge, top: y, transform: 'translateY(-50%)', color }}>
             {text}
         </div>
     )

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 
 import { useChartLayout } from '../core/chart-context'
-import { getTextMeasureCtx, LABEL_FONT } from '../utils/text-measure'
+import { AXIS_LABEL_FONT, getTextMeasureCtx } from '../utils/text-measure'
 
 interface AxisLabelsProps {
     xTickFormatter?: (value: string, index: number) => string | null
@@ -45,7 +45,7 @@ export function computeVisibleXLabels(
     if (!ctx) {
         return candidates
     }
-    ctx.font = LABEL_FONT
+    ctx.font = AXIS_LABEL_FONT
 
     const widths = candidates.map((c) => ctx.measureText(c.text).width)
 
@@ -72,7 +72,6 @@ const TICK_STYLE_BASE: React.CSSProperties = {
     whiteSpace: 'nowrap',
 }
 
-/** Distance in CSS pixels between the plot edge and the start of the tick label. */
 const TICK_GAP = 8
 
 interface ChartBox {
@@ -83,8 +82,6 @@ interface ChartBox {
     plotHeight: number
 }
 
-/** Tick label sitting alongside a y-axis. `side` picks which axis: `left` anchors to the
- *  right of the plot's left edge; `right` anchors to the left of the plot's right edge. */
 function YTickLabel({
     y,
     side,
@@ -111,7 +108,6 @@ function YTickLabel({
     )
 }
 
-/** Tick label sitting under the x-axis (the chart's bottom edge). */
 function XTickLabel({
     x,
     box,

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react'
 
 import { useChartLayout } from '../core/chart-context'
-import { DEFAULT_Y_AXIS_ID } from '../core/types'
+import { resolveYScaleForSeries } from '../core/types'
 import type { ChartScales, ResolvedSeries, ResolveValueFn } from '../core/types'
+import { getTextMeasureCtx } from '../utils/text-measure'
 
 export type ValueLabelsMode = 'per-segment' | 'stack-total'
 
@@ -22,14 +23,6 @@ const LABEL_BORDER = 2
 const LABEL_HORIZONTAL_CHROME = (LABEL_PADDING_X + LABEL_BORDER) * 2
 const STACK_TOTAL_KEY = '__stack_total__'
 
-let measureCtx: CanvasRenderingContext2D | null = null
-function getMeasureCtx(): CanvasRenderingContext2D | null {
-    if (!measureCtx) {
-        measureCtx = document.createElement('canvas').getContext('2d')
-    }
-    return measureCtx
-}
-
 interface Candidate {
     key: string
     seriesIndex: number
@@ -39,11 +32,6 @@ interface Candidate {
     width: number
     color: string
     above: boolean
-}
-
-function resolveYScale(s: { yAxisId?: string }, scales: ChartScales): (value: number) => number {
-    const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
-    return scales.yAxes?.[axisId]?.scale ?? scales.y
 }
 
 function defaultLocaleFormatter(v: number): string {
@@ -88,7 +76,7 @@ function pushCandidate(
 }
 
 function buildCandidates(args: BuildCandidatesArgs): Candidate[] {
-    const ctx = getMeasureCtx()
+    const ctx = getTextMeasureCtx()
     if (ctx) {
         ctx.font = LABEL_FONT
     }
@@ -129,7 +117,7 @@ function buildStackTotal(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
         return out
     }
     const topSeries = visible[visible.length - 1]
-    const yScale = resolveYScale(topSeries, scales)
+    const yScale = resolveYScaleForSeries(scales, topSeries)
     const topColor = topSeries.color
 
     for (let dIdx = 0; dIdx < labels.length; dIdx++) {
@@ -167,7 +155,7 @@ function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
         if (s.visibility?.excluded || s.visibility?.valueLabel === false) {
             continue
         }
-        const yScale = resolveYScale(s, scales)
+        const yScale = resolveYScaleForSeries(scales, s)
         for (let dIdx = 0; dIdx < s.data.length && dIdx < labels.length; dIdx++) {
             const rawValue = s.data[dIdx]
             if (typeof rawValue !== 'number' || !isFinite(rawValue) || rawValue === 0) {

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 
 import { useChartLayout } from '../core/chart-context'
-import { resolveYScaleForSeries } from '../core/types'
+import { resolveYScaleForSeries } from '../core/scales'
 import type { ChartScales, ResolvedSeries, ResolveValueFn } from '../core/types'
 import { getTextMeasureCtx } from '../utils/text-measure'
 

--- a/frontend/src/lib/hog-charts/utils/text-measure.ts
+++ b/frontend/src/lib/hog-charts/utils/text-measure.ts
@@ -1,0 +1,28 @@
+/** Shared offscreen canvas context used by overlays and the margin estimator to measure
+ *  label widths. The context is created lazily on first use and cached for the lifetime
+ *  of the page — `measureText` is fast but `createElement('canvas').getContext('2d')`
+ *  is not.
+ *
+ *  Callers must set `ctx.font` themselves before measuring. */
+
+export const LABEL_FONT =
+    '12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif'
+
+let measureCtx: CanvasRenderingContext2D | null = null
+export function getTextMeasureCtx(): CanvasRenderingContext2D | null {
+    if (!measureCtx) {
+        measureCtx = document.createElement('canvas').getContext('2d')
+    }
+    return measureCtx
+}
+
+/** Measure a single label using the default chart font. Falls back to a coarse
+ *  per-character estimate when the canvas context is unavailable (e.g. SSR). */
+export function measureLabelWidth(text: string, font: string = LABEL_FONT): number {
+    const ctx = getTextMeasureCtx()
+    if (!ctx) {
+        return text.length * 7
+    }
+    ctx.font = font
+    return ctx.measureText(text).width
+}

--- a/frontend/src/lib/hog-charts/utils/text-measure.ts
+++ b/frontend/src/lib/hog-charts/utils/text-measure.ts
@@ -1,11 +1,7 @@
-/** Shared offscreen canvas context used by overlays and the margin estimator to measure
- *  label widths. The context is created lazily on first use and cached for the lifetime
- *  of the page — `measureText` is fast but `createElement('canvas').getContext('2d')`
- *  is not.
- *
- *  Callers must set `ctx.font` themselves before measuring. */
+// Cached offscreen canvas — createElement+getContext is slow, measureText is fast.
+// Callers must set ctx.font themselves before measuring.
 
-export const LABEL_FONT =
+export const AXIS_LABEL_FONT =
     '12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif'
 
 let measureCtx: CanvasRenderingContext2D | null = null
@@ -16,9 +12,8 @@ export function getTextMeasureCtx(): CanvasRenderingContext2D | null {
     return measureCtx
 }
 
-/** Measure a single label using the default chart font. Falls back to a coarse
- *  per-character estimate when the canvas context is unavailable (e.g. SSR). */
-export function measureLabelWidth(text: string, font: string = LABEL_FONT): number {
+/** Falls back to length × 7 when the canvas context is unavailable (SSR). */
+export function measureLabelWidth(text: string, font: string = AXIS_LABEL_FONT): number {
     const ctx = getTextMeasureCtx()
     if (!ctx) {
         return text.length * 7


### PR DESCRIPTION
## Summary

Six small extractions across the hog-charts library (`frontend/src/lib/hog-charts/`) that remove copy-paste between chart types and overlays. Net diff is **+260 / -200** but 100 of the 260 are the two new shared modules — measured on existing files only, the change is **-185 lines** of source.

No behaviour changes — same render output, same scale math, same memoisation semantics.

### What changed

1. **`utils/text-measure.ts`** *(new)* — shared offscreen canvas text-measurement.
   `AxisLabels.tsx` and `ValueLabels.tsx` each had their own `measureCtx` cache + `getMeasureCtx()`. Two independent caches that never shared, identical code. Centralised in one module; `LABEL_FONT` and `measureLabelWidth` move with it. `useChartMargins.ts` now imports from the source-of-truth location instead of going through `AxisLabels`.

2. **`core/types.ts#resolveYScaleForSeries(scales, series)`** — single helper for `scales.yAxes?.[s.yAxisId ?? DEFAULT_Y_AXIS_ID]?.scale ?? scales.y`. Inlining the same fallback in every chart type and overlay was how subtle drift would creep in. Used by `LineChart.drawHover` and `ValueLabels` (×2).

3. **`core/scales.ts#buildStackedResolveValue(stackedData)`** — `LineChart` and `BarChart` both wrap their stacked data in identical `ResolveValueFn` factories ("stacked top, fall back to raw, fall back to 0"). Now a single helper, with `useMemo(() => buildStackedResolveValue(stackedData), [stackedData])` at each call site.

4. **`core/scales.ts#niceLogDomain(minPositive, max)`** — `createYScale` and `buildBarValueScale` had the same `Math.pow(10, Math.ceil(Math.log10(...)) - 1)` decade-rounding math sitting inside two different `if (scaleType === 'log')` branches.

5. **`overlays/AxisLabels.tsx`** — four nearly-identical positioned-`<div>` blocks (top-left axis tick, right axis tick, x-axis tick, horizontal-mode y-cat tick) collapsed into two helpers, `<YTickLabel>` and `<XTickLabel>`. The `+ 8` axis-edge gap is now a named `TICK_GAP` constant. Call sites are six lines instead of fourteen.

6. **`charts/utils/use-value-labels.ts`** *(new)* — `resolveValueLabelsConfig` and the `seriesKeys`-allowlist transform were duplicated verbatim between `TimeSeriesLineChart` and `TimeSeriesBarChart`. Now one hook (`useSeriesWithValueLabelAllowlist`) and one function (`resolveValueLabelsConfig`); the `ValueLabelsConfig` interface lives in one place too.

### On the renderer drawing functions specifically

You asked whether we should extract a `drawBar` (singular). I read through `core/canvas-renderer.ts` and don't think so:

- `drawBars(drawCtx, series, bars, cornerRadius)` carries series-level state (resolves `series.stroke?.partial` to a hatch pattern once, applies it per-bar) — extracting a `drawBar` would either re-resolve the hatch per call or push that responsibility on the caller.
- `drawBarHighlight(ctx, bar, overlayColor, cornerRadius)` is the singular variant for the hover layer; it doesn't need hatches.
- Both already share `traceRoundedBarPath`, which is the path-emitting primitive.

The split is sound: `traceRoundedBarPath` is the geometry, `drawBars` adds the per-series fill resolution, `drawBarHighlight` is a one-shot. I'd leave it.

### Recommendations not applied here

Worth doing later, kept out of this PR to keep the diff focused:

- **`useChartDraw.ts` — extract `useCanvasDrawEffect(ctx, deps, draw)`.** The two RAF effects (static + hover) are structurally identical — cancel ref → bail-on-null → schedule RAF → save/clear/draw/restore → cleanup. ~25 lines of duplication. The reason I held off: the effect deps differ (hover includes `hoverIndex`/`hoverPosition`) and one of them deliberately omits `hoverIndex` with an `eslint-disable` — extracting needs to handle both shapes, and getting exhaustive-deps right is fiddly.
- **Percent-formatter pattern in LineChart/BarChart.** Both have `useMemo` blocks that conditionally inject `yTickFormatter: (v) => Math.round(v * 100) + '%'` when `percentStackView`/`barLayout === 'percent'` is on and no formatter is supplied. Could become a `withDefaultPercentFormatter(config, isPercent)` helper. Small win, easy follow-up.
- **`LineChart` × 2 internal `resolveYScale` for raw d3 scales.** I left this — `resolveYScaleForSeries` returns `(value: number) => number` which loses the raw d3 scale typing that `DrawContext.yScale` requires. Could be solved with a generic helper but the constraint is real.
- **Repeated `s.yAxisId ?? DEFAULT_Y_AXIS_ID` (~10 places).** A tiny `axisIdOf(s)` helper would shave a few characters each but isn't a meaningful clarity win on its own.

### How I verified

- All edits were behaviour-preserving by inspection — same expressions, same memo deps, same render output. Each helper is a literal extraction of code that already existed verbatim somewhere else.
- The full PostHog frontend test suite needs the entire monorepo (~workspace packages, patches, native deps) to run, which I couldn't set up in the cloud-task sandbox. Relying on CI here.

## Test plan

- [ ] CI passes (`frontend` typecheck + jest)
- [ ] `LineChart`, `BarChart`, `TimeSeriesLineChart`, `TimeSeriesBarChart` stories still render identically (visual diff or storybook)
- [ ] `useChartMargins` test still passes — its mock target moved from `'../../overlays/AxisLabels'` to `'../../utils/text-measure'`
- [ ] Spot-check log scale: a bar chart with `yScaleType: 'log'` produces the same y-axis ticks as before
- [ ] Spot-check stacked tooltip: hovering a stacked bar/area still anchors the tooltip at the segment top