### PR TITLE
fix(tracing): fix project-tz conversion on attribute name/value queries

### DIFF
--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -498,6 +498,7 @@ def run_service_names_query(
         team=team,
         workload=Workload.LOGS,
         filters=HogQLFilters(dateRange=date_range),
+        modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
         settings=HogQLGlobalSettings(
             allow_experimental_object_type=False,
             allow_experimental_join_condition=False,

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -19,6 +19,7 @@ from posthog.schema import (
     CompareFilter,
     DateRange,
     HogQLFilters,
+    HogQLQueryModifiers,
     IntervalType,
     PropertyGroupFilter,
     PropertyGroupsMode,
@@ -565,6 +566,11 @@ def run_attribute_names_query(
         team=team,
         workload=Workload.LOGS,
         filters=HogQLFilters(dateRange=date_range),
+        # Skip the printer's automatic team-timezone conversion. Our `QueryDateRange`
+        # already resolves date_from/date_to in UTC explicitly (via `timezone_info=UTC`),
+        # and the underlying `trace_attributes.time_bucket` is UTC; reapplying the team
+        # tz on top would shift the filter by the team offset.
+        modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
         settings=HogQLGlobalSettings(
             read_overflow_mode="break",
             max_bytes_to_read=5_000_000_000,
@@ -636,6 +642,9 @@ def run_attribute_values_query(
         team=team,
         workload=Workload.LOGS,
         filters=HogQLFilters(dateRange=date_range),
+        # See the matching note in `run_attribute_names_query` — the date range
+        # is already UTC-anchored, so skip the printer's team-tz conversion.
+        modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
         settings=HogQLGlobalSettings(
             read_overflow_mode="break",
             max_bytes_to_read=5_000_000_000,

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -566,10 +566,6 @@ def run_attribute_names_query(
         team=team,
         workload=Workload.LOGS,
         filters=HogQLFilters(dateRange=date_range),
-        # Skip the printer's automatic team-timezone conversion. Our `QueryDateRange`
-        # already resolves date_from/date_to in UTC explicitly (via `timezone_info=UTC`),
-        # and the underlying `trace_attributes.time_bucket` is UTC; reapplying the team
-        # tz on top would shift the filter by the team offset.
         modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
         settings=HogQLGlobalSettings(
             read_overflow_mode="break",
@@ -642,8 +638,6 @@ def run_attribute_values_query(
         team=team,
         workload=Workload.LOGS,
         filters=HogQLFilters(dateRange=date_range),
-        # See the matching note in `run_attribute_names_query` — the date range
-        # is already UTC-anchored, so skip the printer's team-tz conversion.
         modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
         settings=HogQLGlobalSettings(
             read_overflow_mode="break",


### PR DESCRIPTION

## Problem

tracing attribute names/values queries were broken on non-UTC project timezones

## Changes

pass in modifiers.convertToProjectTimezone = False as with other tracing queries

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
