### PR TITLE
fix(annotations): warn before discarding unsaved annotation modal input

### DIFF
--- a/frontend/src/scenes/annotations/AnnotationModal.tsx
+++ b/frontend/src/scenes/annotations/AnnotationModal.tsx
@@ -37,6 +37,7 @@ export function AnnotationModal({
         isModalOpen,
         existingModalAnnotation,
         annotationModal,
+        annotationModalChanged,
         isAnnotationModalSubmitting,
         onSavedInsight,
         timezone,
@@ -103,6 +104,7 @@ export function AnnotationModal({
             contentRef={contentRef}
             isOpen={isModalOpen}
             onClose={closeModal}
+            hasUnsavedInput={annotationModalChanged}
             title={existingModalAnnotation ? 'Edit annotation' : 'New annotation'}
             description="Use annotations to comment on insights, dashboards"
             footer={


### PR DESCRIPTION
## Problem

Customers reported losing typed content in the annotation create/edit modal when they clicked outside it (for example, to reach for the side panel to gather context). `LemonModal` defaults to dismissing on overlay click, and the form is reset on the next create via `openModalToCreateAnnotation`'s reset listener, so users had to retype.

## Changes

Wires the kea-forms `annotationModalChanged` flag into `LemonModal`'s `hasUnsavedInput` prop on `AnnotationModal`. With that prop set, overlay clicks on a dirty form bump the close-button highlight + tooltip ("You have unsaved input that will be discarded") instead of dismissing. Escape, Cancel, Delete, and the explicit X button still close as before.

Note on dirtiness semantics: `kea-forms` derives `<formName>Changed` from `setValue` / `setValues` actions, not from comparing values to defaults. In practice that means the form is treated as dirty as soon as any value is set, which covers three cases:

- typed input in create mode (the reported bug)
- create-from-chart, where `openModalToCreateAnnotation(initialDate, insightId, ...)` calls `setAnnotationModalValue` for the prefilled date and insight
- edit mode, where `openModalToEditAnnotation` calls `setAnnotationModalValues` with the existing annotation

So overlay-click protection kicks in immediately after opening edit or chart-context create flows, even before the user types. That's a deliberate side effect: prefilled context is also worth protecting from accidental dismissal. Only "New annotation" opened from `/annotations` with no context starts unprotected and dismisses on overlay click as it did before.

Two-line diff in `frontend/src/scenes/annotations/AnnotationModal.tsx`.

## How did you test this code?

Agent-authored. Static checks only:

- TypeScript compilation passes
- oxlint + oxfmt clean

Suggested manual repro:

1. Go to `/annotations`, click "New annotation", type into the body, then click outside the modal — modal should stay open, X button should highlight with the tooltip.
2. Press Escape — modal closes.
3. Open the same modal from a chart's annotation overlay (prefilled date) and from edit mode (existing annotation) — overlay click should be blocked even before typing, since the form is dirty from prefill. Cancel, X, and Save should all still close.

## Publish to changelog?

No

## Docs update

No

## 🤖 Agent context

Tool: Claude Code (claude-opus-4-7).
