### PR TITLE
fix(replay): guard network snapshot payload before reading requests

### DIFF
--- a/frontend/src/scenes/session-recordings/apm/performance-event-utils.test.ts
+++ b/frontend/src/scenes/session-recordings/apm/performance-event-utils.test.ts
@@ -284,36 +284,22 @@ describe('performance-event-utils', () => {
         expect(actual).toMatchSnapshot()
     })
 
-    it('does not crash when an rrweb network snapshot has no payload', () => {
-        const snapshotWithoutPayload = {
+    it.each([
+        ['rrweb/network@1 with missing payload', { plugin: 'rrweb/network@1' }],
+        ['rrweb/network@1 with null payload', { plugin: 'rrweb/network@1', payload: null }],
+        ['posthog/network@1 with missing payload', { plugin: 'posthog/network@1' }],
+        ['posthog/network@1 with null payload', { plugin: 'posthog/network@1', payload: null }],
+    ])('does not crash when network snapshot has no usable payload (%s)', (_name, snapshotData) => {
+        const snapshot = {
             windowId: '018d5247-079c-7126-8e43-464605576a62',
             type: 6,
-            data: {
-                plugin: 'rrweb/network@1',
-                // payload intentionally omitted — observed in the wild on at least one customer
-            },
+            data: snapshotData,
             timestamp: 1700000000000,
         } as any
 
-        const snapshotWithNullPayload = {
-            windowId: '018d5247-079c-7126-8e43-464605576a62',
-            type: 6,
-            data: {
-                plugin: 'posthog/network@1',
-                payload: null,
-            },
-            timestamp: 1700000000001,
-        } as any
-
-        expect(() =>
-            getPerformanceEvents({
-                '018d5247-079c-7126-8e43-464605576a62': [snapshotWithoutPayload, snapshotWithNullPayload],
-            })
-        ).not.toThrow()
-        expect(
-            getPerformanceEvents({
-                '018d5247-079c-7126-8e43-464605576a62': [snapshotWithoutPayload, snapshotWithNullPayload],
-            })
-        ).toEqual([])
+        const result = getPerformanceEvents({
+            '018d5247-079c-7126-8e43-464605576a62': [snapshot],
+        })
+        expect(result).toEqual([])
     })
 })

--- a/frontend/src/scenes/session-recordings/apm/performance-event-utils.test.ts
+++ b/frontend/src/scenes/session-recordings/apm/performance-event-utils.test.ts
@@ -283,4 +283,37 @@ describe('performance-event-utils', () => {
 
         expect(actual).toMatchSnapshot()
     })
+
+    it('does not crash when an rrweb network snapshot has no payload', () => {
+        const snapshotWithoutPayload = {
+            windowId: '018d5247-079c-7126-8e43-464605576a62',
+            type: 6,
+            data: {
+                plugin: 'rrweb/network@1',
+                // payload intentionally omitted — observed in the wild on at least one customer
+            },
+            timestamp: 1700000000000,
+        } as any
+
+        const snapshotWithNullPayload = {
+            windowId: '018d5247-079c-7126-8e43-464605576a62',
+            type: 6,
+            data: {
+                plugin: 'posthog/network@1',
+                payload: null,
+            },
+            timestamp: 1700000000001,
+        } as any
+
+        expect(() =>
+            getPerformanceEvents({
+                '018d5247-079c-7126-8e43-464605576a62': [snapshotWithoutPayload, snapshotWithNullPayload],
+            })
+        ).not.toThrow()
+        expect(
+            getPerformanceEvents({
+                '018d5247-079c-7126-8e43-464605576a62': [snapshotWithoutPayload, snapshotWithNullPayload],
+            })
+        ).toEqual([])
+    })
 })

--- a/frontend/src/scenes/session-recordings/apm/performance-event-utils.ts
+++ b/frontend/src/scenes/session-recordings/apm/performance-event-utils.ts
@@ -239,6 +239,9 @@ export function getPerformanceEvents(snapshotsByWindowId: Record<string, eventWi
                 snapshot.data.plugin === NETWORK_PLUGIN_NAME
             ) {
                 const properties = snapshot.data.payload as any
+                if (!properties || typeof properties !== 'object') {
+                    return
+                }
 
                 const data: Partial<PerformanceEvent> = {
                     timestamp: snapshot.timestamp,
@@ -261,7 +264,7 @@ export function getPerformanceEvents(snapshotsByWindowId: Record<string, eventWi
             ) {
                 const payload = snapshot.data.payload as any
 
-                if (!Array.isArray(payload.requests) || payload.requests.length === 0) {
+                if (!payload || !Array.isArray(payload.requests) || payload.requests.length === 0) {
                     return
                 }
 


### PR DESCRIPTION
## Problem

The replay player crashes for some sessions with:

```
TypeError: Cannot read properties of undefined (reading 'requests')
    at slr (chunk-FNBKMZHP.js:499:18637)
    at allPerformanceEvents (chunk-FNBKMZHP.js:499:24254)
```

The throw is in `getPerformanceEvents` in `performance-event-utils.ts:264`. The code does:

```ts
const payload = snapshot.data.payload as any

if (!Array.isArray(payload.requests) || payload.requests.length === 0) {
    return
}
```

If a snapshot has `type === 6` and `data.plugin === 'rrweb/network@1'` but `data.payload` is `undefined`/`null`, `payload.requests` throws. The `as any` cast hid this from the type checker.

The same shape problem existed on the sibling `posthog/network@1` branch one block above (`key in properties` would also throw if `payload` were ever `null`/`undefined`).

This branch has been here since the feature was introduced in #18562 (Nov 2023); it only surfaces now because a customer is producing payload-less `rrweb/network@1` snapshots.

## Changes

- `performance-event-utils.ts`: null-guard `payload` on both the `posthog/network@1` and `rrweb/network@1` branches before dereferencing.
- `performance-event-utils.test.ts`: regression test that feeds both a payload-less `rrweb/network@1` snapshot and a `payload: null` `posthog/network@1` snapshot, asserts no throw and an empty result.

## How did you test this code?

I'm an agent (Claude Code) — manual testing was not performed.

Automated:

- `hogli test frontend/src/scenes/session-recordings/apm/performance-event-utils.test.ts` — both existing and new tests pass locally.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Authored by Claude Code (Opus 4.7) at Tue's direction after he pasted the production error stack trace from team 412983.
- Investigation: traced the minified stack (`slr` → `allPerformanceEvents`) to `getPerformanceEvents`, identified the two unguarded `payload` dereferences, confirmed via `git blame`/`git log -S` that the bug has existed since #18562 (2023-11-13).
- Decision: fix both branches (not just the one in the stack trace) since the same root cause exists in the sibling `posthog/network@1` block — it just hasn't crashed yet because no customer hit it.
- Decision: kept the fix minimal (null check + early return) rather than refactoring the `as any` cast away; broader typing cleanup is out of scope for a hotfix.
