### PR TITLE
chore(product-analytics): Add a banner to the dashboard when it's shared publicly

### DIFF
--- a/frontend/src/lib/components/Sharing/SharingModal.test.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.test.tsx
@@ -1,6 +1,9 @@
 import '@testing-library/jest-dom'
 
 import { render, screen, within } from '@testing-library/react'
+import { expectLogic } from 'kea-test-utils'
+
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 import { useAvailableFeatures } from '~/mocks/features'
 import { useMocks } from '~/mocks/jest'
@@ -8,6 +11,7 @@ import { initKeaTests } from '~/test/init'
 import { InsightShortId, QueryBasedInsightModel } from '~/types'
 import { AvailableFeature } from '~/types'
 
+import { sharingLogic } from './sharingLogic'
 import { SharingModal, SharingModalProps } from './SharingModal'
 
 const createdAt = '2022-06-28T12:30:51.459746Z'
@@ -17,13 +21,15 @@ const insightShortId = 'insight456' as InsightShortId
 const defaultInsightId = 456
 
 function mockDashboardSharingConfiguration({
+    enabled = true,
     passwordRequired = false,
 }: {
+    enabled?: boolean
     passwordRequired?: boolean
 }): Record<string, any> {
     const sharingConfiguration = {
         created_at: createdAt,
-        enabled: true,
+        enabled,
         access_token: accessToken,
         password_required: passwordRequired,
     }
@@ -100,6 +106,50 @@ describe('SharingModal (dashboard)', () => {
 
         // Dashboard options smoke checks
         expect(screen.getByText(/Show PostHog branding/i)).toBeInTheDocument()
+    })
+
+    it('calls onSharingEnabledChange after the dashboard sharing switch update succeeds', async () => {
+        const onSharingEnabledChange = jest.fn()
+
+        initKeaTests()
+        useMocks({
+            get: mockDashboardSharingConfiguration({ enabled: false }),
+            patch: mockDashboardSharingConfiguration({ enabled: true }),
+        })
+
+        const logic = sharingLogic({ dashboardId, onSharingEnabledChange })
+        eventUsageLogic.mount()
+        await expectLogic(logic, () => {
+            logic.mount()
+        }).toDispatchActions(['loadSharingConfigurationSuccess'])
+        expect(onSharingEnabledChange).not.toHaveBeenCalled()
+
+        await expectLogic(logic, () => {
+            logic.actions.setIsEnabled(true)
+        }).toDispatchActions(['setIsEnabledSuccess'])
+
+        expect(onSharingEnabledChange).toHaveBeenCalledTimes(1)
+        expect(onSharingEnabledChange).toHaveBeenCalledWith(true)
+        logic.unmount()
+        eventUsageLogic.unmount()
+    })
+
+    it('does not call onSharingEnabledChange on initial dashboard sharing load', async () => {
+        const onSharingEnabledChange = jest.fn()
+
+        initKeaTests()
+        useMocks({
+            get: mockDashboardSharingConfiguration({ enabled: true }),
+        })
+
+        const logic = sharingLogic({ dashboardId, onSharingEnabledChange })
+
+        await expectLogic(logic, () => {
+            logic.mount()
+        }).toDispatchActions(['loadSharingConfigurationSuccess'])
+
+        expect(onSharingEnabledChange).not.toHaveBeenCalled()
+        logic.unmount()
     })
 })
 

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -90,6 +90,7 @@ export interface SharingModalBaseProps {
      */
     recordingLinkTimeForm?: ReactNode
     userAccessLevel?: AccessControlLevel
+    onSharingEnabledChange?: (enabled: boolean) => void
 }
 
 export interface SharingModalProps extends SharingModalBaseProps {
@@ -110,6 +111,7 @@ export function SharingModalContent({
     previewIframe = false,
     recordingLinkTimeForm = undefined,
     userAccessLevel,
+    onSharingEnabledChange,
 }: SharingModalBaseProps): JSX.Element {
     const logicProps = {
         dashboardId,
@@ -117,6 +119,7 @@ export function SharingModalContent({
         recordingId,
         notebookShortId,
         additionalParams,
+        onSharingEnabledChange,
     }
     const {
         whitelabelAvailable,

--- a/frontend/src/lib/components/Sharing/sharingLogic.ts
+++ b/frontend/src/lib/components/Sharing/sharingLogic.ts
@@ -21,6 +21,7 @@ export interface SharingLogicProps {
     recordingId?: string
     notebookShortId?: string
     additionalParams?: Record<string, any>
+    onSharingEnabledChange?: (enabled: boolean) => void
 }
 
 export interface EmbedConfig {
@@ -85,7 +86,11 @@ export const sharingLogic = kea<sharingLogicType>([
                     return await api.sharing.get(await propsToApiParams(props))
                 },
                 setIsEnabled: async (enabled: boolean) => {
-                    return await api.sharing.update(await propsToApiParams(props), { enabled })
+                    const sharingConfiguration = await api.sharing.update(await propsToApiParams(props), { enabled })
+                    if (sharingConfiguration) {
+                        props.onSharingEnabledChange?.(sharingConfiguration.enabled)
+                    }
+                    return sharingConfiguration
                 },
                 setPasswordRequired: async (password_required: boolean) => {
                     return await api.sharing.update(await propsToApiParams(props), {

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -27,6 +27,7 @@ import { AddInsightToDashboardModal } from './addInsightToDashboardModal/AddInsi
 import { addInsightToDashboardLogic } from './addInsightToDashboardModalLogic'
 import { DashboardHeader } from './DashboardHeader'
 import { DashboardOverridesBanner } from './DashboardOverridesBanner'
+import { DashboardPublicAccessBanner } from './DashboardPublicAccessBanner'
 import { DashboardZoomControl } from './DashboardZoomControl'
 import { EmptyDashboardComponent } from './EmptyDashboardComponent'
 
@@ -108,6 +109,7 @@ function DashboardScene({ backTo }: { backTo?: { url: string; name: string } }):
         <SceneContent className={cn('dashboard')}>
             {placement == DashboardPlacement.Dashboard && <DashboardHeader />}
             {canEditDashboard && addInsightToDashboardModalVisible && <AddInsightToDashboardModal />}
+            <DashboardPublicAccessBanner dashboard={dashboard} placement={placement} />
 
             {dashboardFailedToLoad ? (
                 <InsightErrorState title="There was an error loading this dashboard" />

--- a/frontend/src/scenes/dashboard/DashboardModals.tsx
+++ b/frontend/src/scenes/dashboard/DashboardModals.tsx
@@ -9,6 +9,7 @@ import { TerraformExportModal } from 'lib/components/TerraformExporter/Terraform
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
+import { dashboardsModel } from '~/models/dashboardsModel'
 import { DashboardMode, DashboardType, QueryBasedInsightModel } from '~/types'
 
 import { DashboardInsightColorsModal } from './DashboardInsightColorsModal'
@@ -30,6 +31,7 @@ export function DashboardModals({ dashboard }: { dashboard: DashboardType<QueryB
         terraformModalOpen,
     } = useValues(dashboardLogic)
     const { setTerraformModalOpen } = useActions(dashboardLogic)
+    const { updateDashboardSuccess } = useActions(dashboardsModel)
     const { push } = useActions(router)
     const { user } = useValues(userLogic)
 
@@ -47,6 +49,7 @@ export function DashboardModals({ dashboard }: { dashboard: DashboardType<QueryB
                 closeModal={() => push(urls.dashboard(dashboard.id))}
                 dashboardId={dashboard.id}
                 userAccessLevel={dashboard.user_access_level}
+                onSharingEnabledChange={(enabled) => updateDashboardSuccess({ ...dashboard, is_shared: enabled })}
             />
             {canEditDashboard && (
                 <>

--- a/frontend/src/scenes/dashboard/DashboardPublicAccessBanner.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardPublicAccessBanner.test.tsx
@@ -1,0 +1,91 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { AccessControlLevel, DashboardPlacement, DashboardType, QueryBasedInsightModel } from '~/types'
+
+import { DashboardPublicAccessBanner } from './DashboardPublicAccessBanner'
+
+const MOCK_DASHBOARD: DashboardType<QueryBasedInsightModel> = {
+    id: 5,
+    name: 'Test dashboard',
+    description: 'A test dashboard',
+    pinned: false,
+    tiles: [],
+    tags: [],
+    created_at: '2020-01-01T00:00:00Z',
+    created_by: {
+        id: 1,
+        first_name: 'Test',
+        last_name: 'User',
+        email: 'test@posthog.com',
+        uuid: 'abc',
+        distinct_id: 'test-distinct-id',
+    },
+    last_accessed_at: '2020-01-01T00:00:00Z',
+    is_shared: false,
+    deleted: false,
+    creation_mode: 'default',
+    user_access_level: AccessControlLevel.Editor,
+    filters: {},
+    variables: {},
+}
+
+function makeDashboard(
+    overrides: Partial<DashboardType<QueryBasedInsightModel>> = {}
+): DashboardType<QueryBasedInsightModel> {
+    return { ...MOCK_DASHBOARD, ...overrides }
+}
+
+function renderBanner({
+    dashboard = makeDashboard({ is_shared: true }),
+    placement = DashboardPlacement.Dashboard,
+}: {
+    dashboard?: DashboardType<QueryBasedInsightModel>
+    placement?: DashboardPlacement
+} = {}): void {
+    render(<DashboardPublicAccessBanner dashboard={dashboard} placement={placement} />)
+}
+
+describe('DashboardPublicAccessBanner', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('shows when a standard dashboard is shared publicly', async () => {
+        renderBanner()
+
+        expect(
+            screen.getByText(
+                'This dashboard is shared publicly. Updates you make here may be visible to anyone with the public link. Avoid adding sensitive data.'
+            )
+        ).toBeInTheDocument()
+        expect(screen.getAllByText('Manage sharing')).toHaveLength(2)
+    })
+
+    it('shows for read-only team users', async () => {
+        renderBanner({
+            dashboard: makeDashboard({
+                is_shared: true,
+                user_access_level: AccessControlLevel.Viewer,
+            }),
+        })
+
+        expect(screen.getByText(/This dashboard is shared publicly/)).toBeInTheDocument()
+    })
+
+    it('does not show when the dashboard is not shared', async () => {
+        renderBanner({ dashboard: makeDashboard({ is_shared: false }) })
+
+        expect(screen.queryByText(/This dashboard is shared publicly/)).not.toBeInTheDocument()
+    })
+
+    it.each([DashboardPlacement.Public, DashboardPlacement.Export])(
+        'does not show for %s placement',
+        async (placement) => {
+            renderBanner({ placement })
+
+            expect(screen.queryByText(/This dashboard is shared publicly/)).not.toBeInTheDocument()
+        }
+    )
+})

--- a/frontend/src/scenes/dashboard/DashboardPublicAccessBanner.tsx
+++ b/frontend/src/scenes/dashboard/DashboardPublicAccessBanner.tsx
@@ -30,6 +30,7 @@ export function DashboardPublicAccessBanner({
         <LemonBanner
             type="warning"
             className="mb-4"
+            dismissKey={`dashboard-public-access-banner-${dashboard.id}`}
             action={{
                 children: 'Manage sharing',
                 onClick: () => push(urls.dashboardSharing(dashboard.id)),

--- a/frontend/src/scenes/dashboard/DashboardPublicAccessBanner.tsx
+++ b/frontend/src/scenes/dashboard/DashboardPublicAccessBanner.tsx
@@ -1,0 +1,42 @@
+import { useActions } from 'kea'
+import { router } from 'kea-router'
+
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { DashboardPlacement, DashboardType, QueryBasedInsightModel } from '~/types'
+
+const DASHBOARD_PUBLIC_ACCESS_BANNER_PLACEMENTS = [
+    DashboardPlacement.Dashboard,
+    DashboardPlacement.ProjectHomepage,
+    DashboardPlacement.Builtin,
+]
+
+export function DashboardPublicAccessBanner({
+    dashboard,
+    placement,
+}: {
+    dashboard: DashboardType<QueryBasedInsightModel> | null
+    placement: DashboardPlacement
+}): JSX.Element | null {
+    const { push } = useActions(router)
+
+    if (!dashboard?.is_shared || !DASHBOARD_PUBLIC_ACCESS_BANNER_PLACEMENTS.includes(placement)) {
+        return null
+    }
+
+    return (
+        <LemonBanner
+            type="warning"
+            className="mb-4"
+            action={{
+                children: 'Manage sharing',
+                onClick: () => push(urls.dashboardSharing(dashboard.id)),
+            }}
+        >
+            This dashboard is shared publicly. Updates you make here may be visible to anyone with the public link.
+            Avoid adding sensitive data.
+        </LemonBanner>
+    )
+}


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
It is not obvious when a dashboard is being shared publicly, so it is easy for users to forget this and update the dashboard with sensitive data.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds a banner on the owning team's dashboard when it's being shared publicly.
<img width="1259" height="653" alt="image" src="https://github.com/user-attachments/assets/7194d57c-b86a-41b6-acaa-b880c00e9106" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
