### PR TITLE
feat(navigation): remove scene tabs UI strip

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.scss
+++ b/frontend/src/layout/navigation-3000/Navigation.scss
@@ -711,10 +711,7 @@
     /* Default, overridden via inline style */
 
     display: grid;
-    grid-template: 'left top' var(--scene-layout-header-height) 'left content' 1fr / var(--left-nav-width) minmax(
-            0,
-            1fr
-        );
+    grid-template: 'left content' 1fr / var(--left-nav-width) minmax(0, 1fr);
     height: 100vh;
     overflow: hidden;
 
@@ -724,7 +721,7 @@
 
     /* Mobile layout - single column with overlay nav */
     &.app-layout--mobile {
-        grid-template: 'top' var(--scene-layout-header-height) 'content' 1fr / minmax(0, 1fr);
+        grid-template: 'content' 1fr / minmax(0, 1fr);
 
         .main-content-container {
             margin-right: 0;
@@ -734,10 +731,6 @@
 
 .left-nav {
     grid-area: left;
-}
-
-.top-nav {
-    grid-area: top;
 }
 
 .main-content-container {

--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -18,7 +18,6 @@ import { ProjectNotice } from '../navigation/ProjectNotice'
 import { SceneTitlePanelButton } from '../scenes/components/SceneTitleSection'
 import { SceneLayout } from '../scenes/SceneLayout'
 import { sceneLayoutLogic } from '../scenes/sceneLayoutLogic'
-import { SceneTabs } from '../scenes/SceneTabs'
 import { MinimalNavigation } from './components/MinimalNavigation'
 import { navigation3000Logic } from './navigationLogic'
 import { SidePanel } from './sidepanel/SidePanel'
@@ -129,10 +128,6 @@ export function Navigation({
             >
                 <ProjectDragAndDropProvider>
                     <PanelLayout className="left-nav" />
-
-                    <div className="top-nav h-[var(--scene-layout-header-height)] sticky top-0 z-[var(--z-main-nav)] flex justify-center items-start mt-px">
-                        <SceneTabs />
-                    </div>
 
                     <div
                         className={cn(


### PR DESCRIPTION
## Problem

This PR explores what happens if we kill scene tabs in PostHog. Tabs were never gated behind a feature flag and have become a permanent fixture of the top nav, but their visible utility for many users is debatable.

The investigation found that there are effectively two layers:

- The **tab strip UI** — `SceneTabs.tsx`, `SceneTabContextMenu.tsx`, `SceneTabs.css`, `ConfigurePinnedTabsModal.tsx`, and the `<SceneTabs />` mount in `Navigation.tsx`.
- The **tabs _system_** — `sceneLogic.tsx` is effectively the app router, ~55 scene logics use `tabAwareScene` keyed by `tabId`, `tabAwareActionToUrl` / `tabAwareUrlToAction` suppress URL writes on inactive tabs, and `UserHomeSettings` backs pinned-tab sync.

Removing the UI is a 14-line change. Removing the system is a multi-week refactor touching ~60+ frontend files plus a backend model and migration. This PR takes the small option: stop rendering the tab strip while leaving the internal tab plumbing intact so the router and all scene keying keep working unchanged.

## Changes

- Remove the `<SceneTabs />` mount and its wrapper `<div className=\"top-nav ...\">` from `Navigation.tsx`.
- Drop the unused `SceneTabs` import.
- Collapse the `'left top' / 'left content'` grid into a single `'left content'` row in `Navigation.scss` (and the equivalent mobile-layout simplification), and drop the now-orphaned `.top-nav { grid-area: top; }` rule. The 40px `--scene-layout-header-height` CSS variable is preserved because it is still consumed by `DatabaseTree`, `Spinner`, `Max`, `ProjectHomepage`, `HomepageInput`, and the AI-first nav.

What survives untouched:

- `SceneTabs.tsx`, `SceneTabContextMenu.tsx`, `ConfigurePinnedTabsModal.tsx`, and `SceneTabs.css` files (now unrendered — easy to bring back, or to delete in a follow-up).
- `sceneLogic`'s tab reducer, `activeTabId`, `firstTabIsActive`, `tabAwareScene` keying, `tabId` on `SceneExport` / `LoadedScene`.
- `UserHomeSettings` model, migration, and API.
- Session-/localStorage entries for users who already have them.

`firstTabIsActive` is still consulted for the `lg:rounded-tl-none` / `rounded-tl-none` classes on `.main-content-container`. With the strip hidden the value resolves true for the single internal tab, which keeps the top-left corner unrounded — same visual shape as before, just without the tab strip on top.

## How did you test this code?

I'm an agent and did not perform manual testing. No automated tests were added — this is a UI-only mount removal. The changes were verified by inspection: confirmed `SceneTabs` is no longer imported anywhere in the frontend, confirmed `.top-nav` was only referenced in the deleted grid rule, and confirmed `--scene-layout-header-height` consumers outside the deleted grid template are unaffected (they read a CSS variable that still exists with the same value).

Recommended manual smoke before merging: load any scene in `mode === 'full'` and confirm no empty 40px strip at the top, no layout shift on the rounded top-left corner, and that mobile layout still renders the main content area edge-to-edge.

## Publish to changelog?

no — this is exploratory; if we decide to keep the change long-term we can revisit and ship a follow-up that fully deletes the dead tab files and backend model.

## Docs update

No docs update needed.

## 🤖 Agent context

Authored by PostHog Code in response to a prompt asking what the impact of killing tabs would be, and to remove the tabs UI if the impact wasn't drastic.

Decisions made:

- Considered fully ripping out the tabs system. Rejected because `sceneLogic` is the router and ~55 scene logics use `tabAwareScene` keying — a full removal would be a multi-PR refactor and out of scope for an exploratory \"kill the UI\" change.
- Considered leaving the empty 40px top-nav div in place to avoid touching the grid template. Rejected because that leaves a visible empty strip; collapsing the grid row is a cleaner UI outcome.
- Considered preserving `.top-nav` as a defensive selector. Removed because grep confirmed no other consumer.

All changes are agent-authored. Requires human review before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*