### PR TITLE
chore(navbar): remove exports link from footer navigation

### DIFF
--- a/frontend/src/layout/panel-layout/NavBarFooter.tsx
+++ b/frontend/src/layout/panel-layout/NavBarFooter.tsx
@@ -1,4 +1,4 @@
-import { IconDownload, IconGear } from '@posthog/icons'
+import { IconGear } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
 import { DebugNotice } from 'lib/components/DebugNotice'
@@ -41,16 +41,6 @@ export function NavBarFooter({ isLayoutNavCollapsed }: { isLayoutNavCollapsed: b
                 >
                     <IconGear />
                     {!isLayoutNavCollapsed && 'Settings'}
-                </Link>
-                <Link
-                    to={urls.exports()}
-                    buttonProps={{ menuItem: isLayoutNavCollapsed ? false : true }}
-                    tooltip={isLayoutNavCollapsed ? 'Exports' : undefined}
-                    tooltipPlacement="right"
-                    data-attr="navbar-exports-button"
-                >
-                    <IconDownload />
-                    {!isLayoutNavCollapsed && 'Exports'}
                 </Link>
                 <HealthMenu iconOnly={isLayoutNavCollapsed} />
                 <HelpMenu iconOnly={isLayoutNavCollapsed} />


### PR DESCRIPTION
## Problem

The exports link in the navbar footer is being removed as part of UI simplification or feature reorganization.

Jovan: no place for it here imho

<img width="223" height="191" alt="image" src="https://github.com/user-attachments/assets/bf26c129-b015-4667-9ab1-b056bf7deba9" />


## Changes

Removed the "Exports" navigation link from `NavBarFooter.tsx`:
- Deleted the `<Link>` component that pointed to `urls.exports()`
- Removed the unused `IconDownload` import from `@posthog/icons`
- The Settings link and other footer menu items (HealthMenu, HelpMenu, PosthogStatusShownOnlyIfNotOperational) remain unchanged

## How did you test this code?

No testing needed — this is a straightforward removal of a UI component with no logic changes.

## Publish to changelog?

no

https://claude.ai/code/session_01MBH5Nta6wBY7GWGHSoqSkV