### PR TITLE
fix(dags): retry NO_REPLICA_HAS_PART / NO_ACTIVE_REPLICAS in CH class…

### DIFF
--- a/posthog/dags/common/resources.py
+++ b/posthog/dags/common/resources.py
@@ -42,6 +42,12 @@ def _is_retryable_clickhouse_exception(e: Exception) -> bool:
                 ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES,
                 ErrorCodes.NOT_ENOUGH_SPACE,
                 ErrorCodes.SOCKET_TIMEOUT,
+                # Raised by waitMutationToFinishOnReplicas / cross-replica reads when the
+                # coordinator's snapshot of active replicas momentarily lacks the covering
+                # part (e.g. mid-fetch, mid-merge) or no replica is online. The mutation
+                # itself usually proceeds; the wait is what fails. Retry to re-poll.
+                ErrorCodes.NO_REPLICA_HAS_PART,  # 234
+                ErrorCodes.NO_ACTIVE_REPLICAS,  # 254
                 439,  # CANNOT_SCHEDULE_TASK: "Cannot schedule a task: cannot allocate thread"
             )
         )


### PR DESCRIPTION
…ifier

## Problem

The data deletion property-removal DAG exhibited `Code: 234. DB::Exception: ... (NO_REPLICA_HAS_PART)` raised from `waitMutationToFinishOnReplicas`. The DELETE mutation itself completed successfully, verified. The synchronous wait just polled at a moment when the active-replica set didn't yet have the covering part.

The DAG marked the deletion request as `failed` despite the data being in the desired state.

## Changes

Add `NO_REPLICA_HAS_PART` (234) and `NO_ACTIVE_REPLICAS` (254) to `_is_retryable_clickhouse_exception` in `posthog/dags/common/resources.py`. Both are transient cross-replica coordination errors unrelated to the
query itself. With the existing 8-attempt × 20s exponential backoff, the wait now re-polls and finds the mutation done instead of failing the run.

Applies to every Dagster resource that uses this classifier: the default cluster resource, backups, part_breaker.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
