### PR TITLE
chore(web-analytics): Move Web Analytics Live Filters under same feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -491,7 +491,6 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_HEALTH_TAB: 'web_analytics_health_tab', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_INCLUDE_HOST: 'web-analytics-include-host', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_LIVE_CITY_BREAKDOWN: 'web-analytics-live-city-breakdown', // owner: @jordanm-posthog #team-web-analytics
-    WEB_ANALYTICS_LIVE_DOMAIN_FILTER: 'web-analytics-live-domain-filter', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_EDIT_LAYOUT: 'web-analytics-live-edit-layout', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_FILTERS: 'web-analytics-live-filters', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_MAP: 'web-analytics-live-map', // owner: @jordanm-posthog #team-web-analytics

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
@@ -77,28 +77,19 @@ const LiveDashboardFilterRow = (): JSX.Element | null => {
     const { countryFilter, referrerFilter, deviceTypeFilter, validatedDomainFilter } = useValues(webAnalyticsLogic)
     const { setCountryFilter, setReferrerFilter, setDeviceTypeFilter, setDomainFilter } = useActions(webAnalyticsLogic)
 
-    const showDomainFilter = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_DOMAIN_FILTER]
     const showLiveFilters = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_FILTERS]
 
-    if (!showDomainFilter && !showLiveFilters) {
+    if (!showLiveFilters) {
         return null
     }
 
-    if (!showLiveFilters) {
-        return (
-            <div className="mb-4">
-                <WebAnalyticsDomainSelector />
-            </div>
-        )
-    }
-
     const referrerSuggestions = topReferrers.map((r: { referrer: string }) => r.referrer).filter(Boolean)
-    const hasDomainFilter = showDomainFilter && !!validatedDomainFilter && validatedDomainFilter !== 'all'
+    const hasDomainFilter = !!validatedDomainFilter && validatedDomainFilter !== 'all'
     const hasFilters = !!(countryFilter || referrerFilter || deviceTypeFilter || hasDomainFilter)
 
     return (
         <div className="mb-4 flex flex-wrap items-center gap-2">
-            {showDomainFilter && <WebAnalyticsDomainSelector />}
+            <WebAnalyticsDomainSelector />
             <WebAnalyticsLiveCountrySelector />
             <WebAnalyticsLiveDeviceToggle />
             <WebAnalyticsLiveReferrerSelector suggestions={referrerSuggestions} />

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -374,7 +374,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 if (productTab === ProductTab.BOT_ANALYTICS) {
                     return null
                 }
-                return featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_DOMAIN_FILTER] ? rawSelectedHost : null
+                return featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_FILTERS] ? rawSelectedHost : null
             },
         ],
         liveFilters: [
@@ -383,13 +383,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 rawLiveFilters: WebAnalyticsPropertyFilter[],
                 featureFlags: FeatureFlagsSet
             ): WebAnalyticsPropertyFilter[] => {
-                if (featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_FILTERS]) {
-                    return rawLiveFilters
-                }
-                if (featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_DOMAIN_FILTER]) {
-                    return rawLiveFilters.filter((f) => f.key === '$host')
-                }
-                return []
+                return featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_FILTERS] ? rawLiveFilters : []
             },
         ],
         hasActiveFilters: [
@@ -454,9 +448,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     dateTo: handoff,
                     filters: values.liveFilters,
                     includeCity: !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_CITY_BREAKDOWN],
-                    filtersEnabled:
-                        !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_FILTERS] ||
-                        !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_DOMAIN_FILTER],
+                    filtersEnabled: !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_FILTERS],
                 })
 
                 const bucketMap = new Map<number, SlidingWindowBucket>()

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -449,12 +449,15 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     recentUsersResponse,
                     botResponse,
                     cityResponse,
-                ] = await loadQueryData(
+                ] = await loadQueryData({
                     dateFrom,
-                    handoff,
-                    values.liveFilters,
-                    !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_CITY_BREAKDOWN]
-                )
+                    dateTo: handoff,
+                    filters: values.liveFilters,
+                    includeCity: !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_CITY_BREAKDOWN],
+                    filtersEnabled:
+                        !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_FILTERS] ||
+                        !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_DOMAIN_FILTER],
+                })
 
                 const bucketMap = new Map<number, SlidingWindowBucket>()
 
@@ -672,12 +675,19 @@ const startFlushInterval = (cache: FlushCache, actions: FlushActions): void => {
     }, FLUSH_INTERVAL_MS)
 }
 
-const loadQueryData = async (
-    dateFrom: Date,
-    dateTo: Date,
-    filters: WebAnalyticsPropertyFilter[],
+const loadQueryData = async ({
+    dateFrom,
+    dateTo,
+    filters,
+    includeCity,
+    filtersEnabled,
+}: {
+    dateFrom: Date
+    dateTo: Date
+    filters: WebAnalyticsPropertyFilter[]
     includeCity: boolean
-): Promise<
+    filtersEnabled: boolean
+}): Promise<
     [
         HogQLQueryResponse,
         HogQLQueryResponse,
@@ -690,12 +700,17 @@ const loadQueryData = async (
         HogQLQueryResponse | null,
     ]
 > => {
-    // The {filters} placeholder is expanded by HogQL into the property + date predicates.
-    // See HogQLFilters in queries/schema/schema-general.ts.
-    const hogQLFilters = {
-        properties: filters,
-        dateRange: { date_from: dateFrom.toISOString(), date_to: dateTo.toISOString() },
-    }
+    const whereClause = filtersEnabled
+        ? '{filters}'
+        : 'timestamp >= toDateTime({dateFrom}) AND timestamp <= toDateTime({dateTo})'
+    const queryParams: Pick<HogQLQuery, 'values' | 'filters'> = filtersEnabled
+        ? {
+              filters: {
+                  properties: filters,
+                  dateRange: { date_from: dateFrom.toISOString(), date_to: dateTo.toISOString() },
+              },
+          }
+        : { values: { dateFrom: dateFrom.toISOString(), dateTo: dateTo.toISOString() } }
 
     const botEligibleEventsTuple = `(${BOT_ELIGIBLE_EVENTS.map((e) => `'${e}'`).join(', ')})`
 
@@ -707,12 +722,12 @@ const loadQueryData = async (
                     countIf(event = '$pageview') AS pageviews,
                     countIf(event IN ${botEligibleEventsTuple}) AS bot_eligible_events
                 FROM events
-                WHERE {filters}
+                WHERE ${whereClause}
                 GROUP BY
                     minute_bucket
                 ORDER BY
                     minute_bucket ASC`,
-        filters: hogQLFilters,
+        ...queryParams,
     }
 
     const createBreakdownQuery = (property: string, alias: string): HogQLQuery => ({
@@ -741,7 +756,7 @@ const loadQueryData = async (
                             )
                         )) AS device_ids
                     FROM events
-                    WHERE {filters}
+                    WHERE ${whereClause}
                     GROUP BY
                         minute_bucket,
                         ${alias}
@@ -750,7 +765,7 @@ const loadQueryData = async (
                     minute_bucket
                 ORDER BY
                     minute_bucket ASC`,
-        filters: hogQLFilters,
+        ...queryParams,
     })
 
     const deviceQuery = createBreakdownQuery('$device_type', 'device_type')
@@ -770,7 +785,7 @@ const loadQueryData = async (
             date_from: dateFrom.toISOString(),
             date_to: dateTo.toISOString(),
         },
-        properties: filters,
+        properties: filtersEnabled ? filters : [],
     }
 
     const referrerQuery: HogQLQuery = {
@@ -780,11 +795,11 @@ const loadQueryData = async (
                     if(isNotNull(properties.$referring_domain) AND properties.$referring_domain != '', properties.$referring_domain, '$direct') AS referring_domain,
                     count() AS view_count
                 FROM events
-                WHERE {filters}
+                WHERE ${whereClause}
                     AND event = '$pageview'
                 GROUP BY minute_bucket, referring_domain
                 ORDER BY minute_bucket ASC`,
-        filters: hogQLFilters,
+        ...queryParams,
     }
 
     const geoQuery: HogQLQuery = {
@@ -802,7 +817,7 @@ const loadQueryData = async (
                         properties.$geoip_country_code AS country_code,
                         arrayDistinct(groupArray(distinct_id)) AS distinct_ids
                     FROM events
-                    WHERE {filters}
+                    WHERE ${whereClause}
                         AND properties.$geoip_country_code IS NOT NULL
                         AND properties.$geoip_country_code != ''
                     GROUP BY
@@ -811,7 +826,7 @@ const loadQueryData = async (
                 )
                 GROUP BY minute_bucket
                 ORDER BY minute_bucket ASC`,
-        filters: hogQLFilters,
+        ...queryParams,
     }
 
     // Aggregate per-minute first then re-group so the response is bounded by the
@@ -831,12 +846,12 @@ const loadQueryData = async (
                         toStartOfMinute(timestamp) AS minute_bucket,
                         concat(
                             \`$virt_bot_name\`,
-                            {botSeparator},
+                            '${BOT_KEY_SEPARATOR}',
                             ifNull(\`$virt_traffic_category\`, '')
                         ) AS bot_key,
                         count() AS event_count
                     FROM events
-                    WHERE {filters}
+                    WHERE ${whereClause}
                         AND \`$virt_is_bot\` = true
                         AND \`$virt_bot_name\` != ''
                         AND event IN ${botEligibleEventsTuple}
@@ -846,10 +861,7 @@ const loadQueryData = async (
                 )
                 GROUP BY minute_bucket
                 ORDER BY minute_bucket ASC`,
-        values: {
-            botSeparator: BOT_KEY_SEPARATOR,
-        },
-        filters: hogQLFilters,
+        ...queryParams,
     }
 
     const cityQuery: HogQLQuery | null = includeCity
@@ -867,12 +879,12 @@ const loadQueryData = async (
                         toStartOfMinute(timestamp) AS minute_bucket,
                         concat(
                             properties.$geoip_city_name,
-                            {citySeparator},
+                            '${CITY_KEY_SEPARATOR}',
                             ifNull(properties.$geoip_country_code, '')
                         ) AS city_key,
                         arrayDistinct(groupArray(distinct_id)) AS distinct_ids
                     FROM events
-                    WHERE {filters}
+                    WHERE ${whereClause}
                         AND properties.$geoip_city_name IS NOT NULL
                         AND properties.$geoip_city_name != ''
                     GROUP BY
@@ -881,18 +893,12 @@ const loadQueryData = async (
                 )
                 GROUP BY minute_bucket
                 ORDER BY minute_bucket ASC`,
-              values: {
-                  citySeparator: CITY_KEY_SEPARATOR,
-              },
-              filters: hogQLFilters,
+              ...queryParams,
           }
         : null
 
-    // Custom 60-second window for "Users online" — narrower than the dashboard's 30 min,
-    // so we can't reuse hogQLFilters' dateRange. We pass only the property filters and keep
-    // the explicit timestamp predicate. Loaded whenever any filter is active.
     const recentUsersQuery: HogQLQuery | null =
-        filters.length > 0
+        filtersEnabled && filters.length > 0
             ? {
                   kind: NodeKind.HogQLQuery,
                   query: `SELECT
@@ -900,13 +906,16 @@ const loadQueryData = async (
                           toUnixTimestamp(max(timestamp)) AS last_seen
                       FROM events
                       WHERE {filters}
-                          AND timestamp > toDateTime({dateTo}) - INTERVAL ${FILTERED_LIVE_USER_WINDOW_SECONDS} SECOND
-                          AND timestamp <= toDateTime({dateTo})
                       GROUP BY distinct_id`,
-                  values: {
-                      dateTo: dateTo.toISOString(),
+                  filters: {
+                      properties: filters,
+                      dateRange: {
+                          date_from: new Date(
+                              dateTo.getTime() - FILTERED_LIVE_USER_WINDOW_SECONDS * 1000
+                          ).toISOString(),
+                          date_to: dateTo.toISOString(),
+                      },
                   },
-                  filters: { properties: filters },
               }
             : null
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
New filter queries were failing with 400, so guarding everything under a feature flag
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Move new queries behind feature flag
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
