### PR TITLE
chore(error-tracking): add cymbal to soft codeowners

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -119,6 +119,7 @@ products/error_tracking/mcp/** @PostHog/team-error-tracking
 products/error_tracking/skills/** @PostHog/team-error-tracking
 posthog/hogql_queries/error_tracking/error_tracking_query_runner.py @PostHog/team-error-tracking
 posthog/hogql_queries/error_tracking/error_tracking_issue_correlation_query_runner.py @PostHog/team-error-tracking
+rust/cymbal/** @PostHog/team-error-tracking
 
 # Notebooks - owned by @PostHog/team-platform-features
 frontend/src/scenes/notebooks/ @PostHog/team-platform-features


### PR DESCRIPTION
## Problem

Cymbal (\`rust/cymbal/\`) is the Rust ingestion service that handles error-tracking issue resolution, grouping rules, assignment rules, and suppression rules. It isn't currently covered by \`CODEOWNERS-soft\`, so PRs touching it don't surface to @PostHog/team-error-tracking the way the rest of the product does.

## Changes

Add \`rust/cymbal/** @PostHog/team-error-tracking\` to the Error Tracking block in \`.github/CODEOWNERS-soft\`.

Soft codeowners are advisory — PRs aren't blocked on review, but the team gets notified so we can catch regressions or convention drift early. Consistent with how \`products/error_tracking/\` is already configured.

## How did you test this code?

I'm an agent (Claude / Sonnet 4.5). No code change, just a CODEOWNERS entry. No automated test required.

## Docs update

No.

## 🤖 Agent context

Spun out of triage for the \`CymbalRulesDisabledFired\` alert — noticed cymbal wasn't tagged to the team in soft codeowners while every other error-tracking path was.