### PR TITLE
chore: add error tracking mcp and skills to CODEOWNERS-soft

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -115,6 +115,8 @@ products/metrics/** @PostHog/logs
 # Error Tracking - owned by @PostHog/team-error-tracking
 products/error_tracking/backend/** @PostHog/team-error-tracking
 products/error_tracking/frontend/** @PostHog/team-error-tracking
+products/error_tracking/mcp/** @PostHog/team-error-tracking
+products/error_tracking/skills/** @PostHog/team-error-tracking
 posthog/hogql_queries/error_tracking/error_tracking_query_runner.py @PostHog/team-error-tracking
 posthog/hogql_queries/error_tracking/error_tracking_issue_correlation_query_runner.py @PostHog/team-error-tracking
 


### PR DESCRIPTION
## Problem

The auto-assign reviewers workflow (`.github/workflows/auto-assign-reviewers.yml`) reads `.github/CODEOWNERS-soft` to tag teams as reviewers when PRs open. The error tracking block only covered `products/error_tracking/backend/**` and `products/error_tracking/frontend/**`, so PRs touching the product's MCP folder (`products/error_tracking/mcp/`) — which holds `tools.yaml`, prompts, and UI app definitions — were not tagging `@PostHog/team-error-tracking`. A `skills/` entry is added for parity in case the team adds skills later (the directory does not exist yet).

## Changes

Added two glob entries under the existing Error Tracking block in `.github/CODEOWNERS-soft`:

- `products/error_tracking/mcp/**`
- `products/error_tracking/skills/**`

## How did you test this code?

I'm an agent. No automated tests were run — this is a CODEOWNERS-soft data change. The auto-assign workflow always reads CODEOWNERS-soft from `master` (security guard in `.github/workflows/auto-assign-reviewers.yml`), so the new rules will only take effect after merge.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Code).
- The user asked whether there is a PR job auto-assigning reviewers; we walked through `.github/workflows/auto-assign-reviewers.yml` and `.github/scripts/assign-reviewers.js`, then noticed the error tracking block was missing the product's `mcp/` directory.
- Initially the patch also covered the generated artifacts under `services/mcp/src/{generated,tools/generated,ui-apps/apps/generated}/` (mirroring the LLM analytics block). The user opted to keep the change minimal and revert those, so this PR only adds the two product-local globs.