### PR TITLE
feat(insights): show share-of-total on horizontal bar and fix pie tooltip percent

### DIFF
--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -117,6 +117,9 @@ export const formatAggregationAxisValueWithShareOfTotal = (
     if (aggregationAxisFormat === 'percentage' || aggregationAxisFormat === 'percentage_scaled') {
         return formatted
     }
+    if (!total) {
+        return formatted
+    }
     const shareOfTotal = parseFloat(((Number(value) / total) * 100).toFixed(1))
     return `${formatted} (${shareOfTotal}%)`
 }

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -101,6 +101,26 @@ export const formatPercentStackAxisValue = (
     return formatAggregationAxisValue(trendsFilter, value, currency)
 }
 
+// Formats a value and appends its share of the total, e.g. "1,234 (37.5%)".
+// Skips the share-of-total suffix when the axis is already formatted as a percentage
+// to avoid confusing output like "37% (60%)" (metric value vs share of total).
+export const formatAggregationAxisValueWithShareOfTotal = (
+    trendsFilter: TrendsFilter | null | undefined | Partial<TrendsFilterType>,
+    value: number | string,
+    total: number,
+    currency?: CurrencyCode
+): string => {
+    const formatted = formatAggregationAxisValue(trendsFilter, value, currency)
+    const aggregationAxisFormat =
+        (trendsFilter as TrendsFilter)?.aggregationAxisFormat ??
+        (trendsFilter as Partial<TrendsFilterType>)?.aggregation_axis_format
+    if (aggregationAxisFormat === 'percentage' || aggregationAxisFormat === 'percentage_scaled') {
+        return formatted
+    }
+    const shareOfTotal = parseFloat(((Number(value) / total) * 100).toFixed(1))
+    return `${formatted} (${shareOfTotal}%)`
+}
+
 export const axisLabel = (chartDisplayType: ChartDisplayType | null | undefined): string => {
     switch (chartDisplayType) {
         case ChartDisplayType.ActionsLineGraph:

--- a/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
@@ -1,4 +1,7 @@
-import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import {
+    formatAggregationAxisValue,
+    formatAggregationAxisValueWithShareOfTotal,
+} from 'scenes/insights/aggregationAxisFormat'
 
 import { CurrencyCode } from '~/queries/schema/schema-general'
 import { FilterType } from '~/types'
@@ -63,6 +66,65 @@ describe('formatAggregationAxisValue', () => {
                     testcase.filters as Partial<FilterType>,
                     testcase.candidate,
                     testcase.currency
+                )
+            ).toEqual(testcase.expected)
+        })
+    })
+})
+
+describe('formatAggregationAxisValueWithShareOfTotal', () => {
+    const shareTestcases = [
+        { candidate: 250, total: 1000, filters: {}, expected: '250 (25%)' },
+        { candidate: 333, total: 1000, filters: {}, expected: '333 (33.3%)' },
+        { candidate: 1000, total: 1000, filters: {}, expected: '1,000 (100%)' },
+        {
+            candidate: 250,
+            total: 1000,
+            filters: { aggregation_axis_format: 'numeric' },
+            expected: '250 (25%)',
+        },
+        {
+            candidate: 250,
+            total: 1000,
+            filters: { aggregation_axis_format: 'currency' },
+            expected: '$250.00 (25%)',
+        },
+        {
+            candidate: 60,
+            total: 100,
+            filters: { aggregation_axis_format: 'duration' },
+            expected: '1m (60%)',
+        },
+        // Percentage axis formats already render a % suffix, so we skip share-of-total to avoid "37% (60%)".
+        {
+            candidate: 37,
+            total: 100,
+            filters: { aggregation_axis_format: 'percentage' },
+            expected: '37%',
+        },
+        {
+            candidate: 0.37,
+            total: 1,
+            filters: { aggregation_axis_format: 'percentage_scaled' },
+            expected: '37%',
+        },
+        {
+            candidate: 37,
+            total: 100,
+            filters: { aggregationAxisFormat: 'percentage' },
+            expected: '37%',
+        },
+    ]
+
+    shareTestcases.forEach((testcase) => {
+        it(`correctly formats "${testcase.candidate}" of total ${testcase.total} as ${
+            testcase.expected
+        } when filters are ${JSON.stringify(testcase.filters)}`, () => {
+            expect(
+                formatAggregationAxisValueWithShareOfTotal(
+                    testcase.filters as Partial<FilterType>,
+                    testcase.candidate,
+                    testcase.total
                 )
             ).toEqual(testcase.expected)
         })

--- a/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
@@ -114,6 +114,9 @@ describe('formatAggregationAxisValueWithShareOfTotal', () => {
             filters: { aggregationAxisFormat: 'percentage' },
             expected: '37%',
         },
+        // When total is zero (or otherwise falsy), skip the share-of-total to avoid "NaN%".
+        { candidate: 0, total: 0, filters: {}, expected: '0' },
+        { candidate: 0, total: 0, filters: { aggregation_axis_format: 'currency' }, expected: '$0.00' },
     ]
 
     shareTestcases.forEach((testcase) => {

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -16,7 +16,10 @@ import {
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import { useChart } from 'lib/hooks/useChart'
 import { isString } from 'lib/utils'
-import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import {
+    formatAggregationAxisValue,
+    formatAggregationAxisValueWithShareOfTotal,
+} from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -245,14 +248,12 @@ export function PieChart({
                                                         (a: number, b: number) => a + b,
                                                         0
                                                     )
-                                                    const percentageLabel: number = parseFloat(
-                                                        ((value / total) * 100).toFixed(1)
-                                                    )
-                                                    return `${formatAggregationAxisValue(
+                                                    return formatAggregationAxisValueWithShareOfTotal(
                                                         trendsFilter,
                                                         value,
+                                                        total,
                                                         baseCurrency
-                                                    )} (${percentageLabel}%)`
+                                                    )
                                                 })
                                             }
                                             hideInspectActorsSection={!onClick || !showPersonsModal}

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -1,8 +1,10 @@
 import { useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
+import { teamLogic } from 'scenes/teamLogic'
 import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
 
 import { cohortsModel } from '~/models/cohortsModel'
@@ -28,6 +30,7 @@ export function ActionsHorizontalBar({
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
     const { insightProps } = useValues(insightLogic)
+    const { baseCurrency } = useValues(teamLogic)
     const {
         indexedResults,
         labelGroupType,
@@ -94,6 +97,11 @@ export function ActionsHorizontalBar({
             tooltip={{
                 showHeader: false,
                 groupTypeLabel: context?.groupTypeLabel,
+                renderCount: (value: number): string => {
+                    const formatted = formatAggregationAxisValue(trendsFilter, value, baseCurrency)
+                    const percentage = ((value / total) * 100).toFixed(1)
+                    return `${formatted} (${percentage}%)`
+                },
             }}
             labelGroupType={labelGroupType}
             datasets={data}

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import { formatAggregationAxisValueWithShareOfTotal } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { teamLogic } from 'scenes/teamLogic'
@@ -97,11 +97,8 @@ export function ActionsHorizontalBar({
             tooltip={{
                 showHeader: false,
                 groupTypeLabel: context?.groupTypeLabel,
-                renderCount: (value: number): string => {
-                    const formatted = formatAggregationAxisValue(trendsFilter, value, baseCurrency)
-                    const percentage = ((value / total) * 100).toFixed(1)
-                    return `${formatted} (${percentage}%)`
-                },
+                renderCount: (value: number): string =>
+                    formatAggregationAxisValueWithShareOfTotal(trendsFilter, value, total, baseCurrency),
             }}
             labelGroupType={labelGroupType}
             datasets={data}


### PR DESCRIPTION
## Problem

Two related issues with the share-of-total in insight tooltips:

1. The horizontal bar chart only displays absolute aggregated values, both inline and on hover. This came in as customer feedback and matches the horizontal-bar gap already flagged in [#21119](https://github.com/PostHog/posthog/issues/21119). Other chart types already cover this: vertical bars, area, and pie support the `% stack view` toggle; line charts have the unit picker. Horizontal bar is the only display type with no way to read percentages.
2. The pie chart tooltip already shows share-of-total, but when the aggregation axis is itself a percentage (e.g. `aggregationAxisFormat = 'percentage'`) it renders confusingly as `"37% (60%)"`, where the two percentages mean different things (the metric value vs. the share of the total).

## Changes

*   `ActionsHorizontalBar` now wires the already-computed total across visible bars into the existing `renderCount` tooltip override, so hovering a bar shows e.g. `1,234 (37.5%)` instead of just `1,234`.
*   Extracted a shared `formatAggregationAxisValueWithShareOfTotal` helper in `aggregationAxisFormat.ts` that appends the share-of-total only when the axis is not already a percentage, and skips the suffix when the total is zero to avoid `NaN%`.
*   `PieChart` now calls the helper too, so the two charts stay in sync going forward and the `"37% (60%)"` case renders as `"37%"`.
*   Added parameterized unit tests for the helper covering numeric, currency, duration, percentage, and percentage_scaled formats (both camelCase and snake_case filter shapes), plus the zero-total case.

Note: this only addresses the _on hover_ half of [#21119](https://github.com/PostHog/posthog/issues/21119). The broader `absolute ↔ percentage` toggle (axis, value labels, etc.) is a UX call that should be designed separately.

## How did you test this code?

Ran the touched unit tests locally (`frontend/src/scenes/insights/aggregationAxisFormats.test.ts`), all 31 cases pass. TypeScript check on the touched files reports no new errors (pre-existing implicit-any warnings in `ActionsHorizontalBar.tsx` are unchanged).

### Manual testing suggestion:

*    Open a Trends insight with at least 2 series (or one series with a breakdown), switch display type to **Horizontal bar**.
*    Hover any bar: tooltip should show `<absolute> (<percentage>%)` on the same line as the value. The percentages across all visible bars should sum to ~100% (small rounding aside).
*    Hide a series via the legend and hover again: percentages should rebalance across the remaining visible bars.
*    Try with a currency aggregation (e.g. `sum(revenue)` with a currency unit configured): absolute value should still render with the currency symbol followed by `(xx.x%)`.
*    Set the insight's unit to **Percent (0-100)** or **Percent (0-1)** and hover a bar: tooltip should show just `37%` (no `(60%)` suffix). Repeat for the **Pie** display type — same behavior.

## Publish to changelog?

No.

## Docs update

No.

## 🤖 Agent context

Co-authored by PostHog Code (Claude Opus 4.7)
