### PR TITLE
fix(dashboards): show effective date on tile when dashboard overrides it

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -169,13 +169,15 @@ export function InsightMeta({
         placement === DashboardPlacement.Public ||
         placement === DashboardPlacement.Builtin
     const isSqlInsight = isDataVisualizationNode(insight.query)
-    const showCompactHeading = !showCompactTile || (!filtersOverride?.date_from && !isSqlInsight)
+    const showCompactHeading = !showCompactTile || !isSqlInsight
 
     const topHeadingProps = {
         query: insight.query,
         lastRefresh: insight.last_refresh,
         hasTileOverrides: Object.keys(tileFiltersOverride ?? {}).length > 0,
         resolvedDateRange: insightData?.resolved_date_range,
+        dateFromOverride: tileFiltersOverride?.date_from ?? filtersOverride?.date_from,
+        dateToOverride: tileFiltersOverride?.date_to ?? filtersOverride?.date_to,
     }
 
     const summary = useSummarizeInsight()(insight.query)

--- a/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
@@ -53,10 +53,10 @@ export function TopHeading({
             date_to = queryDateRange.date_to
         }
     }
-    if (dateFromOverride !== undefined) {
+    if (dateFromOverride != null) {
         date_from = dateFromOverride
     }
-    if (dateToOverride !== undefined) {
+    if (dateToOverride != null) {
         date_to = dateToOverride
     }
 

--- a/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
@@ -32,12 +32,16 @@ export function TopHeading({
     hasTileOverrides,
     resolvedDateRange,
     showInsightType = true,
+    dateFromOverride,
+    dateToOverride,
 }: {
     query: Node | null
     lastRefresh?: string | null
     hasTileOverrides?: boolean | null
     resolvedDateRange?: ResolvedDateRangeResponse | null
     showInsightType?: boolean
+    dateFromOverride?: string | null
+    dateToOverride?: string | null
 }): JSX.Element {
     const insightType = getInsightType(query)
 
@@ -48,6 +52,12 @@ export function TopHeading({
             date_from = queryDateRange.date_from
             date_to = queryDateRange.date_to
         }
+    }
+    if (dateFromOverride !== undefined) {
+        date_from = dateFromOverride
+    }
+    if (dateToOverride !== undefined) {
+        date_to = dateToOverride
     }
 
     let dateText: string | null = null


### PR DESCRIPTION
## Problem

When a dashboard has a date filter applied (whether persisted on the dashboard or supplied as an override), every tile silently dropped its time-period label. The data was still being queried with the override, but viewers had no per-tile indication of which range was actually rendered — they had to look back at the dashboard filter bar to remember.

The previous behavior was introduced in #48677 to reduce visual noise from redundant "Last 7 days" labels repeating across every tile. The intent was good, but it hid the date even in cases where the rendered range differed from the insight's stored default (per-tile overrides), and it removed a useful at-a-glance signal.

## Changes

`TopHeading` now accepts optional `dateFromOverride` / `dateToOverride` props. When set, they take precedence over the date extracted from the query node.

`InsightMeta` passes the effective override down — tile-level overrides (`tileFiltersOverride`) take precedence over dashboard-level overrides (`filtersOverride`), and the insight's own range is used otherwise. The `filtersOverride?.date_from` branch of `showCompactHeading` is removed so the heading stays visible.

SQL insights (`DataVisualizationNode`) remain excluded from the compact heading. `dateRangeFor` doesn't return a value for them today, and we have no reliable signal (short of parsing the SQL for `{filters}`) that a dashboard date override would actually take effect — so showing a date that may be silently ignored would mislead viewers. The popover-level heading already exists for SQL via `popoverTopHeading`.

## How did you test this code?

Agent-authored. Verified by reading the related code paths:
- `dateRangeFor` ([frontend/src/queries/utils.ts](frontend/src/queries/utils.ts)) confirms SQL insights have no surface-able query date today.
- `HogQLQueryRunner.apply_dashboard_filters` ([posthog/hogql_queries/hogql_query_runner.py](posthog/hogql_queries/hogql_query_runner.py)) confirms dashboard date overrides do propagate into `HogQLQuery.filters.dateRange` server-side — so the SQL exclusion is a display heuristic, not a correctness gap.
- All other `TopHeading` callers (`QueryCard`, `Thread`, `NotebookArtifactAnswer`, `VisualizationArtifactAnswer`, `ExportedInsight`) pass only `query`, so the new optional props are backward compatible.

No automated tests were added or run for this change.

## Publish to changelog?

no

## 🤖 Agent context

Claude Code (Opus 4.7) authored.

Investigation started from a question about two related dashboard behaviors: (1) why filter changes trigger Edit mode, and (2) why per-tile date labels disappear when a dashboard date filter is set. Both turned out to be intentional decisions from #24303 and #48677 respectively, but the date-hiding had a real downside — tile-level overrides were also silently hidden, and viewers lost the at-a-glance "what range am I looking at" signal even when the dashboard default differed from per-insight defaults.

Considered alternative: extend `dateRangeFor` to also return `HogQLQuery.filters.dateRange` so SQL insights participate too. Rejected because (a) without parsing the SQL for the `{filters}` placeholder we can't tell whether the override will actually affect results, and (b) the user explicitly scoped this PR to non-SQL tiles.

The override precedence chosen — tile > dashboard > insight-own — matches the priority the backend uses when resolving filters, so the heading reflects the same range the data is queried with.