### PR TITLE
fix(frontend): wrap conditional text nodes to prevent translate-induced crash

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControlFilters.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControlFilters.tsx
@@ -96,7 +96,7 @@ function RolesFilter(props: {
                 sideIcon={<IconChevronDown />}
                 disabledReason={!props.canUseRoles ? 'You must upgrade your plan to use roles' : undefined}
             >
-                Role{props.selectedRoleIds.length ? ` (${props.selectedRoleIds.length})` : ''}
+                Role{props.selectedRoleIds.length ? <span>{` (${props.selectedRoleIds.length})`}</span> : ''}
             </LemonButton>
         </LemonDropdown>
     )
@@ -125,7 +125,7 @@ function MembersFilter(props: {
             }
         >
             <LemonButton type="secondary" size="small" sideIcon={<IconChevronDown />}>
-                Member{props.selectedMemberIds.length ? ` (${props.selectedMemberIds.length})` : ''}
+                Member{props.selectedMemberIds.length ? <span>{` (${props.selectedMemberIds.length})`}</span> : ''}
             </LemonButton>
         </LemonDropdown>
     )
@@ -151,7 +151,8 @@ function FeaturesFilter(props: {
             }
         >
             <LemonButton type="secondary" size="small" sideIcon={<IconChevronDown />}>
-                Feature{props.selectedResourceKeys.length ? ` (${props.selectedResourceKeys.length})` : ''}
+                Feature
+                {props.selectedResourceKeys.length ? <span>{` (${props.selectedResourceKeys.length})`}</span> : ''}
             </LemonButton>
         </LemonDropdown>
     )
@@ -177,7 +178,7 @@ function AccessLevelFilter(props: {
             }
         >
             <LemonButton type="secondary" size="small" sideIcon={<IconChevronDown />}>
-                Access{props.selectedRuleLevels.length ? ` (${props.selectedRuleLevels.length})` : ''}
+                Access{props.selectedRuleLevels.length ? <span>{` (${props.selectedRuleLevels.length})`}</span> : ''}
             </LemonButton>
         </LemonDropdown>
     )

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
@@ -35,7 +35,7 @@ export const SidePanelDiscussion = (): JSX.Element => {
                 Discussion{' '}
                 {scope ? (
                     <span className="font-normal text-secondary">
-                        about {item_id ? 'this' : ''} {humanizeScope(scope, !!item_id)}
+                        about {item_id ? <span>this</span> : ''} {humanizeScope(scope, !!item_id)}
                     </span>
                 ) : null}
             </span>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
@@ -216,7 +216,7 @@ const SupportResponseTimesTable = ({
                                 {plan.legacy_product && (
                                     <span className="text-muted text-xs font-normal"> (legacy)</span>
                                 )}
-                                {isBold && ' '}
+                                {isBold && <span> </span>}
                                 {isBold && <span className="text-muted text-xs font-normal">(your plan)</span>}
                             </span>
                         </div>

--- a/frontend/src/layout/panel-layout/NavBarFooter.tsx
+++ b/frontend/src/layout/panel-layout/NavBarFooter.tsx
@@ -40,7 +40,7 @@ export function NavBarFooter({ isLayoutNavCollapsed }: { isLayoutNavCollapsed: b
                     data-attr="navbar-settings"
                 >
                     <IconGear />
-                    {!isLayoutNavCollapsed && 'Settings'}
+                    {!isLayoutNavCollapsed && <span>Settings</span>}
                 </Link>
                 <Link
                     to={urls.exports()}
@@ -50,7 +50,7 @@ export function NavBarFooter({ isLayoutNavCollapsed }: { isLayoutNavCollapsed: b
                     data-attr="navbar-exports-button"
                 >
                     <IconDownload />
-                    {!isLayoutNavCollapsed && 'Exports'}
+                    {!isLayoutNavCollapsed && <span>Exports</span>}
                 </Link>
                 <HealthMenu iconOnly={isLayoutNavCollapsed} />
                 <HelpMenu iconOnly={isLayoutNavCollapsed} />

--- a/frontend/src/layout/panel-layout/PinnedFolder/EditCustomProductsModal.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/EditCustomProductsModal.tsx
@@ -45,7 +45,7 @@ export function EditCustomProductsModal(): JSX.Element {
             <div className="flex flex-col gap-2">
                 <div>
                     <p className="text-sm text-muted">
-                        Select which products you want to see in your sidebar. You can change this anytime.
+                        <span>Select which products you want to see in your sidebar. You can change this anytime.</span>
                         {customProductsLoading && <Spinner />}
                     </p>
                 </div>

--- a/frontend/src/lib/KeaDevTools.tsx
+++ b/frontend/src/lib/KeaDevTools.tsx
@@ -311,7 +311,7 @@ function Section({
         <div style={{ marginTop: 10 }}>
             <strong>
                 {title}
-                {typeof count === 'number' ? ` (${count})` : ''}
+                {typeof count === 'number' ? <span>{` (${count})`}</span> : ''}
             </strong>
             <div>{children}</div>
         </div>

--- a/frontend/src/lib/components/ActivityLog/activityDescriptions/tagActivityDescriber.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityDescriptions/tagActivityDescriber.tsx
@@ -92,7 +92,7 @@ const getRelatedObjectDescription = (context: any, preposition?: 'to' | 'from'):
 
     return (
         <>
-            {preposition && `${preposition} `}
+            {preposition && <span>{`${preposition} `}</span>}
             {objectTypeDisplayName} {getObjectLink()}
         </>
     )

--- a/frontend/src/lib/components/Alerts/views/AlertHistoryChart.tsx
+++ b/frontend/src/lib/components/Alerts/views/AlertHistoryChart.tsx
@@ -425,7 +425,7 @@ export function AlertHistoryChart({
             )}
             {hasHistoricalFiringState && thresholdCtx && currentOnlyCount > 0 ? (
                 <p className="text-muted text-xs mb-0">
-                    {historicalCount > 0 ? 'Red squares fired at the time they ran. ' : ''}
+                    {historicalCount > 0 ? <span>Red squares fired at the time they ran. </span> : ''}
                     Orange triangles would fire under the current thresholds but didn't when they ran.
                 </p>
             ) : null}

--- a/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
@@ -65,11 +65,13 @@ function AlertSummary({ alert }: { alert: AlertType }): JSX.Element | null {
 
     return (
         <div className="text-secondary pl-3">
-            {bounds?.lower != null &&
-                `Low ${isPercentage ? bounds.lower * 100 : bounds.lower}${isPercentage ? '%' : ''}`}
-            {bounds?.lower != null && bounds?.upper != null ? ' · ' : ''}
-            {bounds?.upper != null &&
-                `High ${isPercentage ? bounds.upper * 100 : bounds.upper}${isPercentage ? '%' : ''}`}
+            {bounds?.lower != null && (
+                <span>{`Low ${isPercentage ? bounds.lower * 100 : bounds.lower}${isPercentage ? '%' : ''}`}</span>
+            )}
+            {bounds?.lower != null && bounds?.upper != null ? <span> · </span> : ''}
+            {bounds?.upper != null && (
+                <span>{`High ${isPercentage ? bounds.upper * 100 : bounds.upper}${isPercentage ? '%' : ''}`}</span>
+            )}
         </div>
     )
 }

--- a/frontend/src/lib/components/BulkActions/BulkUpdateTagsButton.tsx
+++ b/frontend/src/lib/components/BulkActions/BulkUpdateTagsButton.tsx
@@ -81,7 +81,7 @@ export function BulkUpdateTagsButton({ resource, selectedIds, onSuccess }: BulkU
             overlay={
                 <div className="p-3 space-y-3 w-80">
                     <div className="font-medium text-sm">
-                        Update tags for {selectedIds.length} item{selectedIds.length !== 1 ? 's' : ''}
+                        Update tags for {selectedIds.length} item{selectedIds.length !== 1 ? <span>s</span> : ''}
                     </div>
                     <LemonSegmentedButton
                         value={tagAction}

--- a/frontend/src/lib/components/Cards/InsightCard/CompactUniversalFiltersDisplay.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/CompactUniversalFiltersDisplay.tsx
@@ -158,7 +158,7 @@ export function CompactUniversalFiltersDisplay({
                                                     <code className="SeriesDisplay__value">{String(subValue)}</code>
                                                     {index <
                                                         (propertyFilter.value as PropertyFilterBaseValue[]).length -
-                                                            1 && ' or '}
+                                                            1 && <span> or </span>}
                                                 </React.Fragment>
                                             ))
                                         ) : propertyFilter.value != undefined ? (

--- a/frontend/src/lib/components/Cards/InsightCard/ErrorTrackingUniversalFiltersDisplay.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/ErrorTrackingUniversalFiltersDisplay.tsx
@@ -80,8 +80,8 @@ function IssueCountSummary({ filters }: { filters: MaxErrorTrackingSearchRespons
     return (
         <div className="flex items-center gap-2">
             <LemonTag size="small" type="highlight">
-                {issueCount} {pluralize(issueCount, 'issue', 'issues', false)} found
-                {filters.has_more && ' (more available)'}
+                {issueCount} {pluralize(issueCount, 'issue', 'issues', false)} <span>found</span>
+                {filters.has_more && <span> (more available)</span>}
             </LemonTag>
         </div>
     )

--- a/frontend/src/lib/components/Cards/InsightCard/RecordingsUniversalFiltersDisplay.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/RecordingsUniversalFiltersDisplay.tsx
@@ -23,7 +23,7 @@ function DurationSummary({ filters }: { filters: RecordingUniversalFilters }): J
                     <span className="font-medium">
                         {humanFriendlyDurationFilter(durationFilter, durationFilter.key as DurationType)}
                     </span>
-                    {index < filters.duration.length - 1 && ' and '}
+                    {index < filters.duration.length - 1 && <span> and </span>}
                 </React.Fragment>
             ))}
         </InsightDetailSectionDisplay>

--- a/frontend/src/lib/components/Errors/Frame/RawFrame.tsx
+++ b/frontend/src/lib/components/Errors/Frame/RawFrame.tsx
@@ -12,8 +12,8 @@ export function RawFrame({
     return (
         <>
             <p className="font-mono indent-[1rem] whitespace-no-wrap mb-0 line-clamp-1">
-                File "{frame.source || 'Unknown Source'}"{frame.line ? `, line: ${frame.line}` : ''}
-                {resolvedName ? `, in: ${resolvedName}` : ''}
+                File "{frame.source || 'Unknown Source'}"{frame.line ? <span>{`, line: ${frame.line}`}</span> : ''}
+                {resolvedName ? <span>{`, in: ${resolvedName}`}</span> : ''}
             </p>
             {record && record.context?.line.line && (
                 <p className="font-mono indent-[2rem] whitespace-no-wrap mb-0 text-tertiary line-clamp-1">

--- a/frontend/src/lib/components/HTMLElementsDisplay/SelectableElement.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/SelectableElement.tsx
@@ -227,14 +227,14 @@ export function SelectableElement({
             )}
         >
             {indent}
-            &lt;
+            <span>&lt;</span>
             <TagPart
                 tagName={element.tag_name}
                 selectedParts={parsedCSSSelector || ({} as ParsedCSSSelector)}
                 readonly={readonly}
                 onChange={setParsedCSSSelector}
             />
-            {element.attr_id && ' '}
+            {element.attr_id && <span> </span>}
             <IdPart
                 id={element.attr_id}
                 selectedParts={parsedCSSSelector || ({} as ParsedCSSSelector)}
@@ -257,7 +257,7 @@ export function SelectableElement({
                         />
                     )
                 })}
-            &gt;
+            <span>&gt;</span>
             <WithSelectedText text={element.text} selectedText={selectedText} />
             {isDeepestChild && <span>&lt;/{element.tag_name}&gt;</span>}
         </pre>

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
@@ -268,7 +268,7 @@ function EventTriggerRow({
                 {hasProperties && (
                     <span className="text-xs text-muted flex items-center gap-1">
                         <IconFilter className="w-3 h-3" />
-                        {event.properties!.length} filter{event.properties!.length !== 1 ? 's' : ''}
+                        {event.properties!.length} filter{event.properties!.length !== 1 ? <span>s</span> : ''}
                     </span>
                 )}
                 <LemonButton size="xsmall" status="danger" onClick={onRemove}>

--- a/frontend/src/lib/components/MarkdownEditor/shared/MarkdownEditorCharacterCountFooter.tsx
+++ b/frontend/src/lib/components/MarkdownEditor/shared/MarkdownEditorCharacterCountFooter.tsx
@@ -16,7 +16,7 @@ export function MarkdownEditorCharacterCountFooter({
             }`}
         >
             {currentLength}/{maxLength} characters
-            {isAtCharacterLimit ? ' (limit reached)' : ''}
+            {isAtCharacterLimit ? <span> (limit reached)</span> : ''}
         </div>
     )
 }

--- a/frontend/src/lib/components/MemberSelect.tsx
+++ b/frontend/src/lib/components/MemberSelect.tsx
@@ -126,7 +126,7 @@ export function MemberSelect({
                     {selectedMemberAsUser ? (
                         <span>
                             {fullName(selectedMemberAsUser)}
-                            {meFirstMembers[0].user.uuid === selectedMemberAsUser.uuid ? ` (you)` : ''}
+                            {meFirstMembers[0].user.uuid === selectedMemberAsUser.uuid ? <span>{` (you)`}</span> : ''}
                         </span>
                     ) : (
                         defaultLabel

--- a/frontend/src/lib/components/ProductSetup/ProductSetupPopover.tsx
+++ b/frontend/src/lib/components/ProductSetup/ProductSetupPopover.tsx
@@ -487,7 +487,7 @@ function TaskHoverDescription({ task, anchored = false }: TaskHoverDescriptionPr
                     )}
                     {task.requiresManualCompletion && !task.completed && !task.skipped && (
                         <p className="text-xs text-muted mt-1 italic">
-                            Manual task – {task.docsUrl ? 'click for instructions, then ' : ''}
+                            Manual task – {task.docsUrl ? <span>click for instructions, then </span> : ''}
                             mark as complete when done.
                         </p>
                     )}

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -192,7 +192,7 @@ function ValueDisplay({
                                 icon={isTypeMismatched ? <IconWarning /> : undefined}
                             >
                                 {valueType}
-                                {isTypeMismatched && ' (mismatched)'}
+                                {isTypeMismatched && <span> (mismatched)</span>}
                             </LemonTag>
                         </Link>
                     </Tooltip>

--- a/frontend/src/lib/components/QuickFilters/QuickFiltersModalContent.tsx
+++ b/frontend/src/lib/components/QuickFilters/QuickFiltersModalContent.tsx
@@ -130,8 +130,8 @@ export function QuickFiltersModalContent({
     return (
         <div className="space-y-4">
             <p className="text-muted">
-                Quick filters let you create reusable filter components for specific event properties.
-                {selectionColumnConfig && ' Select the filters you want to show.'}
+                <span>Quick filters let you create reusable filter components for specific event properties.</span>
+                {selectionColumnConfig && <span> Select the filters you want to show.</span>}
             </p>
 
             {quickFilters.length === 0 && !quickFiltersLoading ? (

--- a/frontend/src/lib/components/Scenes/SceneTextInput.tsx
+++ b/frontend/src/lib/components/Scenes/SceneTextInput.tsx
@@ -95,7 +95,7 @@ export function SceneTextInput({
                     localValue
                 ) : (
                     <span className="text-tertiary font-normal">
-                        No {name} {optional ? '(optional)' : ''}
+                        No {name} {optional ? <span>(optional)</span> : ''}
                     </span>
                 )}
             </ButtonPrimitive>

--- a/frontend/src/lib/components/Scenes/SceneTextarea.tsx
+++ b/frontend/src/lib/components/Scenes/SceneTextarea.tsx
@@ -101,7 +101,7 @@ export function SceneTextarea({
                     )
                 ) : (
                     <span className="text-tertiary font-normal">
-                        No {name} {optional ? '(optional)' : ''}
+                        No {name} {optional ? <span>(optional)</span> : ''}
                     </span>
                 )}
             </ButtonPrimitive>

--- a/frontend/src/lib/components/Superpowers/Superpowers.tsx
+++ b/frontend/src/lib/components/Superpowers/Superpowers.tsx
@@ -191,8 +191,8 @@ function SuperpowersContent(): JSX.Element {
 
             <div className="text-xs text-secondary">
                 <div>
-                    User: {user?.email} {user?.is_staff ? '(staff)' : ''}{' '}
-                    {user?.is_impersonated ? '(impersonated)' : ''}
+                    User: {user?.email} {user?.is_staff ? <span>(staff)</span> : ''}{' '}
+                    {user?.is_impersonated ? <span>(impersonated)</span> : ''}
                 </div>
                 <div>Team ID: {currentTeam?.id}</div>
             </div>

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -136,7 +136,7 @@ const unusedIndicator = (eventNames: string[]): JSX.Element => {
                     <span>
                         {eventNames ? (
                             <>
-                                the event{eventNames.length > 1 ? 's' : ''}{' '}
+                                the event{eventNames.length > 1 ? <span>s</span> : ''}{' '}
                                 {eventNames.map((e, index) => (
                                     <>
                                         {index === 0 ? '' : index === eventNames.length - 1 ? ' and ' : ', '}

--- a/frontend/src/lib/components/TaxonomicFilter/headless/Categories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/Categories.tsx
@@ -71,7 +71,9 @@ function TaxonomicFilterCategoryTab({ group, renderTab }: CategoryTabProps): JSX
             ) : (
                 <>
                     {group.name}
-                    {!list.needsMoreSearchCharacters && `: ${list.isLoading ? '…' : list.totalResultCount}`}
+                    {!list.needsMoreSearchCharacters && (
+                        <span>{`: ${list.isLoading ? '…' : list.totalResultCount}`}</span>
+                    )}
                 </>
             )}
         </Button>

--- a/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
@@ -470,7 +470,7 @@ function AggregationTargetContext({ insightProps, isHogQL }: AggregationTargetCo
                 >
                     For more help
                 </Link>
-                . {isHogQL ? '(currently using SQL expression)' : ''}
+                . {isHogQL ? <span>(currently using SQL expression)</span> : ''}
             </span>
         </FieldDescription>
     )

--- a/frontend/src/lib/components/heatmaps/HeatmapEventsPanel.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapEventsPanel.tsx
@@ -68,8 +68,9 @@ export function HeatmapEventsPanel({ context, exportToken }: HeatmapDataLogicPro
                 <>
                     <div className="px-4 py-2 border-b text-sm text-muted">
                         <div>
-                            {areaEvents.total_count} event{areaEvents.total_count !== 1 ? 's' : ''} found
-                            {areaEvents.has_more && ` (showing ${areaEvents.results.length})`}
+                            {areaEvents.total_count} <span>event</span>
+                            {areaEvents.total_count !== 1 ? <span>s</span> : ''} <span>found</span>
+                            {areaEvents.has_more && <span>{` (showing ${areaEvents.results.length})`}</span>}
                         </div>
                         <div className="text-xs mt-1">
                             Note: These are raw events at this exact coordinate. The heatmap display uses interpolation,

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -173,7 +173,7 @@ export function Chart<Meta = unknown>({
                 axisOrientation,
                 labelToCoord,
             }),
-        [showCrosshair, theme.crosshairColor, axisOrientation, labelToCoord]
+        [showCrosshair, theme.crosshairColor, axisOrientation, labelToCoord, drawHoverRef.current]
     )
 
     useChartDraw({

--- a/frontend/src/lib/hog-charts/core/hooks/useChartCanvas.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartCanvas.ts
@@ -98,7 +98,7 @@ export function useChartCanvas(options: UseChartCanvasOptions): UseChartCanvasRe
         return () => {
             observer.disconnect()
         }
-    }, [])
+    }, [marginsRef.current])
 
     // When margins change without a resize, recompute dimensions from the cached rect.
     useEffect(() => {
@@ -107,7 +107,7 @@ export function useChartCanvas(options: UseChartCanvasOptions): UseChartCanvasRe
             return
         }
         setCanvasState((prev) => (prev ? { ...prev, dimensions: buildDimensions(rect, margins) } : prev))
-    }, [margins.left, margins.right, margins.top, margins.bottom])
+    }, [margins.left, margins.right, margins.top, margins.bottom, margins])
 
     return {
         canvasRef,

--- a/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
@@ -177,7 +177,7 @@ export const LemonFileInput = ({
                     {callToAction || (
                         <LemonButton icon={<IconUpload />} type="tertiary" disabledReason={disabledReason}>
                             Click or drag and drop to upload
-                            {accept ? ` ${acceptToDisplayName(accept)}` : ''}
+                            {accept ? <span>{` ${acceptToDisplayName(accept)}`}</span> : ''}
                         </LemonButton>
                     )}
                 </div>

--- a/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
@@ -255,7 +255,7 @@ export function DataTableExport({ query, fileNameForExport }: DataTableExportPro
             ].filter(Boolean)}
         >
             <LemonButton type="secondary" icon={<IconDownload />} data-attr="data-table-export-menu" size="small">
-                Export{filterCount > 0 ? ` (${pluralize(filterCount, 'filter')})` : ''}
+                Export{filterCount > 0 ? <span>{` (${pluralize(filterCount, 'filter')})`}</span> : ''}
             </LemonButton>
         </LemonMenu>
     )

--- a/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
@@ -25,7 +25,7 @@ export const InsightResultMetadata = ({
             {samplingFactor ? (
                 <span className="text-secondary">
                     {!disableLastComputation && <span className="mx-1">•</span>}
-                    Results calculated from {samplingFactor * 100}% of users
+                    <span>Results calculated from {samplingFactor * 100}% of users</span>
                 </span>
             ) : null}
             {trendsFilter?.hideWeekends && featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS] ? (

--- a/frontend/src/scenes/audit-logs/ExportsListHelpers.tsx
+++ b/frontend/src/scenes/audit-logs/ExportsListHelpers.tsx
@@ -89,9 +89,9 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
             <div key="dates">
                 <strong>Date range:</strong>
                 <br />
-                {filters.start_date && `From: ${formatDate(filters.start_date)}`}
+                {filters.start_date && <span>{`From: ${formatDate(filters.start_date)}`}</span>}
                 {filters.start_date && filters.end_date && <br />}
-                {filters.end_date && `To: ${formatDate(filters.end_date)}`}
+                {filters.end_date && <span>{`To: ${formatDate(filters.end_date)}`}</span>}
             </div>
         )
     }
@@ -102,7 +102,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
                 <strong>Users ({filters.users.length}):</strong>
                 <br />
                 {filters.users.slice(0, 5).join(', ')}
-                {filters.users.length > 5 && `... and ${filters.users.length - 5} more`}
+                {filters.users.length > 5 && <span>{`... and ${filters.users.length - 5} more`}</span>}
             </div>
         )
     }
@@ -113,7 +113,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
                 <strong>Scopes ({filters.scopes.length}):</strong>
                 <br />
                 {filters.scopes.slice(0, 5).join(', ')}
-                {filters.scopes.length > 5 && `... and ${filters.scopes.length - 5} more`}
+                {filters.scopes.length > 5 && <span>{`... and ${filters.scopes.length - 5} more`}</span>}
             </div>
         )
     }
@@ -124,7 +124,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
                 <strong>Activities ({filters.activities.length}):</strong>
                 <br />
                 {filters.activities.slice(0, 5).join(', ')}
-                {filters.activities.length > 5 && `... and ${filters.activities.length - 5} more`}
+                {filters.activities.length > 5 && <span>{`... and ${filters.activities.length - 5} more`}</span>}
             </div>
         )
     }
@@ -143,7 +143,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
                 <strong>Detail filters ({detailFilterEntries.length}):</strong>
                 <br />
                 {detailFilterText.slice(0, 3).join(', ')}
-                {detailFilterText.length > 3 && `... and ${detailFilterText.length - 3} more`}
+                {detailFilterText.length > 3 && <span>{`... and ${detailFilterText.length - 3} more`}</span>}
             </div>
         )
     }
@@ -174,7 +174,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
                 <strong>Item IDs ({filters.item_ids.length}):</strong>
                 <br />
                 {filters.item_ids.slice(0, 5).join(', ')}
-                {filters.item_ids.length > 5 && `... and ${filters.item_ids.length - 5} more`}
+                {filters.item_ids.length > 5 && <span>{`... and ${filters.item_ids.length - 5} more`}</span>}
             </div>
         )
     }
@@ -185,7 +185,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
                 <strong>Clients ({filters.clients.length}):</strong>
                 <br />
                 {filters.clients.slice(0, 5).join(', ')}
-                {filters.clients.length > 5 && `... and ${filters.clients.length - 5} more`}
+                {filters.clients.length > 5 && <span>{`... and ${filters.clients.length - 5} more`}</span>}
             </div>
         )
     }

--- a/frontend/src/scenes/authentication/InviteSignup.tsx
+++ b/frontend/src/scenes/authentication/InviteSignup.tsx
@@ -241,7 +241,7 @@ function UnauthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite })
             message={
                 <>
                     Welcome to
-                    <br /> PostHog{preflight?.cloud ? ' Cloud' : ''}!
+                    <br /> PostHog{preflight?.cloud ? <span> Cloud</span> : ''}!
                 </>
             }
             leftContainerContent={

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -124,7 +124,7 @@ export function Login(): JSX.Element {
             message={
                 <>
                     Welcome to
-                    <br /> PostHog{preflight?.cloud ? ' Cloud' : ''}!
+                    <br /> PostHog{preflight?.cloud ? <span> Cloud</span> : ''}!
                 </>
             }
             footer={<SupportModalButton />}

--- a/frontend/src/scenes/authentication/Login2FA.tsx
+++ b/frontend/src/scenes/authentication/Login2FA.tsx
@@ -25,7 +25,7 @@ export function Login2FA(): JSX.Element {
             message={
                 <>
                     Welcome to
-                    <br /> PostHog{preflight?.cloud ? ' Cloud' : ''}!
+                    <br /> PostHog{preflight?.cloud ? <span> Cloud</span> : ''}!
                 </>
             }
         >

--- a/frontend/src/scenes/authentication/TwoFactorReset.tsx
+++ b/frontend/src/scenes/authentication/TwoFactorReset.tsx
@@ -37,7 +37,7 @@ export function TwoFactorReset(): JSX.Element {
                 message={
                     <>
                         Welcome to
-                        <br /> PostHog{preflight?.cloud ? ' Cloud' : ''}!
+                        <br /> PostHog{preflight?.cloud ? <span> Cloud</span> : ''}!
                     </>
                 }
             >
@@ -58,7 +58,7 @@ export function TwoFactorReset(): JSX.Element {
                 message={
                     <>
                         Welcome to
-                        <br /> PostHog{preflight?.cloud ? ' Cloud' : ''}!
+                        <br /> PostHog{preflight?.cloud ? <span> Cloud</span> : ''}!
                     </>
                 }
             >
@@ -82,7 +82,7 @@ export function TwoFactorReset(): JSX.Element {
                 message={
                     <>
                         Welcome to
-                        <br /> PostHog{preflight?.cloud ? ' Cloud' : ''}!
+                        <br /> PostHog{preflight?.cloud ? <span> Cloud</span> : ''}!
                     </>
                 }
             >
@@ -111,7 +111,7 @@ export function TwoFactorReset(): JSX.Element {
             message={
                 <>
                     Welcome to
-                    <br /> PostHog{preflight?.cloud ? ' Cloud' : ''}!
+                    <br /> PostHog{preflight?.cloud ? <span> Cloud</span> : ''}!
                 </>
             }
         >

--- a/frontend/src/scenes/authentication/activityDescriptions.tsx
+++ b/frontend/src/scenes/authentication/activityDescriptions.tsx
@@ -20,8 +20,9 @@ export function userActivityDescriber(logItem: ActivityLogItem, asNotification?:
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> logged in using {loginMethod}
-                    {reauthSensitiveOps && <> (re-authenticated for sensitive operations)</>}
+                    <strong>{userNameForLogItem(logItem)}</strong>
+                    <span> logged in using {loginMethod}</span>
+                    {reauthSensitiveOps && <span> (re-authenticated for sensitive operations)</span>}
                 </>
             ),
         }

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -161,10 +161,16 @@ export function Billing(): JSX.Element {
                         <div>
                             <p className="text-lg">You're on (a) trial</p>
                             <p>
-                                You are currently on a free trial for <b>{toSentenceCase(billing.trial.target)} plan</b>{' '}
-                                until <b>{dayjs(billing.trial.expires_at).format('LL')}</b>.
-                                {billing.trial.type === 'autosubscribe' &&
-                                    ' At the end of the trial you will be automatically subscribed to the plan.'}
+                                <span>You are currently on a free trial for </span>
+                                <b>{toSentenceCase(billing.trial.target)} plan</b> <span>until </span>
+                                <b>{dayjs(billing.trial.expires_at).format('LL')}</b>
+                                <span>.</span>
+                                {billing.trial.type === 'autosubscribe' && (
+                                    <span>
+                                        {' '}
+                                        At the end of the trial you will be automatically subscribed to the plan.
+                                    </span>
+                                )}
                             </p>
                         </div>
                     </div>

--- a/frontend/src/scenes/billing/CodeSeatsSection.tsx
+++ b/frontend/src/scenes/billing/CodeSeatsSection.tsx
@@ -86,7 +86,8 @@ export function CodeSeatsSection(): JSX.Element {
                     <h3 className="mb-1 text-lg font-semibold">Code seats</h3>
                     {isAdmin && (
                         <span className="text-muted text-sm">
-                            {activeCount} active{cancelingCount > 0 ? `, ${cancelingCount} canceling` : ''} &middot;{' '}
+                            {activeCount} active
+                            {cancelingCount > 0 ? <span>{`, ${cancelingCount} canceling`}</span> : ''} &middot;{' '}
                             <Tooltip title="Reflects the monthly rate, not prorated charges">
                                 ${monthlyTotal}/mo
                             </Tooltip>

--- a/frontend/src/scenes/billing/PlanComparison.tsx
+++ b/frontend/src/scenes/billing/PlanComparison.tsx
@@ -38,10 +38,11 @@ export function PlanIcon({
             ) : feature.limit ? (
                 <>
                     <IconWarning className={clsx('text-warning mx-4 shrink-0', className)} />
-                    {feature.limit &&
-                        `${convertLargeNumberToWords(feature.limit, null)} ${feature.unit && feature.unit}${
+                    {feature.limit && (
+                        <span>{`${convertLargeNumberToWords(feature.limit, null)} ${feature.unit && feature.unit}${
                             timeDenominator ? `/${timeDenominator}` : ''
-                        }`}
+                        }`}</span>
+                    )}
                     {feature.note}
                 </>
             ) : (
@@ -140,7 +141,10 @@ export const PlanComparison = ({
             </thead>
             <tbody>
                 <tr className="PlanTable__tr__border">
-                    <td className="font-bold">Monthly {product.tiered && 'base '} price</td>
+                    <td className="font-bold">
+                        <span>Monthly </span>
+                        {product.tiered && <span>base </span>} <span>price</span>
+                    </td>
                     {plans?.map((plan) => {
                         const { prorationAmount, isProrated } = getProration({
                             timeRemainingInSeconds,
@@ -163,9 +167,11 @@ export const PlanComparison = ({
                                           : '$0 per month'}
                                 {isProrated && (
                                     <p className="text-xxs text-secondary font-normal italic mt-2">
-                                        Pay ~${prorationAmount} today{isProrated && ' (prorated)'} and{' '}
-                                        {isProrated && `$${parseInt(plan.unit_amount_usd || '0')} `}every month
-                                        thereafter.
+                                        <span>Pay ~$</span>
+                                        {prorationAmount} <span>today</span>
+                                        {isProrated && <span> (prorated)</span>} <span>and</span>{' '}
+                                        {isProrated && <span>{`$${parseInt(plan.unit_amount_usd || '0')} `}</span>}
+                                        <span>every month thereafter.</span>
                                     </p>
                                 )}
                             </td>

--- a/frontend/src/scenes/billing/PurchaseCreditsModal.tsx
+++ b/frontend/src/scenes/billing/PurchaseCreditsModal.tsx
@@ -73,13 +73,16 @@ export const PurchaseCreditsModal = (): JSX.Element | null => {
                     </LemonButton>
                     <LemonButton type="primary" onClick={() => submitCreditForm()} loading={isCreditFormSubmitting}>
                         Buy{' '}
-                        {creditForm.creditInput
-                            ? `$${Math.round(creditInputValue).toLocaleString('en-US', {
-                                  minimumFractionDigits: 0,
-                                  maximumFractionDigits: 0,
-                              })}`
-                            : ''}{' '}
-                        credits {creditDiscount > 0 ? `at ${floatDiscountToText(creditDiscount)} off` : ''}
+                        {creditForm.creditInput ? (
+                            <span>{`$${Math.round(creditInputValue).toLocaleString('en-US', {
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: 0,
+                            })}`}</span>
+                        ) : (
+                            ''
+                        )}{' '}
+                        credits{' '}
+                        {creditDiscount > 0 ? <span>{`at ${floatDiscountToText(creditDiscount)} off`}</span> : ''}
                     </LemonButton>
                 </>
             }

--- a/frontend/src/scenes/coupons/CouponRedemption.tsx
+++ b/frontend/src/scenes/coupons/CouponRedemption.tsx
@@ -194,7 +194,9 @@ export function CouponRedemption({
 
                     {/* Step 2: Redeem coupon */}
                     <div className="bg-surface-secondary rounded-lg p-6">
-                        <h2 className="text-xl mb-4">{requiresBilling ? 'Step 2: ' : ''}Redeem your coupon</h2>
+                        <h2 className="text-xl mb-4">
+                            {requiresBilling ? <span>Step 2: </span> : ''}Redeem your coupon
+                        </h2>
 
                         {couponsOverviewLoading ? (
                             <div className="flex items-center gap-2">
@@ -208,9 +210,11 @@ export function CouponRedemption({
                                     <span>Coupon redeemed successfully!</span>
                                 </div>
                                 <p className="text-muted">
-                                    Your organization now has access to {config.name} benefits.
-                                    {claimedDetails?.expires_at &&
-                                        ` Valid until ${dayjs(claimedDetails.expires_at).format('LL')}.`}
+                                    <span>Your organization now has access to </span>
+                                    {config.name} <span>benefits.</span>
+                                    {claimedDetails?.expires_at && (
+                                        <span>{` Valid until ${dayjs(claimedDetails.expires_at).format('LL')}.`}</span>
+                                    )}
                                 </p>
                                 {renderSuccessActions ? (
                                     renderSuccessActions()
@@ -240,9 +244,11 @@ export function CouponRedemption({
                                     <span>You've already claimed this offer!</span>
                                 </div>
                                 <p className="text-muted">
-                                    Your organization has already claimed {config.name} coupon.
-                                    {alreadyClaimed.expires_at &&
-                                        ` Valid until ${dayjs(alreadyClaimed.expires_at).format('LL')}.`}
+                                    <span>Your organization has already claimed </span>
+                                    {config.name} <span>coupon.</span>
+                                    {alreadyClaimed.expires_at && (
+                                        <span>{` Valid until ${dayjs(alreadyClaimed.expires_at).format('LL')}.`}</span>
+                                    )}
                                 </p>
                                 {renderSuccessActions ? (
                                     renderSuccessActions()

--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -133,7 +133,7 @@ export function DashboardAdvancedOptionsToggle(): JSX.Element {
             data-attr="dashboard-advanced-filters-toggle"
         >
             <span className="font-semibold">
-                Advanced options
+                <span>Advanced options</span>
                 {totalAdvancedFilters > 0 && <span className="ml-1 text-muted">({totalAdvancedFilters})</span>}
             </span>
         </LemonButton>

--- a/frontend/src/scenes/dashboard/dashboardActivityDescriber.tsx
+++ b/frontend/src/scenes/dashboard/dashboardActivityDescriber.tsx
@@ -44,8 +44,11 @@ const dashboardActionsMapping: Record<
         return {
             description: [
                 <>
-                    renamed {asNotification && 'the dashboard '}"{change?.before}" to{' '}
-                    <strong>"{nameAndLink(logItem)}"</strong>
+                    <span>renamed </span>
+                    {asNotification && <span>the dashboard </span>}
+                    <span>"</span>
+                    {change?.before}
+                    <span>" to</span> <strong>"{nameAndLink(logItem)}"</strong>
                 </>,
             ],
             suffix: <></>,
@@ -58,7 +61,7 @@ const dashboardActionsMapping: Record<
             description: [
                 <>
                     {describeChange}
-                    {asNotification && ' the dashboard '}
+                    {asNotification && <span> the dashboard </span>}
                 </>,
             ],
             suffix: <>{nameAndLink(logItem)}</>,
@@ -68,8 +71,9 @@ const dashboardActionsMapping: Record<
         return {
             description: [
                 <>
-                    changed the description {asNotification && ' of the dashboard '}to{' '}
-                    <strong>"{change?.after as string}"</strong>
+                    <span>changed the description </span>
+                    {asNotification && <span> of the dashboard </span>}
+                    <span>to</span> <strong>"{change?.after as string}"</strong>
                 </>,
             ],
         }
@@ -106,7 +110,9 @@ const dashboardActionsMapping: Record<
             description: [
                 <>
                     <div className="highlighted-activity">
-                        {isFavoriteAfter ? '' : 'un-'}pinned{asNotification && ' the dashboard '}
+                        {isFavoriteAfter ? '' : <span>un-</span>}
+                        <span>pinned</span>
+                        {asNotification && <span> the dashboard </span>}
                     </div>
                 </>,
             ],
@@ -179,7 +185,8 @@ export function dashboardActivityDescriber(logItem: ActivityLogItem, asNotificat
         let extendedDescription: JSX.Element | undefined
         let changeSuffix: Description = (
             <>
-                on {asNotification && ' the dashboard '}
+                <span>on </span>
+                {asNotification && <span> the dashboard </span>}
                 {nameAndLink(logItem)}
             </>
         )

--- a/frontend/src/scenes/data-management/MaterializedColumns/MaterializedColumns.tsx
+++ b/frontend/src/scenes/data-management/MaterializedColumns/MaterializedColumns.tsx
@@ -200,8 +200,8 @@ export function MaterializedColumns(): JSX.Element {
                                                 {typedUsage.used} / {typedUsage.total}
                                             </div>
                                             <div className="text-xs text-muted">
-                                                {typedUsage.available} slot{typedUsage.available !== 1 ? 's' : ''}{' '}
-                                                available
+                                                {typedUsage.available} slot
+                                                {typedUsage.available !== 1 ? <span>s</span> : ''} available
                                             </div>
                                         </div>
                                     )

--- a/frontend/src/scenes/data-management/dataManagementDescribers.tsx
+++ b/frontend/src/scenes/data-management/dataManagementDescribers.tsx
@@ -61,8 +61,9 @@ const dataManagementActionsMapping: Record<
         return {
             description: [
                 <>
-                    marked {nameAndLink(logItem)} as <strong>{verified ? 'verified' : 'unverified'}</strong>{' '}
-                    {verified && <IconVerifiedEvent />}
+                    <span>marked </span>
+                    {nameAndLink(logItem)} <span>as </span>
+                    <strong>{verified ? 'verified' : 'unverified'}</strong> {verified && <IconVerifiedEvent />}
                 </>,
             ],
             suffix: <></>,

--- a/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetImpactModal.tsx
+++ b/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetImpactModal.tsx
@@ -95,7 +95,7 @@ export function DataWarehouseManagedViewsetImpactModal({
 
                 <div>
                     <p className="font-semibold mb-2">
-                        The following {views.length} view{views.length !== 1 ? 's' : ''} {viewsActionText}:
+                        The following {views.length} view{views.length !== 1 ? <span>s</span> : ''} {viewsActionText}:
                     </p>
                     <div className="flex flex-wrap gap-2 max-w-2xl">
                         {viewsLoading ? (

--- a/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
@@ -80,7 +80,7 @@ export function PropertyDefinitionsTable(): JSX.Element {
                 }}
             />
             <LemonBanner type="info">
-                Looking for {filters.type === 'person' ? 'person ' : ''}property usage statistics?{' '}
+                Looking for {filters.type === 'person' ? <span>person </span> : ''}property usage statistics?{' '}
                 <Link
                     to={urls.insightNewHogQL({
                         query:

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportRuns.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportRuns.tsx
@@ -478,7 +478,11 @@ export function BatchExportRunIcon({
             title={
                 <>
                     Run status: {status}
-                    {latestRun.records_failed != null && latestRun.records_failed > 0 ? ' (with failures)' : ''}
+                    {latestRun.records_failed != null && latestRun.records_failed > 0 ? (
+                        <span> (with failures)</span>
+                    ) : (
+                        ''
+                    )}
                     {runs.length > 1 && (
                         <>
                             <br />

--- a/frontend/src/scenes/debug/QueryTabs.tsx
+++ b/frontend/src/scenes/debug/QueryTabs.tsx
@@ -134,7 +134,7 @@ export function QueryTabs<Q extends Node>({
                   key: 'hogql',
                   label: (
                       <>
-                          SQL
+                          <span>SQL</span>
                           {hogQLTime && <LemonTag className="ml-2">{Math.floor(hogQLTime * 10) / 10}s</LemonTag>}
                       </>
                   ),

--- a/frontend/src/scenes/debug/hog/HogRepl.tsx
+++ b/frontend/src/scenes/debug/hog/HogRepl.tsx
@@ -115,7 +115,7 @@ export function ReplChunk({
                                 {line.map((arg, argIndex) => (
                                     <React.Fragment key={argIndex}>
                                         {printRichHogOutput(arg)}
-                                        {argIndex < line.length - 1 ? ' ' : ''}
+                                        {argIndex < line.length - 1 ? <span> </span> : ''}
                                     </React.Fragment>
                                 ))}
                             </div>

--- a/frontend/src/scenes/debug/signals/SignalGraph.tsx
+++ b/frontend/src/scenes/debug/signals/SignalGraph.tsx
@@ -214,7 +214,7 @@ export function SignalGraph({
                                         </div>
                                         <div className="text-muted truncate text-xs">
                                             {signal.source_product}
-                                            {signal.weight !== undefined ? ` · w${signal.weight}` : ''}
+                                            {signal.weight !== undefined ? <span>{` · w${signal.weight}`}</span> : ''}
                                         </div>
                                     </div>
                                 </div>

--- a/frontend/src/scenes/experiments/ExperimentForm/MetricsPanel/MetricOutlierHandling.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/MetricsPanel/MetricOutlierHandling.tsx
@@ -20,9 +20,9 @@ export const MetricOutlierHandling = ({ metric }: MetricOutlierHandlingProps): J
         <div className="text-xs">
             <span className="text-muted">Outlier handling:</span>{' '}
             <span className="font-semibold">
-                {hasLower && `Lower ${metric.lower_bound_percentile}%`}
-                {hasLower && hasUpper && ', '}
-                {hasUpper && `Upper ${metric.upper_bound_percentile}%`}
+                {hasLower && <span>{`Lower ${metric.lower_bound_percentile}%`}</span>}
+                {hasLower && hasUpper && <span>, </span>}
+                {hasUpper && <span>{`Upper ${metric.upper_bound_percentile}%`}</span>}
             </span>
         </div>
     )

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentExecutionPathComparison.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentExecutionPathComparison.tsx
@@ -253,18 +253,28 @@ function MetricComparisonResults({
                         <span className="text-muted">Direct significant:</span>
                         <LemonTag type={directSig.significant ? 'success' : 'default'}>
                             {directSig.significant ? 'Yes' : 'No'}
-                            {directSig.pValue != null ? ` (p=${directSig.pValue.toFixed(4)})` : ''}
-                            {directSig.chanceToWin != null ? ` (${(directSig.chanceToWin * 100).toFixed(1)}%)` : ''}
+                            {directSig.pValue != null ? <span>{` (p=${directSig.pValue.toFixed(4)})`}</span> : ''}
+                            {directSig.chanceToWin != null ? (
+                                <span>{` (${(directSig.chanceToWin * 100).toFixed(1)}%)`}</span>
+                            ) : (
+                                ''
+                            )}
                         </LemonTag>
                     </div>
                     <div className="flex items-center gap-1">
                         <span className="text-muted">Precomputed significant:</span>
                         <LemonTag type={precomputedSig.significant ? 'success' : 'default'}>
                             {precomputedSig.significant ? 'Yes' : 'No'}
-                            {precomputedSig.pValue != null ? ` (p=${precomputedSig.pValue.toFixed(4)})` : ''}
-                            {precomputedSig.chanceToWin != null
-                                ? ` (${(precomputedSig.chanceToWin * 100).toFixed(1)}%)`
-                                : ''}
+                            {precomputedSig.pValue != null ? (
+                                <span>{` (p=${precomputedSig.pValue.toFixed(4)})`}</span>
+                            ) : (
+                                ''
+                            )}
+                            {precomputedSig.chanceToWin != null ? (
+                                <span>{` (${(precomputedSig.chanceToWin * 100).toFixed(1)}%)`}</span>
+                            ) : (
+                                ''
+                            )}
                         </LemonTag>
                     </div>
                 </div>

--- a/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
@@ -154,11 +154,17 @@ export function ExposureCriteriaModal({ onSave }: ExposureCriteriaModalProps): J
                         fullWidth
                     />
                     <div className="text-xs text-muted mt-1">
-                        {exposureCriteria?.multiple_variant_handling === 'first_seen' &&
-                            'Users exposed to multiple variants will be analyzed using their first seen variant.'}
+                        {exposureCriteria?.multiple_variant_handling === 'first_seen' && (
+                            <span>
+                                Users exposed to multiple variants will be analyzed using their first seen variant.
+                            </span>
+                        )}
                         {(!exposureCriteria?.multiple_variant_handling ||
-                            exposureCriteria?.multiple_variant_handling === 'exclude') &&
-                            'Users exposed to multiple variants will be excluded from the analysis (recommended).'}
+                            exposureCriteria?.multiple_variant_handling === 'exclude') && (
+                            <span>
+                                Users exposed to multiple variants will be excluded from the analysis (recommended).
+                            </span>
+                        )}
                     </div>
                 </div>
                 <TestAccountFilterSwitch

--- a/frontend/src/scenes/experiments/ExperimentView/RunningTimeNew.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/RunningTimeNew.tsx
@@ -63,7 +63,7 @@ export const RunningTimeNew = ({
                         <>
                             <span>
                                 ~{Math.ceil(remainingDays)} day
-                                {Math.ceil(remainingDays) !== 1 ? 's' : ''}
+                                {Math.ceil(remainingDays) !== 1 ? <span>s</span> : ''}
                             </span>
                             {showProgress && (
                                 <LemonProgressCircle

--- a/frontend/src/scenes/experiments/notebook/NotebookExperimentComponent.tsx
+++ b/frontend/src/scenes/experiments/notebook/NotebookExperimentComponent.tsx
@@ -224,8 +224,9 @@ export function NotebookExperimentComponent({ id, expanded }: NotebookExperiment
                                     <>
                                         {totalPrimaryMetrics > 1 && (
                                             <div className="text-xs text-muted mb-1">
-                                                Showing most significant of {totalPrimaryMetrics} metrics
-                                                {bestMetric.metric.name && `: ${bestMetric.metric.name}`}
+                                                <span>Showing most significant of </span>
+                                                {totalPrimaryMetrics} <span>metrics</span>
+                                                {bestMetric.metric.name && <span>{`: ${bestMetric.metric.name}`}</span>}
                                             </div>
                                         )}
                                         <NotebookWinningVariantSummary

--- a/frontend/src/scenes/feature-flags/BulkDeleteResultsModal.tsx
+++ b/frontend/src/scenes/feature-flags/BulkDeleteResultsModal.tsx
@@ -148,7 +148,7 @@ export function BulkDeleteResultsModal(): JSX.Element | null {
                         <div className="flex items-center gap-2 text-success font-medium">
                             <IconCheck className="text-lg" />
                             <span>
-                                Deleted {deleted.length} flag{deleted.length !== 1 ? 's' : ''}
+                                Deleted {deleted.length} flag{deleted.length !== 1 ? <span>s</span> : ''}
                             </span>
                         </div>
                         <FlagResultsList flags={deleted} />
@@ -160,7 +160,7 @@ export function BulkDeleteResultsModal(): JSX.Element | null {
                         <div className="flex items-center gap-2 text-danger font-medium">
                             <IconX className="text-lg" />
                             <span>
-                                Failed to delete {errors.length} flag{errors.length !== 1 ? 's' : ''}
+                                Failed to delete {errors.length} flag{errors.length !== 1 ? <span>s</span> : ''}
                             </span>
                         </div>
                         <ul className="list-none pl-6 space-y-1">
@@ -228,7 +228,7 @@ function FlagResultsList({ flags }: { flags: DeletedFlagInfo[] }): JSX.Element {
                     <span className="text-muted-alt">
                         {' '}
                         — {stateLabels[flag.rollout_state] ?? 'unknown state'}
-                        {flag.active_variant ? ` (variant: "${flag.active_variant}")` : ''}
+                        {flag.active_variant ? <span>{` (variant: "${flag.active_variant}")`}</span> : ''}
                     </span>
                 </li>
             ))}

--- a/frontend/src/scenes/feature-flags/ConfirmationModal.tsx
+++ b/frontend/src/scenes/feature-flags/ConfirmationModal.tsx
@@ -106,7 +106,7 @@ export function openConfirmationModal({
                             </p>
                             <p className="mb-0">
                                 This flag is referenced by {dependentFlags.length} other feature flag
-                                {dependentFlags.length === 1 ? '' : 's'}:{' '}
+                                {dependentFlags.length === 1 ? '' : <span>s</span>}:{' '}
                                 {dependentFlags.map((flag, index) => (
                                     <span key={flag.id}>
                                         {index > 0 && (index === dependentFlags.length - 1 ? ' and ' : ', ')}

--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -526,7 +526,12 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                                 <div className="py-1">
                                                     <div className="font-semibold">Advanced options</div>
                                                     <div className="text-secondary text-sm font-normal">
-                                                        Tags,{hasEvaluationContexts ? ' evaluation contexts,' : ''}{' '}
+                                                        Tags,
+                                                        {hasEvaluationContexts ? (
+                                                            <span> evaluation contexts,</span>
+                                                        ) : (
+                                                            ''
+                                                        )}{' '}
                                                         runtime settings, and persistence.
                                                     </div>
                                                 </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -180,8 +180,12 @@ function ConditionHeader({
             </div>
             <div className="flex items-center gap-2 shrink-0">
                 <span className="text-sm text-muted mr-2">
-                    ({rollout}%{group.variant && ` · ${group.variant}`}
-                    {countSummary !== null && ` · ${countSummary}`})
+                    <span>(</span>
+                    {rollout}
+                    <span>%</span>
+                    {group.variant && <span>{` · ${group.variant}`}</span>}
+                    {countSummary !== null && <span>{` · ${countSummary}`}</span>}
+                    <span>)</span>
                 </span>
                 <LemonMenu
                     items={[
@@ -899,7 +903,11 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                         <span>{summary}</span>
                                     </div>
                                     <span className="text-muted">
-                                        ({rollout}%{group.variant && ` · ${group.variant}`})
+                                        <span>(</span>
+                                        {rollout}
+                                        <span>%</span>
+                                        {group.variant && <span>{` · ${group.variant}`}</span>}
+                                        <span>)</span>
                                     </span>
                                 </div>
                             </div>
@@ -1301,8 +1309,13 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                                 </div>
                                                 <div className="flex items-center gap-2 shrink-0">
                                                     <span className="text-sm text-muted mr-2">
-                                                        ({draggedGroup.rollout_percentage ?? 100}%
-                                                        {draggedGroup.variant && ` · ${draggedGroup.variant}`})
+                                                        <span>(</span>
+                                                        {draggedGroup.rollout_percentage ?? 100}
+                                                        <span>%</span>
+                                                        {draggedGroup.variant && (
+                                                            <span>{` · ${draggedGroup.variant}`}</span>
+                                                        )}
+                                                        <span>)</span>
                                                     </span>
                                                 </div>
                                             </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -251,7 +251,7 @@ function ChangeDescription({
                 <IconList className="text-muted" />
                 <span className="font-medium">Update variants:</span>
                 <LemonTag type="highlight">
-                    {variantCount} variant{variantCount !== 1 ? 's' : ''}
+                    {variantCount} variant{variantCount !== 1 ? <span>s</span> : ''}
                 </LemonTag>
             </div>
         )
@@ -1215,7 +1215,7 @@ function FeatureFlagScheduleLegacy(): JSX.Element {
                                 <b>Update variants:</b>
                             </span>
                             <LemonTag type="highlight">
-                                {variantCount} variant{variantCount !== 1 ? 's' : ''}
+                                {variantCount} variant{variantCount !== 1 ? <span>s</span> : ''}
                             </LemonTag>
                         </div>
                     )

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -424,7 +424,8 @@ export function flagActivityDescriber(logItem: ActivityLogItem, asNotification?:
         let changes: Description[] = []
         let changeSuffix: Description = (
             <>
-                on {asNotification && ' the flag '}
+                <span>on </span>
+                {asNotification && <span> the flag </span>}
                 {nameOrLinkToFlag(logItem?.item_id, logItem?.detail.name)}
             </>
         )

--- a/frontend/src/scenes/feature-flags/projects-grid/ProjectsGridPicker.tsx
+++ b/frontend/src/scenes/feature-flags/projects-grid/ProjectsGridPicker.tsx
@@ -87,7 +87,7 @@ export function ProjectsGridPicker(): JSX.Element {
             }
         >
             <LemonButton type="secondary" icon={<IconPlus />} data-attr="projects-grid-picker">
-                Projects
+                <span>Projects</span>
                 {pickedTeamIds.length > 0 && <span className="ml-1 text-tertiary">({pickedTeamIds.length})</span>}
             </LemonButton>
         </LemonDropdown>

--- a/frontend/src/scenes/hog-functions/metrics/HogFunctionEventEstimates.tsx
+++ b/frontend/src/scenes/hog-functions/metrics/HogFunctionEventEstimates.tsx
@@ -58,7 +58,7 @@ export function HogFunctionEventEstimates(): JSX.Element | null {
                         <LemonBanner type="warning">
                             <b>Warning:</b> This destination would have triggered{' '}
                             <strong>
-                                {sparkline.count ?? 0} time{sparkline.count !== 1 ? 's' : ''}
+                                {sparkline.count ?? 0} time{sparkline.count !== 1 ? <span>s</span> : ''}
                             </strong>{' '}
                             in the last 7 days. Consider the impact of this function on your destination.
                         </LemonBanner>
@@ -66,7 +66,7 @@ export function HogFunctionEventEstimates(): JSX.Element | null {
                         <p>
                             This {type} would have triggered{' '}
                             <strong>
-                                {sparkline.count ?? 0} time{sparkline.count !== 1 ? 's' : ''}
+                                {sparkline.count ?? 0} time{sparkline.count !== 1 ? <span>s</span> : ''}
                             </strong>{' '}
                             in the last 7 days.
                         </p>

--- a/frontend/src/scenes/inbox/InboxScene.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.tsx
@@ -497,7 +497,7 @@ function SuggestedReviewers({ reviewers }: { reviewers: EnrichedReviewer[] }): J
                                 <span className="text-[0.6875rem] text-tertiary">
                                     {reviewer.relevant_commits.map((commit, i) => (
                                         <span key={commit.sha}>
-                                            {i > 0 && ', '}
+                                            {i > 0 && <span>, </span>}
                                             <Tooltip title={commit.reason || undefined}>
                                                 <Link
                                                     to={commit.url}

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -710,7 +710,7 @@ export function FunnelDataWarehouseStepIncompleteState(): JSX.Element {
             <IconFunnels className="text-4xl shrink-0 text-muted mb-2" />
 
             <h2 className="text-xl leading-tight font-medium mb-0">
-                Complete your data warehouse step{incompleteSteps.length === 1 ? '' : 's'}!
+                Complete your data warehouse step{incompleteSteps.length === 1 ? '' : <span>s</span>}!
             </h2>
             <p className="text-sm text-muted mb-1">
                 {incompleteSteps.length > 1

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -226,7 +226,7 @@ export function getDatumTitle(
                             ) : (
                                 <span>{midEllipsis(pill, 60)}</span>
                             )}
-                            {index < pillValues.length - 1 && ' · '}
+                            {index < pillValues.length - 1 && <span> · </span>}
                         </React.Fragment>
                     )
                 })}

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -227,7 +227,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                     {queueingEnabled && (queuedMessages.length > 0 || queueSubmitting) && (
                         <div className="px-3 py-2">
                             <div className="text-xs text-muted mb-1.5 flex items-center gap-1.5">
-                                Up next
+                                <span>Up next</span>
                                 {queueSubmitting && <Spinner size="small" />}
                             </div>
                             <div className="space-y-1.5">

--- a/frontend/src/scenes/max/components/SlashCommandAutocomplete.tsx
+++ b/frontend/src/scenes/max/components/SlashCommandAutocomplete.tsx
@@ -23,7 +23,7 @@ const convertSlashCommandToMenuItem = (
         <div>
             <div className="font-mono mt-0.5">
                 {command.name}
-                {command.arg && ` ${command.arg}`}
+                {command.arg && <span>{` ${command.arg}`}</span>}
             </div>
             <div className="text-muted text-xs">{command.description}</div>
         </div>
@@ -112,7 +112,7 @@ export function SlashCommandAutocomplete({ onClose, visible, children }: SlashCo
 function NavigationHint({ isArgRequired }: { isArgRequired: boolean }): JSX.Element {
     return (
         <div className="border-t px-1 pt-1.5 pb-0.5 mt-1 text-xxs text-muted-alt font-medium select-none">
-            {MAX_SLASH_COMMANDS.length > 1 && '↑↓ to navigate • '}
+            {MAX_SLASH_COMMANDS.length > 1 && <span>↑↓ to navigate • </span>}
             {!isArgRequired ? '⏎ to activate • → to select • Esc to close' : '⏎ or → to select • Esc to close'}
         </div>
     )

--- a/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
+++ b/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
@@ -338,7 +338,8 @@ export function SummarizeSessionsWidget({
             type="primary"
             className="bg-surface-primary w-fit mx-1"
         >
-            Open analysis of sessions{title && `: ${title}`}
+            <span>Open analysis of sessions</span>
+            {title && <span>{`: ${title}`}</span>}
         </LemonButton>
     )
 }

--- a/frontend/src/scenes/models/NodeDetailMaterialization.tsx
+++ b/frontend/src/scenes/models/NodeDetailMaterialization.tsx
@@ -82,7 +82,7 @@ export function NodeDetailMaterialization({ id }: { id: string }): JSX.Element |
                                 <Tooltip title={job.error}>
                                     <span className="text-danger truncate max-w-xs inline-block">
                                         {job.error.slice(0, 80)}
-                                        {job.error.length > 80 ? '...' : ''}
+                                        {job.error.length > 80 ? <span>...</span> : ''}
                                     </span>
                                 </Tooltip>
                             ) : (

--- a/frontend/src/scenes/notebooks/NotebookScene.tsx
+++ b/frontend/src/scenes/notebooks/NotebookScene.tsx
@@ -140,9 +140,11 @@ export function NotebookScene(): JSX.Element {
                             }
                         }}
                     >
-                        {selectedNotebook === LOCAL_NOTEBOOK_TEMPLATES[0].short_id && visibility === 'visible'
-                            ? 'Close '
-                            : ''}
+                        {selectedNotebook === LOCAL_NOTEBOOK_TEMPLATES[0].short_id && visibility === 'visible' ? (
+                            <span>Close </span>
+                        ) : (
+                            ''
+                        )}
                         Guide
                     </LemonButton>
                     <NotebookTableOfContentsButton type="secondary" size="small" />

--- a/frontend/src/scenes/onboarding/productSelection/variants/ProductCarousel.tsx
+++ b/frontend/src/scenes/onboarding/productSelection/variants/ProductCarousel.tsx
@@ -696,7 +696,8 @@ export function ProductCarousel({ mode, recommendationSource }: ProductCarouselP
                                 sideIcon={<IconArrowRight />}
                                 data-attr="onboarding-continue"
                             >
-                                Get started{selectedProducts.length > 1 ? ` (${selectedProducts.length})` : ''}
+                                Get started
+                                {selectedProducts.length > 1 ? <span>{` (${selectedProducts.length})`}</span> : ''}
                             </LemonButton>
                         </div>
                     )

--- a/frontend/src/scenes/product-tours/components/AutoShowSection.tsx
+++ b/frontend/src/scenes/product-tours/components/AutoShowSection.tsx
@@ -126,9 +126,11 @@ function EventTriggerContent({ id }: { id: string }): JSX.Element {
                                                         {hasPropertyFilters && (
                                                             <span className="text-xs text-muted bg-border px-1.5 py-0.5 rounded">
                                                                 {Object.keys(event.propertyFilters!).length} filter
-                                                                {Object.keys(event.propertyFilters!).length !== 1
-                                                                    ? 's'
-                                                                    : ''}
+                                                                {Object.keys(event.propertyFilters!).length !== 1 ? (
+                                                                    <span>s</span>
+                                                                ) : (
+                                                                    ''
+                                                                )}
                                                             </span>
                                                         )}
                                                     </div>

--- a/frontend/src/scenes/product-tours/editor/TourSettingsPanel.tsx
+++ b/frontend/src/scenes/product-tours/editor/TourSettingsPanel.tsx
@@ -268,7 +268,7 @@ export function TourSettingsPanel({ tourId }: TourSettingsPanelProps): JSX.Eleme
                                           key: 'translations',
                                           header: (
                                               <div className="flex gap-2 items-center">
-                                                  Translations
+                                                  <span>Translations</span>
                                                   {selectedLanguage && <LemonTag>{selectedLanguage}</LemonTag>}
                                               </div>
                                           ),

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -69,7 +69,11 @@ const insightActionsMapping: Record<
         return {
             description: [
                 <>
-                    renamed {asNotification && 'the insight '}"{change?.before}" to{' '}
+                    <span>renamed </span>
+                    {asNotification && <span>the insight </span>}
+                    <span>"</span>
+                    {change?.before}
+                    <span>" to</span>{' '}
                     <strong>"{nameOrLinkToInsight(logItem?.detail.short_id, change?.after as string)}"</strong>
                 </>,
             ],
@@ -99,7 +103,7 @@ const insightActionsMapping: Record<
             description: [
                 <>
                     {describeChange}
-                    {asNotification && ' the insight '}
+                    {asNotification && <span> the insight </span>}
                 </>,
             ],
             suffix: <>{nameOrLinkToInsight(logItem?.detail.short_id, logItem?.detail.name)}</>,
@@ -109,8 +113,9 @@ const insightActionsMapping: Record<
         return {
             description: [
                 <>
-                    changed the short id {asNotification && ' of the insight '}to{' '}
-                    <strong>"{change?.after as string}"</strong>
+                    <span>changed the short id </span>
+                    {asNotification && <span> of the insight </span>}
+                    <span>to</span> <strong>"{change?.after as string}"</strong>
                 </>,
             ],
         }
@@ -119,7 +124,11 @@ const insightActionsMapping: Record<
         return {
             description: [
                 <>
-                    renamed {asNotification && ' the insight '}"{change?.before}" to{' '}
+                    <span>renamed </span>
+                    {asNotification && <span> the insight </span>}
+                    <span>"</span>
+                    {change?.before}
+                    <span>" to</span>{' '}
                     <strong>"{nameOrLinkToInsight(logItem?.detail.short_id, change?.after as string)}"</strong>
                 </>,
             ],
@@ -130,8 +139,9 @@ const insightActionsMapping: Record<
         return {
             description: [
                 <>
-                    changed the description {asNotification && ' of the insight '}to{' '}
-                    <strong>"{change?.after as string}"</strong>
+                    <span>changed the description </span>
+                    {asNotification && <span> of the insight </span>}
+                    <span>to</span> <strong>"{change?.after as string}"</strong>
                 </>,
             ],
         }
@@ -142,7 +152,9 @@ const insightActionsMapping: Record<
             description: [
                 <>
                     <div className="highlighted-activity">
-                        {isFavoriteAfter ? '' : 'un-'}favorited{asNotification && ' the insight '}
+                        {isFavoriteAfter ? '' : <span>un-</span>}
+                        <span>favorited</span>
+                        {asNotification && <span> the insight </span>}
                     </div>
                 </>,
             ],
@@ -190,8 +202,9 @@ const insightActionsMapping: Record<
             <SentenceList
                 prefix={
                     <>
-                        added {asNotification && ' the insight '}
-                        {nameOrLinkToInsight(logItem?.detail.short_id, logItem?.detail.name)} to
+                        <span>added </span>
+                        {asNotification && <span> the insight </span>}
+                        {nameOrLinkToInsight(logItem?.detail.short_id, logItem?.detail.name)} <span>to</span>
                     </>
                 }
                 listParts={addedDashboards.map((d) => (
@@ -204,8 +217,9 @@ const insightActionsMapping: Record<
             <SentenceList
                 prefix={
                     <>
-                        removed {asNotification && ' the insight '}
-                        {nameOrLinkToInsight(logItem?.detail.short_id, logItem?.detail.name)} from
+                        <span>removed </span>
+                        {asNotification && <span> the insight </span>}
+                        {nameOrLinkToInsight(logItem?.detail.short_id, logItem?.detail.name)} <span>from</span>
                     </>
                 }
                 listParts={removedDashboards.map((d) => (
@@ -328,7 +342,8 @@ export function insightActivityDescriber(logItem: ActivityLogItem, asNotificatio
         let extendedDescription: JSX.Element | undefined
         let changeSuffix: Description = (
             <>
-                on {asNotification && ' the insight '}
+                <span>on </span>
+                {asNotification && <span> the insight </span>}
                 {nameOrLinkToInsight(logItem?.detail.short_id, logItem?.detail.name)}
             </>
         )

--- a/frontend/src/scenes/session-recordings/filters/CurrentFilterIndicator.tsx
+++ b/frontend/src/scenes/session-recordings/filters/CurrentFilterIndicator.tsx
@@ -39,7 +39,7 @@ export function CurrentFilterIndicator(): JSX.Element | null {
                 >
                     <span className="truncate">
                         {appliedSavedFilter.name || appliedSavedFilter.derived_name || 'Unnamed'}
-                        {hasFilterChanges && ' (edited)'}
+                        {hasFilterChanges && <span> (edited)</span>}
                     </span>
                 </LemonTag>
             </div>

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -478,7 +478,7 @@ function SavedFilterNameEditor({
             >
                 <span className="truncate">
                     {appliedSavedFilter.name || appliedSavedFilter.derived_name || 'Unnamed'}
-                    {hasFilterChanges && ' (edited)'}
+                    {hasFilterChanges && <span> (edited)</span>}
                 </span>
             </LemonTag>
             <LemonButton

--- a/frontend/src/scenes/session-recordings/filters/SavedFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SavedFilters.tsx
@@ -64,8 +64,8 @@ export function countColumn(): LemonTableColumn<SessionRecordingPlaylistType, 'r
                                 <p>
                                     You have {unwatchedSavedFiltersCount} unwatched recordings to watch out of a total
                                     of {totalSavedFiltersCount}
-                                    {recordings_counts.saved_filters?.has_more ? '+' : ''} that match these saved
-                                    filters.
+                                    {recordings_counts.saved_filters?.has_more ? <span>+</span> : ''} that match these
+                                    saved filters.
                                 </p>
                             ) : (
                                 <p>

--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryViews.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryViews.tsx
@@ -624,10 +624,10 @@ function SessionSummaryLoadingState({ operation, counter, name, outOf }: Session
                     {counter !== undefined && (
                         <span className="font-semibold">
                             ({counter}
-                            {outOf ? ` out of ${outOf}` : ''})
+                            {outOf ? <span>{` out of ${outOf}`}</span> : ''})
                         </span>
                     )}
-                    {name ? ':' : ''}
+                    {name ? <span>:</span> : ''}
                 </span>
                 <div className="flex items-center gap-1 ml-auto font-mono text-xs">
                     <LoadingTimer operation={operation} />

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -152,7 +152,7 @@ function ConfirmDeleteRecordings({ shortId }: { shortId?: string }): JSX.Element
             <div className="space-y-4">
                 <h4>
                     Are you sure you want to delete {selectedRecordingsIds.length} recording
-                    {selectedRecordingsIds.length > 1 ? 's' : ''}?
+                    {selectedRecordingsIds.length > 1 ? <span>s</span> : ''}?
                 </h4>
                 <div className="space-y-2">
                     <label className="text-sm">
@@ -208,7 +208,7 @@ function NewCollectionModal(): JSX.Element {
                 <p>
                     Collections help you organize and save recordings for later analysis. This will create a new
                     collection with the {selectedRecordingsIds.length} selected recording
-                    {selectedRecordingsIds.length > 1 ? 's' : ''}.
+                    {selectedRecordingsIds.length > 1 ? <span>s</span> : ''}.
                 </p>
                 <div className="space-y-2">
                     <label className="text-sm font-medium">Collection name</label>

--- a/frontend/src/scenes/settings/organization/Approvals/ChangeRequestsList.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ChangeRequestsList.tsx
@@ -208,9 +208,11 @@ function ChangeRequestTableActions({
                                     content: (
                                         <div className="text-sm text-secondary">
                                             This will add your approval to the change request.
-                                            {changeRequest.policy_snapshot?.quorum === 1
-                                                ? ' The change will be applied automatically.'
-                                                : ''}
+                                            {changeRequest.policy_snapshot?.quorum === 1 ? (
+                                                <span> The change will be applied automatically.</span>
+                                            ) : (
+                                                ''
+                                            )}
                                         </div>
                                     ),
                                     primaryButton: {

--- a/frontend/src/scenes/settings/organization/Invites.tsx
+++ b/frontend/src/scenes/settings/organization/Invites.tsx
@@ -87,7 +87,7 @@ export function InvitesTable(): JSX.Element {
                 return invite.target_email ? (
                     <div className="ph-no-capture flex items-center">
                         {invite.target_email}
-                        {invite.first_name ? ` (${invite.first_name})` : ''}
+                        {invite.first_name ? <span>{` (${invite.first_name})`}</span> : ''}
                     </div>
                 ) : (
                     <i>no one</i>

--- a/frontend/src/scenes/settings/user/PersonalIntegrations.tsx
+++ b/frontend/src/scenes/settings/user/PersonalIntegrations.tsx
@@ -67,7 +67,7 @@ function GitHubInstallationRow({ integration }: { integration: PersonalGitHubInt
                     ) : (
                         'Connected'
                     )}
-                    {integration.uses_shared_installation ? ' · Also used by this project' : ''}
+                    {integration.uses_shared_installation ? <span> · Also used by this project</span> : ''}
                 </div>
                 <div className="mt-1">
                     <GitHubRepoSummary

--- a/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
+++ b/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
@@ -489,7 +489,8 @@ export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>([
                         </CodeSnippet>
 
                         <LemonBanner type="warning" className="mt-4">
-                            Your previous key{prevMaskedValue ? ` "${prevMaskedValue}"` : ''} is no longer valid.
+                            Your previous key{prevMaskedValue ? <span>{` "${prevMaskedValue}"`}</span> : ''} is no
+                            longer valid.
                         </LemonBanner>
                     </>
                 ),

--- a/frontend/src/scenes/startups/StartupProgram.tsx
+++ b/frontend/src/scenes/startups/StartupProgram.tsx
@@ -239,7 +239,7 @@ export function StartupProgram(): JSX.Element {
                             <IconCheck className="text-success shrink-0 mt-1 mr-2" />
                             <div>
                                 <h4 className="font-semibold">
-                                    Exclusive founder merch
+                                    <span>Exclusive founder merch</span>
                                     {isYC && <span className="text-[0.66em] align-super text-muted"> 2</span>}
                                 </h4>
                                 <p className="text-muted text-sm">

--- a/frontend/src/scenes/surveys/DuplicateToProjectModal.tsx
+++ b/frontend/src/scenes/surveys/DuplicateToProjectModal.tsx
@@ -81,7 +81,7 @@ export function DuplicateToProjectModal(): JSX.Element {
                         loading={duplicatedSurveyLoading}
                         disabledReason={selectedTeamIds.size === 0 ? 'Select at least one project' : undefined}
                     >
-                        Duplicate to {selectedTeamIds.size} project{selectedTeamIds.size !== 1 ? 's' : ''}
+                        Duplicate to {selectedTeamIds.size} project{selectedTeamIds.size !== 1 ? <span>s</span> : ''}
                     </LemonButton>
                 </>
             }

--- a/frontend/src/scenes/surveys/SurveyResponseFilters.tsx
+++ b/frontend/src/scenes/surveys/SurveyResponseFilters.tsx
@@ -166,8 +166,8 @@ export const SurveyResponseFilters = React.memo(function SurveyResponseFilters()
                             onClick={() => setQuestionFiltersExpanded(!questionFiltersExpanded)}
                             active={questionFiltersExpanded || activeAnswerFiltersCount > 0}
                         >
-                            Filter by response
-                            {activeAnswerFiltersCount > 0 && ` (${activeAnswerFiltersCount})`}
+                            <span>Filter by response</span>
+                            {activeAnswerFiltersCount > 0 && <span>{` (${activeAnswerFiltersCount})`}</span>}
                         </LemonButton>
                     )}
                     <PropertyFilters

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyFilters.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyFilters.tsx
@@ -129,8 +129,8 @@ export function SurveyResultsFiltersBar(): JSX.Element {
                             onClick={() => setQuestionFiltersExpanded(!questionFiltersExpanded)}
                             active={questionFiltersExpanded || activeAnswerFiltersCount > 0}
                         >
-                            Filter by response
-                            {activeAnswerFiltersCount > 0 && ` (${activeAnswerFiltersCount})`}
+                            <span>Filter by response</span>
+                            {activeAnswerFiltersCount > 0 && <span>{` (${activeAnswerFiltersCount})`}</span>}
                         </LemonButton>
                     )}
                     <PropertyFilters

--- a/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
@@ -227,11 +227,12 @@ export function OpenQuestionSummaryV2({
                     <div className="flex items-center justify-between text-xs text-muted mt-3 pt-2 border-t">
                         <div className="flex items-center gap-2">
                             <span>
-                                Based on {summary.responseCount}
+                                <span>Based on </span>
+                                {summary.responseCount}
                                 {totalResponses > summary.responseCount
                                     ? ` of ${totalResponses} responses (sampled)`
                                     : ' responses'}
-                                {generatedTime.isValid() && ` • ${generatedTime.fromNow()}`}
+                                {generatedTime.isValid() && <span>{` • ${generatedTime.fromNow()}`}</span>}
                                 {' • AI-generated • Verify key details'}
                             </span>
                             {dataProcessingAccepted || !showConsentPopover ? (

--- a/frontend/src/scenes/surveys/surveyActivityDescriber.tsx
+++ b/frontend/src/scenes/surveys/surveyActivityDescriber.tsx
@@ -117,7 +117,8 @@ const surveyActionsMapping: Record<
         return {
             description: [
                 <>
-                    updated <strong>{questionChanges.length}</strong> question{questionChanges.length !== 1 ? 's' : ''}:
+                    updated <strong>{questionChanges.length}</strong> question
+                    {questionChanges.length !== 1 ? <span>s</span> : ''}:
                     <ul className="bullet-list">
                         {questionChanges.map(({ index, changes }) => (
                             <li key={index}>
@@ -590,7 +591,7 @@ export function describeFieldChange<T>(fieldName: string, before: T, after: T, u
                 set {fieldName} to{' '}
                 <strong>
                     {String(after)}
-                    {unit ? ` ${unit}` : ''}
+                    {unit ? <span>{` ${unit}`}</span> : ''}
                 </strong>
             </>
         )
@@ -600,7 +601,7 @@ export function describeFieldChange<T>(fieldName: string, before: T, after: T, u
                 removed {fieldName} (was{' '}
                 <strong>
                     {String(before)}
-                    {unit ? ` ${unit}` : ''}
+                    {unit ? <span>{` ${unit}`}</span> : ''}
                 </strong>
                 )
             </>
@@ -611,12 +612,12 @@ export function describeFieldChange<T>(fieldName: string, before: T, after: T, u
                 changed {fieldName} from{' '}
                 <strong>
                     {String(before)}
-                    {unit ? ` ${unit}` : ''}
+                    {unit ? <span>{` ${unit}`}</span> : ''}
                 </strong>{' '}
                 to{' '}
                 <strong>
                     {String(after)}
-                    {unit ? ` ${unit}` : ''}
+                    {unit ? <span>{` ${unit}`}</span> : ''}
                 </strong>
             </>
         )

--- a/frontend/src/scenes/team-activity/teamActivityDescriber.tsx
+++ b/frontend/src/scenes/team-activity/teamActivityDescriber.tsx
@@ -638,7 +638,8 @@ const TEAM_PROPERTIES_MAPPING: Record<keyof TeamType, (change: ActivityChange) =
                     {changedTasks.map(([key, value], index) => (
                         <span key={key}>
                             {index > 0 && <>, </>}
-                            {value === 'completed' ? 'completed' : 'uncompleted'} onboarding task <em>{key}</em>
+                            {value === 'completed' ? 'completed' : 'uncompleted'} <span>onboarding task </span>
+                            <em>{key}</em>
                         </span>
                     ))}
                 </>,

--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -219,7 +219,7 @@ export function PersonsModal({
                                 </>
                             ) : (
                                 <span>
-                                    {actorsResponse?.next || actorsResponse?.offset ? 'More than ' : ''}
+                                    {actorsResponse?.next || actorsResponse?.offset ? <span>More than </span> : ''}
                                     <b>
                                         {totalActorsCount || 'No'} unique{' '}
                                         {pluralize(totalActorsCount, actorLabel.singular, actorLabel.plural, false)}

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -34,7 +34,7 @@ export const funnelTitle = (props: {
                     <PropertyKeyInfo value={props.label || ''} disablePopover type={TaxonomicFilterGroupType.Events} />
                 </>
             )}{' '}
-            {props?.breakdown_value ? `• ${props.breakdown_value}` : ''}
+            {props?.breakdown_value ? <span>{`• ${props.breakdown_value}`}</span> : ''}
         </>
     )
 }

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsSourceStatusBanner.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsSourceStatusBanner.tsx
@@ -57,7 +57,7 @@ const SourceStatusMessage = ({
     return (
         <>
             <strong>
-                {length} source{length > 1 ? 's' : ''} {length > 1 ? pluralVerb : singularVerb} {message}
+                {length} source{length > 1 ? <span>s</span> : ''} {length > 1 ? pluralVerb : singularVerb} {message}
             </strong>
             .{' '}
         </>

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/AttributionSettings.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/AttributionSettings.tsx
@@ -140,7 +140,7 @@ export function AttributionSettings(): JSX.Element {
         <div className="space-y-4">
             <div>
                 <h3 className="text-lg font-semibold mb-2 flex items-center gap-2">
-                    Attribution Settings
+                    <span>Attribution Settings</span>
                     {currentTeamLoading && <Spinner className="text-muted" />}
                 </h3>
                 <p className="text-muted-foreground text-sm mb-4">

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/IntegrationSettingsCard.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/IntegrationSettingsCard.tsx
@@ -42,10 +42,14 @@ export function IntegrationSettingsCard({ integrationName }: IntegrationSettings
                     <div className="font-semibold text-sm">{integrationName}</div>
                     {hasSettings ? (
                         <div className="text-xs text-muted mt-1">
-                            {mappingsCount > 0 && `${mappingsCount} mapping${mappingsCount !== 1 ? 's' : ''}`}
-                            {mappingsCount > 0 && (sourcesCount > 0 || hasFieldPref) && ', '}
-                            {sourcesCount > 0 && `${sourcesCount} source${sourcesCount !== 1 ? 's' : ''}`}
-                            {sourcesCount > 0 && hasFieldPref && ', '}
+                            {mappingsCount > 0 && (
+                                <span>{`${mappingsCount} mapping${mappingsCount !== 1 ? 's' : ''}`}</span>
+                            )}
+                            {mappingsCount > 0 && (sourcesCount > 0 || hasFieldPref) && <span>, </span>}
+                            {sourcesCount > 0 && (
+                                <span>{`${sourcesCount} source${sourcesCount !== 1 ? 's' : ''}`}</span>
+                            )}
+                            {sourcesCount > 0 && hasFieldPref && <span>, </span>}
                             {hasFieldPref && fieldPreference.match_field}
                         </div>
                     ) : (

--- a/frontend/src/toolbar/actions/ActionsListView.tsx
+++ b/frontend/src/toolbar/actions/ActionsListView.tsx
@@ -39,7 +39,7 @@ export function ActionsListView({ actions }: ActionsListViewProps): JSX.Element 
                     <Spinner className="text-4xl" />
                 </div>
             ) : (
-                <div className="p-2">No {searchTerm.length ? 'matching ' : ''}actions found.</div>
+                <div className="p-2">No {searchTerm.length ? <span>matching </span> : ''}actions found.</div>
             )}
         </div>
     )

--- a/frontend/src/toolbar/debug/EventDebugMenu.tsx
+++ b/frontend/src/toolbar/debug/EventDebugMenu.tsx
@@ -356,7 +356,7 @@ export const EventDebugMenu = (): JSX.Element => {
                 </div>
                 {isPaused && bufferedCount > 0 && (
                     <div className="text-xxs text-warning pb-1">
-                        Paused — {bufferedCount} new event{bufferedCount !== 1 ? 's' : ''} buffered
+                        Paused — {bufferedCount} new event{bufferedCount !== 1 ? <span>s</span> : ''} buffered
                     </div>
                 )}
             </ToolbarMenu.Header>

--- a/frontend/src/toolbar/experiments/ExperimentsListView.tsx
+++ b/frontend/src/toolbar/experiments/ExperimentsListView.tsx
@@ -39,7 +39,7 @@ export function ExperimentsListView({ experiments }: ExperimentsListViewProps): 
                     <Spinner className="text-4xl" />
                 </div>
             ) : (
-                <div className="p-2">No {searchTerm.length ? 'matching ' : ''}experiments found.</div>
+                <div className="p-2">No {searchTerm.length ? <span>matching </span> : ''}experiments found.</div>
             )}
         </div>
     )

--- a/products/actions/frontend/utils/deleteAction.tsx
+++ b/products/actions/frontend/utils/deleteAction.tsx
@@ -33,7 +33,7 @@ export async function deleteActionWithWarning(action: ActionType, callback: (und
             description: (
                 <>
                     This action is referenced by <strong>{references.length}</strong> resource
-                    {references.length === 1 ? '' : 's'}. Deleting it may break them.
+                    {references.length === 1 ? '' : <span>s</span>}. Deleting it may break them.
                 </>
             ),
             primaryButton: {

--- a/products/actions/mcp/apps/ActionListView.tsx
+++ b/products/actions/mcp/apps/ActionListView.tsx
@@ -81,7 +81,7 @@ export function ActionListView({ data, onActionClick }: ActionListViewProps): Re
                         <div className="flex flex-col gap-2">
                             <div className="flex items-center justify-between">
                                 <span className="text-sm text-muted-foreground">
-                                    {data.results.length} action{data.results.length === 1 ? '' : 's'}
+                                    {data.results.length} action{data.results.length === 1 ? '' : <span>s</span>}
                                 </span>
                             </div>
                             <DataTable<ActionData>

--- a/products/cohorts/mcp/apps/CohortListView.tsx
+++ b/products/cohorts/mcp/apps/CohortListView.tsx
@@ -80,7 +80,7 @@ export function CohortListView({ data, onCohortClick }: CohortListViewProps): Re
                         <div className="flex flex-col gap-2">
                             <div className="flex items-center justify-between">
                                 <span className="text-sm text-muted-foreground">
-                                    {data.results.length} cohort{data.results.length === 1 ? '' : 's'}
+                                    {data.results.length} cohort{data.results.length === 1 ? '' : <span>s</span>}
                                 </span>
                             </div>
                             <DataTable<CohortData>

--- a/products/conversations/frontend/scenes/settings/SecretApiKeySection.tsx
+++ b/products/conversations/frontend/scenes/settings/SecretApiKeySection.tsx
@@ -39,7 +39,7 @@ export function SecretApiKeySection(): JSX.Element {
             <LemonCard hoverEffect={false} className="flex flex-col gap-y-2 max-w-[800px] px-4 py-3">
                 <div>
                     <h3 className="text-sm font-semibold mb-1">
-                        Primary key{' '}
+                        <span>Primary key</span>{' '}
                         {currentTeam?.secret_api_token && <span className="text-green-700 text-xs ml-2">(Active)</span>}
                     </h3>
                     <CodeSnippet

--- a/products/conversations/frontend/scenes/ticket/ExceptionsPanel.tsx
+++ b/products/conversations/frontend/scenes/ticket/ExceptionsPanel.tsx
@@ -21,7 +21,7 @@ export function ExceptionsPanel({ exceptionsQuery, sessionId, distinctId }: Exce
                     key: 'exceptions',
                     header: (
                         <>
-                            Exceptions
+                            <span>Exceptions</span>
                             {sessionId && <span className="text-muted-alt font-normal ml-1">(session)</span>}
                         </>
                     ),

--- a/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
+++ b/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
@@ -129,7 +129,7 @@ function CustomerAnalyticsSceneContent({ tabId }: { tabId?: string }): JSX.Eleme
                             {isEditMode ? (
                                 <div className="flex items-center gap-2">
                                     <span className="text-sm text-muted font-medium whitespace-nowrap">
-                                        {stagedNodes.length} step{stagedNodes.length !== 1 ? 's' : ''} to add
+                                        {stagedNodes.length} step{stagedNodes.length !== 1 ? <span>s</span> : ''} to add
                                     </span>
                                     <LemonButton type="secondary" size="small" onClick={cancelChanges}>
                                         Cancel

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -1118,8 +1118,8 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                         <div>
                             <span className="text-muted">
                                 {tableCountFormatter(incrementalTables.length)}
-                                {incrementalTables.length === 69 ? ' (nice)' : ''}
-                                {incrementalTables.length === 67 ? ' (nice but only for genz)' : ''}
+                                {incrementalTables.length === 69 ? <span> (nice)</span> : ''}
+                                {incrementalTables.length === 67 ? <span> (nice but only for genz)</span> : ''}
                             </span>{' '}
                             — Ideal. Syncs only changed rows using a field like{' '}
                             <span className="font-mono text-xs">updated_at</span>.

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/WebhookTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/WebhookTab.tsx
@@ -262,7 +262,7 @@ function WebhookDetailsSection({ webhookInfo }: { webhookInfo: WebhookInfo }): J
                 <div>
                     <p className="text-xs font-semibold text-muted uppercase mb-1">
                         Listening to {externalStatus.enabled_events.length} event
-                        {externalStatus.enabled_events.length !== 1 ? 's' : ''}
+                        {externalStatus.enabled_events.length !== 1 ? <span>s</span> : ''}
                     </p>
                     <div className="flex flex-wrap gap-1 mt-1">
                         {externalStatus.enabled_events.map((event) => (

--- a/products/data_warehouse/frontend/shared/components/InlineSourceSetup.tsx
+++ b/products/data_warehouse/frontend/shared/components/InlineSourceSetup.tsx
@@ -109,7 +109,7 @@ function InternalInlineSourceSetup({
                                     size="small"
                                 >
                                     Show {hiddenSources.length} more source
-                                    {hiddenSources.length !== 1 ? 's' : ''}
+                                    {hiddenSources.length !== 1 ? <span>s</span> : ''}
                                 </LemonButton>
                             </div>
                         )}

--- a/products/endpoints/frontend/nodes/EndpointsUsageOverviewNode.tsx
+++ b/products/endpoints/frontend/nodes/EndpointsUsageOverviewNode.tsx
@@ -147,7 +147,7 @@ const ItemCell = ({ item, isPrimary }: { item: Item; isPrimary: boolean }): JSX.
                           : 'text-muted'
                 )}
             >
-                {item.item.changeFromPreviousPct > 0 ? '+' : ''}
+                {item.item.changeFromPreviousPct > 0 ? <span>+</span> : ''}
                 {item.item.changeFromPreviousPct.toFixed(1)}%
             </div>
         ) : null

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/DisabledRuleBanner.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/DisabledRuleBanner.tsx
@@ -25,7 +25,7 @@ export function DisabledRuleBanner({ rule, onClose }: { rule: ErrorTrackingRule;
                 children: 'Contact support',
             }}
         >
-            This rule has been disabled due to an error. Saving will re-enable it.
+            <span>This rule has been disabled due to an error. Saving will re-enable it.</span>
             {message && <div className="mt-1 text-xs text-muted">Error: {message}</div>}
         </LemonBanner>
     )

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/MatchResultBanner.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/MatchResultBanner.tsx
@@ -82,7 +82,7 @@ export function MatchResultBanner({
     const issuesLink = (
         <Link to={`${window.location.origin}${issuesUrl}`} target="_blank" targetBlankIcon={false}>
             {matchResult.issueCount.toLocaleString()} issue
-            {matchResult.issueCount === 1 ? '' : 's'}
+            {matchResult.issueCount === 1 ? '' : <span>s</span>}
         </Link>
     )
 
@@ -95,13 +95,13 @@ export function MatchResultBanner({
                     ~{Math.round(matchResult.exceptionCount * samplingRate).toLocaleString()} of{' '}
                     <Link to={`${window.location.origin}${exceptionsUrl}`} target="_blank" targetBlankIcon={false}>
                         {matchResult.exceptionCount.toLocaleString()} matching exception
-                        {matchResult.exceptionCount === 1 ? '' : 's'}
+                        {matchResult.exceptionCount === 1 ? '' : <span>s</span>}
                     </Link>
                 </>
             ) : (
                 <Link to={`${window.location.origin}${exceptionsUrl}`} target="_blank" targetBlankIcon={false}>
                     {matchResult.exceptionCount.toLocaleString()} exception
-                    {matchResult.exceptionCount === 1 ? '' : 's'}
+                    {matchResult.exceptionCount === 1 ? '' : <span>s</span>}
                 </Link>
             )}{' '}
             {suffix(issuesLink, dateRangeLabel)}

--- a/products/error_tracking/mcp/apps/ErrorDetailsView.tsx
+++ b/products/error_tracking/mcp/apps/ErrorDetailsView.tsx
@@ -119,8 +119,8 @@ export function ErrorDetailsView({ data }: { data: ErrorDetailsData }): ReactEle
 
                 {events.length > 1 && (
                     <span className="text-xs text-muted-foreground">
-                        Showing most recent event. {events.length - 1} more event{events.length - 1 === 1 ? '' : 's'} in
-                        this issue.
+                        Showing most recent event. {events.length - 1} more event
+                        {events.length - 1 === 1 ? '' : <span>s</span>} in this issue.
                     </span>
                 )}
             </div>

--- a/products/error_tracking/mcp/apps/ErrorIssueListView.tsx
+++ b/products/error_tracking/mcp/apps/ErrorIssueListView.tsx
@@ -81,7 +81,7 @@ export function ErrorIssueListView({ data, onIssueClick }: ErrorIssueListViewPro
                             <div className="flex items-center justify-between">
                                 <span className="text-sm text-muted-foreground">
                                     {data.count ?? data.results.length} issue
-                                    {(data.count ?? data.results.length) === 1 ? '' : 's'}
+                                    {(data.count ?? data.results.length) === 1 ? '' : <span>s</span>}
                                 </span>
                             </div>
                             <DataTable<ErrorIssueData>

--- a/products/error_tracking/mcp/apps/StackTraceView.tsx
+++ b/products/error_tracking/mcp/apps/StackTraceView.tsx
@@ -138,7 +138,7 @@ function ExceptionSection({ exception, index }: { exception: ExceptionData; inde
                         <div className="mt-1">
                             <div className="flex items-center gap-2 mb-1">
                                 <span className="text-xs text-muted-foreground">
-                                    {displayFrames.length} frame{displayFrames.length === 1 ? '' : 's'}
+                                    {displayFrames.length} frame{displayFrames.length === 1 ? '' : <span>s</span>}
                                 </span>
                                 {inAppCount > 0 && (
                                     <span className="text-xs text-muted-foreground">({inAppCount} in-app)</span>

--- a/products/experiments/mcp/apps/ExperimentListView.tsx
+++ b/products/experiments/mcp/apps/ExperimentListView.tsx
@@ -76,9 +76,11 @@ export function ExperimentListView({ data, onExperimentClick }: ExperimentListVi
                                     {variants.map((v) => (
                                         <Badge key={v.key} variant={v.key === 'control' ? 'default' : 'info'}>
                                             {v.key}
-                                            {(v.split_percent ?? v.rollout_percentage) != null
-                                                ? `: ${v.split_percent ?? v.rollout_percentage}%`
-                                                : ''}
+                                            {(v.split_percent ?? v.rollout_percentage) != null ? (
+                                                <span>{`: ${v.split_percent ?? v.rollout_percentage}%`}</span>
+                                            ) : (
+                                                ''
+                                            )}
                                         </Badge>
                                     ))}
                                 </div>
@@ -103,7 +105,7 @@ export function ExperimentListView({ data, onExperimentClick }: ExperimentListVi
                         <div className="flex flex-col gap-2">
                             <div className="flex items-center justify-between">
                                 <span className="text-sm text-muted-foreground">
-                                    {data.results.length} experiment{data.results.length === 1 ? '' : 's'}
+                                    {data.results.length} experiment{data.results.length === 1 ? '' : <span>s</span>}
                                 </span>
                             </div>
                             <DataTable<ExperimentData>

--- a/products/live_debugger/frontend/StateInspector.tsx
+++ b/products/live_debugger/frontend/StateInspector.tsx
@@ -110,7 +110,7 @@ export function StateInspector({
                                             </div>
                                             <div className="text-muted text-xs truncate">
                                                 {fileName}
-                                                {lineNumber ? `:${lineNumber}` : ''}
+                                                {lineNumber ? <span>{`:${lineNumber}`}</span> : ''}
                                             </div>
                                         </div>
                                         {lineNumber && (

--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -319,7 +319,7 @@ export function ConversationMessagesDisplay({
                     <h4 className="flex items-center justify-between text-xs font-semibold mb-2">
                         <div className="flex items-center gap-x-1.5">
                             <IconExclamation className="text-base text-danger" />
-                            Error {httpStatus ? `(${httpStatus})` : ''}
+                            Error {httpStatus ? <span>{`(${httpStatus})`}</span> : ''}
                         </div>
                     </h4>
                     <div className="flex items-center gap-1.5 rounded border text-default p-2 font-medium bg-[var(--bg-fill-error-tertiary)] border-danger overflow-x-auto">

--- a/products/llm_analytics/frontend/LLMAnalyticsSessionScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsSessionScene.tsx
@@ -143,7 +143,7 @@ function SessionSceneWrapper(): JSX.Element {
                             </LemonTag>
                             <LemonTag size="medium" className="bg-surface-primary">
                                 {sessionStats.traceCount}
-                                {hasMoreData ? '+' : ''} {sessionStats.traceCount === 1 ? 'trace' : 'traces'}
+                                {hasMoreData ? <span>+</span> : ''} {sessionStats.traceCount === 1 ? 'trace' : 'traces'}
                             </LemonTag>
                             {sessionStats.totalCost > 0 && (
                                 <LemonTag size="medium" className="bg-surface-primary">

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
@@ -203,9 +203,11 @@ function LLMAnalyticsEvaluationsContent({ tabId }: { tabId?: string }): JSX.Elem
                         const propertyCount = condition.properties?.length ?? 0
                         return (
                             <LemonTag key={condition.id} type="option">
-                                {parseFloat((condition.rollout_percentage ?? 0).toFixed(2))}%
-                                {propertyCount > 0 &&
-                                    ` when ${propertyCount} condition${propertyCount !== 1 ? 's' : ''}`}
+                                {parseFloat((condition.rollout_percentage ?? 0).toFixed(2))}
+                                <span>%</span>
+                                {propertyCount > 0 && (
+                                    <span>{` when ${propertyCount} condition${propertyCount !== 1 ? 's' : ''}`}</span>
+                                )}
                             </LemonTag>
                         )
                     })}
@@ -232,7 +234,7 @@ function LLMAnalyticsEvaluationsContent({ tabId }: { tabId?: string }): JSX.Elem
                 return (
                     <div className="flex flex-col items-center">
                         <div className="text-sm">
-                            {stats.runs_count} run{stats.runs_count !== 1 ? 's' : ''}
+                            {stats.runs_count} run{stats.runs_count !== 1 ? <span>s</span> : ''}
                         </div>
                         <div className={`font-semibold ${passRateColor}`}>
                             {parseFloat(stats.pass_rate.toFixed(2))}%

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -215,7 +215,8 @@ function SummaryStatistics({
         <div className="mt-1 text-xs text-muted">
             {filter === 'all' && (
                 <>
-                    {statistics.pass_count} passed, {statistics.fail_count} failed
+                    {statistics.pass_count} <span>passed, </span>
+                    {statistics.fail_count} <span>failed</span>
                     {statistics.na_count > 0 && <>, {statistics.na_count} N/A</>}
                 </>
             )}

--- a/products/llm_analytics/frontend/feedback-view/wizard/FeedbackSurveyWizard.tsx
+++ b/products/llm_analytics/frontend/feedback-view/wizard/FeedbackSurveyWizard.tsx
@@ -336,7 +336,7 @@ function ImplementStep(): JSX.Element {
                                 </CodeSnippet>
                                 <p className="text-xs text-muted mt-2">
                                     Send survey events directly.
-                                    {followUpEnabled ? " You'll need to build your own follow-up UI." : ''}
+                                    {followUpEnabled ? <span> You'll need to build your own follow-up UI.</span> : ''}
                                 </p>
                             </div>
                         ),

--- a/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
+++ b/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
@@ -80,7 +80,8 @@ export function PromptViewDetails(): JSX.Element {
                     </LemonTag>
                 )}
                 <span className="text-secondary text-sm">
-                    This prompt has {prompt.version_count} published version{prompt.version_count === 1 ? '' : 's'}.
+                    This prompt has {prompt.version_count} published version
+                    {prompt.version_count === 1 ? '' : <span>s</span>}.
                 </span>
             </div>
 

--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -606,7 +606,7 @@ function DeleteKeyModal({
                         <div className="bg-bg-light border rounded p-3">
                             <p className="font-medium mb-2">
                                 {dependentConfigs!.evaluations.length} evaluation
-                                {dependentConfigs!.evaluations.length === 1 ? '' : 's'} using this key:
+                                {dependentConfigs!.evaluations.length === 1 ? '' : <span>s</span>} using this key:
                             </p>
                             <ul className="list-disc pl-4 text-sm text-muted space-y-1">
                                 {dependentConfigs!.evaluations.map((evaluation) => (
@@ -704,9 +704,11 @@ function AssignKeyModal(): JSX.Element | null {
                         onClick={() => confirmAssignKey(Array.from(selectedIds), enableAfterAssign && hasDisabledEvals)}
                     >
                         Apply key
-                        {selectedIds.size > 0
-                            ? ` to ${selectedIds.size} evaluation${selectedIds.size !== 1 ? 's' : ''}`
-                            : ''}
+                        {selectedIds.size > 0 ? (
+                            <span>{` to ${selectedIds.size} evaluation${selectedIds.size !== 1 ? 's' : ''}`}</span>
+                        ) : (
+                            ''
+                        )}
                     </LemonButton>
                 </>
             }

--- a/products/llm_analytics/frontend/skills/LLMSkillScene.tsx
+++ b/products/llm_analytics/frontend/skills/LLMSkillScene.tsx
@@ -278,7 +278,8 @@ function SkillViewDetails(): JSX.Element {
                     </LemonTag>
                 )}
                 <span className="text-secondary text-sm">
-                    This skill has {skill.version_count} published version{skill.version_count === 1 ? '' : 's'}.
+                    This skill has {skill.version_count} published version
+                    {skill.version_count === 1 ? '' : <span>s</span>}.
                 </span>
             </div>
 

--- a/products/llm_analytics/frontend/skills/LLMSkillsScene.tsx
+++ b/products/llm_analytics/frontend/skills/LLMSkillsScene.tsx
@@ -165,7 +165,7 @@ function GroupHeader({ node }: { node: SkillGroupNode }): JSX.Element {
         <div className="flex items-center gap-2">
             <span className="font-mono font-semibold">{node.prefix}</span>
             <span className="text-muted-alt text-xs">
-                {node.count} skill{node.count === 1 ? '' : 's'}
+                {node.count} skill{node.count === 1 ? '' : <span>s</span>}
             </span>
         </div>
     )
@@ -244,7 +244,7 @@ function GroupedSkillsView({
                     <div className="flex items-center gap-2 px-2">
                         <span className="font-semibold">Ungrouped</span>
                         <span className="text-muted-alt text-xs">
-                            {tree.ungrouped.length} skill{tree.ungrouped.length === 1 ? '' : 's'}
+                            {tree.ungrouped.length} skill{tree.ungrouped.length === 1 ? '' : <span>s</span>}
                         </span>
                     </div>
                     <SkillLeafTable skills={tree.ungrouped} columns={columns} />

--- a/products/llm_analytics/frontend/text-view/components/NestedContentRenderer.tsx
+++ b/products/llm_analytics/frontend/text-view/components/NestedContentRenderer.tsx
@@ -130,7 +130,7 @@ export function NestedContentRenderer({
                                         title={isNestedExpanded ? 'Collapse' : 'Expand'}
                                     >
                                         {isNestedExpanded ? '[−]' : '[+]'} {hiddenTools.length} more tool
-                                        {hiddenTools.length > 1 ? 's' : ''}
+                                        {hiddenTools.length > 1 ? <span>s</span> : ''}
                                     </button>
                                     {isNestedExpanded && (
                                         <div className="ml-4 mt-2 mb-2">

--- a/products/llm_analytics/frontend/text-view/components/SegmentRenderer.tsx
+++ b/products/llm_analytics/frontend/text-view/components/SegmentRenderer.tsx
@@ -142,7 +142,7 @@ export function SegmentRenderer({
                             title={isExpanded ? 'Collapse' : 'Expand'}
                         >
                             {isExpanded ? '[−]' : '[+]'} {hiddenTools.length} more tool
-                            {hiddenTools.length > 1 ? 's' : ''}
+                            {hiddenTools.length > 1 ? <span>s</span> : ''}
                         </button>
                         {isExpanded && (
                             <div className="ml-4 mt-2 mb-2">

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertSimulation.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertSimulation.tsx
@@ -207,8 +207,8 @@ function SimulationIncidents({ incidents, threshold }: { incidents: Incident[]; 
     if (incidents.length === 0) {
         return (
             <div className="text-center py-4 text-secondary text-sm border rounded">
-                No alerts — the alert would not have fired during this period.
-                {threshold > 0 && ' Consider lowering the threshold.'}
+                <span>No alerts — the alert would not have fired during this period.</span>
+                {threshold > 0 && <span> Consider lowering the threshold.</span>}
             </div>
         )
     }

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/RelatedErrors/RelatedErrorsTab.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/RelatedErrors/RelatedErrorsTab.tsx
@@ -90,7 +90,7 @@ function RelatedIssuesList({ issues }: RelatedIssuesListProps): JSX.Element {
     return (
         <div className="flex flex-col">
             <p className="text-muted text-sm mb-2">
-                {issues.length} error{issues.length !== 1 ? 's' : ''} found in this session
+                {issues.length} error{issues.length !== 1 ? <span>s</span> : ''} found in this session
             </p>
             {issues.map((issue) => (
                 <ErrorTrackingIssueCard key={issue.id} issue={issue} showUserCount={false} />

--- a/products/mcp_store/frontend/scene/InstalledServersList.tsx
+++ b/products/mcp_store/frontend/scene/InstalledServersList.tsx
@@ -54,8 +54,12 @@ export function InstalledServersList(): JSX.Element | null {
                                     <div className="flex-1 min-w-0">
                                         <h4 className="mb-0 truncate">{installation.name}</h4>
                                         <div className="text-xs text-secondary truncate">
-                                            {toolCount} tool{toolCount === 1 ? '' : 's'}
-                                            {installation.description ? ` · ${installation.description}` : ''}
+                                            {toolCount} tool{toolCount === 1 ? '' : <span>s</span>}
+                                            {installation.description ? (
+                                                <span>{` · ${installation.description}`}</span>
+                                            ) : (
+                                                ''
+                                            )}
                                         </div>
                                     </div>
                                     {statusTag}

--- a/products/product_analytics/mcp/apps/InsightActorsView.tsx
+++ b/products/product_analytics/mcp/apps/InsightActorsView.tsx
@@ -118,8 +118,8 @@ export function InsightActorsView({ data, openLink }: InsightActorsViewProps): R
             <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between">
                     <span className="text-sm text-muted-foreground">
-                        {rows.length} actor{rows.length === 1 ? '' : 's'}
-                        {data.hasMore ? '+' : ''}
+                        {rows.length} actor{rows.length === 1 ? '' : <span>s</span>}
+                        {data.hasMore ? <span>+</span> : ''}
                     </span>
                 </div>
                 <DataTable<ActorRow>

--- a/products/revenue_analytics/frontend/settings/ExternalDataSourceConfiguration.tsx
+++ b/products/revenue_analytics/frontend/settings/ExternalDataSourceConfiguration.tsx
@@ -125,7 +125,9 @@ export function ExternalDataSourceConfiguration({
                             return (
                                 <span className="inline-flex items-centet gap-2">
                                     <Link to={urls.dataWarehouseSource(`managed-${source.id}`)}>
-                                        {source.source_type}&nbsp;{source.prefix && `(${source.prefix})`}
+                                        {source.source_type}
+                                        <span>&nbsp;</span>
+                                        {source.prefix && <span>{`(${source.prefix})`}</span>}
                                     </Link>
                                     <AccessControlAction
                                         resourceType={AccessControlResourceType.RevenueAnalytics}

--- a/products/session_summaries/frontend/SessionGroupSummaryDetailsModal.tsx
+++ b/products/session_summaries/frontend/SessionGroupSummaryDetailsModal.tsx
@@ -130,8 +130,9 @@ export function SessionGroupSummaryDetailsModal({ isOpen, onClose, event }: Sess
                                                 {' ('}
                                                 <code className="text-xs text-muted bg-fill-secondary px-1 py-0.5 rounded">
                                                     {event.target_event.event}
-                                                    {event.target_event.event_type &&
-                                                        ` (${event.target_event.event_type})`}
+                                                    {event.target_event.event_type && (
+                                                        <span>{` (${event.target_event.event_type})`}</span>
+                                                    )}
                                                 </code>
                                                 )
                                             </>

--- a/products/session_summaries/frontend/SessionGroupSummaryScene.tsx
+++ b/products/session_summaries/frontend/SessionGroupSummaryScene.tsx
@@ -193,7 +193,8 @@ function PatternCard({
                 <h3 className="text-base font-medium mb-0">{pattern.pattern_name}</h3>
                 <div className="flex flex-wrap items-center gap-2 text-sm text-muted mb-2">
                     <span>
-                        {pattern.stats.sessions_affected} session{pattern.stats.sessions_affected > 1 ? 's' : ''}
+                        {pattern.stats.sessions_affected} session
+                        {pattern.stats.sessions_affected > 1 ? <span>s</span> : ''}
                     </span>
                     <span className="hidden sm:inline">·</span>
                     <span>{(pattern.stats.sessions_affected_ratio * 100).toFixed(0)}%</span>

--- a/products/surveys/mcp/apps/SurveyListView.tsx
+++ b/products/surveys/mcp/apps/SurveyListView.tsx
@@ -90,7 +90,7 @@ export function SurveyListView({ data, onSurveyClick }: SurveyListViewProps): Re
                         <div className="flex flex-col gap-2">
                             <div className="flex items-center justify-between">
                                 <span className="text-sm text-muted-foreground">
-                                    {data.results.length} survey{data.results.length === 1 ? '' : 's'}
+                                    {data.results.length} survey{data.results.length === 1 ? '' : <span>s</span>}
                                 </span>
                             </div>
                             <DataTable<SurveyData>

--- a/products/tracing/frontend/TraceCompareFlame.tsx
+++ b/products/tracing/frontend/TraceCompareFlame.tsx
@@ -234,19 +234,19 @@ function FlameRow({ node, fraction, selfPath, onFocus }: FlameRowProps): JSX.Ele
             <br />
             count: {fmtCount(current)}
             <DeltaPct current={current?.count} previous={previous?.count} />
-            {previous ? ` (prev ${fmtCount(previous)})` : ''}
+            {previous ? <span>{` (prev ${fmtCount(previous)})`}</span> : ''}
             <br />
             p50: {fmtDur(current?.p50_duration_nano)}
             <DeltaPct current={current?.p50_duration_nano} previous={previous?.p50_duration_nano} higherIsWorse />
-            {previous ? ` (prev ${fmtDur(previous.p50_duration_nano)})` : ''}
+            {previous ? <span>{` (prev ${fmtDur(previous.p50_duration_nano)})`}</span> : ''}
             <br />
             p95: {fmtDur(current?.p95_duration_nano)}
             <DeltaPct current={current?.p95_duration_nano} previous={previous?.p95_duration_nano} higherIsWorse />
-            {previous ? ` (prev ${fmtDur(previous.p95_duration_nano)})` : ''}
+            {previous ? <span>{` (prev ${fmtDur(previous.p95_duration_nano)})`}</span> : ''}
             <br />
             total: {fmtDur(current?.total_duration_nano)}
             <DeltaPct current={current?.total_duration_nano} previous={previous?.total_duration_nano} higherIsWorse />
-            {previous ? ` (prev ${fmtDur(previous.total_duration_nano)})` : ''}
+            {previous ? <span>{` (prev ${fmtDur(previous.total_duration_nano)})`}</span> : ''}
             {current && current.error_count > 0 ? (
                 <>
                     <br />

--- a/products/tracing/frontend/TraceFlameChart.tsx
+++ b/products/tracing/frontend/TraceFlameChart.tsx
@@ -569,7 +569,7 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
                                             <strong>{span.name}</strong>
                                             <br />
                                             {span.service_name} · {formatDuration(span.duration_nano)}
-                                            {isError ? ' · Error' : ''}
+                                            {isError ? <span> · Error</span> : ''}
                                         </span>
                                     }
                                 >

--- a/products/tracing/mcp/apps/TraceSpanListView.tsx
+++ b/products/tracing/mcp/apps/TraceSpanListView.tsx
@@ -120,8 +120,8 @@ export function TraceSpanListView({ data, onSpanClick }: TraceSpanListViewProps)
                         <div className="flex flex-col gap-2">
                             <div className="flex items-center justify-between">
                                 <span className="text-sm text-muted-foreground">
-                                    {data.results.length} span{data.results.length === 1 ? '' : 's'}
-                                    {data.hasMore ? '+' : ''}
+                                    {data.results.length} span{data.results.length === 1 ? '' : <span>s</span>}
+                                    {data.hasMore ? <span>+</span> : ''}
                                 </span>
                             </div>
                             <DataTable<TraceSpanData>

--- a/products/visual_review/frontend/components/SnapshotChangeBadge.tsx
+++ b/products/visual_review/frontend/components/SnapshotChangeBadge.tsx
@@ -153,7 +153,7 @@ export function SnapshotChangeBadge({ snapshot, size = 'default' }: ChangeBadgeP
                 }`}
             >
                 <IconWarning className={iconClass} />
-                {!isCompact && 'Size changed'}
+                {!isCompact && <span>Size changed</span>}
             </span>
         </Tooltip>
     ) : null

--- a/products/visual_review/frontend/components/SnapshotClusterPanel.tsx
+++ b/products/visual_review/frontend/components/SnapshotClusterPanel.tsx
@@ -88,8 +88,8 @@ export function SnapshotClusterPanel({
                                     {cluster.x},{cluster.y} · {cluster.width}×{cluster.height}
                                 </div>
                                 <div className="text-muted">
-                                    {formatNumber(cluster.pixel_count)} px
-                                    {pctOfImage != null && ` · ${pctOfImage.toFixed(2)}%`}
+                                    {formatNumber(cluster.pixel_count)} <span>px</span>
+                                    {pctOfImage != null && <span>{` · ${pctOfImage.toFixed(2)}%`}</span>}
                                 </div>
                             </div>
                         </button>

--- a/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
+++ b/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
@@ -143,8 +143,9 @@ export function SnapshotDiffViewer({
                     <h3 className="text-lg font-semibold capitalize">{pageName}</h3>
                     {variant && (
                         <span className="text-sm text-muted">
-                            @ {variant}
-                            {width && height && ` · ${width}×${height}`}
+                            <span>@ </span>
+                            {variant}
+                            {width && height && <span>{` · ${width}×${height}`}</span>}
                         </span>
                     )}
                 </div>
@@ -208,9 +209,11 @@ export function SnapshotDiffViewer({
                     {isQuarantined && quarantineEntry && (
                         <div className="bg-warning-highlight border border-warning rounded px-3 py-2 mb-4 text-sm text-muted-alt flex items-center gap-1.5">
                             <span>
-                                Quarantined — {quarantineEntry.reason}
-                                {quarantineEntry.expires_at &&
-                                    ` · until ${new Date(quarantineEntry.expires_at).toLocaleDateString()}`}
+                                <span>Quarantined — </span>
+                                {quarantineEntry.reason}
+                                {quarantineEntry.expires_at && (
+                                    <span>{` · until ${new Date(quarantineEntry.expires_at).toLocaleDateString()}`}</span>
+                                )}
                             </span>
                             {quarantineEntry.created_by && (
                                 <>

--- a/products/visual_review/frontend/components/SnapshotStatusIndicator.tsx
+++ b/products/visual_review/frontend/components/SnapshotStatusIndicator.tsx
@@ -74,7 +74,7 @@ export function SnapshotStatusIndicator({
                 {review && (
                     <span className={`text-xs ${review.className}`}>
                         {reviewState === 'approved' && <IconCheck className="w-3.5 h-3.5 inline" />}
-                        {reviewState === 'tolerated' && '~'}
+                        {reviewState === 'tolerated' && <span>~</span>}
                     </span>
                 )}
             </span>

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -280,8 +280,8 @@ export function VisualReviewRunScene(): JSX.Element {
             <SceneContent>
                 <SceneTitleSection name={run.branch} resourceType={{ type: 'visual_review' }} />
                 <LemonBanner type="error">
-                    This run failed to process.{run.error_message ? ` ${run.error_message}` : ''} Check the CI logs for
-                    details, or rerun the job to try again.
+                    This run failed to process.{run.error_message ? <span>{` ${run.error_message}`}</span> : ''} Check
+                    the CI logs for details, or rerun the job to try again.
                 </LemonBanner>
             </SceneContent>
         )
@@ -397,7 +397,7 @@ export function VisualReviewRunScene(): JSX.Element {
                                         reviewPending > 0 && (
                                             <span key="pend">
                                                 <span className="font-semibold">{reviewPending}</span>
-                                                {hasMore ? '+' : ''} pending
+                                                {hasMore ? <span>+</span> : ''} pending
                                             </span>
                                         ),
                                         reviewApproved > 0 && (

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotHistoryScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotHistoryScene.tsx
@@ -222,7 +222,10 @@ function QuarantineSection({
                 }}
             >
                 <div className="text-sm flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="font-semibold">Quarantined{label && ` (${label})`}</span>
+                    <span className="font-semibold">
+                        <span>Quarantined</span>
+                        {label && <span>{` (${label})`}</span>}
+                    </span>
                     <span>— {quarantineEntry.reason || 'no reason given'}</span>
                     {expires && (
                         <>

--- a/products/workflows/frontend/OptOuts/CustomerIOImportModal.tsx
+++ b/products/workflows/frontend/OptOuts/CustomerIOImportModal.tsx
@@ -249,7 +249,9 @@ function Step2Content(): JSX.Element {
 
     if (csvFailed) {
         return (
-            <LemonBanner type="error">CSV import failed{csvFailureDetail ? `: ${csvFailureDetail}` : ''}</LemonBanner>
+            <LemonBanner type="error">
+                CSV import failed{csvFailureDetail ? <span>{`: ${csvFailureDetail}`}</span> : ''}
+            </LemonBanner>
         )
     }
 

--- a/products/workflows/frontend/Workflows/BlockedRunsReplay.tsx
+++ b/products/workflows/frontend/Workflows/BlockedRunsReplay.tsx
@@ -172,7 +172,7 @@ export function BlockedRunsReplay({ id }: { id: string }): JSX.Element {
             {selectedCount > 0 && (
                 <div className="flex items-center gap-2">
                     <span className="text-muted text-sm">
-                        {selectedCount} run{selectedCount !== 1 ? 's' : ''} selected
+                        {selectedCount} run{selectedCount !== 1 ? <span>s</span> : ''} selected
                     </span>
                     <LemonButton type="primary" size="small" onClick={confirmReplay}>
                         Replay selected

--- a/products/workflows/frontend/Workflows/WorkflowLogs.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowLogs.tsx
@@ -122,7 +122,7 @@ function UpcomingOccurrences(): JSX.Element | null {
                 )}
                 <div className="text-xs text-muted mb-2">
                     <span className="font-semibold uppercase tracking-wide">Next occurrences</span>
-                    {timezone ? ` in ${timezone}` : ''}
+                    {timezone ? <span>{` in ${timezone}`}</span> : ''}
                 </div>
                 <div className="space-y-1.5">
                     <OccurrencesList

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -366,7 +366,8 @@ export function WorkflowsTable(props: WorkflowsSceneProps): JSX.Element {
                     {isArchived && selectedArchivedCount > 0 && (
                         <div className="flex items-center gap-2 mb-2">
                             <span className="text-muted text-sm">
-                                {selectedArchivedCount} workflow{selectedArchivedCount !== 1 ? 's' : ''} selected
+                                {selectedArchivedCount} workflow{selectedArchivedCount !== 1 ? <span>s</span> : ''}{' '}
+                                selected
                             </span>
                             <LemonButton
                                 type="secondary"

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/OccurrencesList.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/OccurrencesList.tsx
@@ -68,7 +68,7 @@ export function OccurrencesList({
             <>
                 {head.map((date, i) => renderRow(date, i))}
                 <div className="text-xs text-muted italic pl-4">
-                    ...{hiddenCount} more occurrence{hiddenCount > 1 ? 's' : ''}...
+                    ...{hiddenCount} more occurrence{hiddenCount > 1 ? <span>s</span> : ''}...
                 </div>
                 {tail.map((date, i) => renderRow(date, total - VISIBLE_TAIL + i))}
             </>

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/RecurringSchedulePicker.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/RecurringSchedulePicker.tsx
@@ -225,7 +225,7 @@ function SchedulePreview({ state, summary, previewOccurrences, timezone }: Sched
                                 ? `${previewOccurrences.length} occurrences`
                                 : 'Next occurrences'}
                         </span>
-                        {timezone ? ` in ${timezone}` : ''}
+                        {timezone ? <span>{` in ${timezone}`}</span> : ''}
                     </div>
                     <div className="space-y-1.5">
                         <OccurrencesList

--- a/products/workflows/mcp/apps/WorkflowListView.tsx
+++ b/products/workflows/mcp/apps/WorkflowListView.tsx
@@ -85,7 +85,7 @@ export function WorkflowListView({ data, onWorkflowClick }: WorkflowListViewProp
                             <div className="flex items-center justify-between">
                                 <span className="text-sm text-muted-foreground">
                                     {data.count ?? data.results.length} workflow
-                                    {(data.count ?? data.results.length) === 1 ? '' : 's'}
+                                    {(data.count ?? data.results.length) === 1 ? '' : <span>s</span>}
                                 </span>
                             </div>
                             <DataTable<WorkflowData>


### PR DESCRIPTION
## Problem

We've got an ongoing issue https://us.posthog.com/project/2/error_tracking/019c29c3-9af5-7f20-b993-82bfc23a628e, this happens when the user is actively translating the page using a browser extension, or the Chrome in-built translator or even other extensions too.

The issue is documented here, along with some resolutions: https://github.com/facebook/react/issues/11538. It looks like React are not going to be guarding this case, so the choices are to either monkey patch, or fix each occurence. The two options are described concisely here: https://github.com/facebook/react/issues/11538#issuecomment-729716654

## Changes

Updated all instances identified as problematic with the workaround described in the GitHub issue.

## How did you test this code?

CI passes.

## Publish to changelog?

no.

## 🤖 Agent context

Wraps `{cond && 'string'}` and `{cond ? 'string' : ''}` JSX patterns in `<span>` and wraps bare JSXText that sits next to a conditional element sibling. This is the canonical fix for facebook/react#11538: third-party DOM mutators (Chrome Translate, password managers, ad blockers) replace the text node React is still tracking, so a subsequent `removeChild` / `insertBefore` from the reconciler throws a NotFoundError DOMException that crashes the tree.

Patterns transformed throughout `frontend/src` and `products/`:

```
  {cond && 'string'}          -> {cond && <span>string</span>}
  {cond && \`tpl \${x}\`}     -> {cond && <span>{\`tpl \${x}\`}</span>}
  {cond ? 'string' : ''}      -> {cond ? <span>string</span> : ''}
  bare-text-in-cond-parent    -> <span>bare-text</span>
```

Single-child string conditionals are intentionally left alone - React does not call removeChild on them (per the React #11538 analysis). Ternaries with two non-empty string branches are also left alone since React reuses the text node and only updates nodeValue.

Generated-By: PostHog Code
Task-Id: `6ee2d3ec-10e9-4333-89d1-6e167688b5dc`
