### PR TITLE
fix(legal-documents): replace `owner_email` with `sender_email` in PandaDoc envelope creation

### DIFF
--- a/products/legal_documents/backend/logic/__init__.py
+++ b/products/legal_documents/backend/logic/__init__.py
@@ -237,6 +237,7 @@ def create_pandadoc_envelope(document: LegalDocument) -> str | None:
         created = client.create_document_from_template(
             template_id=template_id,
             name=f"PostHog {document.document_type} — {document.company_name}",
+            sender_email=POSTHOG_SIGNING_EMAIL,
             recipients=[
                 pandadoc_client.PandaDocRecipient(
                     email=POSTHOG_SIGNING_EMAIL, role=pandadoc_client.PandaDocRole.POSTHOG
@@ -254,7 +255,6 @@ def create_pandadoc_envelope(document: LegalDocument) -> str | None:
                 "organization_id": str(document.organization_id),
                 "document_type": document.document_type,
             },
-            owner_email=POSTHOG_SIGNING_EMAIL,
         )
         set_pandadoc_document_id(document, created.id)
         return created.id

--- a/products/legal_documents/backend/logic/pandadoc.py
+++ b/products/legal_documents/backend/logic/pandadoc.py
@@ -121,34 +121,35 @@ class PandaDocClient:
         template_id: str,
         name: str,
         recipients: list[PandaDocRecipient],
+        sender_email: str | None = None,
         tokens: dict[str, str] | None = None,
         metadata: dict[str, str] | None = None,
-        owner_email: str | None = None,
     ) -> PandaDocDocument:
         """
         Create a new document from a PandaDoc template. The returned document is in
         `document.uploaded` state — call `send_document` to dispatch the signing email.
 
+        `sender_email` is the email address that will be used to send the signing
+        envelope. Defaults to the email address that owns the API key.
+
         `tokens` is a flat {name: value} map that maps onto the template's token
         placeholders (`[Client.Company]`, `[Client.StreetAddress]`, etc.). Only
         `Client.Email` is auto-populated from the recipient — everything else
         the template references has to be passed explicitly here.
-
-        `owner_email` overrides the document owner. PandaDoc sends the signing
-        envelope on behalf of the owner, so this also controls the From address
-        the signer sees. Defaults to the user that owns the API key.
         """
         payload: dict[str, Any] = {
             "name": name,
             "template_uuid": template_id,
             "recipients": [_serialize_recipient(r) for r in recipients],
         }
+
+        if sender_email:
+            payload["sender"] = {"email": sender_email}
         if tokens:
             payload["tokens"] = [{"name": name, "value": value} for name, value in tokens.items()]
         if metadata:
             payload["metadata"] = metadata
-        if owner_email:
-            payload["owner"] = {"email": owner_email}
+
         data = self._post("/public/v1/documents", payload)
         return PandaDocDocument(
             id=data["id"],

--- a/products/legal_documents/backend/tests/test_pandadoc.py
+++ b/products/legal_documents/backend/tests/test_pandadoc.py
@@ -36,7 +36,7 @@ class TestPandaDocClient(TestCase):
                 recipients=[pandadoc.PandaDocRecipient(email="ada@acme.example", role=pandadoc.PandaDocRole.CLIENT)],
                 tokens={"Client.Company": "Acme, Inc.", "Client.StreetAddress": "1 Analytics Way"},
                 metadata={"legal_document_id": "lid-1"},
-                owner_email="privacy@posthog.com",
+                sender_email="privacy@posthog.com",
             )
 
         mock_post.assert_called_once()
@@ -55,12 +55,12 @@ class TestPandaDocClient(TestCase):
             ],
         )
         self.assertEqual(body["metadata"], {"legal_document_id": "lid-1"})
-        self.assertEqual(body["owner"], {"email": "privacy@posthog.com"})
+        self.assertEqual(body["sender"], {"email": "privacy@posthog.com"})
         self.assertEqual(result.id, "doc_123")
 
     @override_settings(PANDADOC_API_KEY="key", PANDADOC_API_BASE_URL="https://api.pandadoc.com")
-    def test_create_document_omits_owner_when_not_provided(self) -> None:
-        # When `owner_email` is None we leave the field off so PandaDoc falls
+    def test_create_document_omits_sender_when_not_provided(self) -> None:
+        # When `sender_email` is None we leave the field off so PandaDoc falls
         # back to the API key's owning user.
         fake_response = MagicMock()
         fake_response.status_code = 201
@@ -77,7 +77,7 @@ class TestPandaDocClient(TestCase):
             )
 
         body = mock_post.call_args.kwargs["json"]
-        self.assertNotIn("owner", body)
+        self.assertNotIn("sender", body)
 
     @override_settings(PANDADOC_API_KEY="key", PANDADOC_API_BASE_URL="https://api.pandadoc.com")
     def test_stream_document_yields_raw_binary_stream(self) -> None:


### PR DESCRIPTION
Switches the PandaDoc document creation payload from using the `owner` field to the `sender` field when specifying the PostHog signing email address. The `owner` field controls document ownership, while `sender` correctly controls the From address on the signing envelope sent to signers. The parameter on `create_document_from_template` has been renamed from `owner_email` to `sender_email` to reflect this distinction.