### PR TITLE
chore(web-analytics): log team_ids before pre-aggregation insert

### DIFF
--- a/products/web_analytics/dags/web_preaggregated.py
+++ b/products/web_analytics/dags/web_preaggregated.py
@@ -108,6 +108,7 @@ def pre_aggregate_web_analytics_data(
         )
 
         context.log.info(f"Populating staging table with hourly data from {date_start} to {date_end}")
+        context.log.info(f"Processing {len(team_ids) if team_ids else 0} team_ids: {team_ids}")
         context.log.info(insert_query)
         with tags_context(product=ProductKey.WEB_ANALYTICS, feature=Feature.PREAGGREGATION):
             sync_execute(insert_query)


### PR DESCRIPTION
## Problem

Debugging a failing Dagster run on the web analytics pre-aggregation job (`web_pre_aggregate_current_day_schedule`, run `6dc54e6c-bdb5-4a01-8307-c58e54cbb288`, partition `2026-05-11`). Currently we log the full insert query but not a clear summary of which `team_ids` are being processed, which makes it harder to correlate failures with the team selection input.

## Changes

Add a single log line right before the insert runs that prints the count and full list of `team_ids` being processed (or `None`/`0` when falling back to the ClickHouse dictionary configuration).

## How did you test this code?

I'm an agent — no manual testing performed. No automated tests added; this is a logging-only change inside the existing Dagster asset code path.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude)
- Human prompt: add a log on the web analytics pre-aggregated job for printing all the team_ids before running the query, to help debug a failing Dagster run.
- Decision: log both `len(team_ids)` and the list itself, guarded against `team_ids` being `None` (the schema marks it `is_required=False` with no default, so `config.get("team_ids")` returns `None` when the SQL falls back to the ClickHouse dictionary).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*