### PR TITLE
fix(alerts): log raw final message when anomaly agent JSON parse fails

### DIFF
--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -947,13 +947,80 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.2

--- a/posthog/temporal/ai/anomaly_investigation/runner.py
+++ b/posthog/temporal/ai/anomaly_investigation/runner.py
@@ -11,6 +11,7 @@ message with no tool calls, or on budget exhaustion.
 
 from __future__ import annotations
 
+import re
 import json
 import logging
 from collections.abc import Awaitable, Callable
@@ -41,6 +42,11 @@ MAX_TOOL_RESULT_CHARS = 12_000  # ~3K tokens per call — keeps 10 calls well un
 # Per-request cap. The surrounding Temporal activity has its own (longer) deadline;
 # this guards against a single stuck HTTP call hanging for the whole activity budget.
 LLM_REQUEST_TIMEOUT_SECONDS = 90.0
+# Bounded so a runaway final message can't dominate log retention; large enough to fit the would-be JSON payload.
+PARSE_FAILURE_RAW_PREVIEW_CHARS = 2_000
+
+# The model is instructed to emit raw JSON, but sometimes wraps in fences anyway — handle here, not via agent retry.
+_FENCE_RE = re.compile(r"```(?:json|JSON)?\s*\n?(.*?)\n?```", re.DOTALL)
 
 
 ToolHandler = Callable[[dict[str, Any]], Awaitable[str]]
@@ -219,32 +225,75 @@ async def run_investigation(
             messages.append(ToolMessage(content=content, tool_call_id=tool_call_id))
 
     final_message = messages[-1]
-    report = _parse_report(getattr(final_message, "content", ""))
+    report = _parse_report(getattr(final_message, "content", ""), tool_calls_used=tool_calls_used)
     report.tool_calls_used = tool_calls_used
     return InvestigationRunResult(report=report, tool_calls_used=tool_calls_used, model=AGENT_MODEL)
 
 
-def _parse_report(content: Any) -> InvestigationReport:
+def _parse_report(content: Any, *, tool_calls_used: int = 0) -> InvestigationReport:
     text = _stringify(content).strip()
     if not text:
+        logger.warning(
+            "anomaly_investigation.parse_report_failed",
+            extra={"reason": "empty_final_message", "tool_calls_used": tool_calls_used},
+        )
         return _fallback_report("Agent returned no final message.")
-    # Try direct JSON; else find first/last brace.
+
+    parse_errors: list[str] = []
     for candidate in _json_candidates(text):
         try:
             parsed = json.loads(candidate)
-            return InvestigationReport.model_validate(parsed)
-        except (ValueError, TypeError, ValidationError):
+        except (ValueError, TypeError) as err:
+            parse_errors.append(f"json: {err}")
             continue
+        try:
+            return InvestigationReport.model_validate(parsed)
+        except ValidationError as err:
+            parse_errors.append(f"schema: {_summarize_validation_errors(err)}")
+            continue
+
+    logger.warning(
+        "anomaly_investigation.parse_report_failed",
+        extra={
+            "reason": "no_valid_json_found",
+            "tool_calls_used": tool_calls_used,
+            "raw_content_length": len(text),
+            "raw_content_preview": text[:PARSE_FAILURE_RAW_PREVIEW_CHARS],
+            "parse_errors": parse_errors[:5],
+        },
+    )
     return _fallback_report("Agent final message was not valid InvestigationReport JSON.")
 
 
 def _json_candidates(text: str) -> list[str]:
-    candidates: list[str] = [text]
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def _add(candidate: str) -> None:
+        stripped = candidate.strip()
+        if stripped and stripped not in seen:
+            seen.add(stripped)
+            candidates.append(stripped)
+
+    _add(text)
+
+    # finditer handles the rare case of a prose example fence followed by the real report fence.
+    for fence_match in _FENCE_RE.finditer(text):
+        _add(fence_match.group(1))
+
+    # Outermost braces — covers leading and trailing prose around the JSON.
     first = text.find("{")
     last = text.rfind("}")
     if first != -1 and last > first:
-        candidates.append(text[first : last + 1])
+        _add(text[first : last + 1])
+
     return candidates
+
+
+def _summarize_validation_errors(err: ValidationError) -> str:
+    # Keep only loc + type so the log entry stays bounded even if the model returned a huge payload.
+    summary = [f"{'.'.join(str(p) for p in e['loc'])}: {e['type']}" for e in err.errors()[:3]]
+    return ", ".join(summary)
 
 
 def _stringify(content: Any) -> str:

--- a/posthog/temporal/tests/ai/test_anomaly_investigation_parse_report.py
+++ b/posthog/temporal/tests/ai/test_anomaly_investigation_parse_report.py
@@ -1,0 +1,118 @@
+import json
+import logging
+
+import pytest
+
+from posthog.temporal.ai.anomaly_investigation.runner import PARSE_FAILURE_RAW_PREVIEW_CHARS, _parse_report
+
+_VALID_REPORT = {
+    "verdict": "true_positive",
+    "summary": "Confirmed real shift in active orgs.",
+    "hypotheses": [
+        {
+            "title": "Marketing campaign",
+            "rationale": "Campaign launched at the start of the window.",
+            "evidence": ["utm_source share grew 4x"],
+        }
+    ],
+    "recommendations": ["Confirm with marketing team."],
+}
+
+
+def _as_json(payload: dict) -> str:
+    return json.dumps(payload)
+
+
+@pytest.mark.parametrize(
+    "raw,expected_verdict,expected_summary_substr",
+    [
+        # Plain JSON.
+        (_as_json(_VALID_REPORT), "true_positive", "Confirmed real shift"),
+        # Leading + trailing prose around the JSON.
+        (
+            "Here's the report:\n" + _as_json(_VALID_REPORT) + "\n\nLet me know if you need more.",
+            "true_positive",
+            "Confirmed real shift",
+        ),
+        # Markdown ```json fence.
+        ("```json\n" + _as_json(_VALID_REPORT) + "\n```", "true_positive", "Confirmed real shift"),
+        # Bare ``` fence with no language tag.
+        ("```\n" + _as_json(_VALID_REPORT) + "\n```", "true_positive", "Confirmed real shift"),
+        # Uppercase JSON tag (some models capitalize).
+        ("```JSON\n" + _as_json(_VALID_REPORT) + "\n```", "true_positive", "Confirmed real shift"),
+        # A prose example fence followed by the real report fence — second fence wins.
+        (
+            'Example shape: ```json\n{"verdict": "?"}\n``` and the actual report:\n```json\n'
+            + _as_json(_VALID_REPORT)
+            + "\n```",
+            "true_positive",
+            "Confirmed real shift",
+        ),
+    ],
+)
+def test_parse_report_extracts_valid_json(raw, expected_verdict, expected_summary_substr) -> None:
+    report = _parse_report(raw)
+    assert report.verdict == expected_verdict
+    assert expected_summary_substr in report.summary
+
+
+def test_parse_report_accepts_langchain_content_blocks() -> None:
+    content = [
+        {"type": "text", "text": "Here you go:\n"},
+        {"type": "text", "text": _as_json(_VALID_REPORT)},
+    ]
+    report = _parse_report(content)
+    assert report.verdict == "true_positive"
+
+
+def test_parse_report_returns_inconclusive_for_empty_final_message(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger="posthog.temporal.ai.anomaly_investigation.runner"):
+        report = _parse_report("", tool_calls_used=3)
+    assert report.verdict == "inconclusive"
+    assert "no final message" in report.summary
+    # The empty-message branch should be tagged distinctly so we can alert on it separately from JSON failures.
+    assert any(
+        rec.message == "anomaly_investigation.parse_report_failed"
+        and getattr(rec, "reason", None) == "empty_final_message"
+        for rec in caplog.records
+    )
+
+
+def test_parse_report_logs_raw_content_on_failure(caplog: pytest.LogCaptureFixture) -> None:
+    raw = "I considered the metric and decided not to emit JSON, sorry."
+    with caplog.at_level(logging.WARNING, logger="posthog.temporal.ai.anomaly_investigation.runner"):
+        report = _parse_report(raw, tool_calls_used=2)
+    assert report.verdict == "inconclusive"
+    matching = [rec for rec in caplog.records if rec.message == "anomaly_investigation.parse_report_failed"]
+    assert len(matching) == 1
+    rec = matching[0]
+    assert getattr(rec, "reason", None) == "no_valid_json_found"
+    assert getattr(rec, "tool_calls_used", None) == 2
+    assert getattr(rec, "raw_content_length", None) == len(raw)
+    assert getattr(rec, "raw_content_preview", None) == raw
+
+
+def test_parse_report_truncates_raw_preview_in_logs(caplog: pytest.LogCaptureFixture) -> None:
+    raw = "x" * (PARSE_FAILURE_RAW_PREVIEW_CHARS + 500)
+    with caplog.at_level(logging.WARNING, logger="posthog.temporal.ai.anomaly_investigation.runner"):
+        _parse_report(raw)
+    matching = [rec for rec in caplog.records if rec.message == "anomaly_investigation.parse_report_failed"]
+    assert len(matching) == 1
+    rec = matching[0]
+    preview = getattr(rec, "raw_content_preview", None)
+    assert preview is not None
+    assert len(preview) == PARSE_FAILURE_RAW_PREVIEW_CHARS
+    assert getattr(rec, "raw_content_length", None) == len(raw)
+
+
+def test_parse_report_logs_schema_errors_when_json_parses_but_fails_validation(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Valid JSON, but `verdict` is not one of the allowed literals — schema fails.
+    raw = '{"verdict": "maybe", "summary": "Could go either way."}'
+    with caplog.at_level(logging.WARNING, logger="posthog.temporal.ai.anomaly_investigation.runner"):
+        report = _parse_report(raw)
+    assert report.verdict == "inconclusive"
+    rec = next(rec for rec in caplog.records if rec.message == "anomaly_investigation.parse_report_failed")
+    parse_errors = getattr(rec, "parse_errors", None) or []
+    assert any("schema:" in entry and "verdict" in entry for entry in parse_errors)


### PR DESCRIPTION
## Problem

When the anomaly investigation agent's final assistant message can't be validated as `InvestigationReport` JSON, we currently produce a notebook with the line *"Agent final message was not valid InvestigationReport JSON."* and an `inconclusive` verdict — but log nothing about what the model actually wrote. That's the failure mode this PR is responding to: an alert email saying *"Investigation verdict: Inconclusive. Agent final message was not valid InvestigationReport JSON."* with no way to tell whether the model produced free-form text, malformed JSON, valid JSON missing required fields, or wrapped its output in a markdown fence we don't strip.

## Changes

- `posthog/temporal/ai/anomaly_investigation/runner.py`
  - On parse failure, log `anomaly_investigation.parse_report_failed` at `WARNING` with structured fields: `reason` (`empty_final_message` vs `no_valid_json_found`), `tool_calls_used`, `raw_content_length`, the first 2k chars of the raw final message (`raw_content_preview`), and a compact list of `parse_errors` (json vs schema, plus pydantic loc + type). This is what was missing — next time this fires we'll see exactly what the model emitted instead of guessing.
  - Widened `_json_candidates` to also try every ` ```json `, ` ```JSON `, and bare ` ``` ` fenced block in the message, on top of the existing first-`{`-to-last-`}` fallback. Cheaper to handle here than to retry the whole agent run.
  - Threaded `tool_calls_used` into `_parse_report` so the failure log has the full agent-budget context.
- `posthog/temporal/tests/ai/test_anomaly_investigation_parse_report.py` — new parameterized tests covering fenced JSON variants, leading/trailing prose, LangChain content blocks, empty messages, non-JSON output, raw-preview truncation, and schema-error logging.

## How did you test this code?

Agent-authored. Manual testing was not performed. Automated checks run locally:

- [x] New unit tests for `_parse_report` (10 cases) pass under a directly-imported runner module.
- [x] `ruff check` and `ruff format --check` clean on both touched files.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

- Tool: PostHog Code (Claude).
- The user reported a specific firing of the agent with verdict *Inconclusive — Agent final message was not valid InvestigationReport JSON.* and linked the corresponding notebook (`/notebooks/14sGlcAq`). The notebook content shows `Tool calls used: 2`, well below `MAX_TOOL_CALLS = 10`, so the agent reached its own end-of-loop without budget exhaustion — meaning the failure is at the JSON-emit step, not the agent giving up.
- The existing `_parse_report` already tried direct JSON + first-`{`-to-last-`}`, so I added the smaller missing extractions (markdown fences, multi-fence) but resisted bigger architectural rewrites (e.g. forcing structured output via a `submit_report` tool call) because the most actionable next step is *seeing what the model actually emitted*. Once we have a few real samples in logs we can decide whether the fix is a prompt tweak, a wider extractor, or the larger move to tool-call-based finalization.
- Considered also surfacing the raw text into the notebook body for end-user visibility on the failure path, but skipped it for now — keeps the PR focused on the observability gap; we can layer that on once we know the failure shape.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*