### PR TITLE
chore(hogql): trace top-level steps of create_hogql_database

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1,7 +1,6 @@
 import dataclasses
 from collections import defaultdict
-from collections.abc import Callable, Iterator, Sequence
-from contextlib import contextmanager
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -154,12 +153,6 @@ if TYPE_CHECKING:
     from posthog.rbac.user_access_control import UserAccessControl
 
 tracer = trace.get_tracer(__name__)
-
-
-@contextmanager
-def _traced_measure(name: str, timings: HogQLTimings) -> Iterator[None]:
-    with tracer.start_as_current_span(name), timings.measure(name):
-        yield
 
 
 @dataclasses.dataclass
@@ -839,7 +832,7 @@ class Database(BaseModel):
 
         from products.data_warehouse.backend.models import DataWarehouseJoin, DataWarehouseSavedQuery
 
-        with _traced_measure("team", timings):
+        with timings.measure("team", emit_span=True):
             if team_id is None and team is None:
                 raise ValueError("Either team_id or team must be provided")
 
@@ -856,7 +849,7 @@ class Database(BaseModel):
             span = trace.get_current_span()
             span.set_attribute("team_id", team.pk)
 
-        with _traced_measure("feature_flags", timings):
+        with timings.measure("feature_flags", emit_span=True):
             is_managed_viewset_enabled = posthoganalytics.feature_enabled(
                 "managed-viewsets",
                 str(team.uuid),
@@ -875,7 +868,7 @@ class Database(BaseModel):
                 send_feature_flag_events=False,
             )
 
-        with _traced_measure("database", timings):
+        with timings.measure("database", emit_span=True):
             database = Database(
                 timezone=team.timezone,
                 week_start_day=team.week_start_day,
@@ -896,7 +889,7 @@ class Database(BaseModel):
                 if direct_source is not None:
                     database._direct_connection_metadata = direct_source.connection_metadata
 
-        with _traced_measure("filter_system_tables_for_user", timings):
+        with timings.measure("filter_system_tables_for_user", emit_span=True):
             if team is not None:
                 is_hogql_access_control_enabled = posthoganalytics.feature_enabled(
                     "hogql-access-control",
@@ -914,7 +907,7 @@ class Database(BaseModel):
                     else:
                         database._filter_all_scoped_system_tables()
 
-        with _traced_measure("modifiers", timings):
+        with timings.measure("modifiers", emit_span=True):
             modifiers = create_default_modifiers_for_team(team, modifiers)
 
             if not database._is_direct_query():
@@ -945,7 +938,7 @@ class Database(BaseModel):
 
                 _use_error_tracking_issue_id_from_error_tracking_issue_overrides(database)
 
-        with _traced_measure("session_table", timings):
+        with timings.measure("session_table", emit_span=True):
             if not database._is_direct_query() and (
                 modifiers.sessionTableVersion == SessionTableVersion.V2
                 or modifiers.sessionTableVersion == SessionTableVersion.AUTO
@@ -1007,11 +1000,11 @@ class Database(BaseModel):
                 )
                 cast(LazyJoin, raw_replay_events.fields["events"]).join_table = events_table
 
-        with _traced_measure("virtual_fields", timings):
+        with timings.measure("virtual_fields", emit_span=True):
             if not database._is_direct_query():
                 _use_virtual_fields(database, modifiers, timings)
 
-        with _traced_measure("group_type_mapping", timings):
+        with timings.measure("group_type_mapping", emit_span=True):
             if not database._is_direct_query():
                 group_types = get_group_types_for_project(team.project_id)
                 _setup_group_key_fields(database, group_types)
@@ -1027,7 +1020,7 @@ class Database(BaseModel):
         self_managed_warehouse_tables: TableNode = TableNode()
         views: TableNode = TableNode()
         warehouse_tables_to_process: list[tuple[Table, DataWarehouseTable]] = []
-        with _traced_measure("data_warehouse_saved_query", timings):
+        with timings.measure("data_warehouse_saved_query", emit_span=True):
             if database._is_direct_query():
                 queryset = DataWarehouseSavedQuery.objects.filter(team_id=team.pk).exclude(deleted=True)
                 if not is_managed_viewset_enabled:
@@ -1055,7 +1048,7 @@ class Database(BaseModel):
                             table_conflict_mode="ignore",
                         )
 
-        with _traced_measure("endpoint_saved_query", timings):
+        with timings.measure("endpoint_saved_query", emit_span=True):
             if not database._is_direct_query():
                 endpoint_saved_queries = []
                 try:
@@ -1077,7 +1070,7 @@ class Database(BaseModel):
                 except Exception as e:
                     capture_exception(e)
 
-        with _traced_measure("revenue_analytics_views", timings):
+        with timings.measure("revenue_analytics_views", emit_span=True):
             if not database._is_direct_query():
                 revenue_views: list[RevenueAnalyticsBaseView] = []
                 try:
@@ -1098,7 +1091,7 @@ class Database(BaseModel):
                         capture_exception(e)
                         continue
 
-        with _traced_measure("data_warehouse_tables", timings):
+        with timings.measure("data_warehouse_tables", emit_span=True):
 
             class WarehousePropertiesVirtualTable(VirtualTable):
                 fields: dict[str, FieldOrTable]
@@ -1274,7 +1267,7 @@ class Database(BaseModel):
             return root_node
 
         if modifiers.dataWarehouseEventsModifiers:
-            with _traced_measure("data_warehouse_event_modifiers", timings):
+            with timings.measure("data_warehouse_event_modifiers", emit_span=True):
                 for warehouse_modifier in modifiers.dataWarehouseEventsModifiers:
                     with timings.measure(f"data_warehouse_event_modifier_{warehouse_modifier.table_name}"):
                         # Apply mappings to every matching namespace. A saved query and a warehouse table can share a
@@ -1309,7 +1302,7 @@ class Database(BaseModel):
         database._add_warehouse_self_managed_tables(self_managed_warehouse_tables)
         database._add_views(views)
 
-        with _traced_measure("warehouse_foreign_keys", timings):
+        with timings.measure("warehouse_foreign_keys", emit_span=True):
             for hogql_table, warehouse_table_model in warehouse_tables_to_process:
                 add_postgres_foreign_key_lazy_joins(
                     hogql_table=hogql_table,
@@ -1318,7 +1311,7 @@ class Database(BaseModel):
                     schemas=_get_active_external_data_schemas(warehouse_table_model),
                 )
 
-        with _traced_measure("data_warehouse_joins", timings):
+        with timings.measure("data_warehouse_joins", emit_span=True):
             for join in DataWarehouseJoin.objects.filter(team_id=team.pk).exclude(deleted=True):
                 # Skip if either table is not present. This can happen if the table was deleted after the join was created.
                 # User will be prompted on UI to resolve missing tables underlying the JOIN

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1,6 +1,7 @@
 import dataclasses
 from collections import defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -153,6 +154,12 @@ if TYPE_CHECKING:
     from posthog.rbac.user_access_control import UserAccessControl
 
 tracer = trace.get_tracer(__name__)
+
+
+@contextmanager
+def _traced_measure(name: str, timings: HogQLTimings) -> Iterator[None]:
+    with tracer.start_as_current_span(name), timings.measure(name):
+        yield
 
 
 @dataclasses.dataclass
@@ -832,7 +839,7 @@ class Database(BaseModel):
 
         from products.data_warehouse.backend.models import DataWarehouseJoin, DataWarehouseSavedQuery
 
-        with timings.measure("team"):
+        with _traced_measure("team", timings):
             if team_id is None and team is None:
                 raise ValueError("Either team_id or team must be provided")
 
@@ -849,7 +856,7 @@ class Database(BaseModel):
             span = trace.get_current_span()
             span.set_attribute("team_id", team.pk)
 
-        with timings.measure("feature_flags"):
+        with _traced_measure("feature_flags", timings):
             is_managed_viewset_enabled = posthoganalytics.feature_enabled(
                 "managed-viewsets",
                 str(team.uuid),
@@ -868,7 +875,7 @@ class Database(BaseModel):
                 send_feature_flag_events=False,
             )
 
-        with timings.measure("database"):
+        with _traced_measure("database", timings):
             database = Database(
                 timezone=team.timezone,
                 week_start_day=team.week_start_day,
@@ -889,7 +896,7 @@ class Database(BaseModel):
                 if direct_source is not None:
                     database._direct_connection_metadata = direct_source.connection_metadata
 
-        with timings.measure("filter_system_tables_for_user"):
+        with _traced_measure("filter_system_tables_for_user", timings):
             if team is not None:
                 is_hogql_access_control_enabled = posthoganalytics.feature_enabled(
                     "hogql-access-control",
@@ -907,7 +914,7 @@ class Database(BaseModel):
                     else:
                         database._filter_all_scoped_system_tables()
 
-        with timings.measure("modifiers"):
+        with _traced_measure("modifiers", timings):
             modifiers = create_default_modifiers_for_team(team, modifiers)
 
             if not database._is_direct_query():
@@ -938,7 +945,7 @@ class Database(BaseModel):
 
                 _use_error_tracking_issue_id_from_error_tracking_issue_overrides(database)
 
-        with timings.measure("session_table"):
+        with _traced_measure("session_table", timings):
             if not database._is_direct_query() and (
                 modifiers.sessionTableVersion == SessionTableVersion.V2
                 or modifiers.sessionTableVersion == SessionTableVersion.AUTO
@@ -1000,11 +1007,11 @@ class Database(BaseModel):
                 )
                 cast(LazyJoin, raw_replay_events.fields["events"]).join_table = events_table
 
-        with timings.measure("virtual_fields"):
+        with _traced_measure("virtual_fields", timings):
             if not database._is_direct_query():
                 _use_virtual_fields(database, modifiers, timings)
 
-        with timings.measure("group_type_mapping"):
+        with _traced_measure("group_type_mapping", timings):
             if not database._is_direct_query():
                 group_types = get_group_types_for_project(team.project_id)
                 _setup_group_key_fields(database, group_types)
@@ -1020,7 +1027,7 @@ class Database(BaseModel):
         self_managed_warehouse_tables: TableNode = TableNode()
         views: TableNode = TableNode()
         warehouse_tables_to_process: list[tuple[Table, DataWarehouseTable]] = []
-        with timings.measure("data_warehouse_saved_query"):
+        with _traced_measure("data_warehouse_saved_query", timings):
             if database._is_direct_query():
                 queryset = DataWarehouseSavedQuery.objects.filter(team_id=team.pk).exclude(deleted=True)
                 if not is_managed_viewset_enabled:
@@ -1048,7 +1055,7 @@ class Database(BaseModel):
                             table_conflict_mode="ignore",
                         )
 
-        with timings.measure("endpoint_saved_query"):
+        with _traced_measure("endpoint_saved_query", timings):
             if not database._is_direct_query():
                 endpoint_saved_queries = []
                 try:
@@ -1070,7 +1077,7 @@ class Database(BaseModel):
                 except Exception as e:
                     capture_exception(e)
 
-        with timings.measure("revenue_analytics_views"):
+        with _traced_measure("revenue_analytics_views", timings):
             if not database._is_direct_query():
                 revenue_views: list[RevenueAnalyticsBaseView] = []
                 try:
@@ -1091,7 +1098,7 @@ class Database(BaseModel):
                         capture_exception(e)
                         continue
 
-        with timings.measure("data_warehouse_tables"):
+        with _traced_measure("data_warehouse_tables", timings):
 
             class WarehousePropertiesVirtualTable(VirtualTable):
                 fields: dict[str, FieldOrTable]
@@ -1267,7 +1274,7 @@ class Database(BaseModel):
             return root_node
 
         if modifiers.dataWarehouseEventsModifiers:
-            with timings.measure("data_warehouse_event_modifiers"):
+            with _traced_measure("data_warehouse_event_modifiers", timings):
                 for warehouse_modifier in modifiers.dataWarehouseEventsModifiers:
                     with timings.measure(f"data_warehouse_event_modifier_{warehouse_modifier.table_name}"):
                         # Apply mappings to every matching namespace. A saved query and a warehouse table can share a
@@ -1302,7 +1309,7 @@ class Database(BaseModel):
         database._add_warehouse_self_managed_tables(self_managed_warehouse_tables)
         database._add_views(views)
 
-        with timings.measure("warehouse_foreign_keys"):
+        with _traced_measure("warehouse_foreign_keys", timings):
             for hogql_table, warehouse_table_model in warehouse_tables_to_process:
                 add_postgres_foreign_key_lazy_joins(
                     hogql_table=hogql_table,
@@ -1311,7 +1318,7 @@ class Database(BaseModel):
                     schemas=_get_active_external_data_schemas(warehouse_table_model),
                 )
 
-        with timings.measure("data_warehouse_joins"):
+        with _traced_measure("data_warehouse_joins", timings):
             for join in DataWarehouseJoin.objects.filter(team_id=team.pk).exclude(deleted=True):
                 # Skip if either table is not present. This can happen if the table was deleted after the join was created.
                 # User will be prompted on UI to resolve missing tables underlying the JOIN

--- a/posthog/hogql/timings.py
+++ b/posthog/hogql/timings.py
@@ -1,7 +1,11 @@
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from time import perf_counter
 
+from opentelemetry import trace
+
 from posthog.schema import QueryTiming
+
+_tracer = trace.get_tracer(__name__)
 
 TIMING_DECIMAL_PLACES = 3  # round to milliseconds
 
@@ -28,13 +32,15 @@ class HogQLTimings:
         self.timings = {}
 
     @contextmanager
-    def measure(self, key: str):
+    def measure(self, key: str, emit_span: bool = False):
         last_key = self._timing_pointer
         full_key = f"{self._timing_pointer}/{key}"
         self._timing_pointer = full_key
         self._timing_starts[full_key] = perf_counter()
+        span_cm = _tracer.start_as_current_span(key) if emit_span else nullcontext()
         try:
-            yield
+            with span_cm:
+                yield
         finally:
             duration = perf_counter() - self._timing_starts[full_key]
             self.timings[full_key] = self.timings.get(full_key, 0.0) + duration

--- a/products/revenue_analytics/backend/views/orchestrator.py
+++ b/products/revenue_analytics/backend/views/orchestrator.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
-from contextlib import contextmanager
+from collections.abc import Iterable
 from typing import Optional
 
 from django.db.models import Prefetch
-
-from opentelemetry import trace
 
 from posthog.schema import DatabaseSchemaManagedViewTableKind
 
@@ -25,21 +22,13 @@ from products.revenue_analytics.backend.views.sources.registry import BUILDERS
 
 SUPPORTED_SOURCES: list[ExternalDataSourceType] = [ExternalDataSourceType.STRIPE]
 
-tracer = trace.get_tracer(__name__)
-
-
-@contextmanager
-def _traced_measure(name: str, timings: HogQLTimings) -> Iterator[None]:
-    with tracer.start_as_current_span(name), timings.measure(name):
-        yield
-
 
 def _iter_source_handles(team: Team, timings: HogQLTimings) -> Iterable[SourceHandle]:
-    with _traced_measure("for_events", timings):
+    with timings.measure("for_events", emit_span=True):
         for event in team.revenue_analytics_config.events:
             yield SourceHandle(type="events", team=team, event=event)
 
-    with _traced_measure("for_schema_sources", timings):
+    with timings.measure("for_schema_sources", emit_span=True):
         queryset = (
             ExternalDataSource.objects.filter(
                 team_id=team.pk,

--- a/products/revenue_analytics/backend/views/orchestrator.py
+++ b/products/revenue_analytics/backend/views/orchestrator.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from typing import Optional
 
 from django.db.models import Prefetch
+
+from opentelemetry import trace
 
 from posthog.schema import DatabaseSchemaManagedViewTableKind
 
@@ -22,13 +25,21 @@ from products.revenue_analytics.backend.views.sources.registry import BUILDERS
 
 SUPPORTED_SOURCES: list[ExternalDataSourceType] = [ExternalDataSourceType.STRIPE]
 
+tracer = trace.get_tracer(__name__)
+
+
+@contextmanager
+def _traced_measure(name: str, timings: HogQLTimings) -> Iterator[None]:
+    with tracer.start_as_current_span(name), timings.measure(name):
+        yield
+
 
 def _iter_source_handles(team: Team, timings: HogQLTimings) -> Iterable[SourceHandle]:
-    with timings.measure("for_events"):
+    with _traced_measure("for_events", timings):
         for event in team.revenue_analytics_config.events:
             yield SourceHandle(type="events", team=team, event=event)
 
-    with timings.measure("for_schema_sources"):
+    with _traced_measure("for_schema_sources", timings):
         queryset = (
             ExternalDataSource.objects.filter(
                 team_id=team.pk,


### PR DESCRIPTION
## Problem

Some of our hogql timings spans don't have a correspending span in OTEL traces.

## Changes

Let's add them!

AI continues:

- Adds an opt-in `emit_span: bool = False` parameter to `HogQLTimings.measure`. When `True`, the same context manager additionally starts an OpenTelemetry span with the step's short key. The HogQLTimings payload is unchanged in either mode.
- Flips `emit_span=True` on the top-level steps of `Database.create_for` (team lookup, feature flags, filter_system_tables_for_user, modifiers, session_table, virtual_fields, group_type_mapping, data_warehouse_saved_query, endpoint_saved_query, revenue_analytics_views, data_warehouse_tables, data_warehouse_event_modifiers, warehouse_foreign_keys, data_warehouse_joins).
- Flips `emit_span=True` on the two top-level steps inside `build_all_revenue_analytics_views` (`for_events`, `for_schema_sources`).

Per-table, per-saved-query, and per-source-builder inner loops stay on the default `emit_span=False` — for team 2 those would emit hundreds of spans per `/query` call. The new parent spans capture their aggregate cost, and the per-item breakdown is still available in the `HogQLTimings` payload if we ever need it.

## How did you test this code?

I'm an agent (PostHog Code). No manual or browser testing performed. The existing `posthog/hogql/test/test_timings.py` suite (6 tests) passes, and the repo's pre-commit lint / format / `ty` checks ran cleanly. After this lands, validation is: open a `/query` trace from posthog-web-django, find the `create_hogql_database` span, and confirm the new child spans now account for the previously-untraced Python time.

## Publish to changelog?

no

## Docs update

n/a — internal tracing-only change.

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7) in this repo, plus the PostHog MCP for fetching the original traces.
- Investigation started from two traces captured via MCP (a team-2 `create_hogql_database` span at 313 ms and a non-team-2 one at 42 ms). The shape of both — 1 GET + 5 SELECTs as the only child spans — pointed at missing instrumentation rather than at one slow query.
- First iteration used a local `_traced_measure` context manager in each consumer file that wrapped `tracer.start_as_current_span` and `timings.measure`. Switched to an `emit_span` flag on `HogQLTimings.measure` itself so the pattern is reusable across other call sites (e.g. HogQL query execution) without duplicating helpers.
- Considered emitting a span unconditionally from `HogQLTimings.measure`. Rejected because several existing call sites are inside tight per-table / per-saved-query loops where unconditional span emission would explode trace volume for team 2.
- Separately, while reading the trace data we noticed an unrelated N+1 `rbac.access_controls.db + SELECT` pattern on a different `create_hogql_database` call path (no `HogQLQueryExecutor` parent). Not addressed in this PR — flagging for a follow-up.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*