### PR TITLE
feat(query-tagging): attribute HogQLQuery runs from parsed AST features

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -260,6 +260,22 @@ def kind_fallback_tags(kind: NodeKind) -> FallbackTags | None:
     assert_never(kind)
 
 
+class HogQLFeatures(BaseModel):
+    """Product-attribution hints extracted from a parsed HogQL query AST.
+
+    Populated on every HogQL-backed ClickHouse query (HogQLQuery, TrendsQuery,
+    FunnelsQuery, ...). Used by ``add_fallback_query_tags`` to attribute
+    ``HogQLQuery`` runs to a product when the caller hasn't tagged one — the
+    raw query body alone is enough to tell apart e.g. an LLM analytics
+    investigation from an error tracking lookup.
+    """
+
+    tables: list[str] = []
+    events: list[str] = []
+
+    model_config = ConfigDict(validate_assignment=True)
+
+
 class TemporalTags(BaseModel):
     """
     Tags for temporalio workflows and activities.
@@ -388,6 +404,11 @@ class QueryTags(BaseModel):
 
     has_joins: Optional[bool] = None
     has_json_operations: Optional[bool] = None
+
+    # Tables and events referenced by the parsed HogQL AST — set by
+    # HogQLQueryExecutor for any HogQL-backed query. Used as a fallback signal
+    # for product attribution on `kind=HogQLQuery` runs.
+    hogql_features: Optional[HogQLFeatures] = None
 
     modifiers: Optional[object] = None
     number_of_entities: Optional[int] = None
@@ -532,8 +553,48 @@ def _apply_fallback_tags(tags: QueryTags, mapped: FallbackTags) -> None:
         tags.feature = mapped["feature"]
 
 
+# AST-level event filters that pinpoint a single product. Order matters when a
+# query touches multiple products' events — first match wins (LLM > error >
+# web > flags), prioritising the more specific signal.
+_EVENT_TO_TAGS: tuple[tuple[frozenset[str], FallbackTags], ...] = (
+    (
+        frozenset({"$ai_generation", "$ai_span", "$ai_trace", "$ai_embedding", "$ai_metric", "$ai_feedback"}),
+        {"product": Product.LLM_ANALYTICS},
+    ),
+    (frozenset({"$exception"}), {"product": Product.ERROR_TRACKING}),
+    (frozenset({"$web_vitals"}), {"product": Product.WEB_ANALYTICS}),
+    (frozenset({"$feature_flag_called"}), {"product": Product.FEATURE_FLAGS}),
+)
+
+# Table-level fallbacks — only consulted if no event filter narrowed things
+# down. ``events`` on its own implies product analytics by default.
+_TABLE_TO_TAGS: tuple[tuple[frozenset[str], FallbackTags], ...] = (
+    (frozenset({"session_replay_events", "raw_session_replay_events"}), {"product": Product.REPLAY}),
+    (frozenset({"logs", "log_attributes"}), {"product": Product.LOGS}),
+    (frozenset({"events"}), {"product": Product.PRODUCT_ANALYTICS}),
+)
+
+
+def _hogql_features_fallback_tags(features: HogQLFeatures) -> FallbackTags | None:
+    """Pick the most specific product hinted at by an extracted set of HogQL
+    features. Returns ``None`` when the features don't match anything we
+    attribute (e.g. a plain ``SELECT 1`` or a warehouse-only query)."""
+    events = set(features.events)
+    for matchers, mapped in _EVENT_TO_TAGS:
+        if events & matchers:
+            return mapped
+
+    tables = set(features.tables)
+    for matchers, mapped in _TABLE_TO_TAGS:
+        if tables & matchers:
+            return mapped
+
+    return None
+
+
 def add_fallback_query_tags(tags: QueryTags) -> None:
-    """Order: scene → kind → mcp source. Never overrides values that are already set."""
+    """Order: scene → kind → hogql features (HogQLQuery only) → mcp source.
+    Never overrides values that are already set."""
     if tags.scene and (scene_mapped := SCENE_TO_TAGS.get(tags.scene)) is not None:
         _apply_fallback_tags(tags, scene_mapped)
 
@@ -544,6 +605,16 @@ def add_fallback_query_tags(tags: QueryTags) -> None:
             kind = None
         if kind is not None and (kind_mapped := kind_fallback_tags(kind)) is not None:
             _apply_fallback_tags(tags, kind_mapped)
+
+    # HogQLQuery has no inherent product (the kind fallback returns None on
+    # purpose) — fall back to whatever the AST-level features tell us.
+    if (
+        tags.product is None
+        and tags.query_type == NodeKind.HOG_QL_QUERY.value
+        and tags.hogql_features is not None
+        and (features_mapped := _hogql_features_fallback_tags(tags.hogql_features)) is not None
+    ):
+        _apply_fallback_tags(tags, features_mapped)
 
     from posthog.event_usage import EventSource
 

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -555,6 +555,11 @@ _EVENT_TO_TAGS: tuple[tuple[frozenset[str], FallbackTags], ...] = (
     (frozenset({"$feature_flag_called"}), {"product": Product.FEATURE_FLAGS}),
 )
 
+# Union of every event the fallback can match — exposed so HogQLFeatureExtractor can use it as
+# its allow-list without duplicating the names. Adding a new mapping to _EVENT_TO_TAGS
+# automatically widens what the extractor records.
+EVENT_TAG_MATCHERS: frozenset[str] = frozenset().union(*(matchers for matchers, _ in _EVENT_TO_TAGS))
+
 # Table-level fallbacks — only consulted if no event filter narrowed things down.
 _TABLE_TO_TAGS: tuple[tuple[frozenset[str], FallbackTags], ...] = (
     (frozenset({"session_replay_events", "raw_session_replay_events"}), {"product": Product.REPLAY}),

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -7,7 +7,7 @@ import contextvars
 from collections.abc import Generator
 from contextlib import contextmanager, suppress
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal, NotRequired, Optional, TypedDict, assert_never
+from typing import TYPE_CHECKING, Any, NotRequired, Optional, TypedDict, assert_never
 
 if TYPE_CHECKING:
     from posthog.models.team import Team
@@ -544,19 +544,22 @@ def _apply_fallback_tags(tags: QueryTags, mapped: FallbackTags) -> None:
         tags.feature = mapped["feature"]
 
 
-# Order matters: first match wins, so more specific signals (event filters) come before generic ones (tables).
-_HOGQL_FEATURE_TO_TAGS: tuple[tuple[Literal["events", "tables"], frozenset[str], FallbackTags], ...] = (
+# Event-level matches pinpoint a single product; consulted before tables since they're more specific.
+_EVENT_TO_TAGS: tuple[tuple[frozenset[str], FallbackTags], ...] = (
     (
-        "events",
         frozenset({"$ai_generation", "$ai_span", "$ai_trace", "$ai_embedding", "$ai_metric", "$ai_feedback"}),
         {"product": Product.LLM_ANALYTICS},
     ),
-    ("events", frozenset({"$exception"}), {"product": Product.ERROR_TRACKING}),
-    ("events", frozenset({"$web_vitals"}), {"product": Product.WEB_ANALYTICS}),
-    ("events", frozenset({"$feature_flag_called"}), {"product": Product.FEATURE_FLAGS}),
-    ("tables", frozenset({"session_replay_events", "raw_session_replay_events"}), {"product": Product.REPLAY}),
-    ("tables", frozenset({"logs", "log_attributes"}), {"product": Product.LOGS}),
-    ("tables", frozenset({"events"}), {"product": Product.PRODUCT_ANALYTICS}),
+    (frozenset({"$exception"}), {"product": Product.ERROR_TRACKING}),
+    (frozenset({"$web_vitals"}), {"product": Product.WEB_ANALYTICS}),
+    (frozenset({"$feature_flag_called"}), {"product": Product.FEATURE_FLAGS}),
+)
+
+# Table-level fallbacks — only consulted if no event filter narrowed things down.
+_TABLE_TO_TAGS: tuple[tuple[frozenset[str], FallbackTags], ...] = (
+    (frozenset({"session_replay_events", "raw_session_replay_events"}), {"product": Product.REPLAY}),
+    (frozenset({"logs", "log_attributes"}), {"product": Product.LOGS}),
+    (frozenset({"events"}), {"product": Product.PRODUCT_ANALYTICS}),
 )
 
 
@@ -578,11 +581,16 @@ def add_fallback_query_tags(tags: QueryTags) -> None:
         and tags.query_type == NodeKind.HOG_QL_QUERY.value
         and (features := tags.hogql_features) is not None
     ):
-        feature_sets = {"events": set(features.events), "tables": set(features.tables)}
-        for axis, matchers, mapped in _HOGQL_FEATURE_TO_TAGS:
-            if feature_sets[axis] & matchers:
-                _apply_fallback_tags(tags, mapped)
-                break
+        events_set, tables_set = set(features.events), set(features.tables)
+        features_mapped = next(
+            (m for matchers, m in _EVENT_TO_TAGS if events_set & matchers),
+            None,
+        ) or next(
+            (m for matchers, m in _TABLE_TO_TAGS if tables_set & matchers),
+            None,
+        )
+        if features_mapped is not None:
+            _apply_fallback_tags(tags, features_mapped)
 
     from posthog.event_usage import EventSource
 

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -7,7 +7,7 @@ import contextvars
 from collections.abc import Generator
 from contextlib import contextmanager, suppress
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, NotRequired, Optional, TypedDict, assert_never
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, Optional, TypedDict, assert_never
 
 if TYPE_CHECKING:
     from posthog.models.team import Team
@@ -261,14 +261,8 @@ def kind_fallback_tags(kind: NodeKind) -> FallbackTags | None:
 
 
 class HogQLFeatures(BaseModel):
-    """Product-attribution hints extracted from a parsed HogQL query AST.
-
-    Populated on every HogQL-backed ClickHouse query (HogQLQuery, TrendsQuery,
-    FunnelsQuery, ...). Used by ``add_fallback_query_tags`` to attribute
-    ``HogQLQuery`` runs to a product when the caller hasn't tagged one — the
-    raw query body alone is enough to tell apart e.g. an LLM analytics
-    investigation from an error tracking lookup.
-    """
+    """Tables and event filters extracted from a HogQL AST — feeds product
+    attribution in ``add_fallback_query_tags`` for ``kind=HogQLQuery``."""
 
     tables: list[str] = []
     events: list[str] = []
@@ -405,9 +399,6 @@ class QueryTags(BaseModel):
     has_joins: Optional[bool] = None
     has_json_operations: Optional[bool] = None
 
-    # Tables and events referenced by the parsed HogQL AST — set by
-    # HogQLQueryExecutor for any HogQL-backed query. Used as a fallback signal
-    # for product attribution on `kind=HogQLQuery` runs.
     hogql_features: Optional[HogQLFeatures] = None
 
     modifiers: Optional[object] = None
@@ -553,48 +544,24 @@ def _apply_fallback_tags(tags: QueryTags, mapped: FallbackTags) -> None:
         tags.feature = mapped["feature"]
 
 
-# AST-level event filters that pinpoint a single product. Order matters when a
-# query touches multiple products' events — first match wins (LLM > error >
-# web > flags), prioritising the more specific signal.
-_EVENT_TO_TAGS: tuple[tuple[frozenset[str], FallbackTags], ...] = (
+# Order matters: first match wins, so more specific signals (event filters) come before generic ones (tables).
+_HOGQL_FEATURE_TO_TAGS: tuple[tuple[Literal["events", "tables"], frozenset[str], FallbackTags], ...] = (
     (
+        "events",
         frozenset({"$ai_generation", "$ai_span", "$ai_trace", "$ai_embedding", "$ai_metric", "$ai_feedback"}),
         {"product": Product.LLM_ANALYTICS},
     ),
-    (frozenset({"$exception"}), {"product": Product.ERROR_TRACKING}),
-    (frozenset({"$web_vitals"}), {"product": Product.WEB_ANALYTICS}),
-    (frozenset({"$feature_flag_called"}), {"product": Product.FEATURE_FLAGS}),
+    ("events", frozenset({"$exception"}), {"product": Product.ERROR_TRACKING}),
+    ("events", frozenset({"$web_vitals"}), {"product": Product.WEB_ANALYTICS}),
+    ("events", frozenset({"$feature_flag_called"}), {"product": Product.FEATURE_FLAGS}),
+    ("tables", frozenset({"session_replay_events", "raw_session_replay_events"}), {"product": Product.REPLAY}),
+    ("tables", frozenset({"logs", "log_attributes"}), {"product": Product.LOGS}),
+    ("tables", frozenset({"events"}), {"product": Product.PRODUCT_ANALYTICS}),
 )
-
-# Table-level fallbacks — only consulted if no event filter narrowed things
-# down. ``events`` on its own implies product analytics by default.
-_TABLE_TO_TAGS: tuple[tuple[frozenset[str], FallbackTags], ...] = (
-    (frozenset({"session_replay_events", "raw_session_replay_events"}), {"product": Product.REPLAY}),
-    (frozenset({"logs", "log_attributes"}), {"product": Product.LOGS}),
-    (frozenset({"events"}), {"product": Product.PRODUCT_ANALYTICS}),
-)
-
-
-def _hogql_features_fallback_tags(features: HogQLFeatures) -> FallbackTags | None:
-    """Pick the most specific product hinted at by an extracted set of HogQL
-    features. Returns ``None`` when the features don't match anything we
-    attribute (e.g. a plain ``SELECT 1`` or a warehouse-only query)."""
-    events = set(features.events)
-    for matchers, mapped in _EVENT_TO_TAGS:
-        if events & matchers:
-            return mapped
-
-    tables = set(features.tables)
-    for matchers, mapped in _TABLE_TO_TAGS:
-        if tables & matchers:
-            return mapped
-
-    return None
 
 
 def add_fallback_query_tags(tags: QueryTags) -> None:
-    """Order: scene → kind → hogql features (HogQLQuery only) → mcp source.
-    Never overrides values that are already set."""
+    """Order: scene → kind → hogql features (HogQLQuery only) → mcp source. Never overrides set values."""
     if tags.scene and (scene_mapped := SCENE_TO_TAGS.get(tags.scene)) is not None:
         _apply_fallback_tags(tags, scene_mapped)
 
@@ -606,15 +573,16 @@ def add_fallback_query_tags(tags: QueryTags) -> None:
         if kind is not None and (kind_mapped := kind_fallback_tags(kind)) is not None:
             _apply_fallback_tags(tags, kind_mapped)
 
-    # HogQLQuery has no inherent product (the kind fallback returns None on
-    # purpose) — fall back to whatever the AST-level features tell us.
     if (
         tags.product is None
         and tags.query_type == NodeKind.HOG_QL_QUERY.value
-        and tags.hogql_features is not None
-        and (features_mapped := _hogql_features_fallback_tags(tags.hogql_features)) is not None
+        and (features := tags.hogql_features) is not None
     ):
-        _apply_fallback_tags(tags, features_mapped)
+        feature_sets = {"events": set(features.events), "tables": set(features.tables)}
+        for axis, matchers, mapped in _HOGQL_FEATURE_TO_TAGS:
+            if feature_sets[axis] & matchers:
+                _apply_fallback_tags(tags, mapped)
+                break
 
     from posthog.event_usage import EventSource
 

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -15,6 +15,7 @@ from posthog.clickhouse.query_tagging import (
     _PROJECT_ROOT_PREFIX,
     _SOURCE_SKIP_PREFIXES,
     Feature,
+    HogQLFeatures,
     Product,
     QueryTags,
     TemporalTags,
@@ -474,3 +475,77 @@ class TestAddFallbackQueryTags(BaseTest):
         add_fallback_query_tags(tags)
         assert tags.product is None
         assert tags.feature is None
+
+    @parameterized.expand(
+        [
+            ("ai_generation", ["$ai_generation"], Product.LLM_ANALYTICS),
+            ("ai_trace", ["$ai_trace"], Product.LLM_ANALYTICS),
+            ("exception", ["$exception"], Product.ERROR_TRACKING),
+            ("web_vitals", ["$web_vitals"], Product.WEB_ANALYTICS),
+            ("feature_flag_called", ["$feature_flag_called"], Product.FEATURE_FLAGS),
+        ]
+    )
+    def test_hogql_features_event_fills_product(self, _name, events, expected_product):
+        tags = QueryTags(
+            query_type="HogQLQuery",
+            hogql_features=HogQLFeatures(tables=["events"], events=events),
+        )
+        add_fallback_query_tags(tags)
+        assert tags.product == expected_product
+
+    @parameterized.expand(
+        [
+            ("session_replay", ["session_replay_events"], Product.REPLAY),
+            ("logs_table", ["logs"], Product.LOGS),
+            ("events_table", ["events"], Product.PRODUCT_ANALYTICS),
+        ]
+    )
+    def test_hogql_features_table_fills_product_when_no_event_match(self, _name, tables, expected_product):
+        tags = QueryTags(
+            query_type="HogQLQuery",
+            hogql_features=HogQLFeatures(tables=tables, events=[]),
+        )
+        add_fallback_query_tags(tags)
+        assert tags.product == expected_product
+
+    def test_hogql_features_event_takes_precedence_over_table(self):
+        # Querying the events table for $exception should attribute to error
+        # tracking, not product analytics — events are more specific.
+        tags = QueryTags(
+            query_type="HogQLQuery",
+            hogql_features=HogQLFeatures(tables=["events"], events=["$exception"]),
+        )
+        add_fallback_query_tags(tags)
+        assert tags.product == Product.ERROR_TRACKING
+
+    def test_hogql_features_only_apply_to_hogqlquery_kind(self):
+        # A TrendsQuery would already be product_analytics via kind fallback;
+        # we shouldn't let the AST features override that. More importantly,
+        # the AST contents of e.g. an LLM-analytics insight (which uses
+        # TrendsQuery on $ai_generation) shouldn't get re-attributed.
+        tags = QueryTags(
+            query_type="TrendsQuery",
+            hogql_features=HogQLFeatures(tables=["events"], events=["$exception"]),
+        )
+        add_fallback_query_tags(tags)
+        assert tags.product == Product.PRODUCT_ANALYTICS
+
+    def test_hogql_features_does_not_override_set_product(self):
+        tags = QueryTags(
+            product=Product.MCP,
+            query_type="HogQLQuery",
+            hogql_features=HogQLFeatures(tables=["events"], events=["$exception"]),
+        )
+        add_fallback_query_tags(tags)
+        assert tags.product == Product.MCP
+
+    def test_hogql_features_unmapped_features_fall_through_to_mcp(self):
+        # No interesting events, no recognised tables — let the MCP source
+        # fallback fire instead.
+        tags = QueryTags(
+            query_type="HogQLQuery",
+            source="mcp",
+            hogql_features=HogQLFeatures(tables=[], events=[]),
+        )
+        add_fallback_query_tags(tags)
+        assert tags.product == Product.MCP

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -405,6 +405,41 @@ class TestQueryTaggingSourceInQueryLog(BaseTest, ClickhouseTestMixin):
 
         assert comment.get("product") != Product.MCP.value
 
+    def test_execute_hogql_query_populates_hogql_features_tag(self):
+        # End-to-end: a HogQLQuery against `events` filtered by `$exception` should
+        # land in query_log with both the AST-derived hogql_features tag and the
+        # error_tracking product attribution that derives from it.
+        marker = str(uuid.uuid4())
+        reset_query_tags()
+        tag_queries(kind="request", id="test", team_id=self.team.pk, feature="query")
+        execute_hogql_query(
+            f"SELECT count() FROM events WHERE distinct_id = '{marker}' AND event = '$exception'",  # noqa: S608
+            team=self.team,
+            query_type="HogQLQuery",
+        )
+
+        comment = self._get_log_comment(marker)
+
+        assert comment["hogql_features"] == {"tables": ["events"], "events": ["$exception"]}
+        assert comment["product"] == Product.ERROR_TRACKING.value
+
+    def test_execute_hogql_query_attributes_plain_events_query_to_product_analytics(self):
+        # Plain `events` query (no narrowing event filter) should fall back to
+        # product_analytics via the table-level rule.
+        marker = str(uuid.uuid4())
+        reset_query_tags()
+        tag_queries(kind="request", id="test", team_id=self.team.pk, feature="query")
+        execute_hogql_query(
+            f"SELECT count() FROM events WHERE distinct_id = '{marker}'",  # noqa: S608
+            team=self.team,
+            query_type="HogQLQuery",
+        )
+
+        comment = self._get_log_comment(marker)
+
+        assert comment["hogql_features"] == {"tables": ["events"], "events": []}
+        assert comment["product"] == Product.PRODUCT_ANALYTICS.value
+
 
 class TestAddFallbackQueryTags(BaseTest):
     def test_does_not_override_set_product(self):

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -514,7 +514,11 @@ class TestAddFallbackQueryTags(BaseTest):
     @parameterized.expand(
         [
             ("ai_generation", ["$ai_generation"], Product.LLM_ANALYTICS),
+            ("ai_span", ["$ai_span"], Product.LLM_ANALYTICS),
             ("ai_trace", ["$ai_trace"], Product.LLM_ANALYTICS),
+            ("ai_embedding", ["$ai_embedding"], Product.LLM_ANALYTICS),
+            ("ai_metric", ["$ai_metric"], Product.LLM_ANALYTICS),
+            ("ai_feedback", ["$ai_feedback"], Product.LLM_ANALYTICS),
             ("exception", ["$exception"], Product.ERROR_TRACKING),
             ("web_vitals", ["$web_vitals"], Product.WEB_ANALYTICS),
             ("feature_flag_called", ["$feature_flag_called"], Product.FEATURE_FLAGS),

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -440,6 +440,23 @@ class TestQueryTaggingSourceInQueryLog(BaseTest, ClickhouseTestMixin):
         assert comment["hogql_features"] == {"tables": ["events"], "events": []}
         assert comment["product"] == Product.PRODUCT_ANALYTICS.value
 
+    def test_execute_hogql_query_with_mcp_source_still_attributes_via_features(self):
+        # Pulling MCP traffic apart by what it actually does is the whole point
+        # of this fallback — confirm a $exception query from MCP attributes to
+        # error_tracking, not the catch-all MCP product.
+        marker = str(uuid.uuid4())
+        reset_query_tags()
+        tag_queries(kind="request", id="test", team_id=self.team.pk, source="mcp", feature="query")
+        execute_hogql_query(
+            f"SELECT count() FROM events WHERE distinct_id = '{marker}' AND event = '$exception'",  # noqa: S608
+            team=self.team,
+            query_type="HogQLQuery",
+        )
+
+        comment = self._get_log_comment(marker)
+
+        assert comment["product"] == Product.ERROR_TRACKING.value
+
 
 class TestAddFallbackQueryTags(BaseTest):
     def test_does_not_override_set_product(self):
@@ -577,6 +594,28 @@ class TestAddFallbackQueryTags(BaseTest):
         )
         add_fallback_query_tags(tags)
         assert tags.product == Product.MCP
+
+    def test_hogql_features_take_precedence_over_mcp_source(self):
+        # The whole point of the hogql_features fallback is to pull MCP traffic
+        # apart by what it actually does — so even when source=mcp, a recognised
+        # event filter must win over the catch-all MCP attribution.
+        tags = QueryTags(
+            query_type="HogQLQuery",
+            source="mcp",
+            hogql_features=HogQLFeatures(tables=["events"], events=["$exception"]),
+        )
+        add_fallback_query_tags(tags)
+        assert tags.product == Product.ERROR_TRACKING
+
+    def test_hogql_features_table_only_take_precedence_over_mcp_source(self):
+        # Same precedence holds for the table-only path.
+        tags = QueryTags(
+            query_type="HogQLQuery",
+            source="mcp",
+            hogql_features=HogQLFeatures(tables=["session_replay_events"], events=[]),
+        )
+        add_fallback_query_tags(tags)
+        assert tags.product == Product.REPLAY
 
     def test_hogql_features_unmapped_features_fall_through_to_mcp(self):
         # No interesting events, no recognised tables — let the MCP source

--- a/posthog/hogql/feature_extractor.py
+++ b/posthog/hogql/feature_extractor.py
@@ -1,22 +1,15 @@
 """Extract product-attribution features from a HogQL select query.
 
-Used by ``HogQLQueryExecutor`` to tag ClickHouse queries with the set of
-PostHog tables and well-known event filters they reference. The tags feed
-``add_fallback_query_tags`` so HogQL queries (which otherwise carry no
-product information) can be attributed to the right product surface — LLM
-analytics, error tracking, web analytics, replay, etc.
+Feeds ``add_fallback_query_tags`` so HogQL queries can be attributed to a
+product surface (LLM analytics, error tracking, web analytics, replay, …)
+based on what tables and event filters they reference.
 """
 
 from posthog.hogql import ast
+from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.visitor import TraversingVisitor
 
-# Last-identifier match for the events ``event`` column when type info isn't
-# available — covers ``event``, ``events.event``, ``e.event``, etc.
-_EVENT_FIELD_NAMES: frozenset[str] = frozenset({"event"})
-
-# Known event names worth surfacing for product attribution. Restricted to
-# the set used by add_fallback_query_tags — over-collecting bloats query_log
-# without buying anything.
+# Restricted to the set add_fallback_query_tags actually maps — over-collecting bloats query_log without buying anything.
 _INTERESTING_EVENT_NAMES: frozenset[str] = frozenset(
     {
         "$ai_generation",
@@ -33,17 +26,9 @@ _INTERESTING_EVENT_NAMES: frozenset[str] = frozenset(
 
 
 class HogQLFeatureExtractor(TraversingVisitor):
-    """Walk a HogQL ``SelectQuery``/``SelectSetQuery`` and record:
-
-    * ``tables``: identifiers that appear directly as a ``FROM``/``JOIN`` source.
-    * ``events``: string literals compared to an ``event`` field on the events
-      table via ``=`` / ``IN``, restricted to the curated
-      ``_INTERESTING_EVENT_NAMES`` set.
-
-    Works on either a raw parsed AST or a resolved AST. When type info is
-    available (post-Resolver), the event-field check uses it for accuracy;
-    otherwise it falls back to a last-identifier chain match.
-    """
+    """Records ``tables`` (FROM/JOIN sources) and ``events`` (event-name literals
+    compared to the events ``event`` column). Works on raw or resolved ASTs;
+    uses type info when available, falls back to chain matching otherwise."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -59,77 +44,44 @@ class HogQLFeatureExtractor(TraversingVisitor):
 
     def visit_compare_operation(self, node: ast.CompareOperation) -> None:
         if node.op in (ast.CompareOperationOp.Eq, ast.CompareOperationOp.In):
-            self._collect_event_names(node.left, node.right)
-            # Also handle constant-on-the-left (`'$exception' = event`)
-            self._collect_event_names(node.right, node.left)
+            for field_side, value_side in ((node.left, node.right), (node.right, node.left)):
+                if _looks_like_event_field(field_side):
+                    self.events.update(v for v in _iter_string_constants(value_side) if v in _INTERESTING_EVENT_NAMES)
         super().visit_compare_operation(node)
-
-    def _collect_event_names(self, field_side: ast.Expr, value_side: ast.Expr) -> None:
-        if not _looks_like_event_field(field_side):
-            return
-        for value in _iter_string_constants(value_side):
-            if value in _INTERESTING_EVENT_NAMES:
-                self.events.add(value)
 
 
 def _looks_like_event_field(expr: ast.Expr) -> bool:
-    """True if ``expr`` references the ``event`` column on the events table.
-
-    Mirrors ``is_events_only_field`` in the session where-clause extractor:
-    when the AST has been resolved we walk the type chain to confirm the
-    field is ``event`` on ``EventsTable`` exactly. When types aren't
-    populated (e.g. pre-resolution caller, or a partially-typed branch) we
-    fall back to a last-identifier chain match — looser, but still useful.
-    """
+    """``True`` iff ``expr`` references the events table's ``event`` column.
+    Mirrors ``is_events_only_field`` from the session where-clause extractor."""
     expr = _strip_aliases(expr)
     if not isinstance(expr, ast.Field) or not expr.chain:
         return False
 
-    if (events_field := _is_event_field_via_types(expr)) is not None:
-        return events_field
+    type_ = expr.type
+    if isinstance(type_, ast.PropertyType):
+        type_ = type_.field_type
+    if isinstance(type_, ast.FieldAliasType):
+        type_ = type_.type
+    if isinstance(type_, ast.FieldType):
+        if type_.name != "event":
+            return False
+        table_type = type_.table_type
+        while isinstance(table_type, (ast.TableAliasType, ast.ColumnAliasedTableType)):
+            table_type = table_type.table_type
+        return isinstance(table_type, ast.TableType) and isinstance(table_type.table, EventsTable)
 
-    last = expr.chain[-1]
-    return isinstance(last, str) and last in _EVENT_FIELD_NAMES
+    # No type info — fall back to last-identifier chain match (covers ``event``, ``e.event``, ``events.event``).
+    return expr.chain[-1] == "event"
 
 
 def _strip_aliases(expr: ast.Expr) -> ast.Expr:
-    """Aliases can nest — e.g. resolver passes that re-wrap an already-aliased
-    expression — so unwrap until we hit a non-Alias node."""
     while isinstance(expr, ast.Alias):
         expr = expr.expr
     return expr
 
 
-def _is_event_field_via_types(field: ast.Field) -> bool | None:
-    """Return True/False from the type system, or None if types aren't
-    populated and the caller should fall back to chain matching."""
-    from posthog.hogql.database.schema.events import EventsTable
-
-    type_ = field.type
-    if type_ is None:
-        return None
-
-    if isinstance(type_, ast.PropertyType):
-        type_ = type_.field_type
-    if isinstance(type_, ast.FieldAliasType):
-        type_ = type_.type
-    if not isinstance(type_, ast.FieldType):
-        return None
-
-    if type_.name != "event":
-        return False
-
-    table_type = type_.table_type
-    while isinstance(table_type, (ast.TableAliasType, ast.ColumnAliasedTableType)):
-        table_type = table_type.table_type
-    if isinstance(table_type, ast.TableType):
-        return isinstance(table_type.table, EventsTable)
-    return False
-
-
 def _iter_string_constants(expr: ast.Expr):
-    """Yield string literals from a constant, tuple, or array — covers
-    ``event = 'X'`` and ``event IN ('X', 'Y')``."""
+    """Yield string literals from a constant, tuple, or array — covers ``= 'X'`` and ``IN ('X', 'Y')``."""
     expr = _strip_aliases(expr)
     if isinstance(expr, ast.Constant):
         if isinstance(expr.value, str):
@@ -143,12 +95,7 @@ def _iter_string_constants(expr: ast.Expr):
 def extract_hogql_features(
     query: ast.SelectQuery | ast.SelectSetQuery | None,
 ) -> tuple[list[str], list[str]]:
-    """Convenience wrapper around ``HogQLFeatureExtractor``.
-
-    Returns ``(tables, events)`` as sorted lists so the resulting query tag is
-    deterministic across runs (helps log readability and snapshot tests).
-    Returns empty lists if ``query`` is ``None``.
-    """
+    """Returns ``(tables, events)`` sorted for deterministic tag output."""
     if query is None:
         return [], []
     visitor = HogQLFeatureExtractor()

--- a/posthog/hogql/feature_extractor.py
+++ b/posthog/hogql/feature_extractor.py
@@ -1,0 +1,113 @@
+"""Extract product-attribution features from a parsed HogQL select query.
+
+Used by ``HogQLQueryExecutor`` to tag ClickHouse queries with the set of
+PostHog tables and well-known event filters they reference. The tags feed
+``add_fallback_query_tags`` so HogQL queries (which otherwise carry no
+product information) can be attributed to the right product surface — LLM
+analytics, error tracking, web analytics, replay, etc.
+"""
+
+from posthog.hogql import ast
+from posthog.hogql.visitor import TraversingVisitor
+
+# Field chains that name the event-name column on the events table. We match
+# against the *last* identifier so aliases like `e.event` work without us
+# having to resolve types.
+_EVENT_FIELD_NAMES: frozenset[str] = frozenset({"event"})
+
+# Known event names worth surfacing for product attribution. Restricted to
+# the set used by add_fallback_query_tags — over-collecting bloats query_log
+# without buying anything.
+_INTERESTING_EVENT_NAMES: frozenset[str] = frozenset(
+    {
+        "$ai_generation",
+        "$ai_span",
+        "$ai_trace",
+        "$ai_embedding",
+        "$ai_metric",
+        "$ai_feedback",
+        "$exception",
+        "$web_vitals",
+        "$feature_flag_called",
+    }
+)
+
+
+class HogQLFeatureExtractor(TraversingVisitor):
+    """Walk a parsed HogQL ``SelectQuery``/``SelectSetQuery`` and record:
+
+    * ``tables``: identifiers that appear directly as a ``FROM``/``JOIN`` source.
+    * ``events``: string literals compared to an ``event`` field via ``=`` /
+      ``IN``, restricted to the curated ``_INTERESTING_EVENT_NAMES`` set.
+
+    The extractor runs *before* type resolution, so it works on the raw chain
+    structure rather than resolved table types. Aliased and CTE-referenced
+    tables show up as their alias/CTE name, which is intentional — the real
+    underlying table is still captured wherever it is first joined.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.tables: set[str] = set()
+        self.events: set[str] = set()
+
+    def visit_join_expr(self, node: ast.JoinExpr) -> None:
+        if isinstance(node.table, ast.Field) and node.table.chain:
+            head = node.table.chain[0]
+            if isinstance(head, str):
+                self.tables.add(head)
+        super().visit_join_expr(node)
+
+    def visit_compare_operation(self, node: ast.CompareOperation) -> None:
+        if node.op in (ast.CompareOperationOp.Eq, ast.CompareOperationOp.In):
+            self._collect_event_names(node.left, node.right)
+            # Also handle constant-on-the-left (`'$exception' = event`)
+            self._collect_event_names(node.right, node.left)
+        super().visit_compare_operation(node)
+
+    def _collect_event_names(self, field_side: ast.Expr, value_side: ast.Expr) -> None:
+        if not _looks_like_event_field(field_side):
+            return
+        for value in _iter_string_constants(value_side):
+            if value in _INTERESTING_EVENT_NAMES:
+                self.events.add(value)
+
+
+def _looks_like_event_field(expr: ast.Expr) -> bool:
+    """``e.event`` / ``events.event`` / ``event`` all qualify."""
+    if isinstance(expr, ast.Alias):
+        expr = expr.expr
+    if not isinstance(expr, ast.Field) or not expr.chain:
+        return False
+    last = expr.chain[-1]
+    return isinstance(last, str) and last in _EVENT_FIELD_NAMES
+
+
+def _iter_string_constants(expr: ast.Expr):
+    """Yield string literals from a constant, tuple, or array — covers
+    ``event = 'X'`` and ``event IN ('X', 'Y')``."""
+    if isinstance(expr, ast.Alias):
+        expr = expr.expr
+    if isinstance(expr, ast.Constant):
+        if isinstance(expr.value, str):
+            yield expr.value
+        return
+    if isinstance(expr, (ast.Tuple, ast.Array)):
+        for sub in expr.exprs:
+            yield from _iter_string_constants(sub)
+
+
+def extract_hogql_features(
+    query: ast.SelectQuery | ast.SelectSetQuery | None,
+) -> tuple[list[str], list[str]]:
+    """Convenience wrapper around ``HogQLFeatureExtractor``.
+
+    Returns ``(tables, events)`` as sorted lists so the resulting query tag is
+    deterministic across runs (helps log readability and snapshot tests).
+    Returns empty lists if ``query`` is ``None``.
+    """
+    if query is None:
+        return [], []
+    visitor = HogQLFeatureExtractor()
+    visitor.visit(query)
+    return sorted(visitor.tables), sorted(visitor.events)

--- a/posthog/hogql/feature_extractor.py
+++ b/posthog/hogql/feature_extractor.py
@@ -9,7 +9,7 @@ from posthog.hogql import ast
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.visitor import TraversingVisitor
 
-from posthog.clickhouse.query_tagging import EVENT_TAG_MATCHERS
+from posthog.clickhouse.query_tagging import EVENT_TAG_MATCHERS, HogQLFeatures
 
 
 class HogQLFeatureExtractor(TraversingVisitor):
@@ -77,12 +77,10 @@ def _iter_string_constants(expr: ast.Expr):
             yield from _iter_string_constants(sub)
 
 
-def extract_hogql_features(
-    query: ast.SelectQuery | ast.SelectSetQuery | None,
-) -> tuple[list[str], list[str]]:
-    """Returns ``(tables, events)`` sorted for deterministic tag output."""
+def extract_hogql_features(query: ast.SelectQuery | ast.SelectSetQuery | None) -> HogQLFeatures:
+    """Sorted for deterministic tag output."""
     if query is None:
-        return [], []
+        return HogQLFeatures()
     visitor = HogQLFeatureExtractor()
     visitor.visit(query)
-    return sorted(visitor.tables), sorted(visitor.events)
+    return HogQLFeatures(tables=sorted(visitor.tables), events=sorted(visitor.events))

--- a/posthog/hogql/feature_extractor.py
+++ b/posthog/hogql/feature_extractor.py
@@ -44,7 +44,13 @@ class HogQLFeatureExtractor(TraversingVisitor):
 
     def visit_compare_operation(self, node: ast.CompareOperation) -> None:
         if node.op in (ast.CompareOperationOp.Eq, ast.CompareOperationOp.In):
-            for field_side, value_side in ((node.left, node.right), (node.right, node.left)):
+            # Aliases can stack (resolver passes re-wrap), so unroll until we hit a non-Alias node.
+            left, right = node.left, node.right
+            while isinstance(left, ast.Alias):
+                left = left.expr
+            while isinstance(right, ast.Alias):
+                right = right.expr
+            for field_side, value_side in ((left, right), (right, left)):
                 if _looks_like_event_field(field_side):
                     self.events.update(v for v in _iter_string_constants(value_side) if v in _INTERESTING_EVENT_NAMES)
         super().visit_compare_operation(node)
@@ -53,7 +59,6 @@ class HogQLFeatureExtractor(TraversingVisitor):
 def _looks_like_event_field(expr: ast.Expr) -> bool:
     """``True`` iff ``expr`` references the events table's ``event`` column.
     Mirrors ``is_events_only_field`` from the session where-clause extractor."""
-    expr = _strip_aliases(expr)
     if not isinstance(expr, ast.Field) or not expr.chain:
         return False
 
@@ -74,15 +79,8 @@ def _looks_like_event_field(expr: ast.Expr) -> bool:
     return expr.chain[-1] == "event"
 
 
-def _strip_aliases(expr: ast.Expr) -> ast.Expr:
-    while isinstance(expr, ast.Alias):
-        expr = expr.expr
-    return expr
-
-
 def _iter_string_constants(expr: ast.Expr):
     """Yield string literals from a constant, tuple, or array — covers ``= 'X'`` and ``IN ('X', 'Y')``."""
-    expr = _strip_aliases(expr)
     if isinstance(expr, ast.Constant):
         if isinstance(expr.value, str):
             yield expr.value

--- a/posthog/hogql/feature_extractor.py
+++ b/posthog/hogql/feature_extractor.py
@@ -1,4 +1,4 @@
-"""Extract product-attribution features from a parsed HogQL select query.
+"""Extract product-attribution features from a HogQL select query.
 
 Used by ``HogQLQueryExecutor`` to tag ClickHouse queries with the set of
 PostHog tables and well-known event filters they reference. The tags feed
@@ -10,9 +10,8 @@ analytics, error tracking, web analytics, replay, etc.
 from posthog.hogql import ast
 from posthog.hogql.visitor import TraversingVisitor
 
-# Field chains that name the event-name column on the events table. We match
-# against the *last* identifier so aliases like `e.event` work without us
-# having to resolve types.
+# Last-identifier match for the events ``event`` column when type info isn't
+# available — covers ``event``, ``events.event``, ``e.event``, etc.
 _EVENT_FIELD_NAMES: frozenset[str] = frozenset({"event"})
 
 # Known event names worth surfacing for product attribution. Restricted to
@@ -34,16 +33,16 @@ _INTERESTING_EVENT_NAMES: frozenset[str] = frozenset(
 
 
 class HogQLFeatureExtractor(TraversingVisitor):
-    """Walk a parsed HogQL ``SelectQuery``/``SelectSetQuery`` and record:
+    """Walk a HogQL ``SelectQuery``/``SelectSetQuery`` and record:
 
     * ``tables``: identifiers that appear directly as a ``FROM``/``JOIN`` source.
-    * ``events``: string literals compared to an ``event`` field via ``=`` /
-      ``IN``, restricted to the curated ``_INTERESTING_EVENT_NAMES`` set.
+    * ``events``: string literals compared to an ``event`` field on the events
+      table via ``=`` / ``IN``, restricted to the curated
+      ``_INTERESTING_EVENT_NAMES`` set.
 
-    The extractor runs *before* type resolution, so it works on the raw chain
-    structure rather than resolved table types. Aliased and CTE-referenced
-    tables show up as their alias/CTE name, which is intentional — the real
-    underlying table is still captured wherever it is first joined.
+    Works on either a raw parsed AST or a resolved AST. When type info is
+    available (post-Resolver), the event-field check uses it for accuracy;
+    otherwise it falls back to a last-identifier chain match.
     """
 
     def __init__(self) -> None:
@@ -74,13 +73,51 @@ class HogQLFeatureExtractor(TraversingVisitor):
 
 
 def _looks_like_event_field(expr: ast.Expr) -> bool:
-    """``e.event`` / ``events.event`` / ``event`` all qualify."""
+    """True if ``expr`` references the ``event`` column on the events table.
+
+    Mirrors ``is_events_only_field`` in the session where-clause extractor:
+    when the AST has been resolved we walk the type chain to confirm the
+    field is ``event`` on ``EventsTable`` exactly. When types aren't
+    populated (e.g. pre-resolution caller, or a partially-typed branch) we
+    fall back to a last-identifier chain match — looser, but still useful.
+    """
     if isinstance(expr, ast.Alias):
         expr = expr.expr
     if not isinstance(expr, ast.Field) or not expr.chain:
         return False
+
+    if (events_field := _is_event_field_via_types(expr)) is not None:
+        return events_field
+
     last = expr.chain[-1]
     return isinstance(last, str) and last in _EVENT_FIELD_NAMES
+
+
+def _is_event_field_via_types(field: ast.Field) -> bool | None:
+    """Return True/False from the type system, or None if types aren't
+    populated and the caller should fall back to chain matching."""
+    from posthog.hogql.database.schema.events import EventsTable
+
+    type_ = field.type
+    if type_ is None:
+        return None
+
+    if isinstance(type_, ast.PropertyType):
+        type_ = type_.field_type
+    if isinstance(type_, ast.FieldAliasType):
+        type_ = type_.type
+    if not isinstance(type_, ast.FieldType):
+        return None
+
+    if type_.name != "event":
+        return False
+
+    table_type = type_.table_type
+    while isinstance(table_type, (ast.TableAliasType, ast.ColumnAliasedTableType)):
+        table_type = table_type.table_type
+    if isinstance(table_type, ast.TableType):
+        return isinstance(table_type.table, EventsTable)
+    return False
 
 
 def _iter_string_constants(expr: ast.Expr):

--- a/posthog/hogql/feature_extractor.py
+++ b/posthog/hogql/feature_extractor.py
@@ -81,8 +81,7 @@ def _looks_like_event_field(expr: ast.Expr) -> bool:
     populated (e.g. pre-resolution caller, or a partially-typed branch) we
     fall back to a last-identifier chain match — looser, but still useful.
     """
-    if isinstance(expr, ast.Alias):
-        expr = expr.expr
+    expr = _strip_aliases(expr)
     if not isinstance(expr, ast.Field) or not expr.chain:
         return False
 
@@ -91,6 +90,14 @@ def _looks_like_event_field(expr: ast.Expr) -> bool:
 
     last = expr.chain[-1]
     return isinstance(last, str) and last in _EVENT_FIELD_NAMES
+
+
+def _strip_aliases(expr: ast.Expr) -> ast.Expr:
+    """Aliases can nest — e.g. resolver passes that re-wrap an already-aliased
+    expression — so unwrap until we hit a non-Alias node."""
+    while isinstance(expr, ast.Alias):
+        expr = expr.expr
+    return expr
 
 
 def _is_event_field_via_types(field: ast.Field) -> bool | None:
@@ -123,8 +130,7 @@ def _is_event_field_via_types(field: ast.Field) -> bool | None:
 def _iter_string_constants(expr: ast.Expr):
     """Yield string literals from a constant, tuple, or array — covers
     ``event = 'X'`` and ``event IN ('X', 'Y')``."""
-    if isinstance(expr, ast.Alias):
-        expr = expr.expr
+    expr = _strip_aliases(expr)
     if isinstance(expr, ast.Constant):
         if isinstance(expr.value, str):
             yield expr.value

--- a/posthog/hogql/feature_extractor.py
+++ b/posthog/hogql/feature_extractor.py
@@ -9,20 +9,7 @@ from posthog.hogql import ast
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.visitor import TraversingVisitor
 
-# Restricted to the set add_fallback_query_tags actually maps — over-collecting bloats query_log without buying anything.
-_INTERESTING_EVENT_NAMES: frozenset[str] = frozenset(
-    {
-        "$ai_generation",
-        "$ai_span",
-        "$ai_trace",
-        "$ai_embedding",
-        "$ai_metric",
-        "$ai_feedback",
-        "$exception",
-        "$web_vitals",
-        "$feature_flag_called",
-    }
-)
+from posthog.clickhouse.query_tagging import EVENT_TAG_MATCHERS
 
 
 class HogQLFeatureExtractor(TraversingVisitor):
@@ -52,7 +39,7 @@ class HogQLFeatureExtractor(TraversingVisitor):
                 right = right.expr
             for field_side, value_side in ((left, right), (right, left)):
                 if _looks_like_event_field(field_side):
-                    self.events.update(v for v in _iter_string_constants(value_side) if v in _INTERESTING_EVENT_NAMES)
+                    self.events.update(v for v in _iter_string_constants(value_side) if v in EVENT_TAG_MATCHERS)
         super().visit_compare_operation(node)
 
 

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -53,7 +53,7 @@ from posthog.hogql.visitor import clone_expr
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
-from posthog.clickhouse.query_tagging import HogQLFeatures, tag_queries
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import ExposedCHQueryError
 from posthog.exceptions_capture import capture_exception
 from posthog.models.team import Team
@@ -798,13 +798,13 @@ class HogQLQueryExecutor:
         timings_dict = self.timings.to_dict()
         with self.timings.measure("clickhouse_execute"):
             with self.timings.measure("extract_hogql_features"):
-                tables, events = extract_hogql_features(self.select_query)
+                hogql_features = extract_hogql_features(self.select_query)
             tag_queries(
                 team_id=self.team.pk,
                 query_type=self.query_type,
                 has_joins="JOIN" in self.clickhouse_sql,
                 has_json_operations="JSONExtract" in self.clickhouse_sql or "JSONHas" in self.clickhouse_sql,
-                hogql_features=HogQLFeatures(tables=tables, events=events),
+                hogql_features=hogql_features,
                 timings=timings_dict,
                 modifiers=(
                     {k: v for k, v in self.modifiers.model_dump().items() if v is not None} if self.modifiers else {}

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -37,6 +37,7 @@ from posthog.hogql.direct_connection import (
 )
 from posthog.hogql.errors import ExposedHogQLError, QueryError, ResolutionError
 from posthog.hogql.escape_sql import escape_postgres_identifier
+from posthog.hogql.feature_extractor import extract_hogql_features
 from posthog.hogql.filters import replace_filters
 from posthog.hogql.hogql import HogQLContext
 from posthog.hogql.modifiers import create_default_modifiers_for_team
@@ -52,7 +53,7 @@ from posthog.hogql.visitor import clone_expr
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import HogQLFeatures, tag_queries
 from posthog.errors import ExposedCHQueryError
 from posthog.exceptions_capture import capture_exception
 from posthog.models.team import Team
@@ -796,11 +797,14 @@ class HogQLQueryExecutor:
         assert clickhouse_context is not None
         timings_dict = self.timings.to_dict()
         with self.timings.measure("clickhouse_execute"):
+            with self.timings.measure("extract_hogql_features"):
+                tables, events = extract_hogql_features(self.select_query)
             tag_queries(
                 team_id=self.team.pk,
                 query_type=self.query_type,
                 has_joins="JOIN" in self.clickhouse_sql,
                 has_json_operations="JSONExtract" in self.clickhouse_sql or "JSONHas" in self.clickhouse_sql,
+                hogql_features=HogQLFeatures(tables=tables, events=events),
                 timings=timings_dict,
                 modifiers=(
                     {k: v for k, v in self.modifiers.model_dump().items() if v is not None} if self.modifiers else {}

--- a/posthog/hogql/test/test_feature_extractor.py
+++ b/posthog/hogql/test/test_feature_extractor.py
@@ -1,9 +1,15 @@
+from typing import cast
+
 from posthog.test.base import BaseTest
 
 from parameterized import parameterized
 
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
 from posthog.hogql.feature_extractor import HogQLFeatureExtractor, extract_hogql_features
 from posthog.hogql.parser import parse_select
+from posthog.hogql.resolver import resolve_types
 
 
 class TestHogQLFeatureExtractor(BaseTest):
@@ -88,3 +94,37 @@ class TestHogQLFeatureExtractor(BaseTest):
         )
         assert visitor.tables == {"events"}
         assert visitor.events == {"$exception"}
+
+    def _resolve(self, sql: str) -> ast.SelectQuery | ast.SelectSetQuery:
+        database = Database.create_for(team=self.team)
+        context = HogQLContext(database=database, team_id=self.team.pk, enable_select_queries=True)
+        node = parse_select(sql)
+        return cast(ast.SelectQuery | ast.SelectSetQuery, resolve_types(node, context, dialect="clickhouse"))
+
+    def test_resolved_ast_uses_type_system(self):
+        # After resolution, `event = '$exception'` carries a FieldType pointing
+        # at EventsTable; the extractor should pick it up via types just like
+        # it does via chain matching.
+        _tables, events = extract_hogql_features(self._resolve("SELECT * FROM events WHERE event = '$exception'"))
+        assert events == ["$exception"]
+
+    def test_resolved_event_field_on_non_events_table_ignored(self):
+        # Construct a Field whose chain ends in "event" but whose resolved
+        # type lives on a non-EventsTable. The chain-only heuristic would
+        # accept it; the type-aware path must reject it.
+        from posthog.hogql.database.schema.query_log_archive import QueryLogArchiveTable
+
+        non_events_table_type = ast.TableType(table=QueryLogArchiveTable())
+        field = ast.Field(
+            chain=["query_log", "event"],
+            type=ast.FieldType(name="event", table_type=non_events_table_type),
+        )
+        compare = ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=field,
+            right=ast.Constant(value="$exception"),
+        )
+
+        visitor = HogQLFeatureExtractor()
+        visitor.visit(compare)
+        assert visitor.events == set()

--- a/posthog/hogql/test/test_feature_extractor.py
+++ b/posthog/hogql/test/test_feature_extractor.py
@@ -1,0 +1,90 @@
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog.hogql.feature_extractor import HogQLFeatureExtractor, extract_hogql_features
+from posthog.hogql.parser import parse_select
+
+
+class TestHogQLFeatureExtractor(BaseTest):
+    @parameterized.expand(
+        [
+            ("simple_events_select", "SELECT count() FROM events", ["events"], []),
+            ("aliased_events_table", "SELECT * FROM events AS e LIMIT 10", ["events"], []),
+            ("session_replay_table", "SELECT session_id FROM session_replay_events", ["session_replay_events"], []),
+            (
+                "join_persons_and_events",
+                "SELECT * FROM events AS e JOIN persons AS p ON p.id = e.person_id",
+                ["events", "persons"],
+                [],
+            ),
+            ("subquery_inner_join", "SELECT * FROM (SELECT * FROM events) AS sub", ["events"], []),
+        ]
+    )
+    def test_extracts_table_references(self, _name, sql, expected_tables, expected_events):
+        tables, events = extract_hogql_features(parse_select(sql))
+        assert tables == expected_tables
+        assert events == expected_events
+
+    @parameterized.expand(
+        [
+            ("ai_generation_eq", "SELECT * FROM events WHERE event = '$ai_generation'", ["$ai_generation"]),
+            ("exception_eq", "SELECT * FROM events WHERE event = '$exception'", ["$exception"]),
+            ("web_vitals_eq", "SELECT * FROM events WHERE event = '$web_vitals'", ["$web_vitals"]),
+            (
+                "feature_flag_called_eq",
+                "SELECT * FROM events WHERE event = '$feature_flag_called'",
+                ["$feature_flag_called"],
+            ),
+            (
+                "in_clause_multiple_ai",
+                "SELECT * FROM events WHERE event IN ('$ai_generation', '$ai_span')",
+                ["$ai_generation", "$ai_span"],
+            ),
+            (
+                "constant_on_left",
+                "SELECT * FROM events WHERE '$exception' = event",
+                ["$exception"],
+            ),
+            (
+                "aliased_event_field",
+                "SELECT * FROM events AS e WHERE e.event = '$ai_generation'",
+                ["$ai_generation"],
+            ),
+            (
+                "uninteresting_event_dropped",
+                "SELECT * FROM events WHERE event = 'pageview' OR event = '$ai_generation'",
+                ["$ai_generation"],
+            ),
+            ("unknown_event_dropped", "SELECT * FROM events WHERE event = 'random_event'", []),
+        ]
+    )
+    def test_extracts_event_filters(self, _name, sql, expected_events):
+        _tables, events = extract_hogql_features(parse_select(sql))
+        assert events == expected_events
+
+    def test_handles_none_query(self):
+        tables, events = extract_hogql_features(None)
+        assert tables == []
+        assert events == []
+
+    def test_combined_tables_and_events(self):
+        tables, events = extract_hogql_features(
+            parse_select(
+                "SELECT count() FROM events AS e JOIN persons AS p ON p.id = e.person_id "
+                "WHERE e.event = '$ai_generation'"
+            )
+        )
+        assert tables == ["events", "persons"]
+        assert events == ["$ai_generation"]
+
+    def test_visitor_dedups(self):
+        visitor = HogQLFeatureExtractor()
+        visitor.visit(
+            parse_select(
+                "SELECT * FROM events WHERE event = '$exception' "
+                "UNION ALL SELECT * FROM events WHERE event = '$exception'"
+            )
+        )
+        assert visitor.tables == {"events"}
+        assert visitor.events == {"$exception"}

--- a/posthog/hogql/test/test_feature_extractor.py
+++ b/posthog/hogql/test/test_feature_extractor.py
@@ -28,9 +28,9 @@ class TestHogQLFeatureExtractor(BaseTest):
         ]
     )
     def test_extracts_table_references(self, _name, sql, expected_tables, expected_events):
-        tables, events = extract_hogql_features(parse_select(sql))
-        assert tables == expected_tables
-        assert events == expected_events
+        features = extract_hogql_features(parse_select(sql))
+        assert features.tables == expected_tables
+        assert features.events == expected_events
 
     @parameterized.expand(
         [
@@ -66,23 +66,23 @@ class TestHogQLFeatureExtractor(BaseTest):
         ]
     )
     def test_extracts_event_filters(self, _name, sql, expected_events):
-        _tables, events = extract_hogql_features(parse_select(sql))
-        assert events == expected_events
+        features = extract_hogql_features(parse_select(sql))
+        assert features.events == expected_events
 
     def test_handles_none_query(self):
-        tables, events = extract_hogql_features(None)
-        assert tables == []
-        assert events == []
+        features = extract_hogql_features(None)
+        assert features.tables == []
+        assert features.events == []
 
     def test_combined_tables_and_events(self):
-        tables, events = extract_hogql_features(
+        features = extract_hogql_features(
             parse_select(
                 "SELECT count() FROM events AS e JOIN persons AS p ON p.id = e.person_id "
                 "WHERE e.event = '$ai_generation'"
             )
         )
-        assert tables == ["events", "persons"]
-        assert events == ["$ai_generation"]
+        assert features.tables == ["events", "persons"]
+        assert features.events == ["$ai_generation"]
 
     def test_visitor_dedups(self):
         visitor = HogQLFeatureExtractor()
@@ -105,8 +105,8 @@ class TestHogQLFeatureExtractor(BaseTest):
         # After resolution, `event = '$exception'` carries a FieldType pointing
         # at EventsTable; the extractor should pick it up via types just like
         # it does via chain matching.
-        _tables, events = extract_hogql_features(self._resolve("SELECT * FROM events WHERE event = '$exception'"))
-        assert events == ["$exception"]
+        features = extract_hogql_features(self._resolve("SELECT * FROM events WHERE event = '$exception'"))
+        assert features.events == ["$exception"]
 
     def test_nested_aliases_on_field_and_constant(self):
         # Aliases can stack — e.g. resolver passes that re-wrap. Verify both

--- a/posthog/hogql/test/test_feature_extractor.py
+++ b/posthog/hogql/test/test_feature_extractor.py
@@ -108,6 +108,24 @@ class TestHogQLFeatureExtractor(BaseTest):
         _tables, events = extract_hogql_features(self._resolve("SELECT * FROM events WHERE event = '$exception'"))
         assert events == ["$exception"]
 
+    def test_nested_aliases_on_field_and_constant(self):
+        # Aliases can stack — e.g. resolver passes that re-wrap. Verify both
+        # the field and the constant unwrap fully so the comparison is still
+        # recognised.
+        field = ast.Alias(
+            alias="outer",
+            expr=ast.Alias(alias="inner", expr=ast.Field(chain=["event"])),
+        )
+        constant = ast.Alias(
+            alias="outer",
+            expr=ast.Alias(alias="inner", expr=ast.Constant(value="$exception")),
+        )
+        compare = ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=field, right=constant)
+
+        visitor = HogQLFeatureExtractor()
+        visitor.visit(compare)
+        assert visitor.events == {"$exception"}
+
     def test_resolved_event_field_on_non_events_table_ignored(self):
         # Construct a Field whose chain ends in "event" but whose resolved
         # type lives on a non-EventsTable. The chain-only heuristic would


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C0368RPHLQH/p1778265151553629?thread_ts=1778259457.090339&cid=C0368RPHLQH

HogQL query nodes don't have a fallback product/feature. For MCP queries we just fallback to MCP as the product, but we can do better than this, based on the contents of the query.

Let's pick out some event names / table names and tag the query based on those

## Changes

- **New `HogQLFeatureExtractor`** (`posthog/hogql/feature_extractor.py`) — a `TraversingVisitor` that walks the parsed `SelectQuery` / `SelectSetQuery` and records:
  - `tables`: identifiers used as `FROM`/`JOIN` sources.
  - `events`: string literals compared to an `event` field via `=` or `IN`, restricted to a curated allow-list (`$ai_generation`, `$exception`, `$web_vitals`, `$feature_flag_called`, `$ai_span`, etc.).
- **New `HogQLFeatures` model + `hogql_features` field on `QueryTags`** (`posthog/clickhouse/query_tagging.py`). Set on every HogQL-backed ClickHouse query (HogQLQuery, TrendsQuery, FunnelsQuery, …).
- **`add_fallback_query_tags` consults the features** as a new fallback step, but **only when `query_type == "HogQLQuery"`**. Kinds with their own product mapping (TrendsQuery → product analytics, etc.) keep their existing attribution unchanged. Order: scene → kind → hogql features (HogQLQuery only) → mcp source.
- **Wiring**: `HogQLQueryExecutor._execute_clickhouse_query` extracts features from `self.select_query` and tags them just before `sync_execute`, alongside the existing `has_joins` / `has_json_operations` tags.

Why the AST instead of substring-matching the printed SQL: `add_fallback_query_tags` is called inside `sync_execute`, where the original HogQL/AST is already gone.
Adding a tag at the boundary where the AST *does* exist (`HogQLQueryExecutor`) lets the fallback logic work off structured data without resurrecting the AST or re-parsing SQL.

## How did you test this code?

Agent-authored. Automated tests added and run locally:

- `posthog/hogql/test/test_feature_extractor.py` — 17 cases covering table extraction (single table, alias, join, subquery), event-filter detection (each curated event family, `IN` clauses, constant-on-left, unknown events dropped), `None` input, and dedup across `UNION`.
- `posthog/clickhouse/test/test_query_tagging.py::TestAddFallbackQueryTags` — added cases for each event-family → product mapping, table-only fallback, event-takes-precedence-over-table, HogQLQuery-only gating (TrendsQuery with `\$exception` features still attributes to product analytics), no-override-when-product-set, and graceful fall-through to MCP when features are empty.
- Smoke-checked the broader hogql query test path (`test_query.py`) to confirm the new tag wiring doesn't break execution.

I have not manually exercised this against ClickHouse / `system.query_log`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Opus 4.7 in Claude Code.
Robbie asked for an AST-based implementation of the pattern-matching approach Mike sketched in Slack — explicitly preferring an AST visitor over substring-matching the printed ClickHouse SQL, and a new "hogql features" tag set on all HogQL-backed queries with the fallback only firing for `HogQLQuery`.

Decisions:

- Curated event allow-list rather than capturing every string compared to an `event` field — keeps the tag bounded so query_log stays readable, and avoids leaking arbitrary user input into tags.
- Event-level matches take precedence over table-level matches — `events` table with `event = '\$exception'` should attribute to error tracking, not product analytics.
- Tag set on *all* HogQL-backed queries (not just HogQLQuery) so the field is available for ad-hoc analysis even when fallback isn't firing — but `add_fallback_query_tags` only consults it when `query_type == "HogQLQuery"` per Robbie's request, so we don't re-attribute insights that already have a known product from their kind.