### PR TITLE
feat(persons): auto-expand events tab to 7d when 24h is empty

### DIFF
--- a/frontend/src/scenes/persons/PersonEventsTab.tsx
+++ b/frontend/src/scenes/persons/PersonEventsTab.tsx
@@ -1,0 +1,100 @@
+import { BuiltLogic, LogicWrapper, useValues } from 'kea'
+import { useEffect, useRef } from 'react'
+
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import { Query } from '~/queries/Query/Query'
+import { DataTableNode, EventsQuery, EventsQueryResponse, NodeKind } from '~/queries/schema/schema-general'
+import { InsightLogicProps } from '~/types'
+
+import { PERSON_EVENTS_CONTEXT_KEY } from './personsLogic'
+
+const DEFAULT_AFTER = '-24h'
+const EXPANDED_AFTER = '-7d'
+
+interface PersonEventsTabProps {
+    eventsQuery: DataTableNode | null
+    setEventsQuery: (query: DataTableNode | null) => void
+    eventsQueryLogicKey: string
+    tabId?: string
+    attachTo: BuiltLogic | LogicWrapper
+}
+
+export function PersonEventsTab({
+    eventsQuery,
+    setEventsQuery,
+    eventsQueryLogicKey,
+    tabId,
+    attachTo,
+}: PersonEventsTabProps): JSX.Element | null {
+    const insightProps: InsightLogicProps = {
+        dashboardItemId: `new-${PERSON_EVENTS_CONTEXT_KEY}`,
+        tabId,
+        dataNodeCollectionId: eventsQueryLogicKey,
+    }
+    const dataNodeKey = insightVizDataNodeKey(insightProps)
+
+    const source = eventsQuery?.source as EventsQuery | undefined
+    const isEventsQuerySource = source?.kind === NodeKind.EventsQuery
+    const sourceAfter = isEventsQuerySource ? source?.after : undefined
+    const personId = isEventsQuerySource ? source?.personId : undefined
+
+    const { response, responseLoading } = useValues(
+        dataNodeLogic({
+            key: dataNodeKey,
+            query: source,
+            dataNodeCollectionId: eventsQueryLogicKey,
+        })
+    )
+
+    // Auto-expand once per person — if the user manually reverts to 24h, we leave it alone.
+    const autoExpandedPersonIdRef = useRef<string | undefined>(undefined)
+
+    useEffect(() => {
+        if (!eventsQuery || !isEventsQuerySource || sourceAfter !== DEFAULT_AFTER) {
+            return
+        }
+        if (responseLoading || !personId) {
+            return
+        }
+        if (autoExpandedPersonIdRef.current === personId) {
+            return
+        }
+        const eventsResponse = response as EventsQueryResponse | null
+        if (!eventsResponse || !Array.isArray(eventsResponse.results)) {
+            return
+        }
+        if (eventsResponse.results.length > 0) {
+            return
+        }
+
+        autoExpandedPersonIdRef.current = personId
+        setEventsQuery({
+            ...eventsQuery,
+            source: { ...(source as EventsQuery), after: EXPANDED_AFTER },
+        })
+        lemonToast.info('No events in the last 24 hours — showing the last 7 days')
+    }, [isEventsQuerySource, sourceAfter, responseLoading, response, personId, eventsQuery, source, setEventsQuery])
+
+    if (!eventsQuery) {
+        return null
+    }
+
+    return (
+        <Query
+            uniqueKey="person-profile-events"
+            attachTo={attachTo}
+            query={eventsQuery}
+            setQuery={(q) => setEventsQuery(q)}
+            context={{
+                insightProps: {
+                    dashboardItemId: `new-${PERSON_EVENTS_CONTEXT_KEY}`,
+                    tabId,
+                    dataNodeCollectionId: eventsQueryLogicKey,
+                },
+            }}
+        />
+    )
+}

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -44,6 +44,7 @@ import { FeedbackButton } from 'products/customer_analytics/frontend/components/
 import { MergeSplitPerson } from './MergeSplitPerson'
 import { asDisplay } from './person-utils'
 import { PersonCohorts } from './PersonCohorts'
+import { PersonEventsTab } from './PersonEventsTab'
 import PersonProfileCanvas from './PersonProfileCanvas'
 import { PERSON_EVENTS_CONTEXT_KEY, PersonsLogicProps, personsLogic } from './personsLogic'
 import { RelatedFeatureFlags } from './RelatedFeatureFlags'
@@ -295,18 +296,12 @@ export function PersonScene({ tabId }: { tabId?: string }): JSX.Element | null {
                         key: PersonsTabType.EVENTS,
                         label: <span data-attr="persons-events-tab">Events</span>,
                         content: (
-                            <Query
-                                uniqueKey="person-profile-events"
+                            <PersonEventsTab
+                                eventsQuery={eventsQuery}
+                                setEventsQuery={setEventsQuery}
+                                eventsQueryLogicKey={eventsQueryLogicKey}
+                                tabId={tabId}
                                 attachTo={mountedPersonsLogic}
-                                query={eventsQuery}
-                                setQuery={(q) => setEventsQuery(q)}
-                                context={{
-                                    insightProps: {
-                                        dashboardItemId: `new-${PERSON_EVENTS_CONTEXT_KEY}`,
-                                        tabId,
-                                        dataNodeCollectionId: eventsQueryLogicKey,
-                                    },
-                                }}
                             />
                         ),
                     },


### PR DESCRIPTION
## Problem

On the Persons detail page, the Events tab defaults to showing events from the last 24 hours. For many persons that's an empty window, so the tab frequently shows "No results" by default — users have to manually widen the time range to see anything.

## Changes

When the default last-24-hours query returns zero events, automatically re-run the query with a last-7-days window and notify the user with a toast.

- Added `PersonEventsTab` wrapper component around the existing `<Query>` for the Events tab. It subscribes to the same `dataNodeLogic` instance that the table mounts (matching keys via `insightVizDataNodeKey` + `dataNodeCollectionId`) so it can read `response`/`responseLoading` without firing extra queries.
- When loading finishes with `response.results.length === 0` and the current `after` is `-24h`, it dispatches `setEventsQuery` with `after: '-7d'` and surfaces a `lemonToast.info` so the user knows why the window changed.
- Auto-expansion is tracked in a per-component ref keyed by `personId`, so manually reverting back to "Last 24 hours" after the auto-expand doesn't re-trigger it. Navigating to a different person re-evaluates.
- The auto-expand only triggers for the EventsQuery default (24h → 7d, once); the exception and survey-response tabs are untouched.

## How did you test this code?

Agent-authored. Verified:
- `pnpm --filter=@posthog/frontend typescript:check` — no new errors introduced in `frontend/src/scenes/persons/**`. Pre-existing errors in unrelated files (workflows, kea generated types missing) remain.
- `pnpm --filter=@posthog/frontend format` — clean.

Not manually tested in a running app — flagging for human verification of the toast wording, that the time picker reflects the new window after auto-expand, and that the auto-expand doesn't fight with the user's manual changes.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude).
- Approach considered: implementing the auto-expand inside `personsLogic` via kea subscriptions on the events `dataNodeLogic`. Rejected because the `dataNodeLogic` only mounts when the Events tab is rendered, and threading the lifecycle through `personsLogic` was more invasive than the localized wrapper.
- Chose to subscribe to the existing `dataNodeLogic` from a sibling React component (`PersonEventsTab`) using the same key the `Query` → `DataTable` chain mounts. Kea dedupes by `props.key`, so this reads from the same instance without firing an extra fetch.
- Bound to `after === '-24h'` + zero results + per-person ref so it's a one-shot transition. If the user moves to a different person, the new render evaluates again.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*