### PR TITLE
fix(flags): only mount QuickSurveyModal when open

### DIFF
--- a/frontend/src/scenes/surveys/QuickSurveyModal.tsx
+++ b/frontend/src/scenes/surveys/QuickSurveyModal.tsx
@@ -1,6 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { SurveyQuestionType } from 'posthog-js'
-import { useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import {
     LemonBanner,
@@ -287,9 +287,32 @@ export function QuickSurveyModal({
     isOpen: boolean
     modalTitle?: string
     showFollowupToggle?: boolean
-}): JSX.Element {
+}): JSX.Element | null {
+    // Lazy mount: callers may render <QuickSurveyModal> per row (e.g. in a
+    // 100-row feature-flags table). Always-mounting the underlying
+    // react-modal allocates a portal container and ~130 delegated event
+    // listeners per instance even while closed, which adds up to tens of
+    // thousands of listeners. Track mount-state internally so the portal
+    // only exists while the modal is open, while still passing isOpen
+    // through to LemonModal so its 250ms close transition can play
+    // before onAfterClose tears the portal down.
+    const [isMounted, setIsMounted] = useState(isOpen)
+    useEffect(() => {
+        if (isOpen) {
+            setIsMounted(true)
+        }
+    }, [isOpen])
+    if (!isMounted) {
+        return null
+    }
     return (
-        <LemonModal title={modalTitle || 'Quick feedback survey'} isOpen={isOpen} onClose={onCancel} width={900}>
+        <LemonModal
+            title={modalTitle || 'Quick feedback survey'}
+            isOpen={isOpen}
+            onClose={onCancel}
+            onAfterClose={() => setIsMounted(false)}
+            width={900}
+        >
             {context && (
                 <QuickSurveyForm
                     context={context}


### PR DESCRIPTION
## Problem

Visiting `/feature_flags` registers ~32,000 JS event listeners on the page. Investigation traced the cause to `FeatureFlagRowActions`: every row in the feature flags table rendered a `QuickSurveyModal` (`<LemonModal>` / `react-modal`) eagerly, regardless of whether the modal was open. `react-modal` keeps its portal target mounted while `isOpen={false}`, so each row allocated its own portal container, and React's `preparePortalMount` registered the full delegated event set (~130 listeners) on each one.

On a 100-flag overview that adds ~100 portal containers and ~13,000 event listeners to the page on top of the legitimate baseline. Every listener pins its closure graph in memory; the listener counts directly track to the "tab feels slow / uses lots of memory" reports we've been investigating.

## Changes

Pushed the lazy-mount inside `QuickSurveyModal` itself rather than guarding each call site. The component now tracks its own `isMounted` state, returns `null` until the caller first sets `isOpen={true}`, and wires `LemonModal`'s `onAfterClose` to unmount after the 250ms close animation. So the portal only exists while the modal is actually open or animating closed, and the existing fade-out is preserved.

A nice side-effect: this fix automatically covers the other per-row `QuickSurveyModal` call sites (`Experiments.tsx`, `ExperimentView/components.tsx`) without further changes — they were never reported but had the same shape.

Measured before/after on `/project/1/feature_flags`:

| metric | before | after |
| --- | --- | --- |
| `JSEventListeners` (CDP steady-state) | 32,407 | 4,170 |
| React portal containers in fiber tree | 113 | 13 |

The remaining 13 portals are app-level singletons (Tooltip provider, toaster, etc) and don't grow.

A scene-wide audit of 15 other list/table-heavy scenes (experiments, surveys, insights, dashboards, persons, replay/home, error_tracking, etc.) confirmed none of them have the same per-row always-mounted modal pattern.

## How did you test this code?

Agent (PostHog Code) authored. Tested via the leak-hunter tooling (not committed in this PR):

- Re-ran the React fiber inventory walker on `/feature_flags`: portal count 113 → 13, `LemonModal`/`Modal2`/`ModalPortal2` instances no longer mount per row.
- Re-ran the steady-state `Performance.getMetrics` probe: `JSEventListeners` 32,407 → 4,170.
- Drove a Playwright flow that clicks row 0's More menu → "Create survey" → asserts the modal opens with the expected title/body text → Escape closes it. PASS. Close animation continues to play.
- No manual end-to-end testing claimed beyond the automated check above.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Opus 4.7).
- The investigation started from the production "tabs use multi-GB memory" reports. Bisected through several hypotheses (kea-localstorage Chromium bug, posthog-js localStorage churn, session recording, autocapture, network capture, idle replay buffering, portal accumulation across navigation cycles) before landing on this scene-specific anti-pattern.
- Initial approach was a `{isOpen && <QuickSurveyModal>}` guard at the call site (3,761 listeners post-fix, slightly tighter). Greptile's review flagged that the outer conditional bypasses `LemonModal`'s 250ms close transition — modal would "snap" closed. Moved the lazy-mount + `onAfterClose` wiring inside `QuickSurveyModal` to preserve the animation; small listener-count tradeoff (4,170 vs 3,761) but solves the other callsites too.
- Notable rejected branches: portal retention across SPA navigation looked like a smoking gun but turned out to be stable (~13 long-lived singletons, not accumulating per visit); the 32K listener count itself was the real signal, not portal *growth*.
- Decision: keep this PR scoped to the single confirmed fix. Other in-flight experiments (kea persistence backend swap, posthog-js disable flag) stayed local. The scene audit covered 15 other list scenes and none reproduced this pattern, so no follow-up changes here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*