### PR TITLE
fix(cdp): disable hog functions when their integration is deleted

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5785,6 +5785,11 @@ const api = {
         async delete(integrationId: IntegrationType['id']): Promise<IntegrationType> {
             return await new ApiRequest().integration(integrationId).delete()
         },
+        async dependentHogFunctions(
+            integrationId: IntegrationType['id']
+        ): Promise<{ id: string; name: string; enabled: boolean; type: string }[]> {
+            return await new ApiRequest().integration(integrationId).withAction('dependent_hog_functions').get()
+        },
         async list(): Promise<PaginatedResponse<IntegrationType>> {
             return await new ApiRequest().integrations().get()
         },

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -355,10 +355,21 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 return
             }
 
+            let dependentFunctions: { id: string; name: string; enabled: boolean; type: string }[] = []
+            try {
+                dependentFunctions = await api.integrations.dependentHogFunctions(id)
+            } catch {
+                // If the endpoint fails, proceed without the list
+            }
+
+            const enabledDependents = dependentFunctions.filter((f) => f.enabled)
+            const description = enabledDependents.length
+                ? `The following destinations will be disabled:\n\n${enabledDependents.map((f) => `• ${f.name}`).join('\n')}\n\nThis cannot be undone.`
+                : 'This cannot be undone. PostHog resources configured to use this integration will remain but will stop working.'
+
             LemonDialog.open({
                 title: `Do you want to disconnect from this ${integration.kind} integration?`,
-                description:
-                    'This cannot be undone. PostHog resources configured to use this integration will remain but will stop working.',
+                description,
                 primaryButton: {
                     children: 'Yes, disconnect',
                     status: 'danger',

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -614,6 +614,7 @@ class IntegrationViewSet(
         "anthropic_managed_agents",
         "anthropic_managed_agent_environments",
         "anthropic_managed_agent_vaults",
+        "dependent_hog_functions",
     ]
     scope_object_write_actions = [
         "create",
@@ -647,7 +648,30 @@ class IntegrationViewSet(
             return [GitHubRepositoryRefreshThrottle(), *super().get_throttles()]
         return super().get_throttles()
 
-    def perform_destroy(self, instance) -> None:
+    @staticmethod
+    def _get_dependent_hog_functions(integration: Integration) -> list:
+        """Find active hog functions that reference this integration ID in their inputs."""
+        from posthog.models.hog_functions.hog_function import HogFunction
+
+        candidates = HogFunction.objects.filter(
+            team=integration.team,
+            deleted=False,
+        )
+
+        integration_id = integration.id
+        return [
+            hf
+            for hf in candidates
+            if hf.inputs
+            and any(
+                isinstance(input_val, dict) and input_val.get("value") == integration_id
+                for input_val in hf.inputs.values()
+            )
+        ]
+
+    def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        instance = self.get_object()
+
         if instance.kind == "stripe":
             try:
                 stripe_integration = StripeIntegration(instance)
@@ -655,7 +679,46 @@ class IntegrationViewSet(
             except Exception as e:
                 capture_exception(e)
 
-        super().perform_destroy(instance)
+        # Find and disable any hog functions that depend on this integration.
+        dependent_functions = self._get_dependent_hog_functions(instance)
+        disabled_functions = [hf for hf in dependent_functions if hf.enabled]
+
+        if disabled_functions:
+            from posthog.models.hog_functions.hog_function import HogFunction
+
+            function_ids = [hf.id for hf in disabled_functions]
+            HogFunction.objects.filter(id__in=function_ids).update(enabled=False)
+            logger.info(
+                "Disabled hog functions dependent on deleted integration",
+                integration_id=instance.id,
+                integration_kind=instance.kind,
+                disabled_count=len(function_ids),
+                function_ids=[str(fid) for fid in function_ids],
+            )
+
+        instance.delete()
+
+        return Response(status=204)
+
+    @extend_schema(
+        responses={200: None},
+        description="List hog functions that depend on this integration and would be disabled if it is deleted.",
+    )
+    @action(methods=["GET"], detail=True)
+    def dependent_hog_functions(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        instance = self.get_object()
+        dependent = self._get_dependent_hog_functions(instance)
+        return Response(
+            [
+                {
+                    "id": str(hf.id),
+                    "name": hf.name,
+                    "enabled": hf.enabled,
+                    "type": hf.type,
+                }
+                for hf in dependent
+            ]
+        )
 
     @action(methods=["GET"], detail=False)
     def authorize(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -2,6 +2,7 @@ import re
 import hmac
 import json
 import time
+import uuid
 import hashlib
 from datetime import timedelta
 
@@ -18,6 +19,7 @@ from rest_framework import status
 
 from posthog.api.integration import IntegrationViewSet
 from posthog.api.oauth.test_dcr import generate_rsa_key
+from posthog.models.hog_functions.hog_function import HogFunction
 from posthog.models.integration import (
     ERROR_TOKEN_REFRESH_FAILED,
     GITHUB_REPOSITORY_REFRESH_COOLDOWN_SECONDS,
@@ -2935,3 +2937,161 @@ class TestAnthropicIntegration:
         body = response.json()
         assert body["vaults"] == [{"id": "vault_1", "display_name": "Customer secrets"}]
         assert body["has_more"] is False
+
+
+class TestIntegrationDeletionDisablesHogFunctions:
+    @pytest.fixture(autouse=True)
+    def setup_environment(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_and_join(
+            self.organization, "test@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
+        )
+
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            config={"authed_user": {"id": "test_user_id"}},
+            sensitive_config={"access_token": "test-token"},
+        )
+
+    def _create_hog_function(self, integration_id: int, *, enabled: bool = True, deleted: bool = False) -> HogFunction:
+        return HogFunction.objects.create(
+            id=uuid.uuid4(),
+            team=self.team,
+            name=f"Alert using integration {integration_id}",
+            hog="return event",
+            type="internal_destination",
+            enabled=enabled,
+            deleted=deleted,
+            inputs={"slack": {"value": integration_id}},
+            inputs_schema=[{"key": "slack", "type": "integration", "required": True}],
+        )
+
+    def test_deleting_integration_disables_dependent_hog_functions(self, client: HttpClient):
+        hf = self._create_hog_function(self.integration.id)
+
+        client.force_login(self.user)
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        hf.refresh_from_db()
+        assert hf.enabled is False
+
+    def test_deleting_integration_does_not_affect_unrelated_hog_functions(self, client: HttpClient):
+        other_integration = Integration.objects.create(
+            team=self.team,
+            kind="linear",
+            config={},
+            sensitive_config={},
+        )
+        hf_other = self._create_hog_function(other_integration.id)
+
+        client.force_login(self.user)
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        hf_other.refresh_from_db()
+        assert hf_other.enabled is True
+
+    def test_deleting_integration_skips_already_deleted_hog_functions(self, client: HttpClient):
+        hf_deleted = self._create_hog_function(self.integration.id, deleted=True)
+
+        client.force_login(self.user)
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        hf_deleted.refresh_from_db()
+        # Should remain unchanged — already soft-deleted
+        assert hf_deleted.enabled is True
+        assert hf_deleted.deleted is True
+
+    def test_deleting_integration_skips_already_disabled_hog_functions(self, client: HttpClient):
+        hf_disabled = self._create_hog_function(self.integration.id, enabled=False)
+
+        client.force_login(self.user)
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        hf_disabled.refresh_from_db()
+        assert hf_disabled.enabled is False
+
+    def test_deleting_integration_disables_multiple_dependent_functions(self, client: HttpClient):
+        hf1 = self._create_hog_function(self.integration.id)
+        hf2 = self._create_hog_function(self.integration.id)
+        hf1.name = "First alert"
+        hf1.save()
+        hf2.name = "Second alert"
+        hf2.save()
+
+        client.force_login(self.user)
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        hf1.refresh_from_db()
+        hf2.refresh_from_db()
+        assert hf1.enabled is False
+        assert hf2.enabled is False
+
+    def test_dependent_hog_functions_endpoint_returns_functions(self, client: HttpClient):
+        hf = self._create_hog_function(self.integration.id)
+
+        client.force_login(self.user)
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/dependent_hog_functions/"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["id"] == str(hf.id)
+        assert data[0]["name"] == hf.name
+        assert data[0]["enabled"] is True
+        assert data[0]["type"] == "internal_destination"
+
+    def test_dependent_hog_functions_endpoint_excludes_deleted(self, client: HttpClient):
+        self._create_hog_function(self.integration.id, deleted=True)
+
+        client.force_login(self.user)
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/dependent_hog_functions/"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()) == 0
+
+    def test_dependent_hog_functions_endpoint_returns_empty_when_none(self, client: HttpClient):
+        client.force_login(self.user)
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/dependent_hog_functions/"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    def test_deleting_integration_does_not_affect_other_teams(self, client: HttpClient):
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        Integration.objects.create(
+            team=other_team,
+            kind="slack",
+            config={},
+            sensitive_config={},
+        )
+        # Create a function on the other team that happens to reference the same integration ID
+        hf_other_team = HogFunction.objects.create(
+            id=uuid.uuid4(),
+            team=other_team,
+            name="Other team alert",
+            hog="return event",
+            type="internal_destination",
+            enabled=True,
+            inputs={"slack": {"value": self.integration.id}},
+            inputs_schema=[{"key": "slack", "type": "integration", "required": True}],
+        )
+
+        client.force_login(self.user)
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        hf_other_team.refresh_from_db()
+        assert hf_other_team.enabled is True

--- a/products/integrations/frontend/generated/api.ts
+++ b/products/integrations/frontend/generated/api.ts
@@ -346,6 +346,24 @@ export const integrationsClickupWorkspacesRetrieve = async (
     })
 }
 
+export const getIntegrationsDependentHogFunctionsRetrieveUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/integrations/${id}/dependent_hog_functions/`
+}
+
+/**
+ * List hog functions that depend on this integration and would be disabled if it is deleted.
+ */
+export const integrationsDependentHogFunctionsRetrieve = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getIntegrationsDependentHogFunctionsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
 export const getIntegrationsEmailPartialUpdateUrl = (projectId: string, id: number) => {
     return `/api/projects/${projectId}/integrations/${id}/email/`
 }

--- a/products/integrations/mcp/tools.yaml
+++ b/products/integrations/mcp/tools.yaml
@@ -85,6 +85,9 @@ tools:
     integrations-create:
         operation: integrations_create
         enabled: false
+    integrations-dependent-hog-functions-retrieve:
+        operation: integrations_dependent_hog_functions_retrieve
+        enabled: false
     integrations-domain-connect-apply-url-create:
         operation: integrations_domain_connect_apply_url_create
         enabled: false


### PR DESCRIPTION
When a user disconnects an integration (e.g. Linear, Slack), the underlying hog functions that reference it were left enabled. They continued running, failing on every invocation, and triggering daily digest failure alert emails — even though the user believed they had removed the integration.

Now, deleting an integration also disables all hog functions that reference it via their inputs. A new `dependent_hog_functions` endpoint lets the frontend show which functions will be affected before the user confirms the disconnect.

<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
