### PR TITLE
fix(tracing): use correct attribute_type values in attribute queries

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1010,12 +1010,12 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         searchPlaceholder: 'span attributes',
                         type: TaxonomicFilterGroupType.SpanAttributes,
                         endpoint: combineUrl(`api/environments/${projectId}/tracing/spans/attributes`, {
-                            attribute_type: 'span',
+                            attribute_type: 'span_attribute',
                             ...endpointFilters,
                         }).url,
                         valuesEndpoint: (key) =>
                             combineUrl(`api/environments/${projectId}/tracing/spans/values`, {
-                                attribute_type: 'span',
+                                attribute_type: 'span_attribute',
                                 key: key,
                                 ...endpointFilters,
                             }).url,
@@ -1028,12 +1028,12 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         searchPlaceholder: 'span resources',
                         type: TaxonomicFilterGroupType.SpanResourceAttributes,
                         endpoint: combineUrl(`api/environments/${projectId}/tracing/spans/attributes`, {
-                            attribute_type: 'resource',
+                            attribute_type: 'span_resource_attribute',
                             ...endpointFilters,
                         }).url,
                         valuesEndpoint: (key) =>
                             combineUrl(`api/environments/${projectId}/tracing/spans/values`, {
-                                attribute_type: 'resource',
+                                attribute_type: 'span_resource_attribute',
                                 key: key,
                                 ...endpointFilters,
                             }).url,

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -587,12 +587,12 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
             searchPlaceholder: 'span attributes',
             type: TaxonomicFilterGroupType.SpanAttributes,
             endpoint: combineUrl(`api/environments/${projectId}/tracing/spans/attributes`, {
-                attribute_type: 'span',
+                attribute_type: 'span_attribute',
                 ...endpointFilters,
             }).url,
             valuesEndpoint: (key) =>
                 combineUrl(`api/environments/${projectId}/tracing/spans/values`, {
-                    attribute_type: 'span',
+                    attribute_type: 'span_attribute',
                     key: key,
                     ...endpointFilters,
                 }).url,
@@ -605,12 +605,12 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
             searchPlaceholder: 'span resources',
             type: TaxonomicFilterGroupType.SpanResourceAttributes,
             endpoint: combineUrl(`api/environments/${projectId}/tracing/spans/attributes`, {
-                attribute_type: 'resource',
+                attribute_type: 'span_resource_attribute',
                 ...endpointFilters,
             }).url,
             valuesEndpoint: (key) =>
                 combineUrl(`api/environments/${projectId}/tracing/spans/values`, {
-                    attribute_type: 'resource',
+                    attribute_type: 'span_resource_attribute',
                     key: key,
                     ...endpointFilters,
                 }).url,

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -512,7 +512,7 @@ def run_service_names_query(
 def run_attribute_names_query(
     team: "Team",
     date_range: DateRange,
-    attribute_type: str = "span",
+    attribute_type: str = "span_attribute",
     search: str = "",
     limit: int = 100,
     offset: int = 0,
@@ -528,7 +528,7 @@ def run_attribute_names_query(
     )
 
     property_filter_type = (
-        attribute_type if attribute_type in ("span", "span_attribute", "span_resource_attribute") else "span_attribute"
+        attribute_type if attribute_type in ("span_attribute", "span_resource_attribute") else "span_attribute"
     )
 
     query = parse_select(
@@ -584,7 +584,7 @@ def run_attribute_names_query(
 def run_attribute_values_query(
     team: "Team",
     date_range: DateRange,
-    attribute_type: str = "span",
+    attribute_type: str = "span_attribute",
     attribute_key: str = "",
     search: str = "",
     limit: int = 100,

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -163,9 +163,9 @@ class _TracingServiceNamesQuerySerializer(serializers.Serializer):
 class _TracingAttributesQuerySerializer(serializers.Serializer):
     search = serializers.CharField(required=False, help_text="Search filter for attribute names.")
     attribute_type = serializers.ChoiceField(
-        choices=["span", "resource"],
+        choices=["span_attribute", "span_resource_attribute"],
         required=False,
-        help_text='Type of attributes: "span" for span attributes, "resource" for resource attributes.',
+        help_text='Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.',
     )
     limit = serializers.IntegerField(
         required=False, min_value=1, max_value=100, help_text="Max results (default: 100)."
@@ -176,9 +176,9 @@ class _TracingAttributesQuerySerializer(serializers.Serializer):
 class _TracingValuesQuerySerializer(serializers.Serializer):
     key = serializers.CharField(help_text="The attribute key to get values for.")
     attribute_type = serializers.ChoiceField(
-        choices=["span", "resource"],
+        choices=["span", "span_attribute", "span_resource_attribute"],
         required=False,
-        help_text='Type of attribute: "span" or "resource".',
+        help_text='Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.',
     )
     value = serializers.CharField(required=False, help_text="Search filter for attribute values.")
     limit = serializers.IntegerField(
@@ -518,9 +518,9 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         except (json.JSONDecodeError, ValidationError, ValueError):
             date_range = DateRange(date_from="-1h")
 
-        attribute_type = request.GET.get("attribute_type", "span")
-        if attribute_type not in ("span", "resource"):
-            attribute_type = "span"
+        attribute_type = request.GET.get("attribute_type", "span_attribute")
+        if attribute_type not in ("span_attribute", "span_resource_attribute"):
+            attribute_type = "span_attribute"
 
         results, count = run_attribute_names_query(
             team=self.team,
@@ -550,9 +550,9 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         except (json.JSONDecodeError, ValidationError, ValueError):
             date_range = DateRange(date_from="-1h")
 
-        attribute_type = request.GET.get("attribute_type", "span")
-        if attribute_type not in ("span", "resource"):
-            attribute_type = "span"
+        attribute_type = request.GET.get("attribute_type", "span_attribute")
+        if attribute_type not in ("span", "span_attribute", "span_resource_attribute"):
+            attribute_type = "span_attribute"
 
         results = run_attribute_values_query(
             team=self.team,

--- a/products/tracing/frontend/generated/api.schemas.ts
+++ b/products/tracing/frontend/generated/api.schemas.ts
@@ -181,10 +181,10 @@ export interface _TracingTreeRequestApi {
 
 export type TracingSpansAttributesRetrieveParams = {
     /**
- * Type of attributes: "span" for span attributes, "resource" for resource attributes.
+ * Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
 
-* `span` - span
-* `resource` - resource
+* `span_attribute` - span_attribute
+* `span_resource_attribute` - span_resource_attribute
  * @minLength 1
  */
     attribute_type?: TracingSpansAttributesRetrieveAttributeType
@@ -210,8 +210,8 @@ export type TracingSpansAttributesRetrieveAttributeType =
     (typeof TracingSpansAttributesRetrieveAttributeType)[keyof typeof TracingSpansAttributesRetrieveAttributeType]
 
 export const TracingSpansAttributesRetrieveAttributeType = {
-    Span: 'span',
-    Resource: 'resource',
+    SpanAttribute: 'span_attribute',
+    SpanResourceAttribute: 'span_resource_attribute',
 } as const
 
 export type TracingSpansServiceNamesRetrieveParams = {
@@ -229,10 +229,11 @@ export type TracingSpansServiceNamesRetrieveParams = {
 
 export type TracingSpansValuesRetrieveParams = {
     /**
- * Type of attribute: "span" or "resource".
+ * Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
 
 * `span` - span
-* `resource` - resource
+* `span_attribute` - span_attribute
+* `span_resource_attribute` - span_resource_attribute
  * @minLength 1
  */
     attribute_type?: TracingSpansValuesRetrieveAttributeType
@@ -264,5 +265,6 @@ export type TracingSpansValuesRetrieveAttributeType =
 
 export const TracingSpansValuesRetrieveAttributeType = {
     Span: 'span',
-    Resource: 'resource',
+    SpanAttribute: 'span_attribute',
+    SpanResourceAttribute: 'span_resource_attribute',
 } as const

--- a/products/tracing/mcp/tools.yaml
+++ b/products/tracing/mcp/tools.yaml
@@ -46,9 +46,9 @@ tools:
             idempotent: true
         title: List tracing span attributes
         description: >
-            List available span or resource attribute names. Use attribute_type "span" for span-level attributes or
-            "resource" for resource-level attributes (e.g. k8s labels). Use this to discover available attribute keys
-            before building filters.
+            List available span or resource attribute names. Use attribute_type "span_attribute" for span-level
+            attributes or "span_resource_attribute" for resource-level attributes (e.g. k8s labels). Use this to
+            discover available attribute keys before building filters.
         feature_flag: tracing
         response:
             include:

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -301,7 +301,7 @@
         "feature_flag": "tracing"
     },
     "apm-attributes-list": {
-        "description": "List available span or resource attribute names. Use attribute_type \"span\" for span-level attributes or \"resource\" for resource-level attributes (e.g. k8s labels). Use this to discover available attribute keys before building filters.",
+        "description": "List available span or resource attribute names. Use attribute_type \"span_attribute\" for span-level attributes or \"span_resource_attribute\" for resource-level attributes (e.g. k8s labels). Use this to discover available attribute keys before building filters.",
         "category": "Tracing",
         "feature": "tracing",
         "summary": "List tracing span attributes",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -318,7 +318,7 @@
         "feature_flag": "tracing"
     },
     "apm-attributes-list": {
-        "description": "List available span or resource attribute names. Use attribute_type \"span\" for span-level attributes or \"resource\" for resource-level attributes (e.g. k8s labels). Use this to discover available attribute keys before building filters.",
+        "description": "List available span or resource attribute names. Use attribute_type \"span_attribute\" for span-level attributes or \"span_resource_attribute\" for resource-level attributes (e.g. k8s labels). Use this to discover available attribute keys before building filters.",
         "category": "Tracing",
         "feature": "tracing",
         "summary": "List tracing span attributes",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -38948,10 +38948,10 @@ export namespace Schemas {
 
     export type TracingSpansAttributesRetrieveParams = {
     /**
-     * Type of attributes: "span" for span attributes, "resource" for resource attributes.
+     * Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
 
-    * `span` - span
-    * `resource` - resource
+    * `span_attribute` - span_attribute
+    * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: TracingSpansAttributesRetrieveAttributeType;
@@ -38977,8 +38977,8 @@ export namespace Schemas {
 
 
     export const TracingSpansAttributesRetrieveAttributeType = {
-      Span: 'span',
-      Resource: 'resource',
+      SpanAttribute: 'span_attribute',
+      SpanResourceAttribute: 'span_resource_attribute',
     } as const;
 
     export type TracingSpansServiceNamesRetrieveParams = {
@@ -38996,10 +38996,11 @@ export namespace Schemas {
 
     export type TracingSpansValuesRetrieveParams = {
     /**
-     * Type of attribute: "span" or "resource".
+     * Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
 
     * `span` - span
-    * `resource` - resource
+    * `span_attribute` - span_attribute
+    * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: TracingSpansValuesRetrieveAttributeType;
@@ -39031,7 +39032,8 @@ export namespace Schemas {
 
     export const TracingSpansValuesRetrieveAttributeType = {
       Span: 'span',
-      Resource: 'resource',
+      SpanAttribute: 'span_attribute',
+      SpanResourceAttribute: 'span_resource_attribute',
     } as const;
 
     export type UserInterviewsListParams = {

--- a/services/mcp/src/generated/tracing/api.ts
+++ b/services/mcp/src/generated/tracing/api.ts
@@ -22,10 +22,10 @@ export const tracingSpansAttributesRetrieveQueryOffsetMin = 0
 
 export const TracingSpansAttributesRetrieveQueryParams = /* @__PURE__ */ zod.object({
     attribute_type: zod
-        .enum(['span', 'resource'])
+        .enum(['span_attribute', 'span_resource_attribute'])
         .optional()
         .describe(
-            'Type of attributes: "span" for span attributes, "resource" for resource attributes.\n\n* `span` - span\n* `resource` - resource'
+            'Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.\n\n* `span_attribute` - span_attribute\n* `span_resource_attribute` - span_resource_attribute'
         ),
     limit: zod
         .number()
@@ -196,9 +196,11 @@ export const tracingSpansValuesRetrieveQueryOffsetMin = 0
 
 export const TracingSpansValuesRetrieveQueryParams = /* @__PURE__ */ zod.object({
     attribute_type: zod
-        .enum(['span', 'resource'])
+        .enum(['span', 'span_attribute', 'span_resource_attribute'])
         .optional()
-        .describe('Type of attribute: "span" or "resource".\n\n* `span` - span\n* `resource` - resource'),
+        .describe(
+            'Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.\n\n* `span` - span\n* `span_attribute` - span_attribute\n* `span_resource_attribute` - span_resource_attribute'
+        ),
     key: zod.string().min(1).describe('The attribute key to get values for.'),
     limit: zod
         .number()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/apm-attribute-values-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/apm-attribute-values-list.json
@@ -2,8 +2,8 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "attribute_type": {
-            "description": "Type of attribute: \"span\" or \"resource\".\n\n* `span` - span\n* `resource` - resource",
-            "enum": ["span", "resource"],
+            "description": "Type of attribute: \"span\" for built-in span fields (e.g. name), \"span_attribute\" for span-level attributes, \"span_resource_attribute\" for resource-level attributes.\n\n* `span` - span\n* `span_attribute` - span_attribute\n* `span_resource_attribute` - span_resource_attribute",
+            "enum": ["span", "span_attribute", "span_resource_attribute"],
             "type": "string"
         },
         "key": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/apm-attributes-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/apm-attributes-list.json
@@ -2,8 +2,8 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "attribute_type": {
-            "description": "Type of attributes: \"span\" for span attributes, \"resource\" for resource attributes.\n\n* `span` - span\n* `resource` - resource",
-            "enum": ["span", "resource"],
+            "description": "Type of attributes: \"span_attribute\" for span-level attributes, \"span_resource_attribute\" for resource-level attributes.\n\n* `span_attribute` - span_attribute\n* `span_resource_attribute` - span_resource_attribute",
+            "enum": ["span_attribute", "span_resource_attribute"],
             "type": "string"
         },
         "limit": {


### PR DESCRIPTION
## Problem

The tracing `/attributes` and `/values` endpoints in `products/tracing` were sending `attribute_type` as `"span"` or `"resource"`, but the `trace_attributes` ClickHouse table stores them as `"span_attribute"` and `"span_resource_attribute"` (see `bin/clickhouse-logs.sql`). As a result, the attribute name and value lookups returned no results for span attributes and resource attributes.

## Changes

- Backend serializer choices and defaults in `products/tracing/backend/presentation/views.py` updated to use `span_attribute` / `span_resource_attribute`. The values endpoint additionally accepts `span` for the built-in `name` view stored under that type.
- Default args in `products/tracing/backend/logic.py` updated to `span_attribute`.
- Frontend `TaxonomicFilter` callers in `frontend/src/lib/components/TaxonomicFilter/{taxonomicFilterLogic,utils/buildTaxonomicGroups}.tsx` now send the new values.
- MCP tool description in `products/tracing/mcp/tools.yaml` updated to reflect the new values.
- Generated OpenAPI/Zod/MCP types regenerated via `hogli build:openapi`.

The special `name` valuesEndpoint still passes `attribute_type: 'span'` — that's the type the `name` view writes into `trace_attributes`.

## How did you test this code?

I'm an agent. I did not run the app manually. Automated checks I ran:

- `ruff check products/tracing/backend/` — passes
- `pnpm --filter=@posthog/frontend format` — passes
- `hogli build:openapi` — regenerates types cleanly, generated diff matches the serializer changes
- Pre-commit hooks (`ty check`, lint, format) on the commit — passed

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- Diagnosis: cross-referenced the materialized views in `bin/clickhouse-logs.sql` (lines 362, 403) against the serializer choices and the `SpanPropertyFilterType` enum in `posthog/schema.py` — the enum and storage agree on `span_attribute` / `span_resource_attribute`; only the API surface was stale.
- Considered allowing legacy `span`/`resource` values for backwards compatibility, but rejected: the endpoints were silently returning empty results, so there's no working caller to preserve.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*