### PR TITLE
fix(error-tracking): skip cymbal rule on step-budget exhaustion instead of disabling

### DIFF
--- a/rust/cymbal/src/assignment_rules.rs
+++ b/rust/cymbal/src/assignment_rules.rs
@@ -260,12 +260,13 @@ pub async fn try_assignment_rules(
             // budget for an otherwise-fine rule (e.g. a long `$exception_sources` array
             // pushing an `arrayExists` chain past max_steps). Skip the rule for this
             // event rather than disabling it permanently for every future event.
-            Err(VmError::OutOfResource(resource)) => {
+            // Other `OutOfResource` variants (heap memory, (de)serialization depth)
+            // fall through to the catch-all and still disable the rule.
+            Err(VmError::OutOfResource(resource)) if resource == "steps" => {
                 tracing::warn!(
                     rule_id = %rule.id,
                     team_id = %rule.team_id,
-                    resource = %resource,
-                    "assignment rule exceeded HogVM resource budget for this event, skipping"
+                    "assignment rule exceeded HogVM step budget for this event, skipping"
                 );
                 continue;
             }

--- a/rust/cymbal/src/assignment_rules.rs
+++ b/rust/cymbal/src/assignment_rules.rs
@@ -255,6 +255,20 @@ pub async fn try_assignment_rules(
                 metrics::counter!(AUTO_ASSIGNMENTS).increment(1);
                 return Ok(Some(new_assignment));
             }
+            // The HogVM ran out of its per-event step budget on this event. The rule
+            // itself isn't necessarily broken — a single oversized event can blow the
+            // budget for an otherwise-fine rule (e.g. a long `$exception_sources` array
+            // pushing an `arrayExists` chain past max_steps). Skip the rule for this
+            // event rather than disabling it permanently for every future event.
+            Err(VmError::OutOfResource(resource)) => {
+                tracing::warn!(
+                    rule_id = %rule.id,
+                    team_id = %rule.team_id,
+                    resource = %resource,
+                    "assignment rule exceeded HogVM resource budget for this event, skipping"
+                );
+                continue;
+            }
             Err(err) => {
                 rule.disable(
                     &mut *con,

--- a/rust/cymbal/src/fingerprinting/grouping_rules.rs
+++ b/rust/cymbal/src/fingerprinting/grouping_rules.rs
@@ -194,6 +194,18 @@ pub async fn evaluate_grouping_rules(
                 metrics::counter!(CUSTOM_GROUPED_EVENTS).increment(1);
                 return Ok(Some(rule));
             }
+            // See `try_assignment_rules` for the rationale: step-budget exhaustion
+            // is a per-event cost issue, not a logic bug in the rule. Skip this rule
+            // for this event rather than disabling it permanently.
+            Err(VmError::OutOfResource(resource)) => {
+                tracing::warn!(
+                    rule_id = %rule.id,
+                    team_id = %rule.team_id,
+                    resource = %resource,
+                    "grouping rule exceeded HogVM resource budget for this event, skipping"
+                );
+                continue;
+            }
             Err(err) => {
                 rule.disable(&mut *con, err.to_string(), props.clone())
                     .await?

--- a/rust/cymbal/src/fingerprinting/grouping_rules.rs
+++ b/rust/cymbal/src/fingerprinting/grouping_rules.rs
@@ -196,13 +196,13 @@ pub async fn evaluate_grouping_rules(
             }
             // See `try_assignment_rules` for the rationale: step-budget exhaustion
             // is a per-event cost issue, not a logic bug in the rule. Skip this rule
-            // for this event rather than disabling it permanently.
-            Err(VmError::OutOfResource(resource)) => {
+            // for this event rather than disabling it permanently. Other
+            // `OutOfResource` variants still fall through to the disable path.
+            Err(VmError::OutOfResource(resource)) if resource == "steps" => {
                 tracing::warn!(
                     rule_id = %rule.id,
                     team_id = %rule.team_id,
-                    resource = %resource,
-                    "grouping rule exceeded HogVM resource budget for this event, skipping"
+                    "grouping rule exceeded HogVM step budget for this event, skipping"
                 );
                 continue;
             }

--- a/rust/cymbal/src/stages/linking/rule_suppression.rs
+++ b/rust/cymbal/src/stages/linking/rule_suppression.rs
@@ -51,13 +51,13 @@ impl ValueOperator for RuleSuppression {
                 }
                 // See `try_assignment_rules` for the rationale: step-budget exhaustion
                 // is a per-event cost issue, not a logic bug in the rule. Skip this rule
-                // for this event rather than disabling it permanently.
-                Err(VmError::OutOfResource(resource)) => {
+                // for this event rather than disabling it permanently. Other
+                // `OutOfResource` variants still fall through to the disable path.
+                Err(VmError::OutOfResource(resource)) if resource == "steps" => {
                     tracing::warn!(
                         rule_id = %rule.id,
                         team_id = %rule.team_id,
-                        resource = %resource,
-                        "suppression rule exceeded HogVM resource budget for this event, skipping"
+                        "suppression rule exceeded HogVM step budget for this event, skipping"
                     );
                     continue;
                 }

--- a/rust/cymbal/src/stages/linking/rule_suppression.rs
+++ b/rust/cymbal/src/stages/linking/rule_suppression.rs
@@ -1,3 +1,4 @@
+use hogvm::VmError;
 use metrics::counter;
 
 use crate::{
@@ -47,6 +48,18 @@ impl ValueOperator for RuleSuppression {
                 Ok(true) => {
                     counter!(RULE_SUPPRESSED_EVENTS).increment(1);
                     return Ok(Err(EventError::SuppressedByRule(rule.id)));
+                }
+                // See `try_assignment_rules` for the rationale: step-budget exhaustion
+                // is a per-event cost issue, not a logic bug in the rule. Skip this rule
+                // for this event rather than disabling it permanently.
+                Err(VmError::OutOfResource(resource)) => {
+                    tracing::warn!(
+                        rule_id = %rule.id,
+                        team_id = %rule.team_id,
+                        resource = %resource,
+                        "suppression rule exceeded HogVM resource budget for this event, skipping"
+                    );
+                    continue;
                 }
                 Err(err) => {
                     rule.disable(


### PR DESCRIPTION
## Problem

When the HogVM hits its per-event step budget (`max_steps`, default 10,000) while evaluating an assignment, grouping, or suppression rule, cymbal currently treats it identically to a logic failure: it writes `disabled_data` on the PG row and the rule is dead for every future event on that team.

That conflates two very different conditions:

- **logic bug** (invalid bytecode, type errors) — disabling is the right default
- **per-event cost** (this particular event was abnormally expensive) — the rule itself is fine, the next event would have evaluated cleanly

Concrete failure mode we hit: an external developer's React ErrorBoundary fan-out (5 nested `ApolloError`s × 50 frames each → 52 unique `$exception_sources` paths) tripped a Team Platform Features auto-assignment rule on team 2 that has 10 OR'd `Exception source contains X` clauses. Each clause compiles to an `arrayExists` over `$exception_sources`, which is HogVM-bytecode (~21 steps per element, see `rust/common/hogvm/src/stl.rs:405`). 10 × 52 × 21 ≈ 11k steps > 10k cap → `VmError::OutOfResource("steps")` → rule permanently disabled. Surfaced via the `CymbalRulesDisabledFired` Prometheus alert.

## Changes

Match on `VmError::OutOfResource(_)` separately at all three sites that previously fed any `VmError` into `rule.disable()`:

- `rust/cymbal/src/assignment_rules.rs` — `try_assignment_rules`
- `rust/cymbal/src/fingerprinting/grouping_rules.rs` — `evaluate_grouping_rules`
- `rust/cymbal/src/stages/linking/rule_suppression.rs` — `RuleSuppression::execute_value`

Each site now skips the rule for this event (treats it as no-match), keeps the rule active for the next event, and logs a `tracing::warn!` with `rule_id`, `team_id`, and the resource name so the case stays visible.

`CymbalRulesDisabledFired` stays the right alert for genuine bytecode errors; transient cost exhaustion no longer trips it.

No new metrics in this PR per scope — happy to add a `cymbal_*_rules_step_budget_exceeded` counter in a follow-up if it turns out we want to alert on the rate.

## How did you test this code?

I'm an agent (Claude / Sonnet 4.5).

Automated checks run locally:

- `cargo check -p cymbal` — 0 errors
- `cargo clippy -p cymbal --no-deps` — 0 errors (1 pre-existing warning unrelated to this change)

No new automated tests added in this PR. The behavioral change is in three small match arms with no new code paths beyond \"skip rule, log\"; the existing tests cover the surrounding loops. A focused `#[sqlx::test]` proving \"OutOfResource doesn't write `disabled_data`\" would be valuable as a regression guard — happy to add as a follow-up if reviewers want it gated on tests landing in this PR.

Verification path post-merge: re-enable the disabled assignment rule for Team Platform Features (`UPDATE posthog_errortrackingassignmentrule SET disabled_data = NULL WHERE id = ...`) and observe that it stays enabled even when the same Upheal-shaped event class arrives.

## Docs update

No docs change needed.

## 🤖 Agent context

- Triaged the firing `CymbalRulesDisabledFired` alert in prod-us; root-caused to a single oversized event from an external Upheal developer hitting team 2's token.
- Walked through HogVM step accounting: `arrayExists`/`arrayMap`/`arrayFilter`/`arrayCount`/`arrayReduce` are implemented as HogVM bytecode (`rust/common/hogvm/src/stl.rs:402-410`), so their cost scales with array length × loop-body op count. 10-clause OR with 52-element array hit the 10k cap.
- Considered raising `max_steps`, refactoring the iteration stdlib to be native, or short-circuiting the OR operator — all valid follow-ups but out of scope here. This PR addresses the most damaging symptom (permanent disable on a transient cost spike) with the smallest possible change.
- Sibling PR on alert side: <https://github.com/PostHog/charts/pull/11043> changes the alert from `sum(counter) >= 1` to `sum(increase(counter[10m])) > 0` so it stops latching forever after one rule disable, complementing this fix.