### PR TITLE
perf(error-tracking): cache proguard lookup data

### DIFF
--- a/rust/cymbal/src/langs/java.rs
+++ b/rust/cymbal/src/langs/java.rs
@@ -79,7 +79,7 @@ impl RawJavaFrame {
     {
         let r = self.get_ref()?;
         let map: Arc<FetchedMapping> = catalog.lookup(team_id, r.clone()).await?;
-        let mapper = map.get_mapper();
+        let cache = map.get_cache()?;
 
         let frame = match self.filename.as_ref() {
             Some(file) => StackFrame::with_file(
@@ -95,7 +95,7 @@ impl RawJavaFrame {
             ),
         };
 
-        let res: Vec<Frame> = mapper
+        let res: Vec<Frame> = cache
             .remap_frame(&frame)
             .map(|re| (self, re).into())
             .collect();
@@ -138,9 +138,7 @@ impl RawJavaFrame {
     {
         let r = self.get_ref()?;
         let map: Arc<FetchedMapping> = catalog.lookup(team_id, r.clone()).await?;
-        let mapper = map.get_mapper();
-        let result = mapper.remap_class(class).map(|s| s.to_string());
-        Ok(result)
+        Ok(map.remap_class(class)?)
     }
 }
 

--- a/rust/cymbal/src/stages/resolution/symbol/local.rs
+++ b/rust/cymbal/src/stages/resolution/symbol/local.rs
@@ -161,10 +161,8 @@ impl SymbolResolver for LocalSymbolResolver {
         class: String,
     ) -> Result<String, ResolveError> {
         let map: Arc<FetchedMapping> = self.catalog.pg.lookup(team_id, symbolset_ref).await?;
-        let mapper = map.get_mapper();
-        let result = mapper
-            .remap_class(class.as_str())
-            .map(|s| s.to_string())
+        let result = map
+            .remap_class(class.as_str())?
             .ok_or(ProguardError::MissingClass)?;
         Ok(result)
     }

--- a/rust/cymbal/src/symbol_store/proguard.rs
+++ b/rust/cymbal/src/symbol_store/proguard.rs
@@ -9,14 +9,12 @@ use crate::{
 };
 
 pub struct FetchedMapping {
-    inner: ProguardMapping,
-    /// Decompressed byte count from the symbol_data container, used for cache memory accounting.
-    decompressed_bytes: usize,
+    cache_bytes: Vec<u8>,
 }
 
 impl Countable for FetchedMapping {
     fn byte_count(&self) -> usize {
-        self.decompressed_bytes
+        self.cache_bytes.len()
     }
 }
 
@@ -55,28 +53,68 @@ impl Parser for ProguardProvider {
 }
 
 impl FetchedMapping {
-    pub fn new(inner: ProguardMapping, decompressed_bytes: usize) -> Result<Self, ProguardError> {
-        // Map construction is basically free, so we hold onto the underlying data
-        // and re-construct it as needed
+    pub fn new(inner: ProguardMapping, _decompressed_bytes: usize) -> Result<Self, ProguardError> {
         let mapping = proguard::ProguardMapping::new(inner.content.as_bytes());
         if !mapping.is_valid() {
             return Err(ProguardError::InvalidMapping);
         }
-        Ok(Self {
-            inner,
-            decompressed_bytes,
-        })
+
+        let mut cache_bytes = Vec::new();
+        proguard::ProguardCache::write(&mapping, &mut cache_bytes)
+            .map_err(|_| ProguardError::InvalidMapping)?;
+        proguard::ProguardCache::parse(&cache_bytes).map_err(|_| ProguardError::InvalidMapping)?;
+
+        Ok(Self { cache_bytes })
     }
 
-    pub fn get_mapper<'a>(&'a self) -> proguard::ProguardMapper<'a> {
-        let mapping = proguard::ProguardMapping::new(self.inner.content.as_bytes());
-        let mapper = proguard::ProguardMapper::new(mapping);
-        mapper
+    pub fn get_cache<'a>(&'a self) -> Result<proguard::ProguardCache<'a>, ProguardError> {
+        proguard::ProguardCache::parse(&self.cache_bytes).map_err(|_| ProguardError::InvalidMapping)
+    }
+
+    pub fn remap_class(&self, class: &str) -> Result<Option<String>, ProguardError> {
+        Ok(self
+            .get_cache()?
+            .remap_class(class)
+            .map(ToString::to_string))
     }
 }
 
 impl Display for ProguardRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ProguardRef")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use posthog_symbol_data::write_symbol_data;
+
+    use super::*;
+
+    const PROGUARD_MAP: &str = include_str!("../../tests/static/proguard/mapping_example.txt");
+
+    #[test]
+    fn fetched_mapping_uses_proguard_cache_for_lookups() {
+        let source = write_symbol_data(ProguardMapping {
+            content: PROGUARD_MAP.to_string(),
+        })
+        .unwrap();
+        let (mapping, byte_count): (ProguardMapping, usize) =
+            read_symbol_data_with_byte_count(source).unwrap();
+        let fetched = FetchedMapping::new(mapping, byte_count).unwrap();
+
+        assert_eq!(
+            fetched.remap_class("a1.c").unwrap(),
+            Some("com.posthog.android.sample.MyCustomException3".to_string())
+        );
+
+        let cache = fetched.get_cache().unwrap();
+        let frame = proguard::StackFrame::with_file("a1.d", "onClick", 14, "SourceFile");
+        let remapped: Vec<_> = cache.remap_frame(&frame).collect();
+
+        assert!(remapped.iter().any(|frame| {
+            frame.class() == "com.posthog.android.sample.MyCustomException3"
+                && frame.method() == "<init>"
+        }));
     }
 }


### PR DESCRIPTION
## Summary
- store Proguard mappings as `proguard::ProguardCache` bytes after symbol-set load
- use cached Proguard lookup data for Java frame and exception class remapping
- add a focused Proguard cache lookup test covering class and frame remapping

## Context
Prod Cymbal profiles showed repeated `ProguardMapper::create_proguard_mapper` / `ParsedProguardMapping::parse` CPU while processing Android exceptions. The old path cached raw mapping content but rebuilt the mapper per frame/class lookup, so large R8 mappings could be reparsed many times per exception.

## Test plan
- `cargo test -p cymbal`
