### PR TITLE
feat(dashboards): expose activity-log diffs to MCP and add revert action

### DIFF
--- a/ee/hogai/context/activity_log/context.py
+++ b/ee/hogai/context/activity_log/context.py
@@ -6,12 +6,12 @@ from typing import Any, cast
 from django.db.models import QuerySet
 
 from posthog.api.advanced_activity_logs.utils import get_activity_log_lookback_restriction
-from posthog.api.advanced_activity_logs.viewset import apply_organization_scoped_filter
 from posthog.models import Team, User
 from posthog.models.activity_logging.activity_log import (
     ActivityLog,
     ActivityScope,
     apply_activity_visibility_restrictions,
+    apply_organization_scoped_filter,
     field_name_overrides,
 )
 from posthog.sync import database_sync_to_async

--- a/posthog/api/advanced_activity_logs/viewset.py
+++ b/posthog/api/advanced_activity_logs/viewset.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Any, Optional, cast, get_args
 from urllib.parse import urlencode
 
-from django.db.models import Q, QuerySet
+from django.db.models import QuerySet
 
 from drf_spectacular.utils import extend_schema, extend_schema_field
 from rest_framework import mixins, serializers, viewsets
@@ -24,6 +24,7 @@ from posthog.models.activity_logging.activity_log import (
     ActivityLog,
     ActivityScope,
     apply_activity_visibility_restrictions,
+    apply_organization_scoped_filter,
 )
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.organization import Organization, OrganizationMembership
@@ -34,24 +35,6 @@ from posthog.tasks import exporter
 from .field_discovery import AdvancedActivityLogFieldDiscovery
 from .filters import AdvancedActivityLogFilterManager
 from .utils import get_activity_log_lookback_restriction
-
-
-def apply_organization_scoped_filter(
-    queryset: QuerySet[ActivityLog], include_org_scoped: bool, team_id: int, organization_id
-) -> QuerySet[ActivityLog]:
-    """
-    Filter activity log queryset by team/org.
-
-    When include_org_scoped is True, includes both:
-    - Records with team_id matching the given team
-    - Records with team_id=NULL and organization_id matching (org-scoped records)
-
-    When False, only filters by team_id.
-    """
-    if include_org_scoped:
-        return queryset.filter(Q(team_id=team_id) | Q(team_id__isnull=True, organization_id=organization_id))
-    else:
-        return queryset.filter(team_id=team_id)
 
 
 class ActivityLogSerializer(serializers.ModelSerializer):

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -29,7 +29,7 @@ from pydantic import (
     ValidationError as PydanticValidationError,
 )
 from rest_framework import relations, request, serializers, status, viewsets
-from rest_framework.exceptions import APIException, NotFound, ParseError, PermissionDenied, ValidationError
+from rest_framework.exceptions import APIException, ParseError, PermissionDenied, ValidationError
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import BaseRenderer
 from rest_framework.request import Request
@@ -103,7 +103,6 @@ from posthog.models.activity_logging.activity_page import ActivityLogPaginatedRe
 from posthog.models.activity_logging.revert import (
     RevertActivityLogRequestSerializer,
     apply_revert_to_instance,
-    is_activity_log_revert_enabled,
     lookup_revertable_activity_log_entry,
 )
 from posthog.models.alert import AlertConfiguration
@@ -2255,10 +2254,6 @@ When set, the specified dashboard's filters and date range override will be appl
     )
     @action(methods=["POST"], detail=True, required_scopes=["insight:write"])
     def revert(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-        # 404 (not 403) when the experimental flag is off — the endpoint should look
-        # like it doesn't exist to anyone outside the rollout.
-        if not is_activity_log_revert_enabled(cast(User, request.user), self.team):
-            raise NotFound()
         # get_object() runs through AccessControlViewSetMixin, which enforces edit
         # access on the insight. Combined with `insight:write`, this gates the write.
         insight = self.get_object()

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -100,6 +100,11 @@ from posthog.models.activity_logging.activity_log import (
     log_activity,
 )
 from posthog.models.activity_logging.activity_page import ActivityLogPaginatedResponseSerializer, activity_page_response
+from posthog.models.activity_logging.revert import (
+    RevertActivityLogRequestSerializer,
+    apply_revert_to_instance,
+    lookup_revertable_activity_log_entry,
+)
 from posthog.models.alert import AlertConfiguration
 from posthog.models.filters.utils import get_filter
 from posthog.models.insight import InsightViewed
@@ -1206,6 +1211,29 @@ class InsightViewedRequestSerializer(serializers.Serializer):
     )
 
 
+# Fields on Insight whose `before` value can be safely applied during revert.
+# Excludes foreign keys (created_by, last_modified_by, team), m2m (dashboards, tags),
+# derived/computed fields (filters_hash, query_metadata, derived_name), soft-delete
+# (deleted), and UI state (saved, favorited).
+REVERTABLE_INSIGHT_FIELDS: frozenset[str] = frozenset({"name", "description", "filters", "query"})
+
+
+class RevertInsightResponseSerializer(serializers.Serializer):
+    insight = InsightSerializer(help_text="The insight after the revert has been applied.")
+    applied_fields = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Fields that were reset to their `before` value from the activity log entry.",
+    )
+    skipped_fields = serializers.ListField(
+        child=serializers.CharField(),
+        help_text=(
+            "Fields recorded in the activity log entry that this endpoint will not revert — typically "
+            "relations (created_by, dashboards, tags), derived fields (filters_hash, query_metadata), "
+            "or UI state (saved, favorited)."
+        ),
+    )
+
+
 @extend_schema(tags=[ProductKey.PRODUCT_ANALYTICS])
 @extend_schema_view(
     list=extend_schema(
@@ -2203,6 +2231,67 @@ When set, the specified dashboard's filters and date range override will be appl
             page=page,
         )
         return activity_page_response(activity_page, limit, page, request)
+
+    @extend_schema(
+        request=RevertActivityLogRequestSerializer,
+        responses={200: RevertInsightResponseSerializer},
+        description=(
+            "Revert this insight to the state recorded immediately before a specific activity log entry. "
+            "Each field captured in that entry's `changes` is reset to its `before` value. Foreign keys, "
+            "m2m relations (dashboards, tags), derived fields (filters_hash, query_metadata), and UI state "
+            "(saved, favorited) are skipped and listed in `skipped_fields`. Saving the insight records a "
+            "new `updated` activity log entry, so reverts are themselves auditable and can be reverted in turn."
+        ),
+    )
+    @action(methods=["POST"], detail=True, required_scopes=["insight:write"])
+    def revert(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+        # get_object() runs through AccessControlViewSetMixin, which enforces edit
+        # access on the insight. Combined with `insight:write`, this gates the write.
+        insight = self.get_object()
+
+        request_serializer = RevertActivityLogRequestSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+
+        log_entry = lookup_revertable_activity_log_entry(
+            activity_log_id=request_serializer.validated_data["activity_log_id"],
+            scope="Insight",
+            item_id=str(insight.id),
+            team_id=self.team_id,
+            organization_id=self.team.organization_id,
+            include_org_scoped=bool(self.team.receive_org_level_activity_logs),
+            user=request.user,
+        )
+
+        # Snapshot the pre-revert state so we can emit a faithful activity log entry
+        # for the revert itself — Insight uses imperative activity logging, not the
+        # ModelActivityMixin signal, so save() alone does not record anything.
+        before_update = Insight.objects.get(pk=insight.pk)
+        applied, skipped = apply_revert_to_instance(insight, log_entry, REVERTABLE_INSIGHT_FIELDS)
+        insight.save()
+
+        changes = [
+            c for c in changes_between("Insight", previous=before_update, current=insight) if c.field != "dashboards"
+        ]
+        log_and_report_insight_activity(
+            activity="updated",
+            insight=insight,
+            insight_id=insight.id,
+            insight_short_id=insight.short_id,
+            organization_id=cast(User, request.user).current_organization_id,
+            team_id=self.team_id,
+            user=cast(User, request.user),
+            was_impersonated=is_impersonated_session(request),
+            request=request,
+            changes=changes,
+        )
+
+        return Response(
+            {
+                "insight": InsightSerializer(insight, context=self.get_serializer_context()).data,
+                "applied_fields": applied,
+                "skipped_fields": skipped,
+            }
+        )
 
     @action(methods=["POST"], detail=False)
     @monitor(feature=Feature.INSIGHT, endpoint="insight", method="CANCEL")

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -29,7 +29,7 @@ from pydantic import (
     ValidationError as PydanticValidationError,
 )
 from rest_framework import relations, request, serializers, status, viewsets
-from rest_framework.exceptions import APIException, ParseError, PermissionDenied, ValidationError
+from rest_framework.exceptions import APIException, NotFound, ParseError, PermissionDenied, ValidationError
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import BaseRenderer
 from rest_framework.request import Request
@@ -103,6 +103,7 @@ from posthog.models.activity_logging.activity_page import ActivityLogPaginatedRe
 from posthog.models.activity_logging.revert import (
     RevertActivityLogRequestSerializer,
     apply_revert_to_instance,
+    is_activity_log_revert_enabled,
     lookup_revertable_activity_log_entry,
 )
 from posthog.models.alert import AlertConfiguration
@@ -2254,6 +2255,10 @@ When set, the specified dashboard's filters and date range override will be appl
     )
     @action(methods=["POST"], detail=True, required_scopes=["insight:write"])
     def revert(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+        # 404 (not 403) when the experimental flag is off — the endpoint should look
+        # like it doesn't exist to anyone outside the rollout.
+        if not is_activity_log_revert_enabled(cast(User, request.user), self.team):
+            raise NotFound()
         # get_object() runs through AccessControlViewSetMixin, which enforces edit
         # access on the insight. Combined with `insight:write`, this gates the write.
         insight = self.get_object()

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1220,6 +1220,12 @@ REVERTABLE_INSIGHT_FIELDS: frozenset[str] = frozenset({"name", "description", "f
 
 class RevertInsightResponseSerializer(serializers.Serializer):
     insight = InsightSerializer(help_text="The insight after the revert has been applied.")
+    activity_log_id = serializers.UUIDField(
+        help_text=(
+            "ID of the activity log entry that was reverted. When the caller passed an explicit id, "
+            "this echoes it; when omitted, this is the most recent revertable entry the endpoint picked."
+        ),
+    )
     applied_fields = serializers.ListField(
         child=serializers.CharField(),
         help_text="Fields that were reset to their `before` value from the activity log entry.",
@@ -2236,11 +2242,14 @@ When set, the specified dashboard's filters and date range override will be appl
         request=RevertActivityLogRequestSerializer,
         responses={200: RevertInsightResponseSerializer},
         description=(
-            "Revert this insight to the state recorded immediately before a specific activity log entry. "
-            "Each field captured in that entry's `changes` is reset to its `before` value. Foreign keys, "
-            "m2m relations (dashboards, tags), derived fields (filters_hash, query_metadata), and UI state "
-            "(saved, favorited) are skipped and listed in `skipped_fields`. Saving the insight records a "
-            "new `updated` activity log entry, so reverts are themselves auditable and can be reverted in turn."
+            "Revert this insight to a previous state captured in the activity log. Pass `activity_log_id` "
+            "to target a specific entry, or omit it to undo the most recent revertable change — the "
+            "natural meaning of 'revert this insight'. The chosen entry id is echoed back as "
+            "`activity_log_id` so callers can confirm what was reverted. Each captured field is reset "
+            "to its `before` value; foreign keys, m2m relations (dashboards, tags), derived fields "
+            "(filters_hash, query_metadata), and UI state (saved, favorited) are skipped and listed in "
+            "`skipped_fields`. Saving the insight records a new `updated` activity log entry, so "
+            "reverts are themselves auditable and can be reverted in turn."
         ),
     )
     @action(methods=["POST"], detail=True, required_scopes=["insight:write"])
@@ -2253,13 +2262,14 @@ When set, the specified dashboard's filters and date range override will be appl
         request_serializer.is_valid(raise_exception=True)
 
         log_entry = lookup_revertable_activity_log_entry(
-            activity_log_id=request_serializer.validated_data["activity_log_id"],
+            activity_log_id=request_serializer.validated_data.get("activity_log_id"),
             scope="Insight",
             item_id=str(insight.id),
             team_id=self.team_id,
             organization_id=self.team.organization_id,
             include_org_scoped=bool(self.team.receive_org_level_activity_logs),
             user=request.user,
+            revertable_fields=REVERTABLE_INSIGHT_FIELDS,
         )
 
         # Snapshot the pre-revert state so we can emit a faithful activity log entry
@@ -2288,6 +2298,7 @@ When set, the specified dashboard's filters and date range override will be appl
         return Response(
             {
                 "insight": InsightSerializer(insight, context=self.get_serializer_context()).data,
+                "activity_log_id": str(log_entry.id),
                 "applied_fields": applied,
                 "skipped_fields": skipped,
             }

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -2275,7 +2275,9 @@ When set, the specified dashboard's filters and date range override will be appl
         # Snapshot the pre-revert state so we can emit a faithful activity log entry
         # for the revert itself — Insight uses imperative activity logging, not the
         # ModelActivityMixin signal, so save() alone does not record anything.
-        before_update = Insight.objects.get(pk=insight.pk)
+        # `objects_including_soft_deleted` matches the viewset's `get_object()`
+        # queryset; the default manager excludes soft-deleted insights and would 500.
+        before_update = Insight.objects_including_soft_deleted.get(pk=insight.pk)
         applied, skipped = apply_revert_to_instance(insight, log_entry, REVERTABLE_INSIGHT_FIELDS)
         insight.save()
 

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -80,6 +80,18 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.organization.save()
         self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
 
+        # Default the experimental activity-log revert flag to ON so the existing
+        # revert tests exercise the full path. Individual tests can stop this
+        # patcher early (or restart with return_value=False) to assert flag-off
+        # behaviour. The patch only intercepts feature_enabled() calls made from
+        # the revert helper module, so non-revert tests are unaffected.
+        self._revert_flag_patcher = patch(
+            "posthog.models.activity_logging.revert.posthoganalytics.feature_enabled",
+            return_value=True,
+        )
+        self._revert_flag_patcher.start()
+        self.addCleanup(self._revert_flag_patcher.stop)
+
     @snapshot_postgres_queries
     def test_retrieve_dashboard_list(self):
         dashboard_names = ["a dashboard", "b dashboard"]
@@ -3287,6 +3299,21 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         return ActivityLog.objects.filter(scope="Dashboard", item_id=str(dashboard_id), activity="updated").latest(
             "created_at"
         )
+
+    def test_revert_dashboard_returns_404_when_feature_flag_disabled(self):
+        # Stack a return_value=False patch on top of the default-on setUp patcher;
+        # the with-block restores the True patcher on exit so addCleanup is happy.
+        with patch(
+            "posthog.models.activity_logging.revert.posthoganalytics.feature_enabled",
+            return_value=False,
+        ):
+            dashboard = Dashboard.objects.create(team=self.team, name="Dashboard")
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+                {},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_revert_dashboard_without_log_id_picks_latest_revertable(self):
         dashboard = Dashboard.objects.create(team=self.team, name="Original", description="Original description")

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -3288,6 +3288,90 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             "created_at"
         )
 
+    def test_revert_dashboard_without_log_id_picks_latest_revertable(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Original", description="Original description")
+        self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/",
+            {"name": "First edit"},
+            content_type="application/json",
+        )
+        self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/",
+            {"description": "Second edit"},
+            content_type="application/json",
+        )
+        latest_log = self._get_dashboard_activity_log(dashboard.pk)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        body = response.json()
+        self.assertEqual(body["activity_log_id"], str(latest_log.id))
+        self.assertEqual(body["applied_fields"], ["description"])
+        dashboard.refresh_from_db()
+        self.assertEqual(dashboard.description, "Original description")
+        # The earlier name edit should still be intact — we only undid the latest change.
+        self.assertEqual(dashboard.name, "First edit")
+
+    def test_revert_dashboard_without_log_id_skips_non_revertable_entries(self):
+        # An activity log entry that touched only a non-revertable field (created_by)
+        # should be skipped — the endpoint walks back to the next revertable entry.
+        dashboard = Dashboard.objects.create(team=self.team, name="Original")
+        self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/",
+            {"name": "Edited"},
+            content_type="application/json",
+        )
+        revertable_log = self._get_dashboard_activity_log(dashboard.pk)
+        # Now add a more-recent, non-revertable-only log entry.
+        ActivityLog.objects.create(
+            team_id=self.team.pk,
+            organization_id=self.organization.pk,
+            user=self.user,
+            scope="Dashboard",
+            item_id=str(dashboard.pk),
+            activity="updated",
+            detail={
+                "name": dashboard.name,
+                "type": "dashboard",
+                "changes": [
+                    {"type": "Dashboard", "action": "changed", "field": "created_by", "before": None, "after": 1}
+                ],
+            },
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["activity_log_id"], str(revertable_log.id))
+        self.assertEqual(response.json()["applied_fields"], ["name"])
+
+    def test_revert_dashboard_without_log_id_returns_404_when_none_revertable(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Dashboard")
+        # Only a "created"-style entry with no revertable fields exists.
+        ActivityLog.objects.create(
+            team_id=self.team.pk,
+            organization_id=self.organization.pk,
+            user=self.user,
+            scope="Dashboard",
+            item_id=str(dashboard.pk),
+            activity="created",
+            detail={"name": dashboard.name, "type": "dashboard", "changes": []},
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_revert_dashboard_restores_simple_field(self):
         dashboard = Dashboard.objects.create(team=self.team, name="Original Name", description="Original description")
 

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -3427,6 +3427,64 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_revert_dashboard_requires_edit_permission_on_dashboard(self):
+        # A member who is not a collaborator on a restricted dashboard cannot revert it,
+        # even if the activity log entry is otherwise accessible.
+        dashboard = Dashboard.objects.create(team=self.team, name="Original", created_by=self.user)
+        self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/",
+            {"name": "Edited"},
+            content_type="application/json",
+        )
+        target_log = self._get_dashboard_activity_log(dashboard.pk)
+
+        # Restrict the dashboard and switch the request user to a non-collaborator.
+        dashboard.restriction_level = Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+        dashboard.created_by = None
+        dashboard.save()
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        other_user = User.objects.create_and_join(self.organization, "non-collab@example.com", None)
+        self.client.force_login(other_user)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {"activity_log_id": str(target_log.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        dashboard.refresh_from_db()
+        self.assertEqual(dashboard.name, "Edited")
+
+    def test_revert_dashboard_rejects_log_from_another_team(self):
+        # Activity log entries from other teams must not be reachable, even if the
+        # current user can edit the target dashboard.
+        dashboard = Dashboard.objects.create(team=self.team, name="Dashboard")
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+        cross_team_log = ActivityLog.objects.create(
+            team_id=other_team.pk,
+            organization_id=other_org.pk,
+            user=self.user,
+            scope="Dashboard",
+            item_id=str(dashboard.pk),
+            activity="updated",
+            detail={
+                "name": dashboard.name,
+                "type": "dashboard",
+                "changes": [
+                    {"type": "Dashboard", "action": "changed", "field": "name", "before": "Old", "after": "New"}
+                ],
+            },
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {"activity_log_id": str(cross_team_log.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_revert_dashboard_mixed_fields_lists_skipped(self):
         dashboard = Dashboard.objects.create(team=self.team, name="Original")
         # Hand-craft a log entry mixing revertable (name) and skipped (created_by) fields.

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -3420,7 +3420,12 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         names = {c["field"] for c in (newest.detail or {}).get("changes", [])}
         self.assertIn("name", names)
 
-    def test_revert_dashboard_undeletes(self):
+    def test_revert_dashboard_does_not_undelete(self):
+        # `deleted` is intentionally NOT in REVERTABLE_DASHBOARD_FIELDS because the
+        # normal soft-delete/restore path runs related-state bookkeeping (DashboardTile
+        # cleanup, Team.primary_dashboard, group_type_mapping) that a raw setattr would
+        # bypass. A revert targeting only `deleted` should be rejected as having no
+        # revertable fields.
         dashboard = Dashboard.objects.create(team=self.team, name="To delete")
         self.client.patch(
             f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/",
@@ -3434,10 +3439,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             {"activity_log_id": str(target_log.id)},
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("deleted", response.json()["applied_fields"])
-        dashboard.refresh_from_db()
-        self.assertFalse(dashboard.deleted)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_revert_dashboard_with_unknown_log_id_returns_404(self):
         dashboard = Dashboard.objects.create(team=self.team, name="Dashboard")

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -80,18 +80,6 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.organization.save()
         self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
 
-        # Default the experimental activity-log revert flag to ON so the existing
-        # revert tests exercise the full path. Individual tests can stop this
-        # patcher early (or restart with return_value=False) to assert flag-off
-        # behaviour. The patch only intercepts feature_enabled() calls made from
-        # the revert helper module, so non-revert tests are unaffected.
-        self._revert_flag_patcher = patch(
-            "posthog.models.activity_logging.revert.posthoganalytics.feature_enabled",
-            return_value=True,
-        )
-        self._revert_flag_patcher.start()
-        self.addCleanup(self._revert_flag_patcher.stop)
-
     @snapshot_postgres_queries
     def test_retrieve_dashboard_list(self):
         dashboard_names = ["a dashboard", "b dashboard"]
@@ -3299,21 +3287,6 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         return ActivityLog.objects.filter(scope="Dashboard", item_id=str(dashboard_id), activity="updated").latest(
             "created_at"
         )
-
-    def test_revert_dashboard_returns_404_when_feature_flag_disabled(self):
-        # Stack a return_value=False patch on top of the default-on setUp patcher;
-        # the with-block restores the True patcher on exit so addCleanup is happy.
-        with patch(
-            "posthog.models.activity_logging.revert.posthoganalytics.feature_enabled",
-            return_value=False,
-        ):
-            dashboard = Dashboard.objects.create(team=self.team, name="Dashboard")
-            response = self.client.post(
-                f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
-                {},
-                content_type="application/json",
-            )
-            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_revert_dashboard_without_log_id_picks_latest_revertable(self):
         dashboard = Dashboard.objects.create(team=self.team, name="Original", description="Original description")

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -3282,3 +3282,188 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.json()["dashboards"], [dashboard1.pk])
         self.assertTrue(DashboardTile.objects.filter(dashboard=dashboard1, insight=insight).exists())
         self.assertFalse(DashboardTile.objects.filter(dashboard=dashboard2, insight=insight, deleted=False).exists())
+
+    def _get_dashboard_activity_log(self, dashboard_id: int) -> ActivityLog:
+        return ActivityLog.objects.filter(scope="Dashboard", item_id=str(dashboard_id), activity="updated").latest(
+            "created_at"
+        )
+
+    def test_revert_dashboard_restores_simple_field(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Original Name", description="Original description")
+
+        patch_response = self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/",
+            {"name": "Edited Name"},
+            content_type="application/json",
+        )
+        self.assertEqual(patch_response.status_code, status.HTTP_200_OK)
+        log_entry = self._get_dashboard_activity_log(dashboard.pk)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {"activity_log_id": str(log_entry.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["applied_fields"], ["name"])
+        self.assertEqual(body["skipped_fields"], [])
+        self.assertEqual(body["dashboard"]["name"], "Original Name")
+
+        dashboard.refresh_from_db()
+        self.assertEqual(dashboard.name, "Original Name")
+
+    def test_revert_dashboard_records_new_activity_log_entry(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Before")
+        self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/",
+            {"name": "After"},
+            content_type="application/json",
+        )
+        log_count_before = ActivityLog.objects.filter(scope="Dashboard", item_id=str(dashboard.pk)).count()
+        target_log = self._get_dashboard_activity_log(dashboard.pk)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {"activity_log_id": str(target_log.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        log_count_after = ActivityLog.objects.filter(scope="Dashboard", item_id=str(dashboard.pk)).count()
+        self.assertEqual(log_count_after, log_count_before + 1)
+        newest = self._get_dashboard_activity_log(dashboard.pk)
+        names = {c["field"] for c in (newest.detail or {}).get("changes", [])}
+        self.assertIn("name", names)
+
+    def test_revert_dashboard_undeletes(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="To delete")
+        self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/",
+            {"deleted": True},
+            content_type="application/json",
+        )
+        target_log = ActivityLog.objects.filter(scope="Dashboard", item_id=str(dashboard.pk)).latest("created_at")
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {"activity_log_id": str(target_log.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("deleted", response.json()["applied_fields"])
+        dashboard.refresh_from_db()
+        self.assertFalse(dashboard.deleted)
+
+    def test_revert_dashboard_with_unknown_log_id_returns_404(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Dashboard")
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {"activity_log_id": "00000000-0000-0000-0000-000000000000"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_revert_dashboard_with_log_for_different_dashboard_returns_404(self):
+        dashboard1 = Dashboard.objects.create(team=self.team, name="Dashboard 1")
+        dashboard2 = Dashboard.objects.create(team=self.team, name="Dashboard 2")
+        self.client.patch(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard1.pk}/",
+            {"name": "Dashboard 1 edited"},
+            content_type="application/json",
+        )
+        log_for_dashboard1 = self._get_dashboard_activity_log(dashboard1.pk)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard2.pk}/revert/",
+            {"activity_log_id": str(log_for_dashboard1.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_revert_dashboard_with_no_revertable_fields_returns_400(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Dashboard")
+        # Hand-craft a log entry referencing only a non-revertable field (created_by) so the endpoint
+        # has nothing to apply and must reject the request.
+        log_entry = ActivityLog.objects.create(
+            team_id=self.team.pk,
+            organization_id=self.organization.pk,
+            user=self.user,
+            scope="Dashboard",
+            item_id=str(dashboard.pk),
+            activity="updated",
+            detail={
+                "name": dashboard.name,
+                "type": "dashboard",
+                "changes": [
+                    {"type": "Dashboard", "action": "changed", "field": "created_by", "before": None, "after": 1}
+                ],
+            },
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {"activity_log_id": str(log_entry.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_revert_dashboard_with_empty_changes_returns_400(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Dashboard")
+        log_entry = ActivityLog.objects.create(
+            team_id=self.team.pk,
+            organization_id=self.organization.pk,
+            user=self.user,
+            scope="Dashboard",
+            item_id=str(dashboard.pk),
+            activity="updated",
+            detail={"name": dashboard.name, "type": "dashboard", "changes": []},
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {"activity_log_id": str(log_entry.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_revert_dashboard_mixed_fields_lists_skipped(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Original")
+        # Hand-craft a log entry mixing revertable (name) and skipped (created_by) fields.
+        log_entry = ActivityLog.objects.create(
+            team_id=self.team.pk,
+            organization_id=self.organization.pk,
+            user=self.user,
+            scope="Dashboard",
+            item_id=str(dashboard.pk),
+            activity="updated",
+            detail={
+                "name": dashboard.name,
+                "type": "dashboard",
+                "changes": [
+                    {
+                        "type": "Dashboard",
+                        "action": "changed",
+                        "field": "name",
+                        "before": "Original",
+                        "after": "Edited",
+                    },
+                    {"type": "Dashboard", "action": "changed", "field": "created_by", "before": None, "after": 1},
+                ],
+            },
+        )
+        # Move dashboard away from the `before` so revert has something to do.
+        dashboard.name = "Edited"
+        dashboard.save()
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/revert/",
+            {"activity_log_id": str(log_entry.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["applied_fields"], ["name"])
+        self.assertEqual(body["skipped_fields"], ["created_by"])
+        dashboard.refresh_from_db()
+        self.assertEqual(dashboard.name, "Original")

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -4820,3 +4820,95 @@ class TestInsightErrorHandling(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(error_message, str(response.json()))
+
+    def test_revert_insight_restores_name(self):
+        from posthog.models.activity_logging.activity_log import ActivityLog
+
+        insight = Insight.objects.create(team=self.team, name="Original name", created_by=self.user)
+        patch_response = self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{insight.id}/",
+            {"name": "Edited name"},
+            content_type="application/json",
+        )
+        self.assertEqual(patch_response.status_code, status.HTTP_200_OK)
+        log_entry = ActivityLog.objects.filter(scope="Insight", item_id=str(insight.id), activity="updated").latest(
+            "created_at"
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/{insight.id}/revert/",
+            {"activity_log_id": str(log_entry.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        body = response.json()
+        self.assertEqual(body["applied_fields"], ["name"])
+        self.assertEqual(body["skipped_fields"], [])
+        self.assertEqual(body["insight"]["name"], "Original name")
+        insight.refresh_from_db()
+        self.assertEqual(insight.name, "Original name")
+
+    def test_revert_insight_records_new_activity_log_entry(self):
+        from posthog.models.activity_logging.activity_log import ActivityLog
+
+        insight = Insight.objects.create(team=self.team, name="Before", created_by=self.user)
+        self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{insight.id}/",
+            {"name": "After"},
+            content_type="application/json",
+        )
+        target_log = ActivityLog.objects.filter(scope="Insight", item_id=str(insight.id), activity="updated").latest(
+            "created_at"
+        )
+        count_before = ActivityLog.objects.filter(scope="Insight", item_id=str(insight.id)).count()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/{insight.id}/revert/",
+            {"activity_log_id": str(target_log.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        count_after = ActivityLog.objects.filter(scope="Insight", item_id=str(insight.id)).count()
+        self.assertEqual(count_after, count_before + 1)
+        newest = ActivityLog.objects.filter(scope="Insight", item_id=str(insight.id), activity="updated").latest(
+            "created_at"
+        )
+        names = {c["field"] for c in (newest.detail or {}).get("changes", [])}
+        self.assertIn("name", names)
+
+    def test_revert_insight_with_unknown_log_id_returns_404(self):
+        insight = Insight.objects.create(team=self.team, name="Insight", created_by=self.user)
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/{insight.id}/revert/",
+            {"activity_log_id": "00000000-0000-0000-0000-000000000000"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_revert_insight_with_no_revertable_fields_returns_400(self):
+        from posthog.models.activity_logging.activity_log import ActivityLog
+
+        insight = Insight.objects.create(team=self.team, name="Insight", created_by=self.user)
+        log_entry = ActivityLog.objects.create(
+            team_id=self.team.id,
+            organization_id=self.organization.id,
+            user=self.user,
+            scope="Insight",
+            item_id=str(insight.id),
+            activity="updated",
+            detail={
+                "name": insight.name,
+                "type": "insight",
+                "changes": [
+                    {"type": "Insight", "action": "changed", "field": "created_by", "before": None, "after": 1}
+                ],
+            },
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/{insight.id}/revert/",
+            {"activity_log_id": str(log_entry.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -81,6 +81,18 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         super().setUp()
         self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
 
+        # Default the experimental activity-log revert flag to ON so the revert
+        # tests in this class exercise the full path. The patch only intercepts
+        # feature_enabled() calls made from the revert helper module — other
+        # tests are unaffected. Individual tests can stack a return_value=False
+        # patch via `with` to assert flag-off behaviour.
+        self._revert_flag_patcher = patch(
+            "posthog.models.activity_logging.revert.posthoganalytics.feature_enabled",
+            return_value=True,
+        )
+        self._revert_flag_patcher.start()
+        self.addCleanup(self._revert_flag_patcher.stop)
+
     @parameterized.expand(
         [
             ("trend", "/api/projects/{team_id}/insights/trend/"),
@@ -4820,6 +4832,19 @@ class TestInsightErrorHandling(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(error_message, str(response.json()))
+
+    def test_revert_insight_returns_404_when_feature_flag_disabled(self):
+        insight = Insight.objects.create(team=self.team, name="Insight", created_by=self.user)
+        with patch(
+            "posthog.models.activity_logging.revert.posthoganalytics.feature_enabled",
+            return_value=False,
+        ):
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/insights/{insight.id}/revert/",
+                {},
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_revert_insight_restores_name(self):
         from posthog.models.activity_logging.activity_log import ActivityLog

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -81,18 +81,6 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         super().setUp()
         self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
 
-        # Default the experimental activity-log revert flag to ON so the revert
-        # tests in this class exercise the full path. The patch only intercepts
-        # feature_enabled() calls made from the revert helper module — other
-        # tests are unaffected. Individual tests can stack a return_value=False
-        # patch via `with` to assert flag-off behaviour.
-        self._revert_flag_patcher = patch(
-            "posthog.models.activity_logging.revert.posthoganalytics.feature_enabled",
-            return_value=True,
-        )
-        self._revert_flag_patcher.start()
-        self.addCleanup(self._revert_flag_patcher.stop)
-
     @parameterized.expand(
         [
             ("trend", "/api/projects/{team_id}/insights/trend/"),
@@ -4832,19 +4820,6 @@ class TestInsightErrorHandling(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(error_message, str(response.json()))
-
-    def test_revert_insight_returns_404_when_feature_flag_disabled(self):
-        insight = Insight.objects.create(team=self.team, name="Insight", created_by=self.user)
-        with patch(
-            "posthog.models.activity_logging.revert.posthoganalytics.feature_enabled",
-            return_value=False,
-        ):
-            response = self.client.post(
-                f"/api/projects/{self.team.id}/insights/{insight.id}/revert/",
-                {},
-                content_type="application/json",
-            )
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_revert_insight_restores_name(self):
         from posthog.models.activity_logging.activity_log import ActivityLog

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -9,7 +9,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.core.paginator import Paginator
 from django.db import models, transaction
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.db.models.signals import post_save
 from django.dispatch.dispatcher import receiver
 from django.utils import timezone
@@ -1002,8 +1002,6 @@ def apply_organization_scoped_filter(
 
     When False, only filters by team_id.
     """
-    from django.db.models import Q
-
     if include_org_scoped:
         return queryset.filter(Q(team_id=team_id) | Q(team_id__isnull=True, organization_id=organization_id))
     else:

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -990,6 +990,26 @@ def apply_activity_visibility_restrictions(queryset: QuerySet, user: Union["User
     return activity_visibility_manager.apply_to_queryset(queryset, is_staff)
 
 
+def apply_organization_scoped_filter(
+    queryset: QuerySet["ActivityLog"], include_org_scoped: bool, team_id: int, organization_id: Any
+) -> QuerySet["ActivityLog"]:
+    """
+    Filter activity log queryset by team/org.
+
+    When include_org_scoped is True, includes both:
+    - Records with team_id matching the given team
+    - Records with team_id=NULL and organization_id matching (org-scoped records)
+
+    When False, only filters by team_id.
+    """
+    from django.db.models import Q
+
+    if include_org_scoped:
+        return queryset.filter(Q(team_id=team_id) | Q(team_id__isnull=True, organization_id=organization_id))
+    else:
+        return queryset.filter(team_id=team_id)
+
+
 def load_activity(
     scope: ActivityScope,
     team_id: int,

--- a/posthog/models/activity_logging/revert.py
+++ b/posthog/models/activity_logging/revert.py
@@ -25,12 +25,13 @@ sites. The matching MCP tools live under each product's `mcp/tools.yaml`.
 """
 
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Model
 
+import posthoganalytics
 from rest_framework import exceptions, serializers
 
 from posthog.models.activity_logging.activity_log import (
@@ -40,6 +41,32 @@ from posthog.models.activity_logging.activity_log import (
     apply_organization_scoped_filter,
 )
 from posthog.models.user import User
+
+if TYPE_CHECKING:
+    from posthog.models.team.team import Team
+
+
+# Server-side PostHog feature flag that gates every `/revert/` endpoint built on
+# these helpers. Off by default so the feature can be smoke-tested on internal
+# teams in production before opening up to all customers. Enable the flag in the
+# PostHog UI / API for the orgs you want to give access to.
+ACTIVITY_LOG_REVERT_FLAG = "activity-log-revert"
+
+
+def is_activity_log_revert_enabled(user: "User", team: "Team") -> bool:
+    distinct_id = user.distinct_id or str(user.uuid)
+    organization_id = str(team.organization_id)
+    project_id = str(team.id)
+    return bool(
+        posthoganalytics.feature_enabled(
+            ACTIVITY_LOG_REVERT_FLAG,
+            distinct_id,
+            groups={"organization": organization_id, "project": project_id},
+            group_properties={"organization": {"id": organization_id}, "project": {"id": project_id}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+    )
 
 
 class RevertActivityLogRequestSerializer(serializers.Serializer):

--- a/posthog/models/activity_logging/revert.py
+++ b/posthog/models/activity_logging/revert.py
@@ -1,0 +1,120 @@
+"""Shared helpers for resource-level `/revert/` endpoints backed by the activity log.
+
+Any resource that already records changes through `log_activity()` (whether via the
+`ModelActivityMixin` signal or imperative calls) can opt in to a revert endpoint by
+wiring three pieces into its viewset:
+
+1. A scoped `revert` action that calls `get_object()` (to enforce the resource's
+   existing edit permissions) and uses `RevertActivityLogRequestSerializer` for
+   the request body.
+2. A call to `lookup_revertable_activity_log_entry()` with the resource's scope
+   and the `item_id` form the resource's `log_activity()` calls write (some
+   resources use the integer pk, others use a short_id — match what's stored).
+3. A call to `apply_revert_to_instance()` with a *whitelist* of safe scalar /
+   JSON fields. Exclude foreign keys (their serialized JSON form does not round
+   trip), m2m relations, derived fields, soft-delete flags, and any field that
+   carries its own write semantics (e.g. optimistic-concurrency counters).
+
+For resources that use `ModelActivityMixin`, `instance.save()` after the revert
+will record a fresh activity log entry automatically. For resources that log
+activity imperatively (Insight, Notebook, etc.), the action must also call the
+resource's existing activity logger after save so the revert is itself recorded.
+
+`DashboardsViewSet.revert` and `InsightViewSet.revert` are the reference call
+sites. The matching MCP tools live under each product's `mcp/tools.yaml`.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+from uuid import UUID
+
+from django.contrib.auth.models import AnonymousUser
+from django.db.models import Model
+
+from rest_framework import exceptions, serializers
+
+from posthog.models.activity_logging.activity_log import (
+    ActivityLog,
+    ActivityScope,
+    apply_activity_visibility_restrictions,
+    apply_organization_scoped_filter,
+)
+from posthog.models.user import User
+
+
+class RevertActivityLogRequestSerializer(serializers.Serializer):
+    """Shared request body for resource-level `/revert/` endpoints."""
+
+    activity_log_id = serializers.UUIDField(
+        help_text=(
+            "UUID of the ActivityLog entry to revert. The entry must reference this resource "
+            "(scope and item_id match) and belong to the same team. Look it up via the "
+            "activity-log-list or advanced-activity-logs-list MCP tools."
+        )
+    )
+
+
+def lookup_revertable_activity_log_entry(
+    *,
+    activity_log_id: UUID,
+    scope: ActivityScope,
+    item_id: str,
+    team_id: int,
+    organization_id: Any,
+    include_org_scoped: bool,
+    user: User | AnonymousUser | None,
+) -> ActivityLog:
+    """Fetch a single activity log entry, applying the same access controls the
+    activity log endpoints apply: team scoping (with org-level activity log opt-in)
+    and the user-level visibility restrictions used by ActivityLogViewSet.
+
+    Raises rest_framework.exceptions.NotFound if no matching entry exists for this
+    user — callers do not need to handle the lookup themselves.
+    """
+    queryset = ActivityLog.objects.filter(scope=scope, item_id=item_id)
+    queryset = apply_organization_scoped_filter(queryset, include_org_scoped, team_id, organization_id)
+    queryset = apply_activity_visibility_restrictions(queryset, user)
+    try:
+        return queryset.get(id=activity_log_id)
+    except ActivityLog.DoesNotExist:
+        raise exceptions.NotFound("Activity log entry not found for this resource.")
+
+
+def apply_revert_to_instance(
+    instance: Model,
+    log_entry: ActivityLog,
+    revertable_fields: Iterable[str],
+) -> tuple[list[str], list[str]]:
+    """Apply the `before` value of each captured change in `log_entry` back onto
+    `instance`. The caller is responsible for saving the instance afterwards.
+
+    Returns `(applied_fields, skipped_fields)`. A field is applied when its name
+    appears in `revertable_fields`; otherwise it is surfaced in `skipped_fields`
+    so the caller can communicate what wasn't reverted (typically relations,
+    m2m, or immutable metadata that the whitelist deliberately excludes).
+
+    Raises rest_framework.exceptions.ValidationError if the entry has no changes
+    to apply, or if every captured change is in the skip list.
+    """
+    revertable = frozenset(revertable_fields)
+    detail = log_entry.detail or {}
+    changes = detail.get("changes") or []
+    if not changes:
+        raise exceptions.ValidationError("Activity log entry has no field changes to revert.")
+    applied: list[str] = []
+    skipped: list[str] = []
+    for change in changes:
+        field_name = change.get("field")
+        if not field_name:
+            continue
+        if field_name not in revertable:
+            skipped.append(field_name)
+            continue
+        setattr(instance, field_name, change.get("before"))
+        applied.append(field_name)
+    if not applied:
+        raise exceptions.ValidationError(
+            f"None of the recorded changes are revertable through this endpoint. "
+            f"Skipped fields: {sorted(set(skipped))}."
+        )
+    return applied, skipped

--- a/posthog/models/activity_logging/revert.py
+++ b/posthog/models/activity_logging/revert.py
@@ -46,38 +46,75 @@ class RevertActivityLogRequestSerializer(serializers.Serializer):
     """Shared request body for resource-level `/revert/` endpoints."""
 
     activity_log_id = serializers.UUIDField(
+        required=False,
+        allow_null=True,
         help_text=(
-            "UUID of the ActivityLog entry to revert. The entry must reference this resource "
-            "(scope and item_id match) and belong to the same team. Look it up via the "
-            "activity-log-list or advanced-activity-logs-list MCP tools."
-        )
+            "Optional UUID of the ActivityLog entry to revert. If omitted, the endpoint "
+            "picks the most recent revertable entry for this resource — the natural "
+            "meaning of 'undo my last change'. The chosen entry's id is returned in "
+            "`activity_log_id` so callers can confirm what was reverted. Use "
+            "activity-log-list or advanced-activity-logs-list to inspect candidates "
+            "when a specific past state needs to be restored."
+        ),
     )
+
+
+# Number of recent activity log entries to scan when falling back to the most recent
+# revertable entry. Bounded so a long-lived resource with thousands of edits doesn't
+# slow the request down. If none of the last `FALLBACK_LOOKBACK_LIMIT` entries are
+# revertable, the endpoint returns 404 and the caller must supply an explicit id.
+FALLBACK_LOOKBACK_LIMIT = 50
 
 
 def lookup_revertable_activity_log_entry(
     *,
-    activity_log_id: UUID,
+    activity_log_id: UUID | None,
     scope: ActivityScope,
     item_id: str,
     team_id: int,
     organization_id: Any,
     include_org_scoped: bool,
     user: User | AnonymousUser | None,
+    revertable_fields: Iterable[str] | None = None,
 ) -> ActivityLog:
     """Fetch a single activity log entry, applying the same access controls the
     activity log endpoints apply: team scoping (with org-level activity log opt-in)
     and the user-level visibility restrictions used by ActivityLogViewSet.
 
-    Raises rest_framework.exceptions.NotFound if no matching entry exists for this
-    user — callers do not need to handle the lookup themselves.
+    When `activity_log_id` is provided, that entry is returned (or NotFound).
+
+    When `activity_log_id` is None, the most recent entry for this resource that
+    has at least one revertable change is returned — this implements the "revert
+    my last edit" shortcut that agents typically want. `revertable_fields` must
+    be supplied in this case so we can skip entries that touched only fields
+    this endpoint doesn't apply (e.g. tag-only updates).
+
+    Raises rest_framework.exceptions.NotFound if no matching entry exists for
+    this user — callers do not need to handle the lookup themselves.
     """
     queryset = ActivityLog.objects.filter(scope=scope, item_id=item_id)
     queryset = apply_organization_scoped_filter(queryset, include_org_scoped, team_id, organization_id)
     queryset = apply_activity_visibility_restrictions(queryset, user)
-    try:
-        return queryset.get(id=activity_log_id)
-    except ActivityLog.DoesNotExist:
-        raise exceptions.NotFound("Activity log entry not found for this resource.")
+
+    if activity_log_id is not None:
+        try:
+            return queryset.get(id=activity_log_id)
+        except ActivityLog.DoesNotExist:
+            raise exceptions.NotFound("Activity log entry not found for this resource.")
+
+    if revertable_fields is None:
+        raise exceptions.ValidationError(
+            "Either activity_log_id or revertable_fields must be provided to pick a fallback entry."
+        )
+    revertable = frozenset(revertable_fields)
+    for entry in queryset.order_by("-created_at")[:FALLBACK_LOOKBACK_LIMIT]:
+        changes = (entry.detail or {}).get("changes") or []
+        if any(c.get("field") in revertable for c in changes):
+            return entry
+    raise exceptions.NotFound(
+        "No recent revertable activity log entry found for this resource. "
+        "List entries via activity-log-list and pass an explicit activity_log_id."
+    )
 
 
 def apply_revert_to_instance(

--- a/posthog/models/activity_logging/revert.py
+++ b/posthog/models/activity_logging/revert.py
@@ -117,6 +117,22 @@ def lookup_revertable_activity_log_entry(
     )
 
 
+def _field_allows_null(instance: Model, field_name: str) -> bool:
+    """Return True if `field_name` is a real model field whose column is nullable.
+
+    Unknown fields (e.g. dynamic Python-only attributes or renamed fields no
+    longer on the model) return True so the caller can still attempt the
+    setattr — only known-non-null columns are protected.
+    """
+    from django.core.exceptions import FieldDoesNotExist
+
+    try:
+        field = instance._meta.get_field(field_name)
+    except FieldDoesNotExist:
+        return True
+    return bool(getattr(field, "null", True))
+
+
 def apply_revert_to_instance(
     instance: Model,
     log_entry: ActivityLog,
@@ -129,6 +145,12 @@ def apply_revert_to_instance(
     appears in `revertable_fields`; otherwise it is surfaced in `skipped_fields`
     so the caller can communicate what wasn't reverted (typically relations,
     m2m, or immutable metadata that the whitelist deliberately excludes).
+
+    Special case: a `before=None` on a NOT NULL model column is also skipped —
+    `changes_between` records `None` for fields whose previous value was the
+    model default (e.g. `{}` / `""` / `[]`). Blindly applying `None` would
+    raise `IntegrityError` at save time for non-nullable columns and 500 the
+    request. Skipping is consistent with our "preserve the safe parts" promise.
 
     Raises rest_framework.exceptions.ValidationError if the entry has no changes
     to apply, or if every captured change is in the skip list.
@@ -147,7 +169,11 @@ def apply_revert_to_instance(
         if field_name not in revertable:
             skipped.append(field_name)
             continue
-        setattr(instance, field_name, change.get("before"))
+        before = change.get("before")
+        if before is None and not _field_allows_null(instance, field_name):
+            skipped.append(field_name)
+            continue
+        setattr(instance, field_name, before)
         applied.append(field_name)
     if not applied:
         raise exceptions.ValidationError(

--- a/posthog/models/activity_logging/revert.py
+++ b/posthog/models/activity_logging/revert.py
@@ -25,13 +25,12 @@ sites. The matching MCP tools live under each product's `mcp/tools.yaml`.
 """
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from uuid import UUID
 
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Model
 
-import posthoganalytics
 from rest_framework import exceptions, serializers
 
 from posthog.models.activity_logging.activity_log import (
@@ -41,32 +40,6 @@ from posthog.models.activity_logging.activity_log import (
     apply_organization_scoped_filter,
 )
 from posthog.models.user import User
-
-if TYPE_CHECKING:
-    from posthog.models.team.team import Team
-
-
-# Server-side PostHog feature flag that gates every `/revert/` endpoint built on
-# these helpers. Off by default so the feature can be smoke-tested on internal
-# teams in production before opening up to all customers. Enable the flag in the
-# PostHog UI / API for the orgs you want to give access to.
-ACTIVITY_LOG_REVERT_FLAG = "activity-log-revert"
-
-
-def is_activity_log_revert_enabled(user: "User", team: "Team") -> bool:
-    distinct_id = user.distinct_id or str(user.uuid)
-    organization_id = str(team.organization_id)
-    project_id = str(team.id)
-    return bool(
-        posthoganalytics.feature_enabled(
-            ACTIVITY_LOG_REVERT_FLAG,
-            distinct_id,
-            groups={"organization": organization_id, "project": project_id},
-            group_properties={"organization": {"id": organization_id}, "project": {"id": project_id}},
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
-        )
-    )
 
 
 class RevertActivityLogRequestSerializer(serializers.Serializer):

--- a/posthog/test/activity_logging/test_revert.py
+++ b/posthog/test/activity_logging/test_revert.py
@@ -1,0 +1,146 @@
+import pytest
+from posthog.test.base import BaseTest
+
+from rest_framework import exceptions
+
+from posthog.models.activity_logging.activity_log import ActivityLog
+from posthog.models.activity_logging.revert import apply_revert_to_instance, lookup_revertable_activity_log_entry
+
+from products.dashboards.backend.models.dashboard import Dashboard
+
+
+class TestLookupRevertableActivityLogEntry(BaseTest):
+    def _create_log_entry(self, *, team_id: int, organization_id, scope: str, item_id: str) -> ActivityLog:
+        return ActivityLog.objects.create(
+            team_id=team_id,
+            organization_id=organization_id,
+            user=self.user,
+            scope=scope,
+            item_id=item_id,
+            activity="updated",
+            detail={
+                "name": "Dashboard",
+                "type": "dashboard",
+                "changes": [{"type": "Dashboard", "action": "changed", "field": "name", "before": "A", "after": "B"}],
+            },
+        )
+
+    def test_returns_matching_entry(self):
+        entry = self._create_log_entry(
+            team_id=self.team.id, organization_id=self.organization.id, scope="Dashboard", item_id="42"
+        )
+        result = lookup_revertable_activity_log_entry(
+            activity_log_id=entry.id,
+            scope="Dashboard",
+            item_id="42",
+            team_id=self.team.id,
+            organization_id=self.organization.id,
+            include_org_scoped=False,
+            user=self.user,
+        )
+        assert result.id == entry.id
+
+    def test_raises_not_found_when_scope_mismatch(self):
+        entry = self._create_log_entry(
+            team_id=self.team.id, organization_id=self.organization.id, scope="Dashboard", item_id="42"
+        )
+        with pytest.raises(exceptions.NotFound):
+            lookup_revertable_activity_log_entry(
+                activity_log_id=entry.id,
+                scope="Insight",
+                item_id="42",
+                team_id=self.team.id,
+                organization_id=self.organization.id,
+                include_org_scoped=False,
+                user=self.user,
+            )
+
+    def test_raises_not_found_when_item_id_mismatch(self):
+        entry = self._create_log_entry(
+            team_id=self.team.id, organization_id=self.organization.id, scope="Dashboard", item_id="42"
+        )
+        with pytest.raises(exceptions.NotFound):
+            lookup_revertable_activity_log_entry(
+                activity_log_id=entry.id,
+                scope="Dashboard",
+                item_id="99",
+                team_id=self.team.id,
+                organization_id=self.organization.id,
+                include_org_scoped=False,
+                user=self.user,
+            )
+
+    def test_raises_not_found_when_team_mismatch(self):
+        other_org = self.organization.__class__.objects.create(name="Other Org")
+        from posthog.models import Team
+
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+        entry = self._create_log_entry(
+            team_id=other_team.id, organization_id=other_org.id, scope="Dashboard", item_id="42"
+        )
+        with pytest.raises(exceptions.NotFound):
+            lookup_revertable_activity_log_entry(
+                activity_log_id=entry.id,
+                scope="Dashboard",
+                item_id="42",
+                team_id=self.team.id,
+                organization_id=self.organization.id,
+                include_org_scoped=False,
+                user=self.user,
+            )
+
+
+class TestApplyRevertToInstance(BaseTest):
+    def _log_entry_with_changes(self, changes: list[dict]) -> ActivityLog:
+        return ActivityLog.objects.create(
+            team_id=self.team.id,
+            organization_id=self.organization.id,
+            user=self.user,
+            scope="Dashboard",
+            item_id="1",
+            activity="updated",
+            detail={"name": "Dashboard", "type": "dashboard", "changes": changes},
+        )
+
+    def test_applies_revertable_field_and_skips_others(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Edited", description="Edited description")
+        entry = self._log_entry_with_changes(
+            [
+                {"type": "Dashboard", "action": "changed", "field": "name", "before": "Original", "after": "Edited"},
+                {"type": "Dashboard", "action": "changed", "field": "created_by", "before": None, "after": 1},
+            ]
+        )
+        applied, skipped = apply_revert_to_instance(dashboard, entry, {"name"})
+        assert applied == ["name"]
+        assert skipped == ["created_by"]
+        assert dashboard.name == "Original"
+        # The caller is responsible for save() — instance is mutated in place but not persisted.
+        dashboard.refresh_from_db()
+        assert dashboard.name == "Edited"
+
+    def test_raises_validation_error_when_no_changes(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="D")
+        entry = self._log_entry_with_changes([])
+        with pytest.raises(exceptions.ValidationError):
+            apply_revert_to_instance(dashboard, entry, {"name"})
+
+    def test_raises_validation_error_when_all_skipped(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="D")
+        entry = self._log_entry_with_changes(
+            [{"type": "Dashboard", "action": "changed", "field": "created_by", "before": None, "after": 1}]
+        )
+        with pytest.raises(exceptions.ValidationError):
+            apply_revert_to_instance(dashboard, entry, {"name"})
+
+    def test_change_missing_field_is_ignored(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Edited")
+        entry = self._log_entry_with_changes(
+            [
+                {"type": "Dashboard", "action": "changed", "field": None, "before": "x", "after": "y"},
+                {"type": "Dashboard", "action": "changed", "field": "name", "before": "Original", "after": "Edited"},
+            ]
+        )
+        applied, skipped = apply_revert_to_instance(dashboard, entry, {"name"})
+        assert applied == ["name"]
+        assert skipped == []
+        assert dashboard.name == "Original"

--- a/posthog/test/activity_logging/test_revert.py
+++ b/posthog/test/activity_logging/test_revert.py
@@ -89,6 +89,99 @@ class TestLookupRevertableActivityLogEntry(BaseTest):
                 user=self.user,
             )
 
+    def _create_log_with_changes(self, item_id: str, changes: list[dict]) -> ActivityLog:
+        return ActivityLog.objects.create(
+            team_id=self.team.id,
+            organization_id=self.organization.id,
+            user=self.user,
+            scope="Dashboard",
+            item_id=item_id,
+            activity="updated",
+            detail={"name": "D", "type": "dashboard", "changes": changes},
+        )
+
+    def test_fallback_returns_most_recent_revertable_entry(self):
+        # An older revertable entry followed by a newer revertable entry — the newer one wins.
+        self._create_log_with_changes(
+            "42",
+            [{"type": "Dashboard", "action": "changed", "field": "name", "before": "old", "after": "new"}],
+        )
+        newer = self._create_log_with_changes(
+            "42",
+            [
+                {
+                    "type": "Dashboard",
+                    "action": "changed",
+                    "field": "description",
+                    "before": "old desc",
+                    "after": "new desc",
+                }
+            ],
+        )
+        result = lookup_revertable_activity_log_entry(
+            activity_log_id=None,
+            scope="Dashboard",
+            item_id="42",
+            team_id=self.team.id,
+            organization_id=self.organization.id,
+            include_org_scoped=False,
+            user=self.user,
+            revertable_fields={"name", "description"},
+        )
+        assert result.id == newer.id
+
+    def test_fallback_skips_non_revertable_entries(self):
+        # Newest entry only touches a non-revertable field; the previous one is returned.
+        older = self._create_log_with_changes(
+            "42",
+            [{"type": "Dashboard", "action": "changed", "field": "name", "before": "old", "after": "new"}],
+        )
+        self._create_log_with_changes(
+            "42",
+            [{"type": "Dashboard", "action": "changed", "field": "created_by", "before": None, "after": 1}],
+        )
+        result = lookup_revertable_activity_log_entry(
+            activity_log_id=None,
+            scope="Dashboard",
+            item_id="42",
+            team_id=self.team.id,
+            organization_id=self.organization.id,
+            include_org_scoped=False,
+            user=self.user,
+            revertable_fields={"name"},
+        )
+        assert result.id == older.id
+
+    def test_fallback_raises_not_found_when_no_revertable_entry(self):
+        self._create_log_with_changes(
+            "42",
+            [{"type": "Dashboard", "action": "changed", "field": "created_by", "before": None, "after": 1}],
+        )
+        with pytest.raises(exceptions.NotFound):
+            lookup_revertable_activity_log_entry(
+                activity_log_id=None,
+                scope="Dashboard",
+                item_id="42",
+                team_id=self.team.id,
+                organization_id=self.organization.id,
+                include_org_scoped=False,
+                user=self.user,
+                revertable_fields={"name"},
+            )
+
+    def test_fallback_requires_revertable_fields(self):
+        with pytest.raises(exceptions.ValidationError):
+            lookup_revertable_activity_log_entry(
+                activity_log_id=None,
+                scope="Dashboard",
+                item_id="42",
+                team_id=self.team.id,
+                organization_id=self.organization.id,
+                include_org_scoped=False,
+                user=self.user,
+                revertable_fields=None,
+            )
+
 
 class TestApplyRevertToInstance(BaseTest):
     def _log_entry_with_changes(self, changes: list[dict]) -> ActivityLog:

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -62,7 +62,6 @@ from posthog.models.activity_logging.activity_log import Detail, changes_between
 from posthog.models.activity_logging.revert import (
     RevertActivityLogRequestSerializer,
     apply_revert_to_instance,
-    is_activity_log_revert_enabled,
     lookup_revertable_activity_log_entry,
 )
 from posthog.models.alert import AlertConfiguration
@@ -1644,10 +1643,6 @@ class DashboardsViewSet(
     )
     @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
     def revert(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        # 404 (not 403) when the experimental flag is off — the endpoint should look
-        # like it doesn't exist to anyone outside the rollout.
-        if not is_activity_log_revert_enabled(cast(User, request.user), self.team):
-            raise exceptions.NotFound()
         # get_object() enforces CanEditDashboard.has_object_permission, which checks
         # the dashboard's restriction_level and the user's edit privilege. Combined with
         # the `dashboard:write` required scope, this gates write access to the dashboard.

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -34,6 +34,7 @@ from rest_framework.utils.serializer_helpers import ReturnDict
 
 from posthog.schema import InsightVizNode
 
+from posthog.api.advanced_activity_logs.viewset import apply_organization_scoped_filter
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.insight import DashboardTileBasicSerializer, InsightSerializer, InsightViewSet
 from posthog.api.insight_suggestions import summarize_insight_result
@@ -58,7 +59,13 @@ from posthog.helpers.trigram_search import (
 )
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Insight
-from posthog.models.activity_logging.activity_log import ActivityLog, Detail, changes_between, log_activity
+from posthog.models.activity_logging.activity_log import (
+    ActivityLog,
+    Detail,
+    apply_activity_visibility_restrictions,
+    changes_between,
+    log_activity,
+)
 from posthog.models.alert import AlertConfiguration
 from posthog.models.insight_variable import InsightVariable
 from posthog.models.quick_filter import QuickFilter
@@ -1641,19 +1648,28 @@ class DashboardsViewSet(
     )
     @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
     def revert(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        # get_object() enforces CanEditDashboard.has_object_permission, which checks
+        # the dashboard's restriction_level and the user's edit privilege. Combined with
+        # the `dashboard:write` required scope, this gates write access to the dashboard.
         dashboard = self.get_object()
 
         serializer = RevertDashboardRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         activity_log_id = serializer.validated_data["activity_log_id"]
 
+        # Look up the activity log entry with the same access controls the activity log
+        # endpoints apply: team scoping (with org-level activity log opt-in), and the
+        # user-level visibility restrictions used by ActivityLogViewSet.
+        activity_log_queryset = ActivityLog.objects.filter(scope="Dashboard", item_id=str(dashboard.id))
+        activity_log_queryset = apply_organization_scoped_filter(
+            activity_log_queryset,
+            bool(self.team.receive_org_level_activity_logs),
+            self.team_id,
+            self.team.organization_id,
+        )
+        activity_log_queryset = apply_activity_visibility_restrictions(activity_log_queryset, request.user)
         try:
-            log_entry = ActivityLog.objects.get(
-                id=activity_log_id,
-                team_id=self.team_id,
-                scope="Dashboard",
-                item_id=str(dashboard.id),
-            )
+            log_entry = activity_log_queryset.get(id=activity_log_id)
         except ActivityLog.DoesNotExist:
             raise exceptions.NotFound("Activity log entry not found for this dashboard.")
 

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -34,7 +34,6 @@ from rest_framework.utils.serializer_helpers import ReturnDict
 
 from posthog.schema import InsightVizNode
 
-from posthog.api.advanced_activity_logs.viewset import apply_organization_scoped_filter
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.insight import DashboardTileBasicSerializer, InsightSerializer, InsightViewSet
 from posthog.api.insight_suggestions import summarize_insight_result
@@ -59,12 +58,11 @@ from posthog.helpers.trigram_search import (
 )
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Insight
-from posthog.models.activity_logging.activity_log import (
-    ActivityLog,
-    Detail,
-    apply_activity_visibility_restrictions,
-    changes_between,
-    log_activity,
+from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
+from posthog.models.activity_logging.revert import (
+    RevertActivityLogRequestSerializer,
+    apply_revert_to_instance,
+    lookup_revertable_activity_log_entry,
 )
 from posthog.models.alert import AlertConfiguration
 from posthog.models.insight_variable import InsightVariable
@@ -190,17 +188,6 @@ REVERTABLE_DASHBOARD_FIELDS: frozenset[str] = frozenset(
         "deprecated_tags_v2",
     }
 )
-
-
-class RevertDashboardRequestSerializer(serializers.Serializer):
-    activity_log_id = serializers.UUIDField(
-        help_text=(
-            "UUID of the ActivityLog entry to revert. The entry must reference this dashboard "
-            "(scope='Dashboard', item_id equal to this dashboard id) and belong to the same team. "
-            "Look up candidates via the activity-log-list MCP tool or "
-            "GET /api/projects/{team_id}/activity_log/?scope=Dashboard&item_id={dashboard_id}."
-        )
-    )
 
 
 class CanEditDashboard(BasePermission):
@@ -1636,7 +1623,7 @@ class DashboardsViewSet(
         return Response(DashboardSerializer(dashboard, context=self.get_serializer_context()).data)
 
     @extend_schema(
-        request=RevertDashboardRequestSerializer,
+        request=RevertActivityLogRequestSerializer,
         responses={200: RevertDashboardResponseSerializer},
         description=(
             "Revert this dashboard to the state recorded immediately before a specific activity log entry. "
@@ -1653,49 +1640,19 @@ class DashboardsViewSet(
         # the `dashboard:write` required scope, this gates write access to the dashboard.
         dashboard = self.get_object()
 
-        serializer = RevertDashboardRequestSerializer(data=request.data)
+        serializer = RevertActivityLogRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        activity_log_id = serializer.validated_data["activity_log_id"]
 
-        # Look up the activity log entry with the same access controls the activity log
-        # endpoints apply: team scoping (with org-level activity log opt-in), and the
-        # user-level visibility restrictions used by ActivityLogViewSet.
-        activity_log_queryset = ActivityLog.objects.filter(scope="Dashboard", item_id=str(dashboard.id))
-        activity_log_queryset = apply_organization_scoped_filter(
-            activity_log_queryset,
-            bool(self.team.receive_org_level_activity_logs),
-            self.team_id,
-            self.team.organization_id,
+        log_entry = lookup_revertable_activity_log_entry(
+            activity_log_id=serializer.validated_data["activity_log_id"],
+            scope="Dashboard",
+            item_id=str(dashboard.id),
+            team_id=self.team_id,
+            organization_id=self.team.organization_id,
+            include_org_scoped=bool(self.team.receive_org_level_activity_logs),
+            user=request.user,
         )
-        activity_log_queryset = apply_activity_visibility_restrictions(activity_log_queryset, request.user)
-        try:
-            log_entry = activity_log_queryset.get(id=activity_log_id)
-        except ActivityLog.DoesNotExist:
-            raise exceptions.NotFound("Activity log entry not found for this dashboard.")
-
-        detail = log_entry.detail or {}
-        changes = detail.get("changes") or []
-        if not changes:
-            raise exceptions.ValidationError("Activity log entry has no field changes to revert.")
-
-        applied: list[str] = []
-        skipped: list[str] = []
-        for change in changes:
-            field_name = change.get("field")
-            if not field_name:
-                continue
-            if field_name not in REVERTABLE_DASHBOARD_FIELDS:
-                skipped.append(field_name)
-                continue
-            setattr(dashboard, field_name, change.get("before"))
-            applied.append(field_name)
-
-        if not applied:
-            raise exceptions.ValidationError(
-                f"None of the recorded changes are revertable through this endpoint. "
-                f"Skipped fields: {sorted(set(skipped))}."
-            )
-
+        applied, skipped = apply_revert_to_instance(dashboard, log_entry, REVERTABLE_DASHBOARD_FIELDS)
         dashboard.save()
 
         return Response(

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -171,18 +171,24 @@ class CopyDashboardTileRequestSerializer(serializers.Serializer):
 
 
 # Fields on Dashboard whose `before` value can be safely applied during revert.
-# Excludes foreign keys (created_by, data_color_theme, team), m2m (insights, tags),
-# immutable metadata (creation_mode, share_token, is_shared), and bookkeeping fields.
+# Excludes:
+#   - foreign keys (created_by, data_color_theme, team)
+#   - m2m (insights, tags)
+#   - immutable metadata (creation_mode, share_token, is_shared)
+#   - `restriction_level` — the normal PATCH path enforces `can_user_restrict`; a raw
+#     setattr from a historical activity log would silently bypass that check and
+#     let any editor lower the restriction level
+#   - `deleted` — soft-delete/restore runs related-state bookkeeping (DashboardTile
+#     cleanup, Team.primary_dashboard, group_type_mapping); flipping the flag alone
+#     would leave dashboards half-deleted or half-restored
 REVERTABLE_DASHBOARD_FIELDS: frozenset[str] = frozenset(
     {
         "name",
         "description",
         "pinned",
-        "deleted",
         "filters",
         "variables",
         "breakdown_colors",
-        "restriction_level",
         "quick_filter_ids",
         "deprecated_tags",
         "deprecated_tags_v2",

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -58,7 +58,7 @@ from posthog.helpers.trigram_search import (
 )
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Insight
-from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
+from posthog.models.activity_logging.activity_log import ActivityLog, Detail, changes_between, log_activity
 from posthog.models.alert import AlertConfiguration
 from posthog.models.insight_variable import InsightVariable
 from posthog.models.quick_filter import QuickFilter
@@ -163,6 +163,37 @@ class ReorderTilesRequestSerializer(serializers.Serializer):
 class CopyDashboardTileRequestSerializer(serializers.Serializer):
     fromDashboardId = serializers.IntegerField(help_text="Dashboard id the tile currently belongs to.")
     tileId = serializers.IntegerField(help_text="Dashboard tile id to copy.")
+
+
+# Fields on Dashboard whose `before` value can be safely applied during revert.
+# Excludes foreign keys (created_by, data_color_theme, team), m2m (insights, tags),
+# immutable metadata (creation_mode, share_token, is_shared), and bookkeeping fields.
+REVERTABLE_DASHBOARD_FIELDS: frozenset[str] = frozenset(
+    {
+        "name",
+        "description",
+        "pinned",
+        "deleted",
+        "filters",
+        "variables",
+        "breakdown_colors",
+        "restriction_level",
+        "quick_filter_ids",
+        "deprecated_tags",
+        "deprecated_tags_v2",
+    }
+)
+
+
+class RevertDashboardRequestSerializer(serializers.Serializer):
+    activity_log_id = serializers.UUIDField(
+        help_text=(
+            "UUID of the ActivityLog entry to revert. The entry must reference this dashboard "
+            "(scope='Dashboard', item_id equal to this dashboard id) and belong to the same team. "
+            "Look up candidates via the activity-log-list MCP tool or "
+            "GET /api/projects/{team_id}/activity_log/?scope=Dashboard&item_id={dashboard_id}."
+        )
+    )
 
 
 class CanEditDashboard(BasePermission):
@@ -1006,6 +1037,23 @@ class DashboardSerializer(DashboardMetadataSerializer):
         return {**validated_data, "creation_mode": "default"}
 
 
+class RevertDashboardResponseSerializer(serializers.Serializer):
+    dashboard = DashboardSerializer(help_text="The dashboard after the revert has been applied.")
+    applied_fields = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Fields that were reset to their `before` value from the activity log entry.",
+    )
+    skipped_fields = serializers.ListField(
+        child=serializers.CharField(),
+        help_text=(
+            "Fields recorded in the activity log entry that this endpoint will not revert — typically "
+            "relations (created_by, data_color_theme, tags), m2m fields (insights), or immutable metadata "
+            "like creation_mode. Use these to decide whether the revert is sufficient or whether you also "
+            "need to make manual changes."
+        ),
+    )
+
+
 @extend_schema_view(
     list=extend_schema(
         parameters=[
@@ -1579,6 +1627,68 @@ class DashboardsViewSet(
         DashboardTile.objects.bulk_update(tile_map.values(), ["layouts"])
 
         return Response(DashboardSerializer(dashboard, context=self.get_serializer_context()).data)
+
+    @extend_schema(
+        request=RevertDashboardRequestSerializer,
+        responses={200: RevertDashboardResponseSerializer},
+        description=(
+            "Revert this dashboard to the state recorded immediately before a specific activity log entry. "
+            "Each field captured in that entry's `changes` is reset to its `before` value. Foreign keys, m2m "
+            "relations (tags, insights), and immutable metadata are skipped and listed in `skipped_fields`. "
+            "Saving the dashboard records a new `updated` activity log entry, so reverts are themselves auditable "
+            "and can be reverted in turn."
+        ),
+    )
+    @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
+    def revert(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        dashboard = self.get_object()
+
+        serializer = RevertDashboardRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        activity_log_id = serializer.validated_data["activity_log_id"]
+
+        try:
+            log_entry = ActivityLog.objects.get(
+                id=activity_log_id,
+                team_id=self.team_id,
+                scope="Dashboard",
+                item_id=str(dashboard.id),
+            )
+        except ActivityLog.DoesNotExist:
+            raise exceptions.NotFound("Activity log entry not found for this dashboard.")
+
+        detail = log_entry.detail or {}
+        changes = detail.get("changes") or []
+        if not changes:
+            raise exceptions.ValidationError("Activity log entry has no field changes to revert.")
+
+        applied: list[str] = []
+        skipped: list[str] = []
+        for change in changes:
+            field_name = change.get("field")
+            if not field_name:
+                continue
+            if field_name not in REVERTABLE_DASHBOARD_FIELDS:
+                skipped.append(field_name)
+                continue
+            setattr(dashboard, field_name, change.get("before"))
+            applied.append(field_name)
+
+        if not applied:
+            raise exceptions.ValidationError(
+                f"None of the recorded changes are revertable through this endpoint. "
+                f"Skipped fields: {sorted(set(skipped))}."
+            )
+
+        dashboard.save()
+
+        return Response(
+            {
+                "dashboard": DashboardSerializer(dashboard, context=self.get_serializer_context()).data,
+                "applied_fields": applied,
+                "skipped_fields": skipped,
+            }
+        )
 
     @extend_schema(
         parameters=[

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1033,6 +1033,12 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
 class RevertDashboardResponseSerializer(serializers.Serializer):
     dashboard = DashboardSerializer(help_text="The dashboard after the revert has been applied.")
+    activity_log_id = serializers.UUIDField(
+        help_text=(
+            "ID of the activity log entry that was reverted. When the caller passed an explicit id, "
+            "this echoes it; when omitted, this is the most recent revertable entry the endpoint picked."
+        ),
+    )
     applied_fields = serializers.ListField(
         child=serializers.CharField(),
         help_text="Fields that were reset to their `before` value from the activity log entry.",
@@ -1626,11 +1632,13 @@ class DashboardsViewSet(
         request=RevertActivityLogRequestSerializer,
         responses={200: RevertDashboardResponseSerializer},
         description=(
-            "Revert this dashboard to the state recorded immediately before a specific activity log entry. "
-            "Each field captured in that entry's `changes` is reset to its `before` value. Foreign keys, m2m "
-            "relations (tags, insights), and immutable metadata are skipped and listed in `skipped_fields`. "
-            "Saving the dashboard records a new `updated` activity log entry, so reverts are themselves auditable "
-            "and can be reverted in turn."
+            "Revert this dashboard to a previous state captured in the activity log. Pass `activity_log_id` "
+            "to target a specific entry, or omit it to undo the most recent revertable change — the "
+            "natural meaning of 'revert this dashboard'. The chosen entry id is echoed back as "
+            "`activity_log_id` so callers can confirm what was reverted. Each captured field is reset to "
+            "its `before` value; foreign keys, m2m relations (tags, insights), and immutable metadata are "
+            "skipped and listed in `skipped_fields`. Saving the dashboard records a new `updated` activity "
+            "log entry, so reverts are themselves auditable and can be reverted in turn."
         ),
     )
     @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
@@ -1644,13 +1652,14 @@ class DashboardsViewSet(
         serializer.is_valid(raise_exception=True)
 
         log_entry = lookup_revertable_activity_log_entry(
-            activity_log_id=serializer.validated_data["activity_log_id"],
+            activity_log_id=serializer.validated_data.get("activity_log_id"),
             scope="Dashboard",
             item_id=str(dashboard.id),
             team_id=self.team_id,
             organization_id=self.team.organization_id,
             include_org_scoped=bool(self.team.receive_org_level_activity_logs),
             user=request.user,
+            revertable_fields=REVERTABLE_DASHBOARD_FIELDS,
         )
         applied, skipped = apply_revert_to_instance(dashboard, log_entry, REVERTABLE_DASHBOARD_FIELDS)
         dashboard.save()
@@ -1658,6 +1667,7 @@ class DashboardsViewSet(
         return Response(
             {
                 "dashboard": DashboardSerializer(dashboard, context=self.get_serializer_context()).data,
+                "activity_log_id": str(log_entry.id),
                 "applied_fields": applied,
                 "skipped_fields": skipped,
             }

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -62,6 +62,7 @@ from posthog.models.activity_logging.activity_log import Detail, changes_between
 from posthog.models.activity_logging.revert import (
     RevertActivityLogRequestSerializer,
     apply_revert_to_instance,
+    is_activity_log_revert_enabled,
     lookup_revertable_activity_log_entry,
 )
 from posthog.models.alert import AlertConfiguration
@@ -1643,6 +1644,10 @@ class DashboardsViewSet(
     )
     @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
     def revert(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        # 404 (not 403) when the experimental flag is off — the endpoint should look
+        # like it doesn't exist to anyone outside the rollout.
+        if not is_activity_log_revert_enabled(cast(User, request.user), self.team):
+            raise exceptions.NotFound()
         # get_object() enforces CanEditDashboard.has_object_permission, which checks
         # the dashboard's restriction_level and the user's edit privilege. Combined with
         # the `dashboard:write` required scope, this gates write access to the dashboard.

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -431,6 +431,28 @@ export interface ReorderTilesRequestApi {
 }
 
 /**
+ * Shared request body for resource-level `/revert/` endpoints.
+ */
+export interface RevertActivityLogRequestApi {
+    /**
+     * Optional UUID of the ActivityLog entry to revert. If omitted, the endpoint picks the most recent revertable entry for this resource — the natural meaning of 'undo my last change'. The chosen entry's id is returned in `activity_log_id` so callers can confirm what was reverted. Use activity-log-list or advanced-activity-logs-list to inspect candidates when a specific past state needs to be restored.
+     * @nullable
+     */
+    activity_log_id?: string | null
+}
+
+export interface RevertDashboardResponseApi {
+    /** The dashboard after the revert has been applied. */
+    dashboard: DashboardApi
+    /** ID of the activity log entry that was reverted. When the caller passed an explicit id, this echoes it; when omitted, this is the most recent revertable entry the endpoint picked. */
+    activity_log_id: string
+    /** Fields that were reset to their `before` value from the activity log entry. */
+    applied_fields: string[]
+    /** Fields recorded in the activity log entry that this endpoint will not revert — typically relations (created_by, data_color_theme, tags), m2m fields (insights), or immutable metadata like creation_mode. Use these to decide whether the revert is sufficient or whether you also need to make manual changes. */
+    skipped_fields: string[]
+}
+
+/**
  * InsightSerializer restricted to identifiers + result only.
  */
 export interface InsightResultApi {
@@ -693,6 +715,18 @@ export type DashboardsReorderTilesCreateFormat =
     (typeof DashboardsReorderTilesCreateFormat)[keyof typeof DashboardsReorderTilesCreateFormat]
 
 export const DashboardsReorderTilesCreateFormat = {
+    Json: 'json',
+    Txt: 'txt',
+} as const
+
+export type DashboardsRevertCreateParams = {
+    format?: DashboardsRevertCreateFormat
+}
+
+export type DashboardsRevertCreateFormat =
+    (typeof DashboardsRevertCreateFormat)[keyof typeof DashboardsRevertCreateFormat]
+
+export const DashboardsRevertCreateFormat = {
     Json: 'json',
     Txt: 'txt',
 } as const

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -29,6 +29,7 @@ import type {
     DashboardsPartialUpdateParams,
     DashboardsReorderTilesCreateParams,
     DashboardsRetrieveParams,
+    DashboardsRevertCreateParams,
     DashboardsRunInsightsRetrieveParams,
     DashboardsSnapshotCreateParams,
     DashboardsStreamTilesRetrieveParams,
@@ -41,6 +42,8 @@ import type {
     PatchedDashboardApi,
     PatchedDataColorThemeApi,
     ReorderTilesRequestApi,
+    RevertActivityLogRequestApi,
+    RevertDashboardResponseApi,
     RunInsightsResponseApi,
     SharingConfigurationApi,
 } from './api.schemas'
@@ -586,6 +589,40 @@ export const dashboardsReorderTilesCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(reorderTilesRequestApi),
+    })
+}
+
+export const getDashboardsRevertCreateUrl = (projectId: string, id: number, params?: DashboardsRevertCreateParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/dashboards/${id}/revert/?${stringifiedParams}`
+        : `/api/projects/${projectId}/dashboards/${id}/revert/`
+}
+
+/**
+ * Revert this dashboard to a previous state captured in the activity log. Pass `activity_log_id` to target a specific entry, or omit it to undo the most recent revertable change — the natural meaning of 'revert this dashboard'. The chosen entry id is echoed back as `activity_log_id` so callers can confirm what was reverted. Each captured field is reset to its `before` value; foreign keys, m2m relations (tags, insights), and immutable metadata are skipped and listed in `skipped_fields`. Saving the dashboard records a new `updated` activity log entry, so reverts are themselves auditable and can be reverted in turn.
+ */
+export const dashboardsRevertCreate = async (
+    projectId: string,
+    id: number,
+    revertActivityLogRequestApi?: RevertActivityLogRequestApi,
+    params?: DashboardsRevertCreateParams,
+    options?: RequestInit
+): Promise<RevertDashboardResponseApi> => {
+    return apiMutator<RevertDashboardResponseApi>(getDashboardsRevertCreateUrl(projectId, id, params), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(revertActivityLogRequestApi),
     })
 }
 

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -289,6 +289,20 @@ export const DashboardsReorderTilesCreateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Revert this dashboard to a previous state captured in the activity log. Pass `activity_log_id` to target a specific entry, or omit it to undo the most recent revertable change — the natural meaning of 'revert this dashboard'. The chosen entry id is echoed back as `activity_log_id` so callers can confirm what was reverted. Each captured field is reset to its `before` value; foreign keys, m2m relations (tags, insights), and immutable metadata are skipped and listed in `skipped_fields`. Saving the dashboard records a new `updated` activity log entry, so reverts are themselves auditable and can be reverted in turn.
+ */
+export const DashboardsRevertCreateBody = /* @__PURE__ */ zod
+    .object({
+        activity_log_id: zod
+            .uuid()
+            .nullish()
+            .describe(
+                "Optional UUID of the ActivityLog entry to revert. If omitted, the endpoint picks the most recent revertable entry for this resource — the natural meaning of 'undo my last change'. The chosen entry's id is returned in `activity_log_id` so callers can confirm what was reverted. Use activity-log-list or advanced-activity-logs-list to inspect candidates when a specific past state needs to be restored."
+            ),
+    })
+    .describe('Shared request body for resource-level `\/revert\/` endpoints.')
+
+/**
  * Snapshot the current dashboard state (from cache) for AI analysis.
 Returns a cache_key representing the 'before' state, to be used with analyze_refresh_result.
  */

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -183,6 +183,29 @@ tools:
             Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. Computes a
             2-column grid layout (6 columns wide, 5 rows tall per tile). First, use dashboard-get to see current tile
             IDs.
+    dashboard-revert:
+        operation: dashboards_revert_create
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: '{id}'
+        title: Revert dashboard to a previous state
+        description: >
+            Revert a dashboard to the state captured immediately before a specific activity log entry. Provide the
+            dashboard id and the UUID `activity_log_id` of the entry to undo (look it up via activity-log-list or
+            advanced-activity-logs-list with scope=Dashboard and item_id={dashboard_id}). The endpoint resets each
+            field captured in that entry's `changes` to its `before` value. Foreign keys (created_by,
+            data_color_theme), m2m relations (tags, insights), and immutable metadata (creation_mode) are skipped
+            and returned in `skipped_fields`. Saving the dashboard records a new activity log entry, so the revert
+            is itself auditable and reversible. Reverts to "created" entries (no prior state) and entries with no
+            applicable fields return a 400.
+        param_overrides:
+            id:
+                cast: string-int
     dashboard-templates-copy-between-projects-create:
         operation: dashboard_templates_copy_between_projects_create
         enabled: false

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -195,14 +195,13 @@ tools:
         enrich_url: '{id}'
         title: Revert dashboard to a previous state
         description: >
-            Revert a dashboard to a previous state captured in the activity log. The typical case — "undo my
-            last change" — needs only the dashboard id: omit `activity_log_id` and the endpoint picks the
-            most recent revertable entry, returning its id in the response so you can tell the user exactly
-            what was undone. To restore an older state, first call activity-log-list (or
-            advanced-activity-logs-list with scope=Dashboard and item_ids={dashboard_id}) to inspect entries,
-            then pass the chosen `activity_log_id`. Each captured field is reset to its `before` value;
-            foreign keys (created_by, data_color_theme), m2m relations (tags, insights), and immutable
-            metadata (creation_mode) are skipped and returned in `skipped_fields`. Saving the dashboard
+            Revert a dashboard to a previous state captured in the activity log. The typical case — "undo my last
+            change" — needs only the dashboard id: omit `activity_log_id` and the endpoint picks the most recent
+            revertable entry, returning its id in the response so you can tell the user exactly what was undone. To
+            restore an older state, first call activity-log-list (or advanced-activity-logs-list with scope=Dashboard
+            and item_ids={dashboard_id}) to inspect entries, then pass the chosen `activity_log_id`. Each captured field
+            is reset to its `before` value; foreign keys (created_by, data_color_theme), m2m relations (tags, insights),
+            and immutable metadata (creation_mode) are skipped and returned in `skipped_fields`. Saving the dashboard
             records a new activity log entry, so the revert is itself auditable and reversible.
         param_overrides:
             id:

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -195,14 +195,15 @@ tools:
         enrich_url: '{id}'
         title: Revert dashboard to a previous state
         description: >
-            Revert a dashboard to the state captured immediately before a specific activity log entry. Provide the
-            dashboard id and the UUID `activity_log_id` of the entry to undo (look it up via activity-log-list or
-            advanced-activity-logs-list with scope=Dashboard and item_id={dashboard_id}). The endpoint resets each
-            field captured in that entry's `changes` to its `before` value. Foreign keys (created_by,
-            data_color_theme), m2m relations (tags, insights), and immutable metadata (creation_mode) are skipped
-            and returned in `skipped_fields`. Saving the dashboard records a new activity log entry, so the revert
-            is itself auditable and reversible. Reverts to "created" entries (no prior state) and entries with no
-            applicable fields return a 400.
+            Revert a dashboard to a previous state captured in the activity log. The typical case — "undo my
+            last change" — needs only the dashboard id: omit `activity_log_id` and the endpoint picks the
+            most recent revertable entry, returning its id in the response so you can tell the user exactly
+            what was undone. To restore an older state, first call activity-log-list (or
+            advanced-activity-logs-list with scope=Dashboard and item_ids={dashboard_id}) to inspect entries,
+            then pass the chosen `activity_log_id`. Each captured field is reset to its `before` value;
+            foreign keys (created_by, data_color_theme), m2m relations (tags, insights), and immutable
+            metadata (creation_mode) are skipped and returned in `skipped_fields`. Saving the dashboard
+            records a new activity log entry, so the revert is itself auditable and reversible.
         param_overrides:
             id:
                 cast: string-int

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -192,7 +192,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
-        enrich_url: '{id}'
+        enrich_url: '{params.id}'
         title: Revert dashboard to a previous state
         description: >
             Revert a dashboard to a previous state captured in the activity log. The typical case — "undo my last

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -22,7 +22,10 @@ tools:
         title: List recent activity in the project.
         description: >
             List recent activity log entries for the project. Shows who did what and when — feature flag changes,
-            dashboard edits, experiment launches, etc. Supports filtering by scope, user, and date range.
+            dashboard edits, experiment launches, etc. Each entry's `detail.changes` contains per-field diffs
+            (before/after values) so you can see exactly what changed. Supports filtering by scope, user, and date
+            range. To revert a dashboard to a prior state, look up its changes here and pass the entry id to
+            dashboard-revert.
         param_overrides:
             page_size:
                 default: 10
@@ -43,6 +46,7 @@ tools:
                 - detail.name
                 - detail.short_id
                 - detail.type
+                - detail.changes
                 - created_at
     advanced-activity-logs-export:
         operation: advanced_activity_logs_export_create

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -6990,6 +6990,28 @@ export interface ActivityLogPaginatedResponseApi {
 }
 
 /**
+ * Shared request body for resource-level `/revert/` endpoints.
+ */
+export interface RevertActivityLogRequestApi {
+    /**
+     * Optional UUID of the ActivityLog entry to revert. If omitted, the endpoint picks the most recent revertable entry for this resource — the natural meaning of 'undo my last change'. The chosen entry's id is returned in `activity_log_id` so callers can confirm what was reverted. Use activity-log-list or advanced-activity-logs-list to inspect candidates when a specific past state needs to be restored.
+     * @nullable
+     */
+    activity_log_id?: string | null
+}
+
+export interface RevertInsightResponseApi {
+    /** The insight after the revert has been applied. */
+    insight: InsightApi
+    /** ID of the activity log entry that was reverted. When the caller passed an explicit id, this echoes it; when omitted, this is the most recent revertable entry the endpoint picked. */
+    activity_log_id: string
+    /** Fields that were reset to their `before` value from the activity log entry. */
+    applied_fields: string[]
+    /** Fields recorded in the activity log entry that this endpoint will not revert — typically relations (created_by, dashboards, tags), derived fields (filters_hash, query_metadata), or UI state (saved, favorited). */
+    skipped_fields: string[]
+}
+
+/**
  * * `add` - add
  * `remove` - remove
  * `set` - set
@@ -7359,6 +7381,17 @@ export type InsightsAnalyzeRetrieveFormat =
     (typeof InsightsAnalyzeRetrieveFormat)[keyof typeof InsightsAnalyzeRetrieveFormat]
 
 export const InsightsAnalyzeRetrieveFormat = {
+    Csv: 'csv',
+    Json: 'json',
+} as const
+
+export type InsightsRevertCreateParams = {
+    format?: InsightsRevertCreateFormat
+}
+
+export type InsightsRevertCreateFormat = (typeof InsightsRevertCreateFormat)[keyof typeof InsightsRevertCreateFormat]
+
+export const InsightsRevertCreateFormat = {
     Csv: 'csv',
     Json: 'json',
 } as const

--- a/products/product_analytics/frontend/generated/api.ts
+++ b/products/product_analytics/frontend/generated/api.ts
@@ -30,6 +30,7 @@ import type {
     InsightsMyLastViewedRetrieveParams,
     InsightsPartialUpdateParams,
     InsightsRetrieveParams,
+    InsightsRevertCreateParams,
     InsightsSuggestionsCreateParams,
     InsightsSuggestionsRetrieveParams,
     InsightsTrendingRetrieveParams,
@@ -42,6 +43,8 @@ import type {
     PatchedColumnConfigurationApi,
     PatchedElementApi,
     PatchedInsightApi,
+    RevertActivityLogRequestApi,
+    RevertInsightResponseApi,
 } from './api.schemas'
 
 // https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
@@ -595,6 +598,40 @@ export const insightsAnalyzeRetrieve = async (
     return apiMutator<void>(getInsightsAnalyzeRetrieveUrl(projectId, id, params), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getInsightsRevertCreateUrl = (projectId: string, id: number, params?: InsightsRevertCreateParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/insights/${id}/revert/?${stringifiedParams}`
+        : `/api/projects/${projectId}/insights/${id}/revert/`
+}
+
+/**
+ * Revert this insight to a previous state captured in the activity log. Pass `activity_log_id` to target a specific entry, or omit it to undo the most recent revertable change — the natural meaning of 'revert this insight'. The chosen entry id is echoed back as `activity_log_id` so callers can confirm what was reverted. Each captured field is reset to its `before` value; foreign keys, m2m relations (dashboards, tags), derived fields (filters_hash, query_metadata), and UI state (saved, favorited) are skipped and listed in `skipped_fields`. Saving the insight records a new `updated` activity log entry, so reverts are themselves auditable and can be reverted in turn.
+ */
+export const insightsRevertCreate = async (
+    projectId: string,
+    id: number,
+    revertActivityLogRequestApi?: RevertActivityLogRequestApi,
+    params?: InsightsRevertCreateParams,
+    options?: RequestInit
+): Promise<RevertInsightResponseApi> => {
+    return apiMutator<RevertInsightResponseApi>(getInsightsRevertCreateUrl(projectId, id, params), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(revertActivityLogRequestApi),
     })
 }
 

--- a/products/product_analytics/frontend/generated/api.zod.ts
+++ b/products/product_analytics/frontend/generated/api.zod.ts
@@ -210,6 +210,20 @@ export const InsightsPartialUpdateBody = /* @__PURE__ */ zod
     .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
 
 /**
+ * Revert this insight to a previous state captured in the activity log. Pass `activity_log_id` to target a specific entry, or omit it to undo the most recent revertable change — the natural meaning of 'revert this insight'. The chosen entry id is echoed back as `activity_log_id` so callers can confirm what was reverted. Each captured field is reset to its `before` value; foreign keys, m2m relations (dashboards, tags), derived fields (filters_hash, query_metadata), and UI state (saved, favorited) are skipped and listed in `skipped_fields`. Saving the insight records a new `updated` activity log entry, so reverts are themselves auditable and can be reverted in turn.
+ */
+export const InsightsRevertCreateBody = /* @__PURE__ */ zod
+    .object({
+        activity_log_id: zod
+            .uuid()
+            .nullish()
+            .describe(
+                "Optional UUID of the ActivityLog entry to revert. If omitted, the endpoint picks the most recent revertable entry for this resource — the natural meaning of 'undo my last change'. The chosen entry's id is returned in `activity_log_id` so callers can confirm what was reverted. Use activity-log-list or advanced-activity-logs-list to inspect candidates when a specific past state needs to be restored."
+            ),
+    })
+    .describe('Shared request body for resource-level `\/revert\/` endpoints.')
+
+/**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
 
 The QueryCoalescingMiddleware attaches cached response data to

--- a/products/product_analytics/mcp/tools.yaml
+++ b/products/product_analytics/mcp/tools.yaml
@@ -188,13 +188,15 @@ tools:
         enrich_url: '{id}'
         title: Revert insight to a previous state
         description: >
-            Revert an insight to the state recorded immediately before a specific activity log entry. Provide
-            the insight numeric `id` and the UUID `activity_log_id` of the entry to undo (look it up via
-            insights-activity-retrieve to see what changed, or via advanced-activity-logs-list with
-            scope=Insight and item_ids={insight_id} for the full diff). Only scalar/JSON fields (name,
-            description, filters, query) are reverted. Foreign keys, m2m relations (dashboards, tags),
-            derived fields, and UI state are skipped and returned in `skipped_fields`. Saving the insight
-            records a new activity log entry, so the revert is itself auditable and reversible.
+            Revert an insight to a previous state captured in the activity log. The typical case — "undo my
+            last change" — needs only the insight numeric `id`: omit `activity_log_id` and the endpoint
+            picks the most recent revertable entry, returning its id in the response so you can confirm
+            what was undone. To restore an older state, call insights-activity-retrieve (or
+            advanced-activity-logs-list with scope=Insight and item_ids={insight_id}) to inspect entries
+            and pass the chosen `activity_log_id`. Only scalar/JSON fields (name, description, filters,
+            query) are reverted. Foreign keys, m2m relations (dashboards, tags), derived fields, and UI
+            state are skipped and returned in `skipped_fields`. Saving the insight records a new activity
+            log entry, so the revert is itself auditable and reversible.
         param_overrides:
             id:
                 cast: string-int

--- a/products/product_analytics/mcp/tools.yaml
+++ b/products/product_analytics/mcp/tools.yaml
@@ -176,6 +176,28 @@ tools:
                 - query_status
                 - hogql
                 - types
+    insight-revert:
+        operation: insights_revert_create
+        enabled: true
+        scopes:
+            - insight:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: '{id}'
+        title: Revert insight to a previous state
+        description: >
+            Revert an insight to the state recorded immediately before a specific activity log entry. Provide
+            the insight numeric `id` and the UUID `activity_log_id` of the entry to undo (look it up via
+            insights-activity-retrieve to see what changed, or via advanced-activity-logs-list with
+            scope=Insight and item_ids={insight_id} for the full diff). Only scalar/JSON fields (name,
+            description, filters, query) are reverted. Foreign keys, m2m relations (dashboards, tags),
+            derived fields, and UI state are skipped and returned in `skipped_fields`. Saving the insight
+            records a new activity log entry, so the revert is itself auditable and reversible.
+        param_overrides:
+            id:
+                cast: string-int
     insights-activity-retrieve:
         operation: insights_activity_retrieve
         enabled: true

--- a/products/product_analytics/mcp/tools.yaml
+++ b/products/product_analytics/mcp/tools.yaml
@@ -137,6 +137,29 @@ tools:
                 - query_status
                 - hogql
                 - types
+    insight-revert:
+        operation: insights_revert_create
+        enabled: true
+        scopes:
+            - insight:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: '{id}'
+        title: Revert insight to a previous state
+        description: >
+            Revert an insight to a previous state captured in the activity log. The typical case — "undo my last change"
+            — needs only the insight numeric `id`: omit `activity_log_id` and the endpoint picks the most recent
+            revertable entry, returning its id in the response so you can confirm what was undone. To restore an older
+            state, call insights-activity-retrieve (or advanced-activity-logs-list with scope=Insight and
+            item_ids={insight_id}) to inspect entries and pass the chosen `activity_log_id`. Only scalar/JSON fields
+            (name, description, filters, query) are reverted. Foreign keys, m2m relations (dashboards, tags), derived
+            fields, and UI state are skipped and returned in `skipped_fields`. Saving the insight records a new activity
+            log entry, so the revert is itself auditable and reversible.
+        param_overrides:
+            id:
+                cast: string-int
     insight-update:
         operation: insights_partial_update
         enabled: true
@@ -176,30 +199,6 @@ tools:
                 - query_status
                 - hogql
                 - types
-    insight-revert:
-        operation: insights_revert_create
-        enabled: true
-        scopes:
-            - insight:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: false
-        enrich_url: '{id}'
-        title: Revert insight to a previous state
-        description: >
-            Revert an insight to a previous state captured in the activity log. The typical case — "undo my
-            last change" — needs only the insight numeric `id`: omit `activity_log_id` and the endpoint
-            picks the most recent revertable entry, returning its id in the response so you can confirm
-            what was undone. To restore an older state, call insights-activity-retrieve (or
-            advanced-activity-logs-list with scope=Insight and item_ids={insight_id}) to inspect entries
-            and pass the chosen `activity_log_id`. Only scalar/JSON fields (name, description, filters,
-            query) are reverted. Foreign keys, m2m relations (dashboards, tags), derived fields, and UI
-            state are skipped and returned in `skipped_fields`. Saving the insight records a new activity
-            log entry, so the revert is itself auditable and reversible.
-        param_overrides:
-            id:
-                cast: string-int
     insights-activity-retrieve:
         operation: insights_activity_retrieve
         enabled: true

--- a/products/product_analytics/mcp/tools.yaml
+++ b/products/product_analytics/mcp/tools.yaml
@@ -146,7 +146,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
-        enrich_url: '{id}'
+        enrich_url: '{params.id}'
         title: Revert insight to a previous state
         description: >
             Revert an insight to a previous state captured in the activity log. The typical case — "undo my last change"

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -185,6 +185,9 @@ tools:
     dashboards-retrieve:
         operation: dashboards_retrieve
         enabled: false
+    dashboards-revert-create:
+        operation: dashboards_revert_create
+        enabled: false
     dashboards-run-insights-retrieve:
         operation: dashboards_run_insights_retrieve
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -75,7 +75,7 @@
         }
     },
     "activity-log-list": {
-        "description": "List recent activity log entries for the project. Shows who did what and when — feature flag changes, dashboard edits, experiment launches, etc. Supports filtering by scope, user, and date range.",
+        "description": "List recent activity log entries for the project. Shows who did what and when — feature flag changes, dashboard edits, experiment launches, etc. Each entry's `detail.changes` contains per-field diffs (before/after values) so you can see exactly what changed. Supports filtering by scope, user, and date range. To revert a dashboard to a prior state, look up its changes here and pass the entry id to dashboard-revert.",
         "category": "Platform Features",
         "feature": "platform_features",
         "summary": "List recent activity in the project.",
@@ -929,6 +929,21 @@
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-revert": {
+        "description": "Revert a dashboard to a previous state captured in the activity log. The typical case — \"undo my last change\" — needs only the dashboard id: omit `activity_log_id` and the endpoint picks the most recent revertable entry, returning its id in the response so you can tell the user exactly what was undone. To restore an older state, first call activity-log-list (or advanced-activity-logs-list with scope=Dashboard and item_ids={dashboard_id}) to inspect entries, then pass the chosen `activity_log_id`. Each captured field is reset to its `before` value; foreign keys (created_by, data_color_theme), m2m relations (tags, insights), and immutable metadata (creation_mode) are skipped and returned in `skipped_fields`. Saving the dashboard records a new activity log entry, so the revert is itself auditable and reversible.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Revert dashboard to a previous state",
+        "title": "Revert dashboard to a previous state",
+        "required_scopes": ["dashboard:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
             "openWorldHint": true,
             "readOnlyHint": false
         }
@@ -2221,6 +2236,21 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        }
+    },
+    "insight-revert": {
+        "description": "Revert an insight to a previous state captured in the activity log. The typical case — \"undo my last change\" — needs only the insight numeric `id`: omit `activity_log_id` and the endpoint picks the most recent revertable entry, returning its id in the response so you can confirm what was undone. To restore an older state, call insights-activity-retrieve (or advanced-activity-logs-list with scope=Insight and item_ids={insight_id}) to inspect entries and pass the chosen `activity_log_id`. Only scalar/JSON fields (name, description, filters, query) are reverted. Foreign keys, m2m relations (dashboards, tags), derived fields, and UI state are skipped and returned in `skipped_fields`. Saving the insight records a new activity log entry, so the revert is itself auditable and reversible.",
+        "category": "Product analytics",
+        "feature": "product_analytics",
+        "summary": "Revert insight to a previous state",
+        "title": "Revert insight to a previous state",
+        "required_scopes": ["insight:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
         }
     },
     "insight-update": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -75,7 +75,7 @@
         }
     },
     "activity-log-list": {
-        "description": "List recent activity log entries for the project. Shows who did what and when — feature flag changes, dashboard edits, experiment launches, etc. Supports filtering by scope, user, and date range.",
+        "description": "List recent activity log entries for the project. Shows who did what and when — feature flag changes, dashboard edits, experiment launches, etc. Each entry's `detail.changes` contains per-field diffs (before/after values) so you can see exactly what changed. Supports filtering by scope, user, and date range. To revert a dashboard to a prior state, look up its changes here and pass the entry id to dashboard-revert.",
         "category": "Platform Features",
         "feature": "platform_features",
         "summary": "List recent activity in the project.",
@@ -946,6 +946,21 @@
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-revert": {
+        "description": "Revert a dashboard to a previous state captured in the activity log. The typical case — \"undo my last change\" — needs only the dashboard id: omit `activity_log_id` and the endpoint picks the most recent revertable entry, returning its id in the response so you can tell the user exactly what was undone. To restore an older state, first call activity-log-list (or advanced-activity-logs-list with scope=Dashboard and item_ids={dashboard_id}) to inspect entries, then pass the chosen `activity_log_id`. Each captured field is reset to its `before` value; foreign keys (created_by, data_color_theme), m2m relations (tags, insights), and immutable metadata (creation_mode) are skipped and returned in `skipped_fields`. Saving the dashboard records a new activity log entry, so the revert is itself auditable and reversible.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Revert dashboard to a previous state",
+        "title": "Revert dashboard to a previous state",
+        "required_scopes": ["dashboard:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
             "openWorldHint": true,
             "readOnlyHint": false
         }
@@ -2534,6 +2549,21 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        }
+    },
+    "insight-revert": {
+        "description": "Revert an insight to a previous state captured in the activity log. The typical case — \"undo my last change\" — needs only the insight numeric `id`: omit `activity_log_id` and the endpoint picks the most recent revertable entry, returning its id in the response so you can confirm what was undone. To restore an older state, call insights-activity-retrieve (or advanced-activity-logs-list with scope=Insight and item_ids={insight_id}) to inspect entries and pass the chosen `activity_log_id`. Only scalar/JSON fields (name, description, filters, query) are reverted. Foreign keys, m2m relations (dashboards, tags), derived fields, and UI state are skipped and returned in `skipped_fields`. Saving the insight records a new activity log entry, so the revert is itself auditable and reversible.",
+        "category": "Product analytics",
+        "feature": "product_analytics",
+        "summary": "Revert insight to a previous state",
+        "title": "Revert insight to a previous state",
+        "required_scopes": ["insight:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
         }
     },
     "insight-update": {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -32807,6 +32807,39 @@ export namespace Schemas {
       password: string;
     }
 
+    /**
+     * Shared request body for resource-level `/revert/` endpoints.
+     */
+    export interface RevertActivityLogRequest {
+      /**
+         * Optional UUID of the ActivityLog entry to revert. If omitted, the endpoint picks the most recent revertable entry for this resource — the natural meaning of 'undo my last change'. The chosen entry's id is returned in `activity_log_id` so callers can confirm what was reverted. Use activity-log-list or advanced-activity-logs-list to inspect candidates when a specific past state needs to be restored.
+         * @nullable
+         */
+      activity_log_id?: string | null;
+    }
+
+    export interface RevertDashboardResponse {
+      /** The dashboard after the revert has been applied. */
+      dashboard: Dashboard;
+      /** ID of the activity log entry that was reverted. When the caller passed an explicit id, this echoes it; when omitted, this is the most recent revertable entry the endpoint picked. */
+      activity_log_id: string;
+      /** Fields that were reset to their `before` value from the activity log entry. */
+      applied_fields: string[];
+      /** Fields recorded in the activity log entry that this endpoint will not revert — typically relations (created_by, data_color_theme, tags), m2m fields (insights), or immutable metadata like creation_mode. Use these to decide whether the revert is sufficient or whether you also need to make manual changes. */
+      skipped_fields: string[];
+    }
+
+    export interface RevertInsightResponse {
+      /** The insight after the revert has been applied. */
+      insight: Insight;
+      /** ID of the activity log entry that was reverted. When the caller passed an explicit id, this echoes it; when omitted, this is the most recent revertable entry the endpoint picked. */
+      activity_log_id: string;
+      /** Fields that were reset to their `before` value from the activity log entry. */
+      applied_fields: string[];
+      /** Fields recorded in the activity log entry that this endpoint will not revert — typically relations (created_by, dashboards, tags), derived fields (filters_hash, query_metadata), or UI state (saved, favorited). */
+      skipped_fields: string[];
+    }
+
     export interface ReviewQueueCreate {
       /**
          * Human-readable queue name.
@@ -35779,6 +35812,18 @@ export namespace Schemas {
       Txt: 'txt',
     } as const;
 
+    export type EnvironmentsDashboardsRevertCreateParams = {
+    format?: EnvironmentsDashboardsRevertCreateFormat;
+    };
+
+    export type EnvironmentsDashboardsRevertCreateFormat = typeof EnvironmentsDashboardsRevertCreateFormat[keyof typeof EnvironmentsDashboardsRevertCreateFormat];
+
+
+    export const EnvironmentsDashboardsRevertCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
     export type EnvironmentsDashboardsRunInsightsRetrieveParams = {
     /**
      * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
@@ -37031,6 +37076,18 @@ export namespace Schemas {
 
 
     export const EnvironmentsInsightsAnalyzeRetrieveFormat = {
+      Csv: 'csv',
+      Json: 'json',
+    } as const;
+
+    export type EnvironmentsInsightsRevertCreateParams = {
+    format?: EnvironmentsInsightsRevertCreateFormat;
+    };
+
+    export type EnvironmentsInsightsRevertCreateFormat = typeof EnvironmentsInsightsRevertCreateFormat[keyof typeof EnvironmentsInsightsRevertCreateFormat];
+
+
+    export const EnvironmentsInsightsRevertCreateFormat = {
       Csv: 'csv',
       Json: 'json',
     } as const;
@@ -40449,6 +40506,18 @@ export namespace Schemas {
       Txt: 'txt',
     } as const;
 
+    export type DashboardsRevertCreateParams = {
+    format?: DashboardsRevertCreateFormat;
+    };
+
+    export type DashboardsRevertCreateFormat = typeof DashboardsRevertCreateFormat[keyof typeof DashboardsRevertCreateFormat];
+
+
+    export const DashboardsRevertCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
     export type DashboardsRunInsightsRetrieveParams = {
     /**
      * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
@@ -42006,6 +42075,18 @@ export namespace Schemas {
 
 
     export const InsightsAnalyzeRetrieveFormat = {
+      Csv: 'csv',
+      Json: 'json',
+    } as const;
+
+    export type InsightsRevertCreateParams = {
+    format?: InsightsRevertCreateFormat;
+    };
+
+    export type InsightsRevertCreateFormat = typeof InsightsRevertCreateFormat[keyof typeof InsightsRevertCreateFormat];
+
+
+    export const InsightsRevertCreateFormat = {
       Csv: 'csv',
       Json: 'json',
     } as const;

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 7 enabled ops
+ * PostHog API - MCP 8 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -179,6 +179,33 @@ export const DashboardsReorderTilesCreateBody = /* @__PURE__ */ zod.object({
         .min(1)
         .describe('Array of tile IDs in the desired display order (top to bottom, left to right).'),
 })
+
+/**
+ * Revert this dashboard to a previous state captured in the activity log. Pass `activity_log_id` to target a specific entry, or omit it to undo the most recent revertable change — the natural meaning of 'revert this dashboard'. The chosen entry id is echoed back as `activity_log_id` so callers can confirm what was reverted. Each captured field is reset to its `before` value; foreign keys, m2m relations (tags, insights), and immutable metadata are skipped and listed in `skipped_fields`. Saving the dashboard records a new `updated` activity log entry, so reverts are themselves auditable and can be reverted in turn.
+ */
+export const DashboardsRevertCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const DashboardsRevertCreateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const DashboardsRevertCreateBody = /* @__PURE__ */ zod
+    .object({
+        activity_log_id: zod
+            .uuid()
+            .nullish()
+            .describe(
+                "Optional UUID of the ActivityLog entry to revert. If omitted, the endpoint picks the most recent revertable entry for this resource — the natural meaning of 'undo my last change'. The chosen entry's id is returned in `activity_log_id` so callers can confirm what was reverted. Use activity-log-list or advanced-activity-logs-list to inspect candidates when a specific past state needs to be restored."
+            ),
+    })
+    .describe('Shared request body for resource-level `/revert/` endpoints.')
 
 /**
  * Run all insights on a dashboard and return their results.

--- a/services/mcp/src/generated/product_analytics/api.ts
+++ b/services/mcp/src/generated/product_analytics/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 8 enabled ops
+ * PostHog API - MCP 9 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -305,6 +305,33 @@ export const InsightsActivityRetrieveQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Page size. Defaults to 10.'),
     page: zod.number().optional().describe('1-indexed page number. Defaults to 1.'),
 })
+
+/**
+ * Revert this insight to a previous state captured in the activity log. Pass `activity_log_id` to target a specific entry, or omit it to undo the most recent revertable change — the natural meaning of 'revert this insight'. The chosen entry id is echoed back as `activity_log_id` so callers can confirm what was reverted. Each captured field is reset to its `before` value; foreign keys, m2m relations (dashboards, tags), derived fields (filters_hash, query_metadata), and UI state (saved, favorited) are skipped and listed in `skipped_fields`. Saving the insight records a new `updated` activity log entry, so reverts are themselves auditable and can be reverted in turn.
+ */
+export const InsightsRevertCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this insight.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const InsightsRevertCreateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['csv', 'json']).optional(),
+})
+
+export const InsightsRevertCreateBody = /* @__PURE__ */ zod
+    .object({
+        activity_log_id: zod
+            .uuid()
+            .nullish()
+            .describe(
+                "Optional UUID of the ActivityLog entry to revert. If omitted, the endpoint picks the most recent revertable entry for this resource — the natural meaning of 'undo my last change'. The chosen entry's id is returned in `activity_log_id` so callers can confirm what was reverted. Use activity-log-list or advanced-activity-logs-list to inspect candidates when a specific past state needs to be restored."
+            ),
+    })
+    .describe('Shared request body for resource-level `/revert/` endpoints.')
 
 /**
  * Project-wide audit trail across all insights — who created, edited, deleted, or restored insights, what changed (with before/after diffs), and when. Useful for surfacing what people (or agents) have been working on recently.

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -283,7 +283,7 @@ const dashboardRevert = (): ToolBase<
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/revert/`,
             body,
         })
-        return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
+        return await withPostHogUrl(context, result, `/dashboard/${params.id}`)
     },
 })
 

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -12,6 +12,8 @@ import {
     DashboardsReorderTilesCreateParams,
     DashboardsRetrieveParams,
     DashboardsRetrieveQueryParams,
+    DashboardsRevertCreateBody,
+    DashboardsRevertCreateParams,
     DashboardsRunInsightsRetrieveParams,
     DashboardsRunInsightsRetrieveQueryParams,
 } from '@/generated/dashboards/api'
@@ -260,6 +262,31 @@ const dashboardReorderTiles = (): ToolBase<typeof DashboardReorderTilesSchema, W
     },
 })
 
+const DashboardRevertSchema = DashboardsRevertCreateParams.omit({ project_id: true })
+    .extend(DashboardsRevertCreateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsRevertCreateParams.shape['id']) })
+
+const dashboardRevert = (): ToolBase<
+    typeof DashboardRevertSchema,
+    WithPostHogUrl<Schemas.RevertDashboardResponse>
+> => ({
+    name: 'dashboard-revert',
+    schema: DashboardRevertSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardRevertSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.activity_log_id !== undefined) {
+            body['activity_log_id'] = params.activity_log_id
+        }
+        const result = await context.api.request<Schemas.RevertDashboardResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/revert/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/dashboard/${result.id}`)
+    },
+})
+
 const DashboardUpdateSchema = DashboardsPartialUpdateParams.omit({ project_id: true })
     .extend(DashboardsPartialUpdateBody.shape)
     .extend({ id: z.preprocess(castStringToInt, DashboardsPartialUpdateParams.shape['id']) })
@@ -390,6 +417,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'dashboard-get': dashboardGet,
     'dashboard-insights-run': dashboardInsightsRun,
     'dashboard-reorder-tiles': dashboardReorderTiles,
+    'dashboard-revert': dashboardRevert,
     'dashboard-update': dashboardUpdate,
     'dashboards-get-all': dashboardsGetAll,
 }

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -69,6 +69,7 @@ const activityLogList = (): ToolBase<
                     'detail.name',
                     'detail.short_id',
                     'detail.type',
+                    'detail.changes',
                     'created_at',
                 ])
             ),

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -316,7 +316,7 @@ const insightRevert = (): ToolBase<typeof InsightRevertSchema, WithPostHogUrl<Sc
             path: `/api/projects/${encodeURIComponent(String(projectId))}/insights/${encodeURIComponent(String(params.id))}/revert/`,
             body,
         })
-        return await withPostHogUrl(context, result, `/insights/${result.id}`)
+        return await withPostHogUrl(context, result, `/insights/${params.id}`)
     },
 })
 

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -244,6 +244,28 @@ const insightGet = (): ToolBase<typeof InsightGetSchema, WithPostHogUrl<Schemas.
     },
 })
 
+const InsightRevertSchema = InsightsRevertCreateParams.omit({ project_id: true })
+    .extend(InsightsRevertCreateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, InsightsRevertCreateParams.shape['id']) })
+
+const insightRevert = (): ToolBase<typeof InsightRevertSchema, WithPostHogUrl<Schemas.RevertInsightResponse>> => ({
+    name: 'insight-revert',
+    schema: InsightRevertSchema,
+    handler: async (context: Context, params: z.infer<typeof InsightRevertSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.activity_log_id !== undefined) {
+            body['activity_log_id'] = params.activity_log_id
+        }
+        const result = await context.api.request<Schemas.RevertInsightResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/insights/${encodeURIComponent(String(params.id))}/revert/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/insights/${params.id}`)
+    },
+})
+
 const InsightUpdateSchema = InsightsPartialUpdateParams.omit({ project_id: true })
     .extend(
         InsightsPartialUpdateBody.omit({ derived_name: true, order: true, deleted: true, _create_in_folder: true })
@@ -295,28 +317,6 @@ const insightUpdate = (): ToolBase<typeof InsightUpdateSchema, WithPostHogUrl<Sc
             'types',
         ]) as typeof result
         return await withPostHogUrl(context, filtered, `/insights/${filtered.short_id}`)
-    },
-})
-
-const InsightRevertSchema = InsightsRevertCreateParams.omit({ project_id: true })
-    .extend(InsightsRevertCreateBody.shape)
-    .extend({ id: z.preprocess(castStringToInt, InsightsRevertCreateParams.shape['id']) })
-
-const insightRevert = (): ToolBase<typeof InsightRevertSchema, WithPostHogUrl<Schemas.RevertInsightResponse>> => ({
-    name: 'insight-revert',
-    schema: InsightRevertSchema,
-    handler: async (context: Context, params: z.infer<typeof InsightRevertSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.activity_log_id !== undefined) {
-            body['activity_log_id'] = params.activity_log_id
-        }
-        const result = await context.api.request<Schemas.RevertInsightResponse>({
-            method: 'POST',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/insights/${encodeURIComponent(String(params.id))}/revert/`,
-            body,
-        })
-        return await withPostHogUrl(context, result, `/insights/${params.id}`)
     },
 })
 
@@ -513,8 +513,8 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'insight-create': insightCreate,
     'insight-delete': insightDelete,
     'insight-get': insightGet,
-    'insight-update': insightUpdate,
     'insight-revert': insightRevert,
+    'insight-update': insightUpdate,
     'insights-activity-retrieve': insightsActivityRetrieve,
     'insights-all-activity-retrieve': insightsAllActivityRetrieve,
     'insights-list': insightsList,

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -13,6 +13,8 @@ import {
     InsightsPartialUpdateParams,
     InsightsRetrieveParams,
     InsightsRetrieveQueryParams,
+    InsightsRevertCreateBody,
+    InsightsRevertCreateParams,
     InsightsTrendingRetrieveQueryParams,
 } from '@/generated/product_analytics/api'
 import { castStringToInt } from '@/tools/cast-helpers'
@@ -296,6 +298,28 @@ const insightUpdate = (): ToolBase<typeof InsightUpdateSchema, WithPostHogUrl<Sc
     },
 })
 
+const InsightRevertSchema = InsightsRevertCreateParams.omit({ project_id: true })
+    .extend(InsightsRevertCreateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, InsightsRevertCreateParams.shape['id']) })
+
+const insightRevert = (): ToolBase<typeof InsightRevertSchema, WithPostHogUrl<Schemas.RevertInsightResponse>> => ({
+    name: 'insight-revert',
+    schema: InsightRevertSchema,
+    handler: async (context: Context, params: z.infer<typeof InsightRevertSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.activity_log_id !== undefined) {
+            body['activity_log_id'] = params.activity_log_id
+        }
+        const result = await context.api.request<Schemas.RevertInsightResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/insights/${encodeURIComponent(String(params.id))}/revert/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/insights/${result.id}`)
+    },
+})
+
 const InsightsActivityRetrieveSchema = InsightsActivityRetrieveParams.omit({ project_id: true }).extend(
     InsightsActivityRetrieveQueryParams.omit({ format: true }).shape
 )
@@ -490,6 +514,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'insight-delete': insightDelete,
     'insight-get': insightGet,
     'insight-update': insightUpdate,
+    'insight-revert': insightRevert,
     'insights-activity-retrieve': insightsActivityRetrieve,
     'insights-all-activity-retrieve': insightsAllActivityRetrieve,
     'insights-list': insightsList,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-revert.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-revert.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "activity_log_id": {
+            "anyOf": [
+                {
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optional UUID of the ActivityLog entry to revert. If omitted, the endpoint picks the most recent revertable entry for this resource — the natural meaning of 'undo my last change'. The chosen entry's id is returned in `activity_log_id` so callers can confirm what was reverted. Use activity-log-list or advanced-activity-logs-list to inspect candidates when a specific past state needs to be restored."
+        },
+        "id": {
+            "description": "A unique integer value identifying this dashboard.",
+            "type": "number"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-revert.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-revert.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "activity_log_id": {
+            "anyOf": [
+                {
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optional UUID of the ActivityLog entry to revert. If omitted, the endpoint picks the most recent revertable entry for this resource — the natural meaning of 'undo my last change'. The chosen entry's id is returned in `activity_log_id` so callers can confirm what was reverted. Use activity-log-list or advanced-activity-logs-list to inspect candidates when a specific past state needs to be restored."
+        },
+        "id": {
+            "description": "A unique integer value identifying this insight.",
+            "type": "number"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Users (notably an enterprise customer surfaced in #58333 thread context) want a way to "version control" dashboards, which gets sharper now that agents can edit dashboards via MCP. PostHog already records every dashboard change (name, description, filters, pinned, tags, etc.) in the activity log with full before/after diffs — but the MCP surface didn't make them useful:

- The lightweight `activity-log-list` MCP tool was stripping `detail.changes` from its response, so an agent couldn't actually see what changed without falling back to `advanced-activity-logs-list`.
- There was no way to roll a dashboard back to a previous state — neither via API nor MCP. The closest existing pattern is the feature-flag "reconstruct at version" code, which is read-only preview, never write-back.

## Changes

- `products/platform_features/mcp/tools.yaml`: add `detail.changes` to the `activity-log-list` response so agents can see field-level diffs from the simpler listing tool. Tightens the description to point at `dashboard-revert`.
- `products/dashboards/backend/api/dashboard.py`: new `POST /api/projects/{team_id}/dashboards/{id}/revert/` action on `DashboardsViewSet`. Takes `{"activity_log_id": "<uuid>"}`, looks up the matching `ActivityLog` row (validates team / scope=Dashboard / item_id match), and applies the `before` value of every captured change whose `field` is in a whitelist of scalar / JSON dashboard fields. Foreign keys (`created_by`, `data_color_theme`), m2m (tags, insights), and immutable metadata (`creation_mode`) are skipped and returned in `skipped_fields` so the caller knows the revert wasn't total. Saving the dashboard runs through `ModelActivityMixin`, which records a new "updated" entry — so the revert is itself auditable and can be reverted in turn.
- `products/dashboards/mcp/tools.yaml`: enable `dashboard-revert` (operation `dashboards_revert_create`) with `dashboard:write` scope.
- `posthog/api/test/dashboards/test_dashboard.py`: cover the happy paths (simple field, undelete, mixed applied + skipped), and the rejection paths (unknown log id → 404, log id from a different dashboard → 404, no changes → 400, only non-revertable fields → 400). Includes a check that the revert itself writes a new activity log entry.

CI will need to regenerate the OpenAPI schema, Orval Zod schemas, and MCP-generated TypeScript (`hogli build:openapi` + the MCP codegen) to pick up the new endpoint — those generated files are not committed in this PR since the agent environment didn't have flox/hogli available.

## How did you test this code?

I'm an agent (PostHog Code). I wrote 8 backend unit tests against the new endpoint covering revert success cases, the activity-log re-emission, and the four refusal paths. I did not run them locally — the agent environment doesn't have flox or the Django test runner. CI will exercise them. I verified Python syntax (`python -c "import ast; ast.parse(...)"`), passed `ruff check` and `ruff format` on the changed files, and validated both `tools.yaml` files parse and contain the expected entries.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude)
- Decisions:
  - Considered a generic "revert" action shared across resources; rejected because the activity log fields vary per scope (FKs, JSON, M2M behave differently) and a per-resource whitelist keeps the blast radius small and predictable.
  - Considered passing a `version_number` (like feature flags) instead of an activity log UUID; rejected because dashboards have no version counter and the activity log id is already the durable identifier an agent has after listing changes.
  - Considered an extra `log_activity` call to annotate the new entry as "Reverted from <id>"; skipped to avoid double-logging. The new entry's changes already mirror the reverse of the source entry, which is enough for an agent to verify.
  - Considered allowing every field in `changes_between` blindly; rejected — FKs serialize as nested JSON objects in the activity log and applying them as-is would fail. Whitelist explicitly excludes relations.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*