### PR TITLE
fix: Cancel pending uploads on abort

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -789,6 +789,11 @@ class ConcurrentS3Consumer(Consumer):
         # Remove from pending uploads immediately
         self.pending_uploads.pop(part_number, None)
 
+        # Ignore cancellations product of an aborted multi part upload
+        if task.cancelled():
+            self.logger.warning("Upload cancelled for file number %s part %s", self.current_file_index, part_number)
+            return
+
         # Handle any exceptions
         if task.exception() is not None:
             # Log the error - the exception will be re-raised when the task is awaited
@@ -904,12 +909,19 @@ class ConcurrentS3Consumer(Consumer):
         )
 
     async def _abort(self):
-        """Abort this S3 multi-part upload."""
+        """Abort this S3 multi-part upload and cancel any in-flight part uploads."""
+        if self.pending_uploads:
+            for task in self.pending_uploads.values():
+                task.cancel()
+            await asyncio.gather(*self.pending_uploads.values(), return_exceptions=True)
+            self.pending_uploads.clear()
+
         if self.upload_id:
+            upload_id = self.upload_id
             try:
                 client = await self._get_s3_client()
-                await client.abort_multipart_upload(
-                    Bucket=self.bucket, Key=self._get_current_key(), UploadId=self.upload_id
-                )
+                await client.abort_multipart_upload(Bucket=self.bucket, Key=self._get_current_key(), UploadId=upload_id)
             except Exception:
-                pass  # Best effort cleanup
+                self.logger.exception("Best-effort abort of multipart upload %s failed", upload_id)
+            finally:
+                self.upload_id = None


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

When aborting a multipart upload, we should first cancel any pending uploads. This avoids a race condition if the abort is delivered before the pending upload can finish, which would then cause the upload to fail with `NoSuchUpload`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Cancel pending uploads on aborting.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran tests.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
