### PR TITLE
fix(hogql): fix timezone_info override on compare/previous period ranges

### DIFF
--- a/posthog/hogql_queries/utils/query_compare_to_date_range.py
+++ b/posthog/hogql_queries/utils/query_compare_to_date_range.py
@@ -35,7 +35,7 @@ class QueryCompareToDateRange(QueryDateRange):
 
         start_date = relative_date_parse(
             self.compare_to,
-            self._team.timezone_info,
+            self._timezone_info,
             now=current_period_date_from,
             human_friendly_comparison_periods=bool(self._team.human_friendly_comparison_periods),
         )

--- a/posthog/hogql_queries/utils/query_previous_period_date_range.py
+++ b/posthog/hogql_queries/utils/query_previous_period_date_range.py
@@ -35,7 +35,7 @@ class QueryPreviousPeriodDateRange(QueryDateRange):
 
         delta_mapping = relative_date_parse_with_delta_mapping(
             date_from,
-            self._team.timezone_info,
+            self._timezone_info,
             now=self.now_with_timezone,
         )[1]
         return delta_mapping
@@ -44,7 +44,7 @@ class QueryPreviousPeriodDateRange(QueryDateRange):
         if self._date_range and self._date_range.date_to:
             delta_mapping = relative_date_parse_with_delta_mapping(
                 self._date_range.date_to,
-                self._team.timezone_info,
+                self._timezone_info,
                 always_truncate=True,
                 now=self.now_with_timezone,
             )[1]

--- a/posthog/hogql_queries/utils/test/test_query_compare_to_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_compare_to_date_range.py
@@ -1,3 +1,5 @@
+from zoneinfo import ZoneInfo
+
 from posthog.test.base import APIBaseTest
 
 from dateutil import parser
@@ -62,6 +64,46 @@ class TestQueryCompareToDateRange(APIBaseTest):
 
         # Human friendly comparison periods guarantee that the end of the week is same day
         self.assertEqual(query_date_range.date_to().isoweekday(), now.isoweekday())
+
+    def test_explicit_timezone_info_overrides_team_timezone(self):
+        # The compare-period parsing used to read directly from `self._team.timezone_info`,
+        # so a `timezone_info=UTC` override on the constructor was silently ignored.
+        # With the fix it should resolve `compare_to` in the explicitly-passed timezone.
+        self.team.timezone = "US/Pacific"
+        self.team.save()
+
+        now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        date_range = DateRange(date_from="-48h")
+        with_override = QueryCompareToDateRange(
+            team=self.team,
+            date_range=date_range,
+            interval=IntervalType.DAY,
+            now=now,
+            compare_to="-1d",
+            timezone_info=ZoneInfo("UTC"),
+        )
+        without_override = QueryCompareToDateRange(
+            team=self.team,
+            date_range=date_range,
+            interval=IntervalType.DAY,
+            now=now,
+            compare_to="-1d",
+        )
+        # With the override the compare period anchors to UTC; without it, to US/Pacific.
+        # The two must produce different instants — otherwise the override has no effect.
+        self.assertNotEqual(with_override.date_from(), without_override.date_from())
+        # And the override produces the same result as a UTC-team baseline would.
+        self.team.timezone = "UTC"
+        self.team.save()
+        utc_baseline = QueryCompareToDateRange(
+            team=self.team,
+            date_range=date_range,
+            interval=IntervalType.DAY,
+            now=now,
+            compare_to="-1d",
+        )
+        self.assertEqual(with_override.date_from(), utc_baseline.date_from())
+        self.assertEqual(with_override.date_to(), utc_baseline.date_to())
 
     def test_minus_one_year_human_friendly(self):
         self.team.human_friendly_comparison_periods = True

--- a/posthog/hogql_queries/utils/test/test_query_compare_to_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_compare_to_date_range.py
@@ -68,7 +68,13 @@ class TestQueryCompareToDateRange(APIBaseTest):
     def test_explicit_timezone_info_overrides_team_timezone(self):
         # The compare-period parsing used to read directly from `self._team.timezone_info`,
         # so a `timezone_info=UTC` override on the constructor was silently ignored.
-        # With the fix it should resolve `compare_to` in the explicitly-passed timezone.
+        #
+        # The bug surfaces in `date_from_str` / `date_to_str`, not in the datetime
+        # objects themselves: both point to the same UTC instant but display in
+        # different timezones. `format_date` strips the tz suffix via
+        # `strftime("%Y-%m-%d %H:%M:%S")`, so the formatted string carries the
+        # team-tz wall clock under the bug and the UTC wall clock with the fix.
+        # That string is what flows into ClickHouse, so we assert against it.
         self.team.timezone = "US/Pacific"
         self.team.save()
 
@@ -89,9 +95,9 @@ class TestQueryCompareToDateRange(APIBaseTest):
             now=now,
             compare_to="-1d",
         )
-        # With the override the compare period anchors to UTC; without it, to US/Pacific.
-        # The two must produce different instants — otherwise the override has no effect.
-        self.assertNotEqual(with_override.date_from(), without_override.date_from())
+        # The override must change the formatted output — otherwise the test wouldn't
+        # catch a regression of the fix.
+        self.assertNotEqual(with_override.date_from_str, without_override.date_from_str)
         # And the override produces the same result as a UTC-team baseline would.
         self.team.timezone = "UTC"
         self.team.save()
@@ -102,8 +108,8 @@ class TestQueryCompareToDateRange(APIBaseTest):
             now=now,
             compare_to="-1d",
         )
-        self.assertEqual(with_override.date_from(), utc_baseline.date_from())
-        self.assertEqual(with_override.date_to(), utc_baseline.date_to())
+        self.assertEqual(with_override.date_from_str, utc_baseline.date_from_str)
+        self.assertEqual(with_override.date_to_str, utc_baseline.date_to_str)
 
     def test_minus_one_year_human_friendly(self):
         self.team.human_friendly_comparison_periods = True

--- a/posthog/hogql_queries/utils/test/test_query_previous_period_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_previous_period_date_range.py
@@ -16,20 +16,25 @@ class TestQueryPreviousPeriodDateRange(APIBaseTest):
         query_date_range = QueryPreviousPeriodDateRange(
             team=self.team, date_range=date_range, interval=IntervalType.DAY, now=now
         )
-        # 2 days ago from now = 2021-08-23T00:00 → previous period of equal length
-        # goes back another 2 days (-48h shifted back by 48h).
-        self.assertEqual(query_date_range.date_from(), parser.isoparse("2021-08-21T00:00:00Z"))
+        # Current period [2021-08-23T00:00, 2021-08-25T23:59:59] is ~3 days inclusive.
+        # The previous period shifts back by that full span.
+        self.assertEqual(query_date_range.date_from(), parser.isoparse("2021-08-20T00:00:00Z"))
         self.assertEqual(query_date_range.date_to(), parser.isoparse("2021-08-22T23:59:59.999999Z"))
 
     def test_explicit_timezone_info_overrides_team_timezone(self):
         # The previous-period delta parsing used to read directly from
         # `self._team.timezone_info`, so a `timezone_info=UTC` override on the constructor
-        # was silently ignored. With the fix it should resolve the date range in the
-        # explicitly-passed timezone.
+        # was silently ignored.
+        #
+        # The bug surfaces in `date_from_str` / `date_to_str`, not in the datetime
+        # objects themselves: both point to the same UTC instant but display in
+        # different timezones. `format_date` strips the tz suffix via
+        # `strftime("%Y-%m-%d %H:%M:%S")`, so the formatted string carries the
+        # team-tz wall clock under the bug and the UTC wall clock with the fix.
+        # That string is what flows into ClickHouse, so we assert against it.
         #
         # `date_from="-2d"` is day-based, so the midnight-of-day anchor differs between
-        # US/Pacific (08-24 00:00 Pacific = 08-24 07:00 UTC) and UTC (08-24 00:00 UTC).
-        # A fixed-hour input like "-48h" would not exercise this — same delta either way.
+        # US/Pacific (08-24 00:00 PDT = 08-24 07:00 UTC) and UTC (08-24 00:00 UTC).
         self.team.timezone = "US/Pacific"
         self.team.save()
 
@@ -49,9 +54,9 @@ class TestQueryPreviousPeriodDateRange(APIBaseTest):
             interval=IntervalType.DAY,
             now=now,
         )
-        # The override must actually change the result — otherwise the test wouldn't
-        # notice a regression of the fix.
-        self.assertNotEqual(with_override.date_from(), without_override.date_from())
+        # The override must change the formatted output — otherwise the test wouldn't
+        # catch a regression of the fix.
+        self.assertNotEqual(with_override.date_from_str, without_override.date_from_str)
 
         # Same setup with team on UTC and no override — should match the override result.
         self.team.timezone = "UTC"
@@ -62,5 +67,5 @@ class TestQueryPreviousPeriodDateRange(APIBaseTest):
             interval=IntervalType.DAY,
             now=now,
         )
-        self.assertEqual(with_override.date_from(), utc_baseline.date_from())
-        self.assertEqual(with_override.date_to(), utc_baseline.date_to())
+        self.assertEqual(with_override.date_from_str, utc_baseline.date_from_str)
+        self.assertEqual(with_override.date_to_str, utc_baseline.date_to_str)

--- a/posthog/hogql_queries/utils/test/test_query_previous_period_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_previous_period_date_range.py
@@ -1,0 +1,52 @@
+from zoneinfo import ZoneInfo
+
+from posthog.test.base import APIBaseTest
+
+from dateutil import parser
+
+from posthog.schema import DateRange, IntervalType
+
+from posthog.hogql_queries.utils.query_previous_period_date_range import QueryPreviousPeriodDateRange
+
+
+class TestQueryPreviousPeriodDateRange(APIBaseTest):
+    def test_previous_period(self):
+        now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        date_range = DateRange(date_from="-48h")
+        query_date_range = QueryPreviousPeriodDateRange(
+            team=self.team, date_range=date_range, interval=IntervalType.DAY, now=now
+        )
+        # 2 days ago from now = 2021-08-23T00:00 → previous period of equal length
+        # goes back another 2 days (-48h shifted back by 48h).
+        self.assertEqual(query_date_range.date_from(), parser.isoparse("2021-08-21T00:00:00Z"))
+        self.assertEqual(query_date_range.date_to(), parser.isoparse("2021-08-22T23:59:59.999999Z"))
+
+    def test_explicit_timezone_info_overrides_team_timezone(self):
+        # The previous-period delta parsing used to read directly from
+        # `self._team.timezone_info`, so a `timezone_info=UTC` override on the constructor
+        # was silently ignored. With the fix it should resolve the date range in the
+        # explicitly-passed timezone.
+        self.team.timezone = "US/Pacific"
+        self.team.save()
+
+        now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        date_range = DateRange(date_from="-48h")
+        with_override = QueryPreviousPeriodDateRange(
+            team=self.team,
+            date_range=date_range,
+            interval=IntervalType.DAY,
+            now=now,
+            timezone_info=ZoneInfo("UTC"),
+        )
+
+        # Same setup with team on UTC and no override — should match the override result.
+        self.team.timezone = "UTC"
+        self.team.save()
+        utc_baseline = QueryPreviousPeriodDateRange(
+            team=self.team,
+            date_range=date_range,
+            interval=IntervalType.DAY,
+            now=now,
+        )
+        self.assertEqual(with_override.date_from(), utc_baseline.date_from())
+        self.assertEqual(with_override.date_to(), utc_baseline.date_to())

--- a/posthog/hogql_queries/utils/test/test_query_previous_period_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_previous_period_date_range.py
@@ -26,11 +26,16 @@ class TestQueryPreviousPeriodDateRange(APIBaseTest):
         # `self._team.timezone_info`, so a `timezone_info=UTC` override on the constructor
         # was silently ignored. With the fix it should resolve the date range in the
         # explicitly-passed timezone.
+        #
+        # `date_from="-2d"` is day-based, so the midnight-of-day anchor differs between
+        # US/Pacific (08-24 00:00 Pacific = 08-24 07:00 UTC) and UTC (08-24 00:00 UTC).
+        # A fixed-hour input like "-48h" would not exercise this — same delta either way.
         self.team.timezone = "US/Pacific"
         self.team.save()
 
         now = parser.isoparse("2021-08-25T00:00:00.000Z")
-        date_range = DateRange(date_from="-48h")
+        date_range = DateRange(date_from="-2d")
+
         with_override = QueryPreviousPeriodDateRange(
             team=self.team,
             date_range=date_range,
@@ -38,6 +43,15 @@ class TestQueryPreviousPeriodDateRange(APIBaseTest):
             now=now,
             timezone_info=ZoneInfo("UTC"),
         )
+        without_override = QueryPreviousPeriodDateRange(
+            team=self.team,
+            date_range=date_range,
+            interval=IntervalType.DAY,
+            now=now,
+        )
+        # The override must actually change the result — otherwise the test wouldn't
+        # notice a regression of the fix.
+        self.assertNotEqual(with_override.date_from(), without_override.date_from())
 
         # Same setup with team on UTC and no override — should match the override result.
         self.team.timezone = "UTC"


### PR DESCRIPTION

## Problem

the special QueryDateRange subclasses QueryCompareToDateRange / QueryPreviousPeriodDateRange were not correctly handling timezone_info overrides
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

use self._timezone_info from the base class instead of always using the team's timezone
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

locally, unit tests
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
