### PR TITLE
fix(replay): sync inspector scroll when re-enabling sync while paused

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
@@ -97,7 +97,7 @@ export function PlayerInspectorList(): JSX.Element {
                 listRef.current.scrollToRow({ index: playbackIndicatorIndex })
             }
         }
-    }, [playbackIndicatorIndex]) // oxlint-disable-line react-hooks/exhaustive-deps
+    }, [playbackIndicatorIndex, syncScrollPaused]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     const handleScroll = useCallback(() => {
         // TRICKY: There is no way to know for sure whether the scroll is directly from user input


### PR DESCRIPTION
## Problem

Toggling **Sync scrolling** on in the player inspector while playback is paused doesn't move the activity list to the current playback marker. Briefly resuming and re-pausing often doesn't help either, since `playbackIndicatorIndex` is bucketed to whole seconds.

## Changes

The auto-scroll effect in `PlayerInspectorList` was keyed only on `playbackIndicatorIndex`, so toggling `syncScrollPaused` while the index was static did nothing. Adding `syncScrollPaused` to the deps makes re-enabling sync immediately scroll to the current marker, regardless of playback state.

## How did you test this code?

I'm an agent — no manual UI testing, no automated tests added.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) at @tue's request. Single-line dep fix chosen over larger alternatives (listener on `setSyncScrollPaused`, refining index bucketing) as the smallest correct change.