### PR TITLE
fix: sanitize invite email input instead of failing

### DIFF
--- a/posthog/helpers/email_utils.py
+++ b/posthog/helpers/email_utils.py
@@ -6,9 +6,11 @@ lookup by email, and display-name / message validation.
 import re
 import hashlib
 import unicodedata
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, overload
+from functools import partial
+from typing import TYPE_CHECKING, Optional, cast, overload
 from urllib.parse import quote
 
 from django.conf import settings
@@ -107,52 +109,77 @@ def validate_message_body(value: str | None) -> str | None:
     return value
 
 
-def sanitize_display_name(value: str | None, *, fallback: str, context: Optional[dict] = None) -> str:
+def _extract_error_code(err: serializers.ValidationError) -> str:
     """
-    Return a display-name safe to render in an email. If `value` passes
-    `validate_display_name`, it is returned (stripped). Otherwise `fallback`
-    is returned and the rejection is logged with `context` for debugging.
+    Pull the first `code` off a DRF ValidationError. `err.detail` is a union
+    of ErrorDetail | list | dict (when raised from a serializer); for the
+    single-field validators in this module we always raise the list form, but
+    narrow defensively so mypy is happy and we don't crash if a caller hands
+    us something unexpected.
+    """
+    detail = err.detail
+    if isinstance(detail, list) and detail:
+        first = detail[0]
+        return getattr(first, "code", "invalid") or "invalid"
+    if isinstance(detail, dict) and detail:
+        first = next(iter(detail.values()))
+        if isinstance(first, list) and first:
+            first = first[0]
+        return getattr(first, "code", "invalid") or "invalid"
+    return getattr(detail, "code", "invalid") or "invalid"
 
-    Use this in email-sending tasks where dropping the email entirely on a
-    bad legacy value (e.g. an organisation name that happens to be a URL)
-    would be more harmful than substituting a generic placeholder.
+
+def _sanitize(
+    value: str | None,
+    *,
+    validator: Callable[[str | None], str | None],
+    log_event: str,
+    fallback: str,
+    context: Optional[dict] = None,
+) -> str:
+    """
+    Core sanitize-with-fallback flow shared by `sanitize_display_name` and
+    `sanitize_message_body`. Runs `validator`; on a ValidationError or a
+    falsy result (None / empty / whitespace-only, depending on the validator),
+    returns `fallback` and logs the rejection with `context` for diagnostics.
     """
     try:
-        validated = validate_display_name(value)
+        validated = validator(value)
     except serializers.ValidationError as err:
-        detail = err.detail
-        error_code = detail[0].code if isinstance(detail, list) and detail else "invalid"
         logger.info(
-            "email_utils.display_name_sanitized",
-            error_code=error_code,
+            log_event,
+            error_code=_extract_error_code(err),
             fallback=fallback,
             **(context or {}),
         )
         return fallback
-    if not validated:
-        return fallback
-    return validated
-
-
-def sanitize_message_body(value: str | None, *, fallback: str = "", context: Optional[dict] = None) -> str:
-    """
-    Return a message body safe to render in an email. If `value` passes
-    `validate_message_body`, it is returned unchanged. Otherwise `fallback`
-    is returned (defaulting to an empty string, which suppresses the
-    optional message block) and the rejection is logged.
-    """
-    try:
-        validated = validate_message_body(value)
-    except serializers.ValidationError as err:
-        detail = err.detail
-        error_code = detail[0].code if isinstance(detail, list) and detail else "invalid"
-        logger.info(
-            "email_utils.message_body_sanitized",
-            error_code=error_code,
-            **(context or {}),
-        )
-        return fallback
     return validated or fallback
+
+
+# `validate_display_name` is `@overload`-decorated to express the None-in / None-out
+# relationship at call sites; mypy then can't match the overloaded type against the plain
+# `Callable[[str | None], str | None]` signature `_sanitize` expects. Cast once here —
+# `_sanitize` always passes through the `str | None` overload at runtime.
+_Validator = Callable[[Optional[str]], Optional[str]]
+
+# Display-name fallback for identity fields (organization name, inviter / invitee first name).
+# Use in email-sending tasks where dropping the email entirely on a bad legacy value (e.g. an
+# organisation name that happens to be a URL) would be more harmful than substituting a
+# generic placeholder.
+sanitize_display_name = partial(
+    _sanitize,
+    validator=cast(_Validator, validate_display_name),
+    log_event="email_utils.display_name_sanitized",
+)
+
+# Message-body fallback. Defaults `fallback` to an empty string so the optional message block
+# in templates collapses cleanly when an inviter's free-text message fails validation.
+sanitize_message_body = partial(
+    _sanitize,
+    validator=cast(_Validator, validate_message_body),
+    log_event="email_utils.message_body_sanitized",
+    fallback="",
+)
 
 
 class EmailNormalizer:

--- a/posthog/helpers/email_utils.py
+++ b/posthog/helpers/email_utils.py
@@ -107,6 +107,54 @@ def validate_message_body(value: str | None) -> str | None:
     return value
 
 
+def sanitize_display_name(value: str | None, *, fallback: str, context: Optional[dict] = None) -> str:
+    """
+    Return a display-name safe to render in an email. If `value` passes
+    `validate_display_name`, it is returned (stripped). Otherwise `fallback`
+    is returned and the rejection is logged with `context` for debugging.
+
+    Use this in email-sending tasks where dropping the email entirely on a
+    bad legacy value (e.g. an organisation name that happens to be a URL)
+    would be more harmful than substituting a generic placeholder.
+    """
+    try:
+        validated = validate_display_name(value)
+    except serializers.ValidationError as err:
+        detail = err.detail
+        error_code = detail[0].code if isinstance(detail, list) and detail else "invalid"
+        logger.info(
+            "email_utils.display_name_sanitized",
+            error_code=error_code,
+            fallback=fallback,
+            **(context or {}),
+        )
+        return fallback
+    if not validated:
+        return fallback
+    return validated
+
+
+def sanitize_message_body(value: str | None, *, fallback: str = "", context: Optional[dict] = None) -> str:
+    """
+    Return a message body safe to render in an email. If `value` passes
+    `validate_message_body`, it is returned unchanged. Otherwise `fallback`
+    is returned (defaulting to an empty string, which suppresses the
+    optional message block) and the rejection is logged.
+    """
+    try:
+        validated = validate_message_body(value)
+    except serializers.ValidationError as err:
+        detail = err.detail
+        error_code = detail[0].code if isinstance(detail, list) and detail else "invalid"
+        logger.info(
+            "email_utils.message_body_sanitized",
+            error_code=error_code,
+            **(context or {}),
+        )
+        return fallback
+    return validated or fallback
+
+
 class EmailNormalizer:
     @staticmethod
     def normalize(email: str) -> str:

--- a/posthog/helpers/tests/test_email_utils.py
+++ b/posthog/helpers/tests/test_email_utils.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from unittest.mock import MagicMock, patch
 
@@ -18,6 +18,8 @@ from posthog.helpers.email_utils import (
     ESPSuppressionReason,
     _get_esp_suppression_cache_key,
     check_esp_suppression,
+    sanitize_display_name,
+    sanitize_message_body,
     validate_display_name,
     validate_message_body,
 )
@@ -414,3 +416,75 @@ class TestValidateMessageBody(SimpleTestCase):
         self.assertEqual(validate_message_body(""), "")
         self.assertEqual(validate_message_body("   "), "   ")
         self.assertEqual(validate_message_body("   \n\t  "), "   \n\t  ")
+
+
+class TestSanitizeDisplayName(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("plain", "Acme Inc", "Acme Inc"),
+            ("strips_whitespace", "  Acme Inc  ", "Acme Inc"),
+            ("unicode_name", "\u00c9mile", "\u00c9mile"),
+        ]
+    )
+    def test_returns_validated_value(self, _name: str, value: str, expected: str) -> None:
+        self.assertEqual(sanitize_display_name(value, fallback="fallback"), expected)
+
+    @parameterized.expand(
+        [
+            ("url", "https://acme.example.com"),
+            ("www", "www.scam.io"),
+            ("bare_domain", "acme.com"),
+            ("javascript_scheme", "javascript:alert(1)"),
+            ("bracket", "<acme>"),
+            ("zero_width", "foo\u200bbar"),
+            ("newline", "line1\nline2"),
+        ]
+    )
+    def test_returns_fallback_when_invalid(self, _name: str, value: str) -> None:
+        self.assertEqual(
+            sanitize_display_name(value, fallback="their organization"),
+            "their organization",
+        )
+
+    @parameterized.expand(
+        [
+            ("none", None),
+            ("empty", ""),
+            ("whitespace_only", "   "),
+        ]
+    )
+    def test_returns_fallback_when_blank(self, _name: str, value: Optional[str]) -> None:
+        self.assertEqual(sanitize_display_name(value, fallback="Someone"), "Someone")
+
+    def test_context_is_logged_but_does_not_raise(self) -> None:
+        # The context kwarg is purely diagnostic — it should never affect the return value.
+        result = sanitize_display_name(
+            "https://evil.example.com",
+            fallback="their organization",
+            context={"task": "unit_test", "organization_id": "abc"},
+        )
+        self.assertEqual(result, "their organization")
+
+
+class TestSanitizeMessageBody(SimpleTestCase):
+    def test_returns_validated_value(self) -> None:
+        value = "Hey!\nWelcome aboard."
+        self.assertEqual(sanitize_message_body(value), value)
+
+    @parameterized.expand(
+        [
+            ("url", "Check https://evil.com"),
+            ("www", "Visit www.scam.io"),
+            ("bracket", "hello <there>"),
+            ("non_newline_control", "foo\x01bar"),
+        ]
+    )
+    def test_returns_fallback_when_invalid(self, _name: str, value: str) -> None:
+        self.assertEqual(sanitize_message_body(value), "")
+        self.assertEqual(sanitize_message_body(value, fallback="--"), "--")
+
+    def test_passes_through_none_and_blank_via_fallback(self) -> None:
+        # None / empty pass through validate_message_body but the helper still returns the
+        # fallback so callers can rely on getting a non-None string back.
+        self.assertEqual(sanitize_message_body(None), "")
+        self.assertEqual(sanitize_message_body(""), "")

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -12,8 +12,6 @@ import structlog
 import posthoganalytics
 from celery import shared_task
 from posthoganalytics import new_context, tag
-from rest_framework import serializers
-from rest_framework.exceptions import ErrorDetail
 
 from posthog.batch_exports.models import BatchExportRun
 from posthog.caching.login_device_cache import check_and_cache_login_device
@@ -21,9 +19,8 @@ from posthog.cloud_utils import is_cloud
 from posthog.constants import AUTH_BACKEND_DISPLAY_NAMES, INVITE_DAYS_VALIDITY
 from posthog.email import EMAIL_TASK_KWARGS, EmailMessage, is_email_available
 from posthog.event_usage import groups
-from posthog.exceptions_capture import capture_exception
 from posthog.geoip import get_geoip_properties
-from posthog.helpers.email_utils import validate_display_name, validate_message_body
+from posthog.helpers.email_utils import sanitize_display_name, sanitize_message_body
 from posthog.models import (
     Organization,
     OrganizationInvite,
@@ -227,44 +224,40 @@ def send_invite(invite_id: str) -> None:
         # Invite can be deleted (cancelled/accepted) before the worker picks up the task.
         # Treat as terminal no-op instead of retrying.
         return
-    inviter_name_for_validation = invite.created_by.first_name if invite.created_by else "someone"
-    try:
-        validate_display_name(inviter_name_for_validation)
-        validate_display_name(invite.organization.name)
-        validate_display_name(invite.first_name)
-        validate_message_body(invite.message)
-    except serializers.ValidationError as err:
-        detail = cast(list[ErrorDetail], err.detail)
-        error_code = detail[0].code if detail else "invalid"
-        logger.warning(
-            "send_invite.blocked",
-            invite_id=invite_id,
-            organization_id=str(invite.organization_id),
-            created_by_id=invite.created_by_id,
-            error_code=error_code,
-        )
-        capture_exception(
-            err,
-            additional_properties={
-                "task": "send_invite",
-                "invite_id": invite_id,
-                "organization_id": str(invite.organization_id),
-                "error_code": error_code,
-            },
-        )
-        return
-    # Guard against whitespace-only first_name (.strip() returning "" leaves the subject blank).
-    inviter_name = (
-        invite.created_by.first_name.strip()
-        if invite.created_by and invite.created_by.first_name and invite.created_by.first_name.strip()
-        else "Someone"
+    # If a display value fails validation (e.g. a legacy organisation name that
+    # happens to look like a URL), substitute a generic fallback rather than
+    # dropping the email entirely. The recipient still gets a usable invite.
+    log_context = {
+        "invite_id": invite_id,
+        "organization_id": str(invite.organization_id),
+        "created_by_id": invite.created_by_id,
+    }
+    inviter_name = sanitize_display_name(
+        invite.created_by.first_name if invite.created_by else None,
+        fallback="Someone",
+        context={"task": "send_invite", "field": "inviter_first_name", **log_context},
+    )
+    org_name = sanitize_display_name(
+        invite.organization.name,
+        fallback="their organization",
+        context={"task": "send_invite", "field": "organization_name", **log_context},
+    )
+    invitee_first_name = sanitize_display_name(
+        invite.first_name,
+        fallback="",
+        context={"task": "send_invite", "field": "invitee_first_name", **log_context},
+    )
+    invite_message = sanitize_message_body(
+        invite.message,
+        fallback="",
+        context={"task": "send_invite", "field": "message", **log_context},
     )
     is_delegation = bool(invite.is_setup_delegation)
     template_name = "delegation_invite" if is_delegation else "invite"
     if is_delegation:
-        subject = f"{inviter_name} asked you to finish setting up PostHog for {invite.organization.name}"
+        subject = f"{inviter_name} asked you to finish setting up PostHog for {org_name}"
     else:
-        subject = f"{inviter_name} invited you to join {invite.organization.name} on PostHog"
+        subject = f"{inviter_name} invited you to join {org_name} on PostHog"
     message = EmailMessage(
         use_http=True,
         campaign_key=campaign_key,
@@ -277,7 +270,9 @@ def send_invite(invite_id: str) -> None:
             ),
             "inviter_first_name": inviter_name,
             "inviter_email": invite.created_by.email if invite.created_by and invite.created_by.email else "",
-            "org_name": invite.organization.name,
+            "org_name": org_name,
+            "invitee_first_name": invitee_first_name,
+            "invite_message": invite_message,
             "url": f"{settings.SITE_URL}/signup/{invite_id}",
         },
         reply_to=invite.created_by.email if invite.created_by and invite.created_by.email else "",
@@ -346,40 +341,29 @@ def send_member_join(invitee_uuid: str, organization_id: str) -> None:
     if len(members_to_email) == 0:
         return
 
-    try:
-        validate_display_name(invitee.first_name)
-        validate_display_name(organization.name)
-    except serializers.ValidationError as err:
-        detail = cast(list[ErrorDetail], err.detail)
-        error_code = detail[0].code if detail else "invalid"
-        logger.warning(
-            "send_member_join.blocked",
-            invitee_uuid=invitee_uuid,
-            organization_id=organization_id,
-            error_code=error_code,
-        )
-        capture_exception(
-            err,
-            additional_properties={
-                "task": "send_member_join",
-                "invitee_uuid": invitee_uuid,
-                "organization_id": organization_id,
-                "error_code": error_code,
-            },
-        )
-        return
+    log_context = {"invitee_uuid": invitee_uuid, "organization_id": organization_id}
+    invitee_first_name = sanitize_display_name(
+        invitee.first_name,
+        fallback="A new teammate",
+        context={"task": "send_member_join", "field": "invitee_first_name", **log_context},
+    )
+    organization_name = sanitize_display_name(
+        organization.name,
+        fallback="your organization",
+        context={"task": "send_member_join", "field": "organization_name", **log_context},
+    )
 
     campaign_key: str = f"member_join_email_org_{organization_id}_user_{invitee_uuid}"
     message = EmailMessage(
         use_http=True,
         campaign_key=campaign_key,
-        subject=f"{invitee.first_name} joined you on PostHog",
+        subject=f"{invitee_first_name} joined you on PostHog",
         template_name="member_join",
         template_context={
             "invitee": invitee,
             "organization": organization,
-            "invitee_first_name": invitee.first_name,
-            "organization_name": organization.name,
+            "invitee_first_name": invitee_first_name,
+            "organization_name": organization_name,
         },
     )
     for user in members_to_email:
@@ -779,25 +763,16 @@ def send_canary_email(user_email: str) -> None:
 
 @shared_task(**EMAIL_TASK_KWARGS)
 def send_email_change_emails(now_iso: str, user_name: str, old_address: str, new_address: str) -> None:
-    try:
-        validate_display_name(user_name)
-    except serializers.ValidationError as err:
-        detail = cast(list[ErrorDetail], err.detail)
-        error_code = detail[0].code if detail else "invalid"
-        logger.warning(
-            "send_email_change_emails.blocked",
-            old_address=old_address,
-            new_address=new_address,
-            error_code=error_code,
-        )
-        capture_exception(
-            err,
-            additional_properties={
-                "task": "send_email_change_emails",
-                "error_code": error_code,
-            },
-        )
-        return
+    user_name = sanitize_display_name(
+        user_name,
+        fallback="there",
+        context={
+            "task": "send_email_change_emails",
+            "field": "user_name",
+            "old_address": old_address,
+            "new_address": new_address,
+        },
+    )
     message_old_address = EmailMessage(
         use_http=True,
         campaign_key=f"email_change_old_address_{now_iso}",

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -132,6 +132,59 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         assert mocked_email_messages[0].send.call_count == 1
         assert mocked_email_messages[0].html_body
 
+    def test_send_delegation_invite_falls_back_when_organization_name_is_a_url(
+        self, MockEmailMessage: MagicMock
+    ) -> None:
+        # Regression: delegation invites use a different template and subject line, so verify
+        # the org-name fallback flows through both the subject and the dedicated template.
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        org, user = create_org_team_and_user("2022-01-02 00:00:00", "admin@posthog.com")
+        org.name = "https://acme.example.com"
+        org.save()
+        user.first_name = "Admin"
+        user.save()
+        invite = OrganizationInvite.objects.create(
+            organization=org,
+            created_by=user,
+            target_email="delegate@posthog.com",
+            is_setup_delegation=True,
+            message="Welcome aboard, looking forward to working with you!",
+        )
+
+        send_invite(invite.id)
+
+        assert len(mocked_email_messages) == 1
+        subject = MockEmailMessage.call_args.kwargs["subject"]
+        assert subject == "Admin asked you to finish setting up PostHog for their organization"
+        assert MockEmailMessage.call_args.kwargs["template_name"] == "delegation_invite"
+        html = mocked_email_messages[0].html_body
+        assert "their organization" in html
+        assert "https://acme.example.com" not in html
+        # Valid message bodies still render in the delegation template.
+        assert "Welcome aboard" in html
+
+    def test_send_delegation_invite_strips_invalid_message_body(self, MockEmailMessage: MagicMock) -> None:
+        # Regression: the delegation template now reads `invite_message` from the sanitized
+        # context rather than `invite.message` directly, so an unsafe body must not leak.
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        org, user = create_org_team_and_user("2022-01-02 00:00:00", "admin@posthog.com")
+        invite = OrganizationInvite.objects.create(
+            organization=org,
+            created_by=user,
+            target_email="delegate@posthog.com",
+            is_setup_delegation=True,
+            message="Click here: http://phishing.example.com",
+        )
+
+        send_invite(invite.id)
+
+        assert len(mocked_email_messages) == 1
+        html = mocked_email_messages[0].html_body
+        assert "phishing.example.com" not in html
+        assert "Click here" not in html
+
     def test_send_invite_falls_back_when_organization_name_is_a_url(self, MockEmailMessage: MagicMock) -> None:
         # Regression: orgs whose legacy name happens to look like a URL must still be able
         # to send invites — the recipient sees a generic "their organization" instead of

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -28,6 +28,7 @@ from posthog.tasks.email import (
     send_batch_export_run_failure,
     send_canary_email,
     send_discussions_mentioned,
+    send_email_change_emails,
     send_email_verification,
     send_fatal_plugin_error,
     send_hog_functions_daily_digest,
@@ -130,6 +131,140 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         assert len(mocked_email_messages) == 1
         assert mocked_email_messages[0].send.call_count == 1
         assert mocked_email_messages[0].html_body
+
+    def test_send_invite_falls_back_when_organization_name_is_a_url(self, MockEmailMessage: MagicMock) -> None:
+        # Regression: orgs whose legacy name happens to look like a URL must still be able
+        # to send invites — the recipient sees a generic "their organization" instead of
+        # the original value, but the email is delivered rather than silently dropped.
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        org, user = create_org_team_and_user("2022-01-02 00:00:00", "admin@posthog.com")
+        org.name = "https://acme.example.com"
+        org.save()
+        user.first_name = "Admin"
+        user.save()
+        invite = OrganizationInvite.objects.create(organization=org, created_by=user, target_email="test@posthog.com")
+
+        send_invite(invite.id)
+
+        assert len(mocked_email_messages) == 1
+        assert mocked_email_messages[0].send.call_count == 1
+        subject = MockEmailMessage.call_args.kwargs["subject"]
+        assert subject == "Admin invited you to join their organization on PostHog"
+        html = mocked_email_messages[0].html_body
+        assert "their organization" in html
+        assert "https://acme.example.com" not in html
+
+    def test_send_invite_falls_back_when_inviter_name_is_a_url(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        org, user = create_org_team_and_user("2022-01-02 00:00:00", "admin@posthog.com")
+        user.first_name = "https://phishing.example.com"
+        user.save()
+        invite = OrganizationInvite.objects.create(organization=org, created_by=user, target_email="test@posthog.com")
+
+        send_invite(invite.id)
+
+        assert len(mocked_email_messages) == 1
+        subject = MockEmailMessage.call_args.kwargs["subject"]
+        assert subject.startswith("Someone invited you to join ")
+        html = mocked_email_messages[0].html_body
+        assert "phishing.example.com" not in html
+        assert "Someone" in html
+
+    def test_send_invite_strips_invalid_message_body_but_still_sends(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        org, user = create_org_team_and_user("2022-01-02 00:00:00", "admin@posthog.com")
+        invite = OrganizationInvite.objects.create(
+            organization=org,
+            created_by=user,
+            target_email="test@posthog.com",
+            message="Click here: http://phishing.example.com",
+        )
+
+        send_invite(invite.id)
+
+        assert len(mocked_email_messages) == 1
+        html = mocked_email_messages[0].html_body
+        assert "phishing.example.com" not in html
+        assert "Click here" not in html
+
+    def test_send_invite_renders_valid_message_body(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        org, user = create_org_team_and_user("2022-01-02 00:00:00", "admin@posthog.com")
+        invite = OrganizationInvite.objects.create(
+            organization=org,
+            created_by=user,
+            target_email="test@posthog.com",
+            message="Welcome aboard, looking forward to working with you!",
+        )
+
+        send_invite(invite.id)
+
+        assert len(mocked_email_messages) == 1
+        assert "Welcome aboard" in mocked_email_messages[0].html_body
+
+    def test_send_member_join_falls_back_when_organization_name_is_a_url(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        org, _admin = create_org_team_and_user("2022-01-02 00:00:00", "admin@posthog.com")
+        org.name = "https://acme.example.com"
+        org.save()
+
+        new_member = User.objects.create_and_join(
+            organization=org,
+            email="new-user@posthog.com",
+            password=None,
+            level=OrganizationMembership.Level.MEMBER,
+            first_name="Jordan",
+        )
+        send_member_join(new_member.uuid, org.id)
+
+        assert len(mocked_email_messages) == 1
+        html = mocked_email_messages[0].html_body
+        assert "your organization" in html
+        assert "https://acme.example.com" not in html
+        # The invitee's clean first name still surfaces.
+        assert "Jordan" in html
+
+    def test_send_member_join_falls_back_when_invitee_first_name_is_a_url(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        org, _admin = create_org_team_and_user("2022-01-02 00:00:00", "admin@posthog.com")
+
+        new_member = User.objects.create_and_join(
+            organization=org,
+            email="new-user@posthog.com",
+            password=None,
+            level=OrganizationMembership.Level.MEMBER,
+            first_name="http://evil.example.com",
+        )
+        send_member_join(new_member.uuid, org.id)
+
+        assert len(mocked_email_messages) == 1
+        subject = MockEmailMessage.call_args.kwargs["subject"]
+        assert subject == "A new teammate joined you on PostHog"
+        html = mocked_email_messages[0].html_body
+        assert "evil.example.com" not in html
+        assert "A new teammate" in html
+
+    def test_send_email_change_emails_falls_back_when_user_name_is_a_url(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        send_email_change_emails(
+            now_iso="2024-01-01T00:00:00+00:00",
+            user_name="https://phish.example.com",
+            old_address="old@posthog.com",
+            new_address="new@posthog.com",
+        )
+
+        # One for the old address, one for the new address.
+        assert len(mocked_email_messages) == 2
+        for message in mocked_email_messages:
+            assert "phish.example.com" not in message.html_body
+            assert "Hey, there!" in message.html_body
 
     def test_send_member_join_skips_users_who_disabled_org_notifications(self, MockEmailMessage: MagicMock) -> None:
         mocked_email_messages = mock_email_messages(MockEmailMessage)

--- a/posthog/templates/email/delegation_invite.html
+++ b/posthog/templates/email/delegation_invite.html
@@ -12,10 +12,10 @@
     PostHog is an all-in-one platform for product analytics, session replays, feature flags, experiments, surveys,
     and more.
 </p>
-{% if invite.message %}
+{% if invite_message %}
 <div class="invite-message">
     <div class="invite-message-divider"></div>
-    {{ invite.message }}
+    {{ invite_message }}
 </div>
 {% endif %}
 <div class="mb mt text-center">

--- a/posthog/templates/email/invite.html
+++ b/posthog/templates/email/invite.html
@@ -1,17 +1,17 @@
 {% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
 <h1 class="invite-header">
-    <strong>{{ invite.created_by.first_name }}</strong> has invited you to join
-    <strong>{{ invite.organization.name }}</strong> on PostHog
+    <strong>{{ inviter_first_name }}</strong> has invited you to join
+    <strong>{{ org_name }}</strong> on PostHog
 </h1>
 <p class="text-center">
-    <strong>{{ invite.created_by.first_name }}</strong> ({{ invite.created_by.email }}) has invited you to join
-    <strong>{{invite.organization.name }}</strong> on PostHog. PostHog is a product analytics suite that helps you
+    <strong>{{ inviter_first_name }}</strong> ({{ inviter_email }}) has invited you to join
+    <strong>{{ org_name }}</strong> on PostHog. PostHog is a product analytics suite that helps you
     better understand your users. Build the best product <i>together</i>.
 </p>
-{% if invite.message %}
+{% if invite_message %}
 <div class="invite-message">
     <div class="invite-message-divider"></div>
-    {{ invite.message }}
+    {{ invite_message }}
 </div>
 {% endif %}
 <div class="mb mt text-center">

--- a/posthog/templates/email/member_join.html
+++ b/posthog/templates/email/member_join.html
@@ -1,9 +1,9 @@
 {% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
-{% block heading %}{{ invitee.first_name }} accepted their PostHog invitation{% endblock %}
+{% block heading %}{{ invitee_first_name }} accepted their PostHog invitation{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->
 <p>
-    {{ invitee.first_name }} (<a href="mailto:{{ invitee.email }}">{{ invitee.email }}</a>) just joined you at {{ organization.name }}.
+    {{ invitee_first_name }} (<a href="mailto:{{ invitee.email }}">{{ invitee.email }}</a>) just joined you at {{ organization_name }}.
 </p>
 <div class="mb mt text-center">
     <a class="button" href="{% absolute_uri %}">View PostHog insights</a>


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

#56246 fixed a bug where users could put malicious content inside of an invite email. However, it also added a bug where any organization that looks like a domain name could not send invite emails.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Instead of silently failing to send the invite email, replace fields that fail validation with a reasonable fallback in the email. For example, if the organization name is `foobar.com`, it will fail validation and be replaced with `their organization`. Likewise, for user names `Someone`, etc., etc.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
