### PR TITLE
fix(llm-analytics): show error state on sentiment API failure

### DIFF
--- a/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
+++ b/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
@@ -312,6 +312,7 @@ export function LLMAnalyticsSentiment(): JSX.Element {
     const {
         generations,
         generationsLoading,
+        generationsError,
         groupedSentimentCards,
         sentimentCards,
         stillAnalyzing,
@@ -327,6 +328,11 @@ export function LLMAnalyticsSentiment(): JSX.Element {
             {generationsLoading && generations.length === 0 ? (
                 <div className="flex items-center justify-center py-20">
                     <Spinner className="text-4xl" captureTime />
+                </div>
+            ) : generationsError ? (
+                <div className="text-center py-20 text-muted">
+                    <p className="text-lg font-medium mb-1">Failed to load generations</p>
+                    <p className="text-sm">There was an error fetching data. Try refreshing the page.</p>
                 </div>
             ) : generations.length === 0 ? (
                 <div className="text-center py-20 text-muted">

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
@@ -304,6 +304,14 @@ export const llmAnalyticsSentimentLogic = kea<llmAnalyticsSentimentLogicType>([
                 loadGenerations: () => true,
             },
         ],
+        generationsError: [
+            false as boolean,
+            {
+                loadGenerations: () => false,
+                loadGenerationsFailure: () => true,
+                loadGenerationsSuccess: () => false,
+            },
+        ],
     }),
 
     loaders(({ values }) => ({


### PR DESCRIPTION
## Problem

When the sentiment generations endpoint (`/api/environments/{id}/llm_analytics/sentiment/generations/`) returns a 500 error, the kea loader dispatches `loadGenerationsFailure` but the `generations` state stays as `[]`. The UI treats `generations.length === 0` as "no data" and renders the empty-state copy ("No generations with user input found"), which misleads users into thinking there is simply nothing to show rather than signalling that something went wrong.

Closes #58341

## Changes

**`llmAnalyticsSentimentLogic.ts`** — add `generationsError` reducer:
- Set to `true` on `loadGenerationsFailure`
- Reset to `false` on `loadGenerations` (new fetch started) and `loadGenerationsSuccess`

**`LLMAnalyticsSentiment.tsx`** — check `generationsError` before the empty-state branch:
- Show "Failed to load generations — try refreshing the page" when the API call errored
- Leave the existing empty-state and loading paths unchanged

## How did you test this code?

Traced the kea loader lifecycle: loaders dispatch `*Failure` actions on thrown errors; kea does not expose a built-in error state on the generated selectors, so the new reducer is the standard kea pattern for this. Ran the frontend formatter (passed).

## Publish to changelog?

No

## Docs update

No docs change needed.

## 🤖 Agent context

Identified the gap by reading the loader definition and the UI branch: `generations === []` covered both the "no data" and "load failed" cases with identical copy. Added a minimal reducer to distinguish the two states without touching the loader logic or the fetch function.