### PR TITLE
feat(error-tracking): add ingestion problems recommendation

### DIFF
--- a/products/error_tracking/backend/api/test/test_recommendations.py
+++ b/products/error_tracking/backend/api/test/test_recommendations.py
@@ -19,6 +19,7 @@ from products.error_tracking.backend.models import (
     sync_issues_to_clickhouse,
 )
 from products.error_tracking.backend.recommendations.alerts import AlertsRecommendation
+from products.error_tracking.backend.recommendations.ingestion_failures import IngestionFailuresRecommendation
 from products.error_tracking.backend.recommendations.long_running_issues import LongRunningIssuesRecommendation
 
 from ee.clickhouse.materialized_columns.columns import materialize
@@ -37,6 +38,7 @@ MOCK_ALERTS_META_UPDATED = {
         {"key": "error-tracking-issue-spiking", "enabled": True},
     ]
 }
+MOCK_INGESTION_FAILURES_META: dict = {"count_24h": 0, "count_1h": 0, "top_causes": []}
 
 
 def _days_ago(n: int) -> str:
@@ -62,6 +64,10 @@ class TestRecommendationsAPI(ClickhouseTestMixin, APIBaseTest):
         return self.client.post(f"/api/environments/{self.team.id}/error_tracking/recommendations/{rec_id}/refresh/")
 
     @patch(
+        "products.error_tracking.backend.recommendations.ingestion_failures.IngestionFailuresRecommendation.compute",
+        return_value=MOCK_INGESTION_FAILURES_META,
+    )
+    @patch(
         "products.error_tracking.backend.recommendations.long_running_issues.LongRunningIssuesRecommendation.compute",
         return_value={"issues": []},
     )
@@ -69,16 +75,20 @@ class TestRecommendationsAPI(ClickhouseTestMixin, APIBaseTest):
         "products.error_tracking.backend.recommendations.alerts.AlertsRecommendation.compute",
         return_value=MOCK_ALERTS_META,
     )
-    def test_first_list_creates_both_recommendations(self, mock_alerts, mock_long_running):
+    def test_first_list_creates_both_recommendations(self, mock_alerts, mock_long_running, mock_ingestion_failures):
         self.assertEqual(ErrorTrackingRecommendation.objects.filter(team=self.team).count(), 0)
 
         response = self._list()
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(ErrorTrackingRecommendation.objects.filter(team=self.team).count(), 2)
+        self.assertEqual(ErrorTrackingRecommendation.objects.filter(team=self.team).count(), 3)
         types = {r["type"] for r in response.json()["results"]}
-        self.assertEqual(types, {"alerts", "long_running_issues"})
+        self.assertEqual(types, {"alerts", "long_running_issues", "ingestion_failures"})
 
+    @patch(
+        "products.error_tracking.backend.recommendations.ingestion_failures.IngestionFailuresRecommendation.compute",
+        return_value=MOCK_INGESTION_FAILURES_META,
+    )
     @patch(
         "products.error_tracking.backend.recommendations.long_running_issues.LongRunningIssuesRecommendation.compute",
         return_value={"issues": []},
@@ -86,7 +96,7 @@ class TestRecommendationsAPI(ClickhouseTestMixin, APIBaseTest):
     @patch(
         "products.error_tracking.backend.recommendations.alerts.AlertsRecommendation.compute",
     )
-    def test_alerts_recomputes_on_every_list(self, mock_alerts, mock_long_running):
+    def test_alerts_recomputes_on_every_list(self, mock_alerts, mock_long_running, mock_ingestion_failures):
         mock_alerts.return_value = MOCK_ALERTS_META
         self._list()
 
@@ -99,13 +109,19 @@ class TestRecommendationsAPI(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2026-01-01T00:00:00Z", as_kwarg="frozen_time")
     @patch(
+        "products.error_tracking.backend.recommendations.ingestion_failures.IngestionFailuresRecommendation.compute",
+        return_value=MOCK_INGESTION_FAILURES_META,
+    )
+    @patch(
         "products.error_tracking.backend.recommendations.long_running_issues.LongRunningIssuesRecommendation.compute",
     )
     @patch(
         "products.error_tracking.backend.recommendations.alerts.AlertsRecommendation.compute",
         return_value=MOCK_ALERTS_META,
     )
-    def test_long_running_is_cached_until_interval_elapses(self, mock_alerts, mock_long_running, frozen_time):
+    def test_long_running_is_cached_until_interval_elapses(
+        self, mock_alerts, mock_long_running, mock_ingestion_failures, frozen_time
+    ):
         mock_long_running.return_value = {"issues": []}
         self._list()
         self.assertEqual(mock_long_running.call_count, 1)
@@ -119,6 +135,10 @@ class TestRecommendationsAPI(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(mock_long_running.call_count, 2)
 
     @patch(
+        "products.error_tracking.backend.recommendations.ingestion_failures.IngestionFailuresRecommendation.compute",
+        return_value=MOCK_INGESTION_FAILURES_META,
+    )
+    @patch(
         "products.error_tracking.backend.recommendations.long_running_issues.LongRunningIssuesRecommendation.compute",
         return_value={"issues": []},
     )
@@ -126,7 +146,7 @@ class TestRecommendationsAPI(ClickhouseTestMixin, APIBaseTest):
         "products.error_tracking.backend.recommendations.alerts.AlertsRecommendation.compute",
         return_value=MOCK_ALERTS_META,
     )
-    def test_dismiss_persists_across_requests(self, mock_alerts, mock_long_running):
+    def test_dismiss_persists_across_requests(self, mock_alerts, mock_long_running, mock_ingestion_failures):
         response = self._list()
         alerts_id = next(r["id"] for r in response.json()["results"] if r["type"] == "alerts")
 
@@ -297,6 +317,19 @@ class TestRecommendationsAPI(ClickhouseTestMixin, APIBaseTest):
 
     def test_alerts_is_completed_false_when_empty(self):
         self.assertFalse(AlertsRecommendation().is_completed({"alerts": []}))
+
+    def test_ingestion_failures_is_completed_when_zero_24h(self):
+        self.assertTrue(
+            IngestionFailuresRecommendation().is_completed({"count_24h": 0, "count_1h": 0, "top_causes": []})
+        )
+
+    def test_ingestion_failures_is_not_completed_with_failures(self):
+        meta = {
+            "count_24h": 1234,
+            "count_1h": 56,
+            "top_causes": [{"cause": "No sourcemap found", "occurrences": 1000}],
+        }
+        self.assertFalse(IngestionFailuresRecommendation().is_completed(meta))
 
     @patch(
         "products.error_tracking.backend.recommendations.long_running_issues.LongRunningIssuesRecommendation.compute",

--- a/products/error_tracking/backend/recommendations/__init__.py
+++ b/products/error_tracking/backend/recommendations/__init__.py
@@ -1,10 +1,12 @@
 from .alerts import AlertsRecommendation
 from .base import Recommendation
+from .ingestion_failures import IngestionFailuresRecommendation
 from .long_running_issues import LongRunningIssuesRecommendation
 
 RECOMMENDATIONS: list[Recommendation] = [
     AlertsRecommendation(),
     LongRunningIssuesRecommendation(),
+    IngestionFailuresRecommendation(),
 ]
 
 RECOMMENDATIONS_BY_TYPE: dict[str, Recommendation] = {r.type: r for r in RECOMMENDATIONS}

--- a/products/error_tracking/backend/recommendations/ingestion_failures.py
+++ b/products/error_tracking/backend/recommendations/ingestion_failures.py
@@ -1,0 +1,83 @@
+from datetime import timedelta
+from typing import Any
+
+from posthog.schema import HogQLFilters, ProductKey
+
+from posthog.hogql import ast
+
+from posthog.clickhouse.query_tagging import Feature, tag_queries
+from posthog.models.team.team import Team
+
+from .base import Recommendation
+
+TOP_CAUSES_LIMIT = 3
+
+
+class IngestionFailuresRecommendation(Recommendation):
+    type = "ingestion_failures"
+    refresh_interval = timedelta(hours=1)
+
+    def compute(self, team: Team) -> dict[str, Any]:
+        from posthog.hogql.query import execute_hogql_query
+
+        tag_queries(
+            product=ProductKey.ERROR_TRACKING,
+            feature=Feature.ENRICHMENT,
+            team_id=team.pk,
+            name="recommendations:ingestion_failures",
+        )
+
+        counts_response = execute_hogql_query(
+            query="""
+                SELECT
+                    countIf(timestamp >= now() - INTERVAL 24 HOUR) AS count_24h,
+                    countIf(timestamp >= now() - INTERVAL 1 HOUR) AS count_1h
+                FROM events
+                WHERE event = '$exception'
+                AND timestamp >= now() - INTERVAL 24 HOUR
+                AND notEmpty(properties.$cymbal_errors)
+                AND {filters}
+            """,
+            team=team,
+            filters=HogQLFilters(filterTestAccounts=True),
+        )
+
+        count_24h = 0
+        count_1h = 0
+        if counts_response.results and counts_response.results[0]:
+            count_24h, count_1h = counts_response.results[0]
+
+        top_causes: list[dict[str, Any]] = []
+        if count_24h > 0:
+            causes_response = execute_hogql_query(
+                query="""
+                    SELECT
+                        arrayJoin(properties.$cymbal_errors) AS cause,
+                        count() AS occurrences
+                    FROM events
+                    WHERE event = '$exception'
+                    AND timestamp >= now() - INTERVAL 24 HOUR
+                    AND notEmpty(properties.$cymbal_errors)
+                    AND {filters}
+                    GROUP BY cause
+                    ORDER BY occurrences DESC
+                    LIMIT {limit}
+                """,
+                team=team,
+                filters=HogQLFilters(filterTestAccounts=True),
+                placeholders={"limit": ast.Constant(value=TOP_CAUSES_LIMIT)},
+            )
+            top_causes = [
+                {"cause": cause, "occurrences": occurrences}
+                for cause, occurrences in (causes_response.results or [])
+                if cause
+            ]
+
+        return {
+            "count_24h": count_24h,
+            "count_1h": count_1h,
+            "top_causes": top_causes,
+        }
+
+    def is_completed(self, meta: dict[str, Any]) -> bool:
+        return (meta.get("count_24h") or 0) == 0

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/IngestionFailuresRecommendationCard.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/IngestionFailuresRecommendationCard.tsx
@@ -1,0 +1,124 @@
+import { combineUrl } from 'kea-router'
+
+import { Link } from '@posthog/lemon-ui'
+
+import { humanFriendlyLargeNumber } from 'lib/utils'
+import { urls } from 'scenes/urls'
+
+import { ActivityTab, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { RecommendationCard } from './RecommendationCard'
+import type { IngestionFailuresRecommendation } from './types'
+
+const FAILURES_QUERY = {
+    kind: 'DataTableNode' as const,
+    full: true,
+    source: {
+        kind: 'EventsQuery' as const,
+        select: ['*', 'event', 'person', 'timestamp', 'properties.$cymbal_errors'],
+        event: '$exception',
+        after: '-24h',
+        orderBy: ['timestamp DESC'],
+        properties: [
+            {
+                key: '$cymbal_errors',
+                value: 'is_set',
+                operator: PropertyOperator.IsSet,
+                type: PropertyFilterType.Event,
+            },
+        ],
+    },
+    propertiesViaUrl: true,
+    showSavedQueries: true,
+    showPersistentColumnConfigurator: true,
+}
+
+function buildFailuresUrl(): string {
+    return combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: FAILURES_QUERY }).url
+}
+
+export function IngestionFailuresRecommendationCard({
+    recommendation,
+    dismissed,
+}: {
+    recommendation: IngestionFailuresRecommendation
+    dismissed?: boolean
+}): JSX.Element | null {
+    const isFirstLoad = recommendation.computed_at === null
+
+    if (isFirstLoad) {
+        return (
+            <RecommendationCard
+                recommendationId={recommendation.id}
+                title="Ingestion problems"
+                description="Exceptions that hit errors during ingestion processing — they may be missing stack traces, source maps, or other context."
+                dismissed={dismissed}
+            />
+        )
+    }
+
+    const { count_24h, count_1h, top_causes } = recommendation.meta
+
+    if (count_24h === 0) {
+        return (
+            <RecommendationCard recommendationId={recommendation.id} title="Ingestion problems" dismissed={dismissed}>
+                <div className="text-sm text-secondary">No ingestion problems in the last 24 hours — nice work!</div>
+            </RecommendationCard>
+        )
+    }
+
+    const failuresUrl = buildFailuresUrl()
+
+    return (
+        <RecommendationCard
+            recommendationId={recommendation.id}
+            title="Ingestion problems"
+            description="Exceptions that hit errors during ingestion processing — they may be missing stack traces, source maps, or other context."
+            dismissed={dismissed}
+        >
+            <div className="flex flex-col gap-3">
+                <div className="grid grid-cols-2 gap-3">
+                    <div className="border rounded-md p-3 bg-surface-secondary">
+                        <div className="text-xs uppercase tracking-wide text-muted font-semibold">Last 24h</div>
+                        <div className="text-xl font-semibold mt-1">{humanFriendlyLargeNumber(count_24h)}</div>
+                        <div className="text-xs text-secondary">exceptions failed to ingest</div>
+                    </div>
+                    <div className="border rounded-md p-3 bg-surface-secondary">
+                        <div className="text-xs uppercase tracking-wide text-muted font-semibold">Last 1h</div>
+                        <div className="text-xl font-semibold mt-1">{humanFriendlyLargeNumber(count_1h)}</div>
+                        <div className="text-xs text-secondary">exceptions failed to ingest</div>
+                    </div>
+                </div>
+
+                {top_causes.length > 0 && (
+                    <div>
+                        <div className="text-xs uppercase tracking-wide text-muted font-semibold mb-2">
+                            {top_causes.length === 1 ? 'Most common cause' : 'Most common causes'}
+                        </div>
+                        <ul className="flex flex-col gap-1 m-0 p-0 list-none">
+                            {top_causes.map((cause, idx) => (
+                                <li
+                                    key={`${idx}-${cause.cause}`}
+                                    className="flex items-start justify-between gap-3 text-sm"
+                                >
+                                    <span className="font-mono text-xs truncate" title={cause.cause}>
+                                        {cause.cause}
+                                    </span>
+                                    <span className="text-xs text-secondary whitespace-nowrap shrink-0">
+                                        {humanFriendlyLargeNumber(cause.occurrences)}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+
+                <div>
+                    <Link to={failuresUrl} className="text-sm">
+                        View failures →
+                    </Link>
+                </div>
+            </div>
+        </RecommendationCard>
+    )
+}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/RecommendationsTab.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/RecommendationsTab.tsx
@@ -4,9 +4,11 @@ import { IconChevronRight } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 
 import { AlertsRecommendationCard } from './AlertsRecommendationCard'
+import { IngestionFailuresRecommendationCard } from './IngestionFailuresRecommendationCard'
 import { LongRunningIssuesRecommendationCard } from './LongRunningIssuesRecommendationCard'
 import {
     isAlertsRecommendation,
+    isIngestionFailuresRecommendation,
     isLongRunningIssuesRecommendation,
     recommendationsTabLogic,
 } from './recommendationsTabLogic'
@@ -24,6 +26,9 @@ function RecommendationCardForType({
     }
     if (isLongRunningIssuesRecommendation(recommendation)) {
         return <LongRunningIssuesRecommendationCard recommendation={recommendation} dismissed={dismissed} />
+    }
+    if (isIngestionFailuresRecommendation(recommendation)) {
+        return <IngestionFailuresRecommendationCard recommendation={recommendation} dismissed={dismissed} />
     }
     return null
 }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
@@ -7,7 +7,12 @@ import api from 'lib/api'
 import { HogFunctionSubTemplateIdType } from '~/types'
 
 import type { recommendationsTabLogicType } from './recommendationsTabLogicType'
-import type { AlertsRecommendation, ErrorTrackingRecommendation, LongRunningIssuesRecommendation } from './types'
+import type {
+    AlertsRecommendation,
+    ErrorTrackingRecommendation,
+    IngestionFailuresRecommendation,
+    LongRunningIssuesRecommendation,
+} from './types'
 
 export const isAlertsRecommendation = (
     recommendation: ErrorTrackingRecommendation
@@ -16,6 +21,10 @@ export const isAlertsRecommendation = (
 export const isLongRunningIssuesRecommendation = (
     recommendation: ErrorTrackingRecommendation
 ): recommendation is LongRunningIssuesRecommendation => recommendation.type === 'long_running_issues'
+
+export const isIngestionFailuresRecommendation = (
+    recommendation: ErrorTrackingRecommendation
+): recommendation is IngestionFailuresRecommendation => recommendation.type === 'ingestion_failures'
 
 const POLL_INTERVAL_MS = 500
 

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/types.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/types.ts
@@ -1,7 +1,7 @@
 import { ErrorTrackingIssue } from '~/queries/schema/schema-general'
 import { HogFunctionSubTemplateIdType } from '~/types'
 
-export type ErrorTrackingRecommendationType = 'alerts' | 'long_running_issues'
+export type ErrorTrackingRecommendationType = 'alerts' | 'long_running_issues' | 'ingestion_failures'
 
 export type ErrorTrackingRecommendationStatus = 'ready' | 'computing'
 
@@ -62,3 +62,16 @@ export interface LongRunningIssuesRecommendationMeta extends Record<string, unkn
 }
 
 export type LongRunningIssuesRecommendation = ErrorTrackingRecommendation<LongRunningIssuesRecommendationMeta>
+
+export interface IngestionFailureCause {
+    cause: string
+    occurrences: number
+}
+
+export interface IngestionFailuresRecommendationMeta extends Record<string, unknown> {
+    count_24h: number
+    count_1h: number
+    top_causes: IngestionFailureCause[]
+}
+
+export type IngestionFailuresRecommendation = ErrorTrackingRecommendation<IngestionFailuresRecommendationMeta>


### PR DESCRIPTION
## Problem

The error tracking recommendations tab already flags long-running issues and missing alerts, but it doesn't surface a class of problem that's especially painful to debug after the fact: exceptions that made it through capture but hit errors during ingestion processing (no sourcemap found, malformed exception steps, etc.). Those failures get attached to the event as `$cymbal_errors`, but today users have to know to go hunt for them in the events explorer.

This PR adds an "Ingestion problems" recommendation card so the same tab tells users when their exceptions aren't getting the symbolication / processing they expect, and points to the most common root cause.

## Changes

**Backend** (`products/error_tracking/backend/recommendations/ingestion_failures.py`)

- New `IngestionFailuresRecommendation` (type `ingestion_failures`, 1h refresh interval, matching the existing long-running-issues cadence)
- One HogQL query for `count_24h` + `count_1h` (via `countIf`) over `events` filtered to `$exception` with `notEmpty(properties.$cymbal_errors)`
- A second query for the top 3 causes — `arrayJoin(properties.$cymbal_errors)` grouped and ordered by occurrence desc — skipped when 24h count is 0
- `is_completed` returns true when the 24h count is 0, so a healthy project doesn't see clutter

**Frontend** (`IngestionFailuresRecommendationCard.tsx`)

- Two-column stat grid for "Last 24h" and "Last 1h" using `humanFriendlyLargeNumber`
- Compact top-3 causes list with the cymbal error string (monospace, truncated with full-text tooltip) and occurrence count
- "View failures →" link that opens the activity explorer with `event = '$exception'` and `$cymbal_errors is_set`, mirroring the URL pattern the weekly digest already uses
- First-load and empty states reuse the existing `RecommendationCard` shell, so refresh / dismiss / restore work consistently with the other cards
- Wired into `RecommendationsTab` and `recommendationsTabLogic` via a new `isIngestionFailuresRecommendation` type guard

## How did you test this code?

I'm an agent. I did not click through the UI manually — I have no browser in this environment.

What I actually ran:
- `ruff check` and `ruff format --check` on the new and edited Python files — clean
- `pnpm format` over the workspace — only my files changed (unrelated oxlint autofixes on hog-charts were reverted)
- Extended `products/error_tracking/backend/api/test/test_recommendations.py` to mock the new compute path, bumped expected recommendation count from 2 to 3, and added two `is_completed` assertions for the new recommendation. Tests will run in CI; I did not bring up the full Django+ClickHouse stack locally.
- The pre-commit hook (lint-staged → ruff, oxlint, oxfmt, ty check) ran on commit and passed.

Manual verification of the rendered card is still required from a human reviewer.

## Publish to changelog?

no

## Docs update

No docs change needed — the recommendations tab discovers cards dynamically.

## 🤖 Agent context

Authored by Claude (Opus 4.7) on request.

Decisions worth flagging for the reviewer:

- **Two queries instead of one.** I considered combining counts and causes into a single `arrayJoin` + `countIf` query, but that overstates totals because an event with two cymbal errors would be counted twice. Two queries keeps the totals honest and the causes ranking unambiguous.
- **`$cymbal_errors` vs. `issue_id IS NULL`.** `weekly_digest.py` uses `issue_id IS NULL` as its "failed to ingest" proxy. The user explicitly asked for `$cymbal_errors`, which is a stricter signal (Cymbal-reported processing errors specifically) and is what users see attached to the event in the UI. I followed the explicit ask.
- **Auto-complete threshold.** Asked the user — picked "0 in 24h" over a small noise-floor threshold. Anything non-zero will show.
- **Cause display count.** Asked the user — top 3 with counts.
- **Drill-in link.** Asked the user — yes, included. The query is built client-side via `combineUrl` rather than a hardcoded `%`-encoded string so it stays in sync if the events scene's query shape changes.

Tools used: Read/Edit/Write/Bash/Grep, AskUserQuestion (3 clarifying questions answered before implementation).


---
_Generated by [Claude Code](https://claude.ai/code/session_01McS4QnrBvyVSFoJHj449a1)_