### PR TITLE
chore: Postgres: removed chunk cap from partitioned tables sync

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/partitioned_tables.py
+++ b/posthog/temporal/data_imports/sources/postgres/partitioned_tables.py
@@ -21,11 +21,6 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
 
 from products.data_warehouse.backend.types import IncrementalFieldType, PartitionSettings
 
-# Max rows per FETCH when reading a partitioned parent table. A partitioned
-# parent scan dispatches across every child partition; a large chunk size can
-# blow past the source's statement_timeout even when per-row payload is small.
-PARTITIONED_TABLE_MAX_CHUNK_SIZE = 30_000
-
 # Retry budgets for iterate_date_windows. Counters reset on every successful
 # window. Exhausting QueryCanceled surfaces QueryTimeoutException; exhausting
 # SerializationFailure re-raises the original error so the caller can decide
@@ -637,7 +632,6 @@ def is_supported_incremental_type_for_window(field_type: Optional[IncrementalFie
 
 
 __all__ = [
-    "PARTITIONED_TABLE_MAX_CHUNK_SIZE",
     "WINDOW_MAX_QUERY_CANCELED_RETRIES",
     "WINDOW_MAX_SERIALIZATION_RETRIES",
     "ChildPartition",

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -39,7 +39,6 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
 )
 from posthog.temporal.data_imports.sources.common.sql import Column, Table
 from posthog.temporal.data_imports.sources.postgres.partitioned_tables import (
-    PARTITIONED_TABLE_MAX_CHUNK_SIZE,
     build_partition_query,
     get_estimated_row_count_for_partitioned_table as _get_estimated_row_count_for_partitioned_table,
     get_partition_settings_for_partitioned_table as _get_partition_settings_for_partitioned_table,
@@ -1554,15 +1553,7 @@ def postgres_source(
                         logger.debug(f"Using chunk_size_override: {chunk_size_override}")
                     else:
                         chunk_size = _get_table_chunk_size(cursor, inner_query_with_limit, logger)
-                        # Cap chunk size for partitioned tables. Server-cursor FETCH
-                        # on a partitioned parent scans across all child partitions,
-                        # so a large chunk can exceed statement_timeout even when
-                        # per-row size is small.
-                        if is_partitioned and chunk_size > PARTITIONED_TABLE_MAX_CHUNK_SIZE:
-                            logger.debug(
-                                f"Capping chunk_size from {chunk_size} to {PARTITIONED_TABLE_MAX_CHUNK_SIZE} for partitioned table"
-                            )
-                            chunk_size = PARTITIONED_TABLE_MAX_CHUNK_SIZE
+
                     logger.debug("Getting rows to sync...")
                     # For partitioned tables without an incremental cursor (initial
                     # sync, re-sync, or non-incremental), use pg_class.reltuples

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -13,6 +13,7 @@ import pyarrow as pa
 import structlog
 from psycopg import sql
 
+import posthog.temporal.data_imports.sources.postgres.partitioned_tables as partitioned_tables_pkg
 from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     DEFAULT_NUMERIC_SCALE,
     MAX_NUMERIC_SCALE,
@@ -586,6 +587,14 @@ class TestIsPartitionedTable:
             for stmt in setup_ddl:
                 dj_cursor.execute(stmt)
             assert _is_partitioned_table(cast(Any, dj_cursor), "public", table_name) is expected
+
+
+class TestPartitionedTableChunkSizing:
+    """Incremental reads use per-child partition queries; no parent FETCH chunk cap."""
+
+    def test_no_partitioned_fetch_cap_exported(self) -> None:
+        assert not hasattr(partitioned_tables_pkg, "PARTITIONED_TABLE_MAX_CHUNK_SIZE")
+        assert "PARTITIONED_TABLE_MAX_CHUNK_SIZE" not in partitioned_tables_pkg.__all__
 
 
 class TestGetEstimatedRowCountForPartitionedTable:


### PR DESCRIPTION

## Problem
We added a chunk cap of 30k rows for Postgres partitioned tables, to limit partitions being queried and get some actual data back from the db. But now we are querying the partition tables themselves, so this should not be a problem anymore. Removing this will actually help us by re-merging partitions less frequently.

## Changes

- Removed the cap, removed imports and tests related to it

## How did you test this code?

Unit tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

no
