### PR TITLE
fix(caching): cache empty active-teams result to avoid repeated SELECT

### DIFF
--- a/posthog/caching/test/test_caching_utils.py
+++ b/posthog/caching/test/test_caching_utils.py
@@ -1,16 +1,24 @@
 import pytest
 from unittest.mock import patch
 
-from posthog.caching.utils import IN_A_DAY, RECENTLY_ACCESSED_TEAMS_REDIS_KEY, is_team_active
+from posthog.caching.utils import (
+    IN_A_DAY,
+    RECENTLY_ACCESSED_TEAMS_POPULATED_KEY,
+    RECENTLY_ACCESSED_TEAMS_REDIS_KEY,
+    active_teams,
+    is_team_active,
+)
 from posthog.redis import get_client
 
 
 @pytest.fixture(autouse=True)
-def clear_redis_key():
+def clear_redis_keys():
     redis = get_client()
     redis.delete(RECENTLY_ACCESSED_TEAMS_REDIS_KEY)
+    redis.delete(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY)
     yield
     redis.delete(RECENTLY_ACCESSED_TEAMS_REDIS_KEY)
+    redis.delete(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY)
 
 
 @pytest.mark.parametrize(
@@ -25,6 +33,7 @@ def clear_redis_key():
 def test_is_team_active_with_existing_key(members, expected):
     redis = get_client()
     redis.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, members)
+    redis.set(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY, "1")
 
     with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
         assert is_team_active(42) is expected
@@ -39,21 +48,61 @@ def test_is_team_active_populates_when_key_missing():
 
 
 def test_is_team_active_returns_false_when_clickhouse_empty():
-    redis = get_client()
     with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
         mock_sync_execute.return_value = []
         assert is_team_active(42) is False
-        # no populate should have happened — key still missing, no TTL set
-        assert not redis.exists(RECENTLY_ACCESSED_TEAMS_REDIS_KEY)
+        mock_sync_execute.assert_called_once()
 
 
-def test_populate_sets_24h_ttl():
+def test_is_team_active_caches_empty_clickhouse_result():
+    """Regression: signal-fired sync_insight_caching_state used to re-run the SELECT for
+    every firing on a team without recent events because empty results weren't cached."""
+    redis = get_client()
+    with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
+        mock_sync_execute.return_value = []
+
+        assert is_team_active(42) is False
+        assert is_team_active(43) is False
+        assert is_team_active(44) is False
+
+        # One ClickHouse roundtrip serves all three lookups.
+        assert mock_sync_execute.call_count == 1
+        # And the populated marker outlives the empty zset (which never gets created).
+        assert redis.exists(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY)
+
+
+def test_active_teams_caches_empty_clickhouse_result():
+    """Same regression as is_team_active, on the batch-iteration path."""
+    redis = get_client()
+    with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
+        mock_sync_execute.return_value = []
+
+        assert active_teams() == set()
+        assert active_teams() == set()
+
+        assert mock_sync_execute.call_count == 1
+        assert redis.exists(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY)
+
+
+def test_populate_sets_24h_ttl_on_both_keys():
     redis = get_client()
     with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
         mock_sync_execute.return_value = [(42, 10.0), (43, 20.0)]
         is_team_active(42)
 
-    ttl = redis.ttl(RECENTLY_ACCESSED_TEAMS_REDIS_KEY)
-    # TTL is approximate due to the brief gap between EXPIRE and TTL calls
+    for key in (RECENTLY_ACCESSED_TEAMS_REDIS_KEY, RECENTLY_ACCESSED_TEAMS_POPULATED_KEY):
+        ttl = redis.ttl(key)
+        # TTL is approximate due to the brief gap between EXPIRE and TTL calls
+        assert 0 < ttl <= IN_A_DAY, f"{key} ttl={ttl}"
+        assert ttl >= IN_A_DAY - 5, f"{key} ttl={ttl}"
+
+
+def test_populate_sets_24h_ttl_on_marker_when_clickhouse_empty():
+    redis = get_client()
+    with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
+        mock_sync_execute.return_value = []
+        is_team_active(42)
+
+    ttl = redis.ttl(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY)
     assert 0 < ttl <= IN_A_DAY
     assert ttl >= IN_A_DAY - 5

--- a/posthog/caching/test/test_caching_utils.py
+++ b/posthog/caching/test/test_caching_utils.py
@@ -93,6 +93,20 @@ def test_populate_sets_24h_ttl_on_both_keys():
         assert ttl >= IN_A_DAY - 5, f"{key} ttl={ttl}"
 
 
+def test_populate_clears_stale_zset_when_clickhouse_empty():
+    redis = get_client()
+    redis.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, {"42": 10.0})
+
+    with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
+        mock_sync_execute.return_value = []
+        assert is_team_active(99) is False
+
+    assert not redis.exists(RECENTLY_ACCESSED_TEAMS_REDIS_KEY)
+    with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
+        assert is_team_active(42) is False
+        mock_sync_execute.assert_not_called()
+
+
 def test_populate_sets_short_ttl_on_marker_when_clickhouse_empty():
     redis = get_client()
     with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:

--- a/posthog/caching/test/test_caching_utils.py
+++ b/posthog/caching/test/test_caching_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from posthog.caching.utils import (
     IN_A_DAY,
+    IN_AN_HOUR,
     RECENTLY_ACCESSED_TEAMS_POPULATED_KEY,
     RECENTLY_ACCESSED_TEAMS_REDIS_KEY,
     active_teams,
@@ -92,12 +93,12 @@ def test_populate_sets_24h_ttl_on_both_keys():
         assert ttl >= IN_A_DAY - 5, f"{key} ttl={ttl}"
 
 
-def test_populate_sets_24h_ttl_on_marker_when_clickhouse_empty():
+def test_populate_sets_short_ttl_on_marker_when_clickhouse_empty():
     redis = get_client()
     with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
         mock_sync_execute.return_value = []
         is_team_active(42)
 
     ttl = redis.ttl(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY)
-    assert 0 < ttl <= IN_A_DAY
-    assert ttl >= IN_A_DAY - 5
+    assert 0 < ttl <= IN_AN_HOUR
+    assert ttl >= IN_AN_HOUR - 5

--- a/posthog/caching/test/test_caching_utils.py
+++ b/posthog/caching/test/test_caching_utils.py
@@ -55,8 +55,6 @@ def test_is_team_active_returns_false_when_clickhouse_empty():
 
 
 def test_is_team_active_caches_empty_clickhouse_result():
-    """Regression: signal-fired sync_insight_caching_state used to re-run the SELECT for
-    every firing on a team without recent events because empty results weren't cached."""
     redis = get_client()
     with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
         mock_sync_execute.return_value = []
@@ -65,14 +63,11 @@ def test_is_team_active_caches_empty_clickhouse_result():
         assert is_team_active(43) is False
         assert is_team_active(44) is False
 
-        # One ClickHouse roundtrip serves all three lookups.
         assert mock_sync_execute.call_count == 1
-        # And the populated marker outlives the empty zset (which never gets created).
         assert redis.exists(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY)
 
 
 def test_active_teams_caches_empty_clickhouse_result():
-    """Same regression as is_team_active, on the batch-iteration path."""
     redis = get_client()
     with patch("posthog.caching.utils.sync_execute") as mock_sync_execute:
         mock_sync_execute.return_value = []

--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -13,6 +13,9 @@ from posthog.models.team.team import Team
 from posthog.redis import get_client
 
 RECENTLY_ACCESSED_TEAMS_REDIS_KEY = "INSIGHT_CACHE_UPDATE_RECENTLY_ACCESSED_TEAMS"
+# Companion marker key so we remember "we already populated, the answer was empty" without
+# storing a sentinel into the zset (which would leak into `active_teams()` iteration).
+RECENTLY_ACCESSED_TEAMS_POPULATED_KEY = "INSIGHT_CACHE_UPDATE_RECENTLY_ACCESSED_TEAMS_POPULATED"
 
 IN_A_DAY = 86_400
 
@@ -51,11 +54,14 @@ def _populate_active_teams(redis) -> dict[int, float]:
         ORDER BY age;
     """
     )
-    if not teams_by_recency:
-        return {}
     teams = dict(teams_by_recency)
-    redis.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, teams)
-    redis.expire(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, IN_A_DAY)
+    if teams:
+        redis.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, teams)
+        redis.expire(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, IN_A_DAY)
+    # Always set the "populated" marker, even when the query returned nothing. Otherwise
+    # signal-fired hot-path callers re-run the SELECT for every signal firing on every
+    # team that has no recent events.
+    redis.set(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY, "1", ex=IN_A_DAY)
     return teams
 
 
@@ -69,9 +75,10 @@ def is_team_active(team_id: int) -> bool:
     score = redis.zscore(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, team_id)
     if score is not None:
         return True
-    # ZSCORE None: either the team isn't recently active, or the key has expired /
-    # doesn't exist yet. EXISTS disambiguates.
-    if redis.exists(RECENTLY_ACCESSED_TEAMS_REDIS_KEY):
+    # ZSCORE None: either the team isn't recently active, or we haven't populated yet.
+    # The populated marker disambiguates without re-querying ClickHouse — and crucially
+    # exists even when the populated zset would be empty.
+    if redis.exists(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY):
         return False
     populated = _populate_active_teams(redis)
     return team_id in populated
@@ -93,11 +100,12 @@ def active_teams() -> set[int]:
     """
     redis = get_client()
     all_teams: list[tuple[bytes, float]] = redis.zrange(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, 0, -1, withscores=True)
-    if not all_teams:
-        teams = _populate_active_teams(redis)
-        return set(teams.keys())
-
-    return {int(team_id) for team_id, _ in all_teams}
+    if all_teams:
+        return {int(team_id) for team_id, _ in all_teams}
+    if redis.exists(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY):
+        return set()
+    teams = _populate_active_teams(redis)
+    return set(teams.keys())
 
 
 def last_refresh_from_cached_result(cached_result: dict | object) -> Optional[datetime]:

--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -16,6 +16,7 @@ RECENTLY_ACCESSED_TEAMS_REDIS_KEY = "INSIGHT_CACHE_UPDATE_RECENTLY_ACCESSED_TEAM
 # Separate from the zset so an empty result has somewhere to land without a sentinel team.
 RECENTLY_ACCESSED_TEAMS_POPULATED_KEY = "INSIGHT_CACHE_UPDATE_RECENTLY_ACCESSED_TEAMS_POPULATED"
 
+IN_AN_HOUR = 3_600
 IN_A_DAY = 86_400
 
 
@@ -55,11 +56,13 @@ def _populate_active_teams(redis) -> dict[int, float]:
     )
     teams = dict(teams_by_recency)
     # Marker is set even on empty results, so callers don't re-query for every inactive team.
+    # Empty results get a shorter TTL so a newly-active team gets picked up within an hour.
+    marker_ttl = IN_A_DAY if teams else IN_AN_HOUR
     pipe = redis.pipeline()
     if teams:
         pipe.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, teams)
         pipe.expire(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, IN_A_DAY)
-    pipe.set(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY, "1", ex=IN_A_DAY)
+    pipe.set(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY, "1", ex=marker_ttl)
     pipe.execute()
     return teams
 

--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -62,6 +62,9 @@ def _populate_active_teams(redis) -> dict[int, float]:
     if teams:
         pipe.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, teams)
         pipe.expire(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, IN_A_DAY)
+    else:
+        # Clear any stale zset (deploy rollover, LRU eviction of just the marker, etc).
+        pipe.delete(RECENTLY_ACCESSED_TEAMS_REDIS_KEY)
     pipe.set(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY, "1", ex=marker_ttl)
     pipe.execute()
     return teams

--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -63,7 +63,6 @@ def _populate_active_teams(redis) -> dict[int, float]:
         pipe.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, teams)
         pipe.expire(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, IN_A_DAY)
     else:
-        # Clear any stale zset (deploy rollover, LRU eviction of just the marker, etc).
         pipe.delete(RECENTLY_ACCESSED_TEAMS_REDIS_KEY)
     pipe.set(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY, "1", ex=marker_ttl)
     pipe.execute()

--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -13,8 +13,7 @@ from posthog.models.team.team import Team
 from posthog.redis import get_client
 
 RECENTLY_ACCESSED_TEAMS_REDIS_KEY = "INSIGHT_CACHE_UPDATE_RECENTLY_ACCESSED_TEAMS"
-# Companion marker key so we remember "we already populated, the answer was empty" without
-# storing a sentinel into the zset (which would leak into `active_teams()` iteration).
+# Separate from the zset so an empty result has somewhere to land without a sentinel team.
 RECENTLY_ACCESSED_TEAMS_POPULATED_KEY = "INSIGHT_CACHE_UPDATE_RECENTLY_ACCESSED_TEAMS_POPULATED"
 
 IN_A_DAY = 86_400
@@ -55,13 +54,13 @@ def _populate_active_teams(redis) -> dict[int, float]:
     """
     )
     teams = dict(teams_by_recency)
+    # Marker is set even on empty results, so callers don't re-query for every inactive team.
+    pipe = redis.pipeline()
     if teams:
-        redis.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, teams)
-        redis.expire(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, IN_A_DAY)
-    # Always set the "populated" marker, even when the query returned nothing. Otherwise
-    # signal-fired hot-path callers re-run the SELECT for every signal firing on every
-    # team that has no recent events.
-    redis.set(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY, "1", ex=IN_A_DAY)
+        pipe.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, teams)
+        pipe.expire(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, IN_A_DAY)
+    pipe.set(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY, "1", ex=IN_A_DAY)
+    pipe.execute()
     return teams
 
 
@@ -76,8 +75,6 @@ def is_team_active(team_id: int) -> bool:
     if score is not None:
         return True
     # ZSCORE None: either the team isn't recently active, or we haven't populated yet.
-    # The populated marker disambiguates without re-querying ClickHouse — and crucially
-    # exists even when the populated zset would be empty.
     if redis.exists(RECENTLY_ACCESSED_TEAMS_POPULATED_KEY):
         return False
     populated = _populate_active_teams(redis)


### PR DESCRIPTION
## Problem

`is_team_active(team_id)` is a Redis-backed pre-filter that decides whether a team's insights are eligible for background cache refresh, if the team hasn't ingested events in 3 days, none of its insights get pre-computed.

The bug: when that SELECT returned `[]`, `_populate_active_teams` returned without writing anything to Redis, so every subsequent signal firing re-ran the same SELECT.

In tests this meant noise in `@snapshot_clickhouse_queries` as it would be called multiple times in `Organization.objects.bootstrap`, e.g. on my other PR https://github.com/PostHog/posthog/pull/58186 that got unrelated snapshot changes. I don't think the updated snapshots are actually on master

## Changes

- **`_populate_active_teams`** now writes a companion `RECENTLY_ACCESSED_TEAMS_POPULATED_KEY` marker on every call, including when the SELECT returned nothing.
- **`is_team_active`** and **`active_teams`** check the marker before re-querying.
- The marker is a separate string key rather than a sentinel inside the zset, so iteration in `active_teams()` doesn't have to filter out a fake team.
- Both keys are written in a single Redis pipeline so they share a deadline and can't partially commit.

Verified locally:
- Calls to `_populate_active_teams` during `test_trends_breakdown_cumulative` go from **12 → 1**.
- The trends snapshots now match master exactly (no churn).

## How did you test this code?

Agent-authored. Automated tests added and run locally:

- `posthog/caching/test/test_caching_utils.py` — added `test_is_team_active_caches_empty_clickhouse_result`, `test_active_teams_caches_empty_clickhouse_result`, `test_populate_sets_short_ttl_on_marker_when_clickhouse_empty`.
- Updated `test_is_team_active_returns_false_when_clickhouse_empty` (the previous version asserted the buggy behavior — that the empty SELECT result was *not* cached).
- Ran the full `posthog/caching/test/` suite + the previously-failing `test_trends_breakdown_cumulative` — 117/117 pass.

Not exercised against production Redis or measured ClickHouse load reduction.

## Publish to changelog?

no

## 🤖 Agent context

Initially authored by Claude Opus 4.7 while investigating spurious snapshot rewrites on a separate PR — a `tests-posthog[bot]` commit kept replacing `test_trends.ambr` snapshots with copies of an unrelated `/* celery:posthog.tasks.tasks.sync_insight_caching_state */` query. Tracing the celery query led to `_populate_active_teams` and the empty-result branch that never persisted to Redis.

After a QA review pass, the zset writes and the marker `set` were combined into a Redis pipeline so they commit atomically. Comments were trimmed to one-liners.

Decisions:

- Two-key approach over a single-key sentinel because `active_teams()` iterates the zset and would otherwise need to filter out a fake team_id.
- Marker stored as a plain string with `set ... ex=...` rather than reusing the zset's `EXPIRE` (which is a no-op on a non-existent key).
- Empty results use a 1h marker TTL (vs 24h for populated results) so a newly-active team gets picked up within the hour rather than waiting a full day.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*