### PR TITLE
fix(scenes): only sync pinned tabs from storage while visible

### DIFF
--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1727,12 +1727,27 @@ export const sceneLogic = kea<sceneLogicType>([
                     if (event.key !== getStorageKey(PINNED_TAB_STATE_KEY)) {
                         return
                     }
+                    // Skip while hidden so backgrounded tabs don't re-mount on every remote nav.
+                    // The visibilitychange handler below catches up when the tab is foregrounded.
+                    if (document.visibilityState !== 'visible') {
+                        return
+                    }
                     syncPinnedTabsFromStorage()
+                }
+
+                const onVisibility = (): void => {
+                    if (document.visibilityState === 'visible') {
+                        syncPinnedTabsFromStorage()
+                    }
                 }
 
                 syncPinnedTabsFromStorage()
                 window.addEventListener('storage', onStorage)
-                return () => window.removeEventListener('storage', onStorage)
+                document.addEventListener('visibilitychange', onVisibility)
+                return () => {
+                    window.removeEventListener('storage', onStorage)
+                    document.removeEventListener('visibilitychange', onVisibility)
+                }
             },
             'pinnedTabsStorageListener',
             // Passive storage listener — no need to tear down/re-setup on visibility change.


### PR DESCRIPTION
## Problem

PostHog's scene tabs sync pinned-tab state across windows via a `storage` event listener (added in #57853-ish range, see `sceneLogic.tsx:1696-1742`). The handler navigates the local window with `router.actions.replace(...)` whenever another window changes its active pinned tab. This fires regardless of whether the local tab is visible, so any backgrounded tab on a pinned scene re-mounts its scene logic every time the active tab in some other window navigates.

This has two costs:

- Memory churn — repeated scene-logic re-mounts in idle tabs.
- UX surprise — coming back to a window finds it on a different URL because another window was driving it remotely.

Surfaced during a local idle-leak hunt: idle tabs were bouncing through URLs while another window cycled scenes, hiding the underlying retention pattern.

## Changes

- Skip `syncPinnedTabsFromStorage()` inside the `storage` listener when `document.visibilityState !== 'visible'`.
- Add a `visibilitychange` listener that re-syncs from storage when the tab is foregrounded, so users still get the latest pinned-tab state when they return to a window.
- Same `cache.disposables.add` registration so teardown is unchanged.

The pinned-tab list and active-tab URL still sync between actively visible windows. Backgrounded tabs stay where the user left them.

## How did you test this code?

I'm an agent — I made the code change but did not manually validate the behavior in a browser. The mechanism is straightforward (early return + extra listener) but a human should sanity-check that:

1. Opening the same pinned scene in two visible windows and navigating one still updates the other.
2. Switching away from a window while another window navigates does **not** auto-navigate the hidden window.
3. Coming back to the hidden window catches it up to the latest pinned-tab state.

No existing tests cover this listener. Could add a jest test for `sceneLogic`'s `pinnedTabsStorageListener` disposable but the storage event path is hard to exercise without DOM-level setup; happy to do that if reviewers want.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (agent) during a leak-hunting investigation in the local app. Root cause was found by running `tools/leak-hunter/single-tab-heap-diff.mjs` against `/feature_flags?tab=overview` with an active tab cycling through pinned scenes in parallel; the target tab repeatedly bounced through URLs even while idle, which traced back to the storage listener at `sceneLogic.tsx:1728-1733`.

Decision points:

- Considered scoping by tab id (only sync when local active tab id == remote) — rejected, doesn't address the core issue that backgrounded tabs shouldn't re-mount silently.
- Considered dropping URL sync entirely (only sync the pinned-tab list) — rejected, breaks the intentional same-scene-in-two-visible-windows behavior added in the original feature.
- Settled on visibility gating: preserves the feature for visible windows, removes the silent churn for hidden ones.

No tests were added in this PR — see "How did you test this code?" for reviewer-suggested checks.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*