### PR TITLE
fix(phai): Freezegun leaks and fails concurrent Temporal workers

### DIFF
--- a/products/posthog_ai/scripts/hogql_example/__init__.py
+++ b/products/posthog_ai/scripts/hogql_example/__init__.py
@@ -8,7 +8,7 @@ Only available when DEBUG=True, since it requires Django and a database.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 _cached_team: Any = None
@@ -18,8 +18,10 @@ _cached_team: Any = None
 # runner instead of via freezegun: freezegun monkey-patches `datetime.datetime`
 # process-globally, which is not thread-safe and corrupts unrelated workers
 # (Temporal activities, Django request handlers) running in the same process.
-FROZEN_TIME = "2025-12-10T00:00:00"
-_FROZEN_DATETIME = datetime.fromisoformat(FROZEN_TIME)
+# Tz-aware UTC so QueryDateRange.now_with_timezone (which calls .astimezone)
+# produces output that doesn't depend on the build machine's local timezone.
+FROZEN_TIME = "2025-12-10T00:00:00+00:00"
+_FROZEN_DATETIME = datetime.fromisoformat(FROZEN_TIME).astimezone(UTC)
 
 
 def _pin_runner_now(runner: Any, now: datetime) -> None:

--- a/products/posthog_ai/scripts/hogql_example/__init__.py
+++ b/products/posthog_ai/scripts/hogql_example/__init__.py
@@ -8,18 +8,44 @@ Only available when DEBUG=True, since it requires Django and a database.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 _cached_team: Any = None
 
+# Used as the synthetic "now" for relative date ranges (e.g. "-7d") so the
+# rendered HogQL is reproducible and doesn't drift between builds. Pinned per
+# runner instead of via freezegun: freezegun monkey-patches `datetime.datetime`
+# process-globally, which is not thread-safe and corrupts unrelated workers
+# (Temporal activities, Django request handlers) running in the same process.
 FROZEN_TIME = "2025-12-10T00:00:00"
+_FROZEN_DATETIME = datetime.fromisoformat(FROZEN_TIME)
+
+
+def _pin_runner_now(runner: Any, now: datetime) -> None:
+    """Pin the runner's notion of "now" to a fixed datetime.
+
+    Mutates the runner so subsequent ``to_query()`` calls resolve relative date
+    ranges (``-7d``, ``-30d``, ...) against ``now`` instead of the real wall
+    clock. Best-effort: runners without a standard ``query_date_range``/``context``
+    surface keep their default behavior and produce non-deterministic output —
+    that's strictly cosmetic since rendered skills land in a gitignored
+    ``dist/`` directory.
+    """
+    context = getattr(runner, "context", None)
+    if context is not None and hasattr(context, "now"):
+        context.now = now
+
+    query_date_range = getattr(runner, "query_date_range", None)
+    if query_date_range is not None and hasattr(query_date_range, "pin_now"):
+        query_date_range.pin_now(now)
 
 
 def render_hogql_example(query_dict: dict[str, Any]) -> str:
     """Render a query dict to a HogQL string using the query runner pipeline.
 
-    Time is frozen to FROZEN_TIME so that relative date ranges produce
-    deterministic output regardless of when the build runs.
+    Relative date ranges are resolved against ``FROZEN_TIME`` so output is
+    reproducible across builds.
 
     Usage in a template::
 
@@ -41,14 +67,6 @@ def render_hogql_example(query_dict: dict[str, Any]) -> str:
         if _cached_team is None:
             raise RuntimeError("render_hogql_example requires at least one Team in the database")
 
-    import freezegun
-    from freezegun import freeze_time
-
-    # Skip `transformers` when freezegun walks sys.modules: it has a broken
-    # lazy-import path that crashes `getattr`, leaving a partial monkey-patch
-    # on `time.time` that poisons the whole process.
-    freezegun.configure(extend_ignore_list=["transformers"])
-
     from posthog.schema import HogQLFilters
 
     from posthog.hogql import ast
@@ -58,32 +76,32 @@ def render_hogql_example(query_dict: dict[str, Any]) -> str:
 
     from posthog.hogql_queries.query_runner import get_query_runner
 
-    with freeze_time(FROZEN_TIME):
-        kind = query_dict.get("kind")
+    kind = query_dict.get("kind")
 
-        if kind == "RecordingsQuery":
-            return _render_recordings_query(query_dict, _cached_team)
+    if kind == "RecordingsQuery":
+        return _render_recordings_query(query_dict, _cached_team)
 
-        runner = get_query_runner(query_dict, _cached_team)
-        ast_query: ast.Expr = runner.to_query()
+    runner = get_query_runner(query_dict, _cached_team)
+    _pin_runner_now(runner, _FROZEN_DATETIME)
+    ast_query: ast.Expr = runner.to_query()
 
-        from posthog.hogql_queries.ai.trace_query_runner import TraceQueryRunner
+    from posthog.hogql_queries.ai.trace_query_runner import TraceQueryRunner
 
-        from products.error_tracking.backend.hogql_queries.error_tracking_query_runner import ErrorTrackingQueryRunner
-        from products.logs.backend.logs_query_runner import LogsQueryRunner
+    from products.error_tracking.backend.hogql_queries.error_tracking_query_runner import ErrorTrackingQueryRunner
+    from products.logs.backend.logs_query_runner import LogsQueryRunner
 
-        hogql_filters = HogQLFilters()
-        if isinstance(runner, ErrorTrackingQueryRunner):
-            hogql_filters = runner._builder.hogql_filters()
-        elif isinstance(runner, LogsQueryRunner):
-            hogql_filters = HogQLFilters(dateRange=runner.query.dateRange)
+    hogql_filters = HogQLFilters()
+    if isinstance(runner, ErrorTrackingQueryRunner):
+        hogql_filters = runner._builder.hogql_filters()
+    elif isinstance(runner, LogsQueryRunner):
+        hogql_filters = HogQLFilters(dateRange=runner.query.dateRange)
 
-        if isinstance(runner, TraceQueryRunner):
-            ast_query = replace_placeholders(ast_query, {"filter_conditions": runner._get_where_clause()})
+    if isinstance(runner, TraceQueryRunner):
+        ast_query = replace_placeholders(ast_query, {"filter_conditions": runner._get_where_clause()})
 
-        ast_query = replace_filters(ast_query, hogql_filters, _cached_team)
+    ast_query = replace_filters(ast_query, hogql_filters, _cached_team)
 
-        return to_printed_hogql(ast_query, _cached_team)
+    return to_printed_hogql(ast_query, _cached_team)
 
 
 def _render_recordings_query(query_dict: dict[str, Any], team: Any) -> str:

--- a/products/posthog_ai/scripts/hogql_example/test/test_hogql_example.py
+++ b/products/posthog_ai/scripts/hogql_example/test/test_hogql_example.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
 import products.posthog_ai.scripts.hogql_example as hogql_example_module
@@ -29,54 +30,121 @@ def test_raises_when_no_team(_mock_first: MagicMock) -> None:
         render_hogql_example(SAMPLE_QUERY)
 
 
-@patch("posthog.hogql.printer.utils.to_printed_hogql")
-@patch("posthog.hogql.filters.replace_filters")
-@patch("posthog.hogql_queries.query_runner.get_query_runner")
-@patch("posthog.models.team.Team.objects.first")
-@patch("django.conf.settings.DEBUG", True)
-def test_returns_hogql_string(
-    mock_first: MagicMock,
-    mock_get_runner: MagicMock,
-    mock_replace_filters: MagicMock,
-    mock_to_hogql: MagicMock,
-) -> None:
-    fake_team = MagicMock()
-    mock_first.return_value = fake_team
+class TestRenderHogQLExample(BaseTest):
+    """End-to-end tests that exercise the real query runner pipeline.
 
-    fake_ast = MagicMock()
-    filtered_ast = MagicMock()
-    fake_runner = MagicMock()
-    fake_runner.to_query.return_value = fake_ast
-    mock_get_runner.return_value = fake_runner
-    mock_replace_filters.return_value = filtered_ast
+    These guard against regressions where the rendered HogQL would silently
+    drift to wall-clock time, or where the renderer would corrupt global
+    process state (the freezegun bug we replaced with `pin_now`).
+    """
 
-    mock_to_hogql.return_value = "SELECT count() FROM events"
+    def setUp(self) -> None:
+        super().setUp()
+        hogql_example_module._cached_team = None
 
-    result = render_hogql_example(SAMPLE_QUERY)
+    @patch("django.conf.settings.DEBUG", True)
+    def test_trends_relative_range_pins_to_frozen_time(self) -> None:
+        # FROZEN_TIME = 2025-12-10. -7d should anchor to 2025-12-03.
+        result = render_hogql_example(
+            {
+                "kind": "TrendsQuery",
+                "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                "dateRange": {"date_from": "-7d"},
+            }
+        )
 
-    assert result == "SELECT count() FROM events"
-    mock_get_runner.assert_called_once_with(SAMPLE_QUERY, fake_team)
-    fake_runner.to_query.assert_called_once()
-    mock_replace_filters.assert_called_once()
-    mock_to_hogql.assert_called_once_with(filtered_ast, fake_team)
+        assert "2025-12-10" in result
+        assert "2025-12-03" in result
+
+    @patch("django.conf.settings.DEBUG", True)
+    def test_funnel_pins_context_now_for_sub_date_ranges(self) -> None:
+        # FunnelsQuery's sub-helpers read `context.now` rather than the runner's
+        # query_date_range, so this guards the context-pinning branch of
+        # `_pin_runner_now`.
+        result = render_hogql_example(
+            {
+                "kind": "FunnelsQuery",
+                "series": [
+                    {"kind": "EventsNode", "event": "$pageview"},
+                    {"kind": "EventsNode", "event": "user signed up"},
+                ],
+                "dateRange": {"date_from": "-7d"},
+            }
+        )
+
+        assert "2025-12-10" in result
+        assert "2025-12-03" in result
+
+    @patch("django.conf.settings.DEBUG", True)
+    def test_render_does_not_use_freezegun(self) -> None:
+        # The bug: freezegun was used to set `now` for relative date ranges,
+        # but it monkey-patches `datetime.datetime` process-globally. Concurrent
+        # code (Temporal activities, Django request handlers) calling
+        # `timezone.now()` during the freeze races with `tz_offsets.pop()` on
+        # exit, crashing with `IndexError: list index out of range`.
+        #
+        # Single-threaded tests can't observe the race directly because the
+        # freeze cleans up before assertions run. Instead, assert the renderer
+        # never enters `freeze_time` at all — that's the only safe contract.
+        import freezegun
+
+        original_freeze_time = freezegun.freeze_time
+
+        def _explode(*args: object, **kwargs: object) -> object:
+            raise AssertionError(
+                "render_hogql_example called freezegun.freeze_time — this monkey-patches "
+                "datetime globally and crashes concurrent workers. Use _pin_runner_now instead."
+            )
+
+        with patch.object(freezegun, "freeze_time", _explode):
+            render_hogql_example(
+                {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                    "dateRange": {"date_from": "-7d"},
+                }
+            )
+
+        assert freezegun.freeze_time is original_freeze_time
+
+    @patch("django.conf.settings.DEBUG", True)
+    def test_output_is_deterministic_across_calls(self) -> None:
+        query = {
+            "kind": "TrendsQuery",
+            "series": [{"kind": "EventsNode", "event": "$pageview"}],
+            "dateRange": {"date_from": "-30d"},
+        }
+
+        first = render_hogql_example(query)
+        second = render_hogql_example(query)
+
+        assert first == second
 
 
-@patch("posthog.hogql.printer.utils.to_printed_hogql", return_value="SELECT 1")
-@patch("posthog.hogql.filters.replace_filters")
-@patch("posthog.hogql_queries.query_runner.get_query_runner")
-@patch("posthog.models.team.Team.objects.first")
-@patch("django.conf.settings.DEBUG", True)
-def test_caches_team_across_calls(
-    mock_first: MagicMock,
-    mock_get_runner: MagicMock,
-    _mock_replace_filters: MagicMock,
-    _mock_to_hogql: MagicMock,
-) -> None:
-    fake_team = MagicMock()
-    mock_first.return_value = fake_team
-    mock_get_runner.return_value = MagicMock()
+class TestRenderHogQLExampleMocked:
+    """Cheap mock-based tests for control-flow branches that don't need a DB."""
 
-    render_hogql_example(SAMPLE_QUERY)
-    render_hogql_example(SAMPLE_QUERY)
+    @pytest.fixture(autouse=True)
+    def _reset(self) -> None:
+        hogql_example_module._cached_team = None
 
-    mock_first.assert_called_once()
+    @patch("posthog.hogql.printer.utils.to_printed_hogql", return_value="SELECT 1")
+    @patch("posthog.hogql.filters.replace_filters")
+    @patch("posthog.hogql_queries.query_runner.get_query_runner")
+    @patch("posthog.models.team.Team.objects.first")
+    @patch("django.conf.settings.DEBUG", True)
+    def test_caches_team_across_calls(
+        self,
+        mock_first: MagicMock,
+        mock_get_runner: MagicMock,
+        _mock_replace_filters: MagicMock,
+        _mock_to_hogql: MagicMock,
+    ) -> None:
+        fake_team = MagicMock()
+        mock_first.return_value = fake_team
+        mock_get_runner.return_value = MagicMock()
+
+        render_hogql_example(SAMPLE_QUERY)
+        render_hogql_example(SAMPLE_QUERY)
+
+        mock_first.assert_called_once()

--- a/products/posthog_ai/scripts/hogql_example/test/test_hogql_example.py
+++ b/products/posthog_ai/scripts/hogql_example/test/test_hogql_example.py
@@ -88,8 +88,6 @@ class TestRenderHogQLExample(BaseTest):
         # never enters `freeze_time` at all — that's the only safe contract.
         import freezegun
 
-        original_freeze_time = freezegun.freeze_time
-
         def _explode(*args: object, **kwargs: object) -> object:
             raise AssertionError(
                 "render_hogql_example called freezegun.freeze_time — this monkey-patches "
@@ -104,8 +102,6 @@ class TestRenderHogQLExample(BaseTest):
                     "dateRange": {"date_from": "-7d"},
                 }
             )
-
-        assert freezegun.freeze_time is original_freeze_time
 
     @patch("django.conf.settings.DEBUG", True)
     def test_output_is_deterministic_across_calls(self) -> None:
@@ -123,10 +119,6 @@ class TestRenderHogQLExample(BaseTest):
 
 class TestRenderHogQLExampleMocked:
     """Cheap mock-based tests for control-flow branches that don't need a DB."""
-
-    @pytest.fixture(autouse=True)
-    def _reset(self) -> None:
-        hogql_example_module._cached_team = None
 
     @patch("posthog.hogql.printer.utils.to_printed_hogql", return_value="SELECT 1")
     @patch("posthog.hogql.filters.replace_filters")


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
- `render_hogql_example` used `freeze_time(FROZEN_TIME)` to make relative date ranges deterministic, but freezegun monkey-patches `datetime.datetime` process-globally and isn't thread-safe — concurrent Temporal workers calling `timezone.now()` during the freeze raced with its teardown, crashing on `tz_offsets[-1]: IndexError`.

<img width="924" height="511" alt="CleanShot 2026-05-08 at 17 09 05" src="https://github.com/user-attachments/assets/5d2265ab-e0da-48ff-a031-1e01f589832a" />

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Replaced the `freeze_time` block with a `_pin_runner_now` helper that mutates the constructed runner in place (`runner.context.now` + `runner.query_date_range.pin_now(...)`), keeping output byte-deterministic without touching global datetime state.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
