### PR TITLE
fix(subscriptions): prevent dashboard email image overflow in outlook

### DIFF
--- a/ee/tasks/test/subscriptions/test_email_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_email_subscriptions.py
@@ -54,9 +54,8 @@ class TestEmailSubscriptionsTasks(APIBaseTest):
             f"/exporter/export-my-test-subscription-2022-02-02-085500.png?token=ey"
             in mocked_email_messages[0].html_body
         )
-        assert 'width="560"' in mocked_email_messages[0].html_body
-        assert "max-width: 560px;" in mocked_email_messages[0].html_body
-        assert "height: auto;" in mocked_email_messages[0].html_body
+        for expected_attr in ['width="560"', "max-width: 560px;", "height: auto;"]:
+            assert expected_attr in mocked_email_messages[0].html_body
 
     def test_new_subscription_delivery(self, MockEmailMessage: MagicMock) -> None:
         mocked_email_messages = mock_ee_email_messages(MockEmailMessage)

--- a/ee/tasks/test/subscriptions/test_email_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_email_subscriptions.py
@@ -54,6 +54,9 @@ class TestEmailSubscriptionsTasks(APIBaseTest):
             f"/exporter/export-my-test-subscription-2022-02-02-085500.png?token=ey"
             in mocked_email_messages[0].html_body
         )
+        assert 'width="560"' in mocked_email_messages[0].html_body
+        assert "max-width: 560px;" in mocked_email_messages[0].html_body
+        assert "height: auto;" in mocked_email_messages[0].html_body
 
     def test_new_subscription_delivery(self, MockEmailMessage: MagicMock) -> None:
         mocked_email_messages = mock_ee_email_messages(MockEmailMessage)

--- a/posthog/templates/email/subscription_report.html
+++ b/posthog/templates/email/subscription_report.html
@@ -57,7 +57,13 @@
             <p style="margin: 8px 0 0 0; font-style: italic; font-size: 0.9em;">If this issue persists, please contact support.</p>
         </div>
     {% else %}
-        <img class="insight-image mb" src="{{ asset.image_url }}" />
+        <img
+            class="insight-image mb"
+            src="{{ asset.image_url }}"
+            alt="{{ asset.insight_name|default:'Subscription insight' }}"
+            width="560"
+            style="display: block; width: 100%; max-width: 560px; height: auto;"
+        />
     {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
## Problem

Dashboard subscription emails can render chart images too wide in Outlook desktop, which causes horizontal overflow.

Closes #57343

## Changes

- Updated the subscription email template image markup in `posthog/templates/email/subscription_report.html` to include Outlook-safe sizing:
  - `width="560"`
  - inline style with `width: 100%`, `max-width: 560px`, and `height: auto;`
- Added regression assertions in `ee/tasks/test/subscriptions/test_email_subscriptions.py` so these sizing attributes remain present in rendered HTML.

## How did you test this code?

- Added automated regression assertions in `ee/tasks/test/subscriptions/test_email_subscriptions.py` for:
  - `width="560"`
  - `max-width: 560px;`
  - `height: auto;`
- I could not run the full test suite in this shell because required project dependencies are not available in this environment.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## Agent context

- Tooling used: AI assistant.
- Chose a minimal template-level fix rather than broad email CSS changes to reduce risk.
- Used explicit width and inline styles because Outlook desktop may ignore class-based image sizing.
