### PR TITLE
feat(dags): add max_batches knob to get_all_team_ids_op

### DIFF
--- a/posthog/dags/common/ops.py
+++ b/posthog/dags/common/ops.py
@@ -39,6 +39,12 @@ def _filter_team_ids_for_rollout(team_ids: list[int], rollout_percentage: float)
             is_required=False,
             description="Number of team IDs per batch.",
         ),
+        "max_batches": dagster.Field(
+            dagster.Int,
+            default_value=0,
+            is_required=False,
+            description="Cap the number of batches yielded. 0 means unlimited. Use to bound peak parallelism / memory.",
+        ),
         "rollout_percentage": dagster.Field(
             dagster.Float,
             default_value=1.0,
@@ -59,10 +65,14 @@ def get_all_team_ids_op(context: dagster.OpExecutionContext):
 
     override_team_ids = context.op_config["team_ids"]
     batch_size = context.op_config.get("batch_size", 1000)
+    max_batches = int(context.op_config.get("max_batches", 0))
     rollout_percentage = float(context.op_config.get("rollout_percentage", 1.0))
 
     if rollout_percentage < 0 or rollout_percentage > 1:
         raise ValueError(f"rollout_percentage must be in [0, 1], got {rollout_percentage}")
+
+    if max_batches < 0:
+        raise ValueError(f"max_batches must be >= 0, got {max_batches}")
 
     if override_team_ids:
         team_ids = override_team_ids
@@ -75,6 +85,11 @@ def get_all_team_ids_op(context: dagster.OpExecutionContext):
         team_ids = _filter_team_ids_for_rollout(team_ids, rollout_percentage)
         context.log.info(f"After rollout ({rollout_percentage}%), processing {len(team_ids)} teams")
 
+    yielded = 0
     for i in range(0, len(team_ids), batch_size):
+        if max_batches and yielded >= max_batches:
+            context.log.info(f"Reached max_batches={max_batches}; stopping at team index {i} of {len(team_ids)}")
+            break
         batch = team_ids[i : i + batch_size]
         yield dagster.DynamicOutput(batch, mapping_key=f"batch_{i // batch_size}")
+        yielded += 1

--- a/posthog/dags/tests/test_common_ops.py
+++ b/posthog/dags/tests/test_common_ops.py
@@ -1,0 +1,35 @@
+import pytest
+
+from dagster import build_op_context
+
+from posthog.dags.common.ops import get_all_team_ids_op
+
+
+def _collect_batches(op_config: dict) -> list[list[int]]:
+    return [output.value for output in get_all_team_ids_op(build_op_context(op_config=op_config))]
+
+
+class TestGetAllTeamIdsOp:
+    def test_default_yields_all_batches(self):
+        batches = _collect_batches({"team_ids": [1, 2, 3, 4, 5], "batch_size": 2})
+
+        assert batches == [[1, 2], [3, 4], [5]]
+
+    def test_max_batches_truncates_to_first_n(self):
+        batches = _collect_batches({"team_ids": [1, 2, 3, 4, 5, 6, 7], "batch_size": 2, "max_batches": 2})
+
+        assert batches == [[1, 2], [3, 4]]
+
+    def test_max_batches_exceeding_total_yields_all(self):
+        batches = _collect_batches({"team_ids": [1, 2, 3], "batch_size": 1, "max_batches": 100})
+
+        assert batches == [[1], [2], [3]]
+
+    def test_max_batches_zero_means_unlimited(self):
+        batches = _collect_batches({"team_ids": [1, 2, 3, 4, 5], "batch_size": 1, "max_batches": 0})
+
+        assert batches == [[1], [2], [3], [4], [5]]
+
+    def test_negative_max_batches_rejected(self):
+        with pytest.raises(ValueError, match="max_batches must be >= 0"):
+            _collect_batches({"team_ids": [1, 2, 3], "batch_size": 1, "max_batches": -1})

--- a/posthog/dags/tests/test_common_ops.py
+++ b/posthog/dags/tests/test_common_ops.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dagster import build_op_context
+from parameterized import parameterized
 
 from posthog.dags.common.ops import get_all_team_ids_op
 
@@ -10,25 +11,32 @@ def _collect_batches(op_config: dict) -> list[list[int]]:
 
 
 class TestGetAllTeamIdsOp:
-    def test_default_yields_all_batches(self):
-        batches = _collect_batches({"team_ids": [1, 2, 3, 4, 5], "batch_size": 2})
-
-        assert batches == [[1, 2], [3, 4], [5]]
-
-    def test_max_batches_truncates_to_first_n(self):
-        batches = _collect_batches({"team_ids": [1, 2, 3, 4, 5, 6, 7], "batch_size": 2, "max_batches": 2})
-
-        assert batches == [[1, 2], [3, 4]]
-
-    def test_max_batches_exceeding_total_yields_all(self):
-        batches = _collect_batches({"team_ids": [1, 2, 3], "batch_size": 1, "max_batches": 100})
-
-        assert batches == [[1], [2], [3]]
-
-    def test_max_batches_zero_means_unlimited(self):
-        batches = _collect_batches({"team_ids": [1, 2, 3, 4, 5], "batch_size": 1, "max_batches": 0})
-
-        assert batches == [[1], [2], [3], [4], [5]]
+    @parameterized.expand(
+        [
+            (
+                "default_yields_all_batches",
+                {"team_ids": [1, 2, 3, 4, 5], "batch_size": 2},
+                [[1, 2], [3, 4], [5]],
+            ),
+            (
+                "max_batches_truncates_to_first_n",
+                {"team_ids": [1, 2, 3, 4, 5, 6, 7], "batch_size": 2, "max_batches": 2},
+                [[1, 2], [3, 4]],
+            ),
+            (
+                "max_batches_exceeding_total_yields_all",
+                {"team_ids": [1, 2, 3], "batch_size": 1, "max_batches": 100},
+                [[1], [2], [3]],
+            ),
+            (
+                "max_batches_zero_means_unlimited",
+                {"team_ids": [1, 2, 3, 4, 5], "batch_size": 1, "max_batches": 0},
+                [[1], [2], [3], [4], [5]],
+            ),
+        ]
+    )
+    def test_batches(self, _name: str, op_config: dict, expected: list[list[int]]):
+        assert _collect_batches(op_config) == expected
 
     def test_negative_max_batches_rejected(self):
         with pytest.raises(ValueError, match="max_batches must be >= 0"):


### PR DESCRIPTION
## Problem

Running `backfill_persons_on_events_mode_job` against all teams OOM-killed the dagster runner. The shared dynamic-output op `get_all_team_ids_op` fans every team batch into a parallel `.map`, so peak parallelism (and the per-batch resident set) scales with total team count with no upper bound.

## Changes

Adds an optional `max_batches` config field to `get_all_team_ids_op` (default `0` = unlimited, preserving current behavior for every job that uses it). When set to a positive integer, the op stops yielding after N batches, capping peak parallelism for the downstream `.map`. Validates `max_batches >= 0` consistently with the existing `rollout_percentage` validation.

## How did you test this code?

I'm an agent. Automated tests added and run locally:

- `posthog/dags/tests/test_common_ops.py` covering: default-yields-all, truncation when `max_batches < total batches`, no-op when `max_batches > total batches`, `0` means unlimited, and rejection of negative values.
- `hogli test posthog/dags/tests/test_common_ops.py` → 5 passed.
- `ruff check` + `ruff format --check` clean on changed files.

No manual end-to-end run against the real dagster runner — Robbie will set `max_batches=300` when re-launching the PoE backfill.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) at Robbie's direction after his real run of `backfill_persons_on_events_mode_job` was OOM-killed when fanning out across the full team list.

Considered putting the cap inside `backfill_persons_on_events_mode_job` specifically (e.g. via a wrapper op) but went with the shared op since the fan-out behavior — and therefore the OOM risk — is shared across every backfill job that consumes `get_all_team_ids_op` (`backfill_internal_test_users_cohort`, `user_product_list`, the health check framework). Default `0` keeps every existing job untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*