### PR TITLE
feat(saved-insights): add filter for insights not on any dashboard

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
@@ -13,8 +13,15 @@ import { cn } from 'lib/utils/css-classes'
 import { INSIGHT_TYPE_OPTIONS } from 'scenes/saved-insights/SavedInsights'
 import { SavedInsightFilters } from 'scenes/saved-insights/savedInsightsLogic'
 
-export type QuickFilterKind = 'insightType' | 'tags' | 'createdBy' | 'favorites' | 'featureFlags'
-const ALL_QUICK_FILTERS: QuickFilterKind[] = ['insightType', 'tags', 'createdBy', 'favorites', 'featureFlags']
+export type QuickFilterKind = 'insightType' | 'tags' | 'createdBy' | 'favorites' | 'featureFlags' | 'notOnAnyDashboard'
+const ALL_QUICK_FILTERS: QuickFilterKind[] = [
+    'insightType',
+    'tags',
+    'createdBy',
+    'favorites',
+    'featureFlags',
+    'notOnAnyDashboard',
+]
 
 export function SavedInsightsFilters({
     filters,
@@ -28,7 +35,7 @@ export function SavedInsightsFilters({
     /** When true, inactive filters appear borderless. */
     borderless?: boolean
 }): JSX.Element {
-    const { search, hideFeatureFlagInsights, favorited, tags, insightType, createdBy } = filters
+    const { search, hideFeatureFlagInsights, favorited, tags, insightType, createdBy, notOnAnyDashboard } = filters
     const quickFilterSet = new Set(quickFilters)
     const hasInsightTypeSelection = !!insightType && insightType !== 'All types'
 
@@ -115,6 +122,23 @@ export function SavedInsightsFilters({
                             hideFeatureFlagInsights={hideFeatureFlagInsights ?? undefined}
                             onToggle={(checked) => setFilters({ hideFeatureFlagInsights: checked })}
                         />
+                    )}
+                    {quickFilterSet.has('notOnAnyDashboard') && (
+                        <LemonButton
+                            type="secondary"
+                            status={borderless && !notOnAnyDashboard ? 'alt' : 'default'}
+                            active={notOnAnyDashboard || false}
+                            onClick={() => {
+                                setFilters({ notOnAnyDashboard: !notOnAnyDashboard })
+                                posthog.capture('saved insights filtered', {
+                                    filter_type: 'not_on_any_dashboard',
+                                    value: !notOnAnyDashboard,
+                                })
+                            }}
+                            size="small"
+                        >
+                            Not on any dashboard
+                        </LemonButton>
                     )}
                 </div>
             )}

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
@@ -168,6 +168,24 @@ describe('savedInsightsLogic', () => {
             })
     })
 
+    it('sets no_dashboard param when notOnAnyDashboard filter is active', async () => {
+        logic.actions.setSavedInsightsFilters({ notOnAnyDashboard: true })
+        await expectLogic(logic)
+            .toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
+            .toMatchValues({
+                filters: partial({ notOnAnyDashboard: true }),
+                paramsFromFilters: partial({ no_dashboard: true }),
+            })
+
+        logic.actions.setSavedInsightsFilters({ notOnAnyDashboard: false })
+        await expectLogic(logic)
+            .toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
+            .toMatchValues({
+                filters: partial({ notOnAnyDashboard: false }),
+                paramsFromFilters: expect.not.objectContaining({ no_dashboard: true }),
+            })
+    })
+
     it('persists the filter in the url', async () => {
         logic.actions.setSavedInsightsFilters({ search: 'hello' })
         await expectLogic(logic)

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -56,6 +56,7 @@ export interface SavedInsightFilters {
     lastViewedDateTo: string | dayjs.Dayjs | undefined | null
     page: number
     dashboardId: number | undefined | null
+    notOnAnyDashboard: boolean | undefined | null
     events: string[] | undefined | null
     hideFeatureFlagInsights: boolean | undefined | null
     favorited: boolean | undefined | null
@@ -77,6 +78,7 @@ export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsight
         lastViewedDateTo: values.lastViewedDateTo || undefined,
         page: parseInt(String(values.page)) || 1,
         dashboardId: values.dashboardId,
+        notOnAnyDashboard: values.notOnAnyDashboard || false,
         events: values.events,
         hideFeatureFlagInsights: values.hideFeatureFlagInsights || false,
         favorited: values.favorited || false,
@@ -280,6 +282,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
                 ...(!!filters.dashboardId && {
                     dashboards: [filters.dashboardId],
                 }),
+                ...(filters.notOnAnyDashboard && { no_dashboard: true }),
                 ...(filters.hideFeatureFlagInsights && { hide_feature_flag_insights: true }),
             }),
         ],

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1762,6 +1762,13 @@ class InsightViewSet(
                             .values_list("insight__id", flat=True)
                             .all()
                         )
+            elif key == "no_dashboard":
+                if request.GET["no_dashboard"] == "true":
+                    queryset = queryset.exclude(
+                        id__in=DashboardTile.objects.filter(deleted=False)
+                        .values_list("insight__id", flat=True)
+                        .all()
+                    )
             elif key == "tags":
                 tags_filter = request.GET["tags"]
                 if tags_filter:

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1764,8 +1764,11 @@ class InsightViewSet(
                         )
             elif key == "no_dashboard":
                 if request.GET["no_dashboard"] == "true":
+                    # insight__isnull=False excludes text/button tiles (which have no insight FK).
+                    # The DashboardTile manager's get_queryset already excludes deleted=True tiles,
+                    # so no extra deleted filter is needed here.
                     queryset = queryset.exclude(
-                        id__in=DashboardTile.objects.filter(deleted=False)
+                        id__in=DashboardTile.objects.filter(insight__isnull=False)
                         .values_list("insight__id", flat=True)
                         .all()
                     )

--- a/products/product_analytics/backend/api/test/test_insight.py
+++ b/products/product_analytics/backend/api/test/test_insight.py
@@ -1117,6 +1117,39 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         matched_insights = [insight["id"] for insight in any_on_dashboard_one.json()["results"]]
         assert sorted(matched_insights) == [insight_one_id]
 
+    def test_no_dashboard_filter_excludes_insights_on_active_tiles(self) -> None:
+        on_dashboard_id, _ = self.dashboard_api.create_insight(
+            {"name": "on dashboard", "filters": {"events": [{"id": "$pageview"}]}}
+        )
+        not_on_dashboard_id, _ = self.dashboard_api.create_insight(
+            {"name": "not on dashboard", "filters": {"events": [{"id": "$pageview"}]}}
+        )
+        # Insight whose only tile is soft-deleted — should count as "not on dashboard"
+        deleted_tile_id, _ = self.dashboard_api.create_insight(
+            {"name": "deleted tile only", "filters": {"events": [{"id": "$pageview"}]}}
+        )
+
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "test dashboard"})
+        self.dashboard_api.add_insight_to_dashboard([dashboard_id], on_dashboard_id)
+        self.dashboard_api.add_insight_to_dashboard([dashboard_id], deleted_tile_id)
+        # Remove the insight from dashboard — soft-deletes the tile
+        self.dashboard_api.update_insight(deleted_tile_id, {"dashboards": []})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?no_dashboard=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result_ids = {i["id"] for i in response.json()["results"]}
+        self.assertIn(not_on_dashboard_id, result_ids)
+        self.assertIn(deleted_tile_id, result_ids)
+        self.assertNotIn(on_dashboard_id, result_ids)
+
+        # Without the filter all three are returned
+        response_all = self.client.get(f"/api/projects/{self.team.id}/insights/")
+        self.assertEqual(response_all.status_code, status.HTTP_200_OK)
+        all_ids = {i["id"] for i in response_all.json()["results"]}
+        self.assertIn(on_dashboard_id, all_ids)
+        self.assertIn(not_on_dashboard_id, all_ids)
+        self.assertIn(deleted_tile_id, all_ids)
+
     @freeze_time("2012-01-14T03:21:34.000Z")
     def test_create_insight_items(self) -> None:
         response = self.client.post(


### PR DESCRIPTION
## Problem

Users who manage many insights often want to find ones that haven't been added to any dashboard yet — for cleanup, organisation, or to discover forgotten analyses. There's currently no way to filter for this in the insights list.

Closes #26621

## Changes

**Backend** (`posthog/api/insight.py`): adds a `no_dashboard=true` query param to the insights list endpoint. When set, it excludes any insight that has at least one active (non-deleted) dashboard tile.

**Frontend logic** (`savedInsightsLogic.ts`): adds `notOnAnyDashboard: boolean` to `SavedInsightFilters`, carries it through `cleanFilters`, and maps it to `no_dashboard=true` in `paramsFromFilters`.

**Frontend UI** (`SavedInsightsFilters.tsx`): adds `'notOnAnyDashboard'` as a new `QuickFilterKind` and renders it as a toggle button in the filters bar, consistent with the existing Favorites and Feature flag insights toggles.

## How did you test this code?

Agent-authored PR. The backend filter uses a standard Django ORM `exclude` with `DashboardTile` lookups — the same pattern used by the existing `dashboards` filter. No automated tests were added for this iteration; a reviewer may want to add a Python test covering the `no_dashboard=true` param.

## Publish to changelog?

No

## 🤖 Agent context

Authored with Claude Code (claude-sonnet-4-6). Identified the feature request in #26621, traced the existing `dashboards` filter through both backend (`insight.py`) and frontend (`savedInsightsLogic.ts`, `SavedInsightsFilters.tsx`), and extended all three layers. The `no_dashboard` param mirrors the existing `dashboards` filter pattern — exclude rather than include. UI toggle follows the same shape as the existing feature flag insights toggle.