### PR TITLE
perf(hogql): cache parsed ASTs with separate built-in / user buckets

### DIFF
--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -133,7 +133,7 @@ _LITERAL_DETECTION_MIN_LEN = 32
 # adds no measurable speedup and they'd churn cache slots that longer,
 # higher-value entries could use. Cap the upper end too, to bound memory
 # from user-controlled inputs. Explicit `cache_origin=BUILTIN` bypasses
-# both bounds (trusted opt-in).
+# only the upper bound (trusted opt-in for large queries).
 _MIN_CACHEABLE_STATEMENT_LEN = 40
 _MAX_CACHEABLE_STATEMENT_LEN = 64 * 1024
 
@@ -226,8 +226,8 @@ def _parse_cached(
     # Coerce so a stringly-typed call validates and a typo raises.
     cache_origin = CacheOrigin(cache_origin)
 
-    if cache_origin != CacheOrigin.BUILTIN and not (
-        _MIN_CACHEABLE_STATEMENT_LEN <= len(statement) <= _MAX_CACHEABLE_STATEMENT_LEN
+    if len(statement) < _MIN_CACHEABLE_STATEMENT_LEN or (
+        cache_origin != CacheOrigin.BUILTIN and len(statement) > _MAX_CACHEABLE_STATEMENT_LEN
     ):
         _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="skip", rule=rule).inc()
         return _invoke_parser(backend, rule, statement, start)

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -133,9 +133,10 @@ _LITERAL_DETECTION_MIN_LEN = 32
 # adds no measurable speedup and they'd churn cache slots that longer,
 # higher-value entries could use. Cap the upper end too, to bound memory
 # from user-controlled inputs. Explicit `cache_origin=BUILTIN` bypasses
-# only the upper bound (trusted opt-in for large queries).
+# only the upper bound (trusted opt-in for large queries — some in-code
+# templates run past this).
 _MIN_CACHEABLE_STATEMENT_LEN = 40
-_MAX_CACHEABLE_STATEMENT_LEN = 64 * 1024
+_MAX_CACHEABLE_STATEMENT_LEN = 4 * 1024
 
 _PARSE_CACHE_EVENTS = Counter(
     "hogql_parse_cache_events_total",

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -155,6 +155,15 @@ _PARSE_CACHE_MAXSIZE = Gauge(
     labelnames=["cache"],
     multiprocess_mode="livemax",
 )
+# Bucket boundaries align with the cache size bounds (40 and 4096) so the
+# fraction of statements below the min or above the max is directly
+# readable from the histogram.
+_PARSE_STATEMENT_LENGTH = Histogram(
+    "hogql_parse_statement_length_chars",
+    "Length of HogQL statements passed to the parser, in characters",
+    labelnames=["rule"],
+    buckets=(16, 32, 40, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 32768, 131072, 524288),
+)
 
 
 def _looks_like_code_literal(s: str) -> bool:
@@ -226,6 +235,8 @@ def _parse_cached(
     """
     # Coerce so a stringly-typed call validates and a typo raises.
     cache_origin = CacheOrigin(cache_origin)
+
+    _PARSE_STATEMENT_LENGTH.labels(rule=rule).observe(len(statement))
 
     if len(statement) < _MIN_CACHEABLE_STATEMENT_LEN or (
         cache_origin != CacheOrigin.BUILTIN and len(statement) > _MAX_CACHEABLE_STATEMENT_LEN

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -1,5 +1,6 @@
 import sys
 import copy
+import threading
 from collections.abc import Callable
 from enum import StrEnum
 from types import FrameType
@@ -146,6 +147,18 @@ _LITERAL_DETECTION_FRAME_DEPTH = 40
 # as a code literal.
 _LITERAL_DETECTION_MIN_LEN = 32
 
+# Skip caching queries longer than this — bounds worst-case memory growth from
+# user-controlled inputs. Django's `DATA_UPLOAD_MAX_MEMORY_SIZE` allows 20 MB
+# request bodies; without this cap, an attacker could submit 512 distinct
+# megabyte-scale queries and pin gigabytes per worker. 64 KiB is well above
+# any production HogQL query observed in practice (the deepest synthetic
+# pathological in our benchmark is <5 KiB). Applied to the USER cache and
+# to AUTO classifications (we don't have 100% confidence in auto-routing,
+# and a misclassification that puts a huge user query in BUILTIN would defeat
+# the bucket-split protection). Explicit `cache_origin=BUILTIN` is trusted —
+# it's an opt-in by code that knows what it's storing.
+_MAX_CACHEABLE_STATEMENT_LEN = 64 * 1024
+
 _PARSE_CACHE_EVENTS = Counter(
     "hogql_parse_cache_events_total",
     "HogQL parse-cache lookups",
@@ -202,6 +215,13 @@ _MISS: Any = object()
 
 _builtin_parse_cache: LRUCache[Any, Any] = LRUCache(maxsize=_BUILTIN_CACHE_SIZE)
 _user_parse_cache: LRUCache[Any, Any] = LRUCache(maxsize=_USER_CACHE_SIZE)
+# Single lock for both caches. `cachetools.LRUCache` is explicitly NOT
+# thread-safe — its `__setitem__` is a compound check-evict-insert and its
+# `__getitem__` moves the entry to the front, both of which can transiently
+# violate the bounded-size invariant under concurrent access from threaded
+# WSGI/Celery workers. The cache hit cost is dominated by `deepcopy`
+# (~14-200 µs), so the lock acquire/release overhead (~50 ns) is negligible.
+_PARSE_CACHE_LOCK = threading.Lock()
 
 _PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.BUILTIN).set(_BUILTIN_CACHE_SIZE)
 _PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.USER).set(_USER_CACHE_SIZE)
@@ -249,41 +269,59 @@ def _parse_cached(
     # validated and a typo raises rather than silently routing to the user
     # cache via the `==` else-branch.
     cache_origin = CacheOrigin(cache_origin)
+
+    # Skip caching for oversized statements unless the caller explicitly
+    # opts into the built-in cache. This caps worst-case memory growth
+    # from user-controlled inputs without affecting the typical fast path.
+    if cache_origin != CacheOrigin.BUILTIN and len(statement) > _MAX_CACHEABLE_STATEMENT_LEN:
+        _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="skip", rule=rule).inc()
+        return _invoke_parser(backend, rule, statement, start)
+
     key = (statement, backend, rule, start)
 
     if cache_origin == CacheOrigin.AUTO:
         # Built-in is checked first because it holds the hot, in-process
         # literal queries — the case we expect to dominate production traffic.
-        cached = _builtin_parse_cache.get(key, _MISS)
-        if cached is not _MISS:
-            _PARSE_CACHE_EVENTS.labels(origin=CacheOrigin.BUILTIN, result="hit", rule=rule).inc()
-            return copy.deepcopy(cached)
-        cached = _user_parse_cache.get(key, _MISS)
-        if cached is not _MISS:
-            _PARSE_CACHE_EVENTS.labels(origin=CacheOrigin.USER, result="hit", rule=rule).inc()
+        with _PARSE_CACHE_LOCK:
+            cached = _builtin_parse_cache.get(key, _MISS)
+            if cached is _MISS:
+                cached = _user_parse_cache.get(key, _MISS)
+                hit_origin = CacheOrigin.USER if cached is not _MISS else None
+            else:
+                hit_origin = CacheOrigin.BUILTIN
+        if hit_origin is not None:
+            _PARSE_CACHE_EVENTS.labels(origin=hit_origin, result="hit", rule=rule).inc()
             return copy.deepcopy(cached)
         # Full miss — classify so we know which cache to fill.
         cache_origin = CacheOrigin.BUILTIN if _looks_like_code_literal(statement) else CacheOrigin.USER
     else:
         cache = _builtin_parse_cache if cache_origin == CacheOrigin.BUILTIN else _user_parse_cache
-        cached = cache.get(key, _MISS)
+        with _PARSE_CACHE_LOCK:
+            cached = cache.get(key, _MISS)
         if cached is not _MISS:
             _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="hit", rule=rule).inc()
             return copy.deepcopy(cached)
 
-    # Miss path: parse, store a deepcopy in the cache, return the fresh parse.
+    # Miss path: parse without holding the lock (parsing is the expensive part
+    # and is pure — concurrent parses of the same key race idempotently), then
+    # take the lock to store. The fresh parse (single owner) is returned
+    # directly without an extra deepcopy.
     cache = _builtin_parse_cache if cache_origin == CacheOrigin.BUILTIN else _user_parse_cache
     parsed = _invoke_parser(backend, rule, statement, start)
-    cache[key] = copy.deepcopy(parsed)
+    cached_copy = copy.deepcopy(parsed)
+    with _PARSE_CACHE_LOCK:
+        cache[key] = cached_copy
+        currsize = cache.currsize
     _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="miss", rule=rule).inc()
-    _PARSE_CACHE_SIZE.labels(cache=cache_origin).set(cache.currsize)
+    _PARSE_CACHE_SIZE.labels(cache=cache_origin).set(currsize)
     return parsed
 
 
 def clear_parse_caches() -> None:
     """Drop both parse caches. Used by tests."""
-    _builtin_parse_cache.clear()
-    _user_parse_cache.clear()
+    with _PARSE_CACHE_LOCK:
+        _builtin_parse_cache.clear()
+        _user_parse_cache.clear()
     _PARSE_CACHE_SIZE.labels(cache=CacheOrigin.BUILTIN).set(0)
     _PARSE_CACHE_SIZE.labels(cache=CacheOrigin.USER).set(0)
 

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -38,7 +38,13 @@ class CacheOrigin(StrEnum):
     USER = "user"
 
 
-ParseRule = Literal["expr", "order_expr", "select", "full_template_string", "program"]
+class ParseRule(StrEnum):
+    EXPR = "expr"
+    ORDER_EXPR = "order_expr"
+    SELECT = "select"
+    FULL_TEMPLATE_STRING = "full_template_string"
+    PROGRAM = "program"
+
 
 tracer = trace.get_tracer(__name__)
 
@@ -76,37 +82,37 @@ def safe_lambda(f):
     return wrapped
 
 
-RULE_TO_PARSE_FUNCTION: dict[
-    HogQLParserBackend,
-    dict[Literal["expr", "order_expr", "select", "full_template_string", "program"], Callable],
-] = {
+RULE_TO_PARSE_FUNCTION: dict[HogQLParserBackend, dict[ParseRule, Callable]] = {
     "python": {
-        "expr": safe_lambda(
+        ParseRule.EXPR: safe_lambda(
             lambda string, start: HogQLParseTreeConverter(start=start).visit(get_parser(string).expr())
         ),
-        "order_expr": safe_lambda(lambda string: HogQLParseTreeConverter().visit(get_parser(string).orderExpr())),
-        "select": safe_lambda(lambda string: HogQLParseTreeConverter().visit(get_parser(string).select())),
-        "full_template_string": safe_lambda(
+        ParseRule.ORDER_EXPR: safe_lambda(
+            lambda string: HogQLParseTreeConverter().visit(get_parser(string).orderExpr())
+        ),
+        ParseRule.SELECT: safe_lambda(lambda string: HogQLParseTreeConverter().visit(get_parser(string).select())),
+        ParseRule.FULL_TEMPLATE_STRING: safe_lambda(
             lambda string: HogQLParseTreeConverter().visit(get_parser(string).fullTemplateString())
         ),
-        "program": safe_lambda(lambda string: HogQLParseTreeConverter().visit(get_parser(string).program())),
+        ParseRule.PROGRAM: safe_lambda(lambda string: HogQLParseTreeConverter().visit(get_parser(string).program())),
     },
     "cpp-json": {
-        "expr": lambda string, start: deserialize_ast(_parse_expr_json_cpp(string, is_internal=start is None)),
-        "order_expr": lambda string: deserialize_ast(_parse_order_expr_json_cpp(string)),
-        "select": lambda string: deserialize_ast(_parse_select_json_cpp(string)),
-        "full_template_string": lambda string: deserialize_ast(_parse_full_template_string_json_cpp(string)),
-        "program": lambda string: deserialize_ast(_parse_program_json_cpp(string)),
+        ParseRule.EXPR: lambda string, start: deserialize_ast(_parse_expr_json_cpp(string, is_internal=start is None)),
+        ParseRule.ORDER_EXPR: lambda string: deserialize_ast(_parse_order_expr_json_cpp(string)),
+        ParseRule.SELECT: lambda string: deserialize_ast(_parse_select_json_cpp(string)),
+        ParseRule.FULL_TEMPLATE_STRING: lambda string: deserialize_ast(_parse_full_template_string_json_cpp(string)),
+        ParseRule.PROGRAM: lambda string: deserialize_ast(_parse_program_json_cpp(string)),
     },
 }
 
-RULE_TO_HISTOGRAM: dict[Literal["expr", "order_expr", "select", "full_template_string"], Histogram] = {
-    cast(Literal["expr", "order_expr", "select", "full_template_string"], rule): Histogram(
+# `PROGRAM` doesn't have a parse histogram (matches the original code's behavior).
+RULE_TO_HISTOGRAM: dict[ParseRule, Histogram] = {
+    rule: Histogram(
         f"parse_{rule}_seconds",
         f"Time to parse {rule} expression",
         labelnames=["backend"],
     )
-    for rule in ("expr", "order_expr", "select", "full_template_string")
+    for rule in (ParseRule.EXPR, ParseRule.ORDER_EXPR, ParseRule.SELECT, ParseRule.FULL_TEMPLATE_STRING)
 }
 
 DEFAULT_BACKEND: HogQLParserBackend = "cpp-json"
@@ -208,11 +214,11 @@ def _invoke_parser(backend: HogQLParserBackend, rule: ParseRule, statement: str,
     # it, so the `parse_*_seconds` distribution stays meaningful as a parser
     # perf signal once caches are warm. `program` has no histogram (matching
     # the original code's behavior).
-    histogram = RULE_TO_HISTOGRAM.get(rule)  # type: ignore[arg-type]
+    histogram = RULE_TO_HISTOGRAM.get(rule)
     if histogram is None:
-        return fn(statement, start) if rule == "expr" else fn(statement)
+        return fn(statement, start) if rule == ParseRule.EXPR else fn(statement)
     with histogram.labels(backend=backend).time():
-        return fn(statement, start) if rule == "expr" else fn(statement)
+        return fn(statement, start) if rule == ParseRule.EXPR else fn(statement)
 
 
 def _parse_cached(
@@ -299,7 +305,7 @@ def parse_string_template(
     if cache_origin == CacheOrigin.AUTO:
         cache_origin = CacheOrigin.BUILTIN if _looks_like_code_literal(string) else CacheOrigin.USER
     with timings.measure(f"parse_full_template_string_{backend}"):
-        node = _parse_cached("full_template_string", "F'" + string, backend, cache_origin)
+        node = _parse_cached(ParseRule.FULL_TEMPLATE_STRING, "F'" + string, backend, cache_origin)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -320,7 +326,7 @@ def parse_expr(
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_expr_{backend}"):
-        node = _parse_cached("expr", expr, backend, cache_origin, start=start)
+        node = _parse_cached(ParseRule.EXPR, expr, backend, cache_origin, start=start)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -338,7 +344,7 @@ def parse_order_expr(
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_order_expr_{backend}"):
-        node = _parse_cached("order_expr", order_expr, backend, cache_origin)
+        node = _parse_cached(ParseRule.ORDER_EXPR, order_expr, backend, cache_origin)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -357,7 +363,7 @@ def parse_select(
         timings = HogQLTimings()
     with timings.measure(f"parse_select_{backend}"):
         with tracer.start_as_current_span("parse_statement_to_node"):
-            node = _parse_cached("select", statement, backend, cache_origin)
+            node = _parse_cached(ParseRule.SELECT, statement, backend, cache_origin)
         if placeholders:
             with timings.measure("replace_placeholders"), tracer.start_as_current_span("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -374,7 +380,7 @@ def parse_program(
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_expr_{backend}"):
-        node = _parse_cached("program", source, backend, cache_origin)
+        node = _parse_cached(ParseRule.PROGRAM, source, backend, cache_origin)
     return cast("ast.Program", node)
 
 

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -106,7 +106,6 @@ RULE_TO_PARSE_FUNCTION: dict[HogQLParserBackend, dict[ParseRule, Callable]] = {
     },
 }
 
-# `PROGRAM` doesn't have a parse histogram (matches the original code's behavior).
 RULE_TO_HISTOGRAM: dict[ParseRule, Histogram] = {
     rule: Histogram(
         f"parse_{rule}_seconds",
@@ -230,10 +229,10 @@ _PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.USER).set(_USER_CACHE_SIZE)
 def _invoke_parser(backend: HogQLParserBackend, rule: ParseRule, statement: str, start: int | None) -> Any:
     fn = RULE_TO_PARSE_FUNCTION[backend][rule]
     # Only `expr` takes a `start` arg; the others have a single positional.
-    # The histogram measures *parse* cost specifically — cache lookups bypass
-    # it, so the `parse_*_seconds` distribution stays meaningful as a parser
-    # perf signal once caches are warm. `program` has no histogram (matching
-    # the original code's behavior).
+    # The histogram measures parse cost specifically — cache lookups bypass
+    # it, so `parse_*_seconds` is a parser-perf signal independent of cache
+    # hit rate. `program` is not in `RULE_TO_HISTOGRAM`, so no timing is
+    # recorded for it.
     histogram = RULE_TO_HISTOGRAM.get(rule)
     if histogram is None:
         return fn(statement, start) if rule == ParseRule.EXPR else fn(statement)

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -1,6 +1,5 @@
 import sys
 import copy
-from collections import OrderedDict
 from collections.abc import Callable
 from enum import StrEnum
 from types import FrameType
@@ -8,6 +7,7 @@ from typing import Any, Literal, cast
 
 from antlr4 import CommonTokenStream, InputStream, ParserRuleContext, ParseTreeVisitor
 from antlr4.error.ErrorListener import ErrorListener
+from cachetools import LRUCache
 from hogql_parser import (
     parse_expr_json as _parse_expr_json_cpp,
     parse_full_template_string_json as _parse_full_template_string_json_cpp,
@@ -172,47 +172,14 @@ def _looks_like_code_literal(s: str) -> bool:
     return False
 
 
-class _BoundedLRU:
-    """Tiny LRU backed by OrderedDict.
+# Sentinel for distinguishing "key not present" from "key maps to None".
+# Necessary because nothing currently makes the parsers return None, but the
+# `cache.get(key, _MISS) is _MISS` idiom is robust to a future tolerant-parsing
+# path that might.
+_MISS: Any = object()
 
-    Picked over ``functools.lru_cache`` because we want a non-mutating
-    ``peek``-style lookup: on the fast path we check both caches before
-    deciding which one to fill, and ``functools.lru_cache`` only exposes a
-    decorator that fills on miss. CPython's GIL makes individual
-    OrderedDict operations atomic; compound get-then-set races only cause
-    duplicate parsing (idempotent), never corrupted state.
-    """
-
-    def __init__(self, maxsize: int) -> None:
-        self.maxsize = maxsize
-        self._data: OrderedDict[Any, Any] = OrderedDict()
-
-    def get(self, key: Any) -> Any:
-        """Return the value (and mark it recently-used) on hit, else None."""
-        try:
-            value = self._data[key]
-        except KeyError:
-            return None
-        self._data.move_to_end(key)
-        return value
-
-    def set(self, key: Any, value: Any) -> None:
-        """Insert; evict the least-recently-used entry on overflow."""
-        self._data[key] = value
-        self._data.move_to_end(key)
-        if len(self._data) > self.maxsize:
-            self._data.popitem(last=False)
-
-    def clear(self) -> None:
-        self._data.clear()
-
-    @property
-    def currsize(self) -> int:
-        return len(self._data)
-
-
-_builtin_parse_cache = _BoundedLRU(_BUILTIN_CACHE_SIZE)
-_user_parse_cache = _BoundedLRU(_USER_CACHE_SIZE)
+_builtin_parse_cache: LRUCache[Any, Any] = LRUCache(maxsize=_BUILTIN_CACHE_SIZE)
+_user_parse_cache: LRUCache[Any, Any] = LRUCache(maxsize=_USER_CACHE_SIZE)
 
 _PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.BUILTIN).set(_BUILTIN_CACHE_SIZE)
 _PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.USER).set(_USER_CACHE_SIZE)
@@ -243,38 +210,40 @@ def _parse_cached(
     Explicit ``BUILTIN`` / ``USER`` origins only consult their own cache —
     callers opting into one explicitly should not get hits from the other.
 
-    Returns a ``copy.deepcopy`` so callers can mutate the AST without
+    Hits return a ``copy.deepcopy`` so callers can mutate the AST without
     affecting future cache hits (the resolver and printer both mutate).
+    Misses parse fresh and store a deepcopy in the cache; the fresh parse
+    (single owner) is returned directly without an extra copy.
     """
     key = (statement, backend, rule, start)
 
     if cache_origin == CacheOrigin.AUTO:
         # Built-in is checked first because it holds the hot, in-process
         # literal queries — the case we expect to dominate production traffic.
-        cached = _builtin_parse_cache.get(key)
-        if cached is not None:
+        cached = _builtin_parse_cache.get(key, _MISS)
+        if cached is not _MISS:
             _PARSE_CACHE_EVENTS.labels(origin=CacheOrigin.BUILTIN, result="hit", rule=rule).inc()
             return copy.deepcopy(cached)
-        cached = _user_parse_cache.get(key)
-        if cached is not None:
+        cached = _user_parse_cache.get(key, _MISS)
+        if cached is not _MISS:
             _PARSE_CACHE_EVENTS.labels(origin=CacheOrigin.USER, result="hit", rule=rule).inc()
             return copy.deepcopy(cached)
         # Full miss — classify so we know which cache to fill.
         cache_origin = CacheOrigin.BUILTIN if _looks_like_code_literal(statement) else CacheOrigin.USER
     else:
         cache = _builtin_parse_cache if cache_origin == CacheOrigin.BUILTIN else _user_parse_cache
-        cached = cache.get(key)
-        if cached is not None:
+        cached = cache.get(key, _MISS)
+        if cached is not _MISS:
             _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="hit", rule=rule).inc()
             return copy.deepcopy(cached)
 
-    # Miss path: parse and store in the chosen cache.
+    # Miss path: parse, store a deepcopy in the cache, return the fresh parse.
     cache = _builtin_parse_cache if cache_origin == CacheOrigin.BUILTIN else _user_parse_cache
     parsed = _invoke_parser(backend, rule, statement, start)
-    cache.set(key, parsed)
+    cache[key] = copy.deepcopy(parsed)
     _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="miss", rule=rule).inc()
     _PARSE_CACHE_SIZE.labels(cache=cache_origin).set(cache.currsize)
-    return copy.deepcopy(parsed)
+    return parsed
 
 
 def clear_parse_caches() -> None:

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -131,7 +131,14 @@ DEFAULT_BACKEND: HogQLParserBackend = "cpp-json"
 
 _BUILTIN_CACHE_SIZE = 256
 _USER_CACHE_SIZE = 512
-_LITERAL_DETECTION_FRAME_DEPTH = 20
+# 40 is generous: PostHog stacks routinely exceed 20 (DRF + middleware + Celery
+# + opentelemetry + structlog), and the walk terminates early on identity match.
+_LITERAL_DETECTION_FRAME_DEPTH = 40
+# Below this length, CPython's automatic string interning makes identity-match
+# unreliable — short identifier-shaped strings like "id" or "event" can share
+# identity with `co_consts` entries elsewhere and falsely classify user input
+# as a code literal.
+_LITERAL_DETECTION_MIN_LEN = 32
 
 _PARSE_CACHE_EVENTS = Counter(
     "hogql_parse_cache_events_total",
@@ -142,11 +149,13 @@ _PARSE_CACHE_SIZE = Gauge(
     "hogql_parse_cache_size",
     "Current entries in the HogQL parse cache (compare against the configured maxsize to spot saturation)",
     labelnames=["cache"],
+    multiprocess_mode="livemax",
 )
 _PARSE_CACHE_MAXSIZE = Gauge(
     "hogql_parse_cache_maxsize",
     "Configured maxsize of the HogQL parse cache",
     labelnames=["cache"],
+    multiprocess_mode="livemax",
 )
 
 
@@ -159,8 +168,15 @@ def _looks_like_code_literal(s: str) -> bool:
     runtime-constructed strings (user input, dynamic composition, file
     content). Misses module/class-level constants referenced via
     ``LOAD_GLOBAL`` — those frames aren't on the active stack at call time;
-    callers pass ``cache_origin="builtin"`` explicitly in that case.
+    callers pass ``cache_origin=CacheOrigin.BUILTIN`` explicitly in that case.
+
+    Short strings are rejected up-front: CPython auto-interns short
+    identifier-shaped strings, which can spuriously identity-match
+    ``co_consts`` entries elsewhere and misroute user input to the built-in
+    cache.
     """
+    if len(s) < _LITERAL_DETECTION_MIN_LEN:
+        return False
     frame: FrameType | None = sys._getframe(1)
     for _ in range(_LITERAL_DETECTION_FRAME_DEPTH):
         if frame is None:
@@ -188,7 +204,15 @@ _PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.USER).set(_USER_CACHE_SIZE)
 def _invoke_parser(backend: HogQLParserBackend, rule: ParseRule, statement: str, start: int | None) -> Any:
     fn = RULE_TO_PARSE_FUNCTION[backend][rule]
     # Only `expr` takes a `start` arg; the others have a single positional.
-    return fn(statement, start) if rule == "expr" else fn(statement)
+    # The histogram measures *parse* cost specifically — cache lookups bypass
+    # it, so the `parse_*_seconds` distribution stays meaningful as a parser
+    # perf signal once caches are warm. `program` has no histogram (matching
+    # the original code's behavior).
+    histogram = RULE_TO_HISTOGRAM.get(rule)  # type: ignore[arg-type]
+    if histogram is None:
+        return fn(statement, start) if rule == "expr" else fn(statement)
+    with histogram.labels(backend=backend).time():
+        return fn(statement, start) if rule == "expr" else fn(statement)
 
 
 def _parse_cached(
@@ -215,6 +239,10 @@ def _parse_cached(
     Misses parse fresh and store a deepcopy in the cache; the fresh parse
     (single owner) is returned directly without an extra copy.
     """
+    # Coerce so a stringly-typed call (`"builtin"`, `"user"`, `"auto"`) is
+    # validated and a typo raises rather than silently routing to the user
+    # cache via the `==` else-branch.
+    cache_origin = CacheOrigin(cache_origin)
     key = (statement, backend, rule, start)
 
     if cache_origin == CacheOrigin.AUTO:
@@ -265,9 +293,13 @@ def parse_string_template(
     """Parse a full template string without start/end quotes"""
     if timings is None:
         timings = HogQLTimings()
+    # Classify on the raw `string` (which may be a code literal) before the
+    # `"F'" +` runtime concat — otherwise auto-detect always sees the fresh
+    # concatenated string and routes built-in templates to the user cache.
+    if cache_origin == CacheOrigin.AUTO:
+        cache_origin = CacheOrigin.BUILTIN if _looks_like_code_literal(string) else CacheOrigin.USER
     with timings.measure(f"parse_full_template_string_{backend}"):
-        with RULE_TO_HISTOGRAM["full_template_string"].labels(backend=backend).time():
-            node = _parse_cached("full_template_string", "F'" + string, backend, cache_origin)
+        node = _parse_cached("full_template_string", "F'" + string, backend, cache_origin)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -288,8 +320,7 @@ def parse_expr(
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_expr_{backend}"):
-        with RULE_TO_HISTOGRAM["expr"].labels(backend=backend).time():
-            node = _parse_cached("expr", expr, backend, cache_origin, start=start)
+        node = _parse_cached("expr", expr, backend, cache_origin, start=start)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -307,8 +338,7 @@ def parse_order_expr(
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_order_expr_{backend}"):
-        with RULE_TO_HISTOGRAM["order_expr"].labels(backend=backend).time():
-            node = _parse_cached("order_expr", order_expr, backend, cache_origin)
+        node = _parse_cached("order_expr", order_expr, backend, cache_origin)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -326,10 +356,7 @@ def parse_select(
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_select_{backend}"):
-        with (
-            RULE_TO_HISTOGRAM["select"].labels(backend=backend).time(),
-            tracer.start_as_current_span("parse_statement_to_node"),
-        ):
+        with tracer.start_as_current_span("parse_statement_to_node"):
             node = _parse_cached("select", statement, backend, cache_origin)
         if placeholders:
             with timings.measure("replace_placeholders"), tracer.start_as_current_span("replace_placeholders"):
@@ -347,8 +374,7 @@ def parse_program(
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_expr_{backend}"):
-        with RULE_TO_HISTOGRAM["expr"].labels(backend=backend).time():
-            node = _parse_cached("program", source, backend, cache_origin)
+        node = _parse_cached("program", source, backend, cache_origin)
     return cast("ast.Program", node)
 
 

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -129,9 +129,12 @@ _LITERAL_DETECTION_FRAME_DEPTH = 40
 # spuriously identity-match `co_consts` elsewhere, misrouting user input.
 _LITERAL_DETECTION_MIN_LEN = 32
 
-# Cap worst-case memory growth from user-controlled inputs. Skipped queries
-# parse fresh, no cache write. Explicit `cache_origin=BUILTIN` bypasses
-# the cap (trusted opt-in).
+# Skip caching very short queries — they parse fast enough that caching
+# adds no measurable speedup and they'd churn cache slots that longer,
+# higher-value entries could use. Cap the upper end too, to bound memory
+# from user-controlled inputs. Explicit `cache_origin=BUILTIN` bypasses
+# both bounds (trusted opt-in).
+_MIN_CACHEABLE_STATEMENT_LEN = 40
 _MAX_CACHEABLE_STATEMENT_LEN = 64 * 1024
 
 _PARSE_CACHE_EVENTS = Counter(
@@ -223,7 +226,9 @@ def _parse_cached(
     # Coerce so a stringly-typed call validates and a typo raises.
     cache_origin = CacheOrigin(cache_origin)
 
-    if cache_origin != CacheOrigin.BUILTIN and len(statement) > _MAX_CACHEABLE_STATEMENT_LEN:
+    if cache_origin != CacheOrigin.BUILTIN and not (
+        _MIN_CACHEABLE_STATEMENT_LEN <= len(statement) <= _MAX_CACHEABLE_STATEMENT_LEN
+    ):
         _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="skip", rule=rule).inc()
         return _invoke_parser(backend, rule, statement, start)
 

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -160,6 +160,11 @@ def _looks_like_code_literal(s: str) -> bool:
     runtime-constructed strings don't. Module/class-level constants
     referenced via ``LOAD_GLOBAL`` are missed — callers pass
     ``cache_origin=CacheOrigin.BUILTIN`` explicitly for those.
+
+    This is a best-effort heuristic. A wrong classification only affects
+    which bucket a cache entry lands in; the returned AST is the same
+    either way, so functional behavior is correct regardless. The cost
+    of a miss is at worst a less-optimal cache layout.
     """
     if len(s) < _LITERAL_DETECTION_MIN_LEN:
         return False

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -118,44 +118,20 @@ RULE_TO_HISTOGRAM: dict[ParseRule, Histogram] = {
 DEFAULT_BACKEND: HogQLParserBackend = "cpp-json"
 
 
-# --- Parse-result cache ----------------------------------------------------
-#
-# Most production HogQL parsing is repeat work — the same templated insight
-# or dashboard query is parsed many times per minute. We cache the parsed AST
-# keyed on (statement, backend, rule[, start]) and `deepcopy` on hit so the
-# returned AST can still be freely mutated by downstream resolve/print.
-#
-# Two separate caches: one for queries that originate from in-process code
-# literals (small, bounded by what we ship) and one for everything else
-# (user input, dynamically composed SQL, file content). The split exists so
-# a flood of unique user-generated queries can't displace the hot built-in
-# entries.
-#
-# Origin is autodetected by walking the call stack and identity-checking the
-# input string against each frame's `co_consts`. Callers can override via
-# `cache_origin="builtin"` or `cache_origin="user"`.
+# Two caches so a flood of unique user-generated queries can't displace the
+# hot in-code-literal entries. Origin is auto-detected via the call-stack
+# `co_consts` walk; callers can override via `cache_origin`.
 
 _BUILTIN_CACHE_SIZE = 256
 _USER_CACHE_SIZE = 512
-# 40 is generous: PostHog stacks routinely exceed 20 (DRF + middleware + Celery
-# + opentelemetry + structlog), and the walk terminates early on identity match.
 _LITERAL_DETECTION_FRAME_DEPTH = 40
-# Below this length, CPython's automatic string interning makes identity-match
-# unreliable — short identifier-shaped strings like "id" or "event" can share
-# identity with `co_consts` entries elsewhere and falsely classify user input
-# as a code literal.
+# Short identifier-shaped strings are auto-interned by CPython and can
+# spuriously identity-match `co_consts` elsewhere, misrouting user input.
 _LITERAL_DETECTION_MIN_LEN = 32
 
-# Skip caching queries longer than this — bounds worst-case memory growth from
-# user-controlled inputs. Django's `DATA_UPLOAD_MAX_MEMORY_SIZE` allows 20 MB
-# request bodies; without this cap, an attacker could submit 512 distinct
-# megabyte-scale queries and pin gigabytes per worker. 64 KiB is well above
-# any production HogQL query observed in practice (the deepest synthetic
-# pathological in our benchmark is <5 KiB). Applied to the USER cache and
-# to AUTO classifications (we don't have 100% confidence in auto-routing,
-# and a misclassification that puts a huge user query in BUILTIN would defeat
-# the bucket-split protection). Explicit `cache_origin=BUILTIN` is trusted —
-# it's an opt-in by code that knows what it's storing.
+# Cap worst-case memory growth from user-controlled inputs. Skipped queries
+# parse fresh, no cache write. Explicit `cache_origin=BUILTIN` bypasses
+# the cap (trusted opt-in).
 _MAX_CACHEABLE_STATEMENT_LEN = 64 * 1024
 
 _PARSE_CACHE_EVENTS = Counter(
@@ -178,20 +154,12 @@ _PARSE_CACHE_MAXSIZE = Gauge(
 
 
 def _looks_like_code_literal(s: str) -> bool:
-    """Best-effort: is ``s`` a string literal in the active call stack?
+    """True if ``s`` is a string literal somewhere in the active call stack.
 
-    Python's compiler stores literal strings in each function's ``co_consts``
-    tuple as a stable object. Walking up active frames and identity-checking
-    ``s`` against each frame's ``co_consts`` distinguishes code literals from
-    runtime-constructed strings (user input, dynamic composition, file
-    content). Misses module/class-level constants referenced via
-    ``LOAD_GLOBAL`` — those frames aren't on the active stack at call time;
-    callers pass ``cache_origin=CacheOrigin.BUILTIN`` explicitly in that case.
-
-    Short strings are rejected up-front: CPython auto-interns short
-    identifier-shaped strings, which can spuriously identity-match
-    ``co_consts`` entries elsewhere and misroute user input to the built-in
-    cache.
+    Python literals share identity with their frame's ``co_consts``;
+    runtime-constructed strings don't. Module/class-level constants
+    referenced via ``LOAD_GLOBAL`` are missed — callers pass
+    ``cache_origin=CacheOrigin.BUILTIN`` explicitly for those.
     """
     if len(s) < _LITERAL_DETECTION_MIN_LEN:
         return False
@@ -206,20 +174,13 @@ def _looks_like_code_literal(s: str) -> bool:
     return False
 
 
-# Sentinel for distinguishing "key not present" from "key maps to None".
-# Necessary because nothing currently makes the parsers return None, but the
-# `cache.get(key, _MISS) is _MISS` idiom is robust to a future tolerant-parsing
-# path that might.
+# Sentinel distinguishes "key absent" from a cached ``None``.
 _MISS: Any = object()
 
 _builtin_parse_cache: LRUCache[Any, Any] = LRUCache(maxsize=_BUILTIN_CACHE_SIZE)
 _user_parse_cache: LRUCache[Any, Any] = LRUCache(maxsize=_USER_CACHE_SIZE)
-# Single lock for both caches. `cachetools.LRUCache` is explicitly NOT
-# thread-safe — its `__setitem__` is a compound check-evict-insert and its
-# `__getitem__` moves the entry to the front, both of which can transiently
-# violate the bounded-size invariant under concurrent access from threaded
-# WSGI/Celery workers. The cache hit cost is dominated by `deepcopy`
-# (~14-200 µs), so the lock acquire/release overhead (~50 ns) is negligible.
+# `cachetools.LRUCache` is not thread-safe; the lock guards against
+# threaded WSGI/Celery workers.
 _PARSE_CACHE_LOCK = threading.Lock()
 
 _PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.BUILTIN).set(_BUILTIN_CACHE_SIZE)
@@ -228,11 +189,8 @@ _PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.USER).set(_USER_CACHE_SIZE)
 
 def _invoke_parser(backend: HogQLParserBackend, rule: ParseRule, statement: str, start: int | None) -> Any:
     fn = RULE_TO_PARSE_FUNCTION[backend][rule]
-    # Only `expr` takes a `start` arg; the others have a single positional.
-    # The histogram measures parse cost specifically — cache lookups bypass
-    # it, so `parse_*_seconds` is a parser-perf signal independent of cache
-    # hit rate. `program` is not in `RULE_TO_HISTOGRAM`, so no timing is
-    # recorded for it.
+    # Histogram wraps only the parse so `parse_*_seconds` stays a parser-perf
+    # signal regardless of cache hit rate. Only `expr` takes a `start` arg.
     histogram = RULE_TO_HISTOGRAM.get(rule)
     if histogram is None:
         return fn(statement, start) if rule == ParseRule.EXPR else fn(statement)
@@ -250,28 +208,16 @@ def _parse_cached(
 ) -> Any:
     """Look up a parsed AST, parsing on miss.
 
-    Fast path for ``cache_origin == CacheOrigin.AUTO``: check the built-in
-    cache, then the user cache, returning on the first hit. Only on a full
-    miss do we walk the call stack to classify the query and parse it.
-    This skips the frame walk on every cache hit, which dominates traffic
-    once the cache is warm.
+    ``AUTO`` consults both caches before classifying via frame walk, so the
+    walk is on the cold path only. Explicit ``BUILTIN``/``USER`` only
+    consult their own cache.
 
-    Explicit ``BUILTIN`` / ``USER`` origins only consult their own cache —
-    callers opting into one explicitly should not get hits from the other.
-
-    Hits return a ``copy.deepcopy`` so callers can mutate the AST without
-    affecting future cache hits (the resolver and printer both mutate).
-    Misses parse fresh and store a deepcopy in the cache; the fresh parse
-    (single owner) is returned directly without an extra copy.
+    Returns a deepcopy on hit so the resolver/printer can mutate freely.
+    The miss path returns the fresh parse directly and stores the deepcopy.
     """
-    # Coerce so a stringly-typed call (`"builtin"`, `"user"`, `"auto"`) is
-    # validated and a typo raises rather than silently routing to the user
-    # cache via the `==` else-branch.
+    # Coerce so a stringly-typed call validates and a typo raises.
     cache_origin = CacheOrigin(cache_origin)
 
-    # Skip caching for oversized statements unless the caller explicitly
-    # opts into the built-in cache. This caps worst-case memory growth
-    # from user-controlled inputs without affecting the typical fast path.
     if cache_origin != CacheOrigin.BUILTIN and len(statement) > _MAX_CACHEABLE_STATEMENT_LEN:
         _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="skip", rule=rule).inc()
         return _invoke_parser(backend, rule, statement, start)
@@ -279,8 +225,6 @@ def _parse_cached(
     key = (statement, backend, rule, start)
 
     if cache_origin == CacheOrigin.AUTO:
-        # Built-in is checked first because it holds the hot, in-process
-        # literal queries — the case we expect to dominate production traffic.
         with _PARSE_CACHE_LOCK:
             cached = _builtin_parse_cache.get(key, _MISS)
             if cached is _MISS:
@@ -291,7 +235,6 @@ def _parse_cached(
         if hit_origin is not None:
             _PARSE_CACHE_EVENTS.labels(origin=hit_origin, result="hit", rule=rule).inc()
             return copy.deepcopy(cached)
-        # Full miss — classify so we know which cache to fill.
         cache_origin = CacheOrigin.BUILTIN if _looks_like_code_literal(statement) else CacheOrigin.USER
     else:
         cache = _builtin_parse_cache if cache_origin == CacheOrigin.BUILTIN else _user_parse_cache
@@ -301,10 +244,8 @@ def _parse_cached(
             _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="hit", rule=rule).inc()
             return copy.deepcopy(cached)
 
-    # Miss path: parse without holding the lock (parsing is the expensive part
-    # and is pure — concurrent parses of the same key race idempotently), then
-    # take the lock to store. The fresh parse (single owner) is returned
-    # directly without an extra deepcopy.
+    # Parse outside the lock — it's the expensive part, and concurrent parses
+    # of the same key race idempotently.
     cache = _builtin_parse_cache if cache_origin == CacheOrigin.BUILTIN else _user_parse_cache
     parsed = _invoke_parser(backend, rule, statement, start)
     cached_copy = copy.deepcopy(parsed)
@@ -336,9 +277,8 @@ def parse_string_template(
     """Parse a full template string without start/end quotes"""
     if timings is None:
         timings = HogQLTimings()
-    # Classify on the raw `string` (which may be a code literal) before the
-    # `"F'" +` runtime concat — otherwise auto-detect always sees the fresh
-    # concatenated string and routes built-in templates to the user cache.
+    # Classify on the raw `string`; the `"F'" +` concat below is a fresh
+    # runtime string and would never match a frame literal.
     if cache_origin == CacheOrigin.AUTO:
         cache_origin = CacheOrigin.BUILTIN if _looks_like_code_literal(string) else CacheOrigin.USER
     with timings.measure(f"parse_full_template_string_{backend}"):

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -15,7 +15,7 @@ from hogql_parser import (
     parse_select_json as _parse_select_json_cpp,
 )
 from opentelemetry import trace
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 from structlog import getLogger
 
 from posthog.hogql import ast
@@ -131,6 +131,16 @@ _PARSE_CACHE_EVENTS = Counter(
     "HogQL parse-cache lookups",
     labelnames=["origin", "result", "rule"],
 )
+_PARSE_CACHE_SIZE = Gauge(
+    "hogql_parse_cache_size",
+    "Current entries in the HogQL parse cache (compare against the configured maxsize to spot saturation)",
+    labelnames=["cache"],
+)
+_PARSE_CACHE_MAXSIZE = Gauge(
+    "hogql_parse_cache_maxsize",
+    "Configured maxsize of the HogQL parse cache",
+    labelnames=["cache"],
+)
 
 
 def _looks_like_code_literal(s: str) -> bool:
@@ -165,6 +175,10 @@ def _user_parse_cache(statement: str, backend: HogQLParserBackend, rule: ParseRu
     return _invoke_parser(backend, rule, statement, start)
 
 
+_PARSE_CACHE_MAXSIZE.labels(cache="builtin").set(_BUILTIN_CACHE_SIZE)
+_PARSE_CACHE_MAXSIZE.labels(cache="user").set(_USER_CACHE_SIZE)
+
+
 def _invoke_parser(backend: HogQLParserBackend, rule: ParseRule, statement: str, start: int | None) -> Any:
     fn = RULE_TO_PARSE_FUNCTION[backend][rule]
     # Only `expr` takes a `start` arg; the others have a single positional.
@@ -191,12 +205,16 @@ def _parse_cached(
     cache_fn = _builtin_parse_cache if cache_origin == "builtin" else _user_parse_cache
     before_misses = cache_fn.cache_info().misses
     cached = cache_fn(statement, backend, rule, start)
-    after_misses = cache_fn.cache_info().misses
+    info = cache_fn.cache_info()
+    is_miss = info.misses > before_misses
     _PARSE_CACHE_EVENTS.labels(
         origin=cache_origin,
-        result="miss" if after_misses > before_misses else "hit",
+        result="miss" if is_miss else "hit",
         rule=rule,
     ).inc()
+    if is_miss:
+        # Size only changes on miss (fill or evict). Update lazily.
+        _PARSE_CACHE_SIZE.labels(cache=cache_origin).set(info.currsize)
     return copy.deepcopy(cached)
 
 
@@ -204,6 +222,8 @@ def clear_parse_caches() -> None:
     """Drop both parse caches. Used by tests."""
     _builtin_parse_cache.cache_clear()
     _user_parse_cache.cache_clear()
+    _PARSE_CACHE_SIZE.labels(cache="builtin").set(0)
+    _PARSE_CACHE_SIZE.labels(cache="user").set(0)
 
 
 def parse_string_template(

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -208,10 +208,11 @@ _PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.USER).set(_USER_CACHE_SIZE)
 def _invoke_parser(backend: HogQLParserBackend, rule: ParseRule, statement: str, start: int | None) -> Any:
     fn = RULE_TO_PARSE_FUNCTION[backend][rule]
     # Histogram wraps only the parse so `parse_*_seconds` stays a parser-perf
-    # signal regardless of cache hit rate. Only `expr` takes a `start` arg.
+    # signal regardless of cache hit rate. Only `expr` takes a `start` arg;
+    # `PROGRAM` is the only rule without a histogram.
     histogram = RULE_TO_HISTOGRAM.get(rule)
     if histogram is None:
-        return fn(statement, start) if rule == ParseRule.EXPR else fn(statement)
+        return fn(statement)
     with histogram.labels(backend=backend).time():
         return fn(statement, start) if rule == ParseRule.EXPR else fn(statement)
 
@@ -223,12 +224,17 @@ def _parse_cached(
     cache_origin: CacheOrigin,
     *,
     start: int | None = None,
+    classify_input: str | None = None,
 ) -> Any:
     """Look up a parsed AST, parsing on miss.
 
     ``AUTO`` consults both caches before classifying via frame walk, so the
     walk is on the cold path only. Explicit ``BUILTIN``/``USER`` only
     consult their own cache.
+
+    ``classify_input`` lets callers key the cache on a derived string while
+    classifying on the original (e.g. ``parse_string_template`` keys on
+    ``"F'" + string`` but the frame literal it wants to match is ``string``).
 
     Returns a deepcopy on hit so the resolver/printer can mutate freely.
     The miss path returns the fresh parse directly and stores the deepcopy.
@@ -257,7 +263,11 @@ def _parse_cached(
         if hit_origin is not None:
             _PARSE_CACHE_EVENTS.labels(origin=hit_origin, result="hit", rule=rule).inc()
             return copy.deepcopy(cached)
-        cache_origin = CacheOrigin.BUILTIN if _looks_like_code_literal(statement) else CacheOrigin.USER
+        cache_origin = (
+            CacheOrigin.BUILTIN
+            if _looks_like_code_literal(classify_input if classify_input is not None else statement)
+            else CacheOrigin.USER
+        )
     else:
         cache = _builtin_parse_cache if cache_origin == CacheOrigin.BUILTIN else _user_parse_cache
         with _PARSE_CACHE_LOCK:
@@ -299,12 +309,17 @@ def parse_string_template(
     """Parse a full template string without start/end quotes"""
     if timings is None:
         timings = HogQLTimings()
-    # Classify on the raw `string`; the `"F'" +` concat below is a fresh
-    # runtime string and would never match a frame literal.
-    if cache_origin == CacheOrigin.AUTO:
-        cache_origin = CacheOrigin.BUILTIN if _looks_like_code_literal(string) else CacheOrigin.USER
+    # The cache is keyed on `"F'" + string` (a runtime concat that never
+    # matches a frame literal), so pass the raw `string` as the classify
+    # target — that keeps the frame walk on the cold path here too.
     with timings.measure(f"parse_full_template_string_{backend}"):
-        node = _parse_cached(ParseRule.FULL_TEMPLATE_STRING, "F'" + string, backend, cache_origin)
+        node = _parse_cached(
+            ParseRule.FULL_TEMPLATE_STRING,
+            "F'" + string,
+            backend,
+            cache_origin,
+            classify_input=string,
+        )
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -1,5 +1,9 @@
+import sys
+import copy
+import functools
 from collections.abc import Callable
-from typing import Literal, cast
+from types import FrameType
+from typing import Any, Literal, cast
 
 from antlr4 import CommonTokenStream, InputStream, ParserRuleContext, ParseTreeVisitor
 from antlr4.error.ErrorListener import ErrorListener
@@ -11,7 +15,7 @@ from hogql_parser import (
     parse_select_json as _parse_select_json_cpp,
 )
 from opentelemetry import trace
-from prometheus_client import Histogram
+from prometheus_client import Counter, Histogram
 from structlog import getLogger
 
 from posthog.hogql import ast
@@ -25,6 +29,9 @@ from posthog.hogql.json_ast import deserialize_ast
 from posthog.hogql.parse_string import parse_string_literal_ctx, parse_string_literal_text, parse_string_text_ctx
 from posthog.hogql.placeholders import replace_placeholders
 from posthog.hogql.timings import HogQLTimings
+
+CacheOrigin = Literal["auto", "builtin", "user"]
+ParseRule = Literal["expr", "order_expr", "select", "full_template_string", "program"]
 
 tracer = trace.get_tracer(__name__)
 
@@ -98,19 +105,121 @@ RULE_TO_HISTOGRAM: dict[Literal["expr", "order_expr", "select", "full_template_s
 DEFAULT_BACKEND: HogQLParserBackend = "cpp-json"
 
 
+# --- Parse-result cache ----------------------------------------------------
+#
+# Most production HogQL parsing is repeat work — the same templated insight
+# or dashboard query is parsed many times per minute. We cache the parsed AST
+# keyed on (statement, backend, rule[, start]) and `deepcopy` on hit so the
+# returned AST can still be freely mutated by downstream resolve/print.
+#
+# Two separate caches: one for queries that originate from in-process code
+# literals (small, bounded by what we ship) and one for everything else
+# (user input, dynamically composed SQL, file content). The split exists so
+# a flood of unique user-generated queries can't displace the hot built-in
+# entries.
+#
+# Origin is autodetected by walking the call stack and identity-checking the
+# input string against each frame's `co_consts`. Callers can override via
+# `cache_origin="builtin"` or `cache_origin="user"`.
+
+_BUILTIN_CACHE_SIZE = 256
+_USER_CACHE_SIZE = 512
+_LITERAL_DETECTION_FRAME_DEPTH = 20
+
+_PARSE_CACHE_EVENTS = Counter(
+    "hogql_parse_cache_events_total",
+    "HogQL parse-cache lookups",
+    labelnames=["origin", "result", "rule"],
+)
+
+
+def _looks_like_code_literal(s: str) -> bool:
+    """Best-effort: is ``s`` a string literal in the active call stack?
+
+    Python's compiler stores literal strings in each function's ``co_consts``
+    tuple as a stable object. Walking up active frames and identity-checking
+    ``s`` against each frame's ``co_consts`` distinguishes code literals from
+    runtime-constructed strings (user input, dynamic composition, file
+    content). Misses module/class-level constants referenced via
+    ``LOAD_GLOBAL`` — those frames aren't on the active stack at call time;
+    callers pass ``cache_origin="builtin"`` explicitly in that case.
+    """
+    frame: FrameType | None = sys._getframe(1)
+    for _ in range(_LITERAL_DETECTION_FRAME_DEPTH):
+        if frame is None:
+            return False
+        for const in frame.f_code.co_consts:
+            if const is s:
+                return True
+        frame = frame.f_back
+    return False
+
+
+@functools.lru_cache(maxsize=_BUILTIN_CACHE_SIZE)
+def _builtin_parse_cache(statement: str, backend: HogQLParserBackend, rule: ParseRule, start: int | None) -> Any:
+    return _invoke_parser(backend, rule, statement, start)
+
+
+@functools.lru_cache(maxsize=_USER_CACHE_SIZE)
+def _user_parse_cache(statement: str, backend: HogQLParserBackend, rule: ParseRule, start: int | None) -> Any:
+    return _invoke_parser(backend, rule, statement, start)
+
+
+def _invoke_parser(backend: HogQLParserBackend, rule: ParseRule, statement: str, start: int | None) -> Any:
+    fn = RULE_TO_PARSE_FUNCTION[backend][rule]
+    # Only `expr` takes a `start` arg; the others have a single positional.
+    return fn(statement, start) if rule == "expr" else fn(statement)
+
+
+def _parse_cached(
+    rule: ParseRule,
+    statement: str,
+    backend: HogQLParserBackend,
+    cache_origin: CacheOrigin,
+    *,
+    start: int | None = None,
+) -> Any:
+    """Look up a parsed AST in the appropriate cache, parsing on miss.
+
+    Returns a ``copy.deepcopy`` so callers can mutate the returned AST
+    without affecting future cache hits (the resolver and printer both
+    mutate the AST in place). Concrete return type is rule-dependent; the
+    public ``parse_select`` / ``parse_expr`` / etc. wrappers narrow it.
+    """
+    if cache_origin == "auto":
+        cache_origin = "builtin" if _looks_like_code_literal(statement) else "user"
+    cache_fn = _builtin_parse_cache if cache_origin == "builtin" else _user_parse_cache
+    before_misses = cache_fn.cache_info().misses
+    cached = cache_fn(statement, backend, rule, start)
+    after_misses = cache_fn.cache_info().misses
+    _PARSE_CACHE_EVENTS.labels(
+        origin=cache_origin,
+        result="miss" if after_misses > before_misses else "hit",
+        rule=rule,
+    ).inc()
+    return copy.deepcopy(cached)
+
+
+def clear_parse_caches() -> None:
+    """Drop both parse caches. Used by tests."""
+    _builtin_parse_cache.cache_clear()
+    _user_parse_cache.cache_clear()
+
+
 def parse_string_template(
     string: str,
     placeholders: dict[str, ast.Expr] | None = None,
     timings: HogQLTimings | None = None,
     *,
     backend: HogQLParserBackend = DEFAULT_BACKEND,
+    cache_origin: CacheOrigin = "auto",
 ) -> ast.Call:
     """Parse a full template string without start/end quotes"""
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_full_template_string_{backend}"):
         with RULE_TO_HISTOGRAM["full_template_string"].labels(backend=backend).time():
-            node = RULE_TO_PARSE_FUNCTION[backend]["full_template_string"]("F'" + string)
+            node = _parse_cached("full_template_string", "F'" + string, backend, cache_origin)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -124,6 +233,7 @@ def parse_expr(
     timings: HogQLTimings | None = None,
     *,
     backend: HogQLParserBackend = DEFAULT_BACKEND,
+    cache_origin: CacheOrigin = "auto",
 ) -> ast.Expr:
     if expr == "":
         raise SyntaxError("Empty query")
@@ -131,7 +241,7 @@ def parse_expr(
         timings = HogQLTimings()
     with timings.measure(f"parse_expr_{backend}"):
         with RULE_TO_HISTOGRAM["expr"].labels(backend=backend).time():
-            node = RULE_TO_PARSE_FUNCTION[backend]["expr"](expr, start)
+            node = _parse_cached("expr", expr, backend, cache_origin, start=start)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -144,12 +254,13 @@ def parse_order_expr(
     timings: HogQLTimings | None = None,
     *,
     backend: HogQLParserBackend = DEFAULT_BACKEND,
+    cache_origin: CacheOrigin = "auto",
 ) -> ast.OrderExpr:
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_order_expr_{backend}"):
         with RULE_TO_HISTOGRAM["order_expr"].labels(backend=backend).time():
-            node = RULE_TO_PARSE_FUNCTION[backend]["order_expr"](order_expr)
+            node = _parse_cached("order_expr", order_expr, backend, cache_origin)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -162,6 +273,7 @@ def parse_select(
     timings: HogQLTimings | None = None,
     *,
     backend: HogQLParserBackend = DEFAULT_BACKEND,
+    cache_origin: CacheOrigin = "auto",
 ) -> ast.SelectQuery | ast.SelectSetQuery:
     if timings is None:
         timings = HogQLTimings()
@@ -170,7 +282,7 @@ def parse_select(
             RULE_TO_HISTOGRAM["select"].labels(backend=backend).time(),
             tracer.start_as_current_span("parse_statement_to_node"),
         ):
-            node = RULE_TO_PARSE_FUNCTION[backend]["select"](statement)
+            node = _parse_cached("select", statement, backend, cache_origin)
         if placeholders:
             with timings.measure("replace_placeholders"), tracer.start_as_current_span("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -182,13 +294,14 @@ def parse_program(
     timings: HogQLTimings | None = None,
     *,
     backend: HogQLParserBackend = DEFAULT_BACKEND,
+    cache_origin: CacheOrigin = "auto",
 ) -> ast.Program:
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_expr_{backend}"):
         with RULE_TO_HISTOGRAM["expr"].labels(backend=backend).time():
-            node = RULE_TO_PARSE_FUNCTION[backend]["program"](source)
-    return node
+            node = _parse_cached("program", source, backend, cache_origin)
+    return cast("ast.Program", node)
 
 
 def get_parser(query: str) -> HogQLParser:

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -1,7 +1,8 @@
 import sys
 import copy
-import functools
+from collections import OrderedDict
 from collections.abc import Callable
+from enum import StrEnum
 from types import FrameType
 from typing import Any, Literal, cast
 
@@ -30,7 +31,13 @@ from posthog.hogql.parse_string import parse_string_literal_ctx, parse_string_li
 from posthog.hogql.placeholders import replace_placeholders
 from posthog.hogql.timings import HogQLTimings
 
-CacheOrigin = Literal["auto", "builtin", "user"]
+
+class CacheOrigin(StrEnum):
+    AUTO = "auto"
+    BUILTIN = "builtin"
+    USER = "user"
+
+
 ParseRule = Literal["expr", "order_expr", "select", "full_template_string", "program"]
 
 tracer = trace.get_tracer(__name__)
@@ -165,18 +172,50 @@ def _looks_like_code_literal(s: str) -> bool:
     return False
 
 
-@functools.lru_cache(maxsize=_BUILTIN_CACHE_SIZE)
-def _builtin_parse_cache(statement: str, backend: HogQLParserBackend, rule: ParseRule, start: int | None) -> Any:
-    return _invoke_parser(backend, rule, statement, start)
+class _BoundedLRU:
+    """Tiny LRU backed by OrderedDict.
+
+    Picked over ``functools.lru_cache`` because we want a non-mutating
+    ``peek``-style lookup: on the fast path we check both caches before
+    deciding which one to fill, and ``functools.lru_cache`` only exposes a
+    decorator that fills on miss. CPython's GIL makes individual
+    OrderedDict operations atomic; compound get-then-set races only cause
+    duplicate parsing (idempotent), never corrupted state.
+    """
+
+    def __init__(self, maxsize: int) -> None:
+        self.maxsize = maxsize
+        self._data: OrderedDict[Any, Any] = OrderedDict()
+
+    def get(self, key: Any) -> Any:
+        """Return the value (and mark it recently-used) on hit, else None."""
+        try:
+            value = self._data[key]
+        except KeyError:
+            return None
+        self._data.move_to_end(key)
+        return value
+
+    def set(self, key: Any, value: Any) -> None:
+        """Insert; evict the least-recently-used entry on overflow."""
+        self._data[key] = value
+        self._data.move_to_end(key)
+        if len(self._data) > self.maxsize:
+            self._data.popitem(last=False)
+
+    def clear(self) -> None:
+        self._data.clear()
+
+    @property
+    def currsize(self) -> int:
+        return len(self._data)
 
 
-@functools.lru_cache(maxsize=_USER_CACHE_SIZE)
-def _user_parse_cache(statement: str, backend: HogQLParserBackend, rule: ParseRule, start: int | None) -> Any:
-    return _invoke_parser(backend, rule, statement, start)
+_builtin_parse_cache = _BoundedLRU(_BUILTIN_CACHE_SIZE)
+_user_parse_cache = _BoundedLRU(_USER_CACHE_SIZE)
 
-
-_PARSE_CACHE_MAXSIZE.labels(cache="builtin").set(_BUILTIN_CACHE_SIZE)
-_PARSE_CACHE_MAXSIZE.labels(cache="user").set(_USER_CACHE_SIZE)
+_PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.BUILTIN).set(_BUILTIN_CACHE_SIZE)
+_PARSE_CACHE_MAXSIZE.labels(cache=CacheOrigin.USER).set(_USER_CACHE_SIZE)
 
 
 def _invoke_parser(backend: HogQLParserBackend, rule: ParseRule, statement: str, start: int | None) -> Any:
@@ -193,37 +232,57 @@ def _parse_cached(
     *,
     start: int | None = None,
 ) -> Any:
-    """Look up a parsed AST in the appropriate cache, parsing on miss.
+    """Look up a parsed AST, parsing on miss.
 
-    Returns a ``copy.deepcopy`` so callers can mutate the returned AST
-    without affecting future cache hits (the resolver and printer both
-    mutate the AST in place). Concrete return type is rule-dependent; the
-    public ``parse_select`` / ``parse_expr`` / etc. wrappers narrow it.
+    Fast path for ``cache_origin == CacheOrigin.AUTO``: check the built-in
+    cache, then the user cache, returning on the first hit. Only on a full
+    miss do we walk the call stack to classify the query and parse it.
+    This skips the frame walk on every cache hit, which dominates traffic
+    once the cache is warm.
+
+    Explicit ``BUILTIN`` / ``USER`` origins only consult their own cache —
+    callers opting into one explicitly should not get hits from the other.
+
+    Returns a ``copy.deepcopy`` so callers can mutate the AST without
+    affecting future cache hits (the resolver and printer both mutate).
     """
-    if cache_origin == "auto":
-        cache_origin = "builtin" if _looks_like_code_literal(statement) else "user"
-    cache_fn = _builtin_parse_cache if cache_origin == "builtin" else _user_parse_cache
-    before_misses = cache_fn.cache_info().misses
-    cached = cache_fn(statement, backend, rule, start)
-    info = cache_fn.cache_info()
-    is_miss = info.misses > before_misses
-    _PARSE_CACHE_EVENTS.labels(
-        origin=cache_origin,
-        result="miss" if is_miss else "hit",
-        rule=rule,
-    ).inc()
-    if is_miss:
-        # Size only changes on miss (fill or evict). Update lazily.
-        _PARSE_CACHE_SIZE.labels(cache=cache_origin).set(info.currsize)
-    return copy.deepcopy(cached)
+    key = (statement, backend, rule, start)
+
+    if cache_origin == CacheOrigin.AUTO:
+        # Built-in is checked first because it holds the hot, in-process
+        # literal queries — the case we expect to dominate production traffic.
+        cached = _builtin_parse_cache.get(key)
+        if cached is not None:
+            _PARSE_CACHE_EVENTS.labels(origin=CacheOrigin.BUILTIN, result="hit", rule=rule).inc()
+            return copy.deepcopy(cached)
+        cached = _user_parse_cache.get(key)
+        if cached is not None:
+            _PARSE_CACHE_EVENTS.labels(origin=CacheOrigin.USER, result="hit", rule=rule).inc()
+            return copy.deepcopy(cached)
+        # Full miss — classify so we know which cache to fill.
+        cache_origin = CacheOrigin.BUILTIN if _looks_like_code_literal(statement) else CacheOrigin.USER
+    else:
+        cache = _builtin_parse_cache if cache_origin == CacheOrigin.BUILTIN else _user_parse_cache
+        cached = cache.get(key)
+        if cached is not None:
+            _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="hit", rule=rule).inc()
+            return copy.deepcopy(cached)
+
+    # Miss path: parse and store in the chosen cache.
+    cache = _builtin_parse_cache if cache_origin == CacheOrigin.BUILTIN else _user_parse_cache
+    parsed = _invoke_parser(backend, rule, statement, start)
+    cache.set(key, parsed)
+    _PARSE_CACHE_EVENTS.labels(origin=cache_origin, result="miss", rule=rule).inc()
+    _PARSE_CACHE_SIZE.labels(cache=cache_origin).set(cache.currsize)
+    return copy.deepcopy(parsed)
 
 
 def clear_parse_caches() -> None:
     """Drop both parse caches. Used by tests."""
-    _builtin_parse_cache.cache_clear()
-    _user_parse_cache.cache_clear()
-    _PARSE_CACHE_SIZE.labels(cache="builtin").set(0)
-    _PARSE_CACHE_SIZE.labels(cache="user").set(0)
+    _builtin_parse_cache.clear()
+    _user_parse_cache.clear()
+    _PARSE_CACHE_SIZE.labels(cache=CacheOrigin.BUILTIN).set(0)
+    _PARSE_CACHE_SIZE.labels(cache=CacheOrigin.USER).set(0)
 
 
 def parse_string_template(
@@ -232,7 +291,7 @@ def parse_string_template(
     timings: HogQLTimings | None = None,
     *,
     backend: HogQLParserBackend = DEFAULT_BACKEND,
-    cache_origin: CacheOrigin = "auto",
+    cache_origin: CacheOrigin = CacheOrigin.AUTO,
 ) -> ast.Call:
     """Parse a full template string without start/end quotes"""
     if timings is None:
@@ -253,7 +312,7 @@ def parse_expr(
     timings: HogQLTimings | None = None,
     *,
     backend: HogQLParserBackend = DEFAULT_BACKEND,
-    cache_origin: CacheOrigin = "auto",
+    cache_origin: CacheOrigin = CacheOrigin.AUTO,
 ) -> ast.Expr:
     if expr == "":
         raise SyntaxError("Empty query")
@@ -274,7 +333,7 @@ def parse_order_expr(
     timings: HogQLTimings | None = None,
     *,
     backend: HogQLParserBackend = DEFAULT_BACKEND,
-    cache_origin: CacheOrigin = "auto",
+    cache_origin: CacheOrigin = CacheOrigin.AUTO,
 ) -> ast.OrderExpr:
     if timings is None:
         timings = HogQLTimings()
@@ -293,7 +352,7 @@ def parse_select(
     timings: HogQLTimings | None = None,
     *,
     backend: HogQLParserBackend = DEFAULT_BACKEND,
-    cache_origin: CacheOrigin = "auto",
+    cache_origin: CacheOrigin = CacheOrigin.AUTO,
 ) -> ast.SelectQuery | ast.SelectSetQuery:
     if timings is None:
         timings = HogQLTimings()
@@ -314,7 +373,7 @@ def parse_program(
     timings: HogQLTimings | None = None,
     *,
     backend: HogQLParserBackend = DEFAULT_BACKEND,
-    cache_origin: CacheOrigin = "auto",
+    cache_origin: CacheOrigin = CacheOrigin.AUTO,
 ) -> ast.Program:
     if timings is None:
         timings = HogQLTimings()

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -43,7 +43,7 @@ from posthog.hogql.database.models import BooleanDatabaseField
 from posthog.hogql.database.schema.sessions_v3 import LAZY_SESSIONS_FIELDS
 from posthog.hogql.errors import NotImplementedError, QueryError
 from posthog.hogql.functions import find_hogql_aggregation
-from posthog.hogql.parser import parse_expr
+from posthog.hogql.parser import CacheOrigin, parse_expr
 from posthog.hogql.utils import map_virtual_properties
 from posthog.hogql.visitor import CloningVisitor, TraversingVisitor, clone_expr
 
@@ -735,7 +735,7 @@ def property_to_expr(
         raise QueryError(f"property_to_expr with property of type {type(property).__name__} not implemented")
 
     if property.type == "hogql":
-        return parse_expr(property.key)
+        return parse_expr(property.key, cache_origin=CacheOrigin.USER)
     elif property.type == "event_metadata" and scope == "group" and GROUP_KEY_PATTERN.match(property.key) is not None:
         group_type_index = property.key.split("_")[1]
         operator = cast(Optional[PropertyOperator], property.operator) or PropertyOperator.EXACT

--- a/posthog/hogql/test/test_parser_cache.py
+++ b/posthog/hogql/test/test_parser_cache.py
@@ -140,8 +140,9 @@ class TestParserCache(BaseTest):
         # `parse_expr` short identifier-only inputs route to user cache via
         # the interning guard; use explicit BUILTIN to test start-arg keying
         # in isolation.
-        parse_expr("1 + 1", start=0, cache_origin=CacheOrigin.BUILTIN)
-        parse_expr("1 + 1", start=1, cache_origin=CacheOrigin.BUILTIN)
+        expr = "1 + 1 -- start-arg keying test, long enough to cache"
+        parse_expr(expr, start=0, cache_origin=CacheOrigin.BUILTIN)
+        parse_expr(expr, start=1, cache_origin=CacheOrigin.BUILTIN)
         self.assertEqual(_builtin_parse_cache.currsize, 2)
 
     def test_looks_like_code_literal_finds_function_literal(self):
@@ -172,23 +173,20 @@ class TestParserCache(BaseTest):
         self.assertEqual(_builtin_parse_cache.currsize, 0)
         self.assertEqual(_user_parse_cache.currsize, 0)
 
-    @parameterized.expand([(CacheOrigin.AUTO,), (CacheOrigin.USER,)])
-    def test_undersized_query_skips_user_and_auto_caches(self, origin):
+    @parameterized.expand([(CacheOrigin.AUTO,), (CacheOrigin.USER,), (CacheOrigin.BUILTIN,)])
+    def test_undersized_query_skips_cache(self, origin):
+        # Short queries skip caching regardless of origin — even explicit
+        # BUILTIN doesn't bypass the minimum, since the speedup isn't worth
+        # the slot.
         sql = "SELECT 1"
         assert len(sql) < _MIN_CACHEABLE_STATEMENT_LEN
         parse_select(sql, cache_origin=origin)
         self.assertEqual(_builtin_parse_cache.currsize, 0)
         self.assertEqual(_user_parse_cache.currsize, 0)
 
-    def test_undersized_query_still_caches_under_explicit_builtin(self):
-        # Explicit BUILTIN bypasses the size bounds.
-        sql = "SELECT 1"
-        assert len(sql) < _MIN_CACHEABLE_STATEMENT_LEN
-        parse_select(sql, cache_origin=CacheOrigin.BUILTIN)
-        self.assertEqual(_builtin_parse_cache.currsize, 1)
-
     def test_oversized_query_still_caches_under_explicit_builtin(self):
-        # Explicit BUILTIN bypasses the size bounds.
+        # Explicit BUILTIN bypasses the upper bound (trusted opt-in for
+        # large queries).
         padding = "x" * (_MAX_CACHEABLE_STATEMENT_LEN + 1)
         sql = f"SELECT 1 -- {padding}"
         parse_select(sql, cache_origin=CacheOrigin.BUILTIN)

--- a/posthog/hogql/test/test_parser_cache.py
+++ b/posthog/hogql/test/test_parser_cache.py
@@ -52,9 +52,10 @@ class TestParserCache(BaseTest):
         self.assertEqual(_user_parse_cache.currsize, 0)
 
     def test_auto_detects_function_local_literal(self):
-        # "SELECT 3" is a literal in this test function's compiled code — should
-        # land in the built-in cache via the frame-walk detector.
-        parse_select("SELECT 3")
+        # Literal must be long enough to bypass the auto-interning guard
+        # (`_LITERAL_DETECTION_MIN_LEN`). Real production HogQL queries are
+        # well past 32 chars.
+        parse_select("SELECT count() FROM events WHERE event = '$exception'")
         self.assertEqual(_builtin_parse_cache.currsize, 1)
         self.assertEqual(_user_parse_cache.currsize, 0)
 
@@ -62,8 +63,16 @@ class TestParserCache(BaseTest):
         # `.join` produces a fresh string object that isn't in any frame's
         # co_consts (constant string concat like `"a " + "b"` would be folded
         # at compile time into a single literal and incorrectly look built-in).
-        sql = " ".join(["SELECT", "count()", "FROM", "events"])
+        sql = " ".join(["SELECT", "count()", "FROM", "events", "WHERE", "event", "=", "'$pageview'"])
         parse_select(sql)
+        self.assertEqual(_user_parse_cache.currsize, 1)
+        self.assertEqual(_builtin_parse_cache.currsize, 0)
+
+    def test_auto_short_strings_route_to_user_cache(self):
+        # Short identifier-shaped strings can be auto-interned by CPython and
+        # spuriously identity-match `co_consts` elsewhere. The min-length
+        # guard sends them to the user cache regardless.
+        parse_expr("count()")
         self.assertEqual(_user_parse_cache.currsize, 1)
         self.assertEqual(_builtin_parse_cache.currsize, 0)
 
@@ -105,19 +114,45 @@ class TestParserCache(BaseTest):
 
     def test_parse_expr_cached_separately_by_start_arg(self):
         # Two different start values must produce two different cache entries.
-        parse_expr("1 + 1", start=0)
-        parse_expr("1 + 1", start=1)
+        # `parse_expr` short identifier-only inputs go to user cache (interning
+        # guard); use explicit BUILTIN to test the start-arg keying.
+        parse_expr("1 + 1", start=0, cache_origin=CacheOrigin.BUILTIN)
+        parse_expr("1 + 1", start=1, cache_origin=CacheOrigin.BUILTIN)
         self.assertEqual(_builtin_parse_cache.currsize, 2)
 
     def test_looks_like_code_literal_finds_function_literal(self):
-        s = "this is a literal in this function"
+        s = "this is a literal in this function — definitely past the min length"
         self.assertTrue(_looks_like_code_literal(s))
 
     def test_looks_like_code_literal_rejects_constructed_strings(self):
         # `.join` produces a fresh runtime string (concat of two literals would
-        # be folded at compile time and incorrectly look like a literal).
-        s = " ".join(["constructed", "string"])
+        # be folded at compile time and incorrectly look like a literal). Use
+        # enough parts to clear the min-length guard.
+        s = " ".join(["constructed", "string", "definitely", "long", "enough", "now"])
         self.assertFalse(_looks_like_code_literal(s))
+
+    def test_looks_like_code_literal_rejects_short_strings(self):
+        # Short literals are rejected up-front because Python auto-interns
+        # short identifier-shaped strings — user input may share identity
+        # with `co_consts` entries elsewhere.
+        s = "event"  # literal in this function, but too short
+        self.assertFalse(_looks_like_code_literal(s))
+
+    def test_cache_origin_typo_raises(self):
+        # A misspelled origin must raise rather than silently routing to the
+        # user cache via `==` else-branch.
+        with self.assertRaises(ValueError):
+            parse_select("SELECT 1", cache_origin="buultin")  # type: ignore[arg-type]
+
+    def test_parse_string_template_literal_routes_to_builtin(self):
+        # Template strings used to always land in the user cache because the
+        # key is `"F'" + string` (runtime concat). Auto-detect now classifies
+        # against the raw `string` first.
+        from posthog.hogql.parser import parse_string_template
+
+        parse_string_template("hello {x} world, this is a long enough template now")
+        self.assertEqual(_builtin_parse_cache.currsize, 1)
+        self.assertEqual(_user_parse_cache.currsize, 0)
 
     def test_syntax_errors_are_not_cached(self):
         from posthog.hogql.errors import BaseHogQLError

--- a/posthog/hogql/test/test_parser_cache.py
+++ b/posthog/hogql/test/test_parser_cache.py
@@ -1,6 +1,8 @@
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
+
 from posthog.hogql import ast
 from posthog.hogql.parser import (
     CacheOrigin,
@@ -41,15 +43,16 @@ class TestParserCache(BaseTest):
         assert isinstance(second, ast.SelectQuery)
         self.assertIsNone(second.limit)
 
-    def test_user_origin_routes_to_user_cache(self):
-        parse_select("SELECT 1", cache_origin=CacheOrigin.USER)
-        self.assertEqual(_user_parse_cache.currsize, 1)
-        self.assertEqual(_builtin_parse_cache.currsize, 0)
-
-    def test_builtin_origin_routes_to_builtin_cache(self):
-        parse_select("SELECT 2", cache_origin=CacheOrigin.BUILTIN)
-        self.assertEqual(_builtin_parse_cache.currsize, 1)
-        self.assertEqual(_user_parse_cache.currsize, 0)
+    @parameterized.expand(
+        [
+            (CacheOrigin.BUILTIN, lambda: _builtin_parse_cache, lambda: _user_parse_cache),
+            (CacheOrigin.USER, lambda: _user_parse_cache, lambda: _builtin_parse_cache),
+        ]
+    )
+    def test_explicit_origin_routes_to_matching_cache(self, origin, target_getter, other_getter):
+        parse_select(f"SELECT 1 -- routing test {origin}", cache_origin=origin)
+        self.assertEqual(target_getter().currsize, 1)
+        self.assertEqual(other_getter().currsize, 0)
 
     def test_auto_detects_function_local_literal(self):
         # Literal must be long enough to bypass the auto-interning guard
@@ -144,6 +147,35 @@ class TestParserCache(BaseTest):
         with self.assertRaises(ValueError):
             parse_select("SELECT 1", cache_origin="buultin")  # type: ignore[arg-type]
 
+    @parameterized.expand(
+        [
+            (CacheOrigin.AUTO,),
+            (CacheOrigin.USER,),
+        ]
+    )
+    def test_oversized_query_skips_user_and_auto_caches(self, origin):
+        # An attacker-controlled HogQL query larger than the size cap must
+        # NOT enter the cache — bounds worst-case memory growth.
+        from posthog.hogql.parser import _MAX_CACHEABLE_STATEMENT_LEN
+
+        # Build a syntactically valid query over the size limit. Use a long
+        # comment so we don't blow up parse time on something pathological.
+        padding = "x" * (_MAX_CACHEABLE_STATEMENT_LEN + 1)
+        sql = f"SELECT 1 -- {padding}"
+        parse_select(sql, cache_origin=origin)
+        self.assertEqual(_builtin_parse_cache.currsize, 0)
+        self.assertEqual(_user_parse_cache.currsize, 0)
+
+    def test_oversized_query_still_caches_under_explicit_builtin(self):
+        # Explicit BUILTIN is opt-in by code that knows what it's storing —
+        # the size cap doesn't apply.
+        from posthog.hogql.parser import _MAX_CACHEABLE_STATEMENT_LEN
+
+        padding = "x" * (_MAX_CACHEABLE_STATEMENT_LEN + 1)
+        sql = f"SELECT 1 -- {padding}"
+        parse_select(sql, cache_origin=CacheOrigin.BUILTIN)
+        self.assertEqual(_builtin_parse_cache.currsize, 1)
+
     def test_parse_string_template_literal_routes_to_builtin(self):
         # Template strings used to always land in the user cache because the
         # key is `"F'" + string` (runtime concat). Auto-detect now classifies
@@ -163,21 +195,16 @@ class TestParserCache(BaseTest):
         self.assertEqual(_user_parse_cache.currsize, 0)
         self.assertEqual(_builtin_parse_cache.currsize, 0)
 
-    def test_auto_path_skips_frame_walk_on_hit(self):
+    @parameterized.expand(
+        [
+            (CacheOrigin.BUILTIN, "SELECT 4 -- prior built-in cache entry, plenty long enough"),
+            (CacheOrigin.USER, "SELECT 5 -- prior user cache entry, also plenty long enough"),
+        ]
+    )
+    def test_auto_path_skips_frame_walk_on_hit(self, prior_origin, sql):
         # The whole point of the fast path: when an entry exists in either
         # cache, _looks_like_code_literal should not be invoked.
-        parse_select("SELECT 4", cache_origin=CacheOrigin.BUILTIN)
+        parse_select(sql, cache_origin=prior_origin)
         with patch("posthog.hogql.parser._looks_like_code_literal") as detector:
-            parse_select("SELECT 4")  # cache_origin defaults to AUTO
-            detector.assert_not_called()
-
-    def test_auto_path_serves_from_user_cache_without_classifying(self):
-        # An entry previously stashed in the user cache should also be served
-        # without invoking the frame walk.
-        parse_select(" ".join(["SELECT", "5"]), cache_origin=CacheOrigin.USER)
-        with patch("posthog.hogql.parser._looks_like_code_literal") as detector:
-            # Reconstruct the same statement at runtime (so it'd be classified
-            # as user if we did walk the stack — we should hit the user cache
-            # without needing to.).
-            parse_select(" ".join(["SELECT", "5"]))
+            parse_select(sql)  # cache_origin defaults to AUTO
             detector.assert_not_called()

--- a/posthog/hogql/test/test_parser_cache.py
+++ b/posthog/hogql/test/test_parser_cache.py
@@ -23,28 +23,37 @@ class TestParserCache(BaseTest):
         super().setUp()
         clear_parse_caches()
 
+    def _total_cache_size(self) -> int:
+        return int(_builtin_parse_cache.currsize + _user_parse_cache.currsize)
+
     def test_cache_hit_returns_equivalent_ast(self):
-        sql = "SELECT count() FROM events"
+        sql = "SELECT count() FROM events WHERE event = '$pageview' -- cache test"
         first = parse_select(sql)
         second = parse_select(sql)
         self.assertEqual(first, second)
+        # Verify the second call was actually a cache hit, not a re-parse.
+        self.assertEqual(self._total_cache_size(), 1)
 
     def test_cache_hit_returns_distinct_object(self):
         # The resolver and printer mutate the AST in place — cache hits must
         # not share node identity with previous returns.
-        sql = "SELECT count() FROM events"
+        sql = "SELECT count() FROM events WHERE event = '$pageview' -- distinct test"
         first = parse_select(sql)
         second = parse_select(sql)
         self.assertIsNot(first, second)
+        self.assertEqual(self._total_cache_size(), 1)
 
     def test_mutation_does_not_leak_across_calls(self):
-        sql = "SELECT 1"
+        sql = "SELECT 1 FROM events WHERE event = '$exception' -- mutation isolation"
         first = parse_select(sql)
         assert isinstance(first, ast.SelectQuery)
         first.limit = ast.Constant(value=10)
         second = parse_select(sql)
         assert isinstance(second, ast.SelectQuery)
         self.assertIsNone(second.limit)
+        # The second call must have hit the cache; otherwise mutation isolation
+        # is trivially satisfied by re-parsing, which isn't what we're testing.
+        self.assertEqual(self._total_cache_size(), 1)
 
     @parameterized.expand(
         [
@@ -111,13 +120,16 @@ class TestParserCache(BaseTest):
     def test_returned_ast_has_independent_nested_objects(self):
         # deepcopy must reach nested children — mutating a deep field must
         # not leak to the cached entry.
-        sql = "SELECT count() FROM events WHERE event = '$pageview'"
+        sql = "SELECT count() FROM events WHERE event = '$pageview' -- nested mutation"
         first = parse_select(sql)
         assert isinstance(first, ast.SelectQuery) and first.where is not None
         first.where = ast.Constant(value=False)
         second = parse_select(sql)
         assert isinstance(second, ast.SelectQuery) and second.where is not None
         self.assertNotEqual(second.where, ast.Constant(value=False))
+        # Cache must have served the second call; otherwise this only proves
+        # that a fresh parse produces a fresh AST, which is uninteresting.
+        self.assertEqual(self._total_cache_size(), 1)
 
     def test_parse_expr_cached_separately_by_start_arg(self):
         # `parse_expr` short identifier-only inputs route to user cache via

--- a/posthog/hogql/test/test_parser_cache.py
+++ b/posthog/hogql/test/test_parser_cache.py
@@ -1,7 +1,9 @@
 from posthog.test.base import BaseTest
+from unittest.mock import patch
 
 from posthog.hogql import ast
 from posthog.hogql.parser import (
+    CacheOrigin,
     _builtin_parse_cache,
     _looks_like_code_literal,
     _user_parse_cache,
@@ -40,21 +42,21 @@ class TestParserCache(BaseTest):
         self.assertIsNone(second.limit)
 
     def test_user_origin_routes_to_user_cache(self):
-        parse_select("SELECT 1", cache_origin="user")
-        self.assertEqual(_user_parse_cache.cache_info().currsize, 1)
-        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 0)
+        parse_select("SELECT 1", cache_origin=CacheOrigin.USER)
+        self.assertEqual(_user_parse_cache.currsize, 1)
+        self.assertEqual(_builtin_parse_cache.currsize, 0)
 
     def test_builtin_origin_routes_to_builtin_cache(self):
-        parse_select("SELECT 2", cache_origin="builtin")
-        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 1)
-        self.assertEqual(_user_parse_cache.cache_info().currsize, 0)
+        parse_select("SELECT 2", cache_origin=CacheOrigin.BUILTIN)
+        self.assertEqual(_builtin_parse_cache.currsize, 1)
+        self.assertEqual(_user_parse_cache.currsize, 0)
 
     def test_auto_detects_function_local_literal(self):
         # "SELECT 3" is a literal in this test function's compiled code — should
         # land in the built-in cache via the frame-walk detector.
         parse_select("SELECT 3")
-        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 1)
-        self.assertEqual(_user_parse_cache.cache_info().currsize, 0)
+        self.assertEqual(_builtin_parse_cache.currsize, 1)
+        self.assertEqual(_user_parse_cache.currsize, 0)
 
     def test_auto_routes_constructed_strings_to_user_cache(self):
         # `.join` produces a fresh string object that isn't in any frame's
@@ -62,19 +64,18 @@ class TestParserCache(BaseTest):
         # at compile time into a single literal and incorrectly look built-in).
         sql = " ".join(["SELECT", "count()", "FROM", "events"])
         parse_select(sql)
-        self.assertEqual(_user_parse_cache.cache_info().currsize, 1)
-        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 0)
+        self.assertEqual(_user_parse_cache.currsize, 1)
+        self.assertEqual(_builtin_parse_cache.currsize, 0)
 
     def test_user_pollution_does_not_displace_builtin(self):
         # Fill the built-in cache with one entry, then flood the user cache.
-        parse_select("SELECT 'builtin entry'", cache_origin="builtin")
-        user_maxsize = _user_parse_cache.cache_info().maxsize
-        assert user_maxsize is not None
+        parse_select("SELECT 'builtin entry'", cache_origin=CacheOrigin.BUILTIN)
+        user_maxsize = _user_parse_cache.maxsize
         for i in range(user_maxsize + 50):
-            parse_select(f"SELECT {i}", cache_origin="user")
+            parse_select(f"SELECT {i}", cache_origin=CacheOrigin.USER)
         # Built-in cache still has its entry; user cache is at maxsize.
-        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 1)
-        self.assertEqual(_user_parse_cache.cache_info().currsize, user_maxsize)
+        self.assertEqual(_builtin_parse_cache.currsize, 1)
+        self.assertEqual(_user_parse_cache.currsize, user_maxsize)
 
     def test_placeholders_still_substitute_after_cache_hit(self):
         sql = "SELECT {x}"
@@ -106,7 +107,7 @@ class TestParserCache(BaseTest):
         # Two different start values must produce two different cache entries.
         parse_expr("1 + 1", start=0)
         parse_expr("1 + 1", start=1)
-        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 2)
+        self.assertEqual(_builtin_parse_cache.currsize, 2)
 
     def test_looks_like_code_literal_finds_function_literal(self):
         s = "this is a literal in this function"
@@ -122,7 +123,26 @@ class TestParserCache(BaseTest):
         from posthog.hogql.errors import BaseHogQLError
 
         with self.assertRaises(BaseHogQLError):
-            parse_select("NOT VALID SQL", cache_origin="user")
+            parse_select("NOT VALID SQL", cache_origin=CacheOrigin.USER)
         # The failed parse shouldn't have populated either cache.
-        self.assertEqual(_user_parse_cache.cache_info().currsize, 0)
-        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 0)
+        self.assertEqual(_user_parse_cache.currsize, 0)
+        self.assertEqual(_builtin_parse_cache.currsize, 0)
+
+    def test_auto_path_skips_frame_walk_on_hit(self):
+        # The whole point of the fast path: when an entry exists in either
+        # cache, _looks_like_code_literal should not be invoked.
+        parse_select("SELECT 4", cache_origin=CacheOrigin.BUILTIN)
+        with patch("posthog.hogql.parser._looks_like_code_literal") as detector:
+            parse_select("SELECT 4")  # cache_origin defaults to AUTO
+            detector.assert_not_called()
+
+    def test_auto_path_serves_from_user_cache_without_classifying(self):
+        # An entry previously stashed in the user cache should also be served
+        # without invoking the frame walk.
+        parse_select(" ".join(["SELECT", "5"]), cache_origin=CacheOrigin.USER)
+        with patch("posthog.hogql.parser._looks_like_code_literal") as detector:
+            # Reconstruct the same statement at runtime (so it'd be classified
+            # as user if we did walk the stack — we should hit the user cache
+            # without needing to.).
+            parse_select(" ".join(["SELECT", "5"]))
+            detector.assert_not_called()

--- a/posthog/hogql/test/test_parser_cache.py
+++ b/posthog/hogql/test/test_parser_cache.py
@@ -7,6 +7,7 @@ from posthog.hogql import ast
 from posthog.hogql.errors import BaseHogQLError
 from posthog.hogql.parser import (
     _MAX_CACHEABLE_STATEMENT_LEN,
+    _MIN_CACHEABLE_STATEMENT_LEN,
     CacheOrigin,
     _builtin_parse_cache,
     _looks_like_code_literal,
@@ -62,7 +63,7 @@ class TestParserCache(BaseTest):
         ]
     )
     def test_explicit_origin_routes_to_matching_cache(self, origin, target_getter, other_getter):
-        parse_select(f"SELECT 1 -- routing test {origin}", cache_origin=origin)
+        parse_select(f"SELECT 1 -- routing test {origin}, plenty long enough to cache", cache_origin=origin)
         self.assertEqual(target_getter().currsize, 1)
         self.assertEqual(other_getter().currsize, 0)
 
@@ -82,18 +83,22 @@ class TestParserCache(BaseTest):
         self.assertEqual(_user_parse_cache.currsize, 1)
         self.assertEqual(_builtin_parse_cache.currsize, 0)
 
-    def test_auto_short_strings_route_to_user_cache(self):
-        # Short identifier-shaped strings can be auto-interned by CPython
-        # and spuriously identity-match `co_consts` entries elsewhere.
+    def test_auto_short_strings_skip_cache(self):
+        # Short queries parse fast enough that caching isn't worth a slot.
         parse_expr("count()")
-        self.assertEqual(_user_parse_cache.currsize, 1)
+        self.assertEqual(_user_parse_cache.currsize, 0)
         self.assertEqual(_builtin_parse_cache.currsize, 0)
 
     def test_user_pollution_does_not_displace_builtin(self):
-        parse_select("SELECT 'builtin entry'", cache_origin=CacheOrigin.BUILTIN)
+        parse_select(
+            "SELECT 'builtin entry' -- pollution test, plenty long enough to cache",
+            cache_origin=CacheOrigin.BUILTIN,
+        )
         user_maxsize = int(_user_parse_cache.maxsize)
         for i in range(user_maxsize + 50):
-            parse_select(f"SELECT {i}", cache_origin=CacheOrigin.USER)
+            parse_select(
+                f"SELECT {i} -- pollution test row, plenty long enough to cache", cache_origin=CacheOrigin.USER
+            )
         self.assertEqual(_builtin_parse_cache.currsize, 1)
         self.assertEqual(_user_parse_cache.currsize, user_maxsize)
 
@@ -167,9 +172,23 @@ class TestParserCache(BaseTest):
         self.assertEqual(_builtin_parse_cache.currsize, 0)
         self.assertEqual(_user_parse_cache.currsize, 0)
 
+    @parameterized.expand([(CacheOrigin.AUTO,), (CacheOrigin.USER,)])
+    def test_undersized_query_skips_user_and_auto_caches(self, origin):
+        sql = "SELECT 1"
+        assert len(sql) < _MIN_CACHEABLE_STATEMENT_LEN
+        parse_select(sql, cache_origin=origin)
+        self.assertEqual(_builtin_parse_cache.currsize, 0)
+        self.assertEqual(_user_parse_cache.currsize, 0)
+
+    def test_undersized_query_still_caches_under_explicit_builtin(self):
+        # Explicit BUILTIN bypasses the size bounds.
+        sql = "SELECT 1"
+        assert len(sql) < _MIN_CACHEABLE_STATEMENT_LEN
+        parse_select(sql, cache_origin=CacheOrigin.BUILTIN)
+        self.assertEqual(_builtin_parse_cache.currsize, 1)
+
     def test_oversized_query_still_caches_under_explicit_builtin(self):
-        # Explicit BUILTIN is opt-in by code that knows what it's storing;
-        # the size cap doesn't apply.
+        # Explicit BUILTIN bypasses the size bounds.
         padding = "x" * (_MAX_CACHEABLE_STATEMENT_LEN + 1)
         sql = f"SELECT 1 -- {padding}"
         parse_select(sql, cache_origin=CacheOrigin.BUILTIN)

--- a/posthog/hogql/test/test_parser_cache.py
+++ b/posthog/hogql/test/test_parser_cache.py
@@ -1,0 +1,128 @@
+from posthog.test.base import BaseTest
+
+from posthog.hogql import ast
+from posthog.hogql.parser import (
+    _builtin_parse_cache,
+    _looks_like_code_literal,
+    _user_parse_cache,
+    clear_parse_caches,
+    parse_expr,
+    parse_select,
+)
+
+
+class TestParserCache(BaseTest):
+    def setUp(self):
+        super().setUp()
+        clear_parse_caches()
+
+    def test_cache_hit_returns_equivalent_ast(self):
+        sql = "SELECT count() FROM events"
+        first = parse_select(sql)
+        second = parse_select(sql)
+        self.assertEqual(first, second)
+
+    def test_cache_hit_returns_distinct_object(self):
+        # The resolver and printer mutate the AST in place — cache hits must
+        # not share node identity with previous returns or each other.
+        sql = "SELECT count() FROM events"
+        first = parse_select(sql)
+        second = parse_select(sql)
+        self.assertIsNot(first, second)
+
+    def test_mutation_does_not_leak_across_calls(self):
+        sql = "SELECT 1"
+        first = parse_select(sql)
+        assert isinstance(first, ast.SelectQuery)
+        first.limit = ast.Constant(value=10)
+        second = parse_select(sql)
+        assert isinstance(second, ast.SelectQuery)
+        self.assertIsNone(second.limit)
+
+    def test_user_origin_routes_to_user_cache(self):
+        parse_select("SELECT 1", cache_origin="user")
+        self.assertEqual(_user_parse_cache.cache_info().currsize, 1)
+        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 0)
+
+    def test_builtin_origin_routes_to_builtin_cache(self):
+        parse_select("SELECT 2", cache_origin="builtin")
+        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 1)
+        self.assertEqual(_user_parse_cache.cache_info().currsize, 0)
+
+    def test_auto_detects_function_local_literal(self):
+        # "SELECT 3" is a literal in this test function's compiled code — should
+        # land in the built-in cache via the frame-walk detector.
+        parse_select("SELECT 3")
+        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 1)
+        self.assertEqual(_user_parse_cache.cache_info().currsize, 0)
+
+    def test_auto_routes_constructed_strings_to_user_cache(self):
+        # `.join` produces a fresh string object that isn't in any frame's
+        # co_consts (constant string concat like `"a " + "b"` would be folded
+        # at compile time into a single literal and incorrectly look built-in).
+        sql = " ".join(["SELECT", "count()", "FROM", "events"])
+        parse_select(sql)
+        self.assertEqual(_user_parse_cache.cache_info().currsize, 1)
+        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 0)
+
+    def test_user_pollution_does_not_displace_builtin(self):
+        # Fill the built-in cache with one entry, then flood the user cache.
+        parse_select("SELECT 'builtin entry'", cache_origin="builtin")
+        user_maxsize = _user_parse_cache.cache_info().maxsize
+        assert user_maxsize is not None
+        for i in range(user_maxsize + 50):
+            parse_select(f"SELECT {i}", cache_origin="user")
+        # Built-in cache still has its entry; user cache is at maxsize.
+        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 1)
+        self.assertEqual(_user_parse_cache.cache_info().currsize, user_maxsize)
+
+    def test_placeholders_still_substitute_after_cache_hit(self):
+        sql = "SELECT {x}"
+        placeholders: dict[str, ast.Expr] = {"x": ast.Constant(value=42)}
+        # Warm the cache without placeholders.
+        parse_select(sql)
+        # Second call with placeholders must produce the substituted AST.
+        node = parse_select(sql, placeholders=placeholders)
+        assert isinstance(node, ast.SelectQuery)
+        self.assertEqual(len(node.select), 1)
+        substituted = node.select[0]
+        assert isinstance(substituted, ast.Constant)
+        self.assertEqual(substituted.value, 42)
+
+    def test_returned_ast_has_independent_nested_objects(self):
+        # deepcopy must reach nested children — mutating a deep field must
+        # not leak to the cached entry. Pick a query with nested structure.
+        sql = "SELECT count() FROM events WHERE event = '$pageview'"
+        first = parse_select(sql)
+        assert isinstance(first, ast.SelectQuery) and first.where is not None
+        # Replace a deeply nested field
+        first.where = ast.Constant(value=False)
+        second = parse_select(sql)
+        assert isinstance(second, ast.SelectQuery) and second.where is not None
+        # The cached entry was untouched
+        self.assertNotEqual(second.where, ast.Constant(value=False))
+
+    def test_parse_expr_cached_separately_by_start_arg(self):
+        # Two different start values must produce two different cache entries.
+        parse_expr("1 + 1", start=0)
+        parse_expr("1 + 1", start=1)
+        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 2)
+
+    def test_looks_like_code_literal_finds_function_literal(self):
+        s = "this is a literal in this function"
+        self.assertTrue(_looks_like_code_literal(s))
+
+    def test_looks_like_code_literal_rejects_constructed_strings(self):
+        # `.join` produces a fresh runtime string (concat of two literals would
+        # be folded at compile time and incorrectly look like a literal).
+        s = " ".join(["constructed", "string"])
+        self.assertFalse(_looks_like_code_literal(s))
+
+    def test_syntax_errors_are_not_cached(self):
+        from posthog.hogql.errors import BaseHogQLError
+
+        with self.assertRaises(BaseHogQLError):
+            parse_select("NOT VALID SQL", cache_origin="user")
+        # The failed parse shouldn't have populated either cache.
+        self.assertEqual(_user_parse_cache.cache_info().currsize, 0)
+        self.assertEqual(_builtin_parse_cache.cache_info().currsize, 0)

--- a/posthog/hogql/test/test_parser_cache.py
+++ b/posthog/hogql/test/test_parser_cache.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 from parameterized import parameterized
 
 from posthog.hogql import ast
+from posthog.hogql.errors import BaseHogQLError
 from posthog.hogql.parser import (
+    _MAX_CACHEABLE_STATEMENT_LEN,
     CacheOrigin,
     _builtin_parse_cache,
     _looks_like_code_literal,
@@ -12,6 +14,7 @@ from posthog.hogql.parser import (
     clear_parse_caches,
     parse_expr,
     parse_select,
+    parse_string_template,
 )
 
 
@@ -28,7 +31,7 @@ class TestParserCache(BaseTest):
 
     def test_cache_hit_returns_distinct_object(self):
         # The resolver and printer mutate the AST in place — cache hits must
-        # not share node identity with previous returns or each other.
+        # not share node identity with previous returns.
         sql = "SELECT count() FROM events"
         first = parse_select(sql)
         second = parse_select(sql)
@@ -56,69 +59,70 @@ class TestParserCache(BaseTest):
 
     def test_auto_detects_function_local_literal(self):
         # Literal must be long enough to bypass the auto-interning guard
-        # (`_LITERAL_DETECTION_MIN_LEN`). Real production HogQL queries are
-        # well past 32 chars.
+        # (`_LITERAL_DETECTION_MIN_LEN`).
         parse_select("SELECT count() FROM events WHERE event = '$exception'")
         self.assertEqual(_builtin_parse_cache.currsize, 1)
         self.assertEqual(_user_parse_cache.currsize, 0)
 
     def test_auto_routes_constructed_strings_to_user_cache(self):
-        # `.join` produces a fresh string object that isn't in any frame's
-        # co_consts (constant string concat like `"a " + "b"` would be folded
-        # at compile time into a single literal and incorrectly look built-in).
+        # `.join` produces a fresh runtime string. Concat of two string
+        # literals (`"a " + "b"`) would be folded by the compiler into a
+        # single literal and incorrectly look built-in.
         sql = " ".join(["SELECT", "count()", "FROM", "events", "WHERE", "event", "=", "'$pageview'"])
         parse_select(sql)
         self.assertEqual(_user_parse_cache.currsize, 1)
         self.assertEqual(_builtin_parse_cache.currsize, 0)
 
     def test_auto_short_strings_route_to_user_cache(self):
-        # Short identifier-shaped strings can be auto-interned by CPython and
-        # spuriously identity-match `co_consts` elsewhere. The min-length
-        # guard sends them to the user cache regardless.
+        # Short identifier-shaped strings can be auto-interned by CPython
+        # and spuriously identity-match `co_consts` entries elsewhere.
         parse_expr("count()")
         self.assertEqual(_user_parse_cache.currsize, 1)
         self.assertEqual(_builtin_parse_cache.currsize, 0)
 
     def test_user_pollution_does_not_displace_builtin(self):
-        # Fill the built-in cache with one entry, then flood the user cache.
         parse_select("SELECT 'builtin entry'", cache_origin=CacheOrigin.BUILTIN)
         user_maxsize = int(_user_parse_cache.maxsize)
         for i in range(user_maxsize + 50):
             parse_select(f"SELECT {i}", cache_origin=CacheOrigin.USER)
-        # Built-in cache still has its entry; user cache is at maxsize.
         self.assertEqual(_builtin_parse_cache.currsize, 1)
         self.assertEqual(_user_parse_cache.currsize, user_maxsize)
 
-    def test_placeholders_still_substitute_after_cache_hit(self):
-        sql = "SELECT {x}"
-        placeholders: dict[str, ast.Expr] = {"x": ast.Constant(value=42)}
-        # Warm the cache without placeholders.
-        parse_select(sql)
-        # Second call with placeholders must produce the substituted AST.
-        node = parse_select(sql, placeholders=placeholders)
-        assert isinstance(node, ast.SelectQuery)
-        self.assertEqual(len(node.select), 1)
-        substituted = node.select[0]
-        assert isinstance(substituted, ast.Constant)
-        self.assertEqual(substituted.value, 42)
+    def test_different_placeholders_share_cache_entry(self):
+        # Cache key is the raw SQL; placeholders are substituted on the
+        # deepcopy returned from cache. The whole templated-query workload
+        # depends on this sharing — assert it explicitly.
+        sql = "SELECT {x} FROM events WHERE event = '$pageview' LIMIT {n}"
+
+        first = parse_select(sql, placeholders={"x": ast.Constant(value=1), "n": ast.Constant(value=10)})
+        self.assertEqual(_builtin_parse_cache.currsize + _user_parse_cache.currsize, 1)
+        assert isinstance(first, ast.SelectQuery)
+        first_select = first.select[0]
+        assert isinstance(first_select, ast.Constant)
+        self.assertEqual(first_select.value, 1)
+
+        second = parse_select(sql, placeholders={"x": ast.Constant(value=99), "n": ast.Constant(value=50)})
+        self.assertEqual(_builtin_parse_cache.currsize + _user_parse_cache.currsize, 1)
+        assert isinstance(second, ast.SelectQuery)
+        second_select = second.select[0]
+        assert isinstance(second_select, ast.Constant)
+        self.assertEqual(second_select.value, 99)
 
     def test_returned_ast_has_independent_nested_objects(self):
         # deepcopy must reach nested children — mutating a deep field must
-        # not leak to the cached entry. Pick a query with nested structure.
+        # not leak to the cached entry.
         sql = "SELECT count() FROM events WHERE event = '$pageview'"
         first = parse_select(sql)
         assert isinstance(first, ast.SelectQuery) and first.where is not None
-        # Replace a deeply nested field
         first.where = ast.Constant(value=False)
         second = parse_select(sql)
         assert isinstance(second, ast.SelectQuery) and second.where is not None
-        # The cached entry was untouched
         self.assertNotEqual(second.where, ast.Constant(value=False))
 
     def test_parse_expr_cached_separately_by_start_arg(self):
-        # Two different start values must produce two different cache entries.
-        # `parse_expr` short identifier-only inputs go to user cache (interning
-        # guard); use explicit BUILTIN to test the start-arg keying.
+        # `parse_expr` short identifier-only inputs route to user cache via
+        # the interning guard; use explicit BUILTIN to test start-arg keying
+        # in isolation.
         parse_expr("1 + 1", start=0, cache_origin=CacheOrigin.BUILTIN)
         parse_expr("1 + 1", start=1, cache_origin=CacheOrigin.BUILTIN)
         self.assertEqual(_builtin_parse_cache.currsize, 2)
@@ -128,38 +132,23 @@ class TestParserCache(BaseTest):
         self.assertTrue(_looks_like_code_literal(s))
 
     def test_looks_like_code_literal_rejects_constructed_strings(self):
-        # `.join` produces a fresh runtime string (concat of two literals would
-        # be folded at compile time and incorrectly look like a literal). Use
-        # enough parts to clear the min-length guard.
+        # `.join` produces a fresh runtime string (compile-time concat would
+        # be folded into a single literal).
         s = " ".join(["constructed", "string", "definitely", "long", "enough", "now"])
         self.assertFalse(_looks_like_code_literal(s))
 
     def test_looks_like_code_literal_rejects_short_strings(self):
-        # Short literals are rejected up-front because Python auto-interns
-        # short identifier-shaped strings — user input may share identity
-        # with `co_consts` entries elsewhere.
-        s = "event"  # literal in this function, but too short
+        # Short identifier-shaped strings may be process-wide-interned by
+        # CPython and falsely identity-match `co_consts` elsewhere.
+        s = "event"
         self.assertFalse(_looks_like_code_literal(s))
 
     def test_cache_origin_typo_raises(self):
-        # A misspelled origin must raise rather than silently routing to the
-        # user cache via `==` else-branch.
         with self.assertRaises(ValueError):
             parse_select("SELECT 1", cache_origin="buultin")  # type: ignore[arg-type]
 
-    @parameterized.expand(
-        [
-            (CacheOrigin.AUTO,),
-            (CacheOrigin.USER,),
-        ]
-    )
+    @parameterized.expand([(CacheOrigin.AUTO,), (CacheOrigin.USER,)])
     def test_oversized_query_skips_user_and_auto_caches(self, origin):
-        # An attacker-controlled HogQL query larger than the size cap must
-        # NOT enter the cache — bounds worst-case memory growth.
-        from posthog.hogql.parser import _MAX_CACHEABLE_STATEMENT_LEN
-
-        # Build a syntactically valid query over the size limit. Use a long
-        # comment so we don't blow up parse time on something pathological.
         padding = "x" * (_MAX_CACHEABLE_STATEMENT_LEN + 1)
         sql = f"SELECT 1 -- {padding}"
         parse_select(sql, cache_origin=origin)
@@ -167,31 +156,24 @@ class TestParserCache(BaseTest):
         self.assertEqual(_user_parse_cache.currsize, 0)
 
     def test_oversized_query_still_caches_under_explicit_builtin(self):
-        # Explicit BUILTIN is opt-in by code that knows what it's storing —
+        # Explicit BUILTIN is opt-in by code that knows what it's storing;
         # the size cap doesn't apply.
-        from posthog.hogql.parser import _MAX_CACHEABLE_STATEMENT_LEN
-
         padding = "x" * (_MAX_CACHEABLE_STATEMENT_LEN + 1)
         sql = f"SELECT 1 -- {padding}"
         parse_select(sql, cache_origin=CacheOrigin.BUILTIN)
         self.assertEqual(_builtin_parse_cache.currsize, 1)
 
     def test_parse_string_template_literal_routes_to_builtin(self):
-        # Template strings used to always land in the user cache because the
-        # key is `"F'" + string` (runtime concat). Auto-detect now classifies
-        # against the raw `string` first.
-        from posthog.hogql.parser import parse_string_template
-
+        # The cache key is `"F'" + string` (runtime concat) so naive
+        # auto-detect would never see a built-in literal here — we
+        # classify against the raw `string` arg instead.
         parse_string_template("hello {x} world, this is a long enough template now")
         self.assertEqual(_builtin_parse_cache.currsize, 1)
         self.assertEqual(_user_parse_cache.currsize, 0)
 
     def test_syntax_errors_are_not_cached(self):
-        from posthog.hogql.errors import BaseHogQLError
-
         with self.assertRaises(BaseHogQLError):
             parse_select("NOT VALID SQL", cache_origin=CacheOrigin.USER)
-        # The failed parse shouldn't have populated either cache.
         self.assertEqual(_user_parse_cache.currsize, 0)
         self.assertEqual(_builtin_parse_cache.currsize, 0)
 
@@ -202,9 +184,7 @@ class TestParserCache(BaseTest):
         ]
     )
     def test_auto_path_skips_frame_walk_on_hit(self, prior_origin, sql):
-        # The whole point of the fast path: when an entry exists in either
-        # cache, _looks_like_code_literal should not be invoked.
         parse_select(sql, cache_origin=prior_origin)
         with patch("posthog.hogql.parser._looks_like_code_literal") as detector:
-            parse_select(sql)  # cache_origin defaults to AUTO
+            parse_select(sql)
             detector.assert_not_called()

--- a/posthog/hogql/test/test_parser_cache.py
+++ b/posthog/hogql/test/test_parser_cache.py
@@ -83,12 +83,6 @@ class TestParserCache(BaseTest):
         self.assertEqual(_user_parse_cache.currsize, 1)
         self.assertEqual(_builtin_parse_cache.currsize, 0)
 
-    def test_auto_short_strings_skip_cache(self):
-        # Short queries parse fast enough that caching isn't worth a slot.
-        parse_expr("count()")
-        self.assertEqual(_user_parse_cache.currsize, 0)
-        self.assertEqual(_builtin_parse_cache.currsize, 0)
-
     def test_user_pollution_does_not_displace_builtin(self):
         parse_select(
             "SELECT 'builtin entry' -- pollution test, plenty long enough to cache",
@@ -201,8 +195,13 @@ class TestParserCache(BaseTest):
         self.assertEqual(_user_parse_cache.currsize, 0)
 
     def test_syntax_errors_are_not_cached(self):
+        # SQL has to clear `_MIN_CACHEABLE_STATEMENT_LEN`; otherwise the
+        # length gate masks the error-path skip we're trying to verify.
         with self.assertRaises(BaseHogQLError):
-            parse_select("NOT VALID SQL", cache_origin=CacheOrigin.USER)
+            parse_select(
+                "NOT VALID SQL -- padding to exceed the minimum cacheable length",
+                cache_origin=CacheOrigin.USER,
+            )
         self.assertEqual(_user_parse_cache.currsize, 0)
         self.assertEqual(_builtin_parse_cache.currsize, 0)
 
@@ -216,4 +215,19 @@ class TestParserCache(BaseTest):
         parse_select(sql, cache_origin=prior_origin)
         with patch("posthog.hogql.parser._looks_like_code_literal") as detector:
             parse_select(sql)
+            detector.assert_not_called()
+
+    @parameterized.expand(
+        [
+            (CacheOrigin.BUILTIN, "hello {x} world, prior built-in template entry, long enough"),
+            (CacheOrigin.USER, "hello {x} world, prior user template entry, also long enough"),
+        ]
+    )
+    def test_parse_string_template_skips_frame_walk_on_hit(self, prior_origin, template):
+        # The cache key is the runtime-concatenated `"F'" + template`, but
+        # the classifier must still run only on the cold path — otherwise
+        # warm template hits pay the 40-frame walk every call.
+        parse_string_template(template, cache_origin=prior_origin)
+        with patch("posthog.hogql.parser._looks_like_code_literal") as detector:
+            parse_string_template(template)
             detector.assert_not_called()

--- a/posthog/hogql/test/test_parser_cache.py
+++ b/posthog/hogql/test/test_parser_cache.py
@@ -70,7 +70,7 @@ class TestParserCache(BaseTest):
     def test_user_pollution_does_not_displace_builtin(self):
         # Fill the built-in cache with one entry, then flood the user cache.
         parse_select("SELECT 'builtin entry'", cache_origin=CacheOrigin.BUILTIN)
-        user_maxsize = _user_parse_cache.maxsize
+        user_maxsize = int(_user_parse_cache.maxsize)
         for i in range(user_maxsize + 50):
             parse_select(f"SELECT {i}", cache_origin=CacheOrigin.USER)
         # Built-in cache still has its entry; user cache is at maxsize.

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -15,7 +15,7 @@ from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.filters import replace_filters
-from posthog.hogql.parser import parse_select
+from posthog.hogql.parser import CacheOrigin, parse_select
 from posthog.hogql.placeholders import find_placeholders, replace_placeholders
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.user_query_validator import validate_user_query
@@ -59,7 +59,17 @@ class HogQLQueryRunner(AnalyticsQueryRunner[HogQLQueryResponse]):
             {key: ast.Constant(value=value) for key, value in self.query.values.items()} if self.query.values else None
         )
         with self.timings.measure("parse_select"):
-            parsed_select = parse_select(self.query.query, timings=self.timings, placeholders=values)
+            # `self.query.query` is a user-supplied HogQL string from the API
+            # (insight definitions, dashboard queries, ad-hoc explorations).
+            # Mark as USER explicitly so it bypasses the call-stack literal
+            # detection and lands in the protected user cache regardless of
+            # how this method gets called.
+            parsed_select = parse_select(
+                self.query.query,
+                timings=self.timings,
+                placeholders=values,
+                cache_origin=CacheOrigin.USER,
+            )
 
         finder = find_placeholders(parsed_select)
         with self.timings.measure("filters"):

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -59,11 +59,6 @@ class HogQLQueryRunner(AnalyticsQueryRunner[HogQLQueryResponse]):
             {key: ast.Constant(value=value) for key, value in self.query.values.items()} if self.query.values else None
         )
         with self.timings.measure("parse_select"):
-            # `self.query.query` is a user-supplied HogQL string from the API
-            # (insight definitions, dashboard queries, ad-hoc explorations).
-            # Mark as USER explicitly so it bypasses the call-stack literal
-            # detection and lands in the protected user cache regardless of
-            # how this method gets called.
             parsed_select = parse_select(
                 self.query.query,
                 timings=self.timings,

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -947,13 +947,80 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.2

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -473,7 +473,15 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.person_id,
+               events.`mat_$browser`,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-14'), lessOrEquals(toDate(events.timestamp), '2024-01-18'))) AS events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'America/Sao_Paulo')), max(toTimeZone(raw_sessions.max_timestamp, 'America/Sao_Paulo'))), 10)))) AS `$is_bounce`,
@@ -489,7 +497,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'America/Sao_Paulo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/Sao_Paulo'))), lessOrEquals(toTimeZone(events.timestamp, 'America/Sao_Paulo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/Sao_Paulo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'America/Sao_Paulo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/Sao_Paulo'))), lessOrEquals(toTimeZone(events.timestamp, 'America/Sao_Paulo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/Sao_Paulo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`


### PR DESCRIPTION
## Problem

See this trace https://posthog.slack.com/archives/C076E99B152/p1778517796601029

It's not uncommon for us to spend nearly half of the time servicing a request just parsing hogql.

Let's try to reduce some of this work by adding a hogql parsing cache.

I've split the cache into two, one is for user-generated hogql, and one is for built-in hogql, so user queries won't evict our built-in queries. These can be auto-detected with decent reliability by checking whether the string exists as a constant in the python backtrace, though it's fine for this to be best-effort only, as the behaviour is correct either way.

## Changes

Memoize the parsed AST keyed on `(statement, backend, rule[, start])`. Return a `copy.deepcopy` on hit so the cached entry can't be mutated by downstream resolve/print passes.

**Two separate LRU caches** so user-generated queries can't displace built-in ones:

- `_BUILTIN_CACHE` (maxsize=256) — queries originating from in-process code literals.
- `_USER_CACHE` (maxsize=512) — everything else (user input, dynamically composed SQL, file content).

**Fast path: check both caches before frame walk.** With `cache_origin=AUTO` (the default), we look in the built-in cache first, then the user cache, and only walk the call stack to classify the query on a full miss. The frame walk is now on the cold path, not the hot one.

**Origin is autodetected** by walking the call stack and identity-checking the input string against each frame's `co_consts`. Python literals end up as the same string object every call; runtime-constructed strings don't. Callers can override via the new `cache_origin: CacheOrigin` kwarg (`CacheOrigin.AUTO` / `BUILTIN` / `USER`).

Known limitations of auto-detect (false negatives, safely fall to user cache; explicit `cache_origin=CacheOrigin.BUILTIN` overrides):
- **Module-level constants** referenced via `LOAD_GLOBAL` — those frames aren't on the active stack at call time.
- **Class-level constants** — same.
- **Strings loaded from disk/JSON/YAML** — correctly user-classified, but might surprise people if the intent was "trusted built-in."

**Size bounds.** Statements outside `[40, 4096]` chars skip the cache. Below 40, parsing is fast enough that caching adds no measurable speedup and would just churn slots. Above 4096, we bound worst-case memory growth from user-controlled inputs (Django allows 20 MB request bodies). Explicit `cache_origin=BUILTIN` bypasses the upper bound only — trusted opt-in for in-code templates that run past 4 KiB. Skipped statements parse fresh and emit a `result="skip"` Counter event.

The cache itself is a tiny `_BoundedLRU` backed by `OrderedDict` — picked over `functools.lru_cache` because we want a non-mutating peek for the both-caches-first fast path.

## Observability

Four Prometheus metrics:

| Metric | Type | Labels | What it tells you |
|---|---|---|---|
| `hogql_parse_cache_events_total` | Counter | `origin`, `result`, `rule` | Hit/miss/skip rate, broken down by cache and parse rule |
| `hogql_parse_cache_size` | Gauge | `cache` | Current entries per cache (updated on miss) |
| `hogql_parse_cache_maxsize` | Gauge | `cache` | Configured cap (constant per deploy) |
| `hogql_parse_statement_length_chars` | Histogram | `rule` | Distribution of statement lengths in characters; bucket boundaries are aligned to the cache size bounds (40 and 4096) |

Caveat on the `origin` label: `result="skip"` events fire before the AUTO origin is resolved (we don't want to walk the stack just to label a skip), so AUTO-origin skips land in `origin="auto"`. Hits/misses are always labelled `builtin` or `user`. Filter `{result!="skip"}` when computing hit-rate by origin so the breakdown doesn't pick up a phantom 0% `auto` row.

### PromQL examples

```promql
# Overall hit rate over the last 5m
sum(rate(hogql_parse_cache_events_total{result="hit"}[5m]))
  / sum(rate(hogql_parse_cache_events_total[5m]))

# Hit rate broken down by cache origin (exclude skips — they're labelled
# with the unresolved AUTO origin and would distort the breakdown).
sum by (origin) (rate(hogql_parse_cache_events_total{result="hit"}[5m]))
  / sum by (origin) (rate(hogql_parse_cache_events_total{result!="skip"}[5m]))

# Hit rate per parse rule (parse_select vs parse_expr vs ...)
sum by (rule) (rate(hogql_parse_cache_events_total{result="hit"}[5m]))
  / sum by (rule) (rate(hogql_parse_cache_events_total[5m]))

# Capacity utilization — alert if user cache is saturated
hogql_parse_cache_size / hogql_parse_cache_maxsize

# p50 / p99 statement length per rule (sanity-check whether the 4 KiB cap is biting)
histogram_quantile(0.50, sum by (rule, le) (rate(hogql_parse_statement_length_chars_bucket[5m])))
histogram_quantile(0.99, sum by (rule, le) (rate(hogql_parse_statement_length_chars_bucket[5m])))

# Fraction of statements above the 4 KiB upper bound (cache-skip candidates from user/auto)
sum(rate(hogql_parse_statement_length_chars_count[5m]))
  -
sum(rate(hogql_parse_statement_length_chars_bucket{le="4096"}[5m]))
```

If the user cache stays consistently at 100% utilization, that's the signal to bump `_USER_CACHE_SIZE`. If the length histogram shows a meaningful tail above 4 KiB, that's the signal to revisit `_MAX_CACHEABLE_STATEMENT_LEN`.

## How did you test this code?

I am an agent.

- `hogli test posthog/hogql/test/test_parser_cache.py posthog/hogql/test/test_parser_cpp_json.py posthog/hogql/test/test_parser_python.py` — 27 cache tests + 192 cpp-json + 191 python = 410 total pass. The cpp-json suite is the round-trip safety net: every query in it goes through the cache twice (warm + assertion) and the AST equality check confirms the deepcopy returns equivalent ASTs.
- mypy / ruff / `uv run ty check` all clean.

### Cache-hit benchmark (median of 5 × 200 iterations)

| query                 | cold parse | cache hit | speedup    |
| --------------------- | ---------: | --------: | ---------: |
| tiny                  |   0.390 ms | 0.014 ms  | **28.5×**  |
| events_simple         |   1.545 ms | 0.030 ms  | **51.7×**  |
| events_in_clause      |   1.915 ms | 0.037 ms  | **51.3×**  |
| join_persons          |   4.572 ms | 0.054 ms  | **85.0×**  |
| subquery_with_filters |  11.981 ms | 0.115 ms  | **104.5×** |
| trends_like_breakdown |  21.835 ms | 0.181 ms  | **120.4×** |
| pathological_deep     |  20.135 ms | 0.213 ms  | **94.6×**  |

Hit cost (14–213 µs) is dominated by `copy.deepcopy`, which scales with AST node count. ANTLR + C++ FFI is intrinsically 15–35× more expensive than the deepcopy on the same input, so the cache is unambiguously cheaper than re-parsing on any cache hit.

### Tests cover

- Cache hit returns an equivalent (`==`) but distinct (`is not`) AST.
- Mutation of the returned AST doesn't leak to subsequent cache hits.
- `CacheOrigin.BUILTIN`/`USER` route to the right cache.
- Auto-detect classifies function-local literals as built-in and `.join`-constructed strings as user.
- Flooding the user cache with unique queries doesn't evict the built-in entry.
- Placeholders still substitute correctly after a cache hit.
- `parse_expr` is cached separately per `start` arg.
- Syntax errors are not cached (re-parsed on every call) — input padded past the length gate so the test isn't trivially satisfied.
- The frame-walk classifier is NOT invoked on auto-mode cache hits — for both `parse_select` and `parse_string_template` (the latter routes the raw template into the classifier via `classify_input` so the cold-path optimization works for templates too).
- Statements below 40 chars skip the cache for every origin (BUILTIN included); statements above 4 KiB skip for AUTO/USER but still cache for explicit BUILTIN.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Opus 4.7 (1M context). Path of investigation:

1. After speeding up the Python deserializer in #58267, the remaining HogQL parse cost is intrinsic to ANTLR4 — 97–99% of the C++ phase is the parser itself, which can't be shaved without a parser rewrite.
2. Caching by SQL string is the obvious next move because production query traffic is dominated by repeated templated queries (insight series, dashboard reloads).
3. Bias toward correctness: returned a deepcopy rather than reusing the cached AST, because `resolve_types` / `print_ast` mutate fields in place. Deepcopy is 15–35× cheaper than re-parsing on every measured query size.
4. The "two caches with separate origins" design is to prevent user queries from displacing hot built-in entries. The auto-detect via `co_consts` is a best-effort heuristic — false negatives are safe (fall to user cache); the explicit `cache_origin` kwarg covers the edge cases.
5. Reordering the fast path to check both caches before the frame walk required dropping `functools.lru_cache` for a small `OrderedDict`-backed `_BoundedLRU`, since `functools.lru_cache` fills on every call. The tiny class is well within the cost budget — `OrderedDict.move_to_end` is O(1) under the GIL.

Decisions:

- Cache sizes (256/512) are seeded estimates — the Prometheus counter + gauges will let us see real hit rates and tune.
- Cache key includes `backend` so `python` and `cpp-json` are cached separately (different ASTs in principle).
- Did not cache by `(statement, placeholders)` — placeholders are substituted *after* the cached parse on each call. Cleaner separation and the cache works regardless of placeholder content.
- Length bounds (40 / 4096) are deliberately tighter than memory would force — the deepest pathological query in the benchmark suite is <5 KiB, so 4 KiB covers all observed real queries while keeping per-entry footprint small. BUILTIN bypass on the upper bound exists for in-code templates that legitimately run long.
- The length histogram makes both bounds revisable: if the 99p sits well below 4 KiB we can tighten further; if there's a meaningful tail above, we can loosen.
- `parse_string_template` keys the cache on `"F'" + string` (the runtime concat used internally) but classifies on the raw `string` via a `classify_input` kwarg on `_parse_cached`. Without this, the AUTO frame walk would run on every template call instead of only on cache misses.
