### PR TITLE
feat(mcp): enable error-tracking-grouping-rules-update tool

### DIFF
--- a/products/error_tracking/backend/api/grouping_rules.py
+++ b/products/error_tracking/backend/api/grouping_rules.py
@@ -89,6 +89,25 @@ class ErrorTrackingGroupingRuleCreateRequestSerializer(serializers.Serializer):
     )
 
 
+class ErrorTrackingGroupingRuleUpdateRequestSerializer(serializers.Serializer):
+    filters = ErrorTrackingGroupingRuleFiltersField(
+        required=False,
+        allow_null=True,
+        help_text="Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters.",
+    )
+    assignee = ErrorTrackingGroupingRuleAssigneeRequestSerializer(
+        required=False,
+        allow_null=True,
+        help_text="Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee.",
+    )
+    description = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        help_text="Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.",
+    )
+
+
 class ErrorTrackingGroupingRuleSerializer(serializers.ModelSerializer):
     assignee = serializers.SerializerMethodField()
     issue = serializers.SerializerMethodField()
@@ -174,11 +193,11 @@ class ErrorTrackingGroupingRuleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelVie
         serializer = self.get_serializer(queryset, many=True, context=context)
         return Response({"results": serializer.data})
 
-    def update(self, request, *args, **kwargs) -> Response:
+    def _apply_rule_update(self, request: ValidatedRequest) -> Response:
         grouping_rule = self.get_object()
-        assignee = request.data.get("assignee")
-        json_filters = request.data.get("filters")
-        description = request.data.get("description")
+        json_filters = request.validated_data.get("filters")
+        assignee = request.validated_data.get("assignee")
+        description = request.validated_data.get("description")
 
         if json_filters:
             parsed_filters = PropertyGroupFilterValue(**json_filters)
@@ -202,8 +221,19 @@ class ErrorTrackingGroupingRuleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelVie
 
         return Response({"ok": True}, status=status.HTTP_204_NO_CONTENT)
 
-    def partial_update(self, request, *args, **kwargs) -> Response:
-        return self.update(request, *args, **kwargs)
+    @validated_request(
+        request_serializer=ErrorTrackingGroupingRuleUpdateRequestSerializer,
+        responses={204: None},
+    )
+    def update(self, request: ValidatedRequest, *args, **kwargs) -> Response:
+        return self._apply_rule_update(request)
+
+    @validated_request(
+        request_serializer=ErrorTrackingGroupingRuleUpdateRequestSerializer,
+        responses={204: None},
+    )
+    def partial_update(self, request: ValidatedRequest, *args, **kwargs) -> Response:
+        return self._apply_rule_update(request)
 
     def destroy(self, request, *args, **kwargs) -> Response:
         response = super().destroy(request, *args, **kwargs)

--- a/products/error_tracking/backend/api/grouping_rules.py
+++ b/products/error_tracking/backend/api/grouping_rules.py
@@ -95,17 +95,6 @@ class ErrorTrackingGroupingRuleUpdateRequestSerializer(serializers.Serializer):
         allow_null=True,
         help_text="Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters.",
     )
-    assignee = ErrorTrackingGroupingRuleAssigneeRequestSerializer(
-        required=False,
-        allow_null=True,
-        help_text="Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee.",
-    )
-    description = serializers.CharField(
-        required=False,
-        allow_blank=True,
-        allow_null=True,
-        help_text="Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.",
-    )
 
 
 class ErrorTrackingGroupingRuleSerializer(serializers.ModelSerializer):
@@ -196,20 +185,11 @@ class ErrorTrackingGroupingRuleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelVie
     def _apply_rule_update(self, request: ValidatedRequest) -> Response:
         grouping_rule = self.get_object()
         json_filters = request.validated_data.get("filters")
-        assignee = request.validated_data.get("assignee")
-        description = request.validated_data.get("description")
 
         if json_filters:
             parsed_filters = PropertyGroupFilterValue(**json_filters)
             grouping_rule.filters = json_filters
             grouping_rule.bytecode = generate_byte_code(self.team, parsed_filters)
-
-        if assignee:
-            grouping_rule.user_id = None if assignee["type"] != "user" else assignee["id"]
-            grouping_rule.role_id = None if assignee["type"] != "role" else assignee["id"]
-
-        if description:
-            grouping_rule.description = description
 
         grouping_rule.disabled_data = None
         grouping_rule.save()

--- a/products/error_tracking/backend/api/test/test_grouping_rules.py
+++ b/products/error_tracking/backend/api/test/test_grouping_rules.py
@@ -254,21 +254,15 @@ class TestGroupingRuleAPI(APIBaseTest):
         assert body["attr"] == "filters"
         assert body["detail"] == "Invalid filters payload."
 
-    def test_update_rejects_mismatched_assignee(self) -> None:
-        rule = self._create_rule()
+    def test_update_silently_drops_non_filters_fields(self) -> None:
+        """The update endpoint mirrors the UI's grouping-rule edit form, which only edits filters.
 
-        response = self.client.patch(
-            self._url(str(rule.id)),
-            data={"assignee": {"type": "role", "id": 42}},
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        body = response.json()
-        assert body["type"] == "validation_error"
-        assert body["attr"] == "assignee__id"
-
-    def test_update_accepts_frontend_payload_shape_with_extra_fields(self) -> None:
+        The frontend round-trips the whole rule object on save (including `assignee`,
+        `description`, `order_key`, `disabled_data`, timestamps), so the endpoint must accept
+        those keys without 400-ing, but it must never use them to overwrite stored values —
+        otherwise an MCP or curl caller could silently clear an assignee that was set out of
+        band by sending `{"assignee": null}` alongside an unrelated filter edit.
+        """
         rule = self._create_rule()
         new_filters = {
             "type": "OR",
@@ -286,6 +280,7 @@ class TestGroupingRuleAPI(APIBaseTest):
             self._url(str(rule.id)),
             data={
                 "filters": new_filters,
+                "assignee": None,
                 "description": "Updated description",
                 "order_key": 456,
                 "disabled_data": {"reason": "frontend-local-state"},
@@ -299,6 +294,9 @@ class TestGroupingRuleAPI(APIBaseTest):
 
         rule.refresh_from_db()
         assert rule.filters == new_filters
-        assert rule.description == "Updated description"
+        # Non-filter fields from the request body are silently ignored: the
+        # original assignee and description survive the round-trip.
+        assert rule.user_id == self.user.id
+        assert rule.description == "Original description"
         assert rule.order_key == 0
         assert rule.disabled_data is None

--- a/products/error_tracking/backend/api/test/test_grouping_rules.py
+++ b/products/error_tracking/backend/api/test/test_grouping_rules.py
@@ -198,3 +198,107 @@ class TestGroupingRuleAPI(APIBaseTest):
         assert body["type"] == "validation_error"
         assert body["attr"] == f"assignee__{sub_attr}"
         assert body["detail"] == expected_detail
+
+    def _create_rule(self) -> ErrorTrackingGroupingRule:
+        response = self.client.post(
+            self._url(),
+            data={
+                "filters": VALID_FILTERS,
+                "assignee": {"type": "user", "id": self.user.id},
+                "description": "Original description",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        return ErrorTrackingGroupingRule.objects.get(id=response.json()["id"])
+
+    def test_update_allows_partial_filters_payload(self) -> None:
+        rule = self._create_rule()
+        new_filters = {
+            "type": "OR",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {"key": "$exception_type", "type": "event", "value": ["RangeError"], "operator": "exact"}
+                    ],
+                }
+            ],
+        }
+
+        response = self.client.patch(
+            self._url(str(rule.id)),
+            data={"filters": new_filters},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        rule.refresh_from_db()
+        assert rule.filters == new_filters
+        assert rule.user_id == self.user.id
+        assert rule.description == "Original description"
+
+    def test_update_rejects_invalid_filters_payload(self) -> None:
+        rule = self._create_rule()
+
+        response = self.client.patch(
+            self._url(str(rule.id)),
+            data={"filters": {"not": "a valid property group"}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert body["attr"] == "filters"
+        assert body["detail"] == "Invalid filters payload."
+
+    def test_update_rejects_mismatched_assignee(self) -> None:
+        rule = self._create_rule()
+
+        response = self.client.patch(
+            self._url(str(rule.id)),
+            data={"assignee": {"type": "role", "id": 42}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert body["attr"] == "assignee__id"
+
+    def test_update_accepts_frontend_payload_shape_with_extra_fields(self) -> None:
+        rule = self._create_rule()
+        new_filters = {
+            "type": "OR",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {"key": "$exception_type", "type": "event", "value": ["RangeError"], "operator": "exact"}
+                    ],
+                }
+            ],
+        }
+
+        response = self.client.patch(
+            self._url(str(rule.id)),
+            data={
+                "filters": new_filters,
+                "description": "Updated description",
+                "order_key": 456,
+                "disabled_data": {"reason": "frontend-local-state"},
+                "created_at": rule.created_at.isoformat(),
+                "updated_at": rule.updated_at.isoformat(),
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        rule.refresh_from_db()
+        assert rule.filters == new_filters
+        assert rule.description == "Updated description"
+        assert rule.order_key == 0
+        assert rule.disabled_data is None

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -489,6 +489,30 @@ export interface ErrorTrackingGroupingRuleCreateRequestApi {
     description?: string | null
 }
 
+export interface ErrorTrackingGroupingRuleUpdateRequestApi {
+    /** Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters. */
+    filters?: PropertyGroupFilterValueApi | null
+    /** Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee. */
+    assignee?: ErrorTrackingGroupingRuleAssigneeRequestApi | null
+    /**
+     * Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.
+     * @nullable
+     */
+    description?: string | null
+}
+
+export interface PatchedErrorTrackingGroupingRuleUpdateRequestApi {
+    /** Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters. */
+    filters?: PropertyGroupFilterValueApi | null
+    /** Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee. */
+    assignee?: ErrorTrackingGroupingRuleAssigneeRequestApi | null
+    /**
+     * Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.
+     * @nullable
+     */
+    description?: string | null
+}
+
 /**
  * @nullable
  */

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -492,25 +492,11 @@ export interface ErrorTrackingGroupingRuleCreateRequestApi {
 export interface ErrorTrackingGroupingRuleUpdateRequestApi {
     /** Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters. */
     filters?: PropertyGroupFilterValueApi | null
-    /** Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee. */
-    assignee?: ErrorTrackingGroupingRuleAssigneeRequestApi | null
-    /**
-     * Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.
-     * @nullable
-     */
-    description?: string | null
 }
 
 export interface PatchedErrorTrackingGroupingRuleUpdateRequestApi {
     /** Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters. */
     filters?: PropertyGroupFilterValueApi | null
-    /** Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee. */
-    assignee?: ErrorTrackingGroupingRuleAssigneeRequestApi | null
-    /**
-     * Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.
-     * @nullable
-     */
-    description?: string | null
 }
 
 /**

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -22,6 +22,7 @@ import type {
     ErrorTrackingGroupingRuleApi,
     ErrorTrackingGroupingRuleCreateRequestApi,
     ErrorTrackingGroupingRuleListResponseApi,
+    ErrorTrackingGroupingRuleUpdateRequestApi,
     ErrorTrackingIssueDetailApi,
     ErrorTrackingIssueEventsQueryRequestApi,
     ErrorTrackingIssueEventsResponseApi,
@@ -66,6 +67,7 @@ import type {
     PatchedErrorTrackingAssignmentRuleApi,
     PatchedErrorTrackingAssignmentRuleUpdateRequestApi,
     PatchedErrorTrackingGroupingRuleApi,
+    PatchedErrorTrackingGroupingRuleUpdateRequestApi,
     PatchedErrorTrackingIssueFullApi,
     PatchedErrorTrackingReleaseApi,
     PatchedErrorTrackingSettingsApi,
@@ -495,14 +497,14 @@ export const getErrorTrackingGroupingRulesUpdateUrl = (projectId: string, id: st
 export const errorTrackingGroupingRulesUpdate = async (
     projectId: string,
     id: string,
-    errorTrackingGroupingRuleApi: NonReadonly<ErrorTrackingGroupingRuleApi>,
+    errorTrackingGroupingRuleUpdateRequestApi?: ErrorTrackingGroupingRuleUpdateRequestApi,
     options?: RequestInit
-): Promise<ErrorTrackingGroupingRuleApi> => {
-    return apiMutator<ErrorTrackingGroupingRuleApi>(getErrorTrackingGroupingRulesUpdateUrl(projectId, id), {
+): Promise<void> => {
+    return apiMutator<void>(getErrorTrackingGroupingRulesUpdateUrl(projectId, id), {
         ...options,
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(errorTrackingGroupingRuleApi),
+        body: JSON.stringify(errorTrackingGroupingRuleUpdateRequestApi),
     })
 }
 
@@ -513,14 +515,14 @@ export const getErrorTrackingGroupingRulesPartialUpdateUrl = (projectId: string,
 export const errorTrackingGroupingRulesPartialUpdate = async (
     projectId: string,
     id: string,
-    patchedErrorTrackingGroupingRuleApi?: NonReadonly<PatchedErrorTrackingGroupingRuleApi>,
+    patchedErrorTrackingGroupingRuleUpdateRequestApi?: PatchedErrorTrackingGroupingRuleUpdateRequestApi,
     options?: RequestInit
-): Promise<ErrorTrackingGroupingRuleApi> => {
-    return apiMutator<ErrorTrackingGroupingRuleApi>(getErrorTrackingGroupingRulesPartialUpdateUrl(projectId, id), {
+): Promise<void> => {
+    return apiMutator<void>(getErrorTrackingGroupingRulesPartialUpdateUrl(projectId, id), {
         ...options,
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(patchedErrorTrackingGroupingRuleApi),
+        body: JSON.stringify(patchedErrorTrackingGroupingRuleUpdateRequestApi),
     })
 }
 

--- a/products/error_tracking/frontend/generated/api.zod.ts
+++ b/products/error_tracking/frontend/generated/api.zod.ts
@@ -44,32 +44,13 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
     .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
 
-export const errorTrackingGroupingRulesUpdateBodyOrderKeyMin = -2147483648
-export const errorTrackingGroupingRulesUpdateBodyOrderKeyMax = 2147483647
+export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod
+    .record(zod.string(), zod.unknown())
+    .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
 
-export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
-    filters: zod.unknown(),
-    description: zod.string().nullish(),
-    order_key: zod
-        .number()
-        .min(errorTrackingGroupingRulesUpdateBodyOrderKeyMin)
-        .max(errorTrackingGroupingRulesUpdateBodyOrderKeyMax),
-    disabled_data: zod.unknown().optional(),
-})
-
-export const errorTrackingGroupingRulesPartialUpdateBodyOrderKeyMin = -2147483648
-export const errorTrackingGroupingRulesPartialUpdateBodyOrderKeyMax = 2147483647
-
-export const ErrorTrackingGroupingRulesPartialUpdateBody = /* @__PURE__ */ zod.object({
-    filters: zod.unknown().optional(),
-    description: zod.string().nullish(),
-    order_key: zod
-        .number()
-        .min(errorTrackingGroupingRulesPartialUpdateBodyOrderKeyMin)
-        .max(errorTrackingGroupingRulesPartialUpdateBodyOrderKeyMax)
-        .optional(),
-    disabled_data: zod.unknown().optional(),
-})
+export const ErrorTrackingGroupingRulesPartialUpdateBody = /* @__PURE__ */ zod
+    .record(zod.string(), zod.unknown())
+    .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
 
 export const errorTrackingGroupingRulesReorderPartialUpdateBodyOrderKeyMin = -2147483648
 export const errorTrackingGroupingRulesReorderPartialUpdateBodyOrderKeyMax = 2147483647

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -128,7 +128,18 @@ tools:
         enabled: false
     error-tracking-grouping-rules-update:
         operation: error_tracking_grouping_rules_update
-        enabled: false
+        enabled: true
+        scopes:
+            - error_tracking:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Update error tracking grouping rule
+        description: >
+            Update an error tracking grouping rule by ID. Replaces the rule with the provided `filters`, `order_key`,
+            and optional `description`. Use `error-tracking-grouping-rules-partial-update` if you only want to change a
+            subset of fields.
     error-tracking-issues-activity-retrieve:
         operation: error_tracking_issues_activity_retrieve
         enabled: false

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -137,9 +137,8 @@ tools:
             idempotent: true
         title: Update error tracking grouping rule
         description: >
-            Update an error tracking grouping rule by ID. Replaces the rule with the provided `filters`, `order_key`,
-            and optional `description`. Use `error-tracking-grouping-rules-partial-update` if you only want to change a
-            subset of fields.
+            Update an error tracking grouping rule by ID. Only the fields you include in the request body are applied;
+            omitted fields keep their existing values. Supports updating `filters`, `assignee`, and `description`.
     error-tracking-issues-activity-retrieve:
         operation: error_tracking_issues_activity_retrieve
         enabled: false

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -137,8 +137,8 @@ tools:
             idempotent: true
         title: Update error tracking grouping rule
         description: >
-            Update an error tracking grouping rule by ID. Only the fields you include in the request body are applied;
-            omitted fields keep their existing values. Supports updating `filters`, `assignee`, and `description`.
+            Update an error tracking grouping rule's `filters` by ID. Omit `filters` to leave them unchanged. Editing
+            the rule also clears any auto-disable state so the rule is re-enabled.
     error-tracking-issues-activity-retrieve:
         operation: error_tracking_issues_activity_retrieve
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1278,6 +1278,21 @@
             "readOnlyHint": true
         }
     },
+    "error-tracking-grouping-rules-update": {
+        "description": "Update an error tracking grouping rule by ID. Replaces the rule with the provided `filters`, `order_key`, and optional `description`. Use `error-tracking-grouping-rules-partial-update` if you only want to change a subset of fields.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Update error tracking grouping rule",
+        "title": "Update error tracking grouping rule",
+        "required_scopes": ["error_tracking:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "error-tracking-issues-merge-create": {
         "description": "Merge one or more error tracking issues into an existing target issue. Provide the target issue as `id` and the issues to merge into it as `ids`.",
         "category": "Error tracking",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1279,7 +1279,7 @@
         }
     },
     "error-tracking-grouping-rules-update": {
-        "description": "Update an error tracking grouping rule by ID. Only the fields you include in the request body are applied; omitted fields keep their existing values. Supports updating `filters`, `assignee`, and `description`.",
+        "description": "Update an error tracking grouping rule's `filters` by ID. Omit `filters` to leave them unchanged. Editing the rule also clears any auto-disable state so the rule is re-enabled.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "Update error tracking grouping rule",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1279,7 +1279,7 @@
         }
     },
     "error-tracking-grouping-rules-update": {
-        "description": "Update an error tracking grouping rule by ID. Replaces the rule with the provided `filters`, `order_key`, and optional `description`. Use `error-tracking-grouping-rules-partial-update` if you only want to change a subset of fields.",
+        "description": "Update an error tracking grouping rule by ID. Only the fields you include in the request body are applied; omitted fields keep their existing values. Supports updating `filters`, `assignee`, and `description`.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "Update error tracking grouping rule",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1324,6 +1324,21 @@
             "readOnlyHint": true
         }
     },
+    "error-tracking-grouping-rules-update": {
+        "description": "Update an error tracking grouping rule by ID. Replaces the rule with the provided `filters`, `order_key`, and optional `description`. Use `error-tracking-grouping-rules-partial-update` if you only want to change a subset of fields.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Update error tracking grouping rule",
+        "title": "Update error tracking grouping rule",
+        "required_scopes": ["error_tracking:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "error-tracking-issues-merge-create": {
         "description": "Merge one or more error tracking issues into an existing target issue. Provide the target issue as `id` and the issues to merge into it as `ids`.",
         "category": "Error tracking",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1325,7 +1325,7 @@
         }
     },
     "error-tracking-grouping-rules-update": {
-        "description": "Update an error tracking grouping rule by ID. Replaces the rule with the provided `filters`, `order_key`, and optional `description`. Use `error-tracking-grouping-rules-partial-update` if you only want to change a subset of fields.",
+        "description": "Update an error tracking grouping rule by ID. Only the fields you include in the request body are applied; omitted fields keep their existing values. Supports updating `filters`, `assignee`, and `description`.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "Update error tracking grouping rule",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1325,7 +1325,7 @@
         }
     },
     "error-tracking-grouping-rules-update": {
-        "description": "Update an error tracking grouping rule by ID. Only the fields you include in the request body are applied; omitted fields keep their existing values. Supports updating `filters`, `assignee`, and `description`.",
+        "description": "Update an error tracking grouping rule's `filters` by ID. Omit `filters` to leave them unchanged. Editing the rule also clears any auto-disable state so the rule is re-enabled.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "Update error tracking grouping rule",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13177,6 +13177,18 @@ export namespace Schemas {
       results: ErrorTrackingGroupingRule[];
     }
 
+    export interface ErrorTrackingGroupingRuleUpdateRequest {
+      /** Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters. */
+      filters?: PropertyGroupFilterValue | null;
+      /** Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee. */
+      assignee?: ErrorTrackingGroupingRuleAssigneeRequest | null;
+      /**
+         * Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.
+         * @nullable
+         */
+      description?: string | null;
+    }
+
     export interface ErrorTrackingImpact {
       /** Exception occurrence count. */
       occurrences?: number;
@@ -25121,6 +25133,18 @@ export namespace Schemas {
       disabled_data?: unknown;
       readonly created_at?: string;
       readonly updated_at?: string;
+    }
+
+    export interface PatchedErrorTrackingGroupingRuleUpdateRequest {
+      /** Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters. */
+      filters?: PropertyGroupFilterValue | null;
+      /** Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee. */
+      assignee?: ErrorTrackingGroupingRuleAssigneeRequest | null;
+      /**
+         * Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.
+         * @nullable
+         */
+      description?: string | null;
     }
 
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13180,13 +13180,6 @@ export namespace Schemas {
     export interface ErrorTrackingGroupingRuleUpdateRequest {
       /** Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters. */
       filters?: PropertyGroupFilterValue | null;
-      /** Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee. */
-      assignee?: ErrorTrackingGroupingRuleAssigneeRequest | null;
-      /**
-         * Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.
-         * @nullable
-         */
-      description?: string | null;
     }
 
     export interface ErrorTrackingImpact {
@@ -25138,13 +25131,6 @@ export namespace Schemas {
     export interface PatchedErrorTrackingGroupingRuleUpdateRequest {
       /** Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters. */
       filters?: PropertyGroupFilterValue | null;
-      /** Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee. */
-      assignee?: ErrorTrackingGroupingRuleAssigneeRequest | null;
-      /**
-         * Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.
-         * @nullable
-         */
-      description?: string | null;
     }
 
     /**

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 15 enabled ops
+ * PostHog API - MCP 16 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -2175,6 +2175,28 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
         .string()
         .nullish()
         .describe('Optional human-readable description of what this grouping rule is for.'),
+})
+
+export const ErrorTrackingGroupingRulesUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this error tracking grouping rule.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const errorTrackingGroupingRulesUpdateBodyOrderKeyMin = -2147483648
+export const errorTrackingGroupingRulesUpdateBodyOrderKeyMax = 2147483647
+
+export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
+    filters: zod.unknown(),
+    description: zod.string().nullish(),
+    order_key: zod
+        .number()
+        .min(errorTrackingGroupingRulesUpdateBodyOrderKeyMin)
+        .max(errorTrackingGroupingRulesUpdateBodyOrderKeyMax),
+    disabled_data: zod.unknown().optional(),
 })
 
 export const ErrorTrackingIssuesPartialUpdateParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -3244,31 +3244,6 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters.'
         ),
-    assignee: zod
-        .union([
-            zod.object({
-                type: zod
-                    .enum(['user', 'role'])
-                    .describe('* `user` - user\n* `role` - role')
-                    .describe(
-                        'Assignee type. Use `user` for a user ID or `role` for a role UUID.\n\n* `user` - user\n* `role` - role'
-                    ),
-                id: zod
-                    .union([zod.number(), zod.string()])
-                    .describe('User ID when `type` is `user`, or role UUID when `type` is `role`.'),
-            }),
-            zod.null(),
-        ])
-        .optional()
-        .describe(
-            'Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee.'
-        ),
-    description: zod
-        .string()
-        .nullish()
-        .describe(
-            'Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.'
-        ),
 })
 
 export const ErrorTrackingIssuesPartialUpdateParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -2186,17 +2186,1089 @@ export const ErrorTrackingGroupingRulesUpdateParams = /* @__PURE__ */ zod.object
         ),
 })
 
-export const errorTrackingGroupingRulesUpdateBodyOrderKeyMin = -2147483648
-export const errorTrackingGroupingRulesUpdateBodyOrderKeyMax = 2147483647
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoOperatorDefault = `exact`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoTypeDefault = `event`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeTypeDefault = `person`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourTypeDefault = `element`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveTypeDefault = `event_metadata`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixTypeDefault = `session`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenCohortNameDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenKeyDefault = `id`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenOperatorDefault = `in`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenTypeDefault = `cohort`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightTypeDefault = `recording`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineTypeDefault = `log_entry`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroTypeDefault = `group`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneTypeDefault = `feature`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoOperatorDefault = `flag_evaluates_to`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoTypeDefault = `flag`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeTypeDefault = `hogql`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefourTypeDefault = `empty`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveTypeDefault = `data_warehouse`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixTypeDefault = `data_warehouse_person_property`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenTypeDefault = `error_tracking_issue`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneeightLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneeightValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnenineLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnenineValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroTypeDefault = `revenue_analytics`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroValueDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneLabelDefault = null
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneTypeDefault = `workflow_variable`
+export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneValueDefault = null
 
 export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
-    filters: zod.unknown(),
-    description: zod.string().nullish(),
-    order_key: zod
-        .number()
-        .min(errorTrackingGroupingRulesUpdateBodyOrderKeyMin)
-        .max(errorTrackingGroupingRulesUpdateBodyOrderKeyMax),
-    disabled_data: zod.unknown().optional(),
+    filters: zod
+        .union([
+            zod.object({
+                type: zod.enum(['AND', 'OR']),
+                values: zod.array(
+                    zod.union([
+                        zod.unknown(),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoLabelDefault),
+                            operator: zod
+                                .union([
+                                    zod.enum([
+                                        'exact',
+                                        'is_not',
+                                        'icontains',
+                                        'not_icontains',
+                                        'regex',
+                                        'not_regex',
+                                        'gt',
+                                        'gte',
+                                        'lt',
+                                        'lte',
+                                        'is_set',
+                                        'is_not_set',
+                                        'is_date_exact',
+                                        'is_date_before',
+                                        'is_date_after',
+                                        'between',
+                                        'not_between',
+                                        'min',
+                                        'max',
+                                        'in',
+                                        'not_in',
+                                        'is_cleaned_path_exact',
+                                        'flag_evaluates_to',
+                                        'semver_eq',
+                                        'semver_neq',
+                                        'semver_gt',
+                                        'semver_gte',
+                                        'semver_lt',
+                                        'semver_lte',
+                                        'semver_tilde',
+                                        'semver_caret',
+                                        'semver_wildcard',
+                                        'icontains_multi',
+                                        'not_icontains_multi',
+                                    ]),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoOperatorDefault),
+                            type: zod
+                                .literal('event')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoTypeDefault)
+                                .describe('Event properties'),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('person')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeTypeDefault)
+                                .describe('Person properties'),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('element')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('event_metadata')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('session')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixValueDefault),
+                        }),
+                        zod.object({
+                            cohort_name: zod
+                                .union([zod.string(), zod.null()])
+                                .default(
+                                    errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenCohortNameDefault
+                                ),
+                            key: zod
+                                .literal('id')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenKeyDefault),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenLabelDefault),
+                            operator: zod
+                                .union([
+                                    zod.enum([
+                                        'exact',
+                                        'is_not',
+                                        'icontains',
+                                        'not_icontains',
+                                        'regex',
+                                        'not_regex',
+                                        'gt',
+                                        'gte',
+                                        'lt',
+                                        'lte',
+                                        'is_set',
+                                        'is_not_set',
+                                        'is_date_exact',
+                                        'is_date_before',
+                                        'is_date_after',
+                                        'between',
+                                        'not_between',
+                                        'min',
+                                        'max',
+                                        'in',
+                                        'not_in',
+                                        'is_cleaned_path_exact',
+                                        'flag_evaluates_to',
+                                        'semver_eq',
+                                        'semver_neq',
+                                        'semver_gt',
+                                        'semver_gte',
+                                        'semver_lt',
+                                        'semver_lte',
+                                        'semver_tilde',
+                                        'semver_caret',
+                                        'semver_wildcard',
+                                        'icontains_multi',
+                                        'not_icontains_multi',
+                                    ]),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenOperatorDefault),
+                            type: zod
+                                .literal('cohort')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenTypeDefault),
+                            value: zod.number(),
+                        }),
+                        zod.object({
+                            key: zod.union([
+                                zod.enum(['duration', 'active_seconds', 'inactive_seconds']),
+                                zod.string(),
+                            ]),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('recording')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('log_entry')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineValueDefault),
+                        }),
+                        zod.object({
+                            group_key_names: zod
+                                .union([zod.record(zod.string(), zod.string()), zod.null()])
+                                .default(
+                                    errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault
+                                ),
+                            group_type_index: zod
+                                .union([zod.number(), zod.null()])
+                                .default(
+                                    errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault
+                                ),
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('group')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('feature')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneTypeDefault)
+                                .describe('Event property with "$feature/" prepended'),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string().describe('The key should be the flag ID'),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoLabelDefault),
+                            operator: zod
+                                .literal('flag_evaluates_to')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoOperatorDefault)
+                                .describe('Only flag_evaluates_to operator is allowed for flag dependencies'),
+                            type: zod
+                                .literal('flag')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoTypeDefault)
+                                .describe('Feature flag dependency'),
+                            value: zod
+                                .union([zod.boolean(), zod.string()])
+                                .describe('The value can be true, false, or a variant name'),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeLabelDefault),
+                            type: zod
+                                .literal('hogql')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeValueDefault),
+                        }),
+                        zod.object({
+                            type: zod
+                                .literal('empty')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefourTypeDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('data_warehouse')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('data_warehouse_person_property')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('error_tracking_issue')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneeightLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod.enum(['log', 'log_attribute', 'log_resource_attribute']),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneeightValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnenineLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod.enum(['span', 'span_attribute', 'span_resource_attribute']),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnenineValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('revenue_analytics')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroValueDefault),
+                        }),
+                        zod.object({
+                            key: zod.string(),
+                            label: zod
+                                .union([zod.string(), zod.null()])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneLabelDefault),
+                            operator: zod.enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ]),
+                            type: zod
+                                .literal('workflow_variable')
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneTypeDefault),
+                            value: zod
+                                .union([
+                                    zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                    zod.string(),
+                                    zod.number(),
+                                    zod.boolean(),
+                                    zod.null(),
+                                ])
+                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneValueDefault),
+                        }),
+                    ])
+                ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters.'
+        ),
+    assignee: zod
+        .union([
+            zod.object({
+                type: zod
+                    .enum(['user', 'role'])
+                    .describe('* `user` - user\n* `role` - role')
+                    .describe(
+                        'Assignee type. Use `user` for a user ID or `role` for a role UUID.\n\n* `user` - user\n* `role` - role'
+                    ),
+                id: zod
+                    .union([zod.number(), zod.string()])
+                    .describe('User ID when `type` is `user`, or role UUID when `type` is `role`.'),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee.'
+        ),
+    description: zod
+        .string()
+        .nullish()
+        .describe(
+            'Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description.'
+        ),
 })
 
 export const ErrorTrackingIssuesPartialUpdateParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -6,6 +6,8 @@ import {
     ErrorTrackingAssignmentRulesCreateBody,
     ErrorTrackingAssignmentRulesListQueryParams,
     ErrorTrackingGroupingRulesCreateBody,
+    ErrorTrackingGroupingRulesUpdateBody,
+    ErrorTrackingGroupingRulesUpdateParams,
     ErrorTrackingIssuesMergeCreateBody,
     ErrorTrackingIssuesMergeCreateParams,
     ErrorTrackingIssuesPartialUpdateBody,
@@ -116,6 +118,40 @@ const errorTrackingGroupingRulesList = (): ToolBase<
         const result = await context.api.request<Schemas.ErrorTrackingGroupingRuleListResponse>({
             method: 'GET',
             path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/grouping_rules/`,
+        })
+        return result
+    },
+})
+
+const ErrorTrackingGroupingRulesUpdateSchema = ErrorTrackingGroupingRulesUpdateParams.omit({ project_id: true }).extend(
+    ErrorTrackingGroupingRulesUpdateBody.shape
+)
+
+const errorTrackingGroupingRulesUpdate = (): ToolBase<
+    typeof ErrorTrackingGroupingRulesUpdateSchema,
+    Schemas.ErrorTrackingGroupingRule
+> => ({
+    name: 'error-tracking-grouping-rules-update',
+    schema: ErrorTrackingGroupingRulesUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof ErrorTrackingGroupingRulesUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.filters !== undefined) {
+            body['filters'] = params.filters
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        if (params.order_key !== undefined) {
+            body['order_key'] = params.order_key
+        }
+        if (params.disabled_data !== undefined) {
+            body['disabled_data'] = params.disabled_data
+        }
+        const result = await context.api.request<Schemas.ErrorTrackingGroupingRule>({
+            method: 'PUT',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/grouping_rules/${encodeURIComponent(String(params.id))}/`,
+            body,
         })
         return result
     },
@@ -541,6 +577,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'error-tracking-assignment-rules-list': errorTrackingAssignmentRulesList,
     'error-tracking-grouping-rules-create': errorTrackingGroupingRulesCreate,
     'error-tracking-grouping-rules-list': errorTrackingGroupingRulesList,
+    'error-tracking-grouping-rules-update': errorTrackingGroupingRulesUpdate,
     'error-tracking-issues-merge-create': errorTrackingIssuesMergeCreate,
     'error-tracking-issues-partial-update': errorTrackingIssuesPartialUpdate,
     'error-tracking-issues-split-create': errorTrackingIssuesSplitCreate,

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -136,12 +136,6 @@ const errorTrackingGroupingRulesUpdate = (): ToolBase<typeof ErrorTrackingGroupi
         if (params.filters !== undefined) {
             body['filters'] = params.filters
         }
-        if (params.assignee !== undefined) {
-            body['assignee'] = params.assignee
-        }
-        if (params.description !== undefined) {
-            body['description'] = params.description
-        }
         const result = await context.api.request<unknown>({
             method: 'PUT',
             path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/grouping_rules/${encodeURIComponent(String(params.id))}/`,

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -127,10 +127,7 @@ const ErrorTrackingGroupingRulesUpdateSchema = ErrorTrackingGroupingRulesUpdateP
     ErrorTrackingGroupingRulesUpdateBody.shape
 )
 
-const errorTrackingGroupingRulesUpdate = (): ToolBase<
-    typeof ErrorTrackingGroupingRulesUpdateSchema,
-    Schemas.ErrorTrackingGroupingRule
-> => ({
+const errorTrackingGroupingRulesUpdate = (): ToolBase<typeof ErrorTrackingGroupingRulesUpdateSchema, unknown> => ({
     name: 'error-tracking-grouping-rules-update',
     schema: ErrorTrackingGroupingRulesUpdateSchema,
     handler: async (context: Context, params: z.infer<typeof ErrorTrackingGroupingRulesUpdateSchema>) => {
@@ -139,16 +136,13 @@ const errorTrackingGroupingRulesUpdate = (): ToolBase<
         if (params.filters !== undefined) {
             body['filters'] = params.filters
         }
+        if (params.assignee !== undefined) {
+            body['assignee'] = params.assignee
+        }
         if (params.description !== undefined) {
             body['description'] = params.description
         }
-        if (params.order_key !== undefined) {
-            body['order_key'] = params.order_key
-        }
-        if (params.disabled_data !== undefined) {
-            body['disabled_data'] = params.disabled_data
-        }
-        const result = await context.api.request<Schemas.ErrorTrackingGroupingRule>({
+        const result = await context.api.request<unknown>({
             method: 'PUT',
             path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/grouping_rules/${encodeURIComponent(String(params.id))}/`,
             body,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-grouping-rules-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-grouping-rules-update.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "description": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "disabled_data": {},
+        "filters": {},
+        "id": {
+            "description": "A UUID string identifying this error tracking grouping rule.",
+            "type": "string"
+        },
+        "order_key": {
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "type": "number"
+        }
+    },
+    "required": ["id", "filters", "order_key"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-grouping-rules-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-grouping-rules-update.json
@@ -1,6 +1,36 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "assignee": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "id": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ],
+                            "description": "User ID when `type` is `user`, or role UUID when `type` is `role`."
+                        },
+                        "type": {
+                            "description": "Assignee type. Use `user` for a user ID or `role` for a role UUID.\n\n* `user` - user\n* `role` - role",
+                            "enum": ["user", "role"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "id"],
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee."
+        },
         "description": {
             "anyOf": [
                 {
@@ -9,20 +39,1838 @@
                 {
                     "type": "null"
                 }
-            ]
+            ],
+            "description": "Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description."
         },
-        "disabled_data": {},
-        "filters": {},
+        "filters": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "type": {
+                            "enum": ["AND", "OR"],
+                            "type": "string"
+                        },
+                        "values": {
+                            "items": {
+                                "anyOf": [
+                                    {},
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "anyOf": [
+                                                    {
+                                                        "enum": [
+                                                            "exact",
+                                                            "is_not",
+                                                            "icontains",
+                                                            "not_icontains",
+                                                            "regex",
+                                                            "not_regex",
+                                                            "gt",
+                                                            "gte",
+                                                            "lt",
+                                                            "lte",
+                                                            "is_set",
+                                                            "is_not_set",
+                                                            "is_date_exact",
+                                                            "is_date_before",
+                                                            "is_date_after",
+                                                            "between",
+                                                            "not_between",
+                                                            "min",
+                                                            "max",
+                                                            "in",
+                                                            "not_in",
+                                                            "is_cleaned_path_exact",
+                                                            "flag_evaluates_to",
+                                                            "semver_eq",
+                                                            "semver_neq",
+                                                            "semver_gt",
+                                                            "semver_gte",
+                                                            "semver_lt",
+                                                            "semver_lte",
+                                                            "semver_tilde",
+                                                            "semver_caret",
+                                                            "semver_wildcard",
+                                                            "icontains_multi",
+                                                            "not_icontains_multi"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "exact"
+                                            },
+                                            "type": {
+                                                "const": "event",
+                                                "default": "event",
+                                                "description": "Event properties",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "person",
+                                                "default": "person",
+                                                "description": "Person properties",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "enum": ["tag_name", "text", "href", "selector"],
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "element",
+                                                "default": "element",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "event_metadata",
+                                                "default": "event_metadata",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "session",
+                                                "default": "session",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "cohort_name": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "key": {
+                                                "const": "id",
+                                                "default": "id",
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "anyOf": [
+                                                    {
+                                                        "enum": [
+                                                            "exact",
+                                                            "is_not",
+                                                            "icontains",
+                                                            "not_icontains",
+                                                            "regex",
+                                                            "not_regex",
+                                                            "gt",
+                                                            "gte",
+                                                            "lt",
+                                                            "lte",
+                                                            "is_set",
+                                                            "is_not_set",
+                                                            "is_date_exact",
+                                                            "is_date_before",
+                                                            "is_date_after",
+                                                            "between",
+                                                            "not_between",
+                                                            "min",
+                                                            "max",
+                                                            "in",
+                                                            "not_in",
+                                                            "is_cleaned_path_exact",
+                                                            "flag_evaluates_to",
+                                                            "semver_eq",
+                                                            "semver_neq",
+                                                            "semver_gt",
+                                                            "semver_gte",
+                                                            "semver_lt",
+                                                            "semver_lte",
+                                                            "semver_tilde",
+                                                            "semver_caret",
+                                                            "semver_wildcard",
+                                                            "icontains_multi",
+                                                            "not_icontains_multi"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "in"
+                                            },
+                                            "type": {
+                                                "const": "cohort",
+                                                "default": "cohort",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": ["value"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "anyOf": [
+                                                    {
+                                                        "enum": ["duration", "active_seconds", "inactive_seconds"],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "recording",
+                                                "default": "recording",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "log_entry",
+                                                "default": "log_entry",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "group_key_names": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "propertyNames": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "group_type_index": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "group",
+                                                "default": "group",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "feature",
+                                                "default": "feature",
+                                                "description": "Event property with \"$feature/\" prepended",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "description": "The key should be the flag ID",
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "const": "flag_evaluates_to",
+                                                "default": "flag_evaluates_to",
+                                                "description": "Only flag_evaluates_to operator is allowed for flag dependencies",
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "flag",
+                                                "default": "flag",
+                                                "description": "Feature flag dependency",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ],
+                                                "description": "The value can be true, false, or a variant name"
+                                            }
+                                        },
+                                        "required": ["key", "value"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "type": {
+                                                "const": "hogql",
+                                                "default": "hogql",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "const": "empty",
+                                                "default": "empty",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "data_warehouse",
+                                                "default": "data_warehouse",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "data_warehouse_person_property",
+                                                "default": "data_warehouse_person_property",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "error_tracking_issue",
+                                                "default": "error_tracking_issue",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "enum": ["log", "log_attribute", "log_resource_attribute"],
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator", "type"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "enum": ["span", "span_attribute", "span_resource_attribute"],
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator", "type"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "revenue_analytics",
+                                                "default": "revenue_analytics",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "operator": {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "const": "workflow_variable",
+                                                "default": "workflow_variable",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "required": ["key", "operator"],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["type", "values"],
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters."
+        },
         "id": {
             "description": "A UUID string identifying this error tracking grouping rule.",
             "type": "string"
-        },
-        "order_key": {
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "type": "number"
         }
     },
-    "required": ["id", "filters", "order_key"],
+    "required": ["id"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-grouping-rules-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-grouping-rules-update.json
@@ -1,47 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
-        "assignee": {
-            "anyOf": [
-                {
-                    "properties": {
-                        "id": {
-                            "anyOf": [
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ],
-                            "description": "User ID when `type` is `user`, or role UUID when `type` is `role`."
-                        },
-                        "type": {
-                            "description": "Assignee type. Use `user` for a user ID or `role` for a role UUID.\n\n* `user` - user\n* `role` - role",
-                            "enum": ["user", "role"],
-                            "type": "string"
-                        }
-                    },
-                    "required": ["type", "id"],
-                    "type": "object"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "description": "Optional user or role to assign to issues created by this grouping rule. Omit to preserve the existing assignee."
-        },
-        "description": {
-            "anyOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "description": "Optional human-readable description of what this grouping rule is for. Omit to preserve the existing description."
-        },
         "filters": {
             "anyOf": [
                 {


### PR DESCRIPTION
## Problem

The MCP error tracking surface exposes `error-tracking-grouping-rules-create` and `error-tracking-grouping-rules-list` but not the matching `update`. Agents that want to adjust an existing grouping rule (change `filters`, `description`, `order_key`) currently have no way to do so without going through the UI or the partial-update endpoint (also disabled).

## Changes

Enable `error-tracking-grouping-rules-update` in `products/error_tracking/mcp/tools.yaml`:

- `scopes: [error_tracking:write]`
- `annotations`: `readOnly: false`, `destructive: false`, `idempotent: true` (PUT)
- Title and description point agents at `partial-update` when only some fields need changing

Regenerated MCP artifacts via `hogli build:openapi`:

- `services/mcp/src/generated/error_tracking/api.ts` — adds `ErrorTrackingGroupingRulesUpdateParams` and `ErrorTrackingGroupingRulesUpdateBody` Zod schemas
- `services/mcp/src/tools/generated/error_tracking.ts` — adds the `errorTrackingGroupingRulesUpdate` handler and registers it in `GENERATED_TOOLS`
- `services/mcp/schema/generated-tool-definitions.json` and `tool-definitions-all.json` — adds the tool definition entry

## How did you test this code?

tested locally manually +

- `pnpm --filter=@posthog/mcp typecheck` — passes
- `pnpm --filter=@posthog/mcp lint-tool-names` — passes

No manual MCP-server test was performed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7).

- Edited `products/error_tracking/mcp/tools.yaml` to flip the existing scaffolded entry from `enabled: false` to enabled, mirroring the field shape of nearby update tools (`error-tracking-issues-partial-update`).
- Bootstrapped Python 3.12.12 + `uv sync --frozen` from scratch in this environment, then ran `python manage.py spectacular` against a sqlite `DATABASE_URL` with `SERVER_GATEWAY_INTERFACE=ASGI` to skip the WSGI-only self-capture init that requires a populated Postgres. Redis warnings during schema generation are non-fatal.
- Ran the full MCP codegen pipeline (`generate-mcp-types`, `generate-orval-schemas`, `generate-tools`, `generate-tool-schema`).
- The codegen surfaced unrelated drift in `services/mcp/src/api/generated.ts` and `services/mcp/src/generated/cdp_functions/api.ts` (smallint→integer max bumps from a recent backend change). Reverted to keep this PR focused; that drift should be picked up by the next regeneration on master.