### PR TITLE
fix(hogli): handle key:: prefix in user.signingkey

### DIFF
--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -369,7 +369,7 @@ def _resolve_local_signing_key() -> str | None:
     if not value:
         return None
     if value.startswith("key::"):
-        value = value[len("key::") :].strip()
+        value = value.removeprefix("key::")
     if value.startswith(("ssh-", "ecdsa-", "sk-")):
         return value
     try:

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -353,8 +353,9 @@ def _resolve_local_identity_agent_for_coder() -> str | None:
 def _resolve_local_signing_key() -> str | None:
     """Return the engineer's ``git config user.signingkey``, normalized to a literal SSH public key string.
 
-    Git accepts two formats: a literal ``ssh-... / ecdsa-... / sk-...`` string
-    or a path to a public-key file. Both are normalized here. Returns ``None``
+    Git accepts three formats: a literal ``ssh-... / ecdsa-... / sk-...``
+    string, the same with a ``key::`` prefix (used by tools like Secretive),
+    or a path to a public-key file. All are normalized here. Returns ``None``
     when the value is unset or the referenced file can't be read.
     """
     result = subprocess.run(
@@ -367,6 +368,8 @@ def _resolve_local_signing_key() -> str | None:
     value = result.stdout.strip()
     if not value:
         return None
+    if value.startswith("key::"):
+        value = value[len("key::") :].strip()
     if value.startswith(("ssh-", "ecdsa-", "sk-")):
         return value
     try:

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -1587,6 +1587,16 @@ class TestResolveLocalSigningKey:
         )
         assert devbox_cli._resolve_local_signing_key() == "ssh-ed25519 AAAA user@host"
 
+    def test_strips_key_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            devbox_cli.subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                a[0], 0, "key::ecdsa-sha2-nistp256 AAAA GitHub-Commit-Signing@host\n", ""
+            ),
+        )
+        assert devbox_cli._resolve_local_signing_key() == "ecdsa-sha2-nistp256 AAAA GitHub-Commit-Signing@host"
+
     def test_reads_file_when_value_is_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         key_file = tmp_path / "id_ed25519.pub"
         key_file.write_text("ssh-ed25519 AAAAFROMFILE user@host\n")


### PR DESCRIPTION
## Problem

`hogli` reads `git config user.signingkey` to forward the engineer's commit-signing key into devbox sessions. Tools like [Secretive](https://github.com/maxgoedjen/secretive) write the key with a `key::` prefix (the literal-key marker that newer Git versions accept), which `_resolve_local_signing_key()` did not recognize. The function fell through to the file-read branch, failed to open `key::ssh-…` as a path, and returned `None`. Devbox sessions then started without a signing key configured.

## Changes

Strip a leading `key::` from the resolved value before matching against the `ssh-` / `ecdsa-` / `sk-` prefixes, so Secretive-style entries normalize to a plain literal key. Also expanded the docstring to mention the third accepted format.

## How did you test this code?

I'm an agent. Added a unit test (`test_strips_key_prefix`) that mocks `git config` returning a `key::ecdsa-…` value and asserts the prefix is stripped. Ran the existing `_resolve_local_signing_key` test class to confirm the literal-string and file-path paths still pass.

## Publish to changelog?

No.