### PR TITLE
chore(capture): couple of v1 produce metric tweaks

### DIFF
--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -252,50 +252,49 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
             match tokio::time::timeout_at(deadline, pending.next()).await {
                 Ok(Some((uuid, completed_at, ack))) => {
                     resolved_keys.insert(uuid);
-                    match ack {
-                        Ok(()) => {
-                            counter!(
-                                "capture_v1_kafka_publish_total",
-                                "mode" => labels.mode,
-                                "cluster" => labels.sink,
-                                "outcome" => Outcome::Success.as_tag(),
-                                "path" => labels.path.clone(),
-                                "attempt" => labels.attempt.clone(),
-                            )
-                            .increment(1);
-                            let elapsed = completed_at.signed_duration_since(enqueued_at);
-                            if let Ok(secs) = elapsed.to_std() {
-                                histogram!(
-                                    "capture_v1_kafka_ack_duration_seconds",
-                                    "mode" => labels.mode,
-                                    "cluster" => labels.sink,
-                                    "outcome" => Outcome::Success.as_tag(),
-                                    "path" => labels.path.clone(),
-                                    "attempt" => labels.attempt.clone(),
-                                )
-                                .record(secs.as_secs_f64());
-                            }
-                            results.push(Box::new(
-                                KafkaResult::ok(uuid, enqueued_at).with_completed_at(completed_at),
-                            ));
-                        }
+
+                    let outcome_tag = match &ack {
+                        Ok(()) => Outcome::Success.as_tag(),
                         Err(e) => {
-                            let sink_err = KafkaSinkError::Produce(e);
-                            let outcome = sink_err.outcome();
-                            counter!(
-                                "capture_v1_kafka_publish_total",
-                                "mode" => labels.mode,
-                                "cluster" => labels.sink,
-                                "outcome" => outcome.as_tag(),
-                                "path" => labels.path.clone(),
-                                "attempt" => labels.attempt.clone(),
-                            )
-                            .increment(1);
-                            results.push(Box::new(
-                                KafkaResult::err(uuid, sink_err, enqueued_at)
-                                    .with_completed_at(completed_at),
-                            ));
+                            if e.is_retriable() {
+                                Outcome::RetriableError.as_tag()
+                            } else {
+                                Outcome::FatalError.as_tag()
+                            }
                         }
+                    };
+
+                    counter!(
+                        "capture_v1_kafka_publish_total",
+                        "mode" => labels.mode,
+                        "cluster" => labels.sink,
+                        "outcome" => outcome_tag,
+                        "path" => labels.path.clone(),
+                        "attempt" => labels.attempt.clone(),
+                    )
+                    .increment(1);
+
+                    let elapsed = completed_at.signed_duration_since(enqueued_at);
+                    if let Ok(secs) = elapsed.to_std() {
+                        histogram!(
+                            "capture_v1_kafka_ack_duration_seconds",
+                            "mode" => labels.mode,
+                            "cluster" => labels.sink,
+                            "outcome" => outcome_tag,
+                            "path" => labels.path.clone(),
+                            "attempt" => labels.attempt.clone(),
+                        )
+                        .record(secs.as_secs_f64());
+                    }
+
+                    match ack {
+                        Ok(()) => results.push(Box::new(
+                            KafkaResult::ok(uuid, enqueued_at).with_completed_at(completed_at),
+                        )),
+                        Err(e) => results.push(Box::new(
+                            KafkaResult::err(uuid, KafkaSinkError::Produce(e), enqueued_at)
+                                .with_completed_at(completed_at),
+                        )),
                     }
                 }
                 Ok(None) => break,

--- a/rust/capture/src/v1/sinks/kafka/types.rs
+++ b/rust/capture/src/v1/sinks/kafka/types.rs
@@ -25,7 +25,7 @@ pub fn error_code_tag(code: RDKafkaErrorCode) -> &'static str {
         RDKafkaErrorCode::InvalidMessageSize => "invalid_message_size",
         RDKafkaErrorCode::NotLeaderForPartition => "not_leader_for_partition",
         RDKafkaErrorCode::RequestTimedOut => "request_timed_out",
-        // Transport/infra codes surfaced by ClientContext::error() callback
+        // Broker/idempotent-producer codes from delivery reports
         RDKafkaErrorCode::NotEnoughReplicas => "not_enough_replicas",
         RDKafkaErrorCode::NotEnoughReplicasAfterAppend => "not_enough_replicas_after_append",
         RDKafkaErrorCode::OperationNotAttempted => "operation_not_attempted",

--- a/rust/capture/src/v1/sinks/kafka/types.rs
+++ b/rust/capture/src/v1/sinks/kafka/types.rs
@@ -26,6 +26,15 @@ pub fn error_code_tag(code: RDKafkaErrorCode) -> &'static str {
         RDKafkaErrorCode::NotLeaderForPartition => "not_leader_for_partition",
         RDKafkaErrorCode::RequestTimedOut => "request_timed_out",
         // Transport/infra codes surfaced by ClientContext::error() callback
+        RDKafkaErrorCode::NotEnoughReplicas => "not_enough_replicas",
+        RDKafkaErrorCode::NotEnoughReplicasAfterAppend => "not_enough_replicas_after_append",
+        RDKafkaErrorCode::OperationNotAttempted => "operation_not_attempted",
+        RDKafkaErrorCode::OutOfOrderSequenceNumber => "out_of_order_sequence_number",
+        RDKafkaErrorCode::DuplicateSequenceNumber => "duplicate_sequence_number",
+        RDKafkaErrorCode::NetworkException => "network_exception",
+        RDKafkaErrorCode::CoordinatorLoadInProgress => "coordinator_load_in_progress",
+        RDKafkaErrorCode::CoordinatorNotAvailable => "coordinator_not_available",
+        // Transport/infra codes surfaced by ClientContext::error() callback
         RDKafkaErrorCode::BrokerTransportFailure => "broker_transport_failure",
         RDKafkaErrorCode::AllBrokersDown => "all_brokers_down",
         RDKafkaErrorCode::Resolve => "resolve",
@@ -159,5 +168,67 @@ impl SinkResult for KafkaResult {
     fn elapsed(&self) -> Option<std::time::Duration> {
         self.completed_at
             .and_then(|t| t.signed_duration_since(self.enqueued_at).to_std().ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[rstest::rstest]
+    #[case(RDKafkaErrorCode::QueueFull, "queue_full")]
+    #[case(RDKafkaErrorCode::MessageSizeTooLarge, "message_size_too_large")]
+    #[case(RDKafkaErrorCode::MessageTimedOut, "message_timed_out")]
+    #[case(
+        RDKafkaErrorCode::UnknownTopicOrPartition,
+        "unknown_topic_or_partition"
+    )]
+    #[case(
+        RDKafkaErrorCode::TopicAuthorizationFailed,
+        "topic_authorization_failed"
+    )]
+    #[case(
+        RDKafkaErrorCode::ClusterAuthorizationFailed,
+        "cluster_authorization_failed"
+    )]
+    #[case(RDKafkaErrorCode::InvalidMessage, "invalid_message")]
+    #[case(RDKafkaErrorCode::InvalidMessageSize, "invalid_message_size")]
+    #[case(RDKafkaErrorCode::NotLeaderForPartition, "not_leader_for_partition")]
+    #[case(RDKafkaErrorCode::RequestTimedOut, "request_timed_out")]
+    #[case(RDKafkaErrorCode::NotEnoughReplicas, "not_enough_replicas")]
+    #[case(
+        RDKafkaErrorCode::NotEnoughReplicasAfterAppend,
+        "not_enough_replicas_after_append"
+    )]
+    #[case(RDKafkaErrorCode::OperationNotAttempted, "operation_not_attempted")]
+    #[case(
+        RDKafkaErrorCode::OutOfOrderSequenceNumber,
+        "out_of_order_sequence_number"
+    )]
+    #[case(RDKafkaErrorCode::DuplicateSequenceNumber, "duplicate_sequence_number")]
+    #[case(RDKafkaErrorCode::NetworkException, "network_exception")]
+    #[case(
+        RDKafkaErrorCode::CoordinatorLoadInProgress,
+        "coordinator_load_in_progress"
+    )]
+    #[case(RDKafkaErrorCode::CoordinatorNotAvailable, "coordinator_not_available")]
+    #[case(RDKafkaErrorCode::BrokerTransportFailure, "broker_transport_failure")]
+    #[case(RDKafkaErrorCode::AllBrokersDown, "all_brokers_down")]
+    #[case(RDKafkaErrorCode::Resolve, "resolve")]
+    #[case(RDKafkaErrorCode::Authentication, "authentication")]
+    #[case(
+        RDKafkaErrorCode::SaslAuthenticationFailed,
+        "sasl_authentication_failed"
+    )]
+    fn error_code_tag_named_variants(#[case] code: RDKafkaErrorCode, #[case] expected: &str) {
+        assert_eq!(error_code_tag(code), expected);
+    }
+
+    #[rstest::rstest]
+    #[case(RDKafkaErrorCode::Unknown)]
+    #[case(RDKafkaErrorCode::OffsetOutOfRange)]
+    #[case(RDKafkaErrorCode::GroupAuthorizationFailed)]
+    fn error_code_tag_unlisted_codes_fall_through(#[case] code: RDKafkaErrorCode) {
+        assert_eq!(error_code_tag(code), "rdkafka_other");
     }
 }


### PR DESCRIPTION
## Problem
As stated in title
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Small improvements to produce ack histogram
* Expand rdkafka error code tags to track a few more informational labels that can be returned in a failed produce attempt
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
New tests/expanded unit tests
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
Eli planned, Claude typed, Eli reviewed
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
