### PR TITLE
fix(caching): add ThresholdMode.LEGACY to staleness_threshold_map

### DIFF
--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -140,6 +140,14 @@ class ThresholdMode(Enum):
 
 
 staleness_threshold_map: dict[ThresholdMode, dict[Optional[str], timedelta]] = {
+    ThresholdMode.LEGACY: {
+        None: timedelta(hours=6),
+        "minute": timedelta(minutes=5),
+        "hour": timedelta(hours=1),
+        "day": timedelta(hours=6),
+        "week": timedelta(days=1),
+        "month": timedelta(days=1),
+    },
     ThresholdMode.DEFAULT: {
         None: timedelta(hours=6),
         "minute": timedelta(minutes=5),


### PR DESCRIPTION
## Problem

`ThresholdMode.LEGACY` is defined in the `ThresholdMode` enum in `posthog/caching/utils.py` but has no corresponding entry in `staleness_threshold_map`. Any call to `cache_target_age()` or `is_stale()` passing `mode=ThresholdMode.LEGACY` raises a `KeyError` at runtime.

Closes #56405

## Changes

Added `ThresholdMode.LEGACY` to `staleness_threshold_map` with the same thresholds as `ThresholdMode.DEFAULT`. LEGACY represents the original pre-mode cache staleness behavior, so DEFAULT thresholds are the correct baseline.

## How did you test this code?

Verified the map now covers all four enum members (`LEGACY`, `DEFAULT`, `LAZY`, `AI`). Ran `ruff check` and `ty check` — both pass clean. The fix is mechanical: adding the missing dict key.

## Publish to changelog?

No

## Docs update

No docs change needed.

## 🤖 Agent context

Spotted the missing enum entry while reviewing the caching utilities. The enum comment `# enum legacy, default, lazy` signaled that LEGACY was always intended to be there. Chose DEFAULT thresholds as the LEGACY values because the enum was introduced when DEFAULT was the only behavior — LEGACY is the pre-split alias for it.