### PR TITLE
perf(api): warm redis cluster client at worker startup

### DIFF
--- a/posthog/asgi.py
+++ b/posthog/asgi.py
@@ -33,11 +33,13 @@ def _ensure_post_fork_init():
     if _post_fork_initialized:
         return
 
+    from posthog.caching.redis_cluster_connection_factory import warm_query_cache_connection
     from posthog.continuous_profiling import start_continuous_profiling
     from posthog.otel_instrumentation import initialize_otel
 
     start_continuous_profiling()
     initialize_otel()
+    warm_query_cache_connection()
     _post_fork_initialized = True
 
 

--- a/posthog/caching/redis_cluster_connection_factory.py
+++ b/posthog/caching/redis_cluster_connection_factory.py
@@ -1,7 +1,13 @@
 import threading
 
+from django.conf import settings
+from django.core.cache import caches
+
+import structlog
 from django_redis.pool import ConnectionFactory
 from redis.cluster import RedisCluster
+
+logger = structlog.get_logger(__name__)
 
 
 class RedisClusterConnectionFactory(ConnectionFactory):
@@ -28,3 +34,25 @@ class RedisClusterConnectionFactory(ConnectionFactory):
 
     def disconnect(self, connection) -> None:
         connection.close()
+
+
+def warm_query_cache_connection() -> None:
+    """
+    Force the query_cache RedisCluster client to instantiate at worker startup
+    so the first user request doesn't pay the CLUSTER SLOTS + COMMAND handshake.
+
+    Idempotent — django_redis caches the client per process after first use.
+    Safe to call before any request lands; the cluster client and its
+    per-node pools are created post-fork in WSGI (wsgi.py is imported per
+    worker) and post-spawn in Granian, so connection state isn't shared
+    across workers.
+    """
+    if settings.TEST or settings.STATIC_COLLECTION:
+        return
+    if "query_cache" not in settings.CACHES:
+        return
+
+    try:
+        caches["query_cache"].get("__startup_warmup__")
+    except Exception:
+        logger.warning("query_cache_warmup_failure", exc_info=True)

--- a/posthog/caching/test/test_redis_cluster_connection_factory.py
+++ b/posthog/caching/test/test_redis_cluster_connection_factory.py
@@ -1,0 +1,54 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+from parameterized import parameterized
+
+from posthog.caching.redis_cluster_connection_factory import warm_query_cache_connection
+
+
+class TestWarmQueryCacheConnection(TestCase):
+    @parameterized.expand(
+        [
+            ("test_mode", {"TEST": True, "STATIC_COLLECTION": False}),
+            ("static_collection", {"TEST": False, "STATIC_COLLECTION": True}),
+        ]
+    )
+    @patch("posthog.caching.redis_cluster_connection_factory.caches")
+    def test_skips_in_excluded_modes(self, _name: str, settings_override: dict, mock_caches):
+        with override_settings(CACHES={"query_cache": {"BACKEND": "fake"}}, **settings_override):
+            warm_query_cache_connection()
+
+        mock_caches.__getitem__.assert_not_called()
+
+    @patch("posthog.caching.redis_cluster_connection_factory.caches")
+    def test_skips_when_query_cache_not_configured(self, mock_caches):
+        with override_settings(TEST=False, STATIC_COLLECTION=False, CACHES={"default": {"BACKEND": "fake"}}):
+            warm_query_cache_connection()
+
+        mock_caches.__getitem__.assert_not_called()
+
+    @patch("posthog.caching.redis_cluster_connection_factory.caches")
+    def test_triggers_query_cache_get_when_configured(self, mock_caches):
+        mock_backend = MagicMock()
+        mock_caches.__getitem__.return_value = mock_backend
+
+        with override_settings(TEST=False, STATIC_COLLECTION=False, CACHES={"query_cache": {"BACKEND": "fake"}}):
+            warm_query_cache_connection()
+
+        mock_caches.__getitem__.assert_called_once_with("query_cache")
+        mock_backend.get.assert_called_once_with("__startup_warmup__")
+
+    @patch("posthog.caching.redis_cluster_connection_factory.logger")
+    @patch("posthog.caching.redis_cluster_connection_factory.caches")
+    def test_swallows_exceptions_and_logs(self, mock_caches, mock_logger):
+        mock_backend = MagicMock()
+        mock_backend.get.side_effect = ConnectionError("redis down")
+        mock_caches.__getitem__.return_value = mock_backend
+
+        with override_settings(TEST=False, STATIC_COLLECTION=False, CACHES={"query_cache": {"BACKEND": "fake"}}):
+            warm_query_cache_connection()
+
+        mock_logger.warning.assert_called_once()
+        assert "query_cache_warmup_failure" in mock_logger.warning.call_args[0]

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -947,13 +947,80 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.2

--- a/posthog/wsgi.py
+++ b/posthog/wsgi.py
@@ -11,6 +11,7 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
+from posthog.caching.redis_cluster_connection_factory import warm_query_cache_connection
 from posthog.continuous_profiling import start_continuous_profiling
 from posthog.otel_instrumentation import initialize_otel
 
@@ -20,3 +21,4 @@ os.environ.setdefault("SERVER_GATEWAY_INTERFACE", "WSGI")
 start_continuous_profiling()
 initialize_otel()
 application = get_wsgi_application()
+warm_query_cache_connection()


### PR DESCRIPTION
## Problem

The `query_cache` backend uses `RedisClusterConnectionFactory` (see `posthog/caching/redis_cluster_connection_factory.py`), which lazy-initializes the cluster client on first use. APM traces of `insight_api_list` on `posthog-web-django` show the resulting `CLUSTER SLOTS` and `COMMAND` handshake (~80 ms combined) landing inside the first user request to hit a fresh worker. Because pods restart and worker processes recycle frequently, this cost reappears continuously in production tails rather than being a one-off startup cost.

## Changes

- New `warm_query_cache_connection()` helper in `posthog/caching/redis_cluster_connection_factory.py`. Triggers the factory's lazy init by issuing a single GET against the cache. No-op in `TEST` / `STATIC_COLLECTION` modes, no-op when `query_cache` isn't configured, and swallows any connection error so it can't break startup.
- `posthog/wsgi.py` calls the helper at module load (Nginx Unit imports the WSGI app per worker post-fork, so this runs once per worker before any request lands).
- `posthog/asgi.py` calls the helper from the existing `_ensure_post_fork_init()` alongside `start_continuous_profiling()` and `initialize_otel()`. For Granian (spawn), the post-fork hook fires on the first request to each worker — same cost shape as today, just consolidated into a known init point.

## How did you test this code?

I am an agent. I added 5 parameterized automated tests in `posthog/caching/test/test_redis_cluster_connection_factory.py`:

- no-op in `TEST` mode
- no-op in `STATIC_COLLECTION` mode
- no-op when `query_cache` is not configured
- happy path triggers `caches["query_cache"].get("__startup_warmup__")` exactly once
- exceptions are swallowed and logged

## Publish to changelog?

no

## Docs update

No docs change needed — internal performance optimization.

## 🤖 Agent context

Authored by an agent (PostHog Code) under human direction.

Tools used: PostHog MCP (`query-apm-spans`, `apm-trace-get`) to identify the `CLUSTER SLOTS` + `COMMAND` cost inside `insight_api_list`, then `Grep`/`Read`/`Edit` to find the Redis configuration and wire the warmup, and `hogli test` to run the targeted tests. A research subagent traced the Nginx Unit / Granian fork-vs-spawn behaviour and the per-worker init lifecycle.

Decisions along the way:

- **Trigger init via a real `cache.get(...)`** rather than touching the `ConnectionFactory` directly — `cache.get()` exercises the full Django cache path (`get_client` → `connect` → `RedisCluster.from_url`) the same way a real request would, so any breakage shows up here rather than in production traffic.
- **Idempotent + permissive**. The helper short-circuits in `TEST` / `STATIC_COLLECTION` / when the cache isn't configured, and swallows exceptions. If Redis is unreachable at startup we log a warning but don't crash the worker; the first real request would have failed the same way previously.
- **Both `wsgi.py` and `asgi.py` are wired.** Production is WSGI (Nginx Unit), which is where the trace evidence came from, but adding the ASGI call costs nothing and keeps Granian / future ASGI deployments coherent.
- **No timeout on the warmup**. The factory uses redis-py's default cluster connect timeout; wrapping in a separate timeout layer would obscure failures and slow the worker only on the unhappy path.
