### PR TITLE
feat(sdk-doctor): add subscribe-to-alerts

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
@@ -32,7 +32,7 @@ export function IntegrationChoice({
     redirectUrl,
     beforeRedirect,
 }: IntegrationConfigureProps): JSX.Element | null {
-    const { integrationsLoading, integrations, newIntegrationModalKind } = useValues(integrationsLogic)
+    const { integrationsLoading, integrations, newIntegrationModalKind, slackAvailable } = useValues(integrationsLogic)
     const { newGoogleCloudKey, openNewIntegrationModal, closeNewIntegrationModal, deleteIntegration } =
         useActions(integrationsLogic)
     const kind = integration
@@ -90,16 +90,27 @@ export function IntegrationChoice({
     const isSandbox = new URLSearchParams(window.location.search).get('is_sandbox') === 'true'
 
     const setupDef = getIntegrationSetup(kind)
+    // Surface a "go to settings" link instead of redirecting to /integrations/authorize when the
+    // OAuth credentials for the requested kind aren't configured on this instance — otherwise the
+    // user lands on a raw Django REST 400 ("Kind not configured"). Same gate that
+    // SlackIntegration.tsx uses on the settings page.
+    const oauthUnavailable = kind === 'slack' && !slackAvailable
     const setupMenuItem = setupDef
         ? setupDef.menuItem({ kind, openModal: openNewIntegrationModal, uploadKey })
-        : {
-              to: api.integrations.authorizeUrl({ kind, next: redirectUrl, is_sandbox: isSandbox || undefined }),
-              disableClientSideRouting: true,
-              onClick: beforeRedirect,
-              label: integrationsOfKind?.length
-                  ? `Connect to a different integration for ${kindName}`
-                  : `Connect to ${kindName}`,
-          }
+        : oauthUnavailable
+          ? {
+                to: urls.settings('project-integrations'),
+                sideIcon: <IconExternal />,
+                label: `${kindName} is not configured on this instance`,
+            }
+          : {
+                to: api.integrations.authorizeUrl({ kind, next: redirectUrl, is_sandbox: isSandbox || undefined }),
+                disableClientSideRouting: true,
+                onClick: beforeRedirect,
+                label: integrationsOfKind?.length
+                    ? `Connect to a different integration for ${kindName}`
+                    : `Connect to ${kindName}`,
+            }
 
     const button = (
         <LemonMenu

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -202,6 +202,7 @@ export const FEATURE_FLAGS = {
     REPLAY_HOGQL_FILTERS: 'replay-hogql-filters', // owner: @pauldambra #team-replay
     REPLAY_SETTINGS_HELP: 'replay-settings-help', // owner: @veryayskiy #team-replay
     REPLAY_TRIGGER_TYPE_CHOICE: 'replay-trigger-type-choice', // owner: @pauldambra #team-replay
+    SDK_DOCTOR_ALERTS: 'sdk-doctor-alerts', // owner: @slshults #team-growth, gates the Subscribe-to-alerts wizard on /health/sdk-doctor
     SESSION_REPLAY_BACKEND_LOGS: 'session-replay-backend-logs', // owner: #team-replay
     SESSION_REPLAY_DOCTOR: 'session-replay-doctor', // owner: #team-replay
     SETTINGS_BOUNCE_RATE_PAGE_VIEW_MODE: 'settings-bounce-rate-page-view-mode', // owner: #team-web-analytics

--- a/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.ts
+++ b/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.ts
@@ -444,6 +444,7 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
                 const created = await api.hogFunctions.create(configuration)
                 posthog.capture('error_tracking_alert_created', {
                     source: 'wizard',
+                    context: logicProps.logicKey,
                     trigger_event: subTemplate.filters?.events?.[0]?.id ?? null,
                     subtemplate_id: triggerKey,
                     destination_key: destination.key,

--- a/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.ts
+++ b/frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.ts
@@ -48,7 +48,7 @@ export interface AlertWizardLogicProps {
     destinations: WizardDestination[]
     disableUrlSync?: boolean
     presetTriggerKey?: HogFunctionSubTemplateIdType
-    onAlertCreated?: () => void
+    onAlertCreated?: (hogFunctionId?: string) => void
 }
 
 const PRIMARY_DESTINATION_LIMIT = 3
@@ -91,7 +91,7 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
             triggerKey: HogFunctionSubTemplateIdType | null
         }) => ({ state }),
         resetWizard: true,
-        createAlertSuccess: true,
+        createAlertSuccess: (hogFunctionId?: string) => ({ hogFunctionId }),
         submitConfiguration: true,
         submitConfigurationComplete: true,
         testConfiguration: true,
@@ -289,10 +289,10 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
     }),
 
     listeners(({ values, actions, props: logicProps }) => ({
-        createAlertSuccess: () => {
+        createAlertSuccess: ({ hogFunctionId }) => {
             actions.resetWizard()
             actions.loadExistingAlerts()
-            logicProps.onAlertCreated?.()
+            logicProps.onAlertCreated?.(hogFunctionId)
         },
 
         setAlertCreationView: ({ view }) => {
@@ -441,7 +441,7 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
                     inputs: mergedInputs,
                 }
 
-                await api.hogFunctions.create(configuration)
+                const created = await api.hogFunctions.create(configuration)
                 posthog.capture('error_tracking_alert_created', {
                     source: 'wizard',
                     trigger_event: subTemplate.filters?.events?.[0]?.id ?? null,
@@ -451,7 +451,7 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
                     enabled: true,
                 })
                 lemonToast.success('Alert created successfully')
-                actions.createAlertSuccess()
+                actions.createAlertSuccess(created?.id)
             } catch (e: any) {
                 lemonToast.error(e.detail || 'Failed to create alert')
             } finally {

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -880,15 +880,38 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                                                   item_id: 'abcdef',
                                               },
                                           }
-                                        : {
-                                              event: '$pageview',
-                                              properties: {
-                                                  $current_url: currentUrl,
-                                                  $browser: 'Chrome',
-                                                  $ip: '89.160.20.129',
-                                                  this_is_an_example_event: true,
-                                              },
-                                          }),
+                                        : contextId === 'sdk-doctor'
+                                          ? {
+                                                event: '$sdk_doctor_alert_firing',
+                                                properties: {
+                                                    outdated_sdks: [
+                                                        {
+                                                            sdk_type: 'posthog-python',
+                                                            name: 'Python',
+                                                            latest_version: '7.14.0',
+                                                            current_version: '7.0.0',
+                                                            severity: 'warning',
+                                                            is_outdated: true,
+                                                            is_old: false,
+                                                            reason: 'Several minor versions behind',
+                                                            banners: [],
+                                                        },
+                                                    ],
+                                                    needs_updating_count: 1,
+                                                    team_sdk_count: 2,
+                                                    overall_health: 'needs_attention',
+                                                    health: 'warning',
+                                                },
+                                            }
+                                          : {
+                                                event: '$pageview',
+                                                properties: {
+                                                    $current_url: currentUrl,
+                                                    $browser: 'Chrome',
+                                                    $ip: '89.160.20.129',
+                                                    this_is_an_example_event: true,
+                                                },
+                                            }),
                               },
                               person:
                                   contextId !== 'error-tracking'

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.test.ts
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.test.ts
@@ -1,0 +1,25 @@
+import { HogFunctionType } from '~/types'
+
+import { urlForHogFunction } from './HogFunctionsList'
+
+const makeFn = (id: string): HogFunctionType => ({ id }) as HogFunctionType
+
+describe('urlForHogFunction', () => {
+    it('returns the bare hog function path when returnTo is undefined', () => {
+        expect(urlForHogFunction(makeFn('abc123'))).toBe('/functions/abc123')
+    })
+
+    it('appends returnTo as a query param for a hog function id', () => {
+        expect(urlForHogFunction(makeFn('abc123'), '/health/sdk-doctor')).toBe(
+            '/functions/abc123?returnTo=%2Fhealth%2Fsdk-doctor'
+        )
+    })
+
+    it('does not append returnTo for plugin- prefix IDs', () => {
+        expect(urlForHogFunction(makeFn('plugin-7'), '/health/sdk-doctor')).toBe('/pipeline/plugins/7')
+    })
+
+    it('does not append returnTo for batch-export- prefix IDs', () => {
+        expect(urlForHogFunction(makeFn('batch-export-9'), '/health/sdk-doctor')).toBe('/pipeline/batch-exports/9')
+    })
+})

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -1,5 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { router } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import { useCallback, useMemo } from 'react'
 
 import { IconBell } from '@posthog/icons'
@@ -90,14 +90,17 @@ function NotificationContextTag({ hogFunction }: { hogFunction: HogFunctionType 
     )
 }
 
-const urlForHogFunction = (hogFunction: HogFunctionType): string => {
+// `returnTo` only applies to the canonical hog function path; legacy plugin and
+// batch-export scenes don't read it.
+export const urlForHogFunction = (hogFunction: HogFunctionType, returnTo?: string): string => {
     if (hogFunction.id.startsWith('plugin-')) {
         return urls.legacyPlugin(hogFunction.id.replace('plugin-', ''))
     }
     if (hogFunction.id.startsWith('batch-export-')) {
         return urls.batchExport(hogFunction.id.replace('batch-export-', ''))
     }
-    return urls.hogFunction(hogFunction.id)
+    const path = urls.hogFunction(hogFunction.id)
+    return returnTo ? combineUrl(path, { returnTo }).url : path
 }
 
 export function HogFunctionList({
@@ -106,6 +109,7 @@ export function HogFunctionList({
     emptyText,
     onDeleteHogFunction,
     onEditHogFunction,
+    returnTo,
     ...props
 }: HogFunctionListLogicProps & {
     extraControls?: JSX.Element
@@ -113,6 +117,7 @@ export function HogFunctionList({
     emptyText?: string
     onDeleteHogFunction?: (hogFunction: HogFunctionType) => void
     onEditHogFunction?: (hogFunction: HogFunctionType) => void
+    returnTo?: string
 }): JSX.Element {
     const { loading, filteredHogFunctions, filters, hogFunctions, hiddenHogFunctions } = useValues(
         hogFunctionsListLogic(props)
@@ -151,7 +156,7 @@ export function HogFunctionList({
                 render: (_, hogFunction) => {
                     return (
                         <LemonTableLink
-                            to={urlForHogFunction(hogFunction)}
+                            to={urlForHogFunction(hogFunction, returnTo)}
                             onClick={onEditHogFunction ? () => onEditHogFunction(hogFunction) : undefined}
                             title={
                                 <>
@@ -238,7 +243,7 @@ export function HogFunctionList({
                                                   // TRICKY: Hack for now to just link out to the full view
                                                   {
                                                       label: 'View & configure',
-                                                      to: urlForHogFunction(hogFunction),
+                                                      to: urlForHogFunction(hogFunction, returnTo),
                                                   },
                                               ]
                                             : [
@@ -294,6 +299,7 @@ export function HogFunctionList({
         isManualFunction,
         onDeleteHogFunction,
         onEditHogFunction,
+        returnTo,
     ]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     return (

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -129,6 +129,12 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
         filters: { events: [{ id: '$logs_alert_errored', type: 'events' }] },
         flag: FEATURE_FLAGS.LOGS_ALERTING,
     },
+    'sdk-doctor-outdated-sdk': {
+        sub_template_id: 'sdk-doctor-outdated-sdk',
+        type: 'internal_destination',
+        context_id: 'sdk-doctor',
+        filters: { events: [{ id: '$sdk_doctor_alert_firing', type: 'events' }] },
+    },
 }
 
 export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, HogFunctionSubTemplateType[]> = {
@@ -1042,6 +1048,118 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             },
         },
     ],
+    'sdk-doctor-outdated-sdk': [
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['sdk-doctor-outdated-sdk'],
+            template_id: 'template-email',
+            name: 'Email when SDKs are outdated',
+            description: 'Send an email when PostHog SDKs are outdated',
+            inputs: {
+                email: {
+                    value: {
+                        to: { email: '', name: '' },
+                        from: { email: '', name: 'PostHog SDK Doctor' },
+                        replyTo: '',
+                        cc: '',
+                        bcc: '',
+                        subject: 'PostHog SDKs need an update',
+                        preheader:
+                            '{{ event.properties.needs_updating_count }} of {{ event.properties.team_sdk_count }} SDKs are outdated',
+                        text: 'PostHog SDK Doctor: {{ event.properties.needs_updating_count }} of {{ event.properties.team_sdk_count }} SDKs need an update. Open: {{ project.url }}/health/sdk-doctor',
+                        html: `<p>Hi,</p>
+<p><strong>{{ event.properties.needs_updating_count }}</strong> of <strong>{{ event.properties.team_sdk_count }}</strong> PostHog SDKs need an update.</p>
+<p><a href="{{ project.url }}/health/sdk-doctor">Open SDK Doctor</a></p>`,
+                    },
+                },
+            },
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['sdk-doctor-outdated-sdk'],
+            template_id: 'template-webhook',
+            name: 'HTTP Webhook when SDKs are outdated',
+            description: 'Send a webhook when PostHog SDKs are outdated',
+            inputs: {
+                body: {
+                    value: {
+                        alert: 'PostHog SDKs need an update',
+                        summary:
+                            '{event.properties.needs_updating_count} of {event.properties.team_sdk_count} PostHog SDKs are outdated. An outdated SDK means you may be missing out on bug fixes and enhancements.',
+                        health: '{event.properties.health}',
+                        overall_health: '{event.properties.overall_health}',
+                        needs_updating_count: '{event.properties.needs_updating_count}',
+                        team_sdk_count: '{event.properties.team_sdk_count}',
+                        outdated_sdks: '{event.properties.outdated_sdks}',
+                        project: '{project.name}',
+                        sdk_doctor_url: '{project.url}/health/sdk-doctor',
+                    },
+                },
+            },
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['sdk-doctor-outdated-sdk'],
+            template_id: 'template-discord',
+            name: 'Post to Discord when SDKs are outdated',
+            description: 'Post to a Discord channel when PostHog SDKs are outdated',
+            inputs: {
+                content: {
+                    value: `**🩺 PostHog SDK Doctor**
+
+{event.properties.needs_updating_count} of {event.properties.team_sdk_count} SDKs need an update.
+
+[View in PostHog]({project.url}/health/sdk-doctor)`,
+                },
+            },
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['sdk-doctor-outdated-sdk'],
+            template_id: 'template-microsoft-teams',
+            name: 'Post to Microsoft Teams when SDKs are outdated',
+            description: 'Post to a Microsoft Teams channel when PostHog SDKs are outdated',
+            inputs: {
+                text: {
+                    value: '**🩺 PostHog SDK Doctor:** {event.properties.needs_updating_count} of {event.properties.team_sdk_count} SDKs need an update. (View in [PostHog]({project.url}/health/sdk-doctor))',
+                },
+            },
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['sdk-doctor-outdated-sdk'],
+            template_id: 'template-slack',
+            name: 'Post to Slack when SDKs are outdated',
+            description: 'Post to a Slack channel when PostHog SDKs are outdated',
+            inputs: {
+                blocks: {
+                    value: [
+                        { type: 'header', text: { type: 'plain_text', text: '🩺 PostHog SDK Doctor' } },
+                        {
+                            type: 'section',
+                            text: {
+                                type: 'mrkdwn',
+                                text: '*{event.properties.needs_updating_count}* of *{event.properties.team_sdk_count}* SDKs need an update.',
+                            },
+                        },
+                        {
+                            type: 'context',
+                            elements: [{ type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' }],
+                        },
+                        { type: 'divider' },
+                        {
+                            type: 'actions',
+                            elements: [
+                                {
+                                    url: '{project.url}/health/sdk-doctor',
+                                    text: { text: 'Open SDK Doctor', type: 'plain_text' },
+                                    type: 'button',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                text: {
+                    value: 'PostHog SDK Doctor: {event.properties.needs_updating_count} of {event.properties.team_sdk_count} SDKs need an update',
+                },
+            },
+        },
+    ],
 }
 
 export const getSubTemplate = (
@@ -1070,6 +1188,8 @@ export const eventToHogFunctionContextId = (event: string | undefined): HogFunct
         case '$logs_alert_auto_disabled':
         case '$logs_alert_errored':
             return 'logs-alerting'
+        case '$sdk_doctor_alert_firing':
+            return 'sdk-doctor'
         default:
             return 'standard'
     }

--- a/frontend/src/scenes/onboarding/sdks/SdkDoctorAlerting.tsx
+++ b/frontend/src/scenes/onboarding/sdks/SdkDoctorAlerting.tsx
@@ -1,0 +1,117 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { AlertWizard } from 'scenes/hog-functions/AlertWizard/AlertWizard'
+import {
+    AlertCreationView,
+    AlertWizardLogicProps,
+    alertWizardLogic,
+} from 'scenes/hog-functions/AlertWizard/alertWizardLogic'
+import { HogFunctionList } from 'scenes/hog-functions/list/HogFunctionsList'
+import { HogFunctionTemplateList } from 'scenes/hog-functions/list/HogFunctionTemplateList'
+import { getFiltersFromSubTemplateId } from 'scenes/hog-functions/list/LinkedHogFunctions'
+import { urls } from 'scenes/urls'
+
+import { CyclotronJobFiltersType } from '~/types'
+
+import { SDK_DOCTOR_DESTINATIONS, SDK_DOCTOR_SUB_TEMPLATE_IDS, SDK_DOCTOR_TRIGGERS } from './sdkDoctorAlertingConfig'
+
+const HOG_FUNCTION_FILTER_LIST = SDK_DOCTOR_SUB_TEMPLATE_IDS.map(getFiltersFromSubTemplateId).filter(
+    (f) => !!f
+) as CyclotronJobFiltersType[]
+
+export interface SdkDoctorAlertingProps {
+    onAlertCreated?: (hogFunctionId?: string) => void
+}
+
+export function SdkDoctorAlerting({ onAlertCreated }: SdkDoctorAlertingProps = {}): JSX.Element {
+    const wizardProps: AlertWizardLogicProps = {
+        logicKey: 'sdk-doctor',
+        subTemplateIds: SDK_DOCTOR_SUB_TEMPLATE_IDS,
+        triggers: SDK_DOCTOR_TRIGGERS,
+        destinations: SDK_DOCTOR_DESTINATIONS,
+        onAlertCreated,
+    }
+
+    return (
+        <BindLogic logic={alertWizardLogic} props={wizardProps}>
+            <SdkDoctorAlertingInner />
+        </BindLogic>
+    )
+}
+
+function SdkDoctorAlertingInner(): JSX.Element {
+    const { alertCreationView, subTemplateIds } = useValues(alertWizardLogic)
+    const { setAlertCreationView, resetWizard } = useActions(alertWizardLogic)
+
+    if (alertCreationView === AlertCreationView.Wizard) {
+        return (
+            <AlertWizard
+                onCancel={() => {
+                    setAlertCreationView(AlertCreationView.None)
+                    resetWizard()
+                }}
+                onSwitchToTraditional={() => {
+                    posthog.capture('sdk_doctor_alert_creation_switched_to_traditional', {
+                        source: 'wizard',
+                    })
+                    setAlertCreationView(AlertCreationView.Traditional)
+                    resetWizard()
+                }}
+            />
+        )
+    }
+
+    if (alertCreationView === AlertCreationView.Traditional) {
+        return (
+            <HogFunctionTemplateList
+                type="destination"
+                subTemplateIds={subTemplateIds}
+                getConfigurationOverrides={(id) => (id ? getFiltersFromSubTemplateId(id) : undefined)}
+                extraControls={
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        onClick={() => setAlertCreationView(AlertCreationView.None)}
+                    >
+                        Cancel
+                    </LemonButton>
+                }
+            />
+        )
+    }
+
+    return (
+        <HogFunctionList
+            forceFilterGroups={HOG_FUNCTION_FILTER_LIST}
+            type="internal_destination"
+            returnTo={urls.sdkDoctor()}
+            onDeleteHogFunction={(hogFunction) => {
+                posthog.capture('sdk_doctor_alert_deleted', {
+                    hog_function_id: hogFunction.id,
+                })
+            }}
+            onEditHogFunction={(hogFunction) => {
+                posthog.capture('sdk_doctor_alert_edit_clicked', {
+                    hog_function_id: hogFunction.id,
+                })
+            }}
+            extraControls={
+                <LemonButton
+                    type="primary"
+                    size="small"
+                    onClick={() => {
+                        posthog.capture('sdk_doctor_alert_creation_started', {
+                            source: 'wizard_button',
+                        })
+                        setAlertCreationView(AlertCreationView.Wizard)
+                    }}
+                >
+                    New notification
+                </LemonButton>
+            }
+        />
+    )
+}

--- a/frontend/src/scenes/onboarding/sdks/SdkDoctorScene.tsx
+++ b/frontend/src/scenes/onboarding/sdks/SdkDoctorScene.tsx
@@ -1,18 +1,23 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
-import { IconRefresh } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonTag, Link } from '@posthog/lemon-ui'
+import { IconBell, IconRefresh } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonModal, LemonTag, Link } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { SDK_TYPE_READABLE_NAME } from './sdkConstants'
+import { SdkDoctorAlerting } from './SdkDoctorAlerting'
 import { SdkSection } from './SdkDoctorComponents'
 import { type OutdatedTrafficAlert, SdkType, sdkDoctorLogic } from './sdkDoctorLogic'
 import { sdkDoctorSceneLogic } from './sdkDoctorSceneLogic'
@@ -31,6 +36,10 @@ export function SdkDoctorScene(): JSX.Element {
         snoozedUntil,
     } = useValues(sdkDoctorLogic)
     const { isDev } = useValues(preflightLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { alertsModalOpen } = useValues(sdkDoctorSceneLogic)
+    const { setAlertsModalOpen, openAlertsModal } = useActions(sdkDoctorSceneLogic)
+    const alertsEnabled = !!featureFlags[FEATURE_FLAGS.SDK_DOCTOR_ALERTS]
 
     const { loadRawData, snoozeSdkDoctor } = useActions(sdkDoctorLogic)
 
@@ -59,6 +68,17 @@ export function SdkDoctorScene(): JSX.Element {
                 }}
                 actions={
                     <>
+                        {alertsEnabled && (
+                            <LemonButton
+                                size="small"
+                                type="secondary"
+                                onClick={openAlertsModal}
+                                icon={<IconBell className="size-4" />}
+                                tooltip="Subscribe to outdated-SDK alerts via Slack, Discord, Teams, or webhook"
+                            >
+                                Alerts
+                            </LemonButton>
+                        )}
                         <LemonButton
                             size="small"
                             type="primary"
@@ -145,6 +165,29 @@ export function SdkDoctorScene(): JSX.Element {
             {Object.keys(augmentedData).map((sdkType) => (
                 <SdkSection key={sdkType} sdkType={sdkType as SdkType} />
             ))}
+
+            {alertsEnabled && (
+                <LemonModal
+                    isOpen={alertsModalOpen}
+                    onClose={() => setAlertsModalOpen(false)}
+                    title="SDK Doctor alerts"
+                    description="Get notified when your team has outdated PostHog SDKs."
+                    width="80%"
+                >
+                    <SdkDoctorAlerting
+                        onAlertCreated={(hogFunctionId) => {
+                            setAlertsModalOpen(false)
+                            if (hogFunctionId) {
+                                // Pass returnTo so the HogFunctionScene's "Notifications"
+                                // breadcrumb (and back-arrow) sends the user back to SDK Doctor.
+                                router.actions.push(urls.hogFunction(hogFunctionId), {
+                                    returnTo: urls.sdkDoctor(),
+                                })
+                            }
+                        }}
+                    />
+                </LemonModal>
+            )}
         </SceneContent>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/sdkDoctorAlertingConfig.ts
+++ b/frontend/src/scenes/onboarding/sdks/sdkDoctorAlertingConfig.ts
@@ -1,0 +1,51 @@
+import { WizardDestination, WizardTrigger } from 'scenes/hog-functions/AlertWizard/alertWizardLogic'
+
+import { HogFunctionSubTemplateIdType } from '~/types'
+
+export const SDK_DOCTOR_SUB_TEMPLATE_IDS: HogFunctionSubTemplateIdType[] = ['sdk-doctor-outdated-sdk']
+
+export const SDK_DOCTOR_TRIGGERS: WizardTrigger[] = [
+    {
+        key: 'sdk-doctor-outdated-sdk',
+        name: 'SDK is outdated',
+        description: 'Get notified when your team has outdated PostHog SDKs',
+    },
+]
+
+export const SDK_DOCTOR_DESTINATIONS: WizardDestination[] = [
+    {
+        key: 'email',
+        name: 'Email',
+        description: 'Send an email notification',
+        icon: '/static/posthog-icon.svg',
+        templateId: 'template-email',
+    },
+    {
+        key: 'slack',
+        name: 'Slack',
+        description: 'Send a message to a channel',
+        icon: '/static/services/slack.png',
+        templateId: 'template-slack',
+    },
+    {
+        key: 'discord',
+        name: 'Discord',
+        description: 'Post a notification via webhook',
+        icon: '/static/services/discord.png',
+        templateId: 'template-discord',
+    },
+    {
+        key: 'microsoft-teams',
+        name: 'Teams',
+        description: 'Send a message to a channel',
+        icon: '/static/services/microsoft-teams.png',
+        templateId: 'template-microsoft-teams',
+    },
+    {
+        key: 'webhook',
+        name: 'Webhook',
+        description: 'Send an HTTP request to any URL',
+        icon: '/static/services/webhook.svg',
+        templateId: 'template-webhook',
+    },
+]

--- a/frontend/src/scenes/onboarding/sdks/sdkDoctorSceneLogic.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdkDoctorSceneLogic.tsx
@@ -1,4 +1,5 @@
-import { kea, path, selectors } from 'kea'
+import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+import posthog from 'posthog-js'
 
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { sceneConfigurations } from 'scenes/scenes'
@@ -12,6 +13,24 @@ import type { sdkDoctorSceneLogicType } from './sdkDoctorSceneLogicType'
 export const sdkDoctorSceneLogic = kea<sdkDoctorSceneLogicType>([
     path(['scenes', 'onboarding', 'sdks', 'sdkDoctorSceneLogic']),
     tabAwareScene(),
+    actions({
+        setAlertsModalOpen: (open: boolean) => ({ open }),
+        openAlertsModal: true,
+    }),
+    reducers({
+        alertsModalOpen: [
+            false,
+            {
+                setAlertsModalOpen: (_, { open }) => open,
+            },
+        ],
+    }),
+    listeners(({ actions }) => ({
+        openAlertsModal: () => {
+            posthog.capture('sdk doctor alerts modal opened')
+            actions.setAlertsModalOpen(true)
+        },
+    })),
     selectors({
         breadcrumbs: [
             () => [],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6573,6 +6573,7 @@ export type HogFunctionConfigurationContextId =
     | 'insight-alerts'
     | 'experiment-alerts'
     | 'logs-alerting'
+    | 'sdk-doctor'
 
 export type HogFunctionSubTemplateIdType =
     | 'early-access-feature-enrollment'
@@ -6589,6 +6590,7 @@ export type HogFunctionSubTemplateIdType =
     | 'logs-alert-resolved'
     | 'logs-alert-auto-disabled'
     | 'logs-alert-errored'
+    | 'sdk-doctor-outdated-sdk'
 
 export type HogFunctionConfigurationType = Omit<
     HogFunctionType,

--- a/posthog/cdp/templates/hog_function_template.py
+++ b/posthog/cdp/templates/hog_function_template.py
@@ -17,6 +17,7 @@ SubTemplateId = Literal[
     "error-tracking-issue-reopened",
     "error-tracking-issue-spiking",
     "insight-alert-firing",
+    "sdk-doctor-outdated-sdk",
 ]
 
 

--- a/products/growth/backend/sdk_doctor_alerts.py
+++ b/products/growth/backend/sdk_doctor_alerts.py
@@ -1,0 +1,132 @@
+"""
+SDK Doctor alerts — emit `$sdk_doctor_alert_firing` internal events when a team
+has outdated SDKs, with a per-team cooldown so subscribers aren't spammed.
+
+The event is consumed by HogFunctions that users create via the AlertWizard in
+the SDK Doctor scene (Slack / Discord / Teams / email / webhook).
+
+Outdatedness detection lives in `products/growth/backend/sdk_health.py`; this
+module is the thin adapter between that report and the CDP event bus.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
+from posthog.exceptions_capture import capture_exception
+from posthog.redis import get_client
+
+from products.growth.backend.sdk_health import SdkHealthReport
+
+logger = structlog.get_logger(__name__)
+
+
+SDK_DOCTOR_ALERT_EVENT = "$sdk_doctor_alert_firing"
+
+# One week between alert emissions per team, so subscribers aren't spammed daily
+# while the underlying SDKs stay outdated.
+ALERT_COOLDOWN_SECONDS = 7 * 24 * 60 * 60
+
+
+def alert_cooldown_key(team_id: int) -> str:
+    return f"sdk_doctor:alert_cooldown:{team_id}"
+
+
+def _is_on_cooldown(team_id: int) -> bool:
+    try:
+        return bool(get_client().get(alert_cooldown_key(team_id)))
+    except Exception as e:
+        logger.warning(
+            "Failed to read SDK Doctor alert cooldown; proceeding as if not on cooldown",
+            team_id=team_id,
+            error=str(e),
+        )
+        return False
+
+
+def _set_cooldown(team_id: int) -> None:
+    try:
+        get_client().setex(alert_cooldown_key(team_id), ALERT_COOLDOWN_SECONDS, b"1")
+    except Exception as e:
+        logger.warning("Failed to set SDK Doctor alert cooldown", team_id=team_id, error=str(e))
+
+
+def _build_event_properties(report: SdkHealthReport) -> dict[str, Any]:
+    outdated_sdks = [
+        {
+            "sdk_type": sdk.lib,
+            "name": sdk.readable_name,
+            "latest_version": sdk.latest_version,
+            "current_version": sdk.releases[0].version if sdk.releases else None,
+            "severity": sdk.severity,
+            "is_outdated": sdk.is_outdated,
+            "is_old": sdk.is_old,
+            "reason": sdk.reason,
+            "banners": list(sdk.banners),
+        }
+        for sdk in report.sdks
+        if sdk.needs_updating
+    ]
+
+    return {
+        "outdated_sdks": outdated_sdks,
+        "needs_updating_count": report.needs_updating_count,
+        "team_sdk_count": report.team_sdk_count,
+        "overall_health": report.overall_health,
+        "health": report.health,
+    }
+
+
+def emit_sdk_doctor_alert_event(
+    team_id: int,
+    report: SdkHealthReport,
+    *,
+    force: bool = False,
+) -> bool:
+    """
+    Emit `$sdk_doctor_alert_firing` for a team whose SDKs need updating.
+
+    Returns True if the event was produced, False if skipped (report is healthy
+    or cooldown active). Honors a 7-day per-team cooldown; pass `force=True`
+    to bypass (used by manual-trigger paths and tests).
+    """
+    if report.overall_health != "needs_attention" or report.needs_updating_count == 0:
+        return False
+
+    if not force and _is_on_cooldown(team_id):
+        logger.debug("SDK Doctor alert on cooldown, skipping", team_id=team_id)
+        return False
+
+    try:
+        produce_internal_event(
+            team_id=team_id,
+            event=InternalEventEvent(
+                event=SDK_DOCTOR_ALERT_EVENT,
+                distinct_id=f"team_{team_id}",
+                properties=_build_event_properties(report),
+            ),
+        )
+    except Exception as e:
+        logger.exception("Failed to produce SDK Doctor alert event", team_id=team_id, error=str(e))
+        capture_exception(e, additional_properties={"team_id": team_id})
+        return False
+
+    _set_cooldown(team_id)
+    return True
+
+
+def report_to_event_payload(report: SdkHealthReport) -> dict[str, Any]:
+    """Public helper for tests / manual inspection of the event payload shape."""
+    return _build_event_properties(report)
+
+
+__all__ = [
+    "SDK_DOCTOR_ALERT_EVENT",
+    "ALERT_COOLDOWN_SECONDS",
+    "alert_cooldown_key",
+    "emit_sdk_doctor_alert_event",
+    "report_to_event_payload",
+]

--- a/products/growth/backend/temporal/health_checks/sdk_outdated.py
+++ b/products/growth/backend/temporal/health_checks/sdk_outdated.py
@@ -1,9 +1,11 @@
 import json
 from collections import defaultdict
+from typing import Any
 
 import structlog
 
 from posthog.dags.common.owners import JobOwners
+from posthog.exceptions_capture import capture_exception
 from posthog.models.health_issue import HealthIssue
 from posthog.redis import get_client
 from posthog.temporal.health_checks.detectors import HealthExecutionPolicy
@@ -18,6 +20,8 @@ from products.growth.backend.constants import (
     github_sdk_versions_key,
     team_sdk_versions_key,
 )
+from products.growth.backend.sdk_doctor_alerts import emit_sdk_doctor_alert_event
+from products.growth.backend.sdk_health import compute_sdk_health
 
 logger = structlog.get_logger(__name__)
 
@@ -113,6 +117,8 @@ class SdkOutdatedCheck(HealthCheck):
 
         _cache_team_sdk_data({tid: dict(sdk_data) for tid, sdk_data in team_sdk_data.items()})
 
+        self._emit_alerts_for_outdated_teams(team_sdk_data, github_data)
+
         issues: defaultdict[int, list[HealthCheckResult]] = defaultdict(list)
         for team_id, sdk_data in team_sdk_data.items():
             for lib_name, entries in sdk_data.items():
@@ -147,3 +153,60 @@ class SdkOutdatedCheck(HealthCheck):
                     )
 
         return issues
+
+    def _emit_alerts_for_outdated_teams(
+        self,
+        team_sdk_data: dict[int, dict[str, list[SdkVersionEntry]]] | defaultdict,
+        github_data: dict[str, dict],
+    ) -> None:
+        """
+        For each team whose SDKs trip the smart-semver `needs_attention` rule, emit
+        `$sdk_doctor_alert_firing` so subscribed HogFunctions (Slack/Discord/email/etc.)
+        can notify the user. A per-team Redis cooldown inside
+        `emit_sdk_doctor_alert_event` keeps this from spamming daily.
+
+        Alert emission is best-effort: a failure on one team must not break the health
+        check for the rest of the batch.
+        """
+        for team_id, sdk_data in team_sdk_data.items():
+            try:
+                combined = self._build_combined_health_data(sdk_data, github_data)
+                if not combined:
+                    continue
+                report = compute_sdk_health(combined)
+                emit_sdk_doctor_alert_event(team_id=team_id, report=report)
+            except Exception as e:
+                logger.exception("Failed to emit SDK Doctor alert event", team_id=team_id, error=str(e))
+                capture_exception(e, additional_properties={"team_id": team_id})
+
+    @staticmethod
+    def _build_combined_health_data(
+        sdk_data: dict[str, list[SdkVersionEntry]],
+        github_data: dict[str, dict],
+    ) -> dict[str, dict[str, Any]]:
+        """
+        Reshape per-team SDK usage + GitHub version data into the structure
+        `compute_sdk_health` expects — mirrors the combine step in the
+        `/api/projects/:team_id/sdk_doctor/report` endpoint.
+        """
+        combined: dict[str, dict[str, Any]] = {}
+        for lib, entries in sdk_data.items():
+            if lib not in github_data or not entries:
+                continue
+            sdk_for_lib = github_data[lib]
+            latest_version = sdk_for_lib.get("latestVersion")
+            if not latest_version:
+                continue
+            release_dates = sdk_for_lib.get("releaseDates", {})
+            combined[lib] = {
+                "latest_version": latest_version,
+                "usage": [
+                    {
+                        **entry,
+                        "is_latest": entry["lib_version"] == latest_version,
+                        "release_date": release_dates.get(entry["lib_version"]),
+                    }
+                    for entry in entries
+                ],
+            }
+        return combined

--- a/products/growth/backend/temporal/health_checks/sdk_outdated.py
+++ b/products/growth/backend/temporal/health_checks/sdk_outdated.py
@@ -194,9 +194,7 @@ class SdkOutdatedCheck(HealthCheck):
             if lib not in github_data or not entries:
                 continue
             sdk_for_lib = github_data[lib]
-            latest_version = sdk_for_lib.get("latestVersion")
-            if not latest_version:
-                continue
+            latest_version = sdk_for_lib["latestVersion"]
             release_dates = sdk_for_lib.get("releaseDates", {})
             combined[lib] = {
                 "latest_version": latest_version,

--- a/products/growth/backend/temporal/health_checks/tests/test_sdk_outdated.py
+++ b/products/growth/backend/temporal/health_checks/tests/test_sdk_outdated.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime, timedelta
 
 from unittest.mock import MagicMock, patch
 
@@ -189,3 +190,126 @@ class TestSdkOutdatedCheck(TestCase):
         mock_pipe.setex.assert_called_once()
         _key, ttl, _payload = mock_pipe.setex.call_args[0]
         assert ttl == TEAM_SDK_CACHE_EXPIRY
+
+
+class TestSdkOutdatedCheckAlertEmission(TestCase):
+    """Wiring between SdkOutdatedCheck.detect() and emit_sdk_doctor_alert_event."""
+
+    def setUp(self):
+        self.check = SdkOutdatedCheck()
+
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.emit_sdk_doctor_alert_event")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated._cache_team_sdk_data")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.execute_clickhouse_health_team_query")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.get_client")
+    def test_emits_alert_for_team_with_smart_outdated_sdks(
+        self,
+        mock_get_client: MagicMock,
+        mock_ch_query: MagicMock,
+        mock_cache: MagicMock,
+        mock_emit: MagicMock,
+    ):
+        # Major-behind beyond the single-version grace period — triggers needs_attention.
+        release_date = "2025-01-01T00:00:00Z"
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+        mock_redis.mget.return_value = [json.dumps(_make_github_data("2.0.0", {"1.0.0": release_date})).encode()]
+
+        mock_ch_query.return_value = [
+            _make_ch_row(1, "web", "1.0.0", "2026-03-20 12:00:00", 5000),
+        ]
+
+        self.check.detect([1])
+
+        mock_emit.assert_called_once()
+        _, kwargs = mock_emit.call_args
+        assert kwargs["team_id"] == 1
+        assert kwargs["report"].overall_health == "needs_attention"
+
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.emit_sdk_doctor_alert_event")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated._cache_team_sdk_data")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.execute_clickhouse_health_team_query")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.get_client")
+    def test_passes_healthy_report_when_only_patch_behind_and_recent(
+        self,
+        mock_get_client: MagicMock,
+        mock_ch_query: MagicMock,
+        mock_cache: MagicMock,
+        mock_emit: MagicMock,
+    ):
+        # Patch-behind with a recent release should NOT be flagged as needs_attention
+        # by smart semver (patch is never outdated; age threshold not crossed).
+        # Even though the legacy `current != latest` check still creates a HealthIssue,
+        # we pass a healthy report to emit, and emit's internal guard suppresses the event.
+        release_date = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+        mock_redis.mget.return_value = [json.dumps(_make_github_data("1.0.3", {"1.0.0": release_date})).encode()]
+
+        mock_ch_query.return_value = [
+            _make_ch_row(1, "web", "1.0.0", "2026-03-20 12:00:00", 5000),
+        ]
+
+        self.check.detect([1])
+
+        mock_emit.assert_called_once()
+        report = mock_emit.call_args.kwargs["report"]
+        assert report.overall_health == "healthy"
+        assert report.needs_updating_count == 0
+
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.emit_sdk_doctor_alert_event")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated._cache_team_sdk_data")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.execute_clickhouse_health_team_query")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.get_client")
+    def test_emission_failure_does_not_break_detect(
+        self,
+        mock_get_client: MagicMock,
+        mock_ch_query: MagicMock,
+        mock_cache: MagicMock,
+        mock_emit: MagicMock,
+    ):
+        release_date = "2025-01-01T00:00:00Z"
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+        mock_redis.mget.return_value = [json.dumps(_make_github_data("2.0.0", {"1.0.0": release_date})).encode()]
+
+        mock_ch_query.return_value = [
+            _make_ch_row(1, "web", "1.0.0", "2026-03-20 12:00:00", 5000),
+        ]
+
+        mock_emit.side_effect = RuntimeError("kafka is sad")
+
+        with patch("products.growth.backend.temporal.health_checks.sdk_outdated.capture_exception"):
+            results = self.check.detect([1])
+
+        # HealthIssue creation still succeeds — emission failures are isolated.
+        assert 1 in results
+        assert len(results[1]) == 1
+
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.emit_sdk_doctor_alert_event")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated._cache_team_sdk_data")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.execute_clickhouse_health_team_query")
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.get_client")
+    def test_emits_once_per_team(
+        self,
+        mock_get_client: MagicMock,
+        mock_ch_query: MagicMock,
+        mock_cache: MagicMock,
+        mock_emit: MagicMock,
+    ):
+        # Two teams, both critically outdated — expect one call per team, not per SDK.
+        release_date = "2025-01-01T00:00:00Z"
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+        mock_redis.mget.return_value = [json.dumps(_make_github_data("2.0.0", {"1.0.0": release_date})).encode()]
+
+        mock_ch_query.return_value = [
+            _make_ch_row(1, "web", "1.0.0", "2026-03-20 12:00:00", 3000),
+            _make_ch_row(2, "web", "1.0.0", "2026-03-20 12:00:00", 3000),
+        ]
+
+        self.check.detect([1, 2])
+
+        team_ids_called = {call.kwargs["team_id"] for call in mock_emit.call_args_list}
+        assert team_ids_called == {1, 2}
+        assert mock_emit.call_count == 2

--- a/products/growth/backend/tests/test_sdk_doctor_alerts.py
+++ b/products/growth/backend/tests/test_sdk_doctor_alerts.py
@@ -1,0 +1,234 @@
+from datetime import UTC, datetime, timedelta
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from products.growth.backend.sdk_doctor_alerts import (
+    SDK_DOCTOR_ALERT_EVENT,
+    alert_cooldown_key,
+    emit_sdk_doctor_alert_event,
+    report_to_event_payload,
+)
+from products.growth.backend.sdk_health import compute_sdk_health
+
+NOW = datetime(2026, 4, 21, tzinfo=UTC)
+
+
+def _days_ago(days: int) -> str:
+    return (NOW - timedelta(days=days)).isoformat()
+
+
+def _healthy_data() -> dict:
+    return {
+        "web": {
+            "latest_version": "1.5.0",
+            "usage": [
+                {
+                    "lib_version": "1.5.0",
+                    "count": 100,
+                    "max_timestamp": NOW.isoformat(),
+                    "is_latest": True,
+                    "release_date": _days_ago(3),
+                }
+            ],
+        }
+    }
+
+
+def _single_outdated_data() -> dict:
+    return {
+        "web": {
+            "latest_version": "1.5.0",
+            "usage": [
+                {
+                    "lib_version": "1.5.0",
+                    "count": 100,
+                    "max_timestamp": NOW.isoformat(),
+                    "is_latest": True,
+                    "release_date": _days_ago(3),
+                }
+            ],
+        },
+        "posthog-python": {
+            "latest_version": "5.0.0",
+            "usage": [
+                {
+                    "lib_version": "1.0.0",
+                    "count": 100,
+                    "max_timestamp": NOW.isoformat(),
+                    "is_latest": False,
+                    "release_date": _days_ago(200),
+                }
+            ],
+        },
+    }
+
+
+def _critically_outdated_data() -> dict:
+    return {
+        "posthog-node": {
+            "latest_version": "5.0.0",
+            "usage": [
+                {
+                    "lib_version": "1.0.0",
+                    "count": 100,
+                    "max_timestamp": NOW.isoformat(),
+                    "is_latest": False,
+                    "release_date": _days_ago(200),
+                }
+            ],
+        },
+        "posthog-python": {
+            "latest_version": "5.0.0",
+            "usage": [
+                {
+                    "lib_version": "1.0.0",
+                    "count": 100,
+                    "max_timestamp": NOW.isoformat(),
+                    "is_latest": False,
+                    "release_date": _days_ago(200),
+                }
+            ],
+        },
+    }
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store: dict[bytes | str, bytes] = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def setex(self, key, _ttl, value):
+        self.store[key] = value
+
+
+class TestEmitSdkDoctorAlertEvent(SimpleTestCase):
+    def setUp(self):
+        self.fake_redis = FakeRedis()
+        self.redis_patch = patch(
+            "products.growth.backend.sdk_doctor_alerts.get_client",
+            return_value=self.fake_redis,
+        )
+        self.redis_patch.start()
+        self.addCleanup(self.redis_patch.stop)
+
+    def test_skips_when_report_is_healthy(self):
+        report = compute_sdk_health(_healthy_data(), now=NOW)
+        assert report.overall_health == "healthy"
+
+        with patch("products.growth.backend.sdk_doctor_alerts.produce_internal_event") as produce:
+            fired = emit_sdk_doctor_alert_event(team_id=42, report=report)
+
+        assert fired is False
+        produce.assert_not_called()
+
+    def test_emits_when_single_sdk_outdated(self):
+        report = compute_sdk_health(_single_outdated_data(), now=NOW)
+        assert report.overall_health == "needs_attention"
+        assert report.needs_updating_count == 1
+
+        with patch("products.growth.backend.sdk_doctor_alerts.produce_internal_event") as produce:
+            fired = emit_sdk_doctor_alert_event(team_id=42, report=report)
+
+        assert fired is True
+        produce.assert_called_once()
+        _, kwargs = produce.call_args
+        assert kwargs["team_id"] == 42
+        event_arg = kwargs["event"]
+        assert event_arg.event == SDK_DOCTOR_ALERT_EVENT
+        assert event_arg.distinct_id == "team_42"
+        props = event_arg.properties
+        assert props["needs_updating_count"] == 1
+        assert props["overall_health"] == "needs_attention"
+        assert len(props["outdated_sdks"]) == 1
+        assert props["outdated_sdks"][0]["sdk_type"] == "posthog-python"
+
+    def test_emits_when_team_critically_outdated(self):
+        report = compute_sdk_health(_critically_outdated_data(), now=NOW)
+        assert report.health == "danger"
+        assert report.overall_health == "needs_attention"
+
+        with patch("products.growth.backend.sdk_doctor_alerts.produce_internal_event") as produce:
+            fired = emit_sdk_doctor_alert_event(team_id=42, report=report)
+
+        assert fired is True
+        props = produce.call_args.kwargs["event"].properties
+        assert props["health"] == "danger"
+        assert len(props["outdated_sdks"]) == 2
+
+    def test_respects_cooldown(self):
+        report = compute_sdk_health(_single_outdated_data(), now=NOW)
+
+        with patch("products.growth.backend.sdk_doctor_alerts.produce_internal_event") as produce:
+            first = emit_sdk_doctor_alert_event(team_id=42, report=report)
+            second = emit_sdk_doctor_alert_event(team_id=42, report=report)
+
+        assert first is True
+        assert second is False
+        assert produce.call_count == 1
+        assert alert_cooldown_key(42) in self.fake_redis.store
+
+    def test_force_bypasses_cooldown(self):
+        report = compute_sdk_health(_single_outdated_data(), now=NOW)
+        self.fake_redis.store[alert_cooldown_key(42)] = b"1"
+
+        with patch("products.growth.backend.sdk_doctor_alerts.produce_internal_event") as produce:
+            fired = emit_sdk_doctor_alert_event(team_id=42, report=report, force=True)
+
+        assert fired is True
+        produce.assert_called_once()
+
+    def test_cooldown_is_per_team(self):
+        report = compute_sdk_health(_single_outdated_data(), now=NOW)
+
+        with patch("products.growth.backend.sdk_doctor_alerts.produce_internal_event") as produce:
+            fired_a = emit_sdk_doctor_alert_event(team_id=1, report=report)
+            fired_b = emit_sdk_doctor_alert_event(team_id=2, report=report)
+
+        assert fired_a is True
+        assert fired_b is True
+        assert produce.call_count == 2
+
+    def test_produce_failure_does_not_set_cooldown(self):
+        report = compute_sdk_health(_single_outdated_data(), now=NOW)
+
+        with (
+            patch(
+                "products.growth.backend.sdk_doctor_alerts.produce_internal_event",
+                side_effect=RuntimeError("kafka down"),
+            ),
+            patch("products.growth.backend.sdk_doctor_alerts.capture_exception"),
+        ):
+            fired = emit_sdk_doctor_alert_event(team_id=42, report=report)
+
+        assert fired is False
+        assert alert_cooldown_key(42) not in self.fake_redis.store
+
+
+class TestReportToEventPayload(SimpleTestCase):
+    def test_payload_includes_expected_keys(self):
+        report = compute_sdk_health(_single_outdated_data(), now=NOW)
+        payload = report_to_event_payload(report)
+
+        assert set(payload.keys()) == {
+            "outdated_sdks",
+            "needs_updating_count",
+            "team_sdk_count",
+            "overall_health",
+            "health",
+        }
+        assert payload["team_sdk_count"] == 2
+        assert payload["needs_updating_count"] == 1
+        assert payload["outdated_sdks"][0]["sdk_type"] == "posthog-python"
+        assert payload["outdated_sdks"][0]["current_version"] == "1.0.0"
+        assert payload["outdated_sdks"][0]["latest_version"] == "5.0.0"
+
+    def test_payload_omits_healthy_sdks_from_outdated_list(self):
+        report = compute_sdk_health(_single_outdated_data(), now=NOW)
+        payload = report_to_event_payload(report)
+
+        sdk_types = {sdk["sdk_type"] for sdk in payload["outdated_sdks"]}
+        assert sdk_types == {"posthog-python"}


### PR DESCRIPTION
## Problem

SDK Doctor lacks an option to subscribe to alerts. A few customers during the beta have requested the option to subscribe to alerts for outdated SDKs.

## Changes

### Frontend

- New **Alerts** button on `/health/sdk-doctor` opens a wizard backed by the shared `AlertWizard`, with five destination templates pre-populated with defaults: Slack blocks, Discord/Teams content, email subject/body, and an SDK-Doctor-shaped JSON payload for the generic webhook.
- The new button and modal are gated behind a new `sdk-doctor-alerts` feature flag (created on us.posthog.com project 2, id 669902) for staggered rollout: `@posthog.com` employees at 100%, all others at 5%.
- The wizard threads the new HogFunction id through `onAlertCreated` and navigates to the function config page with `returnTo: urls.sdkDoctor()` so the HogFunctionScene back-arrow / "Notifications" breadcrumb returns the user to SDK Doctor instead of the generic destinations list.
- `HogFunctionList` now accepts an optional `returnTo` prop plumbed through `urlForHogFunction` via `combineUrl`, so navigating to an existing alert preserves the same back-arrow behavior as a freshly created one. Other consumers are unaffected — `returnTo` is optional and only applied to the canonical hog-function path.
- `eventToHogFunctionContextId` registers a new `sdk-doctor` context so the in-page Test panel pre-populates a realistic `$sdk_doctor_alert_firing` event matching the function's filter.
- `IntegrationChoice` now surfaces a "not configured on this instance" link to settings when Slack OAuth isn't yet configured.

<img width="2052" height="446" alt="CleanShot 2026-05-08 at 15 10 45@2x" src="https://github.com/user-attachments/assets/1a30413c-ebd1-4599-a78a-6fa1fd3cffa8" />
.
<img width="2022" height="524" alt="CleanShot 2026-05-08 at 15 10 57@2x" src="https://github.com/user-attachments/assets/ade3e665-826b-4074-a3ba-e236dba91b50" />
.
<img width="2002" height="1218" alt="CleanShot 2026-05-08 at 15 11 13@2x" src="https://github.com/user-attachments/assets/5521a561-7d35-4c5f-9c08-0a47e054d5ca" />


### Backend

- New `$sdk_doctor_alert_firing` internal event emitted from the Temporal `sdk_outdated` health check when a team's SDKs trip the smart-semver `needs_attention` rule. 7-day per-team Redis cooldown prevents spam.
- `compute_sdk_health` is reused as the single source of truth for outdated detection: alert emission is best-effort and isolated per team (one team's failure cannot break the batch).

### Not gated by the feature flag

The backend emission code is intentionally ungated. Without the wizard (FE flag-gated), users cannot create the receiving hog function, so the emission code has nothing to fire on. Pre-existing health-menu / inbox behavior is unchanged.

## How did you test this code?

Automated (Run by Claude Opus 4.7):
- Backend: `pytest --reuse-db products/growth/backend/temporal/health_checks/tests/test_sdk_outdated.py products/growth/backend/tests/test_sdk_doctor_alerts.py` — **21/21 passing** (includes 4 new wiring tests for alert-emission and a small expiry-cache test)
- Frontend: new `frontend/src/scenes/hog-functions/list/HogFunctionsList.test.ts` covering `urlForHogFunction` — **4/4 passing**
- Two passes through the `code-reviewer` agent — second pass approved with no blocking issues

Manual (performed by @slshults locally):
- Created a webhook alert and tested with a webhook from webhookDOTsite.
- Clicked through the other options to check the UI in those as well.
- Verified the **Alerts** button is hidden when the `sdk-doctor-alerts` flag is off, and visible when on.

## Publish to changelog?

Yes. Note: staggered rollout.

## Docs update

The SDK Doctor docs page at posthog.com/docs/sdk-doctor should mention the new alerts subscription flow. Inkeep agent should pick this up.

## 🤖 Agent context

PostHog Code session, Opus 4.7. Notable decisions during the session:

- **FE-only feature flag gate** (per @slshults): without the wizard entry point, no hog functions can be created, so the emission code has nothing to fire. Gating the backend would be belt-and-suspenders at the cost of complexity. The flag's "Both client and server" runtime is set anyway, so a future BE gate is a cheap follow-up if needed.
- **`returnTo` scoped to the canonical hog-function path only**, not legacy `plugin-` or `batch-export-` paths (those scenes don't honor it).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*