### PR TITLE
fix(web-analytics): remove dead docs links and open in new tab

### DIFF
--- a/frontend/src/scenes/web-analytics/health/components/HealthCheckItem.tsx
+++ b/frontend/src/scenes/web-analytics/health/components/HealthCheckItem.tsx
@@ -31,7 +31,7 @@ export function HealthCheckItem({ check }: HealthCheckItemProps): JSX.Element {
                         <span className="font-medium">{check.title}</span>
                     )}
                     {check.docsUrl && (
-                        <Link to={check.docsUrl} className="text-xs text-muted">
+                        <Link to={check.docsUrl} target="_blank" className="text-xs text-muted">
                             Docs
                         </Link>
                     )}

--- a/frontend/src/scenes/web-analytics/health/webAnalyticsHealthLogic.ts
+++ b/frontend/src/scenes/web-analytics/health/webAnalyticsHealthLogic.ts
@@ -225,7 +225,6 @@ export const webAnalyticsHealthLogic = kea<webAnalyticsHealthLogicType>([
                         action: hasAuthorizedUrls
                             ? { label: 'Manage domains', to: urls.settings('environment-web-analytics') }
                             : { label: 'Add domains', to: urls.settings('environment-web-analytics') },
-                        docsUrl: 'https://posthog.com/docs/web-analytics/authorized-urls',
                     },
                     reverseProxyCheck,
                 ]


### PR DESCRIPTION
## Problem

We have a dead link on the web analaytics installation health page. It used to go to https://posthog.com/docs/web-analytics/authorized-urls, but this link is no longer valid. I can't find any suitable docs about this, and clicking the "Add domains" button takes you to a page where we describe what this does, so I'm not sure it's worth adding specific docs for this, unless the `/authorized-urls` page was deleted in error.

## Changes

Add target _blank which auto adds the open in new tab glyph. Deleted the docs link for authorized URLs.

<img width="939" height="1015" alt="Screenshot 2026-05-08 at 16 52 59" src="https://github.com/user-attachments/assets/2d6f00f7-d1f8-4b3e-a8fe-a9660623970b" />

## How did you test this code?

Manual in dev.

## Publish to changelog?

no.
