### PR TITLE
fix(surveys): preserve draft state when switching to full editor

### DIFF
--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts
@@ -249,6 +249,47 @@ describe('surveyWizardLogic', () => {
             expect(logic.values.currentStep).toBe('questions')
             expect(logic.values.survey.description).toBe('Edited in the full editor')
         })
+
+        it('preserves unsaved guided editor changes when switching to the full editor', async () => {
+            // surveyLogic is normally mounted by the destination Survey scene; mount it
+            // separately so the wizard logic's connect doesn't tear it down on unmount.
+            const surveyFormLogic = surveyLogic({ id: 'new' })
+            surveyFormLogic.mount()
+
+            const wizardLogic = surveyWizardLogic({ id: 'new' })
+            const unmountWizard = wizardLogic.mount()
+
+            await expectLogic(wizardLogic, () => {
+                wizardLogic.actions.setSurveyValue('description', 'Edited in the guided editor')
+            }).toMatchValues({
+                surveyChanged: true,
+            })
+
+            router.actions.push('/surveys/new#preserveLocalChanges=true')
+            unmountWizard()
+
+            expect(surveyFormLogic.values.survey.description).toBe('Edited in the guided editor')
+            expect(surveyFormLogic.values.surveyChanged).toBe(true)
+        })
+
+        it('resets new survey state when leaving the guided editor without preserveLocalChanges', async () => {
+            const surveyFormLogic = surveyLogic({ id: 'new' })
+            surveyFormLogic.mount()
+
+            const wizardLogic = surveyWizardLogic({ id: 'new' })
+            const unmountWizard = wizardLogic.mount()
+
+            await expectLogic(wizardLogic, () => {
+                wizardLogic.actions.setSurveyValue('description', 'Discarded edit')
+            }).toMatchValues({
+                surveyChanged: true,
+            })
+
+            router.actions.push('/surveys')
+            unmountWizard()
+
+            expect(surveyFormLogic.values.survey.description).toBe('')
+        })
     })
 
     describe('template selection', () => {

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -411,7 +411,7 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
 
     beforeUnmount(({ actions, props }) => {
         actions.resetWizard()
-        if (props.id === 'new') {
+        if (props.id === 'new' && !router.values.hashParams.preserveLocalChanges) {
             actions.resetSurvey()
         }
     }),


### PR DESCRIPTION
## Problem

When a user starts a new survey in the guided editor (`/surveys/guided/new`), edits the title or questions, then clicks "Full editor" to switch to `/surveys/new`, all unsaved changes are wiped and they have to start from scratch. The reverse direction (full → guided) already works correctly.

## Changes

`surveyWizardLogic.beforeUnmount` was unconditionally calling `resetSurvey()` for any new draft (`props.id === 'new'`). This fired *before* the destination scene's `afterMount` could read the `#preserveLocalChanges=true` hash, so by the time `surveyLogic.afterMount` ran its check (which requires `surveyChanged === true`), the form was already reset and the guard evaluated to false — wiping the user's edits.

The fix mirrors the check already present in `surveyWizardLogic.afterMount`: skip the reset when the destination URL has `#preserveLocalChanges=true`. All other unmount paths (navigating to the surveys list, closing the tab) still reset as before.

## How did you test this code?

I'm an agent (PostHog Code). I did not run manual browser testing.

Automated tests added and run:
- `preserves unsaved guided editor changes when switching to the full editor` — pins the bug fix
- `resets new survey state when leaving the guided editor without preserveLocalChanges` — counter-test confirming the reset still fires when the hash is absent

Both pass alongside the existing 8 tests in `surveyWizardLogic.test.ts`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Lucas via PostHog Code (Claude Opus 4.7).

Investigation traced state loss to a timing issue between `surveyWizardLogic.beforeUnmount` and `surveyLogic.afterMount` — the wizard's `beforeUnmount` reset state before the destination logic could read the `preserveLocalChanges` hash param. Considered two fixes:
1. Remove the `resetSurvey()` call from `beforeUnmount` entirely (relying on `afterMount` reset).
2. Make `beforeUnmount` honor `#preserveLocalChanges` (chosen).

Picked option 2 because it preserves existing reset semantics for unrelated unmount paths (e.g. navigating to surveys list, abandoning the draft) — only suppresses the reset for the explicit "I'm switching editors" case the URL hash signals.

Discussed with the user whether `preserveLocalChanges` is the right mechanism at all (it conflates "intentional editor swap" with "keep the draft") — agreed a broader rethink is fine but out of scope for this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*