### PR TITLE
feat(quill): Add variants to `Progress` component

### DIFF
--- a/packages/quill/packages/primitives/src/index.ts
+++ b/packages/quill/packages/primitives/src/index.ts
@@ -179,7 +179,14 @@ export {
     MenubarSubContent,
 } from './menubar'
 export { Popover, PopoverContent, PopoverTrigger } from './popover'
-export { Progress } from './progress'
+export {
+    Progress,
+    ProgressIndicator,
+    ProgressLabel,
+    ProgressTrack,
+    ProgressValue,
+    progressIndicatorVariants,
+} from './progress'
 export { RadioGroup, RadioGroupItem, RadioIndicator } from './radio-group'
 export { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './resizable'
 export { ScrollArea, ScrollBar, scrollShadowsCss, SCROLL_SHADOWS_STYLE_ID } from './scroll-area'

--- a/packages/quill/packages/primitives/src/progress.css
+++ b/packages/quill/packages/primitives/src/progress.css
@@ -9,8 +9,30 @@
 
     .quill-progress__indicator {
         height: 100%;
-        background-color: var(--primary);
         transition: all 0.15s ease;
+    }
+
+    /* Variants — colour the indicator only; track stays neutral so the
+       variant reads as "what value does this represent" rather than tinting
+       the whole control. */
+    .quill-progress__indicator--variant-default {
+        background-color: var(--primary);
+    }
+
+    .quill-progress__indicator--variant-info {
+        background-color: var(--info-foreground);
+    }
+
+    .quill-progress__indicator--variant-success {
+        background-color: var(--success-foreground);
+    }
+
+    .quill-progress__indicator--variant-warning {
+        background-color: var(--warning-foreground);
+    }
+
+    .quill-progress__indicator--variant-destructive {
+        background-color: var(--destructive-foreground);
     }
 
     .quill-progress__label {

--- a/packages/quill/packages/primitives/src/progress.stories.tsx
+++ b/packages/quill/packages/primitives/src/progress.stories.tsx
@@ -1,23 +1,138 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { useEffect, useState } from 'react'
 
-import { Progress, ProgressLabel, ProgressValue } from './progress'
+import { Progress, ProgressIndicator, ProgressLabel, ProgressTrack, ProgressValue } from './progress'
 
-const meta: Meta<typeof Progress> = {
+const meta = {
     title: 'Primitives/Progress',
     component: Progress,
     tags: ['autodocs'],
-}
+    argTypes: {
+        variant: {
+            control: 'select',
+            options: ['default', 'info', 'success', 'warning', 'destructive'],
+        },
+        value: {
+            control: { type: 'range', min: 0, max: 100, step: 1 },
+        },
+    },
+} satisfies Meta<typeof Progress>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
+export const Default = {
+    args: {
+        value: 56,
+        variant: 'default',
+    },
+    render: (args) => (
+        <Progress {...args} className="w-full max-w-sm">
+            <ProgressLabel>Upload progress</ProgressLabel>
+            <ProgressValue />
+        </Progress>
+    ),
+} satisfies Story
+
+export const Variants = {
+    render: () => (
+        <div className="flex w-full max-w-sm flex-col gap-4">
+            <Progress value={68} variant="default">
+                <ProgressLabel>Default</ProgressLabel>
+                <ProgressValue />
+            </Progress>
+            <Progress value={42} variant="info">
+                <ProgressLabel>Info</ProgressLabel>
+                <ProgressValue />
+            </Progress>
+            <Progress value={92} variant="success">
+                <ProgressLabel>Success</ProgressLabel>
+                <ProgressValue />
+            </Progress>
+            <Progress value={31} variant="warning">
+                <ProgressLabel>Warning</ProgressLabel>
+                <ProgressValue />
+            </Progress>
+            <Progress value={12} variant="destructive">
+                <ProgressLabel>Destructive</ProgressLabel>
+                <ProgressValue />
+            </Progress>
+        </div>
+    ),
+} satisfies Story
+
+export const NoLabel = {
+    render: () => (
+        <div className="flex w-full max-w-sm flex-col gap-3">
+            <Progress value={68} variant="default" />
+            <Progress value={42} variant="info" />
+            <Progress value={92} variant="success" />
+            <Progress value={31} variant="warning" />
+            <Progress value={12} variant="destructive" />
+        </div>
+    ),
+} satisfies Story
+
+export const ValueBoundary = {
+    render: () => (
+        <div className="flex w-full max-w-sm flex-col gap-4">
+            <Progress value={0} variant="default">
+                <ProgressLabel>Empty (0%)</ProgressLabel>
+                <ProgressValue />
+            </Progress>
+            <Progress value={100} variant="success">
+                <ProgressLabel>Complete (100%)</ProgressLabel>
+                <ProgressValue />
+            </Progress>
+            <Progress value={null} variant="default">
+                <ProgressLabel>Indeterminate (null)</ProgressLabel>
+                <ProgressValue />
+            </Progress>
+        </div>
+    ),
+} satisfies Story
+
+export const Animated = {
     render: () => {
+        const [value, setValue] = useState(0)
+
+        useEffect(() => {
+            const id = setInterval(() => {
+                setValue((v) => (v >= 100 ? 0 : v + 7))
+            }, 600)
+            return () => clearInterval(id)
+        }, [])
+
+        const variant: 'destructive' | 'warning' | 'success' = value < 33 ? 'destructive' : value < 66 ? 'warning' : 'success'
+
         return (
-            <Progress value={56} className="w-full max-w-sm">
-                <ProgressLabel>Upload progress</ProgressLabel>
+            <Progress value={value} variant={variant} className="w-full max-w-sm">
+                <ProgressLabel>Health score</ProgressLabel>
                 <ProgressValue />
             </Progress>
         )
     },
-}
+} satisfies Story
+
+export const ComposedManually = {
+    name: 'Composed manually',
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    'Use `ProgressTrack` + `ProgressIndicator` directly when the convenience `Progress` shell is not what you want — for example, when the consumer wants control over child order, or to render multiple indicators inside a single track.',
+            },
+        },
+    },
+    render: () => (
+        <div className="flex w-full max-w-sm flex-col gap-4">
+            <Progress value={73} variant="success" className="flex-row items-center gap-3">
+                <ProgressLabel>Inline label</ProgressLabel>
+                <ProgressValue />
+            </Progress>
+            <ProgressTrack>
+                <ProgressIndicator variant="info" style={{ width: '64%' }} />
+            </ProgressTrack>
+        </div>
+    ),
+} satisfies Story

--- a/packages/quill/packages/primitives/src/progress.tsx
+++ b/packages/quill/packages/primitives/src/progress.tsx
@@ -1,21 +1,46 @@
 import { Progress as ProgressPrimitive } from '@base-ui/react/progress'
+import { cva, type VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 
 import './progress.css'
 import { cn } from './lib/utils'
 
-function Progress({ className, children, value, ...props }: ProgressPrimitive.Root.Props): React.ReactElement {
+const progressIndicatorVariants = cva('quill-progress__indicator', {
+    variants: {
+        variant: {
+            default: 'quill-progress__indicator--variant-default',
+            info: 'quill-progress__indicator--variant-info',
+            success: 'quill-progress__indicator--variant-success',
+            warning: 'quill-progress__indicator--variant-warning',
+            destructive: 'quill-progress__indicator--variant-destructive',
+        },
+    },
+    defaultVariants: {
+        variant: 'default',
+    },
+})
+
+type ProgressVariantProps = VariantProps<typeof progressIndicatorVariants>
+
+function Progress({
+    className,
+    children,
+    value,
+    variant = 'default',
+    ...props
+}: ProgressPrimitive.Root.Props & ProgressVariantProps): React.ReactElement {
     return (
         <ProgressPrimitive.Root
             value={value}
             data-quill
             data-slot="progress"
+            data-variant={variant}
             className={cn('flex flex-wrap gap-3', className)}
             {...props}
         >
             {children}
             <ProgressTrack>
-                <ProgressIndicator />
+                <ProgressIndicator variant={variant} />
             </ProgressTrack>
         </ProgressPrimitive.Root>
     )
@@ -31,11 +56,16 @@ function ProgressTrack({ className, ...props }: ProgressPrimitive.Track.Props): 
     )
 }
 
-function ProgressIndicator({ className, ...props }: ProgressPrimitive.Indicator.Props): React.ReactElement {
+function ProgressIndicator({
+    className,
+    variant = 'default',
+    ...props
+}: ProgressPrimitive.Indicator.Props & ProgressVariantProps): React.ReactElement {
     return (
         <ProgressPrimitive.Indicator
             data-slot="progress-indicator"
-            className={cn('quill-progress__indicator', className)}
+            data-variant={variant}
+            className={cn(progressIndicatorVariants({ variant }), className)}
             {...props}
         />
     )
@@ -61,4 +91,4 @@ function ProgressValue({ className, ...props }: ProgressPrimitive.Value.Props): 
     )
 }
 
-export { Progress, ProgressTrack, ProgressIndicator, ProgressLabel, ProgressValue }
+export { Progress, ProgressTrack, ProgressIndicator, ProgressLabel, ProgressValue, progressIndicatorVariants }

--- a/packages/quill/packages/tokens/src/colors.ts
+++ b/packages/quill/packages/tokens/src/colors.ts
@@ -174,8 +174,11 @@ export interface StylesConfig {
      * array — when multiple are given they are combined with `:is()`
      * so any of them activates dark mode.
      *
-     * Default: `['.dark', '[theme="dark"]']` (both `.dark` class and
-     * `theme="dark"` attribute work out of the box).
+     * Default: `['.dark', '[theme="dark"]', '[data-theme="dark"]']`. The
+     * three flavours cover Tailwind's `.dark` class convention, the bare
+     * `theme="dark"` attribute, and the `data-theme="dark"` attribute used
+     * by libraries that follow the HTML `data-*` convention (notably
+     * `@modelcontextprotocol/ext-apps` SDK's `applyDocumentTheme()`).
      */
     darkSelector?: string | string[]
 }
@@ -246,7 +249,7 @@ assertThemeDerivedSyncedWithColors(semanticColors)
 
 /** Normalize darkSelector option into a single CSS selector string. */
 function resolveDarkSelector(raw?: string | string[]): string {
-    const defaults = ['.dark', '[theme="dark"]']
+    const defaults = ['.dark', '[theme="dark"]', '[data-theme="dark"]']
     const selectors = raw === undefined ? defaults : typeof raw === 'string' ? [raw] : raw
     return selectors.length === 1 ? selectors[0] : `:is(${selectors.join(', ')})`
 }


### PR DESCRIPTION
Adds variant support (`default`, `info`, `success`, `warning`, `destructive`) to the `Progress` component. The indicator's background color changes per variant while the track remains neutral, so the color communicates the meaning of the value rather than tinting the entire control.

`ProgressIndicator`, `ProgressLabel`, `ProgressTrack`, `ProgressValue`, and `progressIndicatorVariants` are now exported from the primitives package for consumers who need to compose the component manually — for example, to control child order or render multiple indicators inside a single track.

Storybook stories are expanded to cover all variants, label-free usage, boundary values (0%, 100%, indeterminate), an animated variant that cycles through `destructive` → `warning` → `success` based on the current value, and a manual composition example using the lower-level primitives directly.

The default `darkSelector` list gains `[data-theme="dark"]` to support libraries that follow the HTML `data-*` attribute convention, including the `@modelcontextprotocol/ext-apps` SDK's `applyDocumentTheme()`.