### PR TITLE
chore(taxonomy): document MCP events and properties

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -3344,7 +3344,7 @@
             "label": "MCP feedback submitted"
         },
         "mcp init": {
-            "description": "MCP initialization event emitted by the mcpcat library. Fires alongside mcp_initialize today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_initialize for new dashboards.",
+            "description": "MCP initialization event emitted by the mcpcat library. Fires for all traffic today (alongside mcp_initialize where @posthog/mcp is enabled). Will be retired once @posthog/mcp reaches general availability; until then, filter on this event if you need coverage across all clients, or on mcp_initialize if you only want the @posthog/mcp-enabled slice.",
             "label": "MCP init"
         },
         "mcp organization switched": {
@@ -3356,11 +3356,11 @@
             "label": "MCP project switched"
         },
         "mcp tool call": {
-            "description": "Tool-call event emitted by the mcpcat library. Fires alongside mcp_tool_call today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_tool_call for new dashboards.",
+            "description": "Tool-call event emitted by the mcpcat library. Fires for all traffic today (alongside mcp_tool_call where @posthog/mcp is enabled). Will be retired once @posthog/mcp reaches general availability.",
             "label": "MCP tool call (mcpcat)"
         },
         "mcp tool response": {
-            "description": "Tool-response event emitted by the mcpcat library. Tool responses are also carried inline on mcp_tool_call (under $mcp_response). Will be retired once @posthog/mcp reaches general availability.",
+            "description": "Tool-response event emitted by the mcpcat library. Tool responses are also carried inline on mcp_tool_call (under $mcp_response) for @posthog/mcp-enabled traffic. Will be retired once @posthog/mcp reaches general availability.",
             "label": "MCP tool response (mcpcat)"
         },
         "mcp_custom": {
@@ -3372,11 +3372,11 @@
             "label": "MCP initialize"
         },
         "mcp_mcpcat:identify": {
-            "description": "Identify event emitted by the mcpcat library. Fires alongside posthog_identify today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on posthog_identify for new dashboards.",
+            "description": "Identify event emitted by the mcpcat library. Fires for all traffic today (alongside posthog_identify where @posthog/mcp is enabled). Will be retired once @posthog/mcp reaches general availability.",
             "label": "MCP identify (mcpcat)"
         },
         "mcp_posthog:identify": {
-            "description": "Identify event emitted by PostHog's in-tree MCP analytics path. Fires alongside posthog_identify today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on posthog_identify for new dashboards.",
+            "description": "Identify event emitted by PostHog's in-tree MCP analytics path. Fires for all traffic today (alongside posthog_identify where @posthog/mcp is enabled). Will be retired once @posthog/mcp reaches general availability.",
             "label": "MCP identify (in-tree)"
         },
         "mcp_prompt_get": {
@@ -3400,7 +3400,7 @@
             "label": "MCP tool call"
         },
         "mcp_tool_called": {
-            "description": "Tool-call event emitted by PostHog's in-tree MCP analytics path. Fires alongside mcp_tool_call today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_tool_call for new dashboards.",
+            "description": "Tool-call event emitted by PostHog's in-tree MCP analytics path. Fires for all traffic today (alongside mcp_tool_call where @posthog/mcp is enabled). Will be retired once @posthog/mcp reaches general availability; until then, filter on this event if you need coverage across all clients, or on mcp_tool_call if you only want the @posthog/mcp-enabled slice.",
             "label": "MCP tool called (in-tree)"
         },
         "mcp_tools_list": {

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -659,19 +659,34 @@
             "label": "AI Tags (LLM)"
         },
         "$ai_target_event_id": {
-            "description": "The unique identifier of the event being evaluated.",
+            "description": "Deprecated \u2014 use $ai_target_id with $ai_target_type instead. The unique identifier of the event being evaluated.",
             "examples": [
                 "c9222e05-8708-41b8-98ea-d4a21849e761"
             ],
             "label": "AI Target Event ID (LLM)"
         },
         "$ai_target_event_type": {
-            "description": "The type of event being evaluated (e.g., $ai_generation).",
+            "description": "Deprecated \u2014 use $ai_target_type instead. The type of event being evaluated (e.g., $ai_generation).",
             "examples": [
                 "$ai_generation",
                 "$ai_span"
             ],
             "label": "AI Target Event Type (LLM)"
+        },
+        "$ai_target_id": {
+            "description": "Identifier of the entity this evaluation targets. Pair with $ai_target_type to know which ID space it belongs to (event UUID, trace ID, etc.).",
+            "examples": [
+                "c9222e05-8708-41b8-98ea-d4a21849e761"
+            ],
+            "label": "AI Target ID (LLM)"
+        },
+        "$ai_target_type": {
+            "description": "ID space of $ai_target_id. `generation_uuid` resolves against `events.uuid`; `trace_id` resolves against the `$ai_trace_id` property.",
+            "examples": [
+                "generation_uuid",
+                "trace_id"
+            ],
+            "label": "AI Target Type (LLM)"
         },
         "$ai_temperature": {
             "description": "The temperature parameter used in the request to the LLM API.",
@@ -1803,6 +1818,86 @@
             ],
             "label": "Locale"
         },
+        "$mcp_client_name": {
+            "description": "The MCP client that initiated the connection.",
+            "examples": [
+                "claude-code",
+                "codex-mcp-client",
+                "Anthropic/ClaudeAI"
+            ],
+            "label": "MCP client name"
+        },
+        "$mcp_client_version": {
+            "description": "The version of the MCP client that initiated the connection.",
+            "label": "MCP client version"
+        },
+        "$mcp_duration_ms": {
+            "description": "Wall-clock duration of the MCP tool/resource call in milliseconds.",
+            "examples": [
+                42,
+                1280
+            ],
+            "label": "MCP duration (ms)",
+            "type": "Numeric"
+        },
+        "$mcp_intent": {
+            "description": "Free-text description of why the agent is calling this tool. Comes from the client-supplied context argument when present, otherwise from the server's intentFallback callback.",
+            "examples": [
+                "Listing recent error tracking issues to triage a spike in 500s.",
+                "Fetching the trace referenced by the inbox signal to inspect the user message."
+            ],
+            "label": "MCP intent"
+        },
+        "$mcp_intent_source": {
+            "description": "Where $mcp_intent came from. context_parameter means the client supplied it explicitly; inferred means the server's intentFallback produced it.",
+            "examples": [
+                "context_parameter",
+                "inferred"
+            ],
+            "label": "MCP intent source"
+        },
+        "$mcp_is_error": {
+            "description": "Whether the MCP tool call failed (set from the tool result or a thrown exception).",
+            "label": "MCP is error"
+        },
+        "$mcp_parameters": {
+            "description": "Sanitized MCP request payload (tool arguments). Large strings and sensitive keys are redacted before capture.",
+            "label": "MCP parameters"
+        },
+        "$mcp_resource_name": {
+            "description": "The name of the MCP resource, prompt, or tool the event refers to.",
+            "label": "MCP resource name"
+        },
+        "$mcp_response": {
+            "description": "Sanitized MCP tool response. Large strings and sensitive keys are redacted before capture.",
+            "label": "MCP response"
+        },
+        "$mcp_server_name": {
+            "description": "The advertised name of the MCP server that handled the request.",
+            "examples": [
+                "PostHog"
+            ],
+            "label": "MCP server name"
+        },
+        "$mcp_server_version": {
+            "description": "The advertised version of the MCP server that handled the request.",
+            "label": "MCP server version"
+        },
+        "$mcp_source": {
+            "description": "Constant identifier for the MCP analytics SDK that emitted the event.",
+            "examples": [
+                "posthog_mcp_analytics"
+            ],
+            "label": "MCP source"
+        },
+        "$mcp_tool_name": {
+            "description": "The name of the MCP tool that was invoked. Only present on mcp_tool_call.",
+            "examples": [
+                "execute-sql",
+                "feature-flag-get-all"
+            ],
+            "label": "MCP tool name"
+        },
         "$network_bluetooth": {
             "description": "Whether the user was on Bluetooth when the event was sent.",
             "examples": [
@@ -2808,6 +2903,11 @@
             ],
             "label": "Distinct ID"
         },
+        "duration_ms": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_duration_ms.",
+            "label": "Duration (ms, legacy)",
+            "type": "Numeric"
+        },
         "epik": {
             "description": "Pinterest Click ID",
             "label": "epik"
@@ -2848,6 +2948,10 @@
             "description": "Impact Click ID",
             "label": "irclid"
         },
+        "is_error": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_is_error.",
+            "label": "Is error (legacy)"
+        },
         "li_fat_id": {
             "description": "LinkedIn First-Party Ad Tracking ID",
             "label": "li_fat_id"
@@ -2855,6 +2959,64 @@
         "mc_cid": {
             "description": "Mailchimp Campaign ID",
             "label": "mc_cid"
+        },
+        "mcp_client_name": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_name.",
+            "examples": [
+                "claude-code",
+                "codex-mcp-client"
+            ],
+            "label": "MCP client name (legacy)"
+        },
+        "mcp_client_version": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_version.",
+            "label": "MCP client version (legacy)"
+        },
+        "mcp_consumer": {
+            "description": "The upstream surface that initiated the MCP request (e.g. posthog-code for PostHog Code, slack for Slack-launched runs).",
+            "examples": [
+                "posthog-code",
+                "slack"
+            ],
+            "label": "MCP consumer"
+        },
+        "mcp_mode": {
+            "description": "The MCP server mode (e.g. single-exec for the v2 wrapper, multi-tool for the legacy roster).",
+            "label": "MCP mode"
+        },
+        "mcp_oauth_client_name": {
+            "description": "The OAuth client name captured during the MCP handshake, when present.",
+            "label": "MCP OAuth client name"
+        },
+        "mcp_protocol_version": {
+            "description": "The MCP protocol version negotiated during initialize.",
+            "label": "MCP protocol version"
+        },
+        "mcp_region": {
+            "description": "The region the MCP server resolved for the request (e.g. us, eu).",
+            "examples": [
+                "us",
+                "eu"
+            ],
+            "label": "MCP region"
+        },
+        "mcp_transport": {
+            "description": "The transport used by the MCP client (e.g. stdio, sse, streamable_http).",
+            "examples": [
+                "stdio",
+                "sse",
+                "streamable_http"
+            ],
+            "label": "MCP transport"
+        },
+        "mcp_version": {
+            "description": "Server-resolved MCP version (1 or 2). May differ from the client-reported version because of the mcp-version-2 feature flag.",
+            "examples": [
+                1,
+                2
+            ],
+            "label": "MCP server version (internal)",
+            "type": "Numeric"
         },
         "msclkid": {
             "description": "Microsoft Click ID",
@@ -2889,6 +3051,10 @@
             ],
             "label": "Referrer application"
         },
+        "resource_name": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_resource_name.",
+            "label": "Resource name (legacy)"
+        },
         "revenue": {
             "description": "The revenue associated with the event. By default, this is in USD, but the currency property can be used to specify a different currency.",
             "examples": [
@@ -2907,6 +3073,10 @@
             ],
             "ignored_in_assistant": true,
             "label": "Token"
+        },
+        "tool_name": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_tool_name.",
+            "label": "Tool name (legacy)"
         },
         "ttclid": {
             "description": "TikTok Click ID",
@@ -3168,6 +3338,78 @@
         "Deep link opened": {
             "description": "When a user opens the mobile app via a deep link.",
             "label": "Deep link opened"
+        },
+        "mcp feedback submitted": {
+            "description": "A user submitted feedback through the MCP server's feedback tool.",
+            "label": "MCP feedback submitted"
+        },
+        "mcp init": {
+            "description": "Legacy MCP initialization event from the mcpcat-era SDK. Being replaced by mcp_initialize from @posthog/mcp.",
+            "label": "MCP init (legacy)"
+        },
+        "mcp organization switched": {
+            "description": "A user switched the active organization in their MCP session (services/mcp/src/tools/organizations/setActive.ts).",
+            "label": "MCP organization switched"
+        },
+        "mcp project switched": {
+            "description": "A user switched the active project in their MCP session (services/mcp/src/tools/projects/setActive.ts).",
+            "label": "MCP project switched"
+        },
+        "mcp tool call": {
+            "description": "Legacy MCP tool-call event from the mcpcat-era SDK. Being replaced by mcp_tool_call from @posthog/mcp.",
+            "label": "MCP tool call (legacy)"
+        },
+        "mcp tool response": {
+            "description": "Legacy MCP tool-response event from the mcpcat-era SDK. Tool responses are now carried inline on mcp_tool_call (in $mcp_response).",
+            "label": "MCP tool response (legacy)"
+        },
+        "mcp_custom": {
+            "description": "A custom MCP analytics event emitted via publishCustomEvent().",
+            "label": "MCP custom event"
+        },
+        "mcp_initialize": {
+            "description": "MCP client/server handshake completed. Carries $mcp_client_name, $mcp_client_version, $mcp_server_name, $mcp_server_version.",
+            "label": "MCP initialize"
+        },
+        "mcp_mcpcat:identify": {
+            "description": "Legacy MCP identify event from the mcpcat-era SDK. Being replaced by posthog_identify from @posthog/mcp.",
+            "label": "MCP identify (mcpcat, legacy)"
+        },
+        "mcp_posthog:identify": {
+            "description": "Transitional MCP identify event from the in-tree analytics path. Being replaced by posthog_identify from @posthog/mcp.",
+            "label": "MCP identify (transitional)"
+        },
+        "mcp_prompt_get": {
+            "description": "An MCP prompt was fetched. Carries $mcp_resource_name (prompt name).",
+            "label": "MCP prompt fetched"
+        },
+        "mcp_prompts_list": {
+            "description": "An MCP client requested the list of available prompts.",
+            "label": "MCP prompts listed"
+        },
+        "mcp_resource_read": {
+            "description": "An MCP resource was fetched. Carries $mcp_resource_name.",
+            "label": "MCP resource read"
+        },
+        "mcp_resources_list": {
+            "description": "An MCP client requested the list of available resources.",
+            "label": "MCP resources listed"
+        },
+        "mcp_tool_call": {
+            "description": "An MCP server tool was invoked. Carries $mcp_tool_name, $mcp_duration_ms, $mcp_is_error, and (when the client supplied a context argument) $mcp_intent.",
+            "label": "MCP tool call"
+        },
+        "mcp_tool_called": {
+            "description": "Legacy MCP tool-call event from the in-tree analytics path in services/mcp/src/mcp.ts. Being replaced by mcp_tool_call from @posthog/mcp.",
+            "label": "MCP tool called (legacy)"
+        },
+        "mcp_tools_list": {
+            "description": "An MCP client requested the list of available tools.",
+            "label": "MCP tools listed"
+        },
+        "posthog_identify": {
+            "description": "An MCP session was associated with an identified user. Fires only when the identity returned by options.identify() changes for a given session.",
+            "label": "MCP identify"
         }
     },
     "groups": {
@@ -3813,19 +4055,34 @@
             "label": "AI Tags (LLM)"
         },
         "$ai_target_event_id": {
-            "description": "The unique identifier of the event being evaluated.",
+            "description": "Deprecated \u2014 use $ai_target_id with $ai_target_type instead. The unique identifier of the event being evaluated.",
             "examples": [
                 "c9222e05-8708-41b8-98ea-d4a21849e761"
             ],
             "label": "AI Target Event ID (LLM)"
         },
         "$ai_target_event_type": {
-            "description": "The type of event being evaluated (e.g., $ai_generation).",
+            "description": "Deprecated \u2014 use $ai_target_type instead. The type of event being evaluated (e.g., $ai_generation).",
             "examples": [
                 "$ai_generation",
                 "$ai_span"
             ],
             "label": "AI Target Event Type (LLM)"
+        },
+        "$ai_target_id": {
+            "description": "Identifier of the entity this evaluation targets. Pair with $ai_target_type to know which ID space it belongs to (event UUID, trace ID, etc.).",
+            "examples": [
+                "c9222e05-8708-41b8-98ea-d4a21849e761"
+            ],
+            "label": "AI Target ID (LLM)"
+        },
+        "$ai_target_type": {
+            "description": "ID space of $ai_target_id. `generation_uuid` resolves against `events.uuid`; `trace_id` resolves against the `$ai_trace_id` property.",
+            "examples": [
+                "generation_uuid",
+                "trace_id"
+            ],
+            "label": "AI Target Type (LLM)"
         },
         "$ai_temperature": {
             "description": "The temperature parameter used in the request to the LLM API.",
@@ -5361,6 +5618,86 @@
             ],
             "label": "Locale"
         },
+        "$mcp_client_name": {
+            "description": "The MCP client that initiated the connection.",
+            "examples": [
+                "claude-code",
+                "codex-mcp-client",
+                "Anthropic/ClaudeAI"
+            ],
+            "label": "MCP client name"
+        },
+        "$mcp_client_version": {
+            "description": "The version of the MCP client that initiated the connection.",
+            "label": "MCP client version"
+        },
+        "$mcp_duration_ms": {
+            "description": "Wall-clock duration of the MCP tool/resource call in milliseconds.",
+            "examples": [
+                42,
+                1280
+            ],
+            "label": "MCP duration (ms)",
+            "type": "Numeric"
+        },
+        "$mcp_intent": {
+            "description": "Free-text description of why the agent is calling this tool. Comes from the client-supplied context argument when present, otherwise from the server's intentFallback callback.",
+            "examples": [
+                "Listing recent error tracking issues to triage a spike in 500s.",
+                "Fetching the trace referenced by the inbox signal to inspect the user message."
+            ],
+            "label": "MCP intent"
+        },
+        "$mcp_intent_source": {
+            "description": "Where $mcp_intent came from. context_parameter means the client supplied it explicitly; inferred means the server's intentFallback produced it.",
+            "examples": [
+                "context_parameter",
+                "inferred"
+            ],
+            "label": "MCP intent source"
+        },
+        "$mcp_is_error": {
+            "description": "Whether the MCP tool call failed (set from the tool result or a thrown exception).",
+            "label": "MCP is error"
+        },
+        "$mcp_parameters": {
+            "description": "Sanitized MCP request payload (tool arguments). Large strings and sensitive keys are redacted before capture.",
+            "label": "MCP parameters"
+        },
+        "$mcp_resource_name": {
+            "description": "The name of the MCP resource, prompt, or tool the event refers to.",
+            "label": "MCP resource name"
+        },
+        "$mcp_response": {
+            "description": "Sanitized MCP tool response. Large strings and sensitive keys are redacted before capture.",
+            "label": "MCP response"
+        },
+        "$mcp_server_name": {
+            "description": "The advertised name of the MCP server that handled the request.",
+            "examples": [
+                "PostHog"
+            ],
+            "label": "MCP server name"
+        },
+        "$mcp_server_version": {
+            "description": "The advertised version of the MCP server that handled the request.",
+            "label": "MCP server version"
+        },
+        "$mcp_source": {
+            "description": "Constant identifier for the MCP analytics SDK that emitted the event.",
+            "examples": [
+                "posthog_mcp_analytics"
+            ],
+            "label": "MCP source"
+        },
+        "$mcp_tool_name": {
+            "description": "The name of the MCP tool that was invoked. Only present on mcp_tool_call.",
+            "examples": [
+                "execute-sql",
+                "feature-flag-get-all"
+            ],
+            "label": "MCP tool name"
+        },
         "$network_bluetooth": {
             "description": "Whether the user was on Bluetooth when the event was sent.",
             "examples": [
@@ -6336,6 +6673,11 @@
             ],
             "label": "Distinct ID"
         },
+        "duration_ms": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_duration_ms.",
+            "label": "Duration (ms, legacy)",
+            "type": "Numeric"
+        },
         "email": {
             "description": "The email address of the user.",
             "examples": [
@@ -6386,6 +6728,10 @@
             "description": "Impact Click ID Data from the last time this user was seen.",
             "label": "Latest irclid"
         },
+        "is_error": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_is_error.",
+            "label": "Is error (legacy)"
+        },
         "li_fat_id": {
             "description": "LinkedIn First-Party Ad Tracking ID Data from the last time this user was seen.",
             "label": "Latest li_fat_id"
@@ -6393,6 +6739,64 @@
         "mc_cid": {
             "description": "Mailchimp Campaign ID Data from the last time this user was seen.",
             "label": "Latest mc_cid"
+        },
+        "mcp_client_name": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_name.",
+            "examples": [
+                "claude-code",
+                "codex-mcp-client"
+            ],
+            "label": "MCP client name (legacy)"
+        },
+        "mcp_client_version": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_version.",
+            "label": "MCP client version (legacy)"
+        },
+        "mcp_consumer": {
+            "description": "The upstream surface that initiated the MCP request (e.g. posthog-code for PostHog Code, slack for Slack-launched runs).",
+            "examples": [
+                "posthog-code",
+                "slack"
+            ],
+            "label": "MCP consumer"
+        },
+        "mcp_mode": {
+            "description": "The MCP server mode (e.g. single-exec for the v2 wrapper, multi-tool for the legacy roster).",
+            "label": "MCP mode"
+        },
+        "mcp_oauth_client_name": {
+            "description": "The OAuth client name captured during the MCP handshake, when present.",
+            "label": "MCP OAuth client name"
+        },
+        "mcp_protocol_version": {
+            "description": "The MCP protocol version negotiated during initialize.",
+            "label": "MCP protocol version"
+        },
+        "mcp_region": {
+            "description": "The region the MCP server resolved for the request (e.g. us, eu).",
+            "examples": [
+                "us",
+                "eu"
+            ],
+            "label": "MCP region"
+        },
+        "mcp_transport": {
+            "description": "The transport used by the MCP client (e.g. stdio, sse, streamable_http).",
+            "examples": [
+                "stdio",
+                "sse",
+                "streamable_http"
+            ],
+            "label": "MCP transport"
+        },
+        "mcp_version": {
+            "description": "Server-resolved MCP version (1 or 2). May differ from the client-reported version because of the mcp-version-2 feature flag.",
+            "examples": [
+                1,
+                2
+            ],
+            "label": "MCP server version (internal)",
+            "type": "Numeric"
         },
         "msclkid": {
             "description": "Microsoft Click ID Data from the last time this user was seen.",
@@ -6427,6 +6831,10 @@
             ],
             "label": "Referrer application"
         },
+        "resource_name": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_resource_name.",
+            "label": "Resource name (legacy)"
+        },
         "revenue": {
             "description": "The revenue associated with the event. By default, this is in USD, but the currency property can be used to specify a different currency.",
             "examples": [
@@ -6445,6 +6853,10 @@
             ],
             "ignored_in_assistant": true,
             "label": "Token"
+        },
+        "tool_name": {
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_tool_name.",
+            "label": "Tool name (legacy)"
         },
         "ttclid": {
             "description": "TikTok Click ID Data from the last time this user was seen.",

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1819,7 +1819,7 @@
             "label": "Locale"
         },
         "$mcp_client_name": {
-            "description": "The MCP client that initiated the connection.",
+            "description": "The MCP client that initiated the connection. Common values are coding agents (Claude Code, Codex) and chat clients (Claude desktop, Claude on web).",
             "examples": [
                 "claude-code",
                 "codex-mcp-client",
@@ -1832,7 +1832,7 @@
             "label": "MCP client version"
         },
         "$mcp_duration_ms": {
-            "description": "Wall-clock duration of the MCP tool/resource call in milliseconds.",
+            "description": "Wall-clock duration of the MCP tool or resource call, in milliseconds.",
             "examples": [
                 42,
                 1280
@@ -1841,7 +1841,7 @@
             "type": "Numeric"
         },
         "$mcp_intent": {
-            "description": "Free-text description of why the agent is calling this tool. Comes from the client-supplied context argument when present, otherwise from the server's intentFallback callback.",
+            "description": "Free-text description of why the agent is calling this tool, written by the agent itself. Comes from a context argument the client supplied at call time, or \u2014 if none was supplied \u2014 from an intentFallback the MCP server provides.",
             "examples": [
                 "Listing recent error tracking issues to triage a spike in 500s.",
                 "Fetching the trace referenced by the inbox signal to inspect the user message."
@@ -1849,7 +1849,7 @@
             "label": "MCP intent"
         },
         "$mcp_intent_source": {
-            "description": "Where $mcp_intent came from. context_parameter means the client supplied it explicitly; inferred means the server's intentFallback produced it.",
+            "description": "Where $mcp_intent came from. 'context_parameter' means the client supplied it directly on the call; 'inferred' means the MCP server derived it via its intentFallback.",
             "examples": [
                 "context_parameter",
                 "inferred"
@@ -1857,11 +1857,11 @@
             "label": "MCP intent source"
         },
         "$mcp_is_error": {
-            "description": "Whether the MCP tool call failed (set from the tool result or a thrown exception).",
+            "description": "Whether the MCP tool call failed. True if the tool returned an error result or threw an exception.",
             "label": "MCP is error"
         },
         "$mcp_parameters": {
-            "description": "Sanitized MCP request payload (tool arguments). Large strings and sensitive keys are redacted before capture.",
+            "description": "The arguments the client passed when invoking the tool. Large strings and sensitive keys (tokens, API keys, etc.) are redacted before capture.",
             "label": "MCP parameters"
         },
         "$mcp_resource_name": {
@@ -1869,7 +1869,7 @@
             "label": "MCP resource name"
         },
         "$mcp_response": {
-            "description": "Sanitized MCP tool response. Large strings and sensitive keys are redacted before capture.",
+            "description": "The response the MCP server returned. Large strings and sensitive keys are redacted before capture.",
             "label": "MCP response"
         },
         "$mcp_server_name": {
@@ -1884,7 +1884,7 @@
             "label": "MCP server version"
         },
         "$mcp_source": {
-            "description": "Constant identifier for the MCP analytics SDK that emitted the event.",
+            "description": "Constant identifier for the analytics SDK that emitted the event. Lets you separate events from different SDK versions or unrelated MCP servers.",
             "examples": [
                 "posthog_mcp_analytics"
             ],
@@ -2904,8 +2904,8 @@
             "label": "Distinct ID"
         },
         "duration_ms": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_duration_ms.",
-            "label": "Duration (ms, legacy)",
+            "description": "Older unprefixed variant of $mcp_duration_ms. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_duration_ms for new dashboards.",
+            "label": "Duration (ms, unprefixed)",
             "type": "Numeric"
         },
         "epik": {
@@ -2949,8 +2949,8 @@
             "label": "irclid"
         },
         "is_error": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_is_error.",
-            "label": "Is error (legacy)"
+            "description": "Older unprefixed variant of $mcp_is_error. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_is_error for new dashboards.",
+            "label": "Is error (unprefixed)"
         },
         "li_fat_id": {
             "description": "LinkedIn First-Party Ad Tracking ID",
@@ -2961,19 +2961,19 @@
             "label": "mc_cid"
         },
         "mcp_client_name": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_name.",
+            "description": "Older unprefixed variant of $mcp_client_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_client_name for new dashboards.",
             "examples": [
                 "claude-code",
                 "codex-mcp-client"
             ],
-            "label": "MCP client name (legacy)"
+            "label": "MCP client name (unprefixed)"
         },
         "mcp_client_version": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_version.",
-            "label": "MCP client version (legacy)"
+            "description": "Older unprefixed variant of $mcp_client_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_client_version for new dashboards.",
+            "label": "MCP client version (unprefixed)"
         },
         "mcp_consumer": {
-            "description": "The upstream surface that initiated the MCP request (e.g. posthog-code for PostHog Code, slack for Slack-launched runs).",
+            "description": "The upstream surface that initiated the MCP request. 'posthog-code' means the request came through PostHog Code; 'slack' means it was triggered from Slack.",
             "examples": [
                 "posthog-code",
                 "slack"
@@ -2981,11 +2981,11 @@
             "label": "MCP consumer"
         },
         "mcp_mode": {
-            "description": "The MCP server mode (e.g. single-exec for the v2 wrapper, multi-tool for the legacy roster).",
+            "description": "Which tool-registration mode the MCP server ran in for this request. 'single-exec' means the v2 wrapper that exposes one tool; the alternative exposes every tool individually.",
             "label": "MCP mode"
         },
         "mcp_oauth_client_name": {
-            "description": "The OAuth client name captured during the MCP handshake, when present.",
+            "description": "The OAuth client name captured during the MCP handshake, when the connection used OAuth.",
             "label": "MCP OAuth client name"
         },
         "mcp_protocol_version": {
@@ -2993,7 +2993,7 @@
             "label": "MCP protocol version"
         },
         "mcp_region": {
-            "description": "The region the MCP server resolved for the request (e.g. us, eu).",
+            "description": "The region the MCP server routed the request to.",
             "examples": [
                 "us",
                 "eu"
@@ -3001,7 +3001,7 @@
             "label": "MCP region"
         },
         "mcp_transport": {
-            "description": "The transport used by the MCP client (e.g. stdio, sse, streamable_http).",
+            "description": "The transport the MCP client used to connect to the server.",
             "examples": [
                 "stdio",
                 "sse",
@@ -3010,7 +3010,7 @@
             "label": "MCP transport"
         },
         "mcp_version": {
-            "description": "Server-resolved MCP version (1 or 2). May differ from the client-reported version because of the mcp-version-2 feature flag.",
+            "description": "Server-resolved MCP version. May differ from the version the client reported because of the mcp-version-2 feature flag.",
             "examples": [
                 1,
                 2
@@ -3052,8 +3052,8 @@
             "label": "Referrer application"
         },
         "resource_name": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_resource_name.",
-            "label": "Resource name (legacy)"
+            "description": "Older unprefixed variant of $mcp_resource_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_resource_name for new dashboards.",
+            "label": "Resource name (unprefixed)"
         },
         "revenue": {
             "description": "The revenue associated with the event. By default, this is in USD, but the currency property can be used to specify a different currency.",
@@ -3075,8 +3075,8 @@
             "label": "Token"
         },
         "tool_name": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_tool_name.",
-            "label": "Tool name (legacy)"
+            "description": "Older unprefixed variant of $mcp_tool_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_tool_name for new dashboards.",
+            "label": "Tool name (unprefixed)"
         },
         "ttclid": {
             "description": "TikTok Click ID",
@@ -3340,75 +3340,75 @@
             "label": "Deep link opened"
         },
         "mcp feedback submitted": {
-            "description": "A user submitted feedback through the MCP server's feedback tool.",
+            "description": "Fires when a user submits feedback through the MCP server's feedback tool.",
             "label": "MCP feedback submitted"
         },
         "mcp init": {
-            "description": "Legacy MCP initialization event from the mcpcat-era SDK. Being replaced by mcp_initialize from @posthog/mcp.",
-            "label": "MCP init (legacy)"
+            "description": "MCP initialization event emitted by the mcpcat library. Fires alongside mcp_initialize today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_initialize for new dashboards.",
+            "label": "MCP init"
         },
         "mcp organization switched": {
-            "description": "A user switched the active organization in their MCP session (services/mcp/src/tools/organizations/setActive.ts).",
+            "description": "Fires when a user switches the active organization in their MCP session.",
             "label": "MCP organization switched"
         },
         "mcp project switched": {
-            "description": "A user switched the active project in their MCP session (services/mcp/src/tools/projects/setActive.ts).",
+            "description": "Fires when a user switches the active project in their MCP session.",
             "label": "MCP project switched"
         },
         "mcp tool call": {
-            "description": "Legacy MCP tool-call event from the mcpcat-era SDK. Being replaced by mcp_tool_call from @posthog/mcp.",
-            "label": "MCP tool call (legacy)"
+            "description": "Tool-call event emitted by the mcpcat library. Fires alongside mcp_tool_call today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_tool_call for new dashboards.",
+            "label": "MCP tool call (mcpcat)"
         },
         "mcp tool response": {
-            "description": "Legacy MCP tool-response event from the mcpcat-era SDK. Tool responses are now carried inline on mcp_tool_call (in $mcp_response).",
-            "label": "MCP tool response (legacy)"
+            "description": "Tool-response event emitted by the mcpcat library. Tool responses are also carried inline on mcp_tool_call (under $mcp_response). Will be retired once @posthog/mcp reaches general availability.",
+            "label": "MCP tool response (mcpcat)"
         },
         "mcp_custom": {
-            "description": "A custom MCP analytics event emitted via publishCustomEvent().",
+            "description": "A custom MCP analytics event emitted by a server through the SDK's custom-event API. Properties depend on what the caller passed.",
             "label": "MCP custom event"
         },
         "mcp_initialize": {
-            "description": "MCP client/server handshake completed. Carries $mcp_client_name, $mcp_client_version, $mcp_server_name, $mcp_server_version.",
+            "description": "Fires when an MCP client completes the handshake with the server. Carries the client and server name/version so you can break down usage by client.",
             "label": "MCP initialize"
         },
         "mcp_mcpcat:identify": {
-            "description": "Legacy MCP identify event from the mcpcat-era SDK. Being replaced by posthog_identify from @posthog/mcp.",
-            "label": "MCP identify (mcpcat, legacy)"
+            "description": "Identify event emitted by the mcpcat library. Fires alongside posthog_identify today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on posthog_identify for new dashboards.",
+            "label": "MCP identify (mcpcat)"
         },
         "mcp_posthog:identify": {
-            "description": "Transitional MCP identify event from the in-tree analytics path. Being replaced by posthog_identify from @posthog/mcp.",
-            "label": "MCP identify (transitional)"
+            "description": "Identify event emitted by PostHog's in-tree MCP analytics path. Fires alongside posthog_identify today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on posthog_identify for new dashboards.",
+            "label": "MCP identify (in-tree)"
         },
         "mcp_prompt_get": {
-            "description": "An MCP prompt was fetched. Carries $mcp_resource_name (prompt name).",
+            "description": "Fires when an MCP prompt is fetched by a client. Includes the prompt name.",
             "label": "MCP prompt fetched"
         },
         "mcp_prompts_list": {
-            "description": "An MCP client requested the list of available prompts.",
+            "description": "Fires when an MCP client requests the list of available prompts.",
             "label": "MCP prompts listed"
         },
         "mcp_resource_read": {
-            "description": "An MCP resource was fetched. Carries $mcp_resource_name.",
+            "description": "Fires when an MCP resource is fetched by a client. Includes the resource name.",
             "label": "MCP resource read"
         },
         "mcp_resources_list": {
-            "description": "An MCP client requested the list of available resources.",
+            "description": "Fires when an MCP client requests the list of available resources.",
             "label": "MCP resources listed"
         },
         "mcp_tool_call": {
-            "description": "An MCP server tool was invoked. Carries $mcp_tool_name, $mcp_duration_ms, $mcp_is_error, and (when the client supplied a context argument) $mcp_intent.",
+            "description": "Fires every time an MCP server tool is invoked. Includes the tool name, wall-clock duration, error state, and (when the client supplied a context argument) the agent's stated intent.",
             "label": "MCP tool call"
         },
         "mcp_tool_called": {
-            "description": "Legacy MCP tool-call event from the in-tree analytics path in services/mcp/src/mcp.ts. Being replaced by mcp_tool_call from @posthog/mcp.",
-            "label": "MCP tool called (legacy)"
+            "description": "Tool-call event emitted by PostHog's in-tree MCP analytics path. Fires alongside mcp_tool_call today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_tool_call for new dashboards.",
+            "label": "MCP tool called (in-tree)"
         },
         "mcp_tools_list": {
-            "description": "An MCP client requested the list of available tools.",
+            "description": "Fires when an MCP client requests the list of available tools. Useful for measuring discovery \u2014 i.e. whether new clients are finding the server.",
             "label": "MCP tools listed"
         },
         "posthog_identify": {
-            "description": "An MCP session was associated with an identified user. Fires only when the identity returned by options.identify() changes for a given session.",
+            "description": "Fires when an MCP session becomes associated with an identified user, or when the identity changes for an existing session. Used to attribute subsequent events to a real user instead of an anonymous session.",
             "label": "MCP identify"
         }
     },
@@ -5619,7 +5619,7 @@
             "label": "Locale"
         },
         "$mcp_client_name": {
-            "description": "The MCP client that initiated the connection.",
+            "description": "The MCP client that initiated the connection. Common values are coding agents (Claude Code, Codex) and chat clients (Claude desktop, Claude on web).",
             "examples": [
                 "claude-code",
                 "codex-mcp-client",
@@ -5632,7 +5632,7 @@
             "label": "MCP client version"
         },
         "$mcp_duration_ms": {
-            "description": "Wall-clock duration of the MCP tool/resource call in milliseconds.",
+            "description": "Wall-clock duration of the MCP tool or resource call, in milliseconds.",
             "examples": [
                 42,
                 1280
@@ -5641,7 +5641,7 @@
             "type": "Numeric"
         },
         "$mcp_intent": {
-            "description": "Free-text description of why the agent is calling this tool. Comes from the client-supplied context argument when present, otherwise from the server's intentFallback callback.",
+            "description": "Free-text description of why the agent is calling this tool, written by the agent itself. Comes from a context argument the client supplied at call time, or \u2014 if none was supplied \u2014 from an intentFallback the MCP server provides.",
             "examples": [
                 "Listing recent error tracking issues to triage a spike in 500s.",
                 "Fetching the trace referenced by the inbox signal to inspect the user message."
@@ -5649,7 +5649,7 @@
             "label": "MCP intent"
         },
         "$mcp_intent_source": {
-            "description": "Where $mcp_intent came from. context_parameter means the client supplied it explicitly; inferred means the server's intentFallback produced it.",
+            "description": "Where $mcp_intent came from. 'context_parameter' means the client supplied it directly on the call; 'inferred' means the MCP server derived it via its intentFallback.",
             "examples": [
                 "context_parameter",
                 "inferred"
@@ -5657,11 +5657,11 @@
             "label": "MCP intent source"
         },
         "$mcp_is_error": {
-            "description": "Whether the MCP tool call failed (set from the tool result or a thrown exception).",
+            "description": "Whether the MCP tool call failed. True if the tool returned an error result or threw an exception.",
             "label": "MCP is error"
         },
         "$mcp_parameters": {
-            "description": "Sanitized MCP request payload (tool arguments). Large strings and sensitive keys are redacted before capture.",
+            "description": "The arguments the client passed when invoking the tool. Large strings and sensitive keys (tokens, API keys, etc.) are redacted before capture.",
             "label": "MCP parameters"
         },
         "$mcp_resource_name": {
@@ -5669,7 +5669,7 @@
             "label": "MCP resource name"
         },
         "$mcp_response": {
-            "description": "Sanitized MCP tool response. Large strings and sensitive keys are redacted before capture.",
+            "description": "The response the MCP server returned. Large strings and sensitive keys are redacted before capture.",
             "label": "MCP response"
         },
         "$mcp_server_name": {
@@ -5684,7 +5684,7 @@
             "label": "MCP server version"
         },
         "$mcp_source": {
-            "description": "Constant identifier for the MCP analytics SDK that emitted the event.",
+            "description": "Constant identifier for the analytics SDK that emitted the event. Lets you separate events from different SDK versions or unrelated MCP servers.",
             "examples": [
                 "posthog_mcp_analytics"
             ],
@@ -6674,8 +6674,8 @@
             "label": "Distinct ID"
         },
         "duration_ms": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_duration_ms.",
-            "label": "Duration (ms, legacy)",
+            "description": "Older unprefixed variant of $mcp_duration_ms. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_duration_ms for new dashboards.",
+            "label": "Duration (ms, unprefixed)",
             "type": "Numeric"
         },
         "email": {
@@ -6729,8 +6729,8 @@
             "label": "Latest irclid"
         },
         "is_error": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_is_error.",
-            "label": "Is error (legacy)"
+            "description": "Older unprefixed variant of $mcp_is_error. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_is_error for new dashboards.",
+            "label": "Is error (unprefixed)"
         },
         "li_fat_id": {
             "description": "LinkedIn First-Party Ad Tracking ID Data from the last time this user was seen.",
@@ -6741,19 +6741,19 @@
             "label": "Latest mc_cid"
         },
         "mcp_client_name": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_name.",
+            "description": "Older unprefixed variant of $mcp_client_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_client_name for new dashboards.",
             "examples": [
                 "claude-code",
                 "codex-mcp-client"
             ],
-            "label": "MCP client name (legacy)"
+            "label": "MCP client name (unprefixed)"
         },
         "mcp_client_version": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_version.",
-            "label": "MCP client version (legacy)"
+            "description": "Older unprefixed variant of $mcp_client_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_client_version for new dashboards.",
+            "label": "MCP client version (unprefixed)"
         },
         "mcp_consumer": {
-            "description": "The upstream surface that initiated the MCP request (e.g. posthog-code for PostHog Code, slack for Slack-launched runs).",
+            "description": "The upstream surface that initiated the MCP request. 'posthog-code' means the request came through PostHog Code; 'slack' means it was triggered from Slack.",
             "examples": [
                 "posthog-code",
                 "slack"
@@ -6761,11 +6761,11 @@
             "label": "MCP consumer"
         },
         "mcp_mode": {
-            "description": "The MCP server mode (e.g. single-exec for the v2 wrapper, multi-tool for the legacy roster).",
+            "description": "Which tool-registration mode the MCP server ran in for this request. 'single-exec' means the v2 wrapper that exposes one tool; the alternative exposes every tool individually.",
             "label": "MCP mode"
         },
         "mcp_oauth_client_name": {
-            "description": "The OAuth client name captured during the MCP handshake, when present.",
+            "description": "The OAuth client name captured during the MCP handshake, when the connection used OAuth.",
             "label": "MCP OAuth client name"
         },
         "mcp_protocol_version": {
@@ -6773,7 +6773,7 @@
             "label": "MCP protocol version"
         },
         "mcp_region": {
-            "description": "The region the MCP server resolved for the request (e.g. us, eu).",
+            "description": "The region the MCP server routed the request to.",
             "examples": [
                 "us",
                 "eu"
@@ -6781,7 +6781,7 @@
             "label": "MCP region"
         },
         "mcp_transport": {
-            "description": "The transport used by the MCP client (e.g. stdio, sse, streamable_http).",
+            "description": "The transport the MCP client used to connect to the server.",
             "examples": [
                 "stdio",
                 "sse",
@@ -6790,7 +6790,7 @@
             "label": "MCP transport"
         },
         "mcp_version": {
-            "description": "Server-resolved MCP version (1 or 2). May differ from the client-reported version because of the mcp-version-2 feature flag.",
+            "description": "Server-resolved MCP version. May differ from the version the client reported because of the mcp-version-2 feature flag.",
             "examples": [
                 1,
                 2
@@ -6832,8 +6832,8 @@
             "label": "Referrer application"
         },
         "resource_name": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_resource_name.",
-            "label": "Resource name (legacy)"
+            "description": "Older unprefixed variant of $mcp_resource_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_resource_name for new dashboards.",
+            "label": "Resource name (unprefixed)"
         },
         "revenue": {
             "description": "The revenue associated with the event. By default, this is in USD, but the currency property can be used to specify a different currency.",
@@ -6855,8 +6855,8 @@
             "label": "Token"
         },
         "tool_name": {
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_tool_name.",
-            "label": "Tool name (legacy)"
+            "description": "Older unprefixed variant of $mcp_tool_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_tool_name for new dashboards.",
+            "label": "Tool name (unprefixed)"
         },
         "ttclid": {
             "description": "TikTok Click ID Data from the last time this user was seen.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -289,6 +289,83 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Deep link opened",
             "description": "When a user opens the mobile app via a deep link.",
         },
+        # Events emitted by the @posthog/mcp analytics SDK (services/mcp/src/lib/posthog-mcp-analytics.ts).
+        # These coexist with the legacy mcpcat-era events further down while the migration is in progress.
+        "mcp_tool_call": {
+            "label": "MCP tool call",
+            "description": "An MCP server tool was invoked. Carries $mcp_tool_name, $mcp_duration_ms, $mcp_is_error, and (when the client supplied a context argument) $mcp_intent.",
+        },
+        "mcp_tools_list": {
+            "label": "MCP tools listed",
+            "description": "An MCP client requested the list of available tools.",
+        },
+        "mcp_initialize": {
+            "label": "MCP initialize",
+            "description": "MCP client/server handshake completed. Carries $mcp_client_name, $mcp_client_version, $mcp_server_name, $mcp_server_version.",
+        },
+        "mcp_resources_list": {
+            "label": "MCP resources listed",
+            "description": "An MCP client requested the list of available resources.",
+        },
+        "mcp_resource_read": {
+            "label": "MCP resource read",
+            "description": "An MCP resource was fetched. Carries $mcp_resource_name.",
+        },
+        "mcp_prompts_list": {
+            "label": "MCP prompts listed",
+            "description": "An MCP client requested the list of available prompts.",
+        },
+        "mcp_prompt_get": {
+            "label": "MCP prompt fetched",
+            "description": "An MCP prompt was fetched. Carries $mcp_resource_name (prompt name).",
+        },
+        "mcp_custom": {
+            "label": "MCP custom event",
+            "description": "A custom MCP analytics event emitted via publishCustomEvent().",
+        },
+        "posthog_identify": {
+            "label": "MCP identify",
+            "description": "An MCP session was associated with an identified user. Fires only when the identity returned by options.identify() changes for a given session.",
+        },
+        # Legacy MCP events from the mcpcat-era SDK (services/mcp/src/lib/mcpcat.ts) and the in-tree
+        # trackEvent path in services/mcp/src/mcp.ts. They remain while traffic migrates to
+        # @posthog/mcp; expect their volumes to decline as more clients move over.
+        "mcp init": {
+            "label": "MCP init (legacy)",
+            "description": "Legacy MCP initialization event from the mcpcat-era SDK. Being replaced by mcp_initialize from @posthog/mcp.",
+        },
+        "mcp_mcpcat:identify": {
+            "label": "MCP identify (mcpcat, legacy)",
+            "description": "Legacy MCP identify event from the mcpcat-era SDK. Being replaced by posthog_identify from @posthog/mcp.",
+        },
+        "mcp_posthog:identify": {
+            "label": "MCP identify (transitional)",
+            "description": "Transitional MCP identify event from the in-tree analytics path. Being replaced by posthog_identify from @posthog/mcp.",
+        },
+        "mcp_tool_called": {
+            "label": "MCP tool called (legacy)",
+            "description": "Legacy MCP tool-call event from the in-tree analytics path in services/mcp/src/mcp.ts. Being replaced by mcp_tool_call from @posthog/mcp.",
+        },
+        "mcp tool call": {
+            "label": "MCP tool call (legacy)",
+            "description": "Legacy MCP tool-call event from the mcpcat-era SDK. Being replaced by mcp_tool_call from @posthog/mcp.",
+        },
+        "mcp tool response": {
+            "label": "MCP tool response (legacy)",
+            "description": "Legacy MCP tool-response event from the mcpcat-era SDK. Tool responses are now carried inline on mcp_tool_call (in $mcp_response).",
+        },
+        "mcp project switched": {
+            "label": "MCP project switched",
+            "description": "A user switched the active project in their MCP session (services/mcp/src/tools/projects/setActive.ts).",
+        },
+        "mcp organization switched": {
+            "label": "MCP organization switched",
+            "description": "A user switched the active organization in their MCP session (services/mcp/src/tools/organizations/setActive.ts).",
+        },
+        "mcp feedback submitted": {
+            "label": "MCP feedback submitted",
+            "description": "A user submitted feedback through the MCP server's feedback tool.",
+        },
     },
     "elements": {
         "tag_name": {
@@ -2433,6 +2510,134 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$ai_user_prompt": {
             "label": "AI user prompt (LLM)",
             "description": "The user prompt text sent to the LLM.",
+        },
+        # Properties emitted by the @posthog/mcp analytics SDK. All wire keys are $mcp_*-prefixed
+        # so they don't collide with autocapture or other product events. The legacy mcpcat-era
+        # properties (mcp_client_name, tool_name, duration_ms, is_error, etc.) are listed below
+        # and will be removed once traffic finishes migrating to the new SDK.
+        "$mcp_source": {
+            "label": "MCP source",
+            "description": "Constant identifier for the MCP analytics SDK that emitted the event.",
+            "examples": ["posthog_mcp_analytics"],
+        },
+        "$mcp_tool_name": {
+            "label": "MCP tool name",
+            "description": "The name of the MCP tool that was invoked. Only present on mcp_tool_call.",
+            "examples": ["execute-sql", "feature-flag-get-all"],
+        },
+        "$mcp_resource_name": {
+            "label": "MCP resource name",
+            "description": "The name of the MCP resource, prompt, or tool the event refers to.",
+        },
+        "$mcp_duration_ms": {
+            "label": "MCP duration (ms)",
+            "description": "Wall-clock duration of the MCP tool/resource call in milliseconds.",
+            "type": "Numeric",
+            "examples": [42, 1280],
+        },
+        "$mcp_is_error": {
+            "label": "MCP is error",
+            "description": "Whether the MCP tool call failed (set from the tool result or a thrown exception).",
+        },
+        "$mcp_server_name": {
+            "label": "MCP server name",
+            "description": "The advertised name of the MCP server that handled the request.",
+            "examples": ["PostHog"],
+        },
+        "$mcp_server_version": {
+            "label": "MCP server version",
+            "description": "The advertised version of the MCP server that handled the request.",
+        },
+        "$mcp_client_name": {
+            "label": "MCP client name",
+            "description": "The MCP client that initiated the connection.",
+            "examples": ["claude-code", "codex-mcp-client", "Anthropic/ClaudeAI"],
+        },
+        "$mcp_client_version": {
+            "label": "MCP client version",
+            "description": "The version of the MCP client that initiated the connection.",
+        },
+        "$mcp_intent": {
+            "label": "MCP intent",
+            "description": "Free-text description of why the agent is calling this tool. Comes from the client-supplied context argument when present, otherwise from the server's intentFallback callback.",
+            "examples": [
+                "Listing recent error tracking issues to triage a spike in 500s.",
+                "Fetching the trace referenced by the inbox signal to inspect the user message.",
+            ],
+        },
+        "$mcp_intent_source": {
+            "label": "MCP intent source",
+            "description": "Where $mcp_intent came from. context_parameter means the client supplied it explicitly; inferred means the server's intentFallback produced it.",
+            "examples": ["context_parameter", "inferred"],
+        },
+        "$mcp_parameters": {
+            "label": "MCP parameters",
+            "description": "Sanitized MCP request payload (tool arguments). Large strings and sensitive keys are redacted before capture.",
+        },
+        "$mcp_response": {
+            "label": "MCP response",
+            "description": "Sanitized MCP tool response. Large strings and sensitive keys are redacted before capture.",
+        },
+        # Legacy MCP properties from the mcpcat-era SDK and the in-tree analytics path. These are
+        # still populated on a subset of events while traffic migrates to @posthog/mcp.
+        "mcp_client_name": {
+            "label": "MCP client name (legacy)",
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_name.",
+            "examples": ["claude-code", "codex-mcp-client"],
+        },
+        "mcp_client_version": {
+            "label": "MCP client version (legacy)",
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_version.",
+        },
+        "mcp_protocol_version": {
+            "label": "MCP protocol version",
+            "description": "The MCP protocol version negotiated during initialize.",
+        },
+        "mcp_transport": {
+            "label": "MCP transport",
+            "description": "The transport used by the MCP client (e.g. stdio, sse, streamable_http).",
+            "examples": ["stdio", "sse", "streamable_http"],
+        },
+        "mcp_consumer": {
+            "label": "MCP consumer",
+            "description": "The upstream surface that initiated the MCP request (e.g. posthog-code for PostHog Code, slack for Slack-launched runs).",
+            "examples": ["posthog-code", "slack"],
+        },
+        "mcp_mode": {
+            "label": "MCP mode",
+            "description": "The MCP server mode (e.g. single-exec for the v2 wrapper, multi-tool for the legacy roster).",
+        },
+        "mcp_region": {
+            "label": "MCP region",
+            "description": "The region the MCP server resolved for the request (e.g. us, eu).",
+            "examples": ["us", "eu"],
+        },
+        "mcp_oauth_client_name": {
+            "label": "MCP OAuth client name",
+            "description": "The OAuth client name captured during the MCP handshake, when present.",
+        },
+        "mcp_version": {
+            "label": "MCP server version (internal)",
+            "description": "Server-resolved MCP version (1 or 2). May differ from the client-reported version because of the mcp-version-2 feature flag.",
+            "type": "Numeric",
+            "examples": [1, 2],
+        },
+        "tool_name": {
+            "label": "Tool name (legacy)",
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_tool_name.",
+        },
+        "resource_name": {
+            "label": "Resource name (legacy)",
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_resource_name.",
+        },
+        "duration_ms": {
+            "label": "Duration (ms, legacy)",
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_duration_ms.",
+            "type": "Numeric",
+        },
+        "is_error": {
+            "label": "Is error (legacy)",
+            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_is_error.",
         },
         "$csp_document_url": {
             "label": "Document URL",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -289,9 +289,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Deep link opened",
             "description": "When a user opens the mobile app via a deep link.",
         },
-        # Events emitted by the @posthog/mcp analytics SDK. While @posthog/mcp is in internal testing,
-        # these coexist with the older events further down — both code paths emit on every request.
-        # Once @posthog/mcp reaches general availability the older events will be retired.
+        # Events emitted by the @posthog/mcp analytics SDK. @posthog/mcp is rolled out behind a
+        # feature flag (currently enabled only for some PostHog staff for internal testing). For
+        # traffic where it's enabled, these events fire *alongside* the older events further down;
+        # for traffic where it's not, only the older events fire. Once @posthog/mcp reaches general
+        # availability the older events will be retired.
         "mcp_tool_call": {
             "label": "MCP tool call",
             "description": "Fires every time an MCP server tool is invoked. Includes the tool name, wall-clock duration, error state, and (when the client supplied a context argument) the agent's stated intent.",
@@ -328,34 +330,35 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "MCP identify",
             "description": "Fires when an MCP session becomes associated with an identified user, or when the identity changes for an existing session. Used to attribute subsequent events to a real user instead of an anonymous session.",
         },
-        # Older MCP events emitted alongside the @posthog/mcp events above. Not deprecated today —
-        # @posthog/mcp is still in internal testing — but slated for removal once @posthog/mcp reaches
-        # general availability. They come from two sources:
-        #   - the mcpcat library that PostHog used before @posthog/mcp existed
-        #   - PostHog's own in-tree trackEvent path inside the MCP server (services/mcp/src/mcp.ts)
+        # Older MCP events. Today these are the only events that fire for traffic where @posthog/mcp
+        # isn't enabled yet, and they fire alongside the @posthog/mcp events for traffic where it is.
+        # Not deprecated today — @posthog/mcp is still in internal testing — but slated for removal
+        # once @posthog/mcp reaches general availability. They come from two sources:
+        #   - the mcpcat library PostHog used before @posthog/mcp existed
+        #   - PostHog's in-tree trackEvent path inside the MCP server
         "mcp init": {
             "label": "MCP init",
-            "description": "MCP initialization event emitted by the mcpcat library. Fires alongside mcp_initialize today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_initialize for new dashboards.",
+            "description": "MCP initialization event emitted by the mcpcat library. Fires for all traffic today (alongside mcp_initialize where @posthog/mcp is enabled). Will be retired once @posthog/mcp reaches general availability; until then, filter on this event if you need coverage across all clients, or on mcp_initialize if you only want the @posthog/mcp-enabled slice.",
         },
         "mcp_mcpcat:identify": {
             "label": "MCP identify (mcpcat)",
-            "description": "Identify event emitted by the mcpcat library. Fires alongside posthog_identify today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on posthog_identify for new dashboards.",
+            "description": "Identify event emitted by the mcpcat library. Fires for all traffic today (alongside posthog_identify where @posthog/mcp is enabled). Will be retired once @posthog/mcp reaches general availability.",
         },
         "mcp_posthog:identify": {
             "label": "MCP identify (in-tree)",
-            "description": "Identify event emitted by PostHog's in-tree MCP analytics path. Fires alongside posthog_identify today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on posthog_identify for new dashboards.",
+            "description": "Identify event emitted by PostHog's in-tree MCP analytics path. Fires for all traffic today (alongside posthog_identify where @posthog/mcp is enabled). Will be retired once @posthog/mcp reaches general availability.",
         },
         "mcp_tool_called": {
             "label": "MCP tool called (in-tree)",
-            "description": "Tool-call event emitted by PostHog's in-tree MCP analytics path. Fires alongside mcp_tool_call today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_tool_call for new dashboards.",
+            "description": "Tool-call event emitted by PostHog's in-tree MCP analytics path. Fires for all traffic today (alongside mcp_tool_call where @posthog/mcp is enabled). Will be retired once @posthog/mcp reaches general availability; until then, filter on this event if you need coverage across all clients, or on mcp_tool_call if you only want the @posthog/mcp-enabled slice.",
         },
         "mcp tool call": {
             "label": "MCP tool call (mcpcat)",
-            "description": "Tool-call event emitted by the mcpcat library. Fires alongside mcp_tool_call today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_tool_call for new dashboards.",
+            "description": "Tool-call event emitted by the mcpcat library. Fires for all traffic today (alongside mcp_tool_call where @posthog/mcp is enabled). Will be retired once @posthog/mcp reaches general availability.",
         },
         "mcp tool response": {
             "label": "MCP tool response (mcpcat)",
-            "description": "Tool-response event emitted by the mcpcat library. Tool responses are also carried inline on mcp_tool_call (under $mcp_response). Will be retired once @posthog/mcp reaches general availability.",
+            "description": "Tool-response event emitted by the mcpcat library. Tool responses are also carried inline on mcp_tool_call (under $mcp_response) for @posthog/mcp-enabled traffic. Will be retired once @posthog/mcp reaches general availability.",
         },
         "mcp project switched": {
             "label": "MCP project switched",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -289,82 +289,85 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Deep link opened",
             "description": "When a user opens the mobile app via a deep link.",
         },
-        # Events emitted by the @posthog/mcp analytics SDK (services/mcp/src/lib/posthog-mcp-analytics.ts).
-        # These coexist with the legacy mcpcat-era events further down while the migration is in progress.
+        # Events emitted by the @posthog/mcp analytics SDK. While @posthog/mcp is in internal testing,
+        # these coexist with the older events further down — both code paths emit on every request.
+        # Once @posthog/mcp reaches general availability the older events will be retired.
         "mcp_tool_call": {
             "label": "MCP tool call",
-            "description": "An MCP server tool was invoked. Carries $mcp_tool_name, $mcp_duration_ms, $mcp_is_error, and (when the client supplied a context argument) $mcp_intent.",
+            "description": "Fires every time an MCP server tool is invoked. Includes the tool name, wall-clock duration, error state, and (when the client supplied a context argument) the agent's stated intent.",
         },
         "mcp_tools_list": {
             "label": "MCP tools listed",
-            "description": "An MCP client requested the list of available tools.",
+            "description": "Fires when an MCP client requests the list of available tools. Useful for measuring discovery — i.e. whether new clients are finding the server.",
         },
         "mcp_initialize": {
             "label": "MCP initialize",
-            "description": "MCP client/server handshake completed. Carries $mcp_client_name, $mcp_client_version, $mcp_server_name, $mcp_server_version.",
+            "description": "Fires when an MCP client completes the handshake with the server. Carries the client and server name/version so you can break down usage by client.",
         },
         "mcp_resources_list": {
             "label": "MCP resources listed",
-            "description": "An MCP client requested the list of available resources.",
+            "description": "Fires when an MCP client requests the list of available resources.",
         },
         "mcp_resource_read": {
             "label": "MCP resource read",
-            "description": "An MCP resource was fetched. Carries $mcp_resource_name.",
+            "description": "Fires when an MCP resource is fetched by a client. Includes the resource name.",
         },
         "mcp_prompts_list": {
             "label": "MCP prompts listed",
-            "description": "An MCP client requested the list of available prompts.",
+            "description": "Fires when an MCP client requests the list of available prompts.",
         },
         "mcp_prompt_get": {
             "label": "MCP prompt fetched",
-            "description": "An MCP prompt was fetched. Carries $mcp_resource_name (prompt name).",
+            "description": "Fires when an MCP prompt is fetched by a client. Includes the prompt name.",
         },
         "mcp_custom": {
             "label": "MCP custom event",
-            "description": "A custom MCP analytics event emitted via publishCustomEvent().",
+            "description": "A custom MCP analytics event emitted by a server through the SDK's custom-event API. Properties depend on what the caller passed.",
         },
         "posthog_identify": {
             "label": "MCP identify",
-            "description": "An MCP session was associated with an identified user. Fires only when the identity returned by options.identify() changes for a given session.",
+            "description": "Fires when an MCP session becomes associated with an identified user, or when the identity changes for an existing session. Used to attribute subsequent events to a real user instead of an anonymous session.",
         },
-        # Legacy MCP events from the mcpcat-era SDK (services/mcp/src/lib/mcpcat.ts) and the in-tree
-        # trackEvent path in services/mcp/src/mcp.ts. They remain while traffic migrates to
-        # @posthog/mcp; expect their volumes to decline as more clients move over.
+        # Older MCP events emitted alongside the @posthog/mcp events above. Not deprecated today —
+        # @posthog/mcp is still in internal testing — but slated for removal once @posthog/mcp reaches
+        # general availability. They come from two sources:
+        #   - the mcpcat library that PostHog used before @posthog/mcp existed
+        #   - PostHog's own in-tree trackEvent path inside the MCP server (services/mcp/src/mcp.ts)
         "mcp init": {
-            "label": "MCP init (legacy)",
-            "description": "Legacy MCP initialization event from the mcpcat-era SDK. Being replaced by mcp_initialize from @posthog/mcp.",
+            "label": "MCP init",
+            "description": "MCP initialization event emitted by the mcpcat library. Fires alongside mcp_initialize today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_initialize for new dashboards.",
         },
         "mcp_mcpcat:identify": {
-            "label": "MCP identify (mcpcat, legacy)",
-            "description": "Legacy MCP identify event from the mcpcat-era SDK. Being replaced by posthog_identify from @posthog/mcp.",
+            "label": "MCP identify (mcpcat)",
+            "description": "Identify event emitted by the mcpcat library. Fires alongside posthog_identify today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on posthog_identify for new dashboards.",
         },
         "mcp_posthog:identify": {
-            "label": "MCP identify (transitional)",
-            "description": "Transitional MCP identify event from the in-tree analytics path. Being replaced by posthog_identify from @posthog/mcp.",
+            "label": "MCP identify (in-tree)",
+            "description": "Identify event emitted by PostHog's in-tree MCP analytics path. Fires alongside posthog_identify today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on posthog_identify for new dashboards.",
         },
         "mcp_tool_called": {
-            "label": "MCP tool called (legacy)",
-            "description": "Legacy MCP tool-call event from the in-tree analytics path in services/mcp/src/mcp.ts. Being replaced by mcp_tool_call from @posthog/mcp.",
+            "label": "MCP tool called (in-tree)",
+            "description": "Tool-call event emitted by PostHog's in-tree MCP analytics path. Fires alongside mcp_tool_call today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_tool_call for new dashboards.",
         },
         "mcp tool call": {
-            "label": "MCP tool call (legacy)",
-            "description": "Legacy MCP tool-call event from the mcpcat-era SDK. Being replaced by mcp_tool_call from @posthog/mcp.",
+            "label": "MCP tool call (mcpcat)",
+            "description": "Tool-call event emitted by the mcpcat library. Fires alongside mcp_tool_call today. Will be retired once @posthog/mcp reaches general availability; until then, prefer filtering on mcp_tool_call for new dashboards.",
         },
         "mcp tool response": {
-            "label": "MCP tool response (legacy)",
-            "description": "Legacy MCP tool-response event from the mcpcat-era SDK. Tool responses are now carried inline on mcp_tool_call (in $mcp_response).",
+            "label": "MCP tool response (mcpcat)",
+            "description": "Tool-response event emitted by the mcpcat library. Tool responses are also carried inline on mcp_tool_call (under $mcp_response). Will be retired once @posthog/mcp reaches general availability.",
         },
         "mcp project switched": {
             "label": "MCP project switched",
-            "description": "A user switched the active project in their MCP session (services/mcp/src/tools/projects/setActive.ts).",
+            "description": "Fires when a user switches the active project in their MCP session.",
         },
         "mcp organization switched": {
             "label": "MCP organization switched",
-            "description": "A user switched the active organization in their MCP session (services/mcp/src/tools/organizations/setActive.ts).",
+            "description": "Fires when a user switches the active organization in their MCP session.",
         },
         "mcp feedback submitted": {
             "label": "MCP feedback submitted",
-            "description": "A user submitted feedback through the MCP server's feedback tool.",
+            "description": "Fires when a user submits feedback through the MCP server's feedback tool.",
         },
     },
     "elements": {
@@ -2511,13 +2514,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "AI user prompt (LLM)",
             "description": "The user prompt text sent to the LLM.",
         },
-        # Properties emitted by the @posthog/mcp analytics SDK. All wire keys are $mcp_*-prefixed
-        # so they don't collide with autocapture or other product events. The legacy mcpcat-era
-        # properties (mcp_client_name, tool_name, duration_ms, is_error, etc.) are listed below
-        # and will be removed once traffic finishes migrating to the new SDK.
+        # Core MCP properties emitted by the @posthog/mcp analytics SDK. All wire keys are
+        # $mcp_*-prefixed so they don't collide with autocapture or other product properties.
         "$mcp_source": {
             "label": "MCP source",
-            "description": "Constant identifier for the MCP analytics SDK that emitted the event.",
+            "description": "Constant identifier for the analytics SDK that emitted the event. Lets you separate events from different SDK versions or unrelated MCP servers.",
             "examples": ["posthog_mcp_analytics"],
         },
         "$mcp_tool_name": {
@@ -2531,13 +2532,13 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$mcp_duration_ms": {
             "label": "MCP duration (ms)",
-            "description": "Wall-clock duration of the MCP tool/resource call in milliseconds.",
+            "description": "Wall-clock duration of the MCP tool or resource call, in milliseconds.",
             "type": "Numeric",
             "examples": [42, 1280],
         },
         "$mcp_is_error": {
             "label": "MCP is error",
-            "description": "Whether the MCP tool call failed (set from the tool result or a thrown exception).",
+            "description": "Whether the MCP tool call failed. True if the tool returned an error result or threw an exception.",
         },
         "$mcp_server_name": {
             "label": "MCP server name",
@@ -2550,7 +2551,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$mcp_client_name": {
             "label": "MCP client name",
-            "description": "The MCP client that initiated the connection.",
+            "description": "The MCP client that initiated the connection. Common values are coding agents (Claude Code, Codex) and chat clients (Claude desktop, Claude on web).",
             "examples": ["claude-code", "codex-mcp-client", "Anthropic/ClaudeAI"],
         },
         "$mcp_client_version": {
@@ -2559,7 +2560,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$mcp_intent": {
             "label": "MCP intent",
-            "description": "Free-text description of why the agent is calling this tool. Comes from the client-supplied context argument when present, otherwise from the server's intentFallback callback.",
+            "description": "Free-text description of why the agent is calling this tool, written by the agent itself. Comes from a context argument the client supplied at call time, or — if none was supplied — from an intentFallback the MCP server provides.",
             "examples": [
                 "Listing recent error tracking issues to triage a spike in 500s.",
                 "Fetching the trace referenced by the inbox signal to inspect the user message.",
@@ -2567,77 +2568,82 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$mcp_intent_source": {
             "label": "MCP intent source",
-            "description": "Where $mcp_intent came from. context_parameter means the client supplied it explicitly; inferred means the server's intentFallback produced it.",
+            "description": "Where $mcp_intent came from. 'context_parameter' means the client supplied it directly on the call; 'inferred' means the MCP server derived it via its intentFallback.",
             "examples": ["context_parameter", "inferred"],
         },
         "$mcp_parameters": {
             "label": "MCP parameters",
-            "description": "Sanitized MCP request payload (tool arguments). Large strings and sensitive keys are redacted before capture.",
+            "description": "The arguments the client passed when invoking the tool. Large strings and sensitive keys (tokens, API keys, etc.) are redacted before capture.",
         },
         "$mcp_response": {
             "label": "MCP response",
-            "description": "Sanitized MCP tool response. Large strings and sensitive keys are redacted before capture.",
+            "description": "The response the MCP server returned. Large strings and sensitive keys are redacted before capture.",
         },
-        # Legacy MCP properties from the mcpcat-era SDK and the in-tree analytics path. These are
-        # still populated on a subset of events while traffic migrates to @posthog/mcp.
-        "mcp_client_name": {
-            "label": "MCP client name (legacy)",
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_name.",
-            "examples": ["claude-code", "codex-mcp-client"],
-        },
-        "mcp_client_version": {
-            "label": "MCP client version (legacy)",
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_client_version.",
-        },
+        # PostHog-specific MCP properties added by the PostHog MCP server on top of the SDK's core
+        # set. They identify which deployment, transport, and consumer produced the event. The
+        # @posthog/mcp SDK will continue to carry these — they're not on a deprecation path.
         "mcp_protocol_version": {
             "label": "MCP protocol version",
             "description": "The MCP protocol version negotiated during initialize.",
         },
         "mcp_transport": {
             "label": "MCP transport",
-            "description": "The transport used by the MCP client (e.g. stdio, sse, streamable_http).",
+            "description": "The transport the MCP client used to connect to the server.",
             "examples": ["stdio", "sse", "streamable_http"],
         },
         "mcp_consumer": {
             "label": "MCP consumer",
-            "description": "The upstream surface that initiated the MCP request (e.g. posthog-code for PostHog Code, slack for Slack-launched runs).",
+            "description": "The upstream surface that initiated the MCP request. 'posthog-code' means the request came through PostHog Code; 'slack' means it was triggered from Slack.",
             "examples": ["posthog-code", "slack"],
         },
         "mcp_mode": {
             "label": "MCP mode",
-            "description": "The MCP server mode (e.g. single-exec for the v2 wrapper, multi-tool for the legacy roster).",
+            "description": "Which tool-registration mode the MCP server ran in for this request. 'single-exec' means the v2 wrapper that exposes one tool; the alternative exposes every tool individually.",
         },
         "mcp_region": {
             "label": "MCP region",
-            "description": "The region the MCP server resolved for the request (e.g. us, eu).",
+            "description": "The region the MCP server routed the request to.",
             "examples": ["us", "eu"],
         },
         "mcp_oauth_client_name": {
             "label": "MCP OAuth client name",
-            "description": "The OAuth client name captured during the MCP handshake, when present.",
+            "description": "The OAuth client name captured during the MCP handshake, when the connection used OAuth.",
         },
         "mcp_version": {
             "label": "MCP server version (internal)",
-            "description": "Server-resolved MCP version (1 or 2). May differ from the client-reported version because of the mcp-version-2 feature flag.",
+            "description": "Server-resolved MCP version. May differ from the version the client reported because of the mcp-version-2 feature flag.",
             "type": "Numeric",
             "examples": [1, 2],
         },
+        # Unprefixed MCP properties from the older code paths (the mcpcat library and PostHog's
+        # in-tree trackEvent path). They overlap with the $mcp_*-prefixed core properties above
+        # and will be retired once @posthog/mcp reaches general availability — they are not yet
+        # deprecated, because @posthog/mcp is still in internal testing.
+        "mcp_client_name": {
+            "label": "MCP client name (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_client_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_client_name for new dashboards.",
+            "examples": ["claude-code", "codex-mcp-client"],
+        },
+        "mcp_client_version": {
+            "label": "MCP client version (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_client_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_client_version for new dashboards.",
+        },
         "tool_name": {
-            "label": "Tool name (legacy)",
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_tool_name.",
+            "label": "Tool name (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_tool_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_tool_name for new dashboards.",
         },
         "resource_name": {
-            "label": "Resource name (legacy)",
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_resource_name.",
+            "label": "Resource name (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_resource_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_resource_name for new dashboards.",
         },
         "duration_ms": {
-            "label": "Duration (ms, legacy)",
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_duration_ms.",
+            "label": "Duration (ms, unprefixed)",
+            "description": "Older unprefixed variant of $mcp_duration_ms. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_duration_ms for new dashboards.",
             "type": "Numeric",
         },
         "is_error": {
-            "label": "Is error (legacy)",
-            "description": "Legacy unprefixed property from the mcpcat-era SDK. Replaced by $mcp_is_error.",
+            "label": "Is error (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_is_error. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_is_error for new dashboards.",
         },
         "$csp_document_url": {
             "label": "Document URL",


### PR DESCRIPTION
## Problem

PostHog's MCP analytics events — those emitted by `@posthog/mcp` (currently in internal testing) and the older events still emitted by `mcpcat` and PostHog's in-tree analytics path — weren't documented in the taxonomy. They surfaced in the TaxonomicFilter, event/property autocomplete, and other discovery UIs without labels or descriptions, which made it hard for anyone analyzing MCP usage to tell what each event/property means or which one to pick for new dashboards.

## Changes

- Added entries for the 9 events emitted by `@posthog/mcp`: `mcp_tool_call`, `mcp_tools_list`, `mcp_initialize`, `mcp_resources_list`, `mcp_resource_read`, `mcp_prompts_list`, `mcp_prompt_get`, `mcp_custom`, `posthog_identify`.
- Added entries for the older MCP events that still fire today (`mcp init`, `mcp_mcpcat:identify`, `mcp_posthog:identify`, `mcp_tool_called`, `mcp tool call`, `mcp tool response`, `mcp project switched`, `mcp organization switched`, `mcp feedback submitted`). These are **not deprecated yet** — `@posthog/mcp` is still in internal testing. Each description notes the `@posthog/mcp` equivalent to prefer for new dashboards, and that the older event will be retired once `@posthog/mcp` reaches general availability.
- Added the `$mcp_*` property family (`$mcp_intent`, `$mcp_intent_source`, `$mcp_tool_name`, `$mcp_duration_ms`, `$mcp_is_error`, `$mcp_client_name`, `$mcp_server_name`, `$mcp_parameters`, `$mcp_response`, …).
- Added the PostHog-server extension properties (`mcp_consumer`, `mcp_transport`, `mcp_mode`, `mcp_region`, `mcp_protocol_version`, `mcp_oauth_client_name`, `mcp_version`). These are added by the PostHog MCP server on top of the SDK's core set and **will carry over** onto `@posthog/mcp` events — not on a deprecation path.
- Added the older unprefixed core properties (`mcp_client_name`, `mcp_client_version`, `tool_name`, `resource_name`, `duration_ms`, `is_error`) with descriptions pointing at the `$mcp_*` replacement. Same GA-timing note applies.
- Regenerated `frontend/src/taxonomy/core-filter-definitions-by-group.json` via `pnpm run taxonomy:build`.

## How did you test this code?

I'm an agent (PostHog Code). I ran:

- `python -c "from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP, CORE_EVENTS"` — module imports cleanly, 17 new MCP events and 26 MCP-related properties are present.
- `pnpm run taxonomy:build` — JSON regenerated, new entries visible in the autogenerated file.
- `ruff check posthog/taxonomy/taxonomy.py` and `ruff format --check` — clean.

No manual UI testing of the discovery surfaces (TaxonomicFilter, event/property pickers) was performed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code. Reviewer notes:

- The catalogue was reconciled against the `@posthog/mcp` SDK architecture doc for the new SDK surface and cross-referenced against live event/property taxonomy via `read-data-schema` to confirm which older events are still firing.
- I deliberately avoided "(legacy)" labels and "being replaced by X" phrasing on the older events. They're not deprecated yet — `@posthog/mcp` is still in internal testing. Each description states that the retirement will happen once `@posthog/mcp` reaches general availability and recommends the equivalent `@posthog/mcp` event/property to prefer in the meantime.
- The PostHog-specific server extension properties (`mcp_consumer`, `mcp_transport`, etc.) were initially grouped with the unprefixed legacy ones in an earlier draft — that was wrong. The new SDK also carries them via its `eventProperties` callback, so they aren't on the retirement path. I split them out into their own block with their own comment.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*