### PR TITLE
chore(clickhouse): drop dead MSK Kafka engine tables

### DIFF
--- a/posthog/clickhouse/migrations/0253_drop_dead_msk_kafka_tables.py
+++ b/posthog/clickhouse/migrations/0253_drop_dead_msk_kafka_tables.py
@@ -1,0 +1,82 @@
+from posthog import settings
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+# Drop MSK Kafka engine tables and their materialized views for topics that are
+# no longer actively produced to, or whose functionality has been superseded.
+#
+# These tables still exist on the ingestion layer using the MSK named collection
+# but serve no purpose:
+#
+# - plugin_log_entries: No producer writes to this topic anymore.
+# - app_metrics (v1): Superseded by app_metrics2; no producer writes to v1.
+# - events_dead_letter_queue: No longer needed.
+# - duplicate_events: No longer needed.
+# - error_tracking_issue_fingerprint_embeddings: Experimental table replaced by
+#   the general-purpose document_embeddings tables in migration 0155. The 0155
+#   drop ran on NodeRole.DATA but the tables were created on INGESTION_SMALL,
+#   so the Kafka table and MV survived on ingestion nodes.
+#
+# Order: drop the MV first so it stops feeding the writable target, then drop
+# the Kafka engine table. `IF EXISTS` keeps the migration idempotent.
+#
+# CLOUD-ONLY: In non-cloud environments (CI, dev, hobby) some of these tables
+# may be the only consumer for their topics, so we guard the drops.
+
+operations = (
+    []
+    if settings.CLOUD_DEPLOYMENT not in ("US", "EU", "DEV")
+    else [
+        # plugin_log_entries (INGESTION_SMALL — moved here by migration 0152)
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS plugin_log_entries_mv",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS kafka_plugin_log_entries",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        # app_metrics v1 (INGESTION_SMALL — moved here by migration 0157)
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS app_metrics_mv",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS kafka_app_metrics",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        # events_dead_letter_queue (INGESTION_SMALL — moved here by migration 0157)
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS events_dead_letter_queue_mv",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS kafka_events_dead_letter_queue",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        # duplicate_events (INGESTION_SMALL — created by migration 0156)
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS duplicate_events_mv",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS kafka_duplicate_events",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        # error_tracking_issue_fingerprint_embeddings (INGESTION_SMALL — created
+        # by migration 0153, drop in 0155 missed ingestion nodes because it
+        # ran on NodeRole.DATA instead of INGESTION_SMALL)
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS error_tracking_issue_fingerprint_embeddings_mv",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS kafka_error_tracking_issue_fingerprint_embeddings",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            "DROP TABLE IF EXISTS writable_error_tracking_issue_fingerprint_embeddings",
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+    ]
+)

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0252_extend_session_replay_features
+0253_drop_dead_msk_kafka_tables


### PR DESCRIPTION
## Problem

Several MSK Kafka engine tables on ingestion nodes are consuming resources but serve no purpose — their topics have no active producers or their functionality has been superseded. This is needed as a step to decomission MSK

## Changes

- Add ClickHouse migration 0253 to drop MVs and Kafka engine tables (cloud-only) for:
  - `plugin_log_entries`: no producer writes to this topic
  - `app_metrics` v1: superseded by `app_metrics2`
  - `events_dead_letter_queue`: no longer needed
  - `duplicate_events`: no longer needed
  - `error_tracking_issue_fingerprint_embeddings`: replaced by `document_embeddings` (migration 0155 drop missed ingestion nodes because it targeted `NodeRole.DATA` instead of `INGESTION_SMALL`)

## How did you test this code?

All DROP statements use `IF EXISTS` making the migration idempotent. Cloud-only guard prevents impact on dev/CI/hobby environments.
