### PR TITLE
chore(cdp): remove per-batch info log from cdp consumers

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
@@ -337,10 +337,6 @@ export class CdpBatchHogFlowRequestsConsumer extends CdpConsumerBase<PluginsServ
         await this.cyclotronJobQueue.startAsProducer()
         // Start consuming messages
         await this.kafkaConsumer.connect(async (messages) => {
-            logger.info('🔁', `${this.name} - handling batch`, {
-                size: messages.length,
-            })
-
             return await instrumentFn('cdpConsumer.handleEachBatch', async () => {
                 const batchHogFlowRequestMessages = await this._parseKafkaBatch(messages)
                 const { backgroundTask } = await this.processBatch(batchHogFlowRequestMessages)

--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
@@ -129,10 +129,6 @@ export class CdpCohortMembershipConsumer extends CdpConsumerBase {
         logger.info('🚀', `${this.name} starting...`)
 
         await this.kafkaConsumer.connect(async (messages) => {
-            logger.info('🔁', `${this.name} - handling batch`, {
-                size: messages.length,
-            })
-
             return instrumentFn('cdpCohortMembershipConsumer.handleEachBatch', async () => {
                 const cohortMembershipChanges = this._parseAndValidateBatch(messages)
                 await this.persistCohortMembershipChanges(cohortMembershipChanges)

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -120,10 +120,6 @@ export class CdpCyclotronWorker<
             return { backgroundTask: Promise.resolve(), invocationResults: [] }
         }
 
-        logger.info('🔁', `${this.name} - handling batch`, {
-            size: invocations.length,
-        })
-
         const invocationResults = await this.processInvocations(invocations)
 
         // NOTE: We can queue and publish all metrics in the background whilst processing the next batch of invocations

--- a/nodejs/src/cdp/consumers/cdp-events.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-events.consumer.ts
@@ -473,10 +473,6 @@ export class CdpEventsConsumer<
         await this.cyclotronJobQueue.startAsProducer()
         // Start consuming messages
         await this.kafkaConsumer.connect(async (messages) => {
-            logger.info('🔁', `${this.name} - handling batch`, {
-                size: messages.length,
-            })
-
             return await instrumentFn('cdpConsumer.handleEachBatch', async () => {
                 const invocationGlobals = await this._parseKafkaBatch(messages)
                 const { backgroundTask } = await this.processBatch(invocationGlobals)

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -406,10 +406,6 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
         await this.legacyWebhookService.start()
         // Start consuming messages
         await this.kafkaConsumer.connect(async (messages) => {
-            logger.info('🔁', `${this.name} - handling batch`, {
-                size: messages.length,
-            })
-
             return await instrumentFn('cdpLegacyConsumer.handleEachBatch', async () => {
                 const [webhookBatch, pluginBatch] = await Promise.all([
                     this.legacyWebhookService.processBatch(messages),

--- a/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
@@ -292,10 +292,6 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
         await super.start()
 
         await this.eventKafkaConsumer.connect(async (messages) => {
-            logger.info('🔁', `${this.name} - handling event batch`, {
-                size: messages.length,
-            })
-
             return await instrumentFn('cdpPrecalculatedFiltersConsumer.handleEventBatch', async () => {
                 const { precalculatedEvents, precalculatedPersonProperties } = await this._parseKafkaBatch(messages)
 


### PR DESCRIPTION
## Problem

The `handling batch` / `handling event batch` info log line fires once per Kafka batch in every CDP consumer. At high throughput these spam the log pipeline — we recently observed ~28M log lines in a single minute from `cdp-precalculated-filters-consumer-ws`. Per-service rate limiting is on the way, but the services should also just be quieter under load.

## Changes

Remove the per-batch `logger.info('🔁', '<name> - handling batch', { size })` call from each CDP consumer:

- `cdp-precalculated-filters.consumer.ts` (also `handling event batch`)
- `cdp-events.consumer.ts`
- `cdp-batch-hogflow.consumer.ts`
- `cdp-legacy-event.consumer.ts`
- `cdp-cyclotron-worker.consumer.ts`
- `cdp-cohort-membership.consumer.ts`

Errors that occur while consuming a batch are already logged in their respective handlers, and batch throughput / latency is observable via the `instrumentFn` metrics that wrap each handler — so the info log is redundant.

Out of scope: similar `handling batch` log lines in `logs-ingestion-consumer.ts` and `session-recording/consumer.ts` (not CDP).

## How did you test this code?

I'm an agent. No tests were added — this is a pure log-line removal with no behavioral change. I verified via grep that no remaining CDP code or test references the removed message, and confirmed `logger` is still used elsewhere in each file so no imports needed cleanup.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code in response to a request to drop the per-batch info log from all CDP services and only log when batch consumption fails. Considered keeping a sampled or DEBUG-level version of the log, but landed on a straight removal since the same information is already captured via `instrumentFn` metrics and the error paths still log. Verified the targeted log lines were the only matches for "handling batch" / "handling event batch" inside `nodejs/src/cdp/` (other than the existing `Error handling hogflow batch invocation` error log, which is intentionally kept).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*