### PR TITLE
fix(flags): allow not_in operator for cohort release conditions

### DIFF
--- a/frontend/src/scenes/feature-flags/cohortPickerProps.ts
+++ b/frontend/src/scenes/feature-flags/cohortPickerProps.ts
@@ -3,10 +3,10 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { PropertyOperator } from '~/types'
 
 /**
- * Picker props for surfaces where cohort filters are restricted to `in` only —
- * feature flag release conditions and workflow event triggers. Hides recents
- * carrying any other cohort operator and renders cohort rows as key-only
- * (the cohort *is* the value, operator is implicit).
+ * Picker props for cohort filters in feature flag release conditions and
+ * workflow event triggers. Renders cohort rows as key-only (the cohort *is*
+ * the value, operator is implicit). Both `in` and `not_in` are supported
+ * by the backend, so neither is excluded here.
  *
  * Three call sites use this preset:
  * - `FeatureFlagReleaseConditions.tsx`
@@ -15,9 +15,9 @@ import { PropertyOperator } from '~/types'
  *
  * Spread into `PropertyFilters` / `TaxonomicPropertyFilter` rather than
  * passing each prop individually so the configuration travels as one named
- * idea and a future change (e.g. allowing `not_in`) edits one place.
+ * idea and a future change edits one place.
  */
 export const COHORTS_ONLY_SUPPORT_IN_PICKER_PROPS = {
-    excludedOperators: { [TaxonomicFilterGroupType.Cohorts]: [PropertyOperator.NotIn] },
+    excludedOperators: { [TaxonomicFilterGroupType.Cohorts]: [] as PropertyOperator[] },
     selectingKeyOnly: { [TaxonomicFilterGroupType.Cohorts]: true },
 }


### PR DESCRIPTION
## Problem

The feature flag release condition UI excludes `PropertyOperator.NotIn` for cohort-type filters, making it impossible to create "user is not in cohort X" rules through the UI even though:

- The backend fully supports the `not_in` operator for cohorts (listed in `user_blast_radius.py` supported operators)
- Conditions created via the API with `not_in` work correctly
- The `PropertyOperator.NotIn` enum value exists and is used everywhere else

Closes #57572

## Changes

Single change in `frontend/src/scenes/feature-flags/cohortPickerProps.ts`:

- Remove `PropertyOperator.NotIn` from the `excludedOperators` array for the cohort group type so the operator appears in the dropdown
- Keep `selectingKeyOnly: true` unchanged — the cohort remains key-only (cohort IS the value, no separate value selection step needed)
- Update the comment (it previously described the restriction as intentional "in only")

The file comment even anticipated this: `a future change (e.g. allowing \`not_in\`) edits one place`.

## How did you test this code?

Traced the picker props through all three call sites (`FeatureFlagReleaseConditions.tsx`, `FeatureFlagReleaseConditionsCollapsible.tsx`, `StepTrigger.tsx`). The `excludedOperators` prop is passed to `TaxonomicPropertyFilter` which filters the operator dropdown — removing `NotIn` from the exclusion list will show it in the dropdown. Backend validation in `user_blast_radius.py` and the feature flag property filter logic already handle `not_in`. Ran formatter (passed).

## Publish to changelog?

No

## Docs update

No docs change needed.

## 🤖 Agent context

Found the exclusion by reading `cohortPickerProps.ts` — the file comment (`a future change (e.g. allowing \`not_in\`) edits one place`) confirmed this was an intentional deferral, not a fundamental limitation. Fix is a one-line removal.