### PR TITLE
fix(web-analytics): Fix Web Analytics Digest Cohort / feature flag fetching

### DIFF
--- a/products/web_analytics/backend/temporal/weekly_digest/activities.py
+++ b/products/web_analytics/backend/temporal/weekly_digest/activities.py
@@ -66,6 +66,13 @@ def _get_org_id_batches(input: WAWeeklyDigestInput) -> list[list[str]]:
         org_ids = list(input.org_ids)
         logger.info("processing configured orgs for WA digest", count=len(org_ids))
     else:
+        # Discovery used to also filter by `feature_enabled` here against a
+        # synthetic distinct_id (`digest-worker-{org_id}`). That couldn't
+        # match a user-targeted flag (cohort + percentage rollout) since the
+        # synthetic id has no person record, so it silently filtered every
+        # org out and the workflow short-circuited with zero work. The
+        # per-user check below evaluates the flag against real distinct_ids,
+        # which is the correct gate for this flag's targeting model.
         qs = Organization.objects.all()
         cutoff = None
         if input.active_since_days is not None and input.active_since_days > 0:
@@ -78,23 +85,10 @@ def _get_org_id_batches(input: WAWeeklyDigestInput) -> list[list[str]]:
                     )
                 )
             )
-        all_org_ids = [str(oid) for oid in qs.values_list("id", flat=True)]
-
-        org_ids = [
-            org_id
-            for org_id in all_org_ids
-            if posthoganalytics.feature_enabled(
-                "web-analytics-weekly-digest",
-                distinct_id=f"digest-worker-{org_id}",
-                groups={"organization": org_id},
-                only_evaluate_locally=True,
-                send_feature_flag_events=False,
-            )
-        ]
+        org_ids = [str(oid) for oid in qs.values_list("id", flat=True)]
         logger.info(
             "wa digest org query complete",
-            total=len(all_org_ids),
-            after_flag=len(org_ids),
+            count=len(org_ids),
             active_since_days=input.active_since_days,
             cutoff=cutoff.isoformat() if cutoff else None,
         )
@@ -192,6 +186,39 @@ def _send_digest_for_user(
     return DigestOutcome.SENT
 
 
+def _is_user_targeted_for_digest(user: User, org_id: str) -> bool:
+    """Network-eval the digest flag for a real user. Falls closed on error so a
+    flag-service blip skips the user instead of either silently sending or
+    indefinitely retrying. Mirrors the patterns in
+    `posthog/temporal/data_imports/workflow_activities/create_job_model.py`
+    and `posthog/temporal/subscriptions/snapshot_activities.py`.
+
+    `only_evaluate_locally=False` is required: the flag's release condition
+    is a user cohort, which can't be reliably evaluated against the worker's
+    local cache (cohort membership needs person properties the worker may
+    not have loaded — silently returns `None` in that case).
+    """
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                "web-analytics-weekly-digest",
+                distinct_id=str(user.distinct_id),
+                groups={"organization": org_id},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        logger.warning(
+            "wa digest: flag eval failed, treating user as not targeted",
+            user_id=str(user.uuid),
+            org_id=org_id,
+            error=str(e),
+        )
+        capture_exception(e, {"user_id": str(user.uuid), "org_id": org_id})
+        return False
+
+
 def _build_and_send_for_org(org_id: str, dry_run: bool = False) -> OrgDigestCounts:
     close_old_connections()
 
@@ -205,17 +232,7 @@ def _build_and_send_for_org(org_id: str, dry_run: bool = False) -> OrgDigestCoun
         return counts
 
     memberships = list(OrganizationMembership.objects.prefetch_related("user").filter(organization_id=org.id))
-    targeted_memberships = [
-        m
-        for m in memberships
-        if posthoganalytics.feature_enabled(
-            "web-analytics-weekly-digest",
-            distinct_id=str(m.user.distinct_id),
-            groups={"organization": str(org.id)},
-            only_evaluate_locally=True,
-            send_feature_flag_events=False,
-        )
-    ]
+    targeted_memberships = [m for m in memberships if _is_user_targeted_for_digest(m.user, str(org.id))]
     if not targeted_memberships:
         counts.skipped_reason = "no_targeted_memberships"
         return counts

--- a/products/web_analytics/backend/temporal/weekly_digest/activities.py
+++ b/products/web_analytics/backend/temporal/weekly_digest/activities.py
@@ -66,13 +66,6 @@ def _get_org_id_batches(input: WAWeeklyDigestInput) -> list[list[str]]:
         org_ids = list(input.org_ids)
         logger.info("processing configured orgs for WA digest", count=len(org_ids))
     else:
-        # Discovery used to also filter by `feature_enabled` here against a
-        # synthetic distinct_id (`digest-worker-{org_id}`). That couldn't
-        # match a user-targeted flag (cohort + percentage rollout) since the
-        # synthetic id has no person record, so it silently filtered every
-        # org out and the workflow short-circuited with zero work. The
-        # per-user check below evaluates the flag against real distinct_ids,
-        # which is the correct gate for this flag's targeting model.
         qs = Organization.objects.all()
         cutoff = None
         if input.active_since_days is not None and input.active_since_days > 0:
@@ -187,17 +180,6 @@ def _send_digest_for_user(
 
 
 def _is_user_targeted_for_digest(user: User, org_id: str) -> bool:
-    """Network-eval the digest flag for a real user. Falls closed on error so a
-    flag-service blip skips the user instead of either silently sending or
-    indefinitely retrying. Mirrors the patterns in
-    `posthog/temporal/data_imports/workflow_activities/create_job_model.py`
-    and `posthog/temporal/subscriptions/snapshot_activities.py`.
-
-    `only_evaluate_locally=False` is required: the flag's release condition
-    is a user cohort, which can't be reliably evaluated against the worker's
-    local cache (cohort membership needs person properties the worker may
-    not have loaded — silently returns `None` in that case).
-    """
     try:
         return bool(
             posthoganalytics.feature_enabled(

--- a/products/web_analytics/backend/temporal/weekly_digest/workflows.py
+++ b/products/web_analytics/backend/temporal/weekly_digest/workflows.py
@@ -45,8 +45,6 @@ class WAWeeklyDigestWorkflow(PostHogWorkflow):
 
     @workflow.run
     async def run(self, input: WAWeeklyDigestInput | None = None) -> dict:
-        # Default lets the workflow be started from the Temporal UI without
-        # supplying input — the schedule always passes one explicitly.
         if input is None:
             input = WAWeeklyDigestInput()
 
@@ -92,13 +90,10 @@ class WAWeeklyDigestWorkflow(PostHogWorkflow):
                 else:
                     totals += r
         else:
-            workflow.logger.info("No org batches for WA weekly digest — pushing zero-counts metric")
+            workflow.logger.info("No org batches for WA weekly digest")
 
         threshold_exceeded = totals.batch_size > 0 and totals.failure_rate > input.failure_threshold
 
-        # Always push metrics, even on empty runs — staleness alerts and "did the
-        # run actually happen" dashboards depend on the timestamp gauge updating
-        # on every successful workflow completion.
         await workflow.execute_activity(
             push_wa_digest_metrics_activity,
             args=[dataclasses.asdict(totals), not threshold_exceeded],

--- a/products/web_analytics/backend/temporal/weekly_digest/workflows.py
+++ b/products/web_analytics/backend/temporal/weekly_digest/workflows.py
@@ -44,7 +44,12 @@ class WAWeeklyDigestWorkflow(PostHogWorkflow):
         return WAWeeklyDigestInput()
 
     @workflow.run
-    async def run(self, input: WAWeeklyDigestInput) -> dict:
+    async def run(self, input: WAWeeklyDigestInput | None = None) -> dict:
+        # Default lets the workflow be started from the Temporal UI without
+        # supplying input — the schedule always passes one explicitly.
+        if input is None:
+            input = WAWeeklyDigestInput()
+
         batches = await workflow.execute_activity(
             get_org_id_batches,
             input,
@@ -52,45 +57,48 @@ class WAWeeklyDigestWorkflow(PostHogWorkflow):
             retry_policy=ACTIVITY_RETRY_POLICY,
         )
 
-        if not batches:
-            workflow.logger.info("No org batches for WA weekly digest")
-            return {"orgs": 0, "batches": 0}
-
-        workflow.logger.info(
-            "Fanning out WA digest",
-            batches=len(batches),
-            orgs=sum(len(b) for b in batches),
-        )
-
-        semaphore = asyncio.Semaphore(input.max_concurrent)
-
-        async def _run_batch(batch: list[str]) -> DigestBatchResult:
-            async with semaphore:
-                return await workflow.execute_activity(
-                    run_wa_digest_batch,
-                    DigestBatchInput(org_ids=batch, dry_run=input.dry_run),
-                    start_to_close_timeout=timedelta(minutes=30),
-                    heartbeat_timeout=timedelta(minutes=5),
-                    retry_policy=ACTIVITY_RETRY_POLICY,
-                )
-
-        results = await asyncio.gather(
-            *[_run_batch(b) for b in batches],
-            return_exceptions=True,
-        )
-
         totals = DigestBatchResult()
         failed_batches = 0
-        for batch, r in zip(batches, results):
-            if isinstance(r, BaseException):
-                failed_batches += 1
-                totals += DigestBatchResult(batch_size=len(batch), orgs_failed=len(batch))
-                workflow.logger.error("WA digest batch failed: %s", str(r))
-            else:
-                totals += r
+
+        if batches:
+            workflow.logger.info(
+                "Fanning out WA digest",
+                batches=len(batches),
+                orgs=sum(len(b) for b in batches),
+            )
+
+            semaphore = asyncio.Semaphore(input.max_concurrent)
+
+            async def _run_batch(batch: list[str]) -> DigestBatchResult:
+                async with semaphore:
+                    return await workflow.execute_activity(
+                        run_wa_digest_batch,
+                        DigestBatchInput(org_ids=batch, dry_run=input.dry_run),
+                        start_to_close_timeout=timedelta(minutes=30),
+                        heartbeat_timeout=timedelta(minutes=5),
+                        retry_policy=ACTIVITY_RETRY_POLICY,
+                    )
+
+            results = await asyncio.gather(
+                *[_run_batch(b) for b in batches],
+                return_exceptions=True,
+            )
+
+            for batch, r in zip(batches, results):
+                if isinstance(r, BaseException):
+                    failed_batches += 1
+                    totals += DigestBatchResult(batch_size=len(batch), orgs_failed=len(batch))
+                    workflow.logger.error("WA digest batch failed: %s", str(r))
+                else:
+                    totals += r
+        else:
+            workflow.logger.info("No org batches for WA weekly digest — pushing zero-counts metric")
 
         threshold_exceeded = totals.batch_size > 0 and totals.failure_rate > input.failure_threshold
 
+        # Always push metrics, even on empty runs — staleness alerts and "did the
+        # run actually happen" dashboards depend on the timestamp gauge updating
+        # on every successful workflow completion.
         await workflow.execute_activity(
             push_wa_digest_metrics_activity,
             args=[dataclasses.asdict(totals), not threshold_exceeded],

--- a/products/web_analytics/backend/test/test_weekly_digest_activities.py
+++ b/products/web_analytics/backend/test/test_weekly_digest_activities.py
@@ -15,6 +15,7 @@ from posthog.models.organization import Organization
 
 from products.web_analytics.backend.temporal.weekly_digest.activities import (
     _get_org_id_batches,
+    _is_user_targeted_for_digest,
     _run_wa_digest_batch,
     _send_digest_for_user,
     _send_test_digest,
@@ -331,11 +332,6 @@ class TestSendTestDigestFullUserMode(_DigestTestBase):
 class TestGetOrgIdBatches(APIBaseTest):
     def setUp(self):
         super().setUp()
-        self.flag_patcher = patch(
-            "products.web_analytics.backend.temporal.weekly_digest.activities.posthoganalytics.feature_enabled",
-            return_value=True,
-        )
-        self.flag_patcher.start()
         self.kill_switch_patcher = patch(
             "products.web_analytics.backend.temporal.weekly_digest.activities.get_kill_switch_level",
         )
@@ -355,7 +351,6 @@ class TestGetOrgIdBatches(APIBaseTest):
         self.close_conn_patcher.stop()
         self.email_available_patcher.stop()
         self.kill_switch_patcher.stop()
-        self.flag_patcher.stop()
         super().tearDown()
 
     def test_returns_empty_list_when_kill_switch_active(self):
@@ -552,3 +547,49 @@ class TestRunWaDigestBatch(APIBaseTest):
         assert totals.orgs_processed == 1
         assert totals.emails_sent == 1
         assert totals.emails_skipped_optout == 1
+
+
+class TestIsUserTargetedForDigest(APIBaseTest):
+    """The per-user flag check uses network eval (`only_evaluate_locally=False`)
+    and fails closed: any error treats the user as not targeted, so a flag
+    service outage skips delivery rather than risking double-send on retry.
+    """
+
+    def test_returns_true_when_flag_evaluates_true(self):
+        with patch(
+            "products.web_analytics.backend.temporal.weekly_digest.activities.posthoganalytics.feature_enabled",
+            return_value=True,
+        ) as mock_flag:
+            assert _is_user_targeted_for_digest(self.user, str(self.organization.id)) is True
+
+        # Confirms we are calling the flag service with network eval and the
+        # right group context — guards against accidentally re-introducing
+        # only_evaluate_locally=True.
+        kwargs = mock_flag.call_args.kwargs
+        assert kwargs["only_evaluate_locally"] is False
+        assert kwargs["groups"] == {"organization": str(self.organization.id)}
+        assert kwargs["distinct_id"] == str(self.user.distinct_id)
+
+    def test_returns_false_when_flag_evaluates_false(self):
+        with patch(
+            "products.web_analytics.backend.temporal.weekly_digest.activities.posthoganalytics.feature_enabled",
+            return_value=False,
+        ):
+            assert _is_user_targeted_for_digest(self.user, str(self.organization.id)) is False
+
+    def test_fails_closed_on_flag_service_error(self):
+        with patch(
+            "products.web_analytics.backend.temporal.weekly_digest.activities.posthoganalytics.feature_enabled",
+            side_effect=RuntimeError("decide endpoint timeout"),
+        ):
+            assert _is_user_targeted_for_digest(self.user, str(self.organization.id)) is False
+
+    def test_returns_false_when_flag_evaluator_returns_none(self):
+        # `posthoganalytics.feature_enabled` can return None when even the
+        # network evaluator can't conclusively decide — `bool(None)` is
+        # False, so we treat that as "not targeted" same as an explicit False.
+        with patch(
+            "products.web_analytics.backend.temporal.weekly_digest.activities.posthoganalytics.feature_enabled",
+            return_value=None,
+        ):
+            assert _is_user_targeted_for_digest(self.user, str(self.organization.id)) is False

--- a/products/web_analytics/backend/test/test_weekly_digest_activities.py
+++ b/products/web_analytics/backend/test/test_weekly_digest_activities.py
@@ -550,11 +550,6 @@ class TestRunWaDigestBatch(APIBaseTest):
 
 
 class TestIsUserTargetedForDigest(APIBaseTest):
-    """The per-user flag check uses network eval (`only_evaluate_locally=False`)
-    and fails closed: any error treats the user as not targeted, so a flag
-    service outage skips delivery rather than risking double-send on retry.
-    """
-
     def test_returns_true_when_flag_evaluates_true(self):
         with patch(
             "products.web_analytics.backend.temporal.weekly_digest.activities.posthoganalytics.feature_enabled",
@@ -562,9 +557,6 @@ class TestIsUserTargetedForDigest(APIBaseTest):
         ) as mock_flag:
             assert _is_user_targeted_for_digest(self.user, str(self.organization.id)) is True
 
-        # Confirms we are calling the flag service with network eval and the
-        # right group context — guards against accidentally re-introducing
-        # only_evaluate_locally=True.
         kwargs = mock_flag.call_args.kwargs
         assert kwargs["only_evaluate_locally"] is False
         assert kwargs["groups"] == {"organization": str(self.organization.id)}
@@ -585,9 +577,6 @@ class TestIsUserTargetedForDigest(APIBaseTest):
             assert _is_user_targeted_for_digest(self.user, str(self.organization.id)) is False
 
     def test_returns_false_when_flag_evaluator_returns_none(self):
-        # `posthoganalytics.feature_enabled` can return None when even the
-        # network evaluator can't conclusively decide — `bool(None)` is
-        # False, so we treat that as "not targeted" same as an explicit False.
         with patch(
             "products.web_analytics.backend.temporal.weekly_digest.activities.posthoganalytics.feature_enabled",
             return_value=None,

--- a/products/web_analytics/backend/test/test_weekly_digest_workflows.py
+++ b/products/web_analytics/backend/test/test_weekly_digest_workflows.py
@@ -23,7 +23,12 @@ def _empty_batch_result(batch_size: int) -> DigestBatchResult:
 
 
 @pytest.mark.asyncio
-async def test_wa_weekly_digest_returns_early_when_no_batches() -> None:
+async def test_wa_weekly_digest_skips_batch_fanout_when_no_batches_but_still_pushes_metrics() -> None:
+    """An empty discovery result short-circuits the batch fan-out, but we still
+    push the (zero-count) metrics so staleness alerts on `last_run_timestamp`
+    can detect a worker that quietly stopped finding work to do.
+    """
+
     @activity.defn(name="wa-digest-get-org-batches")
     async def _get_batches(input: WAWeeklyDigestInput) -> list[list[str]]:
         return []
@@ -32,9 +37,11 @@ async def test_wa_weekly_digest_returns_early_when_no_batches() -> None:
     async def _run_batch(input: DigestBatchInput) -> DigestBatchResult:
         raise AssertionError("should not be called when there are no batches")
 
+    metric_pushes: list[tuple[dict, bool]] = []
+
     @activity.defn(name="wa-digest-push-metrics")
     async def _push_metrics(totals_dict: dict, success: bool) -> None:
-        raise AssertionError("should not push metrics when there is no work")
+        metric_pushes.append((totals_dict, success))
 
     task_queue = str(uuid.uuid4())
     async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -52,7 +59,11 @@ async def test_wa_weekly_digest_returns_early_when_no_batches() -> None:
                 task_queue=task_queue,
             )
 
-    assert result == {"orgs": 0, "batches": 0}
+    assert result["orgs"] == 0
+    assert result["batches"] == 0
+    assert result["emails_sent"] == 0
+    assert len(metric_pushes) == 1, "metrics push must happen even on an empty run"
+    assert metric_pushes[0][1] is True, "an empty run is still a successful run"
 
 
 @dataclasses.dataclass

--- a/products/web_analytics/backend/test/test_weekly_digest_workflows.py
+++ b/products/web_analytics/backend/test/test_weekly_digest_workflows.py
@@ -24,11 +24,6 @@ def _empty_batch_result(batch_size: int) -> DigestBatchResult:
 
 @pytest.mark.asyncio
 async def test_wa_weekly_digest_skips_batch_fanout_when_no_batches_but_still_pushes_metrics() -> None:
-    """An empty discovery result short-circuits the batch fan-out, but we still
-    push the (zero-count) metrics so staleness alerts on `last_run_timestamp`
-    can detect a worker that quietly stopped finding work to do.
-    """
-
     @activity.defn(name="wa-digest-get-org-batches")
     async def _get_batches(input: WAWeeklyDigestInput) -> list[list[str]]:
         return []
@@ -62,8 +57,8 @@ async def test_wa_weekly_digest_skips_batch_fanout_when_no_batches_but_still_pus
     assert result["orgs"] == 0
     assert result["batches"] == 0
     assert result["emails_sent"] == 0
-    assert len(metric_pushes) == 1, "metrics push must happen even on an empty run"
-    assert metric_pushes[0][1] is True, "an empty run is still a successful run"
+    assert len(metric_pushes) == 1
+    assert metric_pushes[0][1] is True
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
When using a cohort, we would fail to get the people
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Do not eval locally for now since we're sending small batches
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
