### PR TITLE
feat(llma): expose llm analytics skills to posthog ai

### DIFF
--- a/ee/hogai/chat_agent/toolkit.py
+++ b/ee/hogai/chat_agent/toolkit.py
@@ -35,6 +35,7 @@ from ee.hogai.tools.call_mcp_server.tool import CallMCPServerTool
 from ee.hogai.tools.finalize_plan.tool import FinalizePlanTool
 from ee.hogai.utils.feature_flags import (
     get_llm_gateway_variant,
+    has_llm_analytics_skills_feature_flag,
     has_mcp_servers_feature_flag,
     has_memory_tool_feature_flag,
     has_phai_tasks_feature_flag,
@@ -62,6 +63,31 @@ TASK_TOOLS: list[type[MaxTool]] = [
     ListTaskRunsTool,
     ListRepositoriesTool,
 ]
+
+
+def _llm_analytics_skill_tools() -> list[type[MaxTool]]:
+    """Skills are workflow-encoded instructions that apply across products, so they're exposed
+    cross-mode behind the same feature flag that gates the REST API.
+    """
+    from products.llm_analytics.backend.tools.manage_skills import (
+        ArchiveLLMSkillTool,
+        CreateLLMSkillTool,
+        DuplicateLLMSkillTool,
+        GetLLMSkillFileTool,
+        GetLLMSkillTool,
+        ListLLMSkillsTool,
+        UpdateLLMSkillTool,
+    )
+
+    return [
+        ListLLMSkillsTool,
+        GetLLMSkillTool,
+        GetLLMSkillFileTool,
+        CreateLLMSkillTool,
+        UpdateLLMSkillTool,
+        ArchiveLLMSkillTool,
+        DuplicateLLMSkillTool,
+    ]
 
 
 class ChatAgentPlanToolkit(AgentToolkit):
@@ -93,6 +119,8 @@ class ChatAgentToolkit(AgentToolkit):
             tools.append(TaskTool)
         if has_memory_tool_feature_flag(self._team, self._user):
             tools.append(ManageMemoriesTool)
+        if has_llm_analytics_skills_feature_flag(self._team, self._user):
+            tools.extend(_llm_analytics_skill_tools())
         return tools
 
 

--- a/ee/hogai/chat_agent/toolkit.py
+++ b/ee/hogai/chat_agent/toolkit.py
@@ -69,25 +69,9 @@ def _llm_analytics_skill_tools() -> list[type[MaxTool]]:
     """Skills are workflow-encoded instructions that apply across products, so they're exposed
     cross-mode behind the same feature flag that gates the REST API.
     """
-    from products.llm_analytics.backend.tools.manage_skills import (
-        ArchiveLLMSkillTool,
-        CreateLLMSkillTool,
-        DuplicateLLMSkillTool,
-        GetLLMSkillFileTool,
-        GetLLMSkillTool,
-        ListLLMSkillsTool,
-        UpdateLLMSkillTool,
-    )
+    from products.llm_analytics.backend.tools.manage_skills import all_skill_tools
 
-    return [
-        ListLLMSkillsTool,
-        GetLLMSkillTool,
-        GetLLMSkillFileTool,
-        CreateLLMSkillTool,
-        UpdateLLMSkillTool,
-        ArchiveLLMSkillTool,
-        DuplicateLLMSkillTool,
-    ]
+    return all_skill_tools()
 
 
 class ChatAgentPlanToolkit(AgentToolkit):

--- a/ee/hogai/core/agent_modes/presets/llm_analytics.py
+++ b/ee/hogai/core/agent_modes/presets/llm_analytics.py
@@ -70,7 +70,22 @@ The assistant used run_hog_eval_test because:
 3. The assistant can iterate on the fix by running the tool again
 """.strip()
 
-LLM_ANALYTICS_MODE_DESCRIPTION = "Specialized mode for LLM analytics. Search and analyze LLM traces for usage, costs, latency, and errors. Write and test Hog evaluation code against real events."
+POSITIVE_EXAMPLE_USE_SKILL = """
+User: Investigate why signups dropped this week — follow our standard playbook
+Assistant: I'll check whether we have a saved skill for this and follow it.
+*Uses list_llm_skills to look for a matching skill*
+*Uses get_llm_skill with the matching name to load the SKILL.md body*
+*Follows the instructions in the skill body and uses any bundled files via get_llm_skill_file*
+""".strip()
+
+POSITIVE_EXAMPLE_USE_SKILL_REASONING = """
+The assistant looked up a skill first because:
+1. The user referenced a "standard playbook", which suggests an encoded workflow
+2. list_llm_skills shows what's available without committing to a plan
+3. Following the saved skill respects how the team prefers this work to be done
+""".strip()
+
+LLM_ANALYTICS_MODE_DESCRIPTION = "Specialized mode for LLM analytics. Search and analyze LLM traces for usage, costs, latency, and errors. Write and test Hog evaluation code against real events. Manage and follow LLM analytics skills (saved workflows)."
 
 
 class LLMAnalyticsAgentToolkit(AgentToolkit):
@@ -91,13 +106,41 @@ class LLMAnalyticsAgentToolkit(AgentToolkit):
             example=POSITIVE_EXAMPLE_FIX_EVAL_ERRORS,
             reasoning=POSITIVE_EXAMPLE_FIX_EVAL_ERRORS_REASONING,
         ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_USE_SKILL,
+            reasoning=POSITIVE_EXAMPLE_USE_SKILL_REASONING,
+        ),
     ]
 
     @property
     def tools(self) -> list[type["MaxTool"]]:
+        from products.llm_analytics.backend.tools.manage_skills import (
+            ArchiveLLMSkillTool,
+            CreateLLMSkillTool,
+            DuplicateLLMSkillTool,
+            GetLLMSkillFileTool,
+            GetLLMSkillTool,
+            ListLLMSkillsTool,
+            UpdateLLMSkillTool,
+        )
         from products.llm_analytics.backend.tools.run_hog_eval_test import RunHogEvalTestTool
 
-        return [SearchLLMTracesTool, RunHogEvalTestTool]
+        from ee.hogai.utils.feature_flags import has_llm_analytics_skills_feature_flag
+
+        tools: list[type[MaxTool]] = [SearchLLMTracesTool, RunHogEvalTestTool]
+        if has_llm_analytics_skills_feature_flag(self._team, self._user):
+            tools.extend(
+                [
+                    ListLLMSkillsTool,
+                    GetLLMSkillTool,
+                    GetLLMSkillFileTool,
+                    CreateLLMSkillTool,
+                    UpdateLLMSkillTool,
+                    ArchiveLLMSkillTool,
+                    DuplicateLLMSkillTool,
+                ]
+            )
+        return tools
 
 
 llm_analytics_agent = AgentModeDefinition(

--- a/ee/hogai/core/agent_modes/presets/llm_analytics.py
+++ b/ee/hogai/core/agent_modes/presets/llm_analytics.py
@@ -114,32 +114,14 @@ class LLMAnalyticsAgentToolkit(AgentToolkit):
 
     @property
     def tools(self) -> list[type["MaxTool"]]:
-        from products.llm_analytics.backend.tools.manage_skills import (
-            ArchiveLLMSkillTool,
-            CreateLLMSkillTool,
-            DuplicateLLMSkillTool,
-            GetLLMSkillFileTool,
-            GetLLMSkillTool,
-            ListLLMSkillsTool,
-            UpdateLLMSkillTool,
-        )
+        from products.llm_analytics.backend.tools.manage_skills import all_skill_tools
         from products.llm_analytics.backend.tools.run_hog_eval_test import RunHogEvalTestTool
 
         from ee.hogai.utils.feature_flags import has_llm_analytics_skills_feature_flag
 
         tools: list[type[MaxTool]] = [SearchLLMTracesTool, RunHogEvalTestTool]
         if has_llm_analytics_skills_feature_flag(self._team, self._user):
-            tools.extend(
-                [
-                    ListLLMSkillsTool,
-                    GetLLMSkillTool,
-                    GetLLMSkillFileTool,
-                    CreateLLMSkillTool,
-                    UpdateLLMSkillTool,
-                    ArchiveLLMSkillTool,
-                    DuplicateLLMSkillTool,
-                ]
-            )
+            tools.extend(all_skill_tools())
         return tools
 
 

--- a/ee/hogai/utils/feature_flags.py
+++ b/ee/hogai/utils/feature_flags.py
@@ -81,6 +81,19 @@ def is_core_memory_disabled(team: Team, user: User) -> bool:
     )
 
 
+def has_llm_analytics_skills_feature_flag(team: Team, user: User) -> bool:
+    """Whether the LLM analytics skills tools (list/get/create/update/archive/duplicate) are
+    available to this user. Mirrors the feature flag gating the underlying REST API.
+    """
+    return posthoganalytics.feature_enabled(
+        "llm-analytics-skills",
+        str(user.distinct_id),
+        groups={"organization": str(team.organization_id)},
+        group_properties={"organization": {"id": str(team.organization_id)}},
+        send_feature_flag_events=False,
+    )
+
+
 def has_mcp_servers_feature_flag(team: Team, user: User) -> bool:
     return posthoganalytics.feature_enabled(
         "mcp-servers",

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -865,9 +865,9 @@ snapshots:
     components-pay-gate-mini--pay-gate-mini-without-background--light:
         hash: v1.k794b7964.9a2b166ce4c603be1ede586ac7867f3d31840f6116bd61854300a7c57bb3df7a._1tSFJYtbZ2I5i0evHjkEzSxJyTgj14QfRMPgT4YT5w
     components-playerinspector--default--dark:
-        hash: v1.k794b7964.6eff0ed89297215e8708241105e5030634823ad41719eeb4f36ddea68851d4e1.5e7vmvxuTjAujNINc7PjRpNpG68xrkFXcG7hZ5MVhXI
+        hash: v1.k794b7964.c84ee7044eb3ba70b8635606d6b3a18eaa61a8bb0b5c8d822cb60cae6ffa8c92.a4zxiuYDDD1cxevUhVbya1ijW9obWIB4z1hbuPo1Hgk
     components-playerinspector--default--light:
-        hash: v1.k794b7964.9f107b86c39ee6cbb15727e2b53ec0536e77c262dc3e06336f896cd46ad153f7.UhHTuWcCcKmD1rwJzgIBKSJ3o1ztLYICsXnzpTPhxDA
+        hash: v1.k794b7964.515ac504252b376f1ac721c75faf6ffb2d6a212102bce200d2163854e8e87485.9mJ0smh5M0RIfZCnp2E6llOQbGmTYuHdD0FWKruGhQY
     components-playerinspector--with-logs-filter--dark:
         hash: v1.k794b7964.3851518dc979320cefe65f110005d44a492eec635285f8b2f9162c1e5dbed62b.MZINYfaQXNWzFZMzsPLtnLXpNYVcBMEC5PJnxMR-DlY
     components-playerinspector--with-logs-filter--light:

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3556,7 +3556,14 @@
                 "call_mcp_server",
                 "search_llm_traces",
                 "run_hog_eval_test",
-                "diagnose_proxy"
+                "diagnose_proxy",
+                "list_llm_skills",
+                "get_llm_skill",
+                "get_llm_skill_file",
+                "create_llm_skill",
+                "update_llm_skill",
+                "archive_llm_skill",
+                "duplicate_llm_skill"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -497,6 +497,13 @@ export type AssistantTool =
     | 'search_llm_traces'
     | 'run_hog_eval_test'
     | 'diagnose_proxy'
+    | 'list_llm_skills'
+    | 'get_llm_skill'
+    | 'get_llm_skill_file'
+    | 'create_llm_skill'
+    | 'update_llm_skill'
+    | 'archive_llm_skill'
+    | 'duplicate_llm_skill'
 
 export enum AgentMode {
     ProductAnalytics = 'product_analytics',

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -1034,7 +1034,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
     },
     list_llm_skills: {
         name: 'List skills',
-        description: 'List the LLM analytics skills (saved workflows) in your project',
+        description: 'List skills (saved LLM analytics workflows) in your project',
         icon: <IconBook />,
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
@@ -1045,7 +1045,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
     },
     get_llm_skill: {
         name: 'Read skill',
-        description: 'Read a saved skill so it can be followed as task-specific guidance',
+        description: 'Read skill instructions so they can be followed as task-specific guidance',
         icon: <IconBook />,
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
@@ -1056,7 +1056,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
     },
     get_llm_skill_file: {
         name: 'Read skill file',
-        description: 'Read a bundled file from a skill on demand',
+        description: 'Read skill file content bundled inside a skill on demand',
         icon: <IconDocument />,
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
@@ -1067,7 +1067,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
     },
     create_llm_skill: {
         name: 'Create skill',
-        description: 'Save a workflow as a reusable skill',
+        description: 'Create skill from a workflow so it can be reused later',
         icon: <IconBook />,
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
@@ -1078,7 +1078,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
     },
     update_llm_skill: {
         name: 'Update skill',
-        description: 'Publish a new version of an existing skill',
+        description: 'Update skill by publishing a new version of an existing skill',
         icon: <IconBook />,
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
@@ -1089,7 +1089,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
     },
     archive_llm_skill: {
         name: 'Archive skill',
-        description: 'Archive a skill (soft-delete all of its versions)',
+        description: 'Archive skill, soft-deleting all of its versions',
         icon: <IconBook />,
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
@@ -1100,7 +1100,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
     },
     duplicate_llm_skill: {
         name: 'Duplicate skill',
-        description: 'Copy an existing skill to a new name',
+        description: 'Duplicate skill to a new name as a starting point',
         icon: <IconBook />,
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -1032,6 +1032,83 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
             return 'Testing evaluation code...'
         },
     },
+    list_llm_skills: {
+        name: 'List skills',
+        description: 'List the LLM analytics skills (saved workflows) in your project',
+        icon: <IconBook />,
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Listed skills'
+            }
+            return 'Listing skills...'
+        },
+    },
+    get_llm_skill: {
+        name: 'Read skill',
+        description: 'Read a saved skill so it can be followed as task-specific guidance',
+        icon: <IconBook />,
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Read skill'
+            }
+            return 'Reading skill...'
+        },
+    },
+    get_llm_skill_file: {
+        name: 'Read skill file',
+        description: 'Read a bundled file from a skill on demand',
+        icon: <IconDocument />,
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Read skill file'
+            }
+            return 'Reading skill file...'
+        },
+    },
+    create_llm_skill: {
+        name: 'Create skill',
+        description: 'Save a workflow as a reusable skill',
+        icon: <IconBook />,
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Created skill'
+            }
+            return 'Creating skill...'
+        },
+    },
+    update_llm_skill: {
+        name: 'Update skill',
+        description: 'Publish a new version of an existing skill',
+        icon: <IconBook />,
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Updated skill'
+            }
+            return 'Updating skill...'
+        },
+    },
+    archive_llm_skill: {
+        name: 'Archive skill',
+        description: 'Archive a skill (soft-delete all of its versions)',
+        icon: <IconBook />,
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Archived skill'
+            }
+            return 'Archiving skill...'
+        },
+    },
+    duplicate_llm_skill: {
+        name: 'Duplicate skill',
+        description: 'Copy an existing skill to a new name',
+        icon: <IconBook />,
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Duplicated skill'
+            }
+            return 'Duplicating skill...'
+        },
+    },
 }
 
 export const MODE_DEFINITIONS: Record<

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -727,6 +727,13 @@ class AssistantTool(StrEnum):
     SEARCH_LLM_TRACES = "search_llm_traces"
     RUN_HOG_EVAL_TEST = "run_hog_eval_test"
     DIAGNOSE_PROXY = "diagnose_proxy"
+    LIST_LLM_SKILLS = "list_llm_skills"
+    GET_LLM_SKILL = "get_llm_skill"
+    GET_LLM_SKILL_FILE = "get_llm_skill_file"
+    CREATE_LLM_SKILL = "create_llm_skill"
+    UPDATE_LLM_SKILL = "update_llm_skill"
+    ARCHIVE_LLM_SKILL = "archive_llm_skill"
+    DUPLICATE_LLM_SKILL = "duplicate_llm_skill"
 
 
 class AssistantToolCall(BaseModel):

--- a/products/llm_analytics/backend/tools/manage_skills.py
+++ b/products/llm_analytics/backend/tools/manage_skills.py
@@ -679,6 +679,21 @@ class DuplicateLLMSkillTool(MaxTool):
         )
 
 
+def all_skill_tools() -> list[type[MaxTool]]:
+    """The full set of skill-management Max tools, in display order. Single source of truth so
+    every agent toolkit picks up new skill tools without having to remember to update its list.
+    """
+    return [
+        ListLLMSkillsTool,
+        GetLLMSkillTool,
+        GetLLMSkillFileTool,
+        CreateLLMSkillTool,
+        UpdateLLMSkillTool,
+        ArchiveLLMSkillTool,
+        DuplicateLLMSkillTool,
+    ]
+
+
 __all__ = [
     "ListLLMSkillsTool",
     "GetLLMSkillTool",
@@ -687,4 +702,5 @@ __all__ = [
     "UpdateLLMSkillTool",
     "ArchiveLLMSkillTool",
     "DuplicateLLMSkillTool",
+    "all_skill_tools",
 ]

--- a/products/llm_analytics/backend/tools/manage_skills.py
+++ b/products/llm_analytics/backend/tools/manage_skills.py
@@ -512,6 +512,11 @@ class UpdateLLMSkillTool(MaxTool):
         if body is not None and edits is not None:
             return ("Pass either `body` or `edits`, not both.", None)
 
+        # publish_skill_version validates resulting size only when `edits` are applied; a raw
+        # `body` replacement bypasses that path, so guard it here to match the create-side check.
+        if body is not None and len(body.encode("utf-8")) > MAX_SKILL_BODY_BYTES:
+            return (f"Skill body exceeds the {MAX_SKILL_BODY_BYTES} byte size limit.", None)
+
         edits_payload: list[dict[str, str]] | None = (
             [{"old": e.old, "new": e.new} for e in edits] if edits is not None else None
         )

--- a/products/llm_analytics/backend/tools/manage_skills.py
+++ b/products/llm_analytics/backend/tools/manage_skills.py
@@ -1,0 +1,676 @@
+"""Max AI tools for managing and using LLM analytics skills.
+
+Skills (Agent Skills spec) are reusable, versioned packages of instructions for AI agents.
+These tools let users list, read, create, edit, archive, and duplicate their skills from
+the Max chat, and load a skill's content to use it as task-specific guidance.
+"""
+
+from typing import Any
+
+from django.db import IntegrityError, transaction
+
+from pydantic import BaseModel, Field
+
+from posthog.schema import AssistantTool
+
+from posthog.sync import database_sync_to_async
+
+from ee.hogai.tool import MaxTool
+
+from ..api.skill_serializers import SKILL_NAME_PATTERN, validate_skill_file_path
+from ..api.skill_services import (
+    MAX_SKILL_BODY_BYTES,
+    MAX_SKILL_FILE_COUNT,
+    LLMSkillDuplicateNameConflictError,
+    LLMSkillEditError,
+    LLMSkillNotFoundError,
+    LLMSkillVersionConflictError,
+    LLMSkillVersionLimitError,
+    archive_skill,
+    duplicate_skill,
+    get_latest_skills_queryset,
+    get_skill_by_name_from_db,
+    publish_skill_version,
+)
+from ..models.skills import LLMSkill, LLMSkillFile
+
+SKILLS_RESOURCE_READ: list[tuple] = [("llm_analytics", "viewer")]
+SKILLS_RESOURCE_WRITE: list[tuple] = [("llm_analytics", "editor")]
+
+
+# ---------------------------------------------------------------------------
+# Shared formatters / helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_skill_summary(skill: LLMSkill, *, files_count: int) -> str:
+    lines = [
+        f"- {skill.name} (v{skill.version})",
+        f"    Description: {skill.description}" if skill.description else "    Description: (none)",
+    ]
+    if files_count:
+        lines.append(f"    Bundled files: {files_count}")
+    if skill.allowed_tools:
+        lines.append(f"    Allowed tools: {', '.join(skill.allowed_tools)}")
+    lines.append(f"    Last updated: {skill.updated_at}")
+    return "\n".join(lines)
+
+
+def _format_skill_detail(skill: LLMSkill, *, files: list[LLMSkillFile]) -> str:
+    lines = [
+        f"# {skill.name} (v{skill.version})",
+        "",
+        f"Description: {skill.description or '(none)'}",
+    ]
+    if skill.license:
+        lines.append(f"License: {skill.license}")
+    if skill.compatibility:
+        lines.append(f"Compatibility: {skill.compatibility}")
+    if skill.allowed_tools:
+        lines.append(f"Allowed tools: {', '.join(skill.allowed_tools)}")
+    if skill.metadata:
+        lines.append(f"Metadata: {skill.metadata}")
+    lines.append("")
+    lines.append("## Body (SKILL.md)")
+    lines.append("")
+    lines.append(skill.body or "(empty)")
+
+    if files:
+        lines.append("")
+        lines.append("## Bundled files")
+        for f in files:
+            lines.append(f"- {f.path} ({f.content_type}, {len(f.content)} chars)")
+        lines.append("")
+        lines.append("Use `get_llm_skill_file` with the path to load any of the above bundled files on demand.")
+    return "\n".join(lines)
+
+
+def _conflict_message(err: LLMSkillVersionConflictError) -> str:
+    return (
+        f"This skill changed since you opened it. Current version is {err.current_version}. "
+        "Re-fetch the skill with `get_llm_skill` and retry with the latest base_version."
+    )
+
+
+def _validate_skill_name(name: str) -> str | None:
+    if not name:
+        return "Skill name is required."
+    if name.lower() == "new":
+        return "'new' is a reserved name. Pick another."
+    if len(name) > 64:
+        return "Skill name must be 64 characters or fewer."
+    if not SKILL_NAME_PATTERN.match(name):
+        return (
+            "Skill name must use only lowercase letters, numbers, and hyphens. "
+            "It must not start or end with a hyphen or contain consecutive hyphens."
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: list_llm_skills
+# ---------------------------------------------------------------------------
+
+
+LIST_TOOL_DESCRIPTION = """List the LLM analytics skills available in this project.
+
+# When to use this tool:
+- The user asks "what skills do I have?", "list my skills", "show my workflows"
+- You are deciding whether a relevant skill exists before doing work — check first so the
+  user's encoded workflow drives the answer instead of an ad-hoc plan
+- The user references a skill by a partial name or fuzzy description
+
+Returns a compact summary of each skill (name, version, description, file count). Use
+`get_llm_skill` to load a specific skill's full body and file manifest.
+""".strip()
+
+
+class ListLLMSkillsArgs(BaseModel):
+    search: str | None = Field(
+        default=None,
+        description="Optional substring filter applied to skill names and descriptions.",
+    )
+    limit: int = Field(
+        default=25,
+        ge=1,
+        le=100,
+        description="Maximum number of skills to return (1-100).",
+    )
+
+
+class ListLLMSkillsTool(MaxTool):
+    name: str = AssistantTool.LIST_LLM_SKILLS.value
+    description: str = LIST_TOOL_DESCRIPTION
+    args_schema: type[BaseModel] = ListLLMSkillsArgs
+
+    def get_required_resource_access(self):
+        return SKILLS_RESOURCE_READ
+
+    async def _arun_impl(self, search: str | None = None, limit: int = 25) -> tuple[str, None]:
+        formatted = await database_sync_to_async(self._fetch_and_format)(search, limit)
+        return (formatted, None)
+
+    def _fetch_and_format(self, search: str | None, limit: int) -> str:
+        from django.db.models import Count, Q
+
+        queryset = get_latest_skills_queryset(self._team).annotate(_files_count=Count("files"))
+        if search:
+            queryset = queryset.filter(Q(name__icontains=search) | Q(description__icontains=search))
+        skills = list(queryset.order_by("-updated_at", "-id")[:limit])
+
+        if not skills:
+            if search:
+                return f"No skills found matching '{search}'. Try a different search or list all with no search term."
+            return (
+                "No skills found in this project. You can create one with `create_llm_skill` to "
+                "encode a common workflow."
+            )
+
+        header = f"Found {len(skills)} skill(s):" if len(skills) != 1 else "Found 1 skill:"
+        return "\n".join([header, *(_format_skill_summary(s, files_count=s._files_count) for s in skills)])
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: get_llm_skill
+# ---------------------------------------------------------------------------
+
+
+GET_TOOL_DESCRIPTION = """Load a single LLM analytics skill by name.
+
+# When to use this tool:
+- You found a relevant skill via `list_llm_skills` and want to load its instructions
+- The user names a skill they want you to "use" or "follow" for the current task
+- You need the current `version` before calling `update_llm_skill` (publish needs base_version)
+
+Returns the skill's full SKILL.md body, metadata, and the list of bundled files. Use
+`get_llm_skill_file` to load any bundled file content (progressive disclosure).
+""".strip()
+
+
+class GetLLMSkillArgs(BaseModel):
+    name: str = Field(description="Name of the skill to fetch (kebab-case, e.g. 'investigate-metric').")
+    version: int | None = Field(
+        default=None,
+        ge=1,
+        description="Specific version to load. Omit to load the latest version.",
+    )
+
+
+class GetLLMSkillTool(MaxTool):
+    name: str = AssistantTool.GET_LLM_SKILL.value
+    description: str = GET_TOOL_DESCRIPTION
+    args_schema: type[BaseModel] = GetLLMSkillArgs
+
+    def get_required_resource_access(self):
+        return SKILLS_RESOURCE_READ
+
+    async def _arun_impl(self, name: str, version: int | None = None) -> tuple[str, None]:
+        formatted = await database_sync_to_async(self._fetch_and_format)(name, version)
+        return (formatted, None)
+
+    def _fetch_and_format(self, name: str, version: int | None) -> str:
+        skill = get_skill_by_name_from_db(self._team, name, version)
+        if skill is None:
+            return f"Skill '{name}' not found."
+        files = list(LLMSkillFile.objects.filter(skill=skill).order_by("path"))
+        return _format_skill_detail(skill, files=files)
+
+
+# ---------------------------------------------------------------------------
+# Tool 3: get_llm_skill_file
+# ---------------------------------------------------------------------------
+
+
+GET_FILE_TOOL_DESCRIPTION = """Load the contents of a bundled file inside a skill.
+
+# When to use this tool:
+- A skill's manifest references a bundled file (e.g. `scripts/setup.sh`, `references/schema.md`)
+  and the user's task needs that file's content
+- Follow the progressive disclosure pattern: load files only when needed, not pre-emptively
+""".strip()
+
+
+class GetLLMSkillFileArgs(BaseModel):
+    name: str = Field(description="Skill name.")
+    path: str = Field(description="Bundled file path inside the skill (e.g. 'scripts/setup.sh').")
+    version: int | None = Field(
+        default=None,
+        ge=1,
+        description="Specific skill version to read the file from. Omit for the latest version.",
+    )
+
+
+class GetLLMSkillFileTool(MaxTool):
+    name: str = AssistantTool.GET_LLM_SKILL_FILE.value
+    description: str = GET_FILE_TOOL_DESCRIPTION
+    args_schema: type[BaseModel] = GetLLMSkillFileArgs
+
+    def get_required_resource_access(self):
+        return SKILLS_RESOURCE_READ
+
+    async def _arun_impl(self, name: str, path: str, version: int | None = None) -> tuple[str, None]:
+        try:
+            validate_skill_file_path(path)
+        except Exception as e:
+            return (f"Invalid file path: {e}", None)
+
+        result = await database_sync_to_async(self._fetch_file)(name, path, version)
+        if isinstance(result, str):
+            return (result, None)
+        skill_file: LLMSkillFile = result
+        return (
+            f"File '{skill_file.path}' from skill '{name}' ({skill_file.content_type}):\n\n{skill_file.content}",
+            None,
+        )
+
+    def _fetch_file(self, name: str, path: str, version: int | None) -> "LLMSkillFile | str":
+        skill = get_skill_by_name_from_db(self._team, name, version)
+        if skill is None:
+            return f"Skill '{name}' not found."
+        skill_file = LLMSkillFile.objects.filter(skill=skill, path=path).first()
+        if skill_file is None:
+            return f"File '{path}' not found in skill '{name}'."
+        return skill_file
+
+
+# ---------------------------------------------------------------------------
+# Tool 4: create_llm_skill
+# ---------------------------------------------------------------------------
+
+
+CREATE_TOOL_DESCRIPTION = """Create a new LLM analytics skill (version 1) to encode a reusable workflow.
+
+# When to use this tool:
+- The user asks "save this as a skill", "encode this workflow", "make this a skill"
+- You've helped the user develop a multi-step process they'll want to repeat
+
+# Format:
+- `name`: kebab-case, lowercase letters/numbers/hyphens, max 64 chars (e.g. 'investigate-metric-drop')
+- `description`: short one-liner explaining when to use the skill
+- `body`: the SKILL.md content — a markdown document giving instructions an agent should follow
+  when this skill applies. Keep it focused.
+- `allowed_tools` (optional): names of tools the skill is allowed to call when followed
+
+Returns the created skill so the user can confirm it. Use `update_llm_skill` to publish a
+new version later.
+""".strip()
+
+
+class CreateSkillFileInput(BaseModel):
+    path: str = Field(description="Relative path of the bundled file (e.g. 'scripts/setup.sh').")
+    content: str = Field(description="Text contents of the bundled file.")
+    content_type: str = Field(default="text/plain", description="MIME type. Defaults to text/plain.")
+
+
+class CreateLLMSkillArgs(BaseModel):
+    name: str = Field(description="Kebab-case skill name (max 64 chars).")
+    description: str = Field(description="Short description of when to use this skill.", max_length=4096)
+    body: str = Field(description="SKILL.md markdown body — the instructions an agent will follow.")
+    license: str | None = Field(default=None, description="Optional license string.")
+    compatibility: str | None = Field(default=None, description="Optional compatibility note.")
+    allowed_tools: list[str] | None = Field(
+        default=None,
+        description="Optional list of tool names this skill is allowed to call.",
+    )
+    metadata: dict[str, Any] | None = Field(default=None, description="Optional arbitrary metadata.")
+    files: list[CreateSkillFileInput] | None = Field(
+        default=None,
+        description=f"Optional bundled files (max {MAX_SKILL_FILE_COUNT}).",
+    )
+
+
+class CreateLLMSkillTool(MaxTool):
+    name: str = AssistantTool.CREATE_LLM_SKILL.value
+    description: str = CREATE_TOOL_DESCRIPTION
+    args_schema: type[BaseModel] = CreateLLMSkillArgs
+
+    def get_required_resource_access(self):
+        return SKILLS_RESOURCE_WRITE
+
+    async def _arun_impl(
+        self,
+        name: str,
+        description: str,
+        body: str,
+        license: str | None = None,
+        compatibility: str | None = None,
+        allowed_tools: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        files: list[CreateSkillFileInput] | None = None,
+    ) -> tuple[str, None]:
+        validation_error = _validate_skill_name(name)
+        if validation_error:
+            return (validation_error, None)
+
+        if len(body.encode("utf-8")) > MAX_SKILL_BODY_BYTES:
+            return (f"Skill body exceeds the {MAX_SKILL_BODY_BYTES} byte size limit.", None)
+
+        normalized_files: list[dict[str, str]] = []
+        if files:
+            if len(files) > MAX_SKILL_FILE_COUNT:
+                return (f"A skill may contain at most {MAX_SKILL_FILE_COUNT} files.", None)
+            seen: set[str] = set()
+            for file_input in files:
+                try:
+                    validate_skill_file_path(file_input.path)
+                except Exception as e:
+                    return (f"Invalid file path '{file_input.path}': {e}", None)
+                if file_input.path in seen:
+                    return (f"Duplicate file path '{file_input.path}' in input.", None)
+                seen.add(file_input.path)
+                normalized_files.append(
+                    {
+                        "path": file_input.path,
+                        "content": file_input.content,
+                        "content_type": file_input.content_type or "text/plain",
+                    }
+                )
+
+        try:
+            result = await database_sync_to_async(self._create_skill_and_format)(
+                name=name,
+                description=description,
+                body=body,
+                license=license or "",
+                compatibility=compatibility or "",
+                allowed_tools=allowed_tools or [],
+                metadata=metadata or {},
+                files=normalized_files,
+            )
+        except IntegrityError as err:
+            err_str = str(err)
+            if "unique_llm_skill_latest_per_team" in err_str or "unique_llm_skill_version_per_team" in err_str:
+                return (
+                    f"A skill named '{name}' already exists. Pick a different name or update the existing skill.",
+                    None,
+                )
+            raise
+
+        return (result, None)
+
+    def _create_skill_and_format(
+        self,
+        *,
+        name: str,
+        description: str,
+        body: str,
+        license: str,
+        compatibility: str,
+        allowed_tools: list[str],
+        metadata: dict[str, Any],
+        files: list[dict[str, str]],
+    ) -> str:
+        with transaction.atomic():
+            skill = LLMSkill.objects.create(
+                team=self._team,
+                created_by=self._user,
+                name=name,
+                description=description,
+                body=body,
+                license=license,
+                compatibility=compatibility,
+                allowed_tools=allowed_tools,
+                metadata=metadata,
+                version=1,
+                is_latest=True,
+            )
+            if files:
+                LLMSkillFile.objects.bulk_create(
+                    [
+                        LLMSkillFile(
+                            skill=skill,
+                            path=f["path"],
+                            content=f["content"],
+                            content_type=f["content_type"],
+                        )
+                        for f in files
+                    ]
+                )
+        saved_files = list(LLMSkillFile.objects.filter(skill=skill).order_by("path"))
+        return f"Created skill '{skill.name}' (v{skill.version}).\n\n{_format_skill_detail(skill, files=saved_files)}"
+
+
+# ---------------------------------------------------------------------------
+# Tool 5: update_llm_skill
+# ---------------------------------------------------------------------------
+
+
+UPDATE_TOOL_DESCRIPTION = """Publish a new version of an existing LLM analytics skill.
+
+# When to use this tool:
+- The user wants to edit a skill's instructions, description, or metadata
+- The user wants to add, change, or remove bundled files
+
+# Optimistic concurrency:
+You MUST pass `base_version` — the version number you read most recently via `get_llm_skill`.
+If the skill has changed since, the call fails with a conflict and you should re-fetch.
+
+# Body updates: two options (don't combine):
+- `body`: replace the whole SKILL.md body
+- `edits`: a list of `{old, new}` find-and-replace patches applied sequentially. Each `old`
+  must occur exactly once in the current body — supply enough context to make it unique.
+
+Any field you omit carries forward unchanged.
+""".strip()
+
+
+class SkillBodyEditInput(BaseModel):
+    old: str = Field(description="Exact text to replace in the current body. Must occur exactly once.")
+    new: str = Field(description="Replacement text.")
+
+
+class UpdateLLMSkillArgs(BaseModel):
+    name: str = Field(description="Skill name to update.")
+    base_version: int = Field(
+        ge=1,
+        description="The current version you observed before editing — used for optimistic concurrency.",
+    )
+    body: str | None = Field(
+        default=None,
+        description="New full SKILL.md body. Mutually exclusive with `edits`.",
+    )
+    edits: list[SkillBodyEditInput] | None = Field(
+        default=None,
+        description="Sequential find/replace edits to apply to the current body. Mutually exclusive with `body`.",
+    )
+    description: str | None = Field(default=None, description="New description.")
+    license: str | None = Field(default=None, description="New license string.")
+    compatibility: str | None = Field(default=None, description="New compatibility note.")
+    allowed_tools: list[str] | None = Field(default=None, description="Replacement list of allowed tools.")
+    metadata: dict[str, Any] | None = Field(default=None, description="Replacement metadata dict.")
+
+
+class UpdateLLMSkillTool(MaxTool):
+    name: str = AssistantTool.UPDATE_LLM_SKILL.value
+    description: str = UPDATE_TOOL_DESCRIPTION
+    args_schema: type[BaseModel] = UpdateLLMSkillArgs
+
+    def get_required_resource_access(self):
+        return SKILLS_RESOURCE_WRITE
+
+    async def _arun_impl(
+        self,
+        name: str,
+        base_version: int,
+        body: str | None = None,
+        edits: list[SkillBodyEditInput] | None = None,
+        description: str | None = None,
+        license: str | None = None,
+        compatibility: str | None = None,
+        allowed_tools: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> tuple[str, None]:
+        if body is not None and edits is not None:
+            return ("Pass either `body` or `edits`, not both.", None)
+
+        edits_payload: list[dict[str, str]] | None = (
+            [{"old": e.old, "new": e.new} for e in edits] if edits is not None else None
+        )
+
+        try:
+            result = await database_sync_to_async(self._publish_and_format)(
+                name=name,
+                body=body,
+                edits_payload=edits_payload,
+                description=description,
+                license=license,
+                compatibility=compatibility,
+                allowed_tools=allowed_tools,
+                metadata=metadata,
+                base_version=base_version,
+            )
+        except LLMSkillNotFoundError:
+            return (f"Skill '{name}' not found.", None)
+        except LLMSkillVersionConflictError as err:
+            return (_conflict_message(err), None)
+        except LLMSkillVersionLimitError as err:
+            return (
+                f"Skill '{name}' has reached the maximum of {err.max_version} versions. "
+                "Archive it and create a new one to keep iterating.",
+                None,
+            )
+        except LLMSkillEditError as err:
+            return (f"Failed to apply edit: {err.message}", None)
+
+        return (result, None)
+
+    def _publish_and_format(
+        self,
+        *,
+        name: str,
+        body: str | None,
+        edits_payload: list[dict[str, str]] | None,
+        description: str | None,
+        license: str | None,
+        compatibility: str | None,
+        allowed_tools: list[str] | None,
+        metadata: dict[str, Any] | None,
+        base_version: int,
+    ) -> str:
+        updated = publish_skill_version(
+            self._team,
+            user=self._user,
+            skill_name=name,
+            body=body,
+            edits=edits_payload,
+            description=description,
+            license=license,
+            compatibility=compatibility,
+            allowed_tools=allowed_tools,
+            metadata=metadata,
+            base_version=base_version,
+        )
+        files = list(LLMSkillFile.objects.filter(skill=updated).order_by("path"))
+        return f"Published v{updated.version} of '{updated.name}'.\n\n{_format_skill_detail(updated, files=files)}"
+
+
+# ---------------------------------------------------------------------------
+# Tool 6: archive_llm_skill
+# ---------------------------------------------------------------------------
+
+
+ARCHIVE_TOOL_DESCRIPTION = """Archive an LLM analytics skill (soft-delete all of its versions).
+
+# When to use this tool:
+- The user explicitly asks to delete, archive, or remove a skill
+
+This operation is irreversible from the UI — archived skills are no longer listed and cannot
+be published to. Always confirm with the user before calling.
+""".strip()
+
+
+class ArchiveLLMSkillArgs(BaseModel):
+    name: str = Field(description="Name of the skill to archive.")
+
+
+class ArchiveLLMSkillTool(MaxTool):
+    name: str = AssistantTool.ARCHIVE_LLM_SKILL.value
+    description: str = ARCHIVE_TOOL_DESCRIPTION
+    args_schema: type[BaseModel] = ArchiveLLMSkillArgs
+
+    def get_required_resource_access(self):
+        return SKILLS_RESOURCE_WRITE
+
+    async def is_dangerous_operation(self, **kwargs) -> bool:
+        return True
+
+    async def format_dangerous_operation_preview(self, name: str, **kwargs) -> str:
+        return f"Archive skill '{name}' (all versions). This is irreversible from the UI."
+
+    async def _arun_impl(self, name: str) -> tuple[str, None]:
+        try:
+            versions = await database_sync_to_async(archive_skill)(self._team, name)
+        except LLMSkillNotFoundError:
+            return (f"Skill '{name}' not found.", None)
+
+        return (
+            f"Archived skill '{name}' ({len(versions)} version(s): {versions}).",
+            None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool 7: duplicate_llm_skill
+# ---------------------------------------------------------------------------
+
+
+DUPLICATE_TOOL_DESCRIPTION = """Duplicate an existing skill to a new name (starts at v1).
+
+# When to use this tool:
+- The user asks to "copy", "clone", or "fork" a skill
+- You want to derive a new skill from an existing one as a starting point
+
+The copy includes the body, metadata, and all bundled files of the source skill's latest version.
+""".strip()
+
+
+class DuplicateLLMSkillArgs(BaseModel):
+    source_name: str = Field(description="Name of the skill to duplicate.")
+    new_name: str = Field(description="Name for the new skill (kebab-case, must not exist).")
+
+
+class DuplicateLLMSkillTool(MaxTool):
+    name: str = AssistantTool.DUPLICATE_LLM_SKILL.value
+    description: str = DUPLICATE_TOOL_DESCRIPTION
+    args_schema: type[BaseModel] = DuplicateLLMSkillArgs
+
+    def get_required_resource_access(self):
+        return SKILLS_RESOURCE_WRITE
+
+    async def _arun_impl(self, source_name: str, new_name: str) -> tuple[str, None]:
+        validation_error = _validate_skill_name(new_name)
+        if validation_error:
+            return (validation_error, None)
+
+        try:
+            result = await database_sync_to_async(self._duplicate_and_format)(source_name, new_name)
+        except LLMSkillNotFoundError:
+            return (f"Source skill '{source_name}' not found.", None)
+        except LLMSkillDuplicateNameConflictError:
+            return (f"A skill named '{new_name}' already exists.", None)
+
+        return (result, None)
+
+    def _duplicate_and_format(self, source_name: str, new_name: str) -> str:
+        new_skill = duplicate_skill(
+            self._team,
+            user=self._user,
+            source_name=source_name,
+            new_name=new_name,
+        )
+        files = list(LLMSkillFile.objects.filter(skill=new_skill).order_by("path"))
+        return (
+            f"Duplicated '{source_name}' to '{new_name}' (v{new_skill.version}).\n\n"
+            f"{_format_skill_detail(new_skill, files=files)}"
+        )
+
+
+__all__ = [
+    "ListLLMSkillsTool",
+    "GetLLMSkillTool",
+    "GetLLMSkillFileTool",
+    "CreateLLMSkillTool",
+    "UpdateLLMSkillTool",
+    "ArchiveLLMSkillTool",
+    "DuplicateLLMSkillTool",
+]

--- a/products/llm_analytics/backend/tools/manage_skills.py
+++ b/products/llm_analytics/backend/tools/manage_skills.py
@@ -20,6 +20,7 @@ from ee.hogai.tool import MaxTool
 from ..api.skill_serializers import SKILL_NAME_PATTERN, validate_skill_file_path
 from ..api.skill_services import (
     MAX_SKILL_BODY_BYTES,
+    MAX_SKILL_FILE_BYTES,
     MAX_SKILL_FILE_COUNT,
     LLMSkillDuplicateNameConflictError,
     LLMSkillEditError,
@@ -99,7 +100,9 @@ def _validate_skill_name(name: str) -> str | None:
         return "'new' is a reserved name. Pick another."
     if len(name) > 64:
         return "Skill name must be 64 characters or fewer."
-    if not SKILL_NAME_PATTERN.match(name):
+    # SKILL_NAME_PATTERN allows internal hyphens but doesn't reject consecutive ones (`foo--bar`),
+    # so mirror the REST serializer's explicit check to keep validation parity across surfaces.
+    if "--" in name or not SKILL_NAME_PATTERN.match(name):
         return (
             "Skill name must use only lowercase letters, numbers, and hyphens. "
             "It must not start or end with a hyphen or contain consecutive hyphens."
@@ -357,6 +360,11 @@ class CreateLLMSkillTool(MaxTool):
                     return (f"Invalid file path '{file_input.path}': {e}", None)
                 if file_input.path in seen:
                     return (f"Duplicate file path '{file_input.path}' in input.", None)
+                if len(file_input.content.encode("utf-8")) > MAX_SKILL_FILE_BYTES:
+                    return (
+                        f"File '{file_input.path}' exceeds the {MAX_SKILL_FILE_BYTES} byte size limit.",
+                        None,
+                    )
                 seen.add(file_input.path)
                 normalized_files.append(
                     {
@@ -438,8 +446,8 @@ class CreateLLMSkillTool(MaxTool):
 UPDATE_TOOL_DESCRIPTION = """Publish a new version of an existing LLM analytics skill.
 
 # When to use this tool:
-- The user wants to edit a skill's instructions, description, or metadata
-- The user wants to add, change, or remove bundled files
+- The user wants to edit a skill's instructions, description, license, compatibility, allowed
+  tools, or metadata
 
 # Optimistic concurrency:
 You MUST pass `base_version` — the version number you read most recently via `get_llm_skill`.
@@ -450,7 +458,8 @@ If the skill has changed since, the call fails with a conflict and you should re
 - `edits`: a list of `{old, new}` find-and-replace patches applied sequentially. Each `old`
   must occur exactly once in the current body — supply enough context to make it unique.
 
-Any field you omit carries forward unchanged.
+Any field you omit carries forward unchanged. Bundled files are carried forward as-is — this
+tool does not add, remove, or rewrite files. (Use the REST API for file changes for now.)
 """.strip()
 
 

--- a/products/llm_analytics/backend/tools/test_manage_skills.py
+++ b/products/llm_analytics/backend/tools/test_manage_skills.py
@@ -1,0 +1,397 @@
+from posthog.test.base import BaseTest
+
+from asgiref.sync import async_to_sync
+
+from products.llm_analytics.backend.models.skills import LLMSkill, LLMSkillFile
+from products.llm_analytics.backend.tools.manage_skills import (
+    ArchiveLLMSkillTool,
+    CreateLLMSkillTool,
+    DuplicateLLMSkillTool,
+    GetLLMSkillFileTool,
+    GetLLMSkillTool,
+    ListLLMSkillsTool,
+    UpdateLLMSkillTool,
+)
+
+
+def _run(tool, **kwargs):
+    return async_to_sync(tool._arun_impl)(**kwargs)
+
+
+class TestListLLMSkillsTool(BaseTest):
+    def _tool(self):
+        return ListLLMSkillsTool(team=self.team, user=self.user)
+
+    def test_returns_empty_message_when_no_skills(self):
+        result, artifact = _run(self._tool())
+        assert artifact is None
+        assert "No skills found" in result
+
+    def test_lists_existing_skills(self):
+        LLMSkill.objects.create(
+            team=self.team,
+            name="investigate-metric",
+            description="Find why a metric changed.",
+            body="# Step 1...",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        LLMSkill.objects.create(
+            team=self.team,
+            name="audit-flags",
+            description="Audit stale flags.",
+            body="# Step 1...",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+
+        result, _ = _run(self._tool())
+        assert "investigate-metric" in result
+        assert "audit-flags" in result
+        assert "Found 2 skill" in result
+
+    def test_search_filters_by_name(self):
+        LLMSkill.objects.create(
+            team=self.team,
+            name="investigate-metric",
+            description="A",
+            body="x",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        LLMSkill.objects.create(
+            team=self.team,
+            name="audit-flags",
+            description="B",
+            body="x",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        result, _ = _run(self._tool(), search="audit")
+        assert "audit-flags" in result
+        assert "investigate-metric" not in result
+
+    def test_only_returns_latest_versions(self):
+        LLMSkill.objects.create(
+            team=self.team,
+            name="my-skill",
+            description="d",
+            body="v1 body",
+            version=1,
+            is_latest=False,
+            created_by=self.user,
+        )
+        LLMSkill.objects.create(
+            team=self.team,
+            name="my-skill",
+            description="d",
+            body="v2 body",
+            version=2,
+            is_latest=True,
+            created_by=self.user,
+        )
+
+        result, _ = _run(self._tool())
+        assert "v2" in result
+        assert "Found 1 skill" in result
+
+
+class TestGetLLMSkillTool(BaseTest):
+    def _tool(self):
+        return GetLLMSkillTool(team=self.team, user=self.user)
+
+    def test_returns_not_found(self):
+        result, _ = _run(self._tool(), name="missing")
+        assert "not found" in result
+
+    def test_returns_skill_body_and_metadata(self):
+        skill = LLMSkill.objects.create(
+            team=self.team,
+            name="my-skill",
+            description="A description.",
+            body="# Heading\nDo this.",
+            license="Apache-2.0",
+            allowed_tools=["Bash"],
+            version=3,
+            is_latest=True,
+            created_by=self.user,
+        )
+        LLMSkillFile.objects.create(skill=skill, path="setup.sh", content="echo hi")
+
+        result, _ = _run(self._tool(), name="my-skill")
+        assert "my-skill" in result
+        assert "v3" in result
+        assert "A description." in result
+        assert "Heading" in result
+        assert "Apache-2.0" in result
+        assert "Bash" in result
+        assert "setup.sh" in result
+
+
+class TestGetLLMSkillFileTool(BaseTest):
+    def _tool(self):
+        return GetLLMSkillFileTool(team=self.team, user=self.user)
+
+    def test_returns_file_content(self):
+        skill = LLMSkill.objects.create(
+            team=self.team,
+            name="s",
+            description="d",
+            body="b",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        LLMSkillFile.objects.create(skill=skill, path="docs/notes.md", content="hello world")
+
+        result, _ = _run(self._tool(), name="s", path="docs/notes.md")
+        assert "hello world" in result
+
+    def test_rejects_path_traversal(self):
+        result, _ = _run(self._tool(), name="s", path="../etc/passwd")
+        assert "Invalid file path" in result
+
+    def test_file_not_found(self):
+        LLMSkill.objects.create(
+            team=self.team,
+            name="s",
+            description="d",
+            body="b",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        result, _ = _run(self._tool(), name="s", path="missing.md")
+        assert "not found" in result
+
+
+class TestCreateLLMSkillTool(BaseTest):
+    def _tool(self):
+        return CreateLLMSkillTool(team=self.team, user=self.user)
+
+    def test_creates_skill_at_v1(self):
+        result, _ = _run(
+            self._tool(),
+            name="my-new-skill",
+            description="Investigate metric drops.",
+            body="# Steps\n1. ...",
+        )
+        assert "Created skill 'my-new-skill'" in result
+        assert "v1" in result
+
+        skill = LLMSkill.objects.get(team=self.team, name="my-new-skill")
+        assert skill.version == 1
+        assert skill.is_latest
+        assert skill.body == "# Steps\n1. ..."
+        assert skill.created_by == self.user
+
+    def test_rejects_invalid_name(self):
+        result, _ = _run(
+            self._tool(),
+            name="Bad_Name",
+            description="d",
+            body="b",
+        )
+        assert "lowercase letters" in result
+
+    def test_rejects_duplicate_name(self):
+        LLMSkill.objects.create(
+            team=self.team,
+            name="dup",
+            description="d",
+            body="b",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        result, _ = _run(
+            self._tool(),
+            name="dup",
+            description="d2",
+            body="b2",
+        )
+        assert "already exists" in result
+
+    def test_creates_skill_with_files(self):
+        from products.llm_analytics.backend.tools.manage_skills import CreateSkillFileInput
+
+        result, _ = _run(
+            self._tool(),
+            name="with-files",
+            description="d",
+            body="# x",
+            files=[CreateSkillFileInput(path="a.txt", content="aaa")],
+        )
+        assert "with-files" in result
+        skill = LLMSkill.objects.get(team=self.team, name="with-files")
+        files = list(skill.files.all())
+        assert len(files) == 1
+        assert files[0].path == "a.txt"
+        assert files[0].content == "aaa"
+
+
+class TestUpdateLLMSkillTool(BaseTest):
+    def _tool(self):
+        return UpdateLLMSkillTool(team=self.team, user=self.user)
+
+    def _seed(self, body="# v1 body"):
+        return LLMSkill.objects.create(
+            team=self.team,
+            name="iter-skill",
+            description="d",
+            body=body,
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+
+    def test_publishes_new_version_with_full_body(self):
+        self._seed()
+        result, _ = _run(
+            self._tool(),
+            name="iter-skill",
+            base_version=1,
+            body="# v2 body",
+        )
+        assert "Published v2" in result
+        latest = LLMSkill.objects.get(team=self.team, name="iter-skill", is_latest=True)
+        assert latest.version == 2
+        assert latest.body == "# v2 body"
+
+    def test_publishes_with_edits(self):
+        self._seed(body="alpha\nbeta\ngamma")
+        from products.llm_analytics.backend.tools.manage_skills import SkillBodyEditInput
+
+        result, _ = _run(
+            self._tool(),
+            name="iter-skill",
+            base_version=1,
+            edits=[SkillBodyEditInput(old="beta", new="BETA")],
+        )
+        assert "Published v2" in result
+        latest = LLMSkill.objects.get(team=self.team, name="iter-skill", is_latest=True)
+        assert latest.body == "alpha\nBETA\ngamma"
+
+    def test_rejects_body_and_edits_together(self):
+        self._seed()
+        from products.llm_analytics.backend.tools.manage_skills import SkillBodyEditInput
+
+        result, _ = _run(
+            self._tool(),
+            name="iter-skill",
+            base_version=1,
+            body="x",
+            edits=[SkillBodyEditInput(old="a", new="b")],
+        )
+        assert "either `body` or `edits`" in result
+
+    def test_returns_conflict_when_base_version_mismatched(self):
+        skill = self._seed()
+        skill.is_latest = False
+        skill.save()
+        LLMSkill.objects.create(
+            team=self.team,
+            name="iter-skill",
+            description="d",
+            body="# v2",
+            version=2,
+            is_latest=True,
+            created_by=self.user,
+        )
+
+        result, _ = _run(
+            self._tool(),
+            name="iter-skill",
+            base_version=1,
+            body="# stale",
+        )
+        assert "changed since you opened it" in result
+        assert "Current version is 2" in result
+
+    def test_not_found(self):
+        result, _ = _run(self._tool(), name="nope", base_version=1, body="x")
+        assert "not found" in result
+
+
+class TestArchiveLLMSkillTool(BaseTest):
+    def _tool(self):
+        return ArchiveLLMSkillTool(team=self.team, user=self.user)
+
+    def test_archives_skill(self):
+        LLMSkill.objects.create(
+            team=self.team,
+            name="to-archive",
+            description="d",
+            body="b",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+
+        result, _ = _run(self._tool(), name="to-archive")
+        assert "Archived skill 'to-archive'" in result
+
+        skill = LLMSkill.objects.get(team=self.team, name="to-archive", version=1)
+        assert skill.deleted is True
+        assert skill.is_latest is False
+
+    def test_not_found(self):
+        result, _ = _run(self._tool(), name="nope")
+        assert "not found" in result
+
+
+class TestDuplicateLLMSkillTool(BaseTest):
+    def _tool(self):
+        return DuplicateLLMSkillTool(team=self.team, user=self.user)
+
+    def test_duplicates_skill(self):
+        source = LLMSkill.objects.create(
+            team=self.team,
+            name="source",
+            description="A description.",
+            body="# Source body",
+            license="MIT",
+            allowed_tools=["Bash"],
+            version=4,
+            is_latest=True,
+            created_by=self.user,
+        )
+        LLMSkillFile.objects.create(skill=source, path="a.txt", content="abc")
+
+        result, _ = _run(self._tool(), source_name="source", new_name="copy")
+        assert "Duplicated 'source' to 'copy'" in result
+        new_skill = LLMSkill.objects.get(team=self.team, name="copy")
+        assert new_skill.version == 1
+        assert new_skill.body == "# Source body"
+        assert new_skill.license == "MIT"
+        assert list(new_skill.files.values_list("path", flat=True)) == ["a.txt"]
+
+    def test_rejects_invalid_new_name(self):
+        result, _ = _run(self._tool(), source_name="src", new_name="BAD NAME")
+        assert "lowercase letters" in result
+
+    def test_conflict_when_destination_exists(self):
+        LLMSkill.objects.create(
+            team=self.team,
+            name="src",
+            description="d",
+            body="b",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        LLMSkill.objects.create(
+            team=self.team,
+            name="dest",
+            description="d",
+            body="b",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        result, _ = _run(self._tool(), source_name="src", new_name="dest")
+        assert "already exists" in result

--- a/products/llm_analytics/backend/tools/test_manage_skills.py
+++ b/products/llm_analytics/backend/tools/test_manage_skills.py
@@ -1,6 +1,7 @@
 from posthog.test.base import BaseTest
 
 from asgiref.sync import async_to_sync
+from parameterized import parameterized
 
 from products.llm_analytics.backend.models.skills import LLMSkill, LLMSkillFile
 from products.llm_analytics.backend.tools.manage_skills import (
@@ -12,6 +13,17 @@ from products.llm_analytics.backend.tools.manage_skills import (
     ListLLMSkillsTool,
     UpdateLLMSkillTool,
 )
+
+INVALID_SKILL_NAMES = [
+    ("uppercase", "Bad_Name"),
+    ("consecutive_hyphens", "foo--bar"),
+    ("leading_hyphen", "-foo"),
+    ("trailing_hyphen", "foo-"),
+    ("reserved_new", "new"),
+    ("too_long", "a" * 65),
+    ("contains_space", "foo bar"),
+    ("contains_underscore", "foo_bar"),
+]
 
 
 def _run(tool, **kwargs):
@@ -189,24 +201,20 @@ class TestCreateLLMSkillTool(BaseTest):
         assert skill.body == "# Steps\n1. ..."
         assert skill.created_by == self.user
 
-    def test_rejects_invalid_name(self):
+    @parameterized.expand(INVALID_SKILL_NAMES)
+    def test_rejects_invalid_name(self, _case, invalid_name):
+        # Validation must match the REST serializer so a name created via Max isn't later
+        # rejected by other clients (and vice versa). See _validate_skill_name in manage_skills.py.
         result, _ = _run(
             self._tool(),
-            name="Bad_Name",
+            name=invalid_name,
             description="d",
             body="b",
         )
-        assert "lowercase letters" in result
-
-    def test_rejects_consecutive_hyphens_in_name(self):
-        # Mirrors REST serializer's "--" rejection so validation is consistent across surfaces.
-        result, _ = _run(
-            self._tool(),
-            name="foo--bar",
-            description="d",
-            body="b",
-        )
-        assert "lowercase letters" in result
+        assert not LLMSkill.objects.filter(team=self.team, name=invalid_name).exists()
+        # All the error messages share these phrases — the reserved-name and too-long branches
+        # use slightly different wording but always include one of the two below.
+        assert "reserved" in result or "lowercase letters" in result or "64 characters" in result
 
     def test_rejects_oversized_file(self):
         from products.llm_analytics.backend.api.skill_services import MAX_SKILL_FILE_BYTES
@@ -341,6 +349,22 @@ class TestUpdateLLMSkillTool(BaseTest):
         result, _ = _run(self._tool(), name="nope", base_version=1, body="x")
         assert "not found" in result
 
+    def test_rejects_oversized_body(self):
+        from products.llm_analytics.backend.api.skill_services import MAX_SKILL_BODY_BYTES
+
+        self._seed()
+        oversized = "x" * (MAX_SKILL_BODY_BYTES + 1)
+        result, _ = _run(
+            self._tool(),
+            name="iter-skill",
+            base_version=1,
+            body=oversized,
+        )
+        assert "size limit" in result
+        # Nothing should have been published.
+        latest = LLMSkill.objects.get(team=self.team, name="iter-skill", is_latest=True)
+        assert latest.version == 1
+
 
 class TestArchiveLLMSkillTool(BaseTest):
     def _tool(self):
@@ -395,9 +419,11 @@ class TestDuplicateLLMSkillTool(BaseTest):
         assert new_skill.license == "MIT"
         assert list(new_skill.files.values_list("path", flat=True)) == ["a.txt"]
 
-    def test_rejects_invalid_new_name(self):
-        result, _ = _run(self._tool(), source_name="src", new_name="BAD NAME")
-        assert "lowercase letters" in result
+    @parameterized.expand(INVALID_SKILL_NAMES)
+    def test_rejects_invalid_new_name(self, _case, invalid_name):
+        result, _ = _run(self._tool(), source_name="src", new_name=invalid_name)
+        assert not LLMSkill.objects.filter(team=self.team, name=invalid_name).exists()
+        assert "reserved" in result or "lowercase letters" in result or "64 characters" in result
 
     def test_conflict_when_destination_exists(self):
         LLMSkill.objects.create(

--- a/products/llm_analytics/backend/tools/test_manage_skills.py
+++ b/products/llm_analytics/backend/tools/test_manage_skills.py
@@ -198,6 +198,31 @@ class TestCreateLLMSkillTool(BaseTest):
         )
         assert "lowercase letters" in result
 
+    def test_rejects_consecutive_hyphens_in_name(self):
+        # Mirrors REST serializer's "--" rejection so validation is consistent across surfaces.
+        result, _ = _run(
+            self._tool(),
+            name="foo--bar",
+            description="d",
+            body="b",
+        )
+        assert "lowercase letters" in result
+
+    def test_rejects_oversized_file(self):
+        from products.llm_analytics.backend.api.skill_services import MAX_SKILL_FILE_BYTES
+        from products.llm_analytics.backend.tools.manage_skills import CreateSkillFileInput
+
+        oversized = "x" * (MAX_SKILL_FILE_BYTES + 1)
+        result, _ = _run(
+            self._tool(),
+            name="too-big",
+            description="d",
+            body="# x",
+            files=[CreateSkillFileInput(path="huge.txt", content=oversized)],
+        )
+        assert "size limit" in result
+        assert not LLMSkill.objects.filter(team=self.team, name="too-big").exists()
+
     def test_rejects_duplicate_name(self):
         LLMSkill.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem

PostHog AI (Max) had no awareness of the [LLM analytics skills](https://agentskills.io/specification) system. Users who'd carefully encoded their PostHog workflows as skills (the team's playbook for investigating a metric drop, auditing flags, running an experiment ramp-up, etc.) couldn't ask PHAI to use them, edit them, or save a new one — they had to manage skills through the dedicated UI and re-explain the workflow to PHAI every time.

This PR closes that gap: PostHog AI can now list, read, create, edit, archive, and duplicate the team's skills, and load a skill's body or bundled files to follow it as task-specific guidance.

## Changes

Seven new Max tools that wrap the existing `LLMSkill` API:

| Tool | What it does |
|---|---|
| `list_llm_skills` | List available skills (compact summary; supports search). |
| `get_llm_skill` | Load a skill's full SKILL.md body, metadata, and file manifest. |
| `get_llm_skill_file` | Load a single bundled file (progressive disclosure). |
| `create_llm_skill` | Create a new skill at v1 (with optional bundled files). |
| `update_llm_skill` | Publish a new version via full body replace or `{old,new}` edit patches, with `base_version` optimistic concurrency. |
| `archive_llm_skill` | Soft-delete all versions. Marked dangerous → Max requests user approval first. |
| `duplicate_llm_skill` | Copy a skill to a new name (starts at v1). |

All tools live in `products/llm_analytics/backend/tools/manage_skills.py` and reuse the existing service layer (`skill_services.py`) and validators (`skill_serializers.py`) — no duplication of versioning or conflict-detection logic. Read tools require the `llm_analytics:viewer` resource scope; write tools require `llm_analytics:editor`.

Wiring:

- Added to `LLMAnalyticsAgentToolkit` so they're available in the dedicated LLM analytics mode.
- Also added to `ChatAgentToolkit` (cross-mode) so PHAI can reach for a skill regardless of which mode the user is in — encoded workflows are inherently cross-product (a skill for "investigate metric drop" applies in product analytics, error tracking, web analytics, etc.).
- Both wirings are gated behind the existing `llm-analytics-skills` feature flag (`has_llm_analytics_skills_feature_flag`), the same flag that gates the REST API, so users without skills enabled don't see these tools.

Schema:

- Added `LIST_LLM_SKILLS`, `GET_LLM_SKILL`, `GET_LLM_SKILL_FILE`, `CREATE_LLM_SKILL`, `UPDATE_LLM_SKILL`, `ARCHIVE_LLM_SKILL`, `DUPLICATE_LLM_SKILL` to `AssistantTool` in `posthog/schema.py`, `schema-assistant-messages.ts`, and `schema.json`.

Tests:

- 23 unit tests in `test_manage_skills.py` covering list/search/version-filtering, get + file fetch + path-traversal rejection, create with files / duplicate-name rejection / invalid-name rejection, update via full-body, update via edits, conflict detection on stale `base_version`, archive, duplicate (including conflict).

## How did you test this code?

I'm an agent (PostHog Code). I have not run the test suite manually — Postgres wasn't available in the runner environment. Verified locally:

- Ruff lint + format clean on all modified/new files.
- Pytest collects all 23 new tests cleanly (`pytest --collect-only`).
- Django imports all new tools and toolkits without error; `_llm_analytics_skill_tools()` returns the expected 7 classes; the registry in `MaxTool.__init_subclass__` accepts each tool's `AssistantTool` enum value.

CI will run the test suite.

## Publish to changelog?

Yes — surface this as "Max can now manage and use your LLM analytics skills".

## Docs update

The LLM analytics skills feature is still flagged; docs can be updated in a follow-up when the flag rolls out.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) in response to ticket #824.

Decisions made along the way:

- **Where to put the tool files.** Considered `ee/hogai/tools/` (alongside other shared tools) vs `products/llm_analytics/backend/tools/` (alongside `run_hog_eval_test.py`, the existing LLM analytics Max tool). Chose the latter to keep skill knowledge co-located with the rest of the LLM analytics product, matching the existing pattern.
- **Mode-specific vs cross-mode wiring.** The user explicitly wanted skills usable across modes ("just use the skill to get their job done"). Added them to both `LLMAnalyticsAgentToolkit` (LLM analytics mode) and `ChatAgentToolkit` (cross-mode), both flag-gated. The `ChatAgentToolkit` has a "do not extend" comment, but it already extends conditionally for tasks and memories — skills follow the same pattern.
- **Reuse the service layer.** Instead of going through the DRF `LLMSkillCreateSerializer` (which needs a `Request` object), the `create_llm_skill` tool runs the same DB writes directly in a `transaction.atomic()` block — but read paths and the update / archive / duplicate paths call straight through to `publish_skill_version` / `archive_skill` / `duplicate_skill`, reusing all the optimistic-concurrency and validation logic in `skill_services.py`. This minimises drift.
- **Async safety.** Each tool does all DB work and result formatting inside a single `database_sync_to_async` block so we never touch a Django queryset from async context. The list tool uses `Count("files")` annotation to avoid N+1 queries.
- **archive marked dangerous.** Soft-delete is irreversible from the UI, so `ArchiveLLMSkillTool.is_dangerous_operation` returns True — Max will request explicit user approval before calling it.

Tools used: Read, Edit, Write, Grep, Glob, Bash, Agent (Explore subagents for codebase orientation).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*