### PR TITLE
fix(hog-charts): center value labels on grouped bars

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -489,9 +489,9 @@ snapshots:
     components-hogcharts-barchart--with-reference-line--light:
         hash: v1.k794b7964.081e6b6e0d8258756a42817806f81c4c2c934e5086728e4e57731d618cb0f5bb.LLR8JlGiNzCaW5F55LVIYQ9V5biMi1zPB6HpZ_tpmMk
     components-hogcharts-barchart--with-value-labels--dark:
-        hash: v1.k794b7964.21dacbfe67216e10df7a4f2ef8e45bebff41b2399a3315c217601758c14d297a.VN5fn496LfQhUn60sjiNs58h5B0ZTBAi9jRhtGCX3Vs
+        hash: v1.k794b7964.d3b234d49784932eb4030d36ed1d1f8f74a00ee33921a4b7829a9b5b1acdc1a1.TNkfQrhR3kG9pKFnfFR1jIwuHvcQPeFprQM0nT9bEXs
     components-hogcharts-barchart--with-value-labels--light:
-        hash: v1.k794b7964.3a52da452bcd2bc7c4818c847440a38310c17c9caf834b753e01f90e43bbfe46.-P_DmB3jIS_5XQ0sh1h6BTjDoDGfHp1UJR4vtwmCE4c
+        hash: v1.k794b7964.9c31987f15bf48811309dab07e083a8c48ca7c87810ed55fb5fb1ee5b425d229.eF7z7jVC4P7Sa-vwW7C_jRc36GsRJcUlDz_Z-frOCec
     components-hogcharts-linechart--combined-overlays--dark:
         hash: v1.k794b7964.38753d5c6bab2f9d1be492d0e191aca21265953e220c0f37714913c89d7caf42.0wzgqeeUqe_bxIfIbS861HknzpuGVzxC664U1GTe9S8
     components-hogcharts-linechart--combined-overlays--light:

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
@@ -169,6 +169,40 @@ describe('ValueLabels', () => {
         expect(bgColors).toEqual(['rgb(17, 34, 51)', 'rgb(68, 85, 102)'])
     })
 
+    it('per-segment: passes seriesKey to scales.x so grouped bars anchor on their own bar', () => {
+        // Mirrors BarChart's grouped-layout x-scale: returns a per-series offset when seriesKey
+        // is supplied, otherwise the band center. With the seriesKey wired through, each label
+        // lands on its own bar instead of the shared band center.
+        const series: ResolvedSeries[] = [
+            { key: 'a', label: 'A', color: '#112233', data: [10] },
+            { key: 'b', label: 'B', color: '#445566', data: [20] },
+        ]
+        const xScaleGrouped = (label: string, seriesKey?: string): number | undefined => {
+            const bandStart = X_POSITIONS[label]
+            if (bandStart == null) {
+                return undefined
+            }
+            if (seriesKey === 'a') {
+                return bandStart - 10
+            }
+            if (seriesKey === 'b') {
+                return bandStart + 10
+            }
+            return bandStart
+        }
+        const ctx = makeContext(series, {
+            labels: ['Mon'],
+            scales: { x: xScaleGrouped, y: yScale, yTicks: () => [0, 50, 100] },
+        })
+        const { container } = renderInChart(ctx, <ValueLabels />)
+        const divs = labelDivs(container)
+        expect(divs).toHaveLength(2)
+        // Each label should land on its own bar's x — not the shared band center (60).
+        const byColor = new Map(divs.map((d) => [d.style.backgroundColor, d.style.left]))
+        expect(byColor.get('rgb(17, 34, 51)')).toBe('50px')
+        expect(byColor.get('rgb(68, 85, 102)')).toBe('70px')
+    })
+
     it('renders null when nothing survives filtering', () => {
         const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [NaN, NaN, NaN] }]
         const ctx = makeContext(series, { labels: ['Mon', 'Tue', 'Wed'] })

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -165,7 +165,10 @@ function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2
             if (typeof yValue !== 'number' || !isFinite(yValue)) {
                 continue
             }
-            const categoricalCoord = scales.x(labels[dIdx])
+            // Pass `s.key` so grouped bar charts (compare-against-previous) anchor each
+            // label on its own bar rather than the band center between bars. Other chart
+            // types ignore the second arg and fall back to the band/point center.
+            const categoricalCoord = scales.x(labels[dIdx], s.key)
             const valueCoord = yScale(yValue)
             if (categoricalCoord == null || !isFinite(categoricalCoord) || !isFinite(valueCoord)) {
                 continue


### PR DESCRIPTION
## Problem

In grouped bar layouts (e.g. compare-against-previous), value-label overlays in `hog-charts` were rendered at the band center between two bars in a pair, instead of on top of each individual bar — making labels look misaligned and overlap-prone.

The original report's screenshot shows value labels (264, 1,977, 2,142, …) sitting between the current/comparison-period bars rather than centered above their own bars.

## Changes

`overlays/ValueLabels.tsx` builds candidates per segment and calls `scales.x(labels[dIdx])` to get the categorical pixel coord. `ChartScales.x` accepts an optional `seriesKey` and `BarChart`'s grouped scale uses it to return the per-series bar center; without it, the scale falls back to the band center.

Pass `s.key` through to `scales.x(...)` in `buildPerSegment`. Stack-total mode keeps band-center positioning (the label represents the whole stack). LineChart and other implementations ignore the second arg, so behavior there is unchanged.

## How did you test this code?

I'm an agent (PostHog Code). Manual UI testing was not performed. Automated checks I ran:

- `pnpm jest src/lib/hog-charts/overlays/ValueLabels.test.tsx` — 21/21 pass, including a new test that asserts each label lands on its own per-series x in a mocked grouped x-scale.
- `pnpm jest src/lib/hog-charts/charts/BarChart` — 33/33 pass.
- `pnpm typescript:check` for the touched files — no new errors.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Diagnosed by tracing `scales.x` usage in overlays vs. its grouped/per-series contract in `BarChart.tsx` (the `(label, seriesKey?)` signature documented on `ChartScales`). Considered also fixing `ReferenceLine` / `AnomalyPointsLayer` callsites but they are not the reported regression — kept the change scoped to ValueLabels. Stack-total mode intentionally left at band center.