### PR TITLE
feat(workflows): add manual opt-out entry for messaging preferences

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1934,6 +1934,10 @@ export class ApiRequest {
         return this.environments().current().addPathComponent('messaging_preferences').addPathComponent('opt_outs')
     }
 
+    public messagingPreferencesAddOptOut(): ApiRequest {
+        return this.environments().current().addPathComponent('messaging_preferences').addPathComponent('add_opt_out')
+    }
+
     public hogFlows(): ApiRequest {
         return this.environments().current().addPathComponent('hog_flows')
     }
@@ -6105,6 +6109,11 @@ const api = {
                     page: page || 1,
                 })
                 .get()
+        },
+        async addOptOut(identifier: string, categoryKey?: string): Promise<OptOutEntry> {
+            return await new ApiRequest().messagingPreferencesAddOptOut().create({
+                data: { identifier, category_key: categoryKey },
+            })
         },
     },
     hogFlows: {

--- a/products/messaging/backend/api/message_preferences.py
+++ b/products/messaging/backend/api/message_preferences.py
@@ -104,11 +104,8 @@ class MessagePreferencesViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         serializer = AddOptOutRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        identifier = serializer.validated_data["identifier"].strip()
+        identifier = serializer.validated_data["identifier"]
         category_key = serializer.validated_data.get("category_key")
-
-        if not identifier:
-            return Response({"error": "Identifier cannot be blank"}, status=status.HTTP_400_BAD_REQUEST)
 
         if category_key:
             try:
@@ -119,14 +116,15 @@ class MessagePreferencesViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         else:
             category_id = ALL_MESSAGE_PREFERENCE_CATEGORY_ID
 
-        preference, _created = MessageRecipientPreference.objects.get_or_create(
+        preference, created = MessageRecipientPreference.objects.get_or_create(
             team_id=self.team_id,
             identifier=identifier,
             defaults={"created_by": request.user},
         )
         preference.set_preference(category_id, PreferenceStatus.OPTED_OUT)
 
-        return Response(MessagePreferencesSerializer(preference).data, status=status.HTTP_201_CREATED)
+        response_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        return Response(MessagePreferencesSerializer(preference).data, status=response_status)
 
     @action(detail=False, methods=["get"])
     def webhook_url(self, request, **kwargs):

--- a/products/messaging/backend/api/message_preferences.py
+++ b/products/messaging/backend/api/message_preferences.py
@@ -1,4 +1,5 @@
-from rest_framework import serializers, viewsets
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
@@ -22,9 +23,9 @@ class OptOutsPagination(PageNumberPagination):
 
 
 class MessagePreferencesSerializer(serializers.ModelSerializer):
-    identifier = serializers.CharField()
-    updated_at = serializers.DateTimeField()
-    preferences = serializers.JSONField()
+    identifier = serializers.CharField(help_text="The recipient identifier (e.g. email address).")
+    updated_at = serializers.DateTimeField(help_text="When the preference was last updated.")
+    preferences = serializers.JSONField(help_text="Map of category ID to preference status.")
 
     class Meta:
         model = MessageRecipientPreference
@@ -41,6 +42,17 @@ class MessagePreferencesSerializer(serializers.ModelSerializer):
             "updated_at",
             "created_by",
         ]
+
+
+class AddOptOutRequestSerializer(serializers.Serializer):
+    identifier = serializers.CharField(
+        max_length=512,
+        help_text="The recipient identifier to opt out (e.g. email address).",
+    )
+    category_key = serializers.CharField(
+        required=False,
+        help_text="Optional message category key. If omitted, the recipient is opted out of all marketing messages.",
+    )
 
 
 class MessagePreferencesViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
@@ -80,6 +92,41 @@ class MessagePreferencesViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         # Fallback if pagination fails for some reason
         serializer = MessagePreferencesSerializer(opt_outs, many=True)
         return Response(serializer.data)
+
+    @extend_schema(
+        request=AddOptOutRequestSerializer,
+        responses={201: MessagePreferencesSerializer},
+        summary="Manually add a recipient to the opt-out list",
+    )
+    @action(detail=False, methods=["post"])
+    def add_opt_out(self, request, **kwargs):
+        """Manually add a recipient to the opt-out list for a specific category or all marketing messages."""
+        serializer = AddOptOutRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        identifier = serializer.validated_data["identifier"].strip()
+        category_key = serializer.validated_data.get("category_key")
+
+        if not identifier:
+            return Response({"error": "Identifier cannot be blank"}, status=status.HTTP_400_BAD_REQUEST)
+
+        if category_key:
+            try:
+                category = MessageCategory.objects.get(key=category_key, team_id=self.team_id)
+            except MessageCategory.DoesNotExist:
+                return Response({"error": "Category not found"}, status=status.HTTP_404_NOT_FOUND)
+            category_id = str(category.id)
+        else:
+            category_id = ALL_MESSAGE_PREFERENCE_CATEGORY_ID
+
+        preference, _created = MessageRecipientPreference.objects.get_or_create(
+            team_id=self.team_id,
+            identifier=identifier,
+            defaults={"created_by": request.user},
+        )
+        preference.set_preference(category_id, PreferenceStatus.OPTED_OUT)
+
+        return Response(MessagePreferencesSerializer(preference).data, status=status.HTTP_201_CREATED)
 
     @action(detail=False, methods=["get"])
     def webhook_url(self, request, **kwargs):

--- a/products/messaging/backend/api/test/test_message_preferences.py
+++ b/products/messaging/backend/api/test/test_message_preferences.py
@@ -334,3 +334,93 @@ class TestMessagePreferencesAPIViewSet(APIBaseTest):
         self.assertEqual(data["count"], 1)
         self.assertEqual(len(data["results"]), 1)
         self.assertEqual(data["results"][0]["identifier"], "user1@example.com")
+
+    def test_add_opt_out_global(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
+            {"identifier": "new@example.com"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["identifier"], "new@example.com")
+        self.assertEqual(data["preferences"][ALL_MESSAGE_PREFERENCE_CATEGORY_ID], PreferenceStatus.OPTED_OUT.value)
+
+        pref = MessageRecipientPreference.objects.get(team=self.team, identifier="new@example.com")
+        self.assertEqual(pref.get_preference(ALL_MESSAGE_PREFERENCE_CATEGORY_ID), PreferenceStatus.OPTED_OUT)
+
+    def test_add_opt_out_specific_category(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
+            {"identifier": "user@example.com", "category_key": self.category.key},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["identifier"], "user@example.com")
+        self.assertEqual(data["preferences"][str(self.category.id)], PreferenceStatus.OPTED_OUT.value)
+
+    def test_add_opt_out_nonexistent_category(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
+            {"identifier": "user@example.com", "category_key": "does_not_exist"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"], "Category not found")
+
+    def test_add_opt_out_duplicate_identifier_updates_existing(self):
+        existing = MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="existing@example.com",
+            preferences={str(self.category.id): PreferenceStatus.OPTED_IN.value},
+        )
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
+            {"identifier": "existing@example.com"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        existing.refresh_from_db()
+        self.assertEqual(existing.get_preference(ALL_MESSAGE_PREFERENCE_CATEGORY_ID), PreferenceStatus.OPTED_OUT)
+        # existing category preference is preserved
+        self.assertEqual(existing.get_preference(str(self.category.id)), PreferenceStatus.OPTED_IN)
+
+    def test_add_opt_out_missing_identifier(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
+            {},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_add_opt_out_blank_identifier(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
+            {"identifier": "   "},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_add_opt_out_team_isolation(self):
+        other_team = self.organization.teams.create(name="Other Team")
+        self.client.post(
+            f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
+            {"identifier": "isolated@example.com"},
+            content_type="application/json",
+        )
+        self.assertTrue(
+            MessageRecipientPreference.objects.filter(team=self.team, identifier="isolated@example.com").exists()
+        )
+        self.assertFalse(
+            MessageRecipientPreference.objects.filter(team=other_team, identifier="isolated@example.com").exists()
+        )
+
+    def test_add_opt_out_whitespace_trimmed(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
+            {"identifier": "  trimmed@example.com  "},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["identifier"], "trimmed@example.com")

--- a/products/messaging/backend/api/test/test_message_preferences.py
+++ b/products/messaging/backend/api/test/test_message_preferences.py
@@ -380,27 +380,43 @@ class TestMessagePreferencesAPIViewSet(APIBaseTest):
             {"identifier": "existing@example.com"},
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         existing.refresh_from_db()
         self.assertEqual(existing.get_preference(ALL_MESSAGE_PREFERENCE_CATEGORY_ID), PreferenceStatus.OPTED_OUT)
         # existing category preference is preserved
         self.assertEqual(existing.get_preference(str(self.category.id)), PreferenceStatus.OPTED_IN)
 
-    def test_add_opt_out_missing_identifier(self):
+    @parameterized.expand(
+        [
+            ("missing_identifier", {}, 400),
+            ("blank_identifier", {"identifier": "   "}, 400),
+            ("empty_string", {"identifier": ""}, 400),
+        ]
+    )
+    def test_add_opt_out_invalid_identifier(self, _name, payload, expected_status):
         response = self.client.post(
             f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
-            {},
+            payload,
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, expected_status)
 
-    def test_add_opt_out_blank_identifier(self):
+    @parameterized.expand(
+        [
+            ("leading_trailing", "  trimmed@example.com  ", "trimmed@example.com"),
+            ("leading_only", "  leading@example.com", "leading@example.com"),
+            ("trailing_only", "trailing@example.com  ", "trailing@example.com"),
+            ("no_whitespace", "clean@example.com", "clean@example.com"),
+        ]
+    )
+    def test_add_opt_out_identifier_normalization(self, _name, raw_identifier, expected_identifier):
         response = self.client.post(
             f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
-            {"identifier": "   "},
+            {"identifier": raw_identifier},
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["identifier"], expected_identifier)
 
     def test_add_opt_out_team_isolation(self):
         other_team = self.organization.teams.create(name="Other Team")
@@ -415,12 +431,3 @@ class TestMessagePreferencesAPIViewSet(APIBaseTest):
         self.assertFalse(
             MessageRecipientPreference.objects.filter(team=other_team, identifier="isolated@example.com").exists()
         )
-
-    def test_add_opt_out_whitespace_trimmed(self):
-        response = self.client.post(
-            f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",
-            {"identifier": "  trimmed@example.com  "},
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.json()["identifier"], "trimmed@example.com")

--- a/products/messaging/frontend/generated/api.schemas.ts
+++ b/products/messaging/frontend/generated/api.schemas.ts
@@ -43,6 +43,26 @@ export interface PaginatedMessageCategoryListApi {
     results: MessageCategoryApi[]
 }
 
+export interface AddOptOutRequestApi {
+    /**
+     * The recipient identifier to opt out (e.g. email address).
+     * @maxLength 512
+     */
+    identifier: string
+    /** Optional message category key. If omitted, the recipient is opted out of all marketing messages. */
+    category_key?: string
+}
+
+export interface MessagePreferencesApi {
+    readonly id: string
+    /** The recipient identifier (e.g. email address). */
+    identifier: string
+    /** When the preference was last updated. */
+    updated_at: string
+    /** Map of category ID to preference status. */
+    preferences: unknown
+}
+
 /**
  * * `hog` - hog
  * `liquid` - liquid

--- a/products/messaging/frontend/generated/api.ts
+++ b/products/messaging/frontend/generated/api.ts
@@ -9,7 +9,9 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    AddOptOutRequestApi,
     MessageCategoryApi,
+    MessagePreferencesApi,
     MessageTemplateApi,
     MessagingCategoriesListParams,
     MessagingTemplatesListParams,
@@ -252,6 +254,27 @@ export const messagingCategoriesSaveWebhookConfigCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(messageCategoryApi),
+    })
+}
+
+export const getMessagingPreferencesAddOptOutCreateUrl = (projectId: string) => {
+    return `/api/environments/${projectId}/messaging_preferences/add_opt_out/`
+}
+
+/**
+ * Manually add a recipient to the opt-out list for a specific category or all marketing messages.
+ * @summary Manually add a recipient to the opt-out list
+ */
+export const messagingPreferencesAddOptOutCreate = async (
+    projectId: string,
+    addOptOutRequestApi: AddOptOutRequestApi,
+    options?: RequestInit
+): Promise<MessagePreferencesApi> => {
+    return apiMutator<MessagePreferencesApi>(getMessagingPreferencesAddOptOutCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(addOptOutRequestApi),
     })
 }
 

--- a/products/messaging/frontend/generated/api.zod.ts
+++ b/products/messaging/frontend/generated/api.zod.ts
@@ -114,6 +114,23 @@ export const MessagingCategoriesSaveWebhookConfigCreateBody = /* @__PURE__ */ zo
     deleted: zod.boolean().optional(),
 })
 
+/**
+ * Manually add a recipient to the opt-out list for a specific category or all marketing messages.
+ * @summary Manually add a recipient to the opt-out list
+ */
+export const messagingPreferencesAddOptOutCreateBodyIdentifierMax = 512
+
+export const MessagingPreferencesAddOptOutCreateBody = /* @__PURE__ */ zod.object({
+    identifier: zod
+        .string()
+        .max(messagingPreferencesAddOptOutCreateBodyIdentifierMax)
+        .describe('The recipient identifier to opt out (e.g. email address).'),
+    category_key: zod
+        .string()
+        .optional()
+        .describe('Optional message category key. If omitted, the recipient is opted out of all marketing messages.'),
+})
+
 export const messagingTemplatesCreateBodyNameMax = 400
 
 export const messagingTemplatesCreateBodyTypeMax = 24

--- a/products/workflows/frontend/OptOuts/OptOutList.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutList.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
 
 import { IconChevronLeft, IconChevronRight, IconExternal, IconPlus, IconRefresh } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonModal, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
@@ -23,6 +22,7 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
         loadPreviousPage,
         loadOptOutPersons,
         setShowAddOptOutModal,
+        setNewOptOutIdentifier,
         addOptOut,
     } = useActions(logic)
     const {
@@ -33,8 +33,8 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
         currentPage,
         showAddOptOutModal,
         addOptOutLoading,
+        newOptOutIdentifier,
     } = useValues(logic)
-    const [newOptOutIdentifier, setNewOptOutIdentifier] = useState('')
 
     const handleShowPersons = (identifier: string): void => {
         setSelectedIdentifier(identifier)
@@ -181,20 +181,11 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
 
             <LemonModal
                 isOpen={showAddOptOutModal}
-                onClose={() => {
-                    setShowAddOptOutModal(false)
-                    setNewOptOutIdentifier('')
-                }}
+                onClose={() => setShowAddOptOutModal(false)}
                 title={`Add opt-out${category?.name ? ` for ${category.name}` : ''}`}
                 footer={
                     <>
-                        <LemonButton
-                            type="secondary"
-                            onClick={() => {
-                                setShowAddOptOutModal(false)
-                                setNewOptOutIdentifier('')
-                            }}
-                        >
+                        <LemonButton type="secondary" onClick={() => setShowAddOptOutModal(false)}>
                             Cancel
                         </LemonButton>
                         <LemonButton

--- a/products/workflows/frontend/OptOuts/OptOutList.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutList.tsx
@@ -203,7 +203,6 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
                             disabled={!newOptOutIdentifier.trim()}
                             onClick={() => {
                                 addOptOut(newOptOutIdentifier.trim())
-                                setNewOptOutIdentifier('')
                             }}
                         >
                             Add opt-out
@@ -224,7 +223,6 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
                         onPressEnter={() => {
                             if (newOptOutIdentifier.trim()) {
                                 addOptOut(newOptOutIdentifier.trim())
-                                setNewOptOutIdentifier('')
                             }
                         }}
                     />

--- a/products/workflows/frontend/OptOuts/OptOutList.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutList.tsx
@@ -1,7 +1,8 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 
-import { IconChevronLeft, IconChevronRight, IconExternal, IconRefresh } from '@posthog/icons'
-import { LemonButton, LemonModal, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
+import { IconChevronLeft, IconChevronRight, IconExternal, IconPlus, IconRefresh } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonModal, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -15,10 +16,25 @@ import type { OptOutEntry } from './types'
 
 export function OptOutList({ category }: { category?: MessageCategory }): JSX.Element {
     const logic = optOutListLogic({ category })
-    const { setSelectedIdentifier, openPreferencesPage, loadNextPage, loadPreviousPage, loadOptOutPersons } =
-        useActions(logic)
-    const { selectedIdentifier, optOutPersons, optOutPersonsLoading, preferencesUrlLoading, currentPage } =
-        useValues(logic)
+    const {
+        setSelectedIdentifier,
+        openPreferencesPage,
+        loadNextPage,
+        loadPreviousPage,
+        loadOptOutPersons,
+        setShowAddOptOutModal,
+        addOptOut,
+    } = useActions(logic)
+    const {
+        selectedIdentifier,
+        optOutPersons,
+        optOutPersonsLoading,
+        preferencesUrlLoading,
+        currentPage,
+        showAddOptOutModal,
+        addOptOutLoading,
+    } = useValues(logic)
+    const [newOptOutIdentifier, setNewOptOutIdentifier] = useState('')
 
     const handleShowPersons = (identifier: string): void => {
         setSelectedIdentifier(identifier)
@@ -85,7 +101,15 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
 
     return (
         <>
-            <div className="flex justify-end mb-2 mt-[-3rem]">
+            <div className="flex justify-end gap-2 mb-2 mt-[-3rem]">
+                <LemonButton
+                    icon={<IconPlus />}
+                    size="small"
+                    type="secondary"
+                    onClick={() => setShowAddOptOutModal(true)}
+                >
+                    Add opt-out
+                </LemonButton>
                 <LemonButton
                     icon={<IconRefresh />}
                     size="small"
@@ -153,6 +177,58 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
                         />
                     </div>
                 )}
+            </LemonModal>
+
+            <LemonModal
+                isOpen={showAddOptOutModal}
+                onClose={() => {
+                    setShowAddOptOutModal(false)
+                    setNewOptOutIdentifier('')
+                }}
+                title={`Add opt-out${category?.name ? ` for ${category.name}` : ''}`}
+                footer={
+                    <>
+                        <LemonButton
+                            type="secondary"
+                            onClick={() => {
+                                setShowAddOptOutModal(false)
+                                setNewOptOutIdentifier('')
+                            }}
+                        >
+                            Cancel
+                        </LemonButton>
+                        <LemonButton
+                            type="primary"
+                            loading={addOptOutLoading}
+                            disabled={!newOptOutIdentifier.trim()}
+                            onClick={() => {
+                                addOptOut(newOptOutIdentifier.trim())
+                                setNewOptOutIdentifier('')
+                            }}
+                        >
+                            Add opt-out
+                        </LemonButton>
+                    </>
+                }
+            >
+                <div className="space-y-2">
+                    <label htmlFor="opt-out-identifier" className="text-sm font-medium">
+                        Recipient identifier (e.g. email address)
+                    </label>
+                    <LemonInput
+                        id="opt-out-identifier"
+                        placeholder="email@example.com"
+                        value={newOptOutIdentifier}
+                        onChange={setNewOptOutIdentifier}
+                        autoFocus
+                        onPressEnter={() => {
+                            if (newOptOutIdentifier.trim()) {
+                                addOptOut(newOptOutIdentifier.trim())
+                                setNewOptOutIdentifier('')
+                            }
+                        }}
+                    />
+                </div>
             </LemonModal>
         </>
     )

--- a/products/workflows/frontend/OptOuts/optOutListLogic.ts
+++ b/products/workflows/frontend/OptOuts/optOutListLogic.ts
@@ -87,15 +87,15 @@ export const optOutListLogic = kea<optOutListLogicType>([
     loaders(({ props, values, actions }) => ({
         addOptOut: {
             __default: null as OptOutEntry | null,
-            addOptOut: async (identifier: string): Promise<OptOutEntry | null> => {
+            addOptOut: async (identifier: string): Promise<OptOutEntry> => {
                 try {
                     const result = await api.messaging.addOptOut(identifier, props.category?.key)
                     lemonToast.success(`${identifier} added to opt-out list`)
                     actions.loadOptOutPersons()
                     return result
-                } catch {
+                } catch (e) {
                     lemonToast.error('Failed to add opt-out')
-                    return null
+                    throw e
                 }
             },
         },

--- a/products/workflows/frontend/OptOuts/optOutListLogic.ts
+++ b/products/workflows/frontend/OptOuts/optOutListLogic.ts
@@ -35,6 +35,7 @@ export const optOutListLogic = kea<optOutListLogicType>([
         loadNextPage: true,
         loadPreviousPage: true,
         setShowAddOptOutModal: (show: boolean) => ({ show }),
+        setNewOptOutIdentifier: (identifier: string) => ({ identifier }),
     }),
     reducers({
         personsModalOpen: [
@@ -81,6 +82,14 @@ export const optOutListLogic = kea<optOutListLogicType>([
             {
                 setShowAddOptOutModal: (_, { show }) => show,
                 addOptOutSuccess: () => false,
+            },
+        ],
+        newOptOutIdentifier: [
+            '',
+            {
+                setNewOptOutIdentifier: (_, { identifier }) => identifier,
+                addOptOutSuccess: () => '',
+                setShowAddOptOutModal: (state, { show }) => (show ? state : ''),
             },
         ],
     }),

--- a/products/workflows/frontend/OptOuts/optOutListLogic.ts
+++ b/products/workflows/frontend/OptOuts/optOutListLogic.ts
@@ -34,6 +34,7 @@ export const optOutListLogic = kea<optOutListLogicType>([
         setCurrentPage: (page: number) => ({ page }),
         loadNextPage: true,
         loadPreviousPage: true,
+        setShowAddOptOutModal: (show: boolean) => ({ show }),
     }),
     reducers({
         personsModalOpen: [
@@ -75,8 +76,29 @@ export const optOutListLogic = kea<optOutListLogicType>([
                 loadPreviousPageSuccess: (state) => Math.max(1, state - 1),
             },
         ],
+        showAddOptOutModal: [
+            false,
+            {
+                setShowAddOptOutModal: (_, { show }) => show,
+                addOptOutSuccess: () => false,
+            },
+        ],
     }),
-    loaders(({ props, values }) => ({
+    loaders(({ props, values, actions }) => ({
+        addOptOut: {
+            __default: null as OptOutEntry | null,
+            addOptOut: async (identifier: string): Promise<OptOutEntry | null> => {
+                try {
+                    const result = await api.messaging.addOptOut(identifier, props.category?.key)
+                    lemonToast.success(`${identifier} added to opt-out list`)
+                    actions.loadOptOutPersons()
+                    return result
+                } catch {
+                    lemonToast.error('Failed to add opt-out')
+                    return null
+                }
+            },
+        },
         optOutPersons: {
             __default: { count: 0, next: null, previous: null, results: [] } as PaginatedOptOuts,
             loadOptOutPersons: async (): Promise<PaginatedOptOuts> => {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3499,6 +3499,16 @@ export namespace Schemas {
       version?: number | null;
     }
 
+    export interface AddOptOutRequest {
+      /**
+         * The recipient identifier to opt out (e.g. email address).
+         * @maxLength 512
+         */
+      identifier: string;
+      /** Optional message category key. If omitted, the recipient is opted out of all marketing messages. */
+      category_key?: string;
+    }
+
     export type AddSnapshotsInputBaselineHashes = {[key: string]: string};
 
     export type SnapshotManifestItemMetadata = { [key: string]: unknown };
@@ -19728,6 +19738,16 @@ export namespace Schemas {
     export interface MessageMinimal {
       /** @maxLength 10000 */
       content: string;
+    }
+
+    export interface MessagePreferences {
+      readonly id: string;
+      /** The recipient identifier (e.g. email address). */
+      identifier: string;
+      /** When the preference was last updated. */
+      updated_at: string;
+      /** Map of category ID to preference status. */
+      preferences: unknown;
     }
 
     export type MessageSentimentScores = {[key: string]: number};


### PR DESCRIPTION
## Problem

Customers using workflows and opt-out lists currently have no way to manually add a recipient to their opt-out list. The only paths for adding opt-outs are automated: Customer.io API import, CSV upload, webhook sync, or self-service unsubscribe links. When a customer explicitly requests to be removed from communications (e.g. via support ticket or verbal request), there is no option in the UI to honor that.

## Changes

<img width="2682" height="1846" alt="2026-05-08 15 04 05" src="https://github.com/user-attachments/assets/9abc0e20-be87-490d-a67c-8734d2295b65" />

**Backend** — new `POST /api/environments/{team_id}/messaging_preferences/add_opt_out/` endpoint:
- Accepts an `identifier` (e.g. email address) and optional `category_key`
- If no category is specified, opts the recipient out of all marketing messages (`$all`)
- If a category is specified, opts out of that specific category only
- Creates a new `MessageRecipientPreference` or updates an existing one (preserving other preferences)
- Trims whitespace from identifiers; rejects blank values
- Full `@extend_schema` annotation with typed request/response serializers and `help_text` on all fields

**Frontend** — "Add opt-out" button and modal on the opt-out list:
- New button with `+` icon next to the existing "Reload" button on every opt-out list (global and per-category)
- Modal with a text input for the recipient identifier, Enter key support, and loading state
- On success, shows a toast and refreshes the list automatically

## How did you test this code?

This was agent-authored. 8 new backend tests were added and all 14 tests in the `TestMessagePreferencesAPIViewSet` suite pass:

- `test_add_opt_out_global` — adds a global opt-out
- `test_add_opt_out_specific_category` — adds an opt-out for a specific category
- `test_add_opt_out_nonexistent_category` — returns 404 for unknown category
- `test_add_opt_out_duplicate_identifier_updates_existing` — updates without clobbering other preferences
- `test_add_opt_out_missing_identifier` — returns 400
- `test_add_opt_out_blank_identifier` — returns 400
- `test_add_opt_out_team_isolation` — ensures cross-team isolation
- `test_add_opt_out_whitespace_trimmed` — trims leading/trailing whitespace

## Publish to changelog?

no

## 🤖 Agent context

- **Agent:** Claude Code (Opus)
- **Approach:** Explored the existing opt-out list implementation end-to-end (models, API, frontend components, kea logic), then added the feature across all layers. Chose to use `get_or_create` + `set_preference` on the backend to safely handle both new and existing recipients without data loss. Used the existing `MessagePreferencesSerializer` for the response to stay consistent with the `opt_outs` GET endpoint. On the frontend, added the modal state to the existing kea logic rather than creating a separate logic file, since the add action is tightly coupled to the list it refreshes.