### PR TITLE
feat(scenes): add SceneMenuBar gated behind SCENE_MENU_BAR flag

### DIFF
--- a/.agents/skills/scene-menu-bar/SKILL.md
+++ b/.agents/skills/scene-menu-bar/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: scene-menu-bar
+description: Conventions for adding or editing the SceneMenuBar above a scene's <SceneTitleSection>. Use when adding new menu items, moving items between menus, gating behind feature flags, building a new scene's menubar, or wiring rich inputs (tags, combobox) into the bar.
+---
+
+# SceneMenuBar conventions
+
+PostHog scenes render a Mac-style menu bar above `<SceneTitleSection>` that consolidates
+ScenePanel actions into a discoverable, keyboard-navigable surface. This skill documents
+the taxonomy, the available primitives, and the wiring rules.
+
+The whole bar is gated by the `SCENE_MENU_BAR` feature flag (see `lib/constants.tsx`).
+
+## Components
+
+All primitives live in `frontend/src/layout/scenes/components/SceneMenuBar.tsx`.
+
+| Component                                              | Use for                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<SceneMenuBar>`                                       | Top-level wrapper; renders above `<SceneTitleSection>`. Includes the universal right cluster (PostHog AI / Docs / Support).                                                                                                                              |
+| `<SceneMenuBarMenu label>`                             | Top-level menu (File / Edit / View / Metadata / Staff only).                                                                                                                                                                                             |
+| `<SceneMenuBarSubMenu label>`                          | Nested sub-menu inside a `SceneMenuBarMenu` (e.g. `Create`, `Export`, `Add to notebook`). Auto-prepends a blank icon slot to the trigger so the label aligns with icon-bearing siblings — pass `withIconBlank={false}` to opt out.                       |
+| `<SceneMenuBarItem>`                                   | Standard menu item (action / navigation).                                                                                                                                                                                                                |
+| `<SceneMenuBarCheckboxItem>`                           | Toggle item — reflects boolean state via checkmark.                                                                                                                                                                                                      |
+| `<SceneMenuBarRadioGroup>` + `<SceneMenuBarRadioItem>` | One-of-many mutually-exclusive options.                                                                                                                                                                                                                  |
+| `<SceneMenuBarSeparator>`                              | Horizontal divider between groups.                                                                                                                                                                                                                       |
+| `<SceneMenuBarShortcut>`                               | Right-aligned keyboard shortcut hint.                                                                                                                                                                                                                    |
+| `<SceneMenuBarPopover label>`                          | Drop-in alternative to `SceneMenuBarMenu` when content needs rich form controls (text inputs, comboboxes). Uses Popover under the hood — Menu.Popup intercepts keystrokes and blocks inputs. Trigger does NOT participate in CompositeRoot keyboard nav. |
+
+## Canonical menu set (in order)
+
+| Menu                                       | Items                                                                                                                                                                                                                                  |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File**                                   | `+ Create` sub-menu (top), ── , project tree items (Open / Move / Star), Copy to another project, Manage with Terraform, scene-specific file ops, Export sub-menu, ──, **Delete / Archive / Restore** (destructive at the very bottom) |
+| **Edit**                                   | Duplicate, Rename, Edit in SQL editor, scene-specific edits, state mutations (Pause/Resume, Activate/Deactivate), ──, toggle group (checkbox/radio items, separated by `<SceneMenuBarSeparator>` from regular items)                   |
+| **View** _(conditional)_                   | Cross-resource viewing — View recordings, View metalytics, View related insights, etc. Anything that navigates to _see_ something tangentially related to the current resource. Skip when empty.                                       |
+| **Metadata** _(use `SceneMenuBarPopover`)_ | Tags, Evaluation contexts, Stage, Activity indicator, External references, Comments, etc.                                                                                                                                              |
+| **Staff only** _(conditional)_             | Debug panels, staff-only toggles. Only render for staff / superpowers / impersonated / non-cloud users.                                                                                                                                |
+
+> **State lives in Edit.** Pause/Resume, Activate/Deactivate, Favorite/Pin toggles and similar
+> state mutations all live inside the Edit menu — usually at the bottom, after a
+> `<SceneMenuBarSeparator>` if there's a toggle group. Don't create a separate `State` menu.
+
+Right cluster is fixed and universal: **PostHog AI · Docs · Support**. Do not add to it.
+
+## Rules
+
+### Destructive actions (Delete / Archive / Restore)
+
+- Live at the **bottom of File**, separated from the file ops above by a `<SceneMenuBarSeparator>`.
+- Pass `variant="destructive"` for visual treatment (red text + icon).
+- Do **not** add `opensFloatingUi` to destructive items even when they open a confirmation dialog — the destructive variant + clear label are signal enough.
+- Wrap with `<AccessControlAction>` where the resource has access control levels.
+
+### Toggle groups
+
+- Group all `<SceneMenuBarCheckboxItem>` and `<SceneMenuBarRadioGroup>` items together.
+- Separate them from regular action items with `<SceneMenuBarSeparator>` above and (if more items follow) below.
+- Use stable labels — the checkmark conveys state: `Pinned` not `Pin/Unpin`, `Show debug panel` not `Show/Hide debug panel`.
+- Radios for mutually-exclusive choices (`<SceneMenuBarRadioGroup value onValueChange>`).
+
+### `opensFloatingUi` prop
+
+Append `…` to the item label as a Mac-style affordance for items that open additional floating UI:
+
+- ✅ **Use** for: modal, popover, dialog, side panel openers
+- ❌ **Skip** for: same-page navigations, direct actions, destructive items (the destructive style already signals consequence), toggle items
+
+### `+ Create` cross-sells
+
+- Nest inside a `<SceneMenuBarSubMenu label="Create">` at the **top of File**.
+- Place a `<SceneMenuBarSeparator>` between Create and the rest of File.
+- Cross-sells: Cohort, Survey, Dashboard, Notebook, Endpoint, Subscription, Alert, Share or embed.
+
+### Empty menus
+
+`SceneMenuBarMenu` auto-disables its trigger when its children render nothing at compile
+time — e.g. `{false && <Item/>}`, `{null}`, or an empty fragment. The trigger stays
+visible (greyed out, `cursor-not-allowed`) so the menu set still communicates the bar's
+capabilities to the user.
+
+For menus whose children may render null at runtime (the most common case is
+`<SceneMenuBarFileItems>`, which returns null when no project-tree entry is registered),
+the parent **cannot detect** that the popup will be empty. You must either:
+
+1. **Pass `disabled` explicitly** based on the same value the children depend on, e.g.:
+
+   ```tsx
+   const { projectTreeRefEntry } = useValues(projectTreeDataLogic)
+   const hasFileItems = !!projectTreeRefEntry
+   <SceneMenuBarMenu label="File" disabled={!hasFileItems}>
+       {hasFileItems && <SceneMenuBarFileItems dataAttrKey="…" />}
+   </SceneMenuBarMenu>
+   ```
+
+2. **Gate the whole menu** at the parent if it can't render anything useful:
+
+   ```tsx
+   {
+     hasAnyEditItem && <SceneMenuBarMenu label="Edit">…</SceneMenuBarMenu>
+   }
+   ```
+
+Prefer (1) when the menu's presence is part of the scene's identity (File should always
+be visible even if disabled), and (2) when the menu is genuinely optional (View, Staff
+only).
+
+### Tags / Evaluation contexts / other rich inputs
+
+- Must live inside a `<SceneMenuBarPopover>`, not a `<SceneMenuBarMenu>`. Menu popups
+  intercept keystrokes (typeahead, arrow nav) and prevent text inputs from receiving
+  input.
+- Use `<TagsCombobox>` (`lib/components/Scenes/TagsCombobox.tsx`) for multi-select chip
+  inputs — selection-only by default; pass `allowCustomValues` to surface a
+  "Create new {noun} '...'" item at the bottom.
+- Use `<SceneTagsCombobox>` (`lib/components/Scenes/SceneTagsCombobox.tsx`) as the
+  ready-made wrapper that swaps in for `<SceneTags>` under `SCENE_MENU_BAR`.
+
+### Optimistic saves with debounce
+
+When autosaving from menubar inputs (tags, toggles), use a kea listener with:
+
+1. **Optimistic update** (`setX` + `updateX`) immediately, before the API call.
+2. **`await breakpoint(250)`** to debounce rapid changes.
+3. **`breakpoint()` after the API response** to bail if a newer call has superseded this one.
+4. **Set-equality check** before reconciling with server response to avoid re-ordering
+   when the server returns differently-ordered values.
+5. Re-throw `error.isBreakpoint` so kea swallows it silently.
+
+See `saveTagsInline` in `frontend/src/scenes/feature-flags/featureFlagLogic.ts`.
+
+### File menu — project tree items
+
+Use `<SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />` at the bottom of File
+(before the destructive separator) to render Open in project tree, Move to folder,
+Add/Remove starred. It auto-hides when no project-tree entry is registered.
+
+### Right cluster
+
+Lives outside the `<Menubar>` wrapper to keep CompositeRoot keyboard nav working for
+the actual menus. Do not add items here without UX review.
+
+### Layout-aware bleed
+
+`<SceneMenuBar>` reads `sceneLayoutLogic.sceneLayoutConfig.layout` and bleeds past the
+scene container's padding (`-mx-4 -mt-4`) **only** when the layout is padded:
+`app`, `app-container`, or `app-full-scene-height`. For unpadded layouts (`app-raw`,
+`app-raw-no-header`, `plain`) the negatives would overshoot and visually break the
+header, so they're skipped. You don't need to do anything in your scene — just register
+the right `SceneConfig.layout` and the bar adapts. Sentinel: a `data-scene-layout`
+attribute is set on the wrapper for debugging.
+
+## Scenes already migrated
+
+- Feature Flag — `frontend/src/scenes/feature-flags/FeatureFlag.tsx`
+- Insight — `frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx`
+- Dashboard — `frontend/src/scenes/dashboard/DashboardSceneMenuBar.tsx`
+
+When migrating a new scene, follow the `<Scene>SceneMenuBar.tsx` pattern (component
+that reads `featureFlagLogic`, early-returns null if the flag is off, otherwise renders
+the bar). Mount it directly above `<SceneTitleSection>`.
+
+## Auditing a scene
+
+When migrating a scene, take its existing ScenePanel and map every item to:
+
+1. Which menu it belongs to (File / Edit / View / Metadata / Staff only).
+2. Whether it needs `variant="destructive"` (delete/archive/remove).
+3. Whether it needs `opensFloatingUi` (opens modal/popover/dialog/side panel).
+4. Whether it's a toggle (use `SceneMenuBarCheckboxItem`).
+5. What gates apply (saved state, FF, AccessControl, multi-project).
+
+See `/Users/adamleithp/Desktop/scene-menu-bar-grouping.md` for the running inventory of
+all ScenePanel items across PostHog and their proposed menu placement.

--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -4,6 +4,7 @@ import { useActions, useMountedLogic, useValues } from 'kea'
 import { ReactNode, useCallback, useEffect, useRef } from 'react'
 
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -47,6 +48,9 @@ export function Navigation({
     const { sidePanelWidth } = useValues(panelLayoutLogic)
     const { firstTabIsActive } = useValues(sceneLogic)
     const noPaddingScene = sceneConfig?.layout === 'app-raw-no-header' || sceneConfig?.layout === 'app-raw'
+    // SceneMenuBar (when enabled) replaces ProjectNotice's role of conveying project-level
+    // context above scene content, so we hide the notice for users on the new menu bar.
+    const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
     const inlinePanelRef = useRef<HTMLDivElement | null>(null)
     const inlinePanelCallbackRef = useCallback(
         (node: HTMLDivElement | null) => {
@@ -163,7 +167,7 @@ export function Navigation({
                             }}
                         >
                             <SceneLayout sceneConfig={sceneConfig}>
-                                {!sceneConfig?.hideProjectNotice && (
+                                {!sceneMenuBarEnabled && !sceneConfig?.hideProjectNotice && (
                                     <div
                                         className={cn({
                                             'px-4 empty:hidden': sceneConfig?.layout === 'app-raw-no-header',

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -54,11 +54,12 @@ export function ScenePanelActionsSection({ children }: { children: React.ReactNo
 export function ScenePanelLabel({
     children,
     title,
+    className,
     ...props
 }: PropsWithChildren<Omit<LabelProps, 'title'> & { title: React.ReactNode }>): JSX.Element {
     return (
         <div className="flex flex-col gap-0">
-            <Label intent="menu" {...props}>
+            <Label intent="menu" {...props} className={cn('text-tertiary/80', className)}>
                 {title}
             </Label>
             {children}

--- a/frontend/src/layout/scenes/components/SceneMenuBar.tsx
+++ b/frontend/src/layout/scenes/components/SceneMenuBar.tsx
@@ -1,0 +1,332 @@
+import { useActions, useValues } from 'kea'
+import { Children, ComponentProps, ReactNode } from 'react'
+
+import { IconExternal, IconSidePanel } from '@posthog/icons'
+import {
+    Badge,
+    Button,
+    Menubar,
+    MenubarCheckboxItem,
+    MenubarContent,
+    MenubarItem,
+    MenubarMenu,
+    MenubarRadioGroup,
+    MenubarRadioItem,
+    MenubarSeparator,
+    MenubarShortcut,
+    MenubarSub,
+    MenubarSubContent,
+    MenubarSubTrigger,
+    MenubarTrigger,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@posthog/quill'
+
+import { IconBlank } from 'lib/lemon-ui/icons'
+import { Link } from 'lib/lemon-ui/Link'
+import { cn } from 'lib/utils/css-classes'
+
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
+import { SidePanelTab } from '~/types'
+
+/**
+ * Scene layouts where the surrounding container applies horizontal/vertical padding to
+ * scene content. In those layouts the menu bar uses negative margins to span edge-to-edge.
+ * For unpadded layouts (app-raw, plain, etc.) the negatives would overshoot — we skip them.
+ */
+const PADDED_LAYOUTS = new Set(['app', 'app-container', 'app-full-scene-height'])
+
+type SceneMenuBarProps = {
+    children: ReactNode
+    className?: string
+}
+
+export function SceneMenuBar({ children, className }: SceneMenuBarProps): JSX.Element {
+    const { sceneLayoutConfig } = useValues(sceneLayoutLogic)
+    const layout = sceneLayoutConfig?.layout ?? 'app'
+    const isPaddedLayout = PADDED_LAYOUTS.has(layout)
+
+    return (
+        <div
+            data-attr="scene-menu-bar"
+            data-scene-layout={layout}
+            className={cn(
+                'scene-menu-bar px-0.5 py-0.5 border-b border-primary flex items-center justify-between',
+                // Bleed past the scene container's padding so the bar feels full-width — only
+                // safe when the layout actually has padding to cancel. Unpadded layouts
+                // (app-raw, plain, etc.) would overflow.
+                isPaddedLayout && '-mx-4 -mt-4',
+                // When LemonTabs is the immediately preceding sibling it already bleeds with
+                // its own -mt-6, leaving the menu bar floating in the flex `gap-y-*`. Pull the
+                // bar up so they sit flush.
+                '[.LemonTabs+&]:-mt-6',
+                className
+            )}
+        >
+            {/*
+              Right-side cluster lives OUTSIDE <Menubar> so it doesn't pollute the Menubar's
+              CompositeRoot — that's what coordinates ArrowLeft/Right navigation and
+              hover-to-switch between menus.
+            */}
+            <Menubar className="gap-0 border-0 text-tertiary hover:text-primary">{children}</Menubar>
+
+            <Badge>OS-like menu (alpha)</Badge>
+            <SceneMenuBarRightLinks />
+        </div>
+    )
+}
+
+const RIGHT_TRIGGER_CLASSES = 'px-2 h-7 rounded-sm text-xs font-medium inline-flex items-center gap-1'
+
+function SceneMenuBarRightLinks(): JSX.Element {
+    const { openSidePanel } = useActions(sidePanelStateLogic)
+    return (
+        <div className="flex items-center gap-px pr-1">
+            <Button
+                variant="link"
+                render={
+                    <Link
+                        to="https://posthog.com/docs"
+                        target="_blank"
+                        targetBlankIcon={false}
+                        disableDocsPanel
+                        tooltip="Open docs in a new tab"
+                        data-attr="scene-menu-bar-docs"
+                        className={RIGHT_TRIGGER_CLASSES}
+                    >
+                        Docs
+                        <IconExternal />
+                    </Link>
+                }
+            />
+            <Button
+                type="button"
+                onClick={() => openSidePanel(SidePanelTab.Support)}
+                data-attr="scene-menu-bar-support"
+                className={RIGHT_TRIGGER_CLASSES}
+            >
+                Support
+                <IconSidePanel />
+            </Button>
+            <Button
+                type="button"
+                onClick={() => openSidePanel(SidePanelTab.Max)}
+                data-attr="scene-menu-bar-ai"
+                className={RIGHT_TRIGGER_CLASSES}
+                variant="outline"
+            >
+                PostHog AI
+            </Button>
+        </div>
+    )
+}
+
+/**
+ * Canonical menu set for SceneMenuBar. Use these labels in this order so the bar feels
+ * consistent across PostHog scenes. Render only the menus your scene actually needs.
+ *
+ * Order: File → Edit → View → Metadata → Staff only
+ *
+ * - **File** — `<SceneMenuBarSubMenu label="Create">` at the top, then file/project ops,
+ *   Export sub-menu, ──, **Delete / Archive / Restore** (destructive, at the bottom).
+ * - **Edit** — Duplicate, Rename, scene-specific edits, state mutations
+ *   (Pause/Resume, Activate/Deactivate), ──, grouped toggles
+ *   (Pin/Fullscreen/Favorite/etc) using `<SceneMenuBarCheckboxItem>`.
+ * - **View** *(conditional)* — Cross-resource viewing actions: View recordings,
+ *   View metalytics, View related X. Anything that navigates the user to *see* something
+ *   tangentially related to the current resource. Skip when there's nothing to view.
+ * - **Metadata** *(use `SceneMenuBarPopover`)* — Tags, Evaluation contexts, Stage,
+ *   Activity indicator, ExternalReferences.
+ * - **Staff only** *(conditional)* — Debug panels, internal toggles.
+ *
+ * Right cluster is universal: PostHog AI / Docs / Support.
+ *
+ * Full conventions: `.agents/skills/scene-menu-bar/SKILL.md`.
+ */
+export type SceneMenuBarLabel = 'File' | 'Edit' | 'View' | 'Metadata' | 'Staff only' | (string & {})
+
+type SceneMenuBarMenuProps = {
+    /** Top-level menu label. Use canonical labels (File / Edit / View / Metadata / Staff only). */
+    label: SceneMenuBarLabel
+    children: ReactNode
+    /** data-attr applied to the trigger for tests */
+    dataAttr?: string
+    /** Optional content alignment */
+    align?: 'start' | 'center' | 'end'
+    /** Class applied to the dropdown content — useful for widening menus that hold rich widgets */
+    contentClassName?: string
+    /**
+     * Force the trigger into a disabled state regardless of children. Use when the menu's
+     * items are guaranteed to be empty in a known state (e.g. unsaved resource) and you
+     * still want the label visible. For purely empty children the trigger auto-disables.
+     */
+    disabled?: boolean
+}
+
+/**
+ * True when no direct child of the menu would render anything visible. Catches
+ * `{false && <Item/>}` / `{null}` / empty fragments. Components that return null at
+ * render (e.g. SceneMenuBarFileItems with no tree entry) cannot be detected from the
+ * parent — gate those at the caller or pass `disabled` explicitly.
+ */
+function hasNoRenderableChildren(children: ReactNode): boolean {
+    return Children.toArray(children).length === 0
+}
+
+export function SceneMenuBarMenu({
+    label,
+    children,
+    dataAttr,
+    align = 'start',
+    contentClassName,
+    disabled,
+}: SceneMenuBarMenuProps): JSX.Element {
+    const isDisabled = disabled || hasNoRenderableChildren(children)
+    return (
+        <MenubarMenu>
+            <MenubarTrigger
+                data-attr={dataAttr}
+                disabled={isDisabled}
+                className="px-2 h-7 rounded-sm text-xs font-medium hover:bg-fill-hover data-[popup-open]:bg-fill-selected disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+            >
+                {label}
+            </MenubarTrigger>
+            <MenubarContent
+                align={align}
+                className={cn(
+                    // Override DropdownMenuContent's default `w-(--anchor-width)` so menus size to content.
+                    'w-auto min-w-max',
+                    contentClassName
+                )}
+            >
+                {children}
+            </MenubarContent>
+        </MenubarMenu>
+    )
+}
+
+type SceneMenuBarItemProps = ComponentProps<typeof MenubarItem> & {
+    /**
+     * Append a trailing ellipsis ("…") to the label — Mac-style affordance signalling that
+     * the action opens additional floating UI (modal, popover, dialog, side panel).
+     * Use for items like "Subscribe…", "Duplicate…", "Manage with Terraform…". Skip for
+     * direct actions ("Delete feature flag") and same-page navigations.
+     */
+    opensFloatingUi?: boolean
+}
+
+/**
+ * Pass `variant="destructive"` for any "Delete X" / "Archive X" / "Remove X" action so the
+ * visual signal (red text + icon) is consistent across PostHog scenes.
+ */
+export function SceneMenuBarItem({ opensFloatingUi, children, ...props }: SceneMenuBarItemProps): JSX.Element {
+    return (
+        <MenubarItem {...props}>
+            {children}
+            {/*
+              `-ms-2` cancels MenubarItem's parent flex `gap-2` so the ellipsis sits flush
+              against the trailing edge of the label instead of getting a full gap inserted.
+            */}
+            {opensFloatingUi && (
+                <span aria-hidden className="-ms-2">
+                    …
+                </span>
+            )}
+        </MenubarItem>
+    )
+}
+
+/**
+ * Use for toggle-style items (e.g. "Show debug panel", "Pin", "Favorite"). Renders a
+ * checkmark indicator that reflects `checked` state.
+ */
+export function SceneMenuBarCheckboxItem(props: ComponentProps<typeof MenubarCheckboxItem>): JSX.Element {
+    return <MenubarCheckboxItem {...props} />
+}
+
+/**
+ * Wrap multiple `SceneMenuBarRadioItem` instances to make them mutually-exclusive.
+ * Bind via `value` + `onValueChange`.
+ */
+export function SceneMenuBarRadioGroup(props: ComponentProps<typeof MenubarRadioGroup>): JSX.Element {
+    return <MenubarRadioGroup {...props} />
+}
+
+/**
+ * One of several mutually-exclusive options inside a `<SceneMenuBarRadioGroup>`.
+ */
+export function SceneMenuBarRadioItem(props: ComponentProps<typeof MenubarRadioItem>): JSX.Element {
+    return <MenubarRadioItem {...props} />
+}
+
+export function SceneMenuBarSeparator(props: ComponentProps<typeof MenubarSeparator>): JSX.Element {
+    return <MenubarSeparator {...props} />
+}
+
+export function SceneMenuBarShortcut(props: ComponentProps<typeof MenubarShortcut>): JSX.Element {
+    return <MenubarShortcut {...props} />
+}
+
+type SceneMenuBarSubMenuProps = {
+    label: ReactNode
+    children: ReactNode
+    /**
+     * Whether to prepend a blank icon slot to the trigger so the label aligns with sibling
+     * items that have leading icons. Default true — opt out via `withIconBlank={false}`
+     * when the trigger already supplies its own leading icon.
+     */
+    withIconBlank?: boolean
+}
+
+export function SceneMenuBarSubMenu({ label, children, withIconBlank = true }: SceneMenuBarSubMenuProps): JSX.Element {
+    return (
+        <MenubarSub>
+            <MenubarSubTrigger>
+                {withIconBlank && <IconBlank />}
+                {label}
+            </MenubarSubTrigger>
+            <MenubarSubContent>{children}</MenubarSubContent>
+        </MenubarSub>
+    )
+}
+
+type SceneMenuBarPopoverProps = {
+    /** Trigger label — styled identically to a SceneMenuBarMenu trigger */
+    label: SceneMenuBarLabel
+    children: ReactNode
+    dataAttr?: string
+    align?: 'start' | 'center' | 'end'
+    contentClassName?: string
+}
+
+/**
+ * Drop-in alternative to `SceneMenuBarMenu` for menus whose content needs rich form controls
+ * (text inputs, comboboxes, etc). Renders a Popover instead of a Menu — Menu.Popup intercepts
+ * keystrokes for typeahead/arrow-nav which prevents text inputs from receiving input.
+ *
+ * Use for: Metadata-style panels with `<TagsCombobox>`, inline edit fields, free-form widgets.
+ * Avoid for: lists of action items (use `SceneMenuBarMenu` so keyboard nav still works).
+ *
+ * Trade-off: Popover trigger does NOT participate in the Menubar's CompositeRoot, so
+ * ArrowLeft/Right won't switch to/from it.
+ */
+export function SceneMenuBarPopover({
+    label,
+    children,
+    dataAttr,
+    align = 'start',
+    contentClassName,
+}: SceneMenuBarPopoverProps): JSX.Element {
+    return (
+        <Popover>
+            <PopoverTrigger data-attr={dataAttr} render={<Button />}>
+                {label}
+            </PopoverTrigger>
+            <PopoverContent align={align} className={cn('w-80 p-2', contentClassName)}>
+                {children}
+            </PopoverContent>
+        </Popover>
+    )
+}

--- a/frontend/src/layout/scenes/components/Untitled
+++ b/frontend/src/layout/scenes/components/Untitled
@@ -1,1 +1,0 @@
-{cn(buttonClassName, 

--- a/frontend/src/lib/components/Scenes/SceneMenuBarAddToNotebook.tsx
+++ b/frontend/src/lib/components/Scenes/SceneMenuBarAddToNotebook.tsx
@@ -1,0 +1,107 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { IconNotebook, IconPlusSmall } from '@posthog/icons'
+
+import { dayjs } from 'lib/dayjs'
+import {
+    NotebookSelectButtonLogicProps,
+    notebookSelectButtonLogic,
+} from 'scenes/notebooks/NotebookSelectButton/notebookSelectButtonLogic'
+import { NotebookListItemType, NotebookTarget } from 'scenes/notebooks/types'
+
+import { SceneMenuBarItem, SceneMenuBarSeparator, SceneMenuBarSubMenu } from '~/layout/scenes/components/SceneMenuBar'
+import { notebooksModel, openNotebook } from '~/models/notebooksModel'
+
+type SceneMenuBarAddToNotebookProps = {
+    dataAttrKey: string
+    notebookSelectButtonProps?: NotebookSelectButtonLogicProps
+    /** Title used when "New notebook" is clicked */
+    newNotebookTitle?: string
+}
+
+/**
+ * Add-to-notebook sub-menu intended to live inside a `<SceneMenuBarMenu label="Create">`.
+ * Renders a sub-menu trigger that, on open, shows:
+ *   - New notebook
+ *   - Scratchpad
+ *   - Notebooks already containing this resource (if any)
+ *   - Other notebooks (capped by `NOTEBOOK_DROPDOWN_LIMIT`)
+ */
+export function SceneMenuBarAddToNotebook({
+    dataAttrKey,
+    notebookSelectButtonProps,
+    newNotebookTitle,
+}: SceneMenuBarAddToNotebookProps): JSX.Element {
+    const logic = notebookSelectButtonLogic({ ...notebookSelectButtonProps })
+    const { loadNotebooksContainingResource, loadAllNotebooks } = useActions(logic)
+    const { notebooksContainingResource, notebooksNotContainingResource } = useValues(logic)
+    const { createNotebook } = useActions(notebooksModel)
+    const { resource } = notebookSelectButtonProps || {}
+    const notebookResource = resource && typeof resource !== 'boolean' ? resource : null
+
+    useEffect(() => {
+        if (resource) {
+            loadNotebooksContainingResource()
+        }
+        loadAllNotebooks()
+        // oxlint-disable-next-line exhaustive-deps
+    }, [resource])
+
+    const openAndAdd = (notebookShortId: string, exists: boolean): void => {
+        const position = notebookSelectButtonProps?.resource ? 'end' : 'start'
+        void openNotebook(notebookShortId, NotebookTarget.Popover, position, (theNotebookLogic) => {
+            if (!exists && notebookSelectButtonProps?.resource) {
+                theNotebookLogic.actions.insertAfterLastNode([notebookSelectButtonProps.resource])
+            }
+        })
+    }
+
+    const openNew = (): void => {
+        const title = newNotebookTitle ?? `Notes ${dayjs().format('DD/MM')}`
+        createNotebook(NotebookTarget.Popover, title, notebookResource ? [notebookResource] : undefined, () => {
+            loadNotebooksContainingResource()
+        })
+    }
+
+    return (
+        <SceneMenuBarSubMenu label="Add to notebook">
+            <SceneMenuBarItem opensFloatingUi onClick={openNew} data-attr={`${dataAttrKey}-menubar-new-notebook`}>
+                <IconPlusSmall />
+                New notebook
+            </SceneMenuBarItem>
+            <SceneMenuBarItem
+                opensFloatingUi
+                onClick={() => openAndAdd('scratchpad', false)}
+                data-attr={`${dataAttrKey}-menubar-scratchpad`}
+            >
+                <IconNotebook />
+                My scratchpad
+            </SceneMenuBarItem>
+            {notebooksContainingResource.length > 0 && <SceneMenuBarSeparator />}
+            {notebooksContainingResource.map((notebook: NotebookListItemType) => (
+                <SceneMenuBarItem
+                    key={`in-${notebook.short_id}`}
+                    opensFloatingUi
+                    onClick={() => openAndAdd(notebook.short_id, true)}
+                    data-attr={`${dataAttrKey}-menubar-continue-notebook`}
+                >
+                    <IconNotebook />
+                    {notebook.title || `Untitled (${notebook.short_id})`}
+                </SceneMenuBarItem>
+            ))}
+            {notebooksNotContainingResource.length > 0 && <SceneMenuBarSeparator />}
+            {notebooksNotContainingResource.map((notebook: NotebookListItemType) => (
+                <SceneMenuBarItem
+                    key={`out-${notebook.short_id}`}
+                    opensFloatingUi
+                    onClick={() => openAndAdd(notebook.short_id, false)}
+                    data-attr={`${dataAttrKey}-menubar-add-notebook`}
+                >
+                    <IconNotebook />
+                    {notebook.title || `Untitled (${notebook.short_id})`}
+                </SceneMenuBarItem>
+            ))}
+        </SceneMenuBarSubMenu>
+    )
+}

--- a/frontend/src/lib/components/Scenes/SceneMenuBarFileItems.tsx
+++ b/frontend/src/lib/components/Scenes/SceneMenuBarFileItems.tsx
@@ -1,0 +1,81 @@
+import { useActions, useValues } from 'kea'
+
+import { IconFolderMove, IconFolderOpen, IconStar, IconStarFilled } from '@posthog/icons'
+
+import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
+import { PROJECT_TREE_KEY } from '~/layout/panel-layout/ProjectTree/ProjectTree'
+import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
+import { projectTreeLogic } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
+import { joinPath, splitPath } from '~/layout/panel-layout/ProjectTree/utils'
+import { SceneMenuBarItem } from '~/layout/scenes/components/SceneMenuBar'
+
+import { moveToLogic } from '../FileSystem/MoveTo/moveToLogic'
+
+type SceneMenuBarFileItemsProps = {
+    /** Used as a prefix on data-attr for testing */
+    dataAttrKey: string
+}
+
+/**
+ * File-system actions for the current scene's tree entry, intended to be placed inside
+ * a <SceneMenuBarMenu label="File">. Returns null if no project tree entry is registered.
+ */
+export function SceneMenuBarFileItems({ dataAttrKey }: SceneMenuBarFileItemsProps): JSX.Element | null {
+    const { assureVisibility } = useActions(projectTreeLogic({ key: PROJECT_TREE_KEY }))
+    const { showLayoutPanel, setActivePanelIdentifier } = useActions(panelLayoutLogic)
+    const { addShortcutItem, deleteShortcut } = useActions(projectTreeDataLogic)
+    const { projectTreeRefEntry, shortcutNonFolderPaths, shortcutData } = useValues(projectTreeDataLogic)
+    const { openMoveToModal } = useActions(moveToLogic)
+
+    if (!projectTreeRefEntry) {
+        return null
+    }
+
+    const itemShortcutPath = joinPath([splitPath(projectTreeRefEntry.path).pop() ?? 'Unnamed'])
+    const isAlreadyStarred = projectTreeRefEntry.type !== 'folder' && shortcutNonFolderPaths.has(itemShortcutPath)
+
+    return (
+        <>
+            <SceneMenuBarItem
+                opensFloatingUi
+                onClick={() => {
+                    assureVisibility({ type: 'folder', ref: projectTreeRefEntry.path })
+                    showLayoutPanel(true)
+                    setActivePanelIdentifier('Project')
+                }}
+                data-attr={`${dataAttrKey}-menubar-open-in-project-tree`}
+            >
+                <IconFolderOpen />
+                Open in project tree
+            </SceneMenuBarItem>
+            <SceneMenuBarItem
+                opensFloatingUi
+                onClick={() => openMoveToModal([projectTreeRefEntry])}
+                data-attr={`${dataAttrKey}-menubar-move-to`}
+            >
+                <IconFolderMove />
+                Move to another folder
+            </SceneMenuBarItem>
+            <SceneMenuBarItem
+                onClick={() => {
+                    if (isAlreadyStarred) {
+                        const shortcut = shortcutData.find((s) => s.path === itemShortcutPath && s.type !== 'folder')
+                        if (shortcut?.id) {
+                            deleteShortcut(shortcut.id)
+                        }
+                    } else {
+                        addShortcutItem(projectTreeRefEntry)
+                    }
+                }}
+                data-attr={
+                    isAlreadyStarred
+                        ? `${dataAttrKey}-menubar-remove-from-starred`
+                        : `${dataAttrKey}-menubar-add-to-starred`
+                }
+            >
+                {isAlreadyStarred ? <IconStarFilled className="text-warning" /> : <IconStar />}
+                {isAlreadyStarred ? 'Remove from starred' : 'Add to starred'}
+            </SceneMenuBarItem>
+        </>
+    )
+}

--- a/frontend/src/lib/components/Scenes/SceneTagsCombobox.tsx
+++ b/frontend/src/lib/components/Scenes/SceneTagsCombobox.tsx
@@ -1,0 +1,49 @@
+import { Spinner } from 'lib/lemon-ui/Spinner'
+
+import { ScenePanelLabel } from '~/layout/scenes/SceneLayout'
+
+import { TagsCombobox } from './TagsCombobox'
+import { SceneCanEditProps, SceneDataAttrKeyProps } from './utils'
+
+type SceneTagsComboboxProps = SceneCanEditProps &
+    SceneDataAttrKeyProps & {
+        onSave?: (value: string[]) => void
+        tags?: string[]
+        tagsAvailable?: string[]
+        loading?: boolean
+    }
+
+/**
+ * Quill-Combobox variant of `<SceneTags>`. Always-rendered input + chips, with autosave on change.
+ * Gate behind the `SCENE_MENU_BAR` feature flag at call sites.
+ */
+export function SceneTagsCombobox({
+    onSave,
+    tags,
+    tagsAvailable,
+    dataAttrKey,
+    canEdit = true,
+    loading,
+}: SceneTagsComboboxProps): JSX.Element {
+    const label = (
+        <span className="flex items-center gap-1.5">
+            Tags
+            {loading ? <Spinner className="text-sm" /> : null}
+        </span>
+    )
+
+    return (
+        <ScenePanelLabel title={label}>
+            <TagsCombobox
+                value={tags ?? []}
+                onChange={(next) => onSave?.(next)}
+                options={tagsAvailable}
+                placeholder="Add tags..."
+                disabled={!onSave || !canEdit}
+                allowCustomValues
+                customValueNoun="tag"
+                dataAttr={`${dataAttrKey}-tags-input`}
+            />
+        </ScenePanelLabel>
+    )
+}

--- a/frontend/src/lib/components/Scenes/TagsCombobox.tsx
+++ b/frontend/src/lib/components/Scenes/TagsCombobox.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react'
+
+import {
+    Combobox,
+    ComboboxChip,
+    ComboboxChips,
+    ComboboxChipsInput,
+    ComboboxContent,
+    ComboboxEmpty,
+    ComboboxItem,
+    ComboboxList,
+    ComboboxValue,
+    useComboboxAnchor,
+} from '@posthog/quill'
+
+type TagsComboboxProps = {
+    value: string[]
+    onChange: (next: string[]) => void
+    options?: string[]
+    placeholder?: string
+    autoFocus?: boolean
+    disabled?: boolean
+    /** When true (default), typing a value not in options surfaces a "Create X" entry. */
+    allowCustomValues?: boolean
+    /** Label used in the "Create X" placeholder, e.g. "tag" → "Create new tag "foo"". */
+    customValueNoun?: string
+    /** data-attr applied to the input */
+    dataAttr?: string
+    className?: string
+}
+
+/**
+ * Multi-select tag/chip input on Quill's Combobox. Mirrors the storybook "Multiple" pattern.
+ * Adds a synthetic "Create X" item when the typed input doesn't match any option — selecting it
+ * commits the typed value via `onChange`.
+ */
+export function TagsCombobox(props: TagsComboboxProps): JSX.Element {
+    return <TagsComboboxInner {...props} />
+}
+
+function TagsComboboxInner({
+    value,
+    onChange,
+    options = [],
+    placeholder,
+    autoFocus,
+    disabled,
+    allowCustomValues = true,
+    customValueNoun = 'tag',
+    dataAttr,
+    className,
+}: TagsComboboxProps): JSX.Element {
+    const [inputValue, setInputValue] = useState('')
+    const trimmed = inputValue.trim()
+    const showCreateItem =
+        allowCustomValues && trimmed.length > 0 && !value.includes(trimmed) && !options.includes(trimmed)
+
+    // Synthetic items list: existing options + (optionally) the "Create X" sentinel at the bottom.
+    const items: string[] = [...options]
+    const createSentinel = `__create__:${trimmed}`
+    if (showCreateItem) {
+        items.push(createSentinel)
+    }
+
+    return (
+        <Combobox
+            multiple
+            autoHighlight
+            items={items}
+            value={value}
+            onValueChange={(next: string[]) => {
+                // Convert any sentinel selection into the real typed value, dedupe.
+                const cleaned = (next ?? []).map((v) =>
+                    v.startsWith('__create__:') ? v.slice('__create__:'.length) : v
+                )
+                onChange(Array.from(new Set(cleaned)))
+                setInputValue('')
+            }}
+            inputValue={inputValue}
+            onInputValueChange={(v: string) => setInputValue(v)}
+        >
+            <TagsComboboxBody
+                placeholder={placeholder}
+                autoFocus={autoFocus}
+                disabled={disabled}
+                dataAttr={dataAttr}
+                className={className}
+                createSentinel={showCreateItem ? createSentinel : null}
+                customValueNoun={customValueNoun}
+                trimmed={trimmed}
+            />
+        </Combobox>
+    )
+}
+
+function TagsComboboxBody({
+    placeholder,
+    autoFocus,
+    disabled,
+    dataAttr,
+    className,
+    createSentinel,
+    customValueNoun,
+    trimmed,
+}: {
+    placeholder?: string
+    autoFocus?: boolean
+    disabled?: boolean
+    dataAttr?: string
+    className?: string
+    createSentinel: string | null
+    customValueNoun: string
+    trimmed: string
+}): JSX.Element {
+    const anchor = useComboboxAnchor()
+    return (
+        <>
+            <ComboboxChips ref={anchor} className={className}>
+                <ComboboxValue>
+                    {(values) => (
+                        <>
+                            {(values as string[])
+                                .filter((v) => !v.startsWith('__create__:'))
+                                .map((v) => (
+                                    <ComboboxChip key={v} title={v}>
+                                        {v}
+                                    </ComboboxChip>
+                                ))}
+                            <ComboboxChipsInput
+                                placeholder={placeholder}
+                                autoFocus={autoFocus}
+                                disabled={disabled}
+                                data-attr={dataAttr}
+                            />
+                        </>
+                    )}
+                </ComboboxValue>
+            </ComboboxChips>
+            <ComboboxContent anchor={anchor}>
+                <ComboboxEmpty>
+                    {trimmed ? `No matching ${customValueNoun}` : `No ${customValueNoun}s yet`}
+                </ComboboxEmpty>
+                <ComboboxList>
+                    {(item: string) => {
+                        if (item === createSentinel) {
+                            return (
+                                <ComboboxItem key={item} value={item}>
+                                    Create new {customValueNoun} "{trimmed}"
+                                </ComboboxItem>
+                            )
+                        }
+                        return (
+                            <ComboboxItem key={item} value={item}>
+                                {item}
+                            </ComboboxItem>
+                        )
+                    }}
+                </ComboboxList>
+            </ComboboxContent>
+        </>
+    )
+}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -446,6 +446,7 @@ export const FEATURE_FLAGS = {
     REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW: 'replay-x-llm-analytics-conversation-view', // owner: @pauldambra #team-replay
     REVENUE_ANALYTICS: 'revenue-analytics', // owner: @rafaeelaudibert #team-customer-analytics
     REVENUE_FIELDS_IN_POWER_USERS_TABLE: 'revenue-fields-in-power-users-table', // owner: @arthurdedeus #team-customer-analytics
+    SCENE_MENU_BAR: 'scene-menu-bar', // owner: @adamleithp #team-platform-ux, gates the per-scene MenuBar above SceneTitleSection
     SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE: 'schedule-feature-flag-variants-update', // owner: @gustavo #team-feature-flags
     SCHEMA_ENFORCEMENT_REJECT: 'schema-enforcement-reject', // owner: @aspicer, gates the ability to set schema enforcement mode to "reject"
     SCHEMA_MANAGEMENT: 'schema-management', // owner: @aspicer

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -43,6 +43,7 @@ import { CohortType, SidePanelTab } from '~/types'
 import { AddPersonToCohortModal } from './AddPersonToCohortModal'
 import { addPersonToCohortModalLogic } from './addPersonToCohortModalLogic'
 import { cohortCountWarningLogic } from './cohortCountWarningLogic'
+import { CohortSceneMenuBar } from './CohortSceneMenuBar'
 import { createCohortDataNodeLogicKey } from './cohortUtils'
 import { PersonSelectList } from './PersonSelectList'
 import { PersonDisplayNameType, RemovePersonFromCohortButton } from './RemovePersonFromCohortButton'
@@ -121,6 +122,7 @@ export function CohortEdit({ id, attachTo, tabId }: CohortEditProps): JSX.Elemen
     if (cohort.deleted) {
         return (
             <div>
+                <CohortSceneMenuBar id={id} tabId={tabId} />
                 <LemonBanner type="error">The cohort '{cohort.name}' has been soft deleted.</LemonBanner>
                 <ScenePanel>
                     <ButtonPrimitive
@@ -141,6 +143,7 @@ export function CohortEdit({ id, attachTo, tabId }: CohortEditProps): JSX.Elemen
         <BindLogic logic={cohortEditLogic} props={logicProps}>
             <div className="cohort">
                 <AddPersonToCohortModal id={id} tabId={tabId} />
+                <CohortSceneMenuBar id={id} tabId={tabId} />
 
                 <ScenePanel>
                     <ScenePanelInfoSection>

--- a/frontend/src/scenes/cohorts/CohortSceneMenuBar.tsx
+++ b/frontend/src/scenes/cohorts/CohortSceneMenuBar.tsx
@@ -1,0 +1,165 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { IconClock, IconCopy, IconRefresh, IconTrash } from '@posthog/icons'
+import { LemonDialog } from '@posthog/lemon-ui'
+
+import { SceneMenuBarAddToNotebook } from 'lib/components/Scenes/SceneMenuBarAddToNotebook'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { cohortEditLogic } from 'scenes/cohorts/cohortEditLogic'
+import { NotebookNodeType } from 'scenes/notebooks/types'
+import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopyLogic'
+import { urls } from 'scenes/urls'
+
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+    SceneMenuBarSubMenu,
+} from '~/layout/scenes/components/SceneMenuBar'
+import { CohortType } from '~/types'
+
+const RESOURCE_TYPE = 'cohort'
+
+export function CohortSceneMenuBar({ id, tabId }: { id?: CohortType['id']; tabId: string }): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
+        return null
+    }
+    return <CohortSceneMenuBarInner id={id} tabId={tabId} />
+}
+
+function CohortSceneMenuBarInner({ id, tabId }: { id?: CohortType['id']; tabId: string }): JSX.Element | null {
+    const logic = cohortEditLogic({ id, tabId })
+    const { cohort, cohortLoading } = useValues(logic)
+    const { duplicateCohort, deleteCohort, restoreCohort } = useActions(logic)
+    const { canCopyToProject } = useValues(interProjectCopyLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    if (!cohort) {
+        return null
+    }
+
+    const isNewCohort = cohort.id === 'new' || cohort.id === undefined
+    const isDeleted = cohort.deleted
+
+    const cohortIdNumber = typeof cohort.id === 'number' ? cohort.id : undefined
+
+    return (
+        <SceneMenuBar>
+            <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                {!isNewCohort && cohortIdNumber !== undefined && (
+                    <>
+                        <SceneMenuBarSubMenu label="Create">
+                            <SceneMenuBarAddToNotebook
+                                dataAttrKey={RESOURCE_TYPE}
+                                notebookSelectButtonProps={{
+                                    resource: {
+                                        type: NotebookNodeType.Cohort,
+                                        attrs: { id: cohortIdNumber },
+                                    },
+                                }}
+                            />
+                        </SceneMenuBarSubMenu>
+                        <SceneMenuBarSeparator />
+                    </>
+                )}
+                <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                {!isNewCohort && canCopyToProject && (
+                    <SceneMenuBarItem
+                        onClick={() => router.actions.push(urls.resourceTransfer('Cohort', cohort.id))}
+                        data-attr={`${RESOURCE_TYPE}-menubar-copy-to-project`}
+                    >
+                        <IconCopy />
+                        Copy to another project
+                    </SceneMenuBarItem>
+                )}
+                {!isNewCohort && !cohort.is_static && !!featureFlags[FEATURE_FLAGS.COHORT_CALCULATION_HISTORY] && (
+                    <SceneMenuBarItem
+                        onClick={() => router.actions.push(urls.cohortCalculationHistory(cohort.id))}
+                        data-attr={`${RESOURCE_TYPE}-menubar-calculation-history`}
+                    >
+                        <IconClock />
+                        Calculation history
+                    </SceneMenuBarItem>
+                )}
+                {(isDeleted || !isNewCohort) && <SceneMenuBarSeparator />}
+                {isDeleted && (
+                    <SceneMenuBarItem
+                        disabled={cohortLoading}
+                        onClick={() => restoreCohort()}
+                        data-attr={`${RESOURCE_TYPE}-menubar-restore`}
+                    >
+                        <IconRefresh />
+                        Restore
+                    </SceneMenuBarItem>
+                )}
+                {!isNewCohort && !isDeleted && (
+                    <SceneMenuBarItem
+                        variant="destructive"
+                        onClick={() => {
+                            LemonDialog.open({
+                                title: 'Delete cohort?',
+                                description: `Are you sure you want to delete "${cohort.name}"?`,
+                                primaryButton: {
+                                    children: 'Delete',
+                                    status: 'danger',
+                                    onClick: () => deleteCohort(),
+                                    size: 'small',
+                                },
+                                secondaryButton: {
+                                    children: 'Cancel',
+                                    type: 'tertiary',
+                                    size: 'small',
+                                },
+                            })
+                        }}
+                        data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                    >
+                        <IconTrash />
+                        Delete
+                    </SceneMenuBarItem>
+                )}
+            </SceneMenuBarMenu>
+            {!isDeleted && (
+                <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
+                    <SceneMenuBarItem
+                        onClick={() => duplicateCohort(false)}
+                        disabled={isNewCohort || cohort.is_static === true || (cohort.is_calculating ?? false)}
+                        tooltip={
+                            isNewCohort
+                                ? 'Save the cohort first'
+                                : cohort.is_static === true
+                                  ? 'Cohort must be dynamic to duplicate'
+                                  : cohort.is_calculating
+                                    ? 'Cohort is still calculating'
+                                    : undefined
+                        }
+                        data-attr={`${RESOURCE_TYPE}-menubar-duplicate-dynamic`}
+                    >
+                        <IconCopy />
+                        Duplicate as dynamic cohort
+                    </SceneMenuBarItem>
+                    <SceneMenuBarItem
+                        onClick={() => duplicateCohort(true)}
+                        disabled={isNewCohort || (cohort.is_calculating ?? false)}
+                        tooltip={
+                            isNewCohort
+                                ? 'Save the cohort first'
+                                : cohort.is_calculating
+                                  ? 'Cohort is still calculating'
+                                  : undefined
+                        }
+                        data-attr={`${RESOURCE_TYPE}-menubar-duplicate-static`}
+                    >
+                        <IconCopy />
+                        Duplicate as static cohort
+                    </SceneMenuBarItem>
+                </SceneMenuBarMenu>
+            )}
+        </SceneMenuBar>
+    )
+}

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -13,6 +13,7 @@ import { DashboardMode } from '~/types'
 import { EditModeActions, FullscreenModeActions, ViewModeActions } from './DashboardHeaderActions'
 import { DashboardLoadAction, dashboardLogic } from './dashboardLogic'
 import { DashboardModals } from './DashboardModals'
+import { DashboardSceneMenuBar } from './DashboardSceneMenuBar'
 import { DashboardScenePanel } from './DashboardScenePanel'
 
 export const DASHBOARD_CANNOT_EDIT_MESSAGE =
@@ -36,6 +37,7 @@ export function DashboardHeader(): JSX.Element | null {
             {dashboard && <DashboardModals dashboard={dashboard} />}
 
             <DashboardScenePanel />
+            <DashboardSceneMenuBar />
 
             <SceneTitleSection
                 name={dashboard?.name}

--- a/frontend/src/scenes/dashboard/DashboardSceneMenuBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSceneMenuBar.tsx
@@ -1,0 +1,351 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+
+import {
+    IconBell,
+    IconCode2,
+    IconCopy,
+    IconDownload,
+    IconGraph,
+    IconNotebook,
+    IconPalette,
+    IconPulse,
+    IconScreen,
+    IconTrash,
+} from '@posthog/icons'
+import { Button } from '@posthog/quill'
+
+import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
+import { metalyticsLogic } from 'lib/components/Metalytics/metalyticsLogic'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { SceneTagsCombobox } from 'lib/components/Scenes/SceneTagsCombobox'
+import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
+import { urlForSubscriptions } from 'lib/components/Subscriptions/utils'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { slugify } from 'lib/utils'
+import { getAccessControlDisabledReason, userHasAccess } from 'lib/utils/accessControlUtils'
+import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
+import { deleteDashboardLogic } from 'scenes/dashboard/deleteDashboardLogic'
+import { duplicateDashboardLogic } from 'scenes/dashboard/duplicateDashboardLogic'
+import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopyLogic'
+import { sceneLogic } from 'scenes/sceneLogic'
+import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
+
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import {
+    SceneMenuBar,
+    SceneMenuBarCheckboxItem,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarPopover,
+    SceneMenuBarSeparator,
+    SceneMenuBarSubMenu,
+} from '~/layout/scenes/components/SceneMenuBar'
+import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
+import { notebooksModel } from '~/models/notebooksModel'
+import { tagsModel } from '~/models/tagsModel'
+import { AccessControlLevel, AccessControlResourceType, DashboardMode, ExporterFormat, SidePanelTab } from '~/types'
+
+import { dashboardInsightColorsModalLogic } from './dashboardInsightColorsModalLogic'
+import { dashboardLogic } from './dashboardLogic'
+import { dashboardTemplateModalLogic } from './dashboards/templates/dashboardTemplateModalLogic'
+
+const RESOURCE_TYPE = 'dashboard'
+
+export function DashboardSceneMenuBar(): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
+        return null
+    }
+    return <DashboardSceneMenuBarInner />
+}
+
+function DashboardSceneMenuBarInner(): JSX.Element | null {
+    const {
+        dashboard,
+        dashboardMode,
+        canEditDashboard,
+        isSavingTags,
+        isPinned,
+        asDashboardTemplate,
+        canSaveProjectDashboardTemplate,
+        effectiveEditBarFilters,
+        effectiveDashboardVariableOverrides,
+        tiles,
+        apiUrl,
+    } = useValues(dashboardLogic)
+    const { setDashboardMode, updateDashboardTags, togglePinned, setTerraformModalOpen } = useActions(dashboardLogic)
+    const { startExport } = useActions(exportsLogic)
+    const { createNotebookFromDashboard } = useActions(notebooksModel)
+    const { showInsightColorsModal } = useActions(dashboardInsightColorsModalLogic)
+    const { newTab } = useActions(sceneLogic)
+    const { setScenePanelOpen } = useActions(sceneLayoutLogic)
+    const { showDuplicateDashboardModal } = useActions(duplicateDashboardLogic)
+    const { showDeleteDashboardModal } = useActions(deleteDashboardLogic)
+    const { openSidePanel } = useActions(sidePanelStateLogic)
+    const { instanceId: metalyticsInstanceId } = useValues(metalyticsLogic)
+
+    const { user } = useValues(userLogic)
+    const { tags } = useValues(tagsModel)
+    const { canCopyToProject } = useValues(interProjectCopyLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const hasDashboardColors = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_DASHBOARD_COLORS]
+    const showMetalytics = dashboard != null && metalyticsInstanceId != null && !!featureFlags[FEATURE_FLAGS.METALYTICS]
+
+    const { push } = useActions(router)
+
+    if (!dashboard) {
+        return null
+    }
+
+    const canShowDelete = canEditDashboard
+    const customerTemplateEditorAccess = userHasAccess(AccessControlResourceType.Dashboard, AccessControlLevel.Editor)
+    const customerTemplateDisabledReason = getAccessControlDisabledReason(
+        AccessControlResourceType.Dashboard,
+        AccessControlLevel.Editor,
+        undefined,
+        true
+    )
+    const missingTemplatePayload = !asDashboardTemplate
+    const saveTemplateDisabled = !customerTemplateEditorAccess || missingTemplatePayload
+    const saveTemplateTooltip = !customerTemplateEditorAccess
+        ? (customerTemplateDisabledReason ?? 'You need edit access to dashboard templates to save a template.')
+        : missingTemplatePayload
+          ? 'Template data is not ready yet. Try again in a moment.'
+          : undefined
+
+    const openInsightsInNewTabsDisabled =
+        dashboardMode === DashboardMode.Edit
+            ? 'Cannot open insights when editing dashboard'
+            : tiles.length === 0
+              ? 'Dashboard has no insights'
+              : undefined
+
+    const showCreateMenu = canEditDashboard // notebook + subscribe both gated on canEdit
+    const showEditMenu = true // duplicate always
+    const showFileMenu = true
+    const showMetadataMenu = true
+
+    return (
+        <SceneMenuBar>
+            {showFileMenu && (
+                <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                    {showCreateMenu && (
+                        <>
+                            <SceneMenuBarSubMenu label="Create">
+                                <SceneMenuBarItem
+                                    onClick={() => createNotebookFromDashboard(dashboard)}
+                                    data-attr={`${RESOURCE_TYPE}-menubar-create-notebook`}
+                                >
+                                    <IconNotebook />
+                                    Notebook from dashboard
+                                </SceneMenuBarItem>
+                                <SceneMenuBarItem
+                                    onClick={() => push(urlForSubscriptions({ dashboardId: dashboard.id }))}
+                                    data-attr={`${RESOURCE_TYPE}-menubar-subscribe`}
+                                >
+                                    <IconBell />
+                                    Subscription
+                                </SceneMenuBarItem>
+                            </SceneMenuBarSubMenu>
+                            <SceneMenuBarSeparator />
+                        </>
+                    )}
+                    <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                    {canCopyToProject && (
+                        <SceneMenuBarItem
+                            onClick={() => push(urls.resourceTransfer('Dashboard', dashboard.id))}
+                            data-attr={`${RESOURCE_TYPE}-menubar-copy-to-project`}
+                        >
+                            <IconCopy />
+                            Copy to another project
+                        </SceneMenuBarItem>
+                    )}
+                    <SceneMenuBarItem
+                        opensFloatingUi
+                        onClick={() => setTerraformModalOpen(true)}
+                        data-attr={`${RESOURCE_TYPE}-menubar-terraform`}
+                    >
+                        <IconCode2 />
+                        Manage with Terraform
+                    </SceneMenuBarItem>
+                    <SceneMenuBarItem
+                        onClick={() => {
+                            tiles.forEach((tile) => {
+                                if (tile.insight?.short_id == null) {
+                                    return
+                                }
+                                const url = urls.insightView(
+                                    tile.insight.short_id,
+                                    dashboard.id,
+                                    effectiveDashboardVariableOverrides,
+                                    effectiveEditBarFilters,
+                                    tile?.filters_overrides
+                                )
+                                newTab(url)
+                            })
+                            setScenePanelOpen(false)
+                        }}
+                        disabled={!!openInsightsInNewTabsDisabled}
+                        data-attr={`${RESOURCE_TYPE}-menubar-open-insights`}
+                    >
+                        <IconGraph />
+                        Open insights in new tabs
+                    </SceneMenuBarItem>
+                    {canEditDashboard && (
+                        <SceneMenuBarSubMenu label="Export">
+                            <SceneMenuBarItem
+                                onClick={() =>
+                                    startExport({
+                                        export_format: ExporterFormat.PNG,
+                                        dashboard: dashboard.id,
+                                        export_context: {
+                                            path: apiUrl(),
+                                            variables_override: effectiveDashboardVariableOverrides,
+                                        },
+                                    })
+                                }
+                                data-attr={`${RESOURCE_TYPE}-menubar-export-png`}
+                            >
+                                <IconDownload />
+                                PNG
+                            </SceneMenuBarItem>
+                            {user?.is_staff && (
+                                <SceneMenuBarItem
+                                    onClick={() =>
+                                        startExport({
+                                            export_format: ExporterFormat.JSON,
+                                            export_context: {
+                                                localData: JSON.stringify(asDashboardTemplate),
+                                                filename: `dashboard-${slugify(
+                                                    dashboard?.name || 'nameless dashboard'
+                                                )}.json`,
+                                                mediaType: ExporterFormat.JSON,
+                                            },
+                                        })
+                                    }
+                                    data-attr={`${RESOURCE_TYPE}-menubar-export-json`}
+                                >
+                                    <IconDownload />
+                                    JSON (staff)
+                                </SceneMenuBarItem>
+                            )}
+                        </SceneMenuBarSubMenu>
+                    )}
+                    {canShowDelete && (
+                        <>
+                            <SceneMenuBarSeparator />
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.Dashboard}
+                                minAccessLevel={AccessControlLevel.Editor}
+                                userAccessLevel={dashboard.user_access_level}
+                            >
+                                {({ disabledReason }) => (
+                                    <SceneMenuBarItem
+                                        variant="destructive"
+                                        disabled={!!disabledReason}
+                                        onClick={() => showDeleteDashboardModal(dashboard.id)}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                                    >
+                                        <IconTrash />
+                                        Delete dashboard
+                                    </SceneMenuBarItem>
+                                )}
+                            </AccessControlAction>
+                        </>
+                    )}
+                </SceneMenuBarMenu>
+            )}
+            {showEditMenu && (
+                <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
+                    <SceneMenuBarItem
+                        opensFloatingUi
+                        onClick={() => showDuplicateDashboardModal(dashboard.id, dashboard.name)}
+                        data-attr={`${RESOURCE_TYPE}-menubar-duplicate`}
+                    >
+                        <IconCopy />
+                        Duplicate
+                    </SceneMenuBarItem>
+                    {canEditDashboard && hasDashboardColors && (
+                        <SceneMenuBarItem
+                            opensFloatingUi
+                            onClick={() => showInsightColorsModal(dashboard.id)}
+                            data-attr={`${RESOURCE_TYPE}-menubar-customize-colors`}
+                        >
+                            <IconPalette />
+                            Customize colors
+                        </SceneMenuBarItem>
+                    )}
+                    {canSaveProjectDashboardTemplate && (
+                        <SceneMenuBarItem
+                            opensFloatingUi
+                            onClick={() => {
+                                if (asDashboardTemplate) {
+                                    dashboardTemplateModalLogic.actions.openCreate(asDashboardTemplate)
+                                }
+                            }}
+                            disabled={saveTemplateDisabled}
+                            tooltip={saveTemplateTooltip}
+                            data-attr={`${RESOURCE_TYPE}-menubar-save-as-template`}
+                        >
+                            <IconScreen />
+                            Save as dashboard template
+                        </SceneMenuBarItem>
+                    )}
+                    {/* Toggle group — separated from regular Edit actions */}
+                    <SceneMenuBarSeparator />
+                    <SceneMenuBarCheckboxItem
+                        checked={isPinned}
+                        onCheckedChange={() => togglePinned()}
+                        data-attr={`${RESOURCE_TYPE}-menubar-pin`}
+                    >
+                        Pinned
+                    </SceneMenuBarCheckboxItem>
+                    <SceneMenuBarCheckboxItem
+                        checked={dashboardMode === DashboardMode.Fullscreen}
+                        onCheckedChange={(checked) => {
+                            setDashboardMode(
+                                checked ? DashboardMode.Fullscreen : null,
+                                DashboardEventSource.SceneCommonButtons
+                            )
+                        }}
+                        data-attr={`${RESOURCE_TYPE}-menubar-fullscreen`}
+                    >
+                        Fullscreen
+                    </SceneMenuBarCheckboxItem>
+                </SceneMenuBarMenu>
+            )}
+            {showMetadataMenu && (
+                <SceneMenuBarPopover
+                    label="Metadata"
+                    dataAttr={`${RESOURCE_TYPE}-menubar-metadata`}
+                    contentClassName="w-80 p-2 flex flex-col gap-2"
+                >
+                    <SceneTagsCombobox
+                        onSave={(t) => updateDashboardTags(t)}
+                        canEdit={canEditDashboard}
+                        tags={dashboard?.tags}
+                        tagsAvailable={tags.filter((t) => !dashboard?.tags?.includes(t))}
+                        dataAttrKey={RESOURCE_TYPE}
+                        loading={isSavingTags}
+                    />
+                    <SceneActivityIndicator at={dashboard?.created_at} by={dashboard?.created_by} prefix="Created" />
+                    {showMetalytics && (
+                        <Button
+                            type="button"
+                            left
+                            onClick={() => openSidePanel(SidePanelTab.Activity, 'metalytics')}
+                            data-attr={`${RESOURCE_TYPE}-menubar-metalytics`}
+                        >
+                            <IconPulse />
+                            View metalytics
+                        </Button>
+                    )}
+                </SceneMenuBarPopover>
+            )}
+        </SceneMenuBar>
+    )
+}

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentSceneMenuBar.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentSceneMenuBar.tsx
@@ -1,0 +1,322 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { useState } from 'react'
+
+import {
+    IconArchive,
+    IconCopy,
+    IconEye,
+    IconPause,
+    IconPlay,
+    IconPlusSmall,
+    IconRefresh,
+    IconTrash,
+} from '@posthog/icons'
+import { LemonDialog } from '@posthog/lemon-ui'
+
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { superpowersLogic } from 'lib/components/Superpowers/superpowersLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { userHasAccess } from 'lib/utils/accessControlUtils'
+import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { projectLogic } from 'scenes/projectLogic'
+import { sceneLogic } from 'scenes/sceneLogic'
+import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
+import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
+import { urls } from 'scenes/urls'
+
+import {
+    SceneMenuBar,
+    SceneMenuBarCheckboxItem,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+    SceneMenuBarSubMenu,
+} from '~/layout/scenes/components/SceneMenuBar'
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { CopyExperimentToProjectModal } from '../CopyExperimentToProjectModal'
+import { DuplicateExperimentModal } from '../DuplicateExperimentModal'
+import { canArchiveExperiment, confirmArchiveExperiment, confirmDeleteExperiment } from '../experimentActions'
+import { experimentLogic } from '../experimentLogic'
+import { isExperimentPaused } from '../experimentsLogic'
+import { modalsLogic } from '../modalsLogic'
+import { isLegacyExperiment } from '../utils'
+
+const RESOURCE_TYPE = 'experiment'
+
+export function ExperimentSceneMenuBar(): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
+        return null
+    }
+    return <ExperimentSceneMenuBarInner />
+}
+
+function ExperimentSceneMenuBarInner(): JSX.Element | null {
+    const {
+        experiment,
+        isExperimentRunning,
+        isExperimentLaunched,
+        isExperimentStopped,
+        isCreatingExperimentDashboard,
+        showDebugPanel,
+    } = useValues(experimentLogic)
+    const {
+        archiveExperiment,
+        unarchiveExperiment,
+        createExposureCohort,
+        createExperimentDashboard,
+        resetRunningExperiment,
+        toggleDebugPanel,
+    } = useActions(experimentLogic)
+    const { currentProjectId } = useValues(projectLogic)
+    const { currentOrganization } = useValues(organizationLogic)
+    const { openPauseExperimentModal, openResumeExperimentModal } = useActions(modalsLogic)
+    const { superpowersEnabled } = useValues(superpowersLogic)
+    const { newTab } = useActions(sceneLogic)
+
+    const [duplicateModalOpen, setDuplicateModalOpen] = useState(false)
+    const [copyToProjectModalOpen, setCopyToProjectModalOpen] = useState(false)
+    const [surveyModalOpen, setSurveyModalOpen] = useState(false)
+
+    if (!experiment) {
+        return null
+    }
+
+    const hasMultipleProjects = (currentOrganization?.projects?.length ?? 0) > 1
+    const canEdit = userHasAccess(
+        AccessControlResourceType.Experiment,
+        AccessControlLevel.Editor,
+        experiment.user_access_level
+    )
+    const canArchive = canEdit && canArchiveExperiment(experiment)
+    const canDelete = canEdit
+    const exposureCohortId = experiment?.exposure_cohort
+    const showRunningState = isExperimentRunning && !isExperimentStopped && !!experiment.feature_flag
+    const paused = isExperimentPaused(experiment)
+
+    const handleArchive = (): void => confirmArchiveExperiment(() => archiveExperiment())
+    const handleDelete = (): void =>
+        confirmDeleteExperiment({
+            projectId: currentProjectId,
+            experiment,
+            onDelete: () => router.actions.push(urls.experiments()),
+        })
+
+    const handleReset = (): void => {
+        LemonDialog.open({
+            title: 'Reset analysis?',
+            content: (
+                <>
+                    <div className="text-sm text-secondary max-w-md">
+                        <p>
+                            The experiment start and end dates will be reset and the experiment will go back to draft
+                            mode.
+                        </p>
+                        <p>
+                            All events collected thus far will still exist, but won't be applied to the experiment
+                            unless you manually change the start date after launching the experiment again.
+                        </p>
+                        <p>
+                            The <b>feature flag remains untouched</b>, so variants stay visible to users.
+                        </p>
+                    </div>
+                    {experiment.archived && (
+                        <div className="text-sm text-secondary">Resetting will also unarchive the experiment.</div>
+                    )}
+                </>
+            ),
+            primaryButton: {
+                children: 'Confirm',
+                type: 'primary',
+                onClick: resetRunningExperiment,
+                size: 'small',
+            },
+            secondaryButton: {
+                children: 'Cancel',
+                type: 'tertiary',
+                size: 'small',
+            },
+        })
+    }
+
+    const showCreateMenu = isExperimentLaunched
+    const showStateMenu = showRunningState
+    const showStaffMenu = superpowersEnabled
+
+    return (
+        <>
+            <SceneMenuBar>
+                <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                    {showCreateMenu && (
+                        <>
+                            <SceneMenuBarSubMenu label="Create">
+                                {exposureCohortId ? (
+                                    <SceneMenuBarItem
+                                        onClick={() => newTab(urls.cohort(exposureCohortId))}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-view-exposure-cohort`}
+                                    >
+                                        <IconEye />
+                                        View exposure cohort as new tab
+                                    </SceneMenuBarItem>
+                                ) : (
+                                    <SceneMenuBarItem
+                                        onClick={() => createExposureCohort()}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-create-exposure-cohort`}
+                                    >
+                                        <IconPlusSmall />
+                                        Exposure cohort
+                                    </SceneMenuBarItem>
+                                )}
+                                <SceneMenuBarItem
+                                    onClick={() => createExperimentDashboard()}
+                                    disabled={isCreatingExperimentDashboard}
+                                    data-attr={`${RESOURCE_TYPE}-menubar-create-dashboard`}
+                                >
+                                    <IconPlusSmall />
+                                    Dashboard
+                                </SceneMenuBarItem>
+                                {experiment.feature_flag && (
+                                    <SceneMenuBarItem
+                                        opensFloatingUi
+                                        onClick={() => {
+                                            setSurveyModalOpen(true)
+                                            void addProductIntentForCrossSell({
+                                                from: ProductKey.EXPERIMENTS,
+                                                to: ProductKey.SURVEYS,
+                                                intent_context: ProductIntentContext.QUICK_SURVEY_STARTED,
+                                            })
+                                        }}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-create-survey`}
+                                    >
+                                        <IconPlusSmall />
+                                        Survey
+                                    </SceneMenuBarItem>
+                                )}
+                            </SceneMenuBarSubMenu>
+                            <SceneMenuBarSeparator />
+                        </>
+                    )}
+                    <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                    {hasMultipleProjects && (
+                        <SceneMenuBarItem
+                            opensFloatingUi
+                            onClick={() => setCopyToProjectModalOpen(true)}
+                            disabled={isLegacyExperiment(experiment)}
+                            tooltip={
+                                isLegacyExperiment(experiment)
+                                    ? 'Copying is not supported for experiments using legacy metrics.'
+                                    : undefined
+                            }
+                            data-attr={`${RESOURCE_TYPE}-menubar-copy-to-project`}
+                        >
+                            <IconCopy />
+                            Copy to another project
+                        </SceneMenuBarItem>
+                    )}
+                    {(canArchive || (canEdit && experiment.archived) || canDelete) && <SceneMenuBarSeparator />}
+                    {canArchive && (
+                        <SceneMenuBarItem
+                            variant="destructive"
+                            onClick={handleArchive}
+                            data-attr={`${RESOURCE_TYPE}-menubar-archive`}
+                        >
+                            <IconArchive />
+                            Archive experiment
+                        </SceneMenuBarItem>
+                    )}
+                    {canEdit && experiment.archived && (
+                        <SceneMenuBarItem
+                            onClick={() => unarchiveExperiment()}
+                            data-attr={`${RESOURCE_TYPE}-menubar-unarchive`}
+                        >
+                            <IconArchive />
+                            Unarchive experiment
+                        </SceneMenuBarItem>
+                    )}
+                    {canDelete && (
+                        <SceneMenuBarItem
+                            variant="destructive"
+                            onClick={handleDelete}
+                            data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                        >
+                            <IconTrash />
+                            Delete experiment
+                        </SceneMenuBarItem>
+                    )}
+                </SceneMenuBarMenu>
+                <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
+                    <SceneMenuBarItem
+                        opensFloatingUi
+                        onClick={() => setDuplicateModalOpen(true)}
+                        data-attr={`${RESOURCE_TYPE}-menubar-duplicate`}
+                    >
+                        <IconCopy />
+                        Duplicate
+                    </SceneMenuBarItem>
+                    {isExperimentLaunched && (
+                        <SceneMenuBarItem
+                            opensFloatingUi
+                            onClick={handleReset}
+                            data-attr={`${RESOURCE_TYPE}-menubar-reset`}
+                        >
+                            <IconRefresh />
+                            Reset analysis
+                        </SceneMenuBarItem>
+                    )}
+                    {showStateMenu &&
+                        (paused ? (
+                            <SceneMenuBarItem
+                                opensFloatingUi
+                                onClick={() => openResumeExperimentModal()}
+                                data-attr={`${RESOURCE_TYPE}-menubar-resume`}
+                            >
+                                <IconPlay />
+                                Resume experiment
+                            </SceneMenuBarItem>
+                        ) : (
+                            <SceneMenuBarItem
+                                opensFloatingUi
+                                variant="destructive"
+                                onClick={() => openPauseExperimentModal()}
+                                data-attr={`${RESOURCE_TYPE}-menubar-pause`}
+                            >
+                                <IconPause />
+                                Pause experiment
+                            </SceneMenuBarItem>
+                        ))}
+                </SceneMenuBarMenu>
+                {showStaffMenu && (
+                    <SceneMenuBarMenu label="Staff only" dataAttr={`${RESOURCE_TYPE}-menubar-staff`}>
+                        <SceneMenuBarCheckboxItem
+                            checked={showDebugPanel}
+                            onCheckedChange={toggleDebugPanel}
+                            data-attr={`${RESOURCE_TYPE}-menubar-debug-panel`}
+                        >
+                            Show debug panel
+                        </SceneMenuBarCheckboxItem>
+                    </SceneMenuBarMenu>
+                )}
+            </SceneMenuBar>
+            <DuplicateExperimentModal
+                isOpen={duplicateModalOpen}
+                onClose={() => setDuplicateModalOpen(false)}
+                experiment={experiment}
+            />
+            <CopyExperimentToProjectModal
+                isOpen={copyToProjectModalOpen}
+                onClose={() => setCopyToProjectModalOpen(false)}
+                experiment={experiment}
+            />
+            <QuickSurveyModal
+                context={{ type: QuickSurveyType.EXPERIMENT, experiment }}
+                isOpen={surveyModalOpen}
+                onCancel={() => setSurveyModalOpen(false)}
+            />
+        </>
+    )
+}

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -68,6 +68,7 @@ import { experimentLogic } from '../experimentLogic'
 import { getExperimentStatusColor, getExperimentStatusLabel, isExperimentPaused } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
 import { getVariantColor, isLegacyExperiment } from '../utils'
+import { ExperimentSceneMenuBar } from './ExperimentSceneMenuBar'
 
 export function VariantTag({
     variantKey,
@@ -208,6 +209,7 @@ export function PageHeaderCustom(): JSX.Element {
 
     return (
         <>
+            <ExperimentSceneMenuBar />
             <SceneTitleSection
                 name={experiment?.name}
                 description={null}

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -4,13 +4,21 @@ import { IconBalance, IconCheckCircle, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDialog, Spinner } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { SceneTags } from 'lib/components/Scenes/SceneTags'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import {
     ScenePanel,
@@ -39,6 +47,7 @@ export const scene: SceneExport<SharedMetricLogicProps> = {
 
 export function SharedMetric(): JSX.Element {
     const { sharedMetric, action } = useValues(sharedMetricLogic)
+    const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
     const { setSharedMetric, createSharedMetric, updateSharedMetric, deleteSharedMetric } =
         useActions(sharedMetricLogic)
 
@@ -104,6 +113,52 @@ export function SharedMetric(): JSX.Element {
                 </div>
             )}
 
+            {sceneMenuBarEnabled && action === 'update' && (
+                <SceneMenuBar>
+                    <SceneMenuBarMenu label="File" dataAttr="shared-metric-menubar-file">
+                        <SceneMenuBarFileItems dataAttrKey="shared-metric" />
+                        <SceneMenuBarSeparator />
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.ExperimentSavedMetric}
+                            minAccessLevel={AccessControlLevel.Editor}
+                            userAccessLevel={sharedMetric.user_access_level}
+                        >
+                            {({ disabledReason }) => (
+                                <SceneMenuBarItem
+                                    variant="destructive"
+                                    opensFloatingUi
+                                    disabled={!!disabledReason}
+                                    onClick={() => {
+                                        LemonDialog.open({
+                                            title: 'Delete this metric?',
+                                            content: (
+                                                <div className="text-sm text-secondary">
+                                                    This action cannot be undone.
+                                                </div>
+                                            ),
+                                            primaryButton: {
+                                                children: 'Delete',
+                                                type: 'primary',
+                                                onClick: () => deleteSharedMetric(),
+                                                size: 'small',
+                                            },
+                                            secondaryButton: {
+                                                children: 'Cancel',
+                                                type: 'tertiary',
+                                                size: 'small',
+                                            },
+                                        })
+                                    }}
+                                    data-attr="shared-metric-menubar-delete"
+                                >
+                                    <IconTrash />
+                                    Delete
+                                </SceneMenuBarItem>
+                            )}
+                        </AccessControlAction>
+                    </SceneMenuBarMenu>
+                </SceneMenuBar>
+            )}
             <ScenePanel>
                 <ScenePanelInfoSection>
                     <SceneTags

--- a/frontend/src/scenes/experiments/legacy/components/LegacyPageHeader.tsx
+++ b/frontend/src/scenes/experiments/legacy/components/LegacyPageHeader.tsx
@@ -4,11 +4,19 @@ import { router } from 'kea-router'
 import { IconArchive, IconFlask, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDivider, Tooltip } from '@posthog/lemon-ui'
 
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { projectLogic } from 'scenes/projectLogic'
 import { urls } from 'scenes/urls'
 
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ScenePanel, ScenePanelActionsSection } from '~/layout/scenes/SceneLayout'
 import {
@@ -53,9 +61,38 @@ export function LegacyPageHeader(): JSX.Element {
     const isExperimentRunning =
         experiment.status === ExperimentStatus.Running || experiment.status === ExperimentStatus.Paused
     const isExperimentStopped = experiment.status === ExperimentStatus.Stopped
+    const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
 
     return (
         <>
+            {sceneMenuBarEnabled && experiment && (
+                <SceneMenuBar>
+                    <SceneMenuBarMenu label="File" dataAttr="experiment-menubar-file">
+                        <SceneMenuBarFileItems dataAttrKey="experiment" />
+                        {(canArchive || canDelete) && <SceneMenuBarSeparator />}
+                        {canArchive && (
+                            <SceneMenuBarItem
+                                variant="destructive"
+                                onClick={handleArchive}
+                                data-attr="experiment-menubar-archive"
+                            >
+                                <IconArchive />
+                                Archive experiment
+                            </SceneMenuBarItem>
+                        )}
+                        {canDelete && (
+                            <SceneMenuBarItem
+                                variant="destructive"
+                                onClick={handleDelete}
+                                data-attr="experiment-menubar-delete"
+                            >
+                                <IconTrash />
+                                Delete experiment
+                            </SceneMenuBarItem>
+                        )}
+                    </SceneMenuBarMenu>
+                </SceneMenuBar>
+            )}
             <SceneTitleSection
                 name={experiment?.name}
                 description={null}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -28,7 +28,10 @@ import { NotFound } from 'lib/components/NotFound'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { SceneAddToNotebookDropdownMenu } from 'lib/components/Scenes/InsightOrDashboard/SceneAddToNotebookDropdownMenu'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
+import { SceneMenuBarAddToNotebook } from 'lib/components/Scenes/SceneMenuBarAddToNotebook'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { SceneTags } from 'lib/components/Scenes/SceneTags'
+import { SceneTagsCombobox } from 'lib/components/Scenes/SceneTagsCombobox'
 import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
@@ -58,6 +61,7 @@ import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { EmptyDashboardComponent } from 'scenes/dashboard/EmptyDashboardComponent'
 import { JSONEditorInput } from 'scenes/feature-flags/JSONEditorInput'
 import { FeatureFlagPermissions } from 'scenes/FeatureFlagPermissions'
+import { NotebookNodeType } from 'scenes/notebooks/types'
 import { SceneExport } from 'scenes/sceneTypes'
 import { SURVEY_CREATED_SOURCE } from 'scenes/surveys/constants'
 import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
@@ -68,6 +72,14 @@ import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarPopover,
+    SceneMenuBarSeparator,
+    SceneMenuBarSubMenu,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import {
@@ -147,6 +159,7 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
         updateFlag,
         saveFeatureFlag,
         saveDescriptionInline,
+        saveTagsInline,
     } = useActions(featureFlagLogic)
 
     const { earlyAccessFeaturesList } = useValues(featureFlagLogic)
@@ -849,6 +862,110 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
                                     switch your code to this feature flag when you're ready to release to your early
                                     access users.
                                 </LemonBanner>
+                            )}
+                            {featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR] && (
+                                <SceneMenuBar>
+                                    <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                                        <SceneMenuBarSubMenu label="Create">
+                                            {featureFlag.id && (
+                                                <SceneMenuBarAddToNotebook
+                                                    dataAttrKey={RESOURCE_TYPE}
+                                                    notebookSelectButtonProps={{
+                                                        resource: {
+                                                            type: NotebookNodeType.FeatureFlag,
+                                                            attrs: { id: featureFlag.id },
+                                                        },
+                                                    }}
+                                                />
+                                            )}
+                                            {featureFlags[FEATURE_FLAGS.FEATURE_FLAG_COHORT_CREATION] && (
+                                                <SceneMenuBarItem
+                                                    onClick={() => createStaticCohort()}
+                                                    data-attr={`${RESOURCE_TYPE}-menubar-create-cohort`}
+                                                >
+                                                    <IconPlusSmall />
+                                                    Cohort
+                                                </SceneMenuBarItem>
+                                            )}
+                                            <SceneMenuBarItem
+                                                opensFloatingUi
+                                                onClick={() => handleGetFeedback()}
+                                                data-attr={`${RESOURCE_TYPE}-menubar-create-survey`}
+                                            >
+                                                <IconPlusSmall />
+                                                Survey
+                                            </SceneMenuBarItem>
+                                        </SceneMenuBarSubMenu>
+                                        <SceneMenuBarSeparator />
+                                        <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                                        <SceneMenuBarSeparator />
+                                        <AccessControlAction
+                                            resourceType={AccessControlResourceType.FeatureFlag}
+                                            minAccessLevel={AccessControlLevel.Editor}
+                                        >
+                                            {({ disabledReason }) => (
+                                                <SceneMenuBarItem
+                                                    variant="destructive"
+                                                    disabled={!!disabledReason}
+                                                    data-attr={
+                                                        featureFlag.deleted
+                                                            ? `${RESOURCE_TYPE}-menubar-restore`
+                                                            : `${RESOURCE_TYPE}-menubar-delete`
+                                                    }
+                                                    onClick={() => {
+                                                        if (featureFlag.deleted) {
+                                                            restoreFeatureFlag(featureFlag)
+                                                        } else {
+                                                            LemonDialog.open({
+                                                                title: 'Delete feature flag?',
+                                                                description: `Are you sure you want to delete "${featureFlag.key}"?`,
+                                                                primaryButton: {
+                                                                    children: 'Delete',
+                                                                    status: 'danger',
+                                                                    onClick: () => deleteFeatureFlag(featureFlag),
+                                                                    size: 'small',
+                                                                },
+                                                                secondaryButton: {
+                                                                    children: 'Cancel',
+                                                                    type: 'tertiary',
+                                                                    size: 'small',
+                                                                },
+                                                            })
+                                                        }
+                                                    }}
+                                                >
+                                                    {featureFlag.deleted ? <IconRewind /> : <IconTrash />}
+                                                    {featureFlag.deleted ? 'Restore' : 'Delete'} feature flag
+                                                </SceneMenuBarItem>
+                                            )}
+                                        </AccessControlAction>
+                                    </SceneMenuBarMenu>
+                                    <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
+                                        <SceneMenuBarItem
+                                            onClick={() => {
+                                                router.actions.push(urls.featureFlagNew({ sourceId: featureFlag.id }))
+                                            }}
+                                            data-attr={`${RESOURCE_TYPE}-menubar-duplicate`}
+                                        >
+                                            <IconCopy />
+                                            Duplicate
+                                        </SceneMenuBarItem>
+                                    </SceneMenuBarMenu>
+                                    <SceneMenuBarPopover
+                                        label="Metadata"
+                                        dataAttr={`${RESOURCE_TYPE}-menubar-metadata`}
+                                    >
+                                        <SceneTagsCombobox
+                                            onSave={(updatedTags) => saveTagsInline(updatedTags)}
+                                            canEdit
+                                            tags={featureFlag.tags}
+                                            tagsAvailable={tags.filter(
+                                                (tag: string) => !featureFlag.tags?.includes(tag)
+                                            )}
+                                            dataAttrKey={RESOURCE_TYPE}
+                                        />
+                                    </SceneMenuBarPopover>
+                                </SceneMenuBar>
                             )}
                             <SceneTitleSection
                                 name={featureFlag.key}

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -628,6 +628,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             isBeingDisabled?: boolean
         }) => payload,
         saveDescriptionInline: (name: string) => ({ name }),
+        saveTagsInline: (tags: string[]) => ({ tags }),
         // V2 form UI actions
         setShowImplementation: (show: boolean) => ({ show }),
         setOpenVariants: (openVariants: string[]) => ({ openVariants }),
@@ -2137,6 +2138,52 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 lemonToast.success('Description saved')
             } catch {
                 lemonToast.error('Failed to save description')
+            }
+        },
+        saveTagsInline: async ({ tags }, breakpoint) => {
+            const flag = values.featureFlag
+            if (!flag.id) {
+                return
+            }
+            // Optimistic update applies immediately on every call so the chips reflect the
+            // user's intent without waiting for the API.
+            const previousTags = flag.tags
+            actions.setFeatureFlag({ ...flag, tags })
+            actions.updateFlag({ ...flag, tags })
+
+            // Debounce — rapid changes (e.g. quickly removing several chips) collapse into a
+            // single API call with the final tag set. Without this, overlapping requests
+            // can land out-of-order and stomp the latest local state when their responses
+            // resolve.
+            await breakpoint(250)
+
+            try {
+                const savedFlag = await api.update(`api/projects/${values.currentProjectId}/feature_flags/${flag.id}`, {
+                    tags,
+                })
+                // If the listener has been invoked again since this await started, bail out
+                // — the newer call owns reconciliation.
+                breakpoint()
+
+                // Reconcile with server only if the *set* of tags differs (e.g. server-side
+                // normalization added/removed a tag). Avoid blindly overwriting — the
+                // server may return tags in a different order which would re-shuffle chips.
+                const localSet = new Set(tags)
+                const serverTags = savedFlag.tags ?? []
+                const serverSet = new Set(serverTags)
+                const setsEqual = localSet.size === serverSet.size && tags.every((t) => serverSet.has(t))
+                if (!setsEqual) {
+                    actions.setFeatureFlag({ ...flag, tags: serverTags })
+                    actions.updateFlag({ ...flag, tags: serverTags })
+                }
+            } catch (error: any) {
+                // Re-throw breakpoint cancellation so kea swallows it silently.
+                if (error?.isBreakpoint) {
+                    throw error
+                }
+                actions.setFeatureFlag({ ...flag, tags: previousTags })
+                actions.updateFlag({ ...flag, tags: previousTags })
+                lemonToast.error('Failed to save tags')
             }
         },
         editFeatureFlag: async ({ editing }) => {

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -25,6 +25,7 @@ import {
 } from '~/queries/utils'
 import { AccessControlLevel, AccessControlResourceType, InsightLogicProps, ItemMode } from '~/types'
 
+import { InsightSceneMenuBar } from './SidePanel/InsightSceneMenuBar'
 import { InsightSidePanelContent } from './SidePanel/InsightSidePanelContent'
 import { getInsightIconTypeFromQuery, getOverrideWarningPropsForButton } from './utils'
 
@@ -91,6 +92,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     return (
         <>
             <InsightSidePanelContent insightLogicProps={insightLogicProps} />
+            <InsightSceneMenuBar insightLogicProps={insightLogicProps} />
 
             <SceneTitleSection
                 name={defaultInsightName || ''}

--- a/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
@@ -1,0 +1,401 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+
+import {
+    IconBell,
+    IconCode2,
+    IconCopy,
+    IconDownload,
+    IconEndpoints,
+    IconPencil,
+    IconPeople,
+    IconPlusSmall,
+    IconPulse,
+    IconShare,
+    IconTrash,
+    IconWarning,
+} from '@posthog/icons'
+import { Button } from '@posthog/quill'
+
+import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
+import { metalyticsLogic } from 'lib/components/Metalytics/metalyticsLogic'
+import { SceneMenuBarAddToNotebook } from 'lib/components/Scenes/SceneMenuBarAddToNotebook'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { SceneTagsCombobox } from 'lib/components/Scenes/SceneTagsCombobox'
+import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
+import { urlForSubscriptions } from 'lib/components/Subscriptions/utils'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
+import { NotebookNodeType } from 'scenes/notebooks/types'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopyLogic'
+import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
+
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import {
+    SceneMenuBar,
+    SceneMenuBarCheckboxItem,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarPopover,
+    SceneMenuBarSeparator,
+    SceneMenuBarSubMenu,
+} from '~/layout/scenes/components/SceneMenuBar'
+import { tagsModel } from '~/models/tagsModel'
+import { NodeKind } from '~/queries/schema/schema-general'
+import { isDataTableNode, isDataVisualizationNode, isEventsQuery, isHogQLQuery } from '~/queries/utils'
+import {
+    AccessControlLevel,
+    AccessControlResourceType,
+    AvailableFeature,
+    ExporterFormat,
+    InsightLogicProps,
+    ItemMode,
+    QueryBasedInsightModel,
+    SidePanelTab,
+} from '~/types'
+
+import { endpointLogic } from 'products/endpoints/frontend/endpointLogic'
+
+import { insightModalsLogic } from '../insightModalsLogic'
+import { openSaveAsCohortDialog } from './insightSidePanelDialogs'
+
+const RESOURCE_TYPE = 'insight'
+
+export function InsightSceneMenuBar({
+    insightLogicProps,
+}: {
+    insightLogicProps: InsightLogicProps
+}): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
+        return null
+    }
+
+    return <InsightSceneMenuBarInner insightLogicProps={insightLogicProps} />
+}
+
+function InsightSceneMenuBarInner({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
+    const theInsightLogic = insightLogic(insightLogicProps)
+    const { insightProps, insight, hasDashboardItemId, canEditInsight, isSavingTags } = useValues(theInsightLogic)
+    const { duplicateInsight, deleteInsight, setInsightMetadata } = useActions(theInsightLogic)
+
+    const theInsightDataLogic = insightDataLogic(insightProps)
+    const { query, hogQL, exportContext, hogQLVariables, canEditInSqlEditor, showQueryEditor, showDebugPanel } =
+        useValues(theInsightDataLogic)
+    const { toggleQueryEditorPanel, toggleDebugPanel } = useActions(theInsightDataLogic)
+
+    const { insightMode, dashboardId } = useValues(insightSceneLogic)
+    const { setInsightMode } = useActions(insightSceneLogic)
+
+    const { createStaticCohort, startExport } = useActions(exportsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { openCreateFromInsightModal } = useActions(endpointLogic({ tabId: insightProps.tabId || '' }))
+    const { push } = useActions(router)
+    const { openTerraformModal, openAddToDashboardModal } = useActions(insightModalsLogic(insightLogicProps))
+
+    const { canCopyToProject } = useValues(interProjectCopyLogic)
+    const { tags: allExistingTags } = useValues(tagsModel)
+
+    const { user, hasAvailableFeature } = useValues(userLogic)
+    const { preflight } = useValues(preflightLogic)
+    const { openSidePanel } = useActions(sidePanelStateLogic)
+    const { instanceId: metalyticsInstanceId } = useValues(metalyticsLogic)
+
+    const isSavedInsight = hasDashboardItemId && !!insight?.id && !!insight?.short_id
+    const canExport = exportContext != null && insight.short_id != null
+    const showCohort =
+        hogQL != null &&
+        (isDataTableNode(query) || isDataVisualizationNode(query) || isHogQLQuery(query) || isEventsQuery(query))
+    const canShowDebugPanel = isSavedInsight && (user?.is_staff || user?.is_impersonated || !preflight?.cloud)
+    const hasSubscriptionsFeature = hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS)
+    const showMetalytics =
+        isSavedInsight &&
+        metalyticsInstanceId != null &&
+        featureFlags['metalytics'] &&
+        hasAvailableFeature(AvailableFeature.AUDIT_LOGS)
+
+    const handleToggleQueryEditorPanel = (): void => {
+        if (hasDashboardItemId && insightMode !== ItemMode.Edit) {
+            setInsightMode(ItemMode.Edit, null)
+            if (showQueryEditor) {
+                return
+            }
+        }
+        toggleQueryEditorPanel()
+    }
+
+    // Per-menu visibility — empty menus' triggers are not rendered.
+    const showCopyToProject = isSavedInsight && canCopyToProject
+    const showFileMenu = true // file ops (project tree, terraform) always available
+    const showEditMenu = true // duplicate always available
+    const showCreateEndpoint = featureFlags[FEATURE_FLAGS.ENDPOINTS] && isSavedInsight
+    const showAddToNotebook = isSavedInsight
+    const showCreateMenu =
+        showCreateEndpoint ||
+        showCohort ||
+        isSavedInsight /* add-to-dashboard, add-to-notebook, subscribe, alerts, share */
+    const showMetadataMenu = true // tags + activity always shown
+    const showStateMenu = isSavedInsight // favorite + view-source toggle
+    const showStaffMenu = canShowDebugPanel
+
+    return (
+        <SceneMenuBar>
+            {showFileMenu && (
+                <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                    {showCreateMenu && (
+                        <>
+                            <SceneMenuBarSubMenu label="Create">
+                                {isSavedInsight && (
+                                    <SceneMenuBarItem
+                                        opensFloatingUi
+                                        onClick={openAddToDashboardModal}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-add-to-dashboard`}
+                                    >
+                                        <IconPlusSmall />
+                                        Add to dashboard
+                                    </SceneMenuBarItem>
+                                )}
+                                {showAddToNotebook && (
+                                    <SceneMenuBarAddToNotebook
+                                        dataAttrKey={RESOURCE_TYPE}
+                                        notebookSelectButtonProps={{
+                                            resource: {
+                                                type: NotebookNodeType.Query,
+                                                attrs: {
+                                                    query: {
+                                                        kind: NodeKind.SavedInsightNode,
+                                                        shortId: insight.short_id,
+                                                    },
+                                                },
+                                            },
+                                        }}
+                                    />
+                                )}
+                                {showCreateEndpoint && (
+                                    <SceneMenuBarItem
+                                        opensFloatingUi
+                                        onClick={openCreateFromInsightModal}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-create-endpoint`}
+                                    >
+                                        <IconEndpoints />
+                                        Endpoint
+                                    </SceneMenuBarItem>
+                                )}
+                                {showCohort && (
+                                    <SceneMenuBarItem
+                                        opensFloatingUi
+                                        onClick={() =>
+                                            openSaveAsCohortDialog(createStaticCohort, hogQL!, hogQLVariables)
+                                        }
+                                        data-attr={`${RESOURCE_TYPE}-menubar-create-cohort`}
+                                    >
+                                        <IconPeople />
+                                        Static cohort
+                                    </SceneMenuBarItem>
+                                )}
+                                {isSavedInsight && hasSubscriptionsFeature && (
+                                    <SceneMenuBarItem
+                                        onClick={() => push(urlForSubscriptions({ insightShortId: insight.short_id }))}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-subscribe`}
+                                    >
+                                        <IconBell />
+                                        Subscription
+                                    </SceneMenuBarItem>
+                                )}
+                                {isSavedInsight && (
+                                    <SceneMenuBarItem
+                                        onClick={() => push(urls.insightAlerts(insight.short_id!))}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-alerts`}
+                                    >
+                                        <IconWarning />
+                                        Alert
+                                    </SceneMenuBarItem>
+                                )}
+                                {isSavedInsight && (
+                                    <SceneMenuBarItem
+                                        onClick={() => push(urls.insightSharing(insight.short_id!))}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-share`}
+                                    >
+                                        <IconShare />
+                                        Share or embed
+                                    </SceneMenuBarItem>
+                                )}
+                            </SceneMenuBarSubMenu>
+                            <SceneMenuBarSeparator />
+                        </>
+                    )}
+                    <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                    {showCopyToProject && (
+                        <SceneMenuBarItem
+                            onClick={() => push(urls.resourceTransfer('Insight', insight.id!))}
+                            data-attr={`${RESOURCE_TYPE}-menubar-copy-to-project`}
+                        >
+                            <IconCopy />
+                            Copy to another project
+                        </SceneMenuBarItem>
+                    )}
+                    <SceneMenuBarItem
+                        opensFloatingUi
+                        onClick={openTerraformModal}
+                        data-attr={`${RESOURCE_TYPE}-menubar-terraform`}
+                    >
+                        <IconCode2 />
+                        Manage with Terraform
+                    </SceneMenuBarItem>
+                    {canExport && (
+                        <SceneMenuBarSubMenu label="Export">
+                            <SceneMenuBarItem
+                                onClick={() =>
+                                    startExport({
+                                        export_format: ExporterFormat.PNG,
+                                        insight: insight.id,
+                                        export_context: exportContext,
+                                    })
+                                }
+                                data-attr={`${RESOURCE_TYPE}-menubar-export-png`}
+                            >
+                                <IconDownload />
+                                PNG
+                            </SceneMenuBarItem>
+                            <SceneMenuBarItem
+                                onClick={() =>
+                                    startExport({
+                                        export_format: ExporterFormat.CSV,
+                                        export_context: exportContext,
+                                    })
+                                }
+                                data-attr={`${RESOURCE_TYPE}-menubar-export-csv`}
+                            >
+                                <IconDownload />
+                                CSV
+                            </SceneMenuBarItem>
+                            <SceneMenuBarItem
+                                onClick={() =>
+                                    startExport({
+                                        export_format: ExporterFormat.XLSX,
+                                        export_context: exportContext,
+                                    })
+                                }
+                                data-attr={`${RESOURCE_TYPE}-menubar-export-xlsx`}
+                            >
+                                <IconDownload />
+                                XLSX
+                            </SceneMenuBarItem>
+                        </SceneMenuBarSubMenu>
+                    )}
+                    {isSavedInsight && (
+                        <>
+                            <SceneMenuBarSeparator />
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.Insight}
+                                minAccessLevel={AccessControlLevel.Editor}
+                            >
+                                {({ disabledReason }) => (
+                                    <SceneMenuBarItem
+                                        variant="destructive"
+                                        disabled={!!disabledReason}
+                                        onClick={() => deleteInsight(dashboardId ?? null)}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                                    >
+                                        <IconTrash />
+                                        Delete insight
+                                    </SceneMenuBarItem>
+                                )}
+                            </AccessControlAction>
+                        </>
+                    )}
+                </SceneMenuBarMenu>
+            )}
+            {showEditMenu && (
+                <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
+                    <SceneMenuBarItem
+                        onClick={() => duplicateInsight(insight as QueryBasedInsightModel, true)}
+                        data-attr={`${RESOURCE_TYPE}-menubar-duplicate`}
+                    >
+                        <IconCopy />
+                        Duplicate
+                    </SceneMenuBarItem>
+                    {canEditInSqlEditor && (
+                        <SceneMenuBarItem
+                            onClick={() => push(urls.sqlEditor({ query: hogQL ?? undefined }))}
+                            data-attr={`${RESOURCE_TYPE}-menubar-edit-sql`}
+                        >
+                            <IconPencil />
+                            Edit in SQL editor
+                        </SceneMenuBarItem>
+                    )}
+                    {showStateMenu && (
+                        <>
+                            <SceneMenuBarSeparator />
+                            <SceneMenuBarCheckboxItem
+                                checked={!!insight.favorited}
+                                onCheckedChange={(checked) => setInsightMetadata({ favorited: checked })}
+                                data-attr={`${RESOURCE_TYPE}-menubar-favorite`}
+                            >
+                                Favorite
+                            </SceneMenuBarCheckboxItem>
+                            <SceneMenuBarCheckboxItem
+                                checked={showQueryEditor}
+                                onCheckedChange={handleToggleQueryEditorPanel}
+                                data-attr={`${RESOURCE_TYPE}-menubar-view-source`}
+                            >
+                                View source
+                            </SceneMenuBarCheckboxItem>
+                        </>
+                    )}
+                </SceneMenuBarMenu>
+            )}
+            {showMetadataMenu && (
+                <SceneMenuBarPopover
+                    label="Metadata"
+                    dataAttr={`${RESOURCE_TYPE}-menubar-metadata`}
+                    contentClassName="w-80 p-2 flex flex-col gap-2"
+                >
+                    <SceneTagsCombobox
+                        onSave={(tags) => setInsightMetadata({ tags })}
+                        tags={insight.tags}
+                        tagsAvailable={allExistingTags}
+                        dataAttrKey={RESOURCE_TYPE}
+                        canEdit={canEditInsight}
+                        loading={isSavingTags}
+                    />
+                    <SceneActivityIndicator
+                        at={insight.last_modified_at}
+                        by={insight.last_modified_by}
+                        prefix="Last modified"
+                    />
+                    {showMetalytics && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            left
+                            onClick={() => openSidePanel(SidePanelTab.Activity, 'metalytics')}
+                            data-attr={`${RESOURCE_TYPE}-menubar-metalytics`}
+                        >
+                            <IconPulse />
+                            View metalytics
+                        </Button>
+                    )}
+                </SceneMenuBarPopover>
+            )}
+            {showStaffMenu && (
+                <SceneMenuBarMenu label="Staff only" dataAttr={`${RESOURCE_TYPE}-menubar-staff`}>
+                    <SceneMenuBarCheckboxItem
+                        checked={showDebugPanel}
+                        onCheckedChange={toggleDebugPanel}
+                        data-attr={`${RESOURCE_TYPE}-menubar-debug-panel`}
+                    >
+                        Show debug panel
+                    </SceneMenuBarCheckboxItem>
+                </SceneMenuBarMenu>
+            )}
+        </SceneMenuBar>
+    )
+}

--- a/frontend/src/scenes/persons/PersonsScene.tsx
+++ b/frontend/src/scenes/persons/PersonsScene.tsx
@@ -3,6 +3,8 @@ import { useActions, useAsyncActions, useValues } from 'kea'
 import { IconRewind } from '@posthog/icons'
 import { LemonDialog, LemonInput } from '@posthog/lemon-ui'
 
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { Link } from 'lib/lemon-ui/Link'
@@ -14,6 +16,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneMenuBar, SceneMenuBarItem, SceneMenuBarMenu } from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ScenePanel, ScenePanelActionsSection } from '~/layout/scenes/SceneLayout'
 import { Query } from '~/queries/Query/Query'
@@ -48,14 +51,51 @@ export function PersonsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
     const { currentTeam, baseCurrency } = useValues(teamLogic)
     const { loadConfigs } = useActions(customerProfileConfigLogic({ scope: CustomerProfileScope.PERSON }))
     const queryUniqueKey = `persons-query-${tabId}`
+    const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
 
     useOnMountEffect(() => {
         loadConfigs()
     })
 
+    const onResetDeletedPerson = (): void => {
+        LemonDialog.openForm({
+            width: '30rem',
+            title: 'Reset deleted person',
+            description: `Once a person is deleted, the "distinct_id" associated with them can no longer be used.
+                You can use this tool to reset the "distinct_id" for a person so that new events associated with it will create a new Person profile.`,
+            initialValues: { distinct_id: '' },
+            content: (
+                <LemonField name="distinct_id" label="Distinct ID to reset">
+                    <LemonInput type="text" autoFocus />
+                </LemonField>
+            ),
+            errors: {
+                distinct_id: (distinct_id) => (!distinct_id ? 'This is required' : undefined),
+            },
+            onSubmit: async ({ distinct_id }) => await resetDeletedDistinctId(distinct_id),
+        })
+    }
+
     return (
         <SceneContent>
             <PersonsManagementSceneTabs tabKey="persons" />
+
+            {sceneMenuBarEnabled && (
+                <SceneMenuBar>
+                    <SceneMenuBarMenu label="File" dataAttr="persons-menubar-file">
+                        <SceneMenuBarFileItems dataAttrKey="persons" />
+                        <SceneMenuBarItem
+                            variant="destructive"
+                            opensFloatingUi
+                            onClick={onResetDeletedPerson}
+                            data-attr="persons-menubar-reset-deleted"
+                        >
+                            <IconRewind />
+                            Reset a deleted person
+                        </SceneMenuBarItem>
+                    </SceneMenuBarMenu>
+                </SceneMenuBar>
+            )}
 
             <SceneTitleSection
                 name={sceneConfigurations[Scene.Persons].name}

--- a/frontend/src/scenes/product-tours/ProductTourView.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourView.tsx
@@ -8,6 +8,8 @@ import { LemonBanner, LemonButton, LemonDialog, LemonDivider, LemonSelect, Lemon
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
@@ -16,6 +18,12 @@ import { FeatureFlagReleaseConditions } from 'scenes/feature-flags/FeatureFlagRe
 import { SurveyMatchTypeLabels } from 'scenes/surveys/constants'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import {
     ScenePanel,
@@ -131,6 +139,7 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
     const { deleteProductTour } = useActions(productToursLogic)
 
     const [tabKey, setTabKey] = useState(() => (router.values.searchParams.activity ? 'history' : 'overview'))
+    const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
 
     if (productTourLoading || !productTour) {
         return <LemonSkeleton />
@@ -141,6 +150,43 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
 
     return (
         <SceneContent>
+            {sceneMenuBarEnabled && (
+                <SceneMenuBar>
+                    <SceneMenuBarMenu label="File" dataAttr="product_tour-menubar-file">
+                        <SceneMenuBarFileItems dataAttrKey="product_tour" />
+                        <SceneMenuBarSeparator />
+                        <SceneMenuBarItem
+                            variant="destructive"
+                            opensFloatingUi
+                            onClick={() => {
+                                LemonDialog.open({
+                                    title: 'Delete this product tour?',
+                                    content: (
+                                        <div className="text-sm text-secondary">
+                                            This action cannot be undone. All tour data will be permanently removed.
+                                        </div>
+                                    ),
+                                    primaryButton: {
+                                        children: 'Delete',
+                                        type: 'primary',
+                                        onClick: () => deleteProductTour(id),
+                                        size: 'small',
+                                    },
+                                    secondaryButton: {
+                                        children: 'Cancel',
+                                        type: 'tertiary',
+                                        size: 'small',
+                                    },
+                                })
+                            }}
+                            data-attr="product_tour-menubar-delete"
+                        >
+                            <IconTrash />
+                            Delete product tour
+                        </SceneMenuBarItem>
+                    </SceneMenuBarMenu>
+                </SceneMenuBar>
+            )}
             <ScenePanel>
                 <ScenePanelInfoSection>
                     <SceneFile dataAttrKey="product_tour" />

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
@@ -2,21 +2,32 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useEffect, useMemo } from 'react'
 
+import { IconCopy, IconTrash } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
 import { SceneDuplicate } from 'lib/components/Scenes/SceneDuplicate'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { SceneMetalyticsSummaryButton } from 'lib/components/Scenes/SceneMetalyticsSummaryButton'
 import { ScenePin } from 'lib/components/Scenes/ScenePin'
 import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { SceneExport } from 'scenes/sceneTypes'
 import { playerSettingsLogic } from 'scenes/session-recordings/player/playerSettingsLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import {
+    SceneMenuBar,
+    SceneMenuBarCheckboxItem,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import {
     ScenePanel,
@@ -73,6 +84,8 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
 
     const { showFilters } = useValues(playerSettingsLogic)
     const { setShowFilters } = useActions(playerSettingsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
 
     const isNewPlaylist = useMemo(() => {
         if (!playlist || playlistLoading) {
@@ -110,6 +123,45 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
 
     return (
         <div>
+            {sceneMenuBarEnabled && (
+                <SceneMenuBar>
+                    <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                        <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                        {!playlist.is_synthetic && (
+                            <>
+                                <SceneMenuBarSeparator />
+                                <SceneMenuBarItem
+                                    variant="destructive"
+                                    onClick={() => deletePlaylist()}
+                                    data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                                >
+                                    <IconTrash />
+                                    Delete collection
+                                </SceneMenuBarItem>
+                            </>
+                        )}
+                    </SceneMenuBarMenu>
+                    {!playlist.is_synthetic && (
+                        <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
+                            <SceneMenuBarItem
+                                onClick={() => duplicatePlaylist()}
+                                data-attr={`${RESOURCE_TYPE}-menubar-duplicate`}
+                            >
+                                <IconCopy />
+                                Duplicate
+                            </SceneMenuBarItem>
+                            <SceneMenuBarSeparator />
+                            <SceneMenuBarCheckboxItem
+                                checked={playlist.pinned ?? false}
+                                onCheckedChange={(checked) => updatePlaylist({ pinned: checked })}
+                                data-attr={`${RESOURCE_TYPE}-menubar-pin`}
+                            >
+                                Pinned
+                            </SceneMenuBarCheckboxItem>
+                        </SceneMenuBarMenu>
+                    )}
+                </SceneMenuBar>
+            )}
             <ScenePanel>
                 <ScenePanelInfoSection>
                     <SceneFile dataAttrKey={RESOURCE_TYPE} />

--- a/frontend/src/scenes/surveys/SurveySceneMenuBar.tsx
+++ b/frontend/src/scenes/surveys/SurveySceneMenuBar.tsx
@@ -1,0 +1,125 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { IconArchive, IconCopy, IconTrash } from '@posthog/icons'
+
+import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopyLogic'
+import { canDeleteSurvey, openArchiveSurveyDialog, openDeleteSurveyDialog } from 'scenes/surveys/surveyDialogs'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { surveysLogic } from 'scenes/surveys/surveysLogic'
+import { urls } from 'scenes/urls'
+
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
+import { AccessControlLevel, AccessControlResourceType, Survey } from '~/types'
+
+const RESOURCE_TYPE = 'survey'
+
+export function SurveySceneMenuBar({ id }: { id: string }): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
+        return null
+    }
+    return <SurveySceneMenuBarInner id={id} />
+}
+
+function SurveySceneMenuBarInner({ id }: { id: string }): JSX.Element | null {
+    const { survey } = useValues(surveyLogic)
+    const { archiveSurvey } = useActions(surveyLogic)
+    const { deleteSurvey, duplicateSurvey, setSurveyToDuplicate } = useActions(surveysLogic)
+    const { currentOrganization } = useValues(organizationLogic)
+    const { canCopyToProject } = useValues(interProjectCopyLogic)
+    const { push } = useActions(router)
+
+    if (!survey || !survey.id) {
+        return null
+    }
+
+    const surveyId = survey.id as string
+    const hasMultipleProjects = !!(currentOrganization?.teams && currentOrganization.teams.length > 1)
+    const canDelete = canDeleteSurvey(survey)
+    const canArchive = !survey.archived
+
+    return (
+        <SceneMenuBar>
+            <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                {canCopyToProject && (
+                    <SceneMenuBarItem
+                        onClick={() => push(urls.resourceTransfer('Survey', surveyId))}
+                        data-attr={`${RESOURCE_TYPE}-menubar-copy-to-project`}
+                    >
+                        <IconCopy />
+                        Copy to another project
+                    </SceneMenuBarItem>
+                )}
+                {(canArchive || canDelete) && <SceneMenuBarSeparator />}
+                {canArchive && (
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.Survey}
+                        minAccessLevel={AccessControlLevel.Editor}
+                        userAccessLevel={survey.user_access_level}
+                    >
+                        {({ disabledReason }) => (
+                            <SceneMenuBarItem
+                                variant="destructive"
+                                disabled={!!disabledReason}
+                                opensFloatingUi
+                                onClick={() => openArchiveSurveyDialog(survey as Survey, archiveSurvey)}
+                                data-attr={`${RESOURCE_TYPE}-menubar-archive`}
+                            >
+                                <IconArchive />
+                                Archive
+                            </SceneMenuBarItem>
+                        )}
+                    </AccessControlAction>
+                )}
+                {canDelete && (
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.Survey}
+                        minAccessLevel={AccessControlLevel.Editor}
+                        userAccessLevel={survey.user_access_level}
+                    >
+                        {({ disabledReason }) => (
+                            <SceneMenuBarItem
+                                variant="destructive"
+                                disabled={!!disabledReason}
+                                opensFloatingUi
+                                onClick={() => openDeleteSurveyDialog(survey as Survey, () => deleteSurvey(id))}
+                                data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                            >
+                                <IconTrash />
+                                Delete permanently
+                            </SceneMenuBarItem>
+                        )}
+                    </AccessControlAction>
+                )}
+            </SceneMenuBarMenu>
+            <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
+                <SceneMenuBarItem
+                    onClick={() => {
+                        const existing = survey as Survey
+                        if (hasMultipleProjects) {
+                            setSurveyToDuplicate(existing)
+                        } else {
+                            duplicateSurvey(existing)
+                        }
+                    }}
+                    data-attr={`${RESOURCE_TYPE}-menubar-duplicate`}
+                >
+                    <IconCopy />
+                    Duplicate
+                </SceneMenuBarItem>
+            </SceneMenuBarMenu>
+        </SceneMenuBar>
+    )
+}

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -66,6 +66,7 @@ import {
 import { SurveyResultsRefreshStatus } from './components/SurveyResultsRefreshStatus'
 import { NEW_SURVEY } from './constants'
 import { SurveyHeadline } from './SurveyHeadline'
+import { SurveySceneMenuBar } from './SurveySceneMenuBar'
 import { canUseSurveyWizard, getSurveyResponse, isThumbQuestion } from './utils'
 
 const RESOURCE_TYPE = 'survey'
@@ -129,6 +130,7 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
                 <LemonSkeleton />
             ) : (
                 <SceneContent>
+                    <SurveySceneMenuBar id={id} />
                     <ScenePanel>
                         <ScenePanelInfoSection>
                             <SceneFile dataAttrKey={RESOURCE_TYPE} />

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -9,9 +9,12 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { SceneDuplicate } from 'lib/components/Scenes/SceneDuplicate'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -34,6 +37,12 @@ import { urls } from 'scenes/urls'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import {
     ScenePanel,
@@ -74,6 +83,8 @@ export function SurveyViewRedesign(): JSX.Element {
     const { canCopyToProject } = useValues(interProjectCopyLogic)
     const { push } = useActions(router)
     const { location, searchParams, hashParams } = useValues(router)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
     const isInitialSurveyLoad = surveyLoading && survey.id === NEW_SURVEY.id
 
     const hasMultipleProjects = currentOrganization?.teams && currentOrganization.teams.length > 1
@@ -205,6 +216,89 @@ export function SurveyViewRedesign(): JSX.Element {
 
     return (
         <SceneContent className="gap-y-4 flex-1 min-h-full">
+            {sceneMenuBarEnabled && (
+                <SceneMenuBar>
+                    <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                        <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                        {canCopyToProject && surveyIdForTransfer && (
+                            <SceneMenuBarItem
+                                onClick={() => push(urls.resourceTransfer('Survey', surveyIdForTransfer))}
+                                data-attr={`${RESOURCE_TYPE}-menubar-copy-to-project`}
+                            >
+                                <IconCopy />
+                                Copy to another project
+                            </SceneMenuBarItem>
+                        )}
+                        {(!survey.archived || canDeleteSurvey(survey)) && <SceneMenuBarSeparator />}
+                        {!survey.archived && (
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.Survey}
+                                minAccessLevel={AccessControlLevel.Editor}
+                                userAccessLevel={survey.user_access_level}
+                            >
+                                {({ disabledReason }) => (
+                                    <SceneMenuBarItem
+                                        variant="destructive"
+                                        opensFloatingUi
+                                        disabled={!!disabledReason}
+                                        onClick={() => openArchiveSurveyDialog(survey, archiveSurvey)}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-archive`}
+                                    >
+                                        <IconArchive />
+                                        Archive
+                                    </SceneMenuBarItem>
+                                )}
+                            </AccessControlAction>
+                        )}
+                        {canDeleteSurvey(survey) && (
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.Survey}
+                                minAccessLevel={AccessControlLevel.Editor}
+                                userAccessLevel={survey.user_access_level}
+                            >
+                                {({ disabledReason }) => (
+                                    <SceneMenuBarItem
+                                        variant="destructive"
+                                        opensFloatingUi
+                                        disabled={!!disabledReason}
+                                        onClick={() => openDeleteSurveyDialog(survey, () => deleteSurvey(survey.id))}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                                    >
+                                        <IconTrash />
+                                        Delete permanently
+                                    </SceneMenuBarItem>
+                                )}
+                            </AccessControlAction>
+                        )}
+                    </SceneMenuBarMenu>
+                    <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
+                        <SceneMenuBarItem
+                            onClick={() => {
+                                const existingSurvey = survey as Survey
+                                if (hasMultipleProjects) {
+                                    setSurveyToDuplicate(existingSurvey)
+                                } else {
+                                    duplicateSurvey(existingSurvey)
+                                }
+                            }}
+                            data-attr={`${RESOURCE_TYPE}-menubar-duplicate`}
+                        >
+                            <IconCopy />
+                            Duplicate
+                        </SceneMenuBarItem>
+                        {!isDraft && (
+                            <SceneMenuBarItem
+                                opensFloatingUi
+                                onClick={() => setSqlHelperOpen(true)}
+                                data-attr={`${RESOURCE_TYPE}-menubar-sql-query`}
+                            >
+                                <IconCode />
+                                SQL query
+                            </SceneMenuBarItem>
+                        )}
+                    </SceneMenuBarMenu>
+                </SceneMenuBar>
+            )}
             <ScenePanel>
                 <ScenePanelInfoSection>
                     <SceneFile dataAttrKey={RESOURCE_TYPE} />

--- a/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
@@ -3,6 +3,7 @@ import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { WebAnalyticsDashboard } from 'scenes/web-analytics/WebAnalyticsDashboard'
 import { WebAnalyticsHeaderButtons } from 'scenes/web-analytics/WebAnalyticsHeaderButtons'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
+import { WebAnalyticsSceneMenuBar } from 'scenes/web-analytics/WebAnalyticsSceneMenuBar'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
@@ -12,6 +13,7 @@ export function WebAnalyticsScene(): JSX.Element {
     return (
         <>
             <SceneContent>
+                <WebAnalyticsSceneMenuBar />
                 <SceneTitleSection
                     name={sceneConfigurations[Scene.WebAnalytics].name}
                     description={sceneConfigurations[Scene.WebAnalytics].description}

--- a/frontend/src/scenes/web-analytics/WebAnalyticsSceneMenuBar.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsSceneMenuBar.tsx
@@ -1,0 +1,172 @@
+import { useActions, useValues } from 'kea'
+
+import { IconBolt, IconSearch } from '@posthog/icons'
+import { Badge, Tooltip, TooltipContent, TooltipTrigger } from '@posthog/quill'
+
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
+
+import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
+import {
+    SceneMenuBar,
+    SceneMenuBarCheckboxItem,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+    SceneMenuBarSubMenu,
+} from '~/layout/scenes/components/SceneMenuBar'
+
+import { ProductTab, TILE_LABELS, TileId } from './common'
+
+const ANALYTICS_TILES = [
+    TileId.OVERVIEW,
+    TileId.GRAPHS,
+    TileId.PATHS,
+    TileId.SOURCES,
+    TileId.DEVICES,
+    TileId.GEOGRAPHY,
+    TileId.ACTIVE_HOURS,
+    TileId.RETENTION,
+    TileId.GOALS,
+    TileId.REPLAY,
+    TileId.ERROR_TRACKING,
+    TileId.FRUSTRATING_PAGES,
+]
+
+function NewQueryEngineTooltipBody(): JSX.Element {
+    return (
+        <div className="max-w-100 p-1 text-xs">
+            <div className="mb-2 flex items-center gap-2">
+                <strong>About the new query engine</strong>
+                <Badge variant="info" size="sm" className="uppercase">
+                    Beta
+                </Badge>
+            </div>
+            <p className="mb-2">
+                Our new web analytics query engine powers faster queries using pre-aggregated data, giving you quicker
+                access to insights and it's much better at handling large datasets.
+            </p>
+            <div className="mb-2">
+                <strong>A few things to note:</strong>
+                <ul className="list-disc ml-4 mt-1 space-y-1">
+                    <li>Some filters may not yet be supported, but we're working on expanding coverage.</li>
+                    <li>
+                        We use smart approximation techniques to keep performance high, and we aim for less than 1%
+                        difference compared to exact results.
+                    </li>
+                    <li>Results are currently tied to UTC timezone for query and display.</li>
+                </ul>
+            </div>
+            <div>
+                <strong>Coming soon:</strong>
+                <ul className="list-disc ml-4 mt-1 space-y-1">
+                    <li>Use the new engine for chart visualizations</li>
+                    <li>Support for channel types in breakdowns</li>
+                    <li>Enable conversion goals</li>
+                    <li>Further improvements in accuracy</li>
+                    <li>More filters!</li>
+                </ul>
+            </div>
+        </div>
+    )
+}
+
+export function WebAnalyticsSceneMenuBar(): JSX.Element | null {
+    const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
+    if (!sceneMenuBarEnabled) {
+        return null
+    }
+    return <WebAnalyticsSceneMenuBarInner />
+}
+
+function WebAnalyticsSceneMenuBarInner(): JSX.Element {
+    const { shouldFilterTestAccounts, hiddenTiles, productTab } = useValues(webAnalyticsLogic)
+    const { setShouldFilterTestAccounts, setTileVisibility } = useActions(webAnalyticsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { projectTreeRefEntry } = useValues(projectTreeDataLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const { updateCurrentTeam } = useActions(teamLogic)
+
+    const showTileToggles = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_TOGGLES]
+    const showQueryEngineToggle = !!featureFlags[FEATURE_FLAGS.SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES]
+    const isUsingNewEngine = !!currentTeam?.modifiers?.useWebAnalyticsPreAggregatedTables
+    const availableTiles = productTab === ProductTab.ANALYTICS ? ANALYTICS_TILES : []
+    const hasFileItems = !!projectTreeRefEntry
+
+    const handleToggleEngine = (checked: boolean): void => {
+        updateCurrentTeam({
+            modifiers: {
+                ...currentTeam?.modifiers,
+                useWebAnalyticsPreAggregatedTables: checked,
+            },
+        })
+    }
+
+    return (
+        <SceneMenuBar>
+            <SceneMenuBarMenu label="File" dataAttr="web-analytics-menubar-file" disabled={!hasFileItems}>
+                {hasFileItems && <SceneMenuBarFileItems dataAttrKey="web-analytics" />}
+            </SceneMenuBarMenu>
+            {showQueryEngineToggle && (
+                <SceneMenuBarMenu label="Edit" dataAttr="web-analytics-menubar-edit">
+                    <Tooltip>
+                        <TooltipTrigger
+                            render={
+                                <SceneMenuBarCheckboxItem
+                                    checked={isUsingNewEngine}
+                                    onCheckedChange={handleToggleEngine}
+                                    data-attr="web-analytics-menubar-query-engine"
+                                >
+                                    <IconBolt />
+                                    New query engine
+                                    <Badge variant="info" size="sm" className="ml-1 uppercase">
+                                        Beta
+                                    </Badge>
+                                </SceneMenuBarCheckboxItem>
+                            }
+                        />
+                        <TooltipContent>
+                            <NewQueryEngineTooltipBody />
+                        </TooltipContent>
+                    </Tooltip>
+                </SceneMenuBarMenu>
+            )}
+            <SceneMenuBarMenu label="View" dataAttr="web-analytics-menubar-view">
+                <SceneMenuBarItem
+                    onClick={() => window.location.assign(urls.sessionAttributionExplorer())}
+                    data-attr="web-analytics-menubar-session-attribution"
+                >
+                    <IconSearch />
+                    Session Attribution Explorer
+                </SceneMenuBarItem>
+                <SceneMenuBarSeparator />
+                <SceneMenuBarCheckboxItem
+                    checked={shouldFilterTestAccounts}
+                    onCheckedChange={(checked) => setShouldFilterTestAccounts(checked)}
+                    data-attr="web-analytics-menubar-filter-test"
+                >
+                    Filter out internal and test users
+                </SceneMenuBarCheckboxItem>
+                {showTileToggles && availableTiles.length > 0 && (
+                    <SceneMenuBarSubMenu label="Visible tiles">
+                        {availableTiles.map((tileId) => (
+                            <SceneMenuBarCheckboxItem
+                                key={tileId}
+                                checked={!hiddenTiles.includes(tileId)}
+                                onCheckedChange={(checked) => setTileVisibility(tileId, !checked)}
+                                data-attr={`web-analytics-menubar-tile-${tileId}`}
+                            >
+                                {TILE_LABELS[tileId]}
+                            </SceneMenuBarCheckboxItem>
+                        ))}
+                    </SceneMenuBarSubMenu>
+                )}
+            </SceneMenuBarMenu>
+        </SceneMenuBar>
+    )
+}

--- a/packages/quill/packages/blocks/package.json
+++ b/packages/quill/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-blocks",
-    "version": "0.3.0-beta.1",
+    "version": "0.3.0-beta.7",
     "private": true,
     "description": "Internal workspace package (private, not published). The highest layer of the quill design system — product-level patterns made of components + primitives (e.g. a PageHeader with title + breadcrumb + action slot, an EmptyState with icon + copy + CTA, a CommandPalette, a user-menu dropdown). Opinionated and shape-stable across products so they feel consistent. Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/components/package.json
+++ b/packages/quill/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-components",
-    "version": "0.3.0-beta.1",
+    "version": "0.3.0-beta.7",
     "private": true,
     "description": "Internal workspace package (private, not published). The middle layer of the quill design system — higher-level compositions of primitives that wire several of them together with sensible defaults (e.g. a FormField that composes Label + Input + validation state, or a ConfirmDialog that composes Dialog + Button + destructive variant). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/primitives/package.json
+++ b/packages/quill/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-primitives",
-    "version": "0.3.0-beta.1",
+    "version": "0.3.0-beta.7",
     "private": true,
     "description": "Internal workspace package (private, not published). The lowest layer of the quill design system — unstyled Base UI primitives wrapped with quill's Tailwind classes (Button, Card, Dialog, Input, Popover, Combobox, etc.). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/primitives/src/combobox.tsx
+++ b/packages/quill/packages/primitives/src/combobox.tsx
@@ -216,7 +216,7 @@ function ComboboxChips({
     return (
         <ComboboxPrimitive.Chips
             data-slot="combobox-chips"
-            className={cn('quill-combobox__chips flex flex-wrap items-center gap-1', className)}
+            className={cn('quill-combobox__chips flex flex-wrap items-center gap-1 py-1', className)}
             {...props}
         />
     )

--- a/packages/quill/packages/primitives/src/menubar.tsx
+++ b/packages/quill/packages/primitives/src/menubar.tsx
@@ -84,7 +84,9 @@ function MenubarItem({
         <DropdownMenuItem
             data-slot="menubar-item"
             data-inset={inset}
-            data-variant={variant}
+            // Forward variant so the inner <Button render> (which colours bg/text via Quill button variants)
+            // receives `destructive` instead of falling back to `default`.
+            variant={variant}
             className={cn(
                 "group/menubar-item min-h-7 gap-2 rounded-sm px-2 py-1 text-xs/relaxed focus:bg-fill-hover data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-3.5 data-[variant=destructive]:*:[svg]:text-destructive!",
                 className
@@ -108,7 +110,9 @@ function MenubarCheckboxItem({
             data-slot="menubar-checkbox-item"
             data-inset={inset}
             className={cn(
-                'quill-menu-item--inset relative flex min-h-7 cursor-default items-center gap-2 rounded-sm py-1.5 pe-2 text-xs outline-hidden select-none focus:bg-fill-hover data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+                // Match the focus-visible ring on the inner <Button> that MenubarItem uses, so
+                // keyboard navigation through checkbox/radio items shows the same affordance.
+                'quill-menu-item--inset relative flex min-h-7 cursor-default items-center gap-2 rounded-sm py-1.5 pe-2 text-xs outline-hidden select-none hover:bg-[var(--fill-hover)] focus:bg-[var(--fill-hover)] focus-visible:shadow-[0_0_0_2px_color-mix(in_oklab,var(--ring)_30%,transparent)] data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
                 className
             )}
             checked={checked}
@@ -142,7 +146,7 @@ function MenubarRadioItem({
             data-slot="menubar-radio-item"
             data-inset={inset}
             className={cn(
-                "quill-menu-item--inset relative flex min-h-7 cursor-default items-center gap-2 rounded-sm py-1.5 pe-2 text-xs outline-hidden select-none focus:bg-fill-hover data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+                "quill-menu-item--inset relative flex min-h-7 cursor-default items-center gap-2 rounded-sm py-1.5 pe-2 text-xs outline-hidden select-none hover:bg-[var(--fill-hover)] focus:bg-[var(--fill-hover)] focus-visible:shadow-[0_0_0_2px_color-mix(in_oklab,var(--ring)_30%,transparent)] data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
                 className
             )}
             {...props}

--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill",
-    "version": "0.3.0-beta.1",
+    "version": "0.3.0-beta.7",
     "description": "PostHog's unified design system — primitives, components, and blocks designed to be compiled by the consumer's Tailwind v4.",
     "license": "MIT",
     "repository": {

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-tokens",
-    "version": "0.3.0-beta.1",
+    "version": "0.3.0-beta.7",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/products/actions/frontend/pages/ActionEdit.tsx
+++ b/products/actions/frontend/pages/ActionEdit.tsx
@@ -9,9 +9,11 @@ import { LemonCollapse } from '@posthog/lemon-ui'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { NotFound } from 'lib/components/NotFound'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { SceneTags } from 'lib/components/Scenes/SceneTags'
 import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
 import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -21,6 +23,7 @@ import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { getAccessControlDisabledReason, userHasAccess } from 'lib/utils/accessControlUtils'
@@ -30,6 +33,12 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import {
     ScenePanel,
@@ -88,6 +97,8 @@ export function ActionEdit({ action: loadedAction, id, tabId, actionLoading, att
     const { tags } = useValues(tagsModel)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
     const { canCopyToProject } = useValues(interProjectCopyLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
 
     // Check if user can edit this action
     const canEdit = userHasAccess(AccessControlResourceType.Action, AccessControlLevel.Editor, action.user_access_level)
@@ -134,6 +145,39 @@ export function ActionEdit({ action: loadedAction, id, tabId, actionLoading, att
                 enableFormOnSubmit
                 className="flex flex-col gap-y-4"
             >
+                {sceneMenuBarEnabled && action && (
+                    <SceneMenuBar>
+                        <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                            <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                            {actionId && canCopyToProject && (
+                                <SceneMenuBarItem
+                                    onClick={() => router.actions.push(urls.resourceTransfer('Action', actionId))}
+                                    data-attr={`${RESOURCE_TYPE}-menubar-copy-to-project`}
+                                >
+                                    <IconCopy />
+                                    Copy to another project
+                                </SceneMenuBarItem>
+                            )}
+                            <SceneMenuBarSeparator />
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.Action}
+                                minAccessLevel={AccessControlLevel.Editor}
+                            >
+                                {({ disabledReason }) => (
+                                    <SceneMenuBarItem
+                                        variant="destructive"
+                                        disabled={!!disabledReason}
+                                        onClick={() => deleteAction()}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                                    >
+                                        <IconTrash />
+                                        Delete
+                                    </SceneMenuBarItem>
+                                )}
+                            </AccessControlAction>
+                        </SceneMenuBarMenu>
+                    </SceneMenuBar>
+                )}
                 <ScenePanel>
                     <ScenePanelInfoSection>
                         <SceneTags

--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -19,12 +19,15 @@ import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { FlagSelector } from 'lib/components/FlagSelector'
 import { NotFound } from 'lib/components/NotFound'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { SceneMetalyticsSummaryButton } from 'lib/components/Scenes/SceneMetalyticsSummaryButton'
 import { SceneSelect } from 'lib/components/Scenes/SceneSelect'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { JSONEditorInput } from 'scenes/feature-flags/JSONEditorInput'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
@@ -36,6 +39,12 @@ import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import {
@@ -148,6 +157,8 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
     } = useActions(earlyAccessFeatureLogic)
     const { currentTeamId } = useValues(teamLogic)
     const { canCopyToProject } = useValues(interProjectCopyLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
 
     const isNewEarlyAccessFeature = id === 'new' || id === undefined
 
@@ -197,6 +208,57 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
     return (
         <Form id="early-access-feature" formKey="earlyAccessFeature" logic={earlyAccessFeatureLogic}>
             <SceneContent>
+                {sceneMenuBarEnabled && !isNewEarlyAccessFeature && (
+                    <SceneMenuBar>
+                        <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                            <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                            {canCopyToProject && earlyAccessFeatureId && (
+                                <SceneMenuBarItem
+                                    onClick={() =>
+                                        router.actions.push(
+                                            urls.resourceTransfer('EarlyAccessFeature', earlyAccessFeatureId)
+                                        )
+                                    }
+                                    data-attr={`${RESOURCE_TYPE}-menubar-copy-to-project`}
+                                >
+                                    <IconCopy />
+                                    Copy to another project
+                                </SceneMenuBarItem>
+                            )}
+                            <SceneMenuBarSeparator />
+                            <SceneMenuBarItem
+                                variant="destructive"
+                                opensFloatingUi
+                                onClick={() => {
+                                    LemonDialog.open({
+                                        title: 'Permanently delete feature?',
+                                        description:
+                                            'Doing so will remove any opt in conditions from the feature flag.',
+                                        primaryButton: {
+                                            children: 'Delete',
+                                            type: 'primary',
+                                            status: 'danger',
+                                            'data-attr': 'confirm-delete-feature',
+                                            onClick: () => {
+                                                deleteEarlyAccessFeature(
+                                                    (earlyAccessFeature as EarlyAccessFeatureType)?.id
+                                                )
+                                            },
+                                        },
+                                        secondaryButton: {
+                                            children: 'Close',
+                                            type: 'secondary',
+                                        },
+                                    })
+                                }}
+                                data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                            >
+                                <IconTrash />
+                                Delete
+                            </SceneMenuBarItem>
+                        </SceneMenuBarMenu>
+                    </SceneMenuBar>
+                )}
                 <SceneTitleSection
                     name={earlyAccessFeature.name}
                     description={earlyAccessFeature.description}

--- a/products/endpoints/frontend/EndpointScene.tsx
+++ b/products/endpoints/frontend/EndpointScene.tsx
@@ -5,13 +5,23 @@ import { IconPause, IconPlay, IconTrash } from '@posthog/icons'
 import { LemonBanner, LemonDialog, LemonDivider } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { FEATURE_FLAGS } from 'lib/constants'
 import 'lib/lemon-ui/LemonModal/LemonModal'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import {
+    SceneMenuBar,
+    SceneMenuBarCheckboxItem,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { ScenePanel, ScenePanelActionsSection } from '~/layout/scenes/SceneLayout'
 import { ProductKey } from '~/queries/schema/schema-general'
 import { ActivityScope } from '~/types'
@@ -44,6 +54,8 @@ export function EndpointScene({ tabId }: EndpointProps = {}): JSX.Element {
     const { setViewingVersion } = useActions(endpointSceneLogic({ tabId }))
     const { deleteEndpoint, confirmToggleActive } = useActions(endpointLogic({ tabId }))
     const { searchParams } = useValues(router)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
 
     const tabs: LemonTab<EndpointTab>[] = [
         {
@@ -153,6 +165,33 @@ export function EndpointScene({ tabId }: EndpointProps = {}): JSX.Element {
                 {!endpointLoading && <EndpointOverview tabId={tabId} />}
                 <LemonTabs activeKey={activeTab} tabs={tabs} />
             </SceneContent>
+            {sceneMenuBarEnabled && endpoint && (
+                <SceneMenuBar>
+                    <SceneMenuBarMenu label="File" dataAttr="endpoint-menubar-file">
+                        <SceneMenuBarFileItems dataAttrKey="endpoint" />
+                        <SceneMenuBarSeparator />
+                        <SceneMenuBarItem
+                            variant="destructive"
+                            opensFloatingUi
+                            onClick={handleDelete}
+                            data-attr="endpoint-menubar-delete"
+                        >
+                            <IconTrash />
+                            Delete endpoint
+                        </SceneMenuBarItem>
+                    </SceneMenuBarMenu>
+                    <SceneMenuBarMenu label="Edit" dataAttr="endpoint-menubar-edit">
+                        <SceneMenuBarSeparator />
+                        <SceneMenuBarCheckboxItem
+                            checked={endpoint.is_active}
+                            onCheckedChange={handleToggleActive}
+                            data-attr="endpoint-menubar-active"
+                        >
+                            Active
+                        </SceneMenuBarCheckboxItem>
+                    </SceneMenuBarMenu>
+                </SceneMenuBar>
+            )}
             {endpoint && (
                 <ScenePanel>
                     <ScenePanelActionsSection>

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -5,11 +5,12 @@ import { BindLogic, useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useEffect, useRef } from 'react'
 
-import { IconFilter, IconList, IconSearch, IconX } from '@posthog/icons'
+import { IconFilter, IconList, IconRewindPlay, IconSearch, IconX } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { TZLabel } from 'lib/components/TZLabel'
 import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
@@ -22,10 +23,13 @@ import {
     TabsPrimitiveList,
     TabsPrimitiveTrigger,
 } from 'lib/ui/TabsPrimitive/TabsPrimitive'
+import { newInternalTab } from 'lib/utils/newInternalTab'
 import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
 
+import { SceneMenuBar, SceneMenuBarItem, SceneMenuBarMenu } from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
+import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, ReplayTabs } from '~/types'
 
 import { PostHogSDKIssueBanner } from '../../components/Banners/PostHogSDKIssueBanner'
 import { BreakdownsChart } from '../../components/Breakdowns/BreakdownsChart'
@@ -68,6 +72,8 @@ export function ErrorTrackingIssueScene(): JSX.Element {
     const { updateAssignee, updateStatus, updateName, setMobileDetailOpen } = useActions(errorTrackingIssueSceneLogic)
     const { isWindowLessThan } = useWindowSize()
     const isMobile = isWindowLessThan('md')
+    const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
+    const hasIssueSplitting = useFeatureFlag('ERROR_TRACKING_ISSUE_SPLITTING')
 
     useEffect(() => {
         const utmSource = new URLSearchParams(window.location.search).get('utm_source')
@@ -84,6 +90,57 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                     <BindLogic logic={miniBreakdownsLogic} props={{ issueId }}>
                         {issue && (
                             <div className="flex flex-col h-[calc(var(--scene-layout-rect-height))]">
+                                {sceneMenuBarEnabled && (
+                                    <SceneMenuBar>
+                                        <SceneMenuBarMenu label="File" dataAttr="issue-menubar-file">
+                                            <SceneMenuBarFileItems dataAttrKey="issue" />
+                                            {hasIssueSplitting && (
+                                                <SceneMenuBarItem
+                                                    onClick={() =>
+                                                        window.open(
+                                                            urls.errorTrackingIssueFingerprints(issue.id),
+                                                            '_self'
+                                                        )
+                                                    }
+                                                    data-attr="issue-menubar-fingerprints"
+                                                >
+                                                    Manage fingerprints
+                                                </SceneMenuBarItem>
+                                            )}
+                                        </SceneMenuBarMenu>
+                                        <SceneMenuBarMenu label="View" dataAttr="issue-menubar-view">
+                                            <SceneMenuBarItem
+                                                onClick={() => {
+                                                    const url = urls.replay(ReplayTabs.Home, {
+                                                        date_from: issue.first_seen ?? '-30d',
+                                                        date_to: lastSeen ? lastSeen.toISOString() : null,
+                                                        filter_group: {
+                                                            type: FilterLogicalOperator.And,
+                                                            values: [
+                                                                {
+                                                                    type: FilterLogicalOperator.And,
+                                                                    values: [
+                                                                        {
+                                                                            key: '$exception_issue_id',
+                                                                            type: PropertyFilterType.Event,
+                                                                            operator: PropertyOperator.Exact,
+                                                                            value: [issue.id],
+                                                                        },
+                                                                    ],
+                                                                },
+                                                            ],
+                                                        },
+                                                    })
+                                                    newInternalTab(url)
+                                                }}
+                                                data-attr="issue-menubar-view-recordings"
+                                            >
+                                                <IconRewindPlay />
+                                                View recordings
+                                            </SceneMenuBarItem>
+                                        </SceneMenuBarMenu>
+                                    </SceneMenuBar>
+                                )}
                                 <SceneTitleSection
                                     canEdit
                                     name={issue.name ?? undefined}

--- a/products/llm_analytics/frontend/datasets/LLMAnalyticsDatasetScene.tsx
+++ b/products/llm_analytics/frontend/datasets/LLMAnalyticsDatasetScene.tsx
@@ -9,16 +9,25 @@ import { LemonButton, LemonDivider, LemonTab, LemonTabs, Link, ProfilePicture } 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { HighlightedJSONViewer } from 'lib/components/HighlightedJSONViewer'
 import { NotFound } from 'lib/components/NotFound'
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { createdAtColumn, updatedAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import {
     ScenePanel,
@@ -72,6 +81,8 @@ export function LLMAnalyticsDatasetScene(): JSX.Element {
         onUnmount,
     } = useActions(llmAnalyticsDatasetLogic)
     const { searchParams } = useValues(router)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
 
     const displayEditForm = isNewDataset || isEditingDataset
 
@@ -177,6 +188,47 @@ export function LLMAnalyticsDatasetScene(): JSX.Element {
                     }
                 />
 
+                {isDataset(dataset) && sceneMenuBarEnabled && (
+                    <SceneMenuBar>
+                        <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                            <SceneMenuBarFileItems dataAttrKey={RESOURCE_TYPE} />
+                            <SceneMenuBarSeparator />
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.LlmAnalytics}
+                                minAccessLevel={AccessControlLevel.Editor}
+                            >
+                                {({ disabledReason }) => (
+                                    <SceneMenuBarItem
+                                        variant="destructive"
+                                        opensFloatingUi
+                                        disabled={!!disabledReason || datasetLoading || isDeletingDataset}
+                                        onClick={() => {
+                                            LemonDialog.open({
+                                                title: 'Permanently delete dataset?',
+                                                description: 'This action cannot be undone.',
+                                                primaryButton: {
+                                                    children: 'Delete',
+                                                    type: 'primary',
+                                                    status: 'danger',
+                                                    'data-attr': 'confirm-delete-dataset',
+                                                    onClick: deleteDataset,
+                                                },
+                                                secondaryButton: {
+                                                    children: 'Close',
+                                                    type: 'secondary',
+                                                },
+                                            })
+                                        }}
+                                        data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                                    >
+                                        <IconTrash />
+                                        Delete
+                                    </SceneMenuBarItem>
+                                )}
+                            </AccessControlAction>
+                        </SceneMenuBarMenu>
+                    </SceneMenuBar>
+                )}
                 {isDataset(dataset) && (
                     <ScenePanel>
                         <ScenePanelInfoSection>

--- a/products/tasks/frontend/components/TaskDetailPage.tsx
+++ b/products/tasks/frontend/components/TaskDetailPage.tsx
@@ -3,14 +3,23 @@ import { useActions, useValues } from 'kea'
 import { IconArchive, IconExternal, IconGithub, IconPlay } from '@posthog/icons'
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { TZLabel } from 'lib/components/TZLabel'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { humanFriendlyDuration } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import {
     ScenePanel,
@@ -33,6 +42,8 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
     const { task, runs, selectedRunId, selectedRun, runsLoading, logs, shouldPoll, streamEntries, isStreaming } =
         useValues(sceneLogic)
     const { setSelectedRunId, runTask, deleteTask } = useActions(sceneLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
 
     if (!task) {
         return <div className="text-center py-8 text-muted">Task not found</div>
@@ -48,6 +59,18 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
 
     return (
         <SceneContent>
+            {sceneMenuBarEnabled && (
+                <SceneMenuBar>
+                    <SceneMenuBarMenu label="File" dataAttr="task-menubar-file">
+                        <SceneMenuBarFileItems dataAttrKey="task" />
+                        <SceneMenuBarSeparator />
+                        <SceneMenuBarItem variant="destructive" onClick={deleteTask} data-attr="task-menubar-archive">
+                            <IconArchive />
+                            Archive task
+                        </SceneMenuBarItem>
+                    </SceneMenuBarMenu>
+                </SceneMenuBar>
+            )}
             <ScenePanel>
                 <ScenePanelInfoSection>
                     <div className="flex flex-col gap-3">

--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -5,8 +5,17 @@ import { useEffect, useRef, useState } from 'react'
 import { IconArchive, IconCopy, IconScreen } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 
+import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 
+import {
+    SceneMenuBar,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+} from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ScenePanel, ScenePanelActionsSection, ScenePanelDivider } from '~/layout/scenes/SceneLayout'
 
@@ -36,6 +45,8 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
     const isSavedWorkflow = props.id && props.id !== 'new'
     const isCreatedFromTemplate = props.id === 'new' && !!templateId
     const isManualWorkflow = ['manual', 'batch'].includes(workflow?.trigger?.type || '')
+    const { featureFlags } = useValues(featureFlagLogic)
+    const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
     const [displayStatus, setDisplayStatus] = useState(workflow?.status)
     const [isTransitioning, setIsTransitioning] = useState(false)
     const prevStatusRef = useRef(workflow?.status)
@@ -59,6 +70,36 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
     return (
         <>
             <SaveAsTemplateModal {...props} editTemplateId={editTemplateId} />
+            {sceneMenuBarEnabled && isSavedWorkflow && (
+                <SceneMenuBar>
+                    <SceneMenuBarMenu label="File" dataAttr="workflow-menubar-file">
+                        <SceneMenuBarFileItems dataAttrKey="workflow" />
+                        <SceneMenuBarSeparator />
+                        <SceneMenuBarItem
+                            variant="destructive"
+                            onClick={() => archiveWorkflow(workflow)}
+                            data-attr="workflow-menubar-archive"
+                        >
+                            <IconArchive />
+                            Archive
+                        </SceneMenuBarItem>
+                    </SceneMenuBarMenu>
+                    <SceneMenuBarMenu label="Edit" dataAttr="workflow-menubar-edit">
+                        <SceneMenuBarItem onClick={() => duplicate()} data-attr="workflow-menubar-duplicate">
+                            <IconCopy />
+                            Duplicate
+                        </SceneMenuBarItem>
+                        <SceneMenuBarItem
+                            opensFloatingUi
+                            onClick={showSaveAsTemplateModal}
+                            data-attr="workflow-menubar-save-as-template"
+                        >
+                            <IconScreen />
+                            Save as template
+                        </SceneMenuBarItem>
+                    </SceneMenuBarMenu>
+                </SceneMenuBar>
+            )}
             <SceneTitleSection
                 name={workflow?.name}
                 description={workflow?.description}


### PR DESCRIPTION
## Problem

PostHog scenes spread their actions across a "ScenePanel" sidepanel button cluster
and ad-hoc page header buttons. Discoverability is poor (users don't know what
actions exist), keyboard navigation is inconsistent, and similar resources land
actions in different places.

This PR introduces a **Mac-style menu bar** rendered above `SceneTitleSection`
on a per-scene basis. The bar consolidates scene-level actions into a
discoverable, keyboard-navigable surface with a canonical taxonomy.

<img width="1492" height="508" alt="2026-05-13 11 20 20" src="https://github.com/user-attachments/assets/f7d6d185-50d6-4ab4-b966-7130ea0ab22f" />


## Changes

### New primitives — `frontend/src/layout/scenes/components/SceneMenuBar.tsx`

- `SceneMenuBar` — top-level wrapper. Reads `sceneLayoutLogic.sceneLayoutConfig.layout`
  and only bleeds with `-mx-4 -mt-4` for padded layouts (`app`, `app-container`,
  `app-full-scene-height`); skips negatives for `app-raw` / `plain` to avoid
  visual overshoot. When `.LemonTabs` is the immediately-preceding sibling, an
  additional `-mt-6` is applied so the bar sits flush with the tab strip.
- `SceneMenuBarMenu` — top-level menu (File / Edit / View / Metadata / Staff only).
  Trigger auto-disables when children render empty at compile time
  (`{false && <Item/>}`, `{null}`, empty fragments). Caller can also pass
  `disabled` explicitly for runtime-empty cases (e.g.
  `<SceneMenuBarFileItems>` returning null with no project-tree entry).
- `SceneMenuBarItem` with `variant="destructive"` and `opensFloatingUi` prop
  (appends a Mac-style "…" affordance for modal/popover openers).
- `SceneMenuBarCheckboxItem` / `SceneMenuBarRadioGroup` for toggle items.
- `SceneMenuBarSubMenu` — auto-prepends `<IconBlank />` so labels align with
  icon-bearing siblings (opt out via `withIconBlank={false}`).
- `SceneMenuBarPopover` — alternative to `SceneMenuBarMenu` for menus that
  hold rich inputs (text inputs, comboboxes). `Menu.Popup` intercepts
  keystrokes and prevents inputs from receiving input, so the Metadata menu
  uses a `Popover` instead.

### Reusable helpers — `frontend/src/lib/components/Scenes/`

- `SceneMenuBarFileItems` — Open in project tree / Move to folder / Star,
  returns null when no project tree entry is registered.
- `SceneMenuBarAddToNotebook` — sub-menu of New notebook / Scratchpad /
  notebooks-containing / other notebooks.
- `TagsCombobox` + `SceneTagsCombobox` — Quill `Combobox.Chips` multi-select
  tag input with optional "Create new …" custom-value support at the bottom.

### Scenes migrated (each gated by `FEATURE_FLAGS.SCENE_MENU_BAR`)

Feature Flag, Insight, Dashboard, Experiment, Cohort, Survey (legacy +
redesign), Action, Early Access Feature, Endpoint, Error Tracking Issue,
LLM Analytics Dataset, Persons, Product Tour, Session Recordings Playlist,
Shared Metric, Task, Web Analytics, Workflow, Legacy Experiment.

### Quill primitives — `packages/quill/packages/primitives/src/`

- `MenubarItem` now forwards the `variant` prop to the inner `<Button render>`
  so `destructive` items get the red treatment (previously fell back to
  `default`).
- `MenubarCheckboxItem` / `MenubarRadioItem` gain matching focus-visible ring
  and hover/focus background to mirror `MenubarItem` keyboard affordances.
- `ComboboxChips` gets `py-1` so the chip row breathes inside an `InputGroup`.
- Quill packages bumped to `0.3.0-beta.7`.

### Other

- `frontend/src/scenes/feature-flags/featureFlagLogic.ts` — new
  `saveTagsInline` action with optimistic update + breakpoint debounce +
  race-safe set-equality reconciliation (avoids re-ordering chips when the
  server returns differently-ordered tags).
- `frontend/src/layout/navigation-3000/Navigation.tsx` — hides the global
  `ProjectNotice` when `SCENE_MENU_BAR` is on, since the menu bar reclaims
  that strip of vertical space.
- `frontend/src/layout/scenes/SceneLayout.tsx` — `ScenePanelLabel` accepts a
  `className`; defaults bumped to `text-tertiary/80` so the label colour
  matches the menu bar treatment when both are visible.

### What is NOT gated behind `SCENE_MENU_BAR`

- **Quill primitive changes** — `MenubarItem` variant forwarding,
  checkbox/radio focus styles, `ComboboxChips` padding, package version
  bumps. These are core improvements to Quill that benefit any consumer.
- **`featureFlagLogic.saveTagsInline`** — the action lives in the logic
  unconditionally, but is only invoked by `<SceneTagsCombobox>` which is
  rendered inside the FF-gated Metadata popover. Effectively unreachable
  without the flag.
- **`<ProjectNotice>` hidden when flag is on** — the gating itself is
  intentional (when the menu bar is enabled, the notice is hidden);
  pre-flag behaviour is preserved by the `!sceneMenuBarEnabled` guard.
- **`SceneLayout.tsx` `ScenePanelLabel` className change** — minor styling
  tweak that applies regardless of flag.
- **`.agents/skills/scene-menu-bar/SKILL.md`** — agent skill documenting
  conventions; docs only.

## How did you test this code?

- `tsc --noEmit` passes.
- `oxlint` / `oxfmt` pre-commit hooks pass.
- Visual verification across migrated scenes via dev server (Feature Flag,
  Dashboard, Insight, Web Analytics, Error Tracking Issue, Cohort, etc.).
- Manually exercised optimistic tag save: rapid add/remove no longer
  re-orders chips; race conditions resolved via breakpoint cancellation +
  set-equality check.

I'm an agent — claims above are limited to what I actually ran.
Manual UX feedback was driven by the human author throughout the
implementation.

## Publish to changelog?

no

## Docs update

Skip — feature flag–gated rollout, not yet user-facing.

## 🤖 Agent context

Co-authored with Claude Opus 4.7 across an extended session covering:
the menu bar primitive build-out, scene-by-scene migration, Quill
primitive fixes (variant forwarding, focus-visible affordances),
TagsCombobox + custom-value pattern, optimistic-save debounce/race-safety
in `featureFlagLogic`, layout-aware bleed via `sceneLayoutLogic`,
auto-disable behaviour for empty menus, sub-menu icon alignment,
rolling State items into Edit. Convention guide lives at
`.agents/skills/scene-menu-bar/SKILL.md`.

Decisions:
- **Quill (not Base UI directly)** — keeps a single dependency surface and
  preserves CompositeRoot keyboard nav. The right cluster (Docs / Support /
  PostHog AI) lives outside `<Menubar>` so it doesn't pollute the
  composite.
- **Metadata uses `SceneMenuBarPopover`, not `SceneMenuBarMenu`** — Menu
  popups intercept keystrokes and block text inputs. Trade-off: the
  Popover trigger does not participate in the Menubar's CompositeRoot, so
  ArrowLeft/Right won't switch focus to/from it.
- **State items rolled into Edit** — Pause/Resume, Activate/Deactivate,
  Favorite/Pin toggles all live in Edit (toggle group separated by
  `<SceneMenuBarSeparator>`) rather than a dedicated State menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)