### PR TITLE
fix(llma): prefix bedrock model id with bedrock/ for litellm

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -92,18 +92,21 @@ async def _send_bedrock_messages(
     bedrock_region_name = ensure_bedrock_configured(settings)
 
     data = dict(request_data)
-    data["model"] = map_to_bedrock_model(data["model"], region_name=bedrock_region_name)
+    bedrock_model = map_to_bedrock_model(data["model"], region_name=bedrock_region_name)
+    # litellm can't infer the bedrock provider from regional inference profile
+    # ids like "us.anthropic.claude-opus-4-7-v1", so prefix explicitly.
+    data["model"] = f"bedrock/{bedrock_model}"
 
     anthropic_beta = request.headers.get("anthropic-beta")
     if anthropic_beta:
         data["anthropic_beta"] = [h.strip() for h in anthropic_beta.split(",") if h.strip()]
 
-    strip_server_side_tools(data, model=data["model"], product=product)
+    strip_server_side_tools(data, model=bedrock_model, product=product)
 
     return await handle_llm_request(
         request_data=data,
         user=user,
-        model=data["model"],
+        model=bedrock_model,
         is_streaming=is_streaming,
         provider_config=BEDROCK_CONFIG,
         llm_call=litellm.anthropic_messages,

--- a/services/llm-gateway/tests/test_bedrock.py
+++ b/services/llm-gateway/tests/test_bedrock.py
@@ -109,7 +109,45 @@ class TestBedrockSpecific:
         )
 
         assert response.status_code == 200
-        assert mock_litellm.call_args.kwargs["model"] == "us.anthropic.claude-sonnet-4-6"
+        assert mock_litellm.call_args.kwargs["model"] == "bedrock/us.anthropic.claude-sonnet-4-6"
+
+    @pytest.mark.parametrize(
+        "model,expected_litellm_model",
+        [
+            pytest.param("claude-sonnet-4-6", "bedrock/us.anthropic.claude-sonnet-4-6", id="anthropic_name_mapped"),
+            pytest.param("claude-opus-4-7", "bedrock/us.anthropic.claude-opus-4-7-v1", id="opus_4_7_inference_profile"),
+            pytest.param(
+                "us.anthropic.claude-sonnet-4-6", "bedrock/us.anthropic.claude-sonnet-4-6", id="already_bedrock_id"
+            ),
+        ],
+    )
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    @BEDROCK_SETTINGS_PATCH
+    def test_bedrock_model_passed_to_litellm_with_bedrock_prefix(
+        self,
+        mock_get_settings: MagicMock,
+        mock_litellm: MagicMock,
+        authenticated_client: TestClient,
+        mock_bedrock_response: dict,
+        model: str,
+        expected_litellm_model: str,
+    ) -> None:
+        # Regression: litellm needs the "bedrock/" prefix to route requests; without
+        # it, regional inference profile ids (e.g. "us.anthropic.claude-opus-4-7-v1")
+        # don't match litellm's pattern matchers and the request 400s with
+        # "LLM Provider NOT provided" before leaving the gateway.
+        mock_response = MagicMock()
+        mock_response.model_dump = MagicMock(return_value=mock_bedrock_response)
+        mock_litellm.return_value = mock_response
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json={"model": model, "messages": [{"role": "user", "content": "Hello"}]},
+            headers={"Authorization": "Bearer phx_test_key", "X-PostHog-Provider": "bedrock"},
+        )
+
+        assert response.status_code == 200
+        assert mock_litellm.call_args.kwargs["model"] == expected_litellm_model
 
 
 class TestBedrockFallback:


### PR DESCRIPTION
## Problem

The bedrock fallback path in the LLM gateway has been silently broken since it landed: every fallback request 400s before leaving the gateway, so users have effectively been running with no fallback. During an upstream Anthropic blip on 2026-05-08 (16:56–17:05 UTC), this surfaced as 25 identical `BadRequestError`s across multiple teams (mostly internal, but also external traffic), with bodies like:

```
litellm.BadRequestError: LLM Provider NOT provided.
You passed model=us.anthropic.claude-opus-4-7-v1
```

## Root cause

`_send_bedrock_messages` in `services/llm-gateway/src/llm_gateway/api/anthropic.py` mapped Anthropic model names to bedrock regional inference profile ids (e.g. `us.anthropic.claude-opus-4-7-v1`) and then passed them to `litellm.anthropic_messages` without a provider prefix. litellm's auto-routing only pattern-matches bare `claude-*` for native Anthropic — it cannot infer `bedrock` from `us.anthropic.*` / `eu.anthropic.*` profile ids — so every call 400s with `LLM Provider NOT provided` before any AWS request is made.

## Changes

- Prefix the mapped model with `bedrock/` (e.g. `bedrock/us.anthropic.claude-opus-4-7-v1`) when handing it to litellm in `_send_bedrock_messages`.
- Keep the un-prefixed bedrock model id for metric labels and `strip_server_side_tools` so we don't change cardinality of existing dashboards.
- Update the existing assertion that checked the un-prefixed model in litellm kwargs.
- Add a parametrized regression test covering plain Anthropic names, the specific opus 4.7 inference profile id from the incident, and an already-bedrock id — all should reach litellm with the `bedrock/` prefix.

## How did you test this code?

I'm an agent. I could not run the test suite in this environment (no `uv` / `hogli` / `pytest` available), so the verification is limited to:
- Manual inspection of `_send_bedrock_messages` to confirm the prefix is applied to `data["model"]` before it flows into `handle_llm_request` → `litellm.anthropic_messages(**request_data)`.
- Updated `tests/test_bedrock.py::TestBedrockSpecific::test_uses_aws_region_when_gateway_region_setting_missing` and added `test_bedrock_model_passed_to_litellm_with_bedrock_prefix`. Both rely on the same `litellm.anthropic_messages` mock path the existing tests use.

CI should run the bedrock tests on push. A human reviewer should run `hogli test services/llm-gateway/tests/test_bedrock.py` locally before merge.

## Publish to changelog?

no

## 🤖 Agent context

Authored by an agent (PostHog Code) acting on a triage report that traced the 25 4xx bedrock_messages errors to a missing provider prefix.

Decisions:
- Prefixed `data["model"]` rather than passing `custom_llm_provider="bedrock"` because `custom_llm_provider` is in the gateway's `FORBIDDEN_REQUEST_PARAMS` allowlist (would be stripped by `_sanitize_request_data`), and the prefix form is what litellm documents as canonical.
- Kept the bare bedrock model id flowing into metric labels (Prometheus `model=` label) and `strip_server_side_tools` to avoid silently changing label cardinality on existing dashboards/alerts that already key off `us.anthropic.*` ids.
- Added a parametrized regression test using the exact `claude-opus-4-7` → `us.anthropic.claude-opus-4-7-v1` mapping from the incident, so any future regression on that specific profile id is caught.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*