### PR TITLE
fix: handle role_based_access feature when previewing access

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -493,10 +493,17 @@ class AccessControlViewSetMixin(_GenericViewSet):
                 else:
                     role_resource_overrides[(str(role_id), resource_type)] = level
 
-        # Role-based overrides only take effect if the organization has the
-        # ROLE_BASED_ACCESS feature; otherwise role rows in the DB are inert and we
-        # must not surface them as the effective access level.
-        role_based_access_supported = team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
+        # Resource-level role overrides only take effect if the organization has the
+        # ROLE_BASED_ACCESS feature; otherwise role rows in the DB are inert for
+        # resource access and we must not surface them as the effective access level.
+        # NOTE: project-level role overrides are intentionally NOT gated here because
+        # UserTeamPermissions.effective_membership_level_for_parent_membership honors
+        # role-backed project AccessControl rows whenever ADVANCED_PERMISSIONS is
+        # enabled (no ROLE_BASED_ACCESS check), so gating the preview here would lie
+        # about a user's actual project access.
+        role_based_resource_access_supported = team.organization.is_feature_available(
+            AvailableFeature.ROLE_BASED_ACCESS
+        )
 
         # Build results for each role
         roles = Role.objects.filter(organization=team.organization)
@@ -505,7 +512,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
         for role in roles:
             rid = str(role.id)
 
-            project_role_level = role_project_overrides.get(rid) if role_based_access_supported else None
+            project_role_level = role_project_overrides.get(rid)
             project_result = get_effective_access_level_for_role(
                 resource="project",
                 default_level=project_default_level,
@@ -515,7 +522,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
             resource_entries: dict[str, dict] = {}
             for resource in ACCESS_CONTROL_RESOURCES:
                 resource_role_level = (
-                    role_resource_overrides.get((rid, resource)) if role_based_access_supported else None
+                    role_resource_overrides.get((rid, resource)) if role_based_resource_access_supported else None
                 )
                 resource_default = resource_default_levels.get(resource)
                 resource_result = get_effective_access_level_for_role(
@@ -598,10 +605,17 @@ class AccessControlViewSetMixin(_GenericViewSet):
                 else:
                     member_resource_overrides[(str(member_id), resource_type)] = level
 
-        # Role-based overrides only take effect if the organization has the
-        # ROLE_BASED_ACCESS feature; otherwise role rows in the DB are inert and we
-        # must not let them influence members' effective access level.
-        role_based_access_supported = team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
+        # Resource-level role overrides only take effect if the organization has the
+        # ROLE_BASED_ACCESS feature; otherwise role rows in the DB are inert for
+        # resource access and we must not let them influence members' effective
+        # resource access level. NOTE: project-level role overrides are intentionally
+        # NOT gated here because UserTeamPermissions.effective_membership_level_for_
+        # parent_membership honors role-backed project AccessControl rows whenever
+        # ADVANCED_PERMISSIONS is enabled (no ROLE_BASED_ACCESS check), so gating the
+        # preview here would lie about a user's actual project access.
+        role_based_resource_access_supported = team.organization.is_feature_available(
+            AvailableFeature.ROLE_BASED_ACCESS
+        )
 
         # Build results for each member
         memberships = (
@@ -617,11 +631,9 @@ class AccessControlViewSetMixin(_GenericViewSet):
             member_role_ids = [str(rm.role_id) for rm in membership.role_memberships.all()]
 
             project_member_level = member_project_overrides.get(mid)
-            project_role_levels: list[AccessControlLevel] = (
-                [role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides]
-                if role_based_access_supported
-                else []
-            )
+            project_role_levels: list[AccessControlLevel] = [
+                role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides
+            ]
             project_result = get_effective_access_level_for_member(
                 resource="project",
                 default_level=project_default_level,
@@ -640,7 +652,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
                         for rid in member_role_ids
                         if (rid, resource) in role_resource_overrides
                     ]
-                    if role_based_access_supported
+                    if role_based_resource_access_supported
                     else []
                 )
                 resource_result = get_effective_access_level_for_member(

--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from posthog.api.documentation import extend_schema
+from posthog.constants import AvailableFeature
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.rbac.user_access_control import (
@@ -492,6 +493,11 @@ class AccessControlViewSetMixin(_GenericViewSet):
                 else:
                     role_resource_overrides[(str(role_id), resource_type)] = level
 
+        # Role-based overrides only take effect if the organization has the
+        # ROLE_BASED_ACCESS feature; otherwise role rows in the DB are inert and we
+        # must not surface them as the effective access level.
+        role_based_access_supported = team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
+
         # Build results for each role
         roles = Role.objects.filter(organization=team.organization)
         results = []
@@ -499,7 +505,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
         for role in roles:
             rid = str(role.id)
 
-            project_role_level = role_project_overrides.get(rid)
+            project_role_level = role_project_overrides.get(rid) if role_based_access_supported else None
             project_result = get_effective_access_level_for_role(
                 resource="project",
                 default_level=project_default_level,
@@ -508,7 +514,9 @@ class AccessControlViewSetMixin(_GenericViewSet):
 
             resource_entries: dict[str, dict] = {}
             for resource in ACCESS_CONTROL_RESOURCES:
-                resource_role_level = role_resource_overrides.get((rid, resource))
+                resource_role_level = (
+                    role_resource_overrides.get((rid, resource)) if role_based_access_supported else None
+                )
                 resource_default = resource_default_levels.get(resource)
                 resource_result = get_effective_access_level_for_role(
                     resource=resource,
@@ -590,6 +598,11 @@ class AccessControlViewSetMixin(_GenericViewSet):
                 else:
                     member_resource_overrides[(str(member_id), resource_type)] = level
 
+        # Role-based overrides only take effect if the organization has the
+        # ROLE_BASED_ACCESS feature; otherwise role rows in the DB are inert and we
+        # must not let them influence members' effective access level.
+        role_based_access_supported = team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
+
         # Build results for each member
         memberships = (
             OrganizationMembership.objects.filter(organization=team.organization, user__is_active=True)
@@ -604,9 +617,11 @@ class AccessControlViewSetMixin(_GenericViewSet):
             member_role_ids = [str(rm.role_id) for rm in membership.role_memberships.all()]
 
             project_member_level = member_project_overrides.get(mid)
-            project_role_levels: list[AccessControlLevel] = [
-                role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides
-            ]
+            project_role_levels: list[AccessControlLevel] = (
+                [role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides]
+                if role_based_access_supported
+                else []
+            )
             project_result = get_effective_access_level_for_member(
                 resource="project",
                 default_level=project_default_level,
@@ -619,11 +634,15 @@ class AccessControlViewSetMixin(_GenericViewSet):
             for resource in ACCESS_CONTROL_RESOURCES:
                 resource_member_level = member_resource_overrides.get((mid, resource))
                 resource_default = resource_default_levels.get(resource)
-                resource_role_levels: list[AccessControlLevel] = [
-                    role_resource_overrides[(rid, resource)]
-                    for rid in member_role_ids
-                    if (rid, resource) in role_resource_overrides
-                ]
+                resource_role_levels: list[AccessControlLevel] = (
+                    [
+                        role_resource_overrides[(rid, resource)]
+                        for rid in member_role_ids
+                        if (rid, resource) in role_resource_overrides
+                    ]
+                    if role_based_access_supported
+                    else []
+                )
                 resource_result = get_effective_access_level_for_member(
                     resource=resource,
                     default_level=resource_default,

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -1816,6 +1816,35 @@ class TestAccessControlMembersEndpoint(BaseAccessControlTest):
         assert ff["effective_access_level"] is None
         assert ff["inherited_access_level"] is None
 
+    def test_role_overrides_ignored_when_role_based_access_not_available(self):
+        """When the organization does not have the ROLE_BASED_ACCESS feature, role-based
+        overrides must not influence a member's effective resource access level. The member
+        should fall back to the resource default."""
+        # Remove the ROLE_BASED_ACCESS feature, keep ADVANCED_PERMISSIONS
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
+        ]
+        self.organization.save()
+
+        # Make user2 a regular member so org-admin highest-access doesn't mask the bug
+        self.user2_membership.level = OrganizationMembership.Level.MEMBER
+        self.user2_membership.save()
+
+        # Default dashboard access for the project is 'viewer'
+        self._put_global_access_control({"resource": "dashboard", "access_level": "viewer"})
+        # A role-based override grants 'manager' on dashboards
+        self._put_global_access_control({"resource": "dashboard", "access_level": "manager", "role": str(self.role.id)})
+        # user2 is in that role
+        RoleMembership.objects.create(user=self.user2, role=self.role, organization_member=self.user2_membership)
+
+        res = self.client.get("/api/projects/@current/access_control_members")
+        member_data = self._find_member(res.json()["results"], self.user2_membership.id)
+        dashboard = member_data["resources"]["dashboard"]
+        # Without ROLE_BASED_ACCESS, the role override must be ignored
+        assert dashboard["effective_access_level"] == "viewer"
+        assert dashboard["inherited_access_level"] == "viewer"
+        assert dashboard["inherited_access_level_reason"] == "project_default"
+
     def test_only_returns_current_team_member_overrides(self):
         """Member overrides from other teams are not included."""
         from ee.models.rbac.access_control import AccessControl

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -1677,6 +1677,37 @@ class TestAccessControlRolesEndpoint(BaseAccessControlTest):
         role_data = self._find_role(res.json()["results"], self.role.id)
         assert role_data["project"]["access_level"] == "member"
 
+    def test_resource_role_overrides_ignored_when_role_based_access_not_available(self):
+        """Without ROLE_BASED_ACCESS, role-based resource overrides are inert at runtime,
+        so the per-role preview must show the resource default as the effective level.
+        Project-level role overrides remain effective (runtime still honors them via
+        UserTeamPermissions when ADVANCED_PERMISSIONS is enabled)."""
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
+        ]
+        self.organization.save()
+
+        # Project default 'member', role-based project override 'admin'
+        self._put_project_access_control({"access_level": "member"})
+        self._put_project_access_control({"role": str(self.role.id), "access_level": "admin"})
+        # Dashboard default 'viewer', role-based override 'manager'
+        self._put_global_access_control({"resource": "dashboard", "access_level": "viewer"})
+        self._put_global_access_control({"resource": "dashboard", "access_level": "manager", "role": str(self.role.id)})
+
+        res = self.client.get("/api/projects/@current/access_control_roles")
+        role_data = self._find_role(res.json()["results"], self.role.id)
+
+        # Resource-level role override must be ignored
+        dashboard = role_data["resources"]["dashboard"]
+        assert dashboard["effective_access_level"] == "viewer"
+        assert dashboard["inherited_access_level"] == "viewer"
+        assert dashboard["inherited_access_level_reason"] == "project_default"
+
+        # Project-level role override is still effective (mirrors runtime)
+        project = role_data["project"]
+        assert project["access_level"] == "admin"
+        assert project["effective_access_level"] == "admin"
+
 
 class TestAccessControlMembersEndpoint(BaseAccessControlTest):
     def setUp(self):
@@ -1816,10 +1847,16 @@ class TestAccessControlMembersEndpoint(BaseAccessControlTest):
         assert ff["effective_access_level"] is None
         assert ff["inherited_access_level"] is None
 
-    def test_role_overrides_ignored_when_role_based_access_not_available(self):
+    def test_resource_role_overrides_ignored_when_role_based_access_not_available(self):
         """When the organization does not have the ROLE_BASED_ACCESS feature, role-based
-        overrides must not influence a member's effective resource access level. The member
-        should fall back to the resource default."""
+        *resource* overrides must not influence a member's effective resource access level.
+        The member should fall back to the resource default.
+
+        Project-level role overrides are deliberately NOT gated by this feature, because
+        UserTeamPermissions.effective_membership_level_for_parent_membership honors
+        role-backed project AccessControl rows whenever ADVANCED_PERMISSIONS is enabled
+        (no ROLE_BASED_ACCESS check). The preview must match that runtime behaviour.
+        """
         # Remove the ROLE_BASED_ACCESS feature, keep ADVANCED_PERMISSIONS
         self.organization.available_product_features = [
             {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
@@ -1830,20 +1867,30 @@ class TestAccessControlMembersEndpoint(BaseAccessControlTest):
         self.user2_membership.level = OrganizationMembership.Level.MEMBER
         self.user2_membership.save()
 
+        # Project default 'member', role-based project override 'admin'
+        self._put_project_access_control({"access_level": "member"})
+        self._put_project_access_control({"role": str(self.role.id), "access_level": "admin"})
         # Default dashboard access for the project is 'viewer'
         self._put_global_access_control({"resource": "dashboard", "access_level": "viewer"})
-        # A role-based override grants 'manager' on dashboards
+        # A role-based resource override grants 'manager' on dashboards
         self._put_global_access_control({"resource": "dashboard", "access_level": "manager", "role": str(self.role.id)})
         # user2 is in that role
         RoleMembership.objects.create(user=self.user2, role=self.role, organization_member=self.user2_membership)
 
         res = self.client.get("/api/projects/@current/access_control_members")
         member_data = self._find_member(res.json()["results"], self.user2_membership.id)
+
+        # Resource-level: role override must be ignored, fall back to project default
         dashboard = member_data["resources"]["dashboard"]
-        # Without ROLE_BASED_ACCESS, the role override must be ignored
         assert dashboard["effective_access_level"] == "viewer"
         assert dashboard["inherited_access_level"] == "viewer"
         assert dashboard["inherited_access_level_reason"] == "project_default"
+
+        # Project-level: role override IS still honored at runtime, so the preview must reflect it
+        project = member_data["project"]
+        assert project["effective_access_level"] == "admin"
+        assert project["inherited_access_level"] == "admin"
+        assert project["inherited_access_level_reason"] == "role_override"
 
     def test_only_returns_current_team_member_overrides(self):
         """Member overrides from other teams are not included."""


### PR DESCRIPTION
## Problem

When displaying the effective access control rules for a user, we do not consider if the organization has role based access when calculating the effective rule. This means if a org has role-based rules in their DB, then there is an inconsistency between what we show here and what we enforce in the UI and viewsets.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Check if the role based access control feature is available when getting the effective access control rules to display in the UI.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Tests
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
