### PR TITLE
chore(docs): update sandbox setup guide

### DIFF
--- a/docs/internal/sandboxes-setup-guide.md
+++ b/docs/internal/sandboxes-setup-guide.md
@@ -86,14 +86,14 @@ The activities live in
 ## Running via the UI
 
 This is very minimal at the moment, but the tasks page can be used to see what
-is happening with a background cloud run.
+is happening with a background cloud run and for debugging. You can also use PostHog Code to do this rather than the debug UI.
 
-1. Navigate to Tasks in PostHog (requires the `tasks` feature flag)
+1. Navigate to Tasks in PostHog (requires the `tasks` feature flag) by visiting `/tasks` (it will not show up in the sidebar)
 2. Create a task with a title, description, and repository (format: `owner/repo`)
 3. Click "Run task"
 4. Watch logs stream in the session view
 
-## Testing with local agent packages
+## Testing with local agent packages (you only need to do this if you are making changes to the agent package, otherwise ignore this)
 
 To test changes to `@posthog/agent` before publishing:
 
@@ -109,7 +109,7 @@ MODAL_TOKEN_SECRET=<token_secret>
 
 ### Tunnel gateway, API, and MCP
 
-Since Modal sandboxes run in the cloud and can't reach `localhost` directly,
+If you run in a docker sandbox you don't need to do this. If you are testing with Modal sandboxes, since they run in the cloud and can't reach `localhost` directly,
 you'll need to expose the Django API, LLM gateway, and MCP server via a tunnel (e.g. ngrok or Cloudflare Tunnel).
 
 With ngrok, add tunnels to your ngrok config, `~/.config/ngrok/ngrok.yml` (Linux) or `~/Library/Application Support/ngrok/ngrok.yml` (MacOS):
@@ -195,7 +195,7 @@ cd /path/to/posthog-code/packages/agent && pnpm build
 | ----------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `modal` (default) | `SANDBOX_PROVIDER=modal`        | Production. Uses the published `@posthog/agent` npm package from the GHCR image.                                                                                                                                                                                                       |
 | `MODAL_DOCKER`    | `SANDBOX_PROVIDER=MODAL_DOCKER` | **Local development with Modal.** Same as `modal` but uses a separate Modal app (`posthog-sandbox-modal-docker-*`) so local image builds don't pollute the production app cache. When `LOCAL_POSTHOG_CODE_MONOREPO_ROOT` is set, the local agent packages are overlaid onto the image. |
-| `docker`          | `SANDBOX_PROVIDER=docker`       | Local-only Docker containers (`DEBUG=True` required). No Modal account needed.                                                                                                                                                                                                         |
+| `docker`          | `SANDBOX_PROVIDER=docker`       | Local-only Docker containers (`DEBUG=True` required). No Modal account needed. This is the recommended option for local development.                                                                                                                                                   |
 
 ### Optional: local repository mounts (Docker only)
 


### PR DESCRIPTION
tasks page isn’t visible in ui