### PR TITLE
feat(subscriptions): add hourly frequency option

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -402,12 +402,12 @@ class SubscriptionSerializer(serializers.ModelSerializer):
                 }
             )
 
-    def _hourly_frequency_feature_enabled(self) -> bool:
-        """Evaluate the hourly-frequency feature flag for the caller's organization.
+    def _evaluate_feature_flag(self, flag_key: str) -> bool:
+        """Evaluate a feature flag for the caller's organization.
 
-        Scoped by organization so the gate is stable across a team's members.
-        `only_evaluate_locally=False` so we respect server-side cohort / property
-        conditions — this isn't on a hot path.
+        Scoped by organization (not user) so gates are stable across a team's
+        members. `only_evaluate_locally=False` so we respect server-side cohort
+        / property conditions — these checks aren't on a hot path.
         """
         request = self.context.get("request")
         if not request or not getattr(request, "user", None) or not getattr(request.user, "distinct_id", None):
@@ -416,35 +416,19 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         org_id = str(organization.id) if organization else ""
         return bool(
             posthoganalytics.feature_enabled(
-                SUBSCRIPTION_HOURLY_FREQUENCY_FEATURE_FLAG_KEY,
+                flag_key,
                 str(request.user.distinct_id),
                 groups={"organization": org_id},
                 group_properties={"organization": {"id": org_id}},
                 only_evaluate_locally=False,
             )
         )
+
+    def _hourly_frequency_feature_enabled(self) -> bool:
+        return self._evaluate_feature_flag(SUBSCRIPTION_HOURLY_FREQUENCY_FEATURE_FLAG_KEY)
 
     def _prompt_guide_feature_enabled(self) -> bool:
-        """Evaluate the prompt-guide feature flag for the caller's organization.
-
-        Scoped by organization (not user) so the gate is stable across a team's
-        members. `only_evaluate_locally=False` so we respect server-side cohort
-        / property conditions — this isn't on a hot path.
-        """
-        request = self.context.get("request")
-        if not request or not getattr(request, "user", None) or not getattr(request.user, "distinct_id", None):
-            return False
-        organization = self.context["get_organization"]()
-        org_id = str(organization.id) if organization else ""
-        return bool(
-            posthoganalytics.feature_enabled(
-                SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY,
-                str(request.user.distinct_id),
-                groups={"organization": org_id},
-                group_properties={"organization": {"id": org_id}},
-                only_evaluate_locally=False,
-            )
-        )
+        return self._evaluate_feature_flag(SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY)
 
     def _validate_dashboard_export_subscription(self, attrs):
         dashboard = attrs.get("dashboard") or (self.instance.dashboard if self.instance else None)

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -26,7 +26,11 @@ from temporalio.exceptions import WorkflowAlreadyStartedError
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
-from posthog.constants import SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY, AvailableFeature
+from posthog.constants import (
+    SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY,
+    SUBSCRIPTION_HOURLY_FREQUENCY_FEATURE_FLAG_KEY,
+    AvailableFeature,
+)
 from posthog.event_usage import groups
 from posthog.exceptions import QuotaLimitExceeded
 from posthog.exceptions_capture import capture_exception
@@ -158,7 +162,12 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             "target_value": {
                 "help_text": "Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook."
             },
-            "frequency": {"help_text": "How often to deliver: daily, weekly, monthly, or yearly."},
+            "frequency": {
+                "help_text": (
+                    "How often to deliver: hourly, daily, weekly, monthly, or yearly. "
+                    "Hourly is feature-flagged and limited to one active subscription per organization."
+                )
+            },
             "interval": {
                 "help_text": "Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Default 1."
             },
@@ -284,6 +293,17 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             organization = self.context["get_organization"]()
             self._validate_summary_enabled_org_limit(organization)
 
+        # Hourly frequency is feature-flagged and capped at one active
+        # subscription per organization. Fire whenever the row is *becoming*
+        # an active hourly subscription (frequency=hourly AND enabled=True AND
+        # deleted=False) but wasn't before — catches creates, frequency
+        # changes, re-enables, and undeletes.
+        if self._is_becoming_active_hourly(attrs):
+            organization = self.context["get_organization"]()
+            if not self._hourly_frequency_feature_enabled():
+                raise exceptions.PermissionDenied("Hourly subscriptions are not enabled for this organization.")
+            self._validate_hourly_org_limit(organization)
+
         return attrs
 
     def _is_becoming_active_summary(self, attrs: dict) -> bool:
@@ -346,6 +366,63 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         except Exception:
             # Telemetry must never poison the validation path.
             pass
+
+    def _is_becoming_active_hourly(self, attrs: dict) -> bool:
+        pre_frequency = self.instance.frequency if self.instance else None
+        pre_enabled = self.instance.enabled if self.instance else True
+        pre_deleted = self.instance.deleted if self.instance else False
+        post_frequency = attrs.get("frequency", pre_frequency)
+        post_enabled = attrs.get("enabled", pre_enabled)
+        post_deleted = attrs.get("deleted", pre_deleted)
+
+        pre_active_hourly = (
+            pre_frequency == Subscription.SubscriptionFrequency.HOURLY and pre_enabled and not pre_deleted
+        )
+        post_active_hourly = (
+            post_frequency == Subscription.SubscriptionFrequency.HOURLY and post_enabled and not post_deleted
+        )
+        return post_active_hourly and not pre_active_hourly
+
+    def _validate_hourly_org_limit(self, organization) -> None:
+        existing = Subscription.objects.filter(
+            team__organization_id=organization.id,
+            frequency=Subscription.SubscriptionFrequency.HOURLY,
+            enabled=True,
+            deleted=False,
+        )
+        if self.instance is not None:
+            existing = existing.exclude(pk=self.instance.pk)
+        if existing.exists():
+            raise ValidationError(
+                {
+                    "frequency": [
+                        "Only one active hourly subscription is allowed per organization. "
+                        "Disable or delete the existing hourly subscription before adding another."
+                    ]
+                }
+            )
+
+    def _hourly_frequency_feature_enabled(self) -> bool:
+        """Evaluate the hourly-frequency feature flag for the caller's organization.
+
+        Scoped by organization so the gate is stable across a team's members.
+        `only_evaluate_locally=False` so we respect server-side cohort / property
+        conditions — this isn't on a hot path.
+        """
+        request = self.context.get("request")
+        if not request or not getattr(request, "user", None) or not getattr(request.user, "distinct_id", None):
+            return False
+        organization = self.context["get_organization"]()
+        org_id = str(organization.id) if organization else ""
+        return bool(
+            posthoganalytics.feature_enabled(
+                SUBSCRIPTION_HOURLY_FREQUENCY_FEATURE_FLAG_KEY,
+                str(request.user.distinct_id),
+                groups={"organization": org_id},
+                group_properties={"organization": {"id": org_id}},
+                only_evaluate_locally=False,
+            )
+        )
 
     def _prompt_guide_feature_enabled(self) -> bool:
         """Evaluate the prompt-guide feature flag for the caller's organization.

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -52,6 +52,7 @@ from ee.tasks.subscriptions.subscription_utils import DEFAULT_MAX_ASSET_COUNT
 
 SUMMARY_QUOTA_CACHE_TTL_SECONDS = 60
 SUMMARY_CAP_HIT_DEDUPE_TTL_SECONDS = 600
+HOURLY_CAP_HIT_DEDUPE_TTL_SECONDS = 600
 
 
 def _summary_quota_cache_key(organization_id) -> str:
@@ -60,6 +61,10 @@ def _summary_quota_cache_key(organization_id) -> str:
 
 def _summary_cap_hit_dedupe_key(organization_id) -> str:
     return f"subscription:summary_cap_hit:org:{organization_id}"
+
+
+def _hourly_cap_hit_dedupe_key(organization_id) -> str:
+    return f"subscription:hourly_cap_hit:org:{organization_id}"
 
 
 def _count_active_summaries(organization) -> int:
@@ -393,6 +398,7 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         if self.instance is not None:
             existing = existing.exclude(pk=self.instance.pk)
         if existing.exists():
+            self._capture_hourly_cap_hit(organization)
             raise ValidationError(
                 {
                     "frequency": [
@@ -401,6 +407,36 @@ class SubscriptionSerializer(serializers.ModelSerializer):
                     ]
                 }
             )
+
+    def _capture_hourly_cap_hit(self, organization) -> None:
+        # Rate-limited to one event per org per 10 minutes so a misbehaving
+        # client retrying in a loop doesn't spam the analytics stream. Within
+        # that window the user-visible 400 still fires every time.
+        dedupe_key = _hourly_cap_hit_dedupe_key(organization.id)
+        if cache.get(dedupe_key):
+            return
+        cache.set(dedupe_key, True, HOURLY_CAP_HIT_DEDUPE_TTL_SECONDS)
+
+        request = self.context.get("request")
+        distinct_id = (
+            str(request.user.distinct_id)
+            if request and getattr(request, "user", None) and getattr(request.user, "distinct_id", None)
+            else f"team_{self.context.get('team_id')}"
+        )
+        try:
+            posthoganalytics.capture(
+                distinct_id=distinct_id,
+                event="subscription_hourly_cap_hit",
+                properties={
+                    "team_id": self.context.get("team_id"),
+                    "organization_id": str(organization.id),
+                    "is_create": self.instance is None,
+                },
+                groups={"organization": str(organization.id)},
+            )
+        except Exception:
+            # Telemetry must never poison the validation path.
+            pass
 
     def _evaluate_feature_flag(self, flag_key: str) -> bool:
         """Evaluate a feature flag for the caller's organization.

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -644,6 +644,26 @@ class TestSubscriptionTemporal(APILicensedTest):
 
         assert second.status_code == status.HTTP_201_CREATED
 
+    def test_hourly_cap_hit_emits_telemetry(self):
+        cache.clear()
+        with (
+            patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True),
+            patch("ee.api.subscription.posthoganalytics.capture") as mock_capture,
+        ):
+            first = self._create_subscription(frequency="hourly", title="first hourly")
+            assert first.status_code == status.HTTP_201_CREATED
+
+            second = self._create_subscription(frequency="hourly", title="second hourly")
+            assert second.status_code == status.HTTP_400_BAD_REQUEST
+
+        cap_hit_calls = [
+            c for c in mock_capture.call_args_list if c.kwargs.get("event") == "subscription_hourly_cap_hit"
+        ]
+        assert len(cap_hit_calls) == 1
+        props = cap_hit_calls[0].kwargs["properties"]
+        assert props["organization_id"] == str(self.organization.id)
+        assert props["is_create"] is True
+
     def _seed_active_summary_subscriptions(self, count: int) -> list[Subscription]:
         # Build raw rows so we can place an org over its tier cap to exercise
         # grandfathering paths without going through the enforced API.

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -596,19 +596,27 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "AI summary context" in response.json()["detail"]
 
-    def test_cannot_create_hourly_subscription_when_feature_flag_disabled(self):
-        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=False):
+    @parameterized.expand(
+        [
+            ("flag_disabled_rejects", False, status.HTTP_403_FORBIDDEN, "Hourly subscriptions"),
+            ("flag_enabled_allows", True, status.HTTP_201_CREATED, "hourly"),
+        ]
+    )
+    def test_hourly_subscription_create_respects_feature_flag(
+        self,
+        _case_name: str,
+        flag_value: bool,
+        expected_status: int,
+        expected_fragment: str,
+    ):
+        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=flag_value):
             response = self._create_subscription(frequency="hourly")
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "Hourly subscriptions" in response.json()["detail"]
-
-    def test_can_create_hourly_subscription_when_feature_flag_enabled(self):
-        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True):
-            response = self._create_subscription(frequency="hourly")
-
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()["frequency"] == "hourly"
+        assert response.status_code == expected_status, response.content
+        if expected_status == status.HTTP_201_CREATED:
+            assert response.json()["frequency"] == expected_fragment
+        else:
+            assert expected_fragment in response.json()["detail"]
 
     def test_cannot_create_second_active_hourly_subscription_in_org(self):
         with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True):

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -596,6 +596,46 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "AI summary context" in response.json()["detail"]
 
+    def test_cannot_create_hourly_subscription_when_feature_flag_disabled(self):
+        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=False):
+            response = self._create_subscription(frequency="hourly")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Hourly subscriptions" in response.json()["detail"]
+
+    def test_can_create_hourly_subscription_when_feature_flag_enabled(self):
+        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True):
+            response = self._create_subscription(frequency="hourly")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["frequency"] == "hourly"
+
+    def test_cannot_create_second_active_hourly_subscription_in_org(self):
+        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True):
+            first = self._create_subscription(frequency="hourly", title="first hourly")
+            assert first.status_code == status.HTTP_201_CREATED
+
+            second = self._create_subscription(frequency="hourly", title="second hourly")
+
+        assert second.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Only one active hourly subscription" in str(second.json())
+
+    def test_can_replace_hourly_subscription_after_disable(self):
+        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True):
+            first = self._create_subscription(frequency="hourly", title="first hourly")
+            assert first.status_code == status.HTTP_201_CREATED
+
+            # Disable the first hourly subscription — it should free up the org slot.
+            patch_response = self.client.patch(
+                f"/api/projects/{self.team.id}/subscriptions/{first.json()['id']}",
+                {"enabled": False},
+            )
+            assert patch_response.status_code == status.HTTP_200_OK
+
+            second = self._create_subscription(frequency="hourly", title="second hourly")
+
+        assert second.status_code == status.HTTP_201_CREATED
+
     def _seed_active_summary_subscriptions(self, count: int) -> list[Subscription]:
         # Build raw rows so we can place an org over its tier cap to exercise
         # grandfathering paths without going through the enforced API.

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -2546,7 +2546,8 @@ export const TargetTypeEnumApi = {
 } as const
 
 /**
- * * `daily` - Daily
+ * * `hourly` - Hourly
+ * `daily` - Daily
  * `weekly` - Weekly
  * `monthly` - Monthly
  * `yearly` - Yearly
@@ -2555,6 +2556,7 @@ export type SubscriptionFrequencyEnumApi =
     (typeof SubscriptionFrequencyEnumApi)[keyof typeof SubscriptionFrequencyEnumApi]
 
 export const SubscriptionFrequencyEnumApi = {
+    Hourly: 'hourly',
     Daily: 'daily',
     Weekly: 'weekly',
     Monthly: 'monthly',
@@ -2612,8 +2614,9 @@ export interface SubscriptionApi {
     target_type: TargetTypeEnumApi
     /** Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook. */
     target_value: string
-    /** How often to deliver: daily, weekly, monthly, or yearly.
+    /** How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.
 
+  * `hourly` - Hourly
   * `daily` - Daily
   * `weekly` - Weekly
   * `monthly` - Monthly
@@ -2742,8 +2745,9 @@ export interface PatchedSubscriptionApi {
     target_type?: TargetTypeEnumApi
     /** Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook. */
     target_value?: string
-    /** How often to deliver: daily, weekly, monthly, or yearly.
+    /** How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.
 
+  * `hourly` - Hourly
   * `daily` - Daily
   * `weekly` - Weekly
   * `monthly` - Monthly

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -2594,10 +2594,12 @@ export const SubscriptionsCreateBody = /* @__PURE__ */ zod
                 'Recipient(s): comma-separated email addresses for email, Slack channel name\/ID for slack, or full URL for webhook.'
             ),
         frequency: zod
-            .enum(['daily', 'weekly', 'monthly', 'yearly'])
-            .describe('\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly')
+            .enum(['hourly', 'daily', 'weekly', 'monthly', 'yearly'])
             .describe(
-                'How often to deliver: daily, weekly, monthly, or yearly.\n\n\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly'
+                '\* `hourly` - Hourly\n\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly'
+            )
+            .describe(
+                'How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.\n\n\* `hourly` - Hourly\n\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly'
             ),
         interval: zod
             .number()
@@ -2700,10 +2702,12 @@ export const SubscriptionsUpdateBody = /* @__PURE__ */ zod
                 'Recipient(s): comma-separated email addresses for email, Slack channel name\/ID for slack, or full URL for webhook.'
             ),
         frequency: zod
-            .enum(['daily', 'weekly', 'monthly', 'yearly'])
-            .describe('\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly')
+            .enum(['hourly', 'daily', 'weekly', 'monthly', 'yearly'])
             .describe(
-                'How often to deliver: daily, weekly, monthly, or yearly.\n\n\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly'
+                '\* `hourly` - Hourly\n\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly'
+            )
+            .describe(
+                'How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.\n\n\* `hourly` - Hourly\n\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly'
             ),
         interval: zod
             .number()
@@ -2808,11 +2812,13 @@ export const SubscriptionsPartialUpdateBody = /* @__PURE__ */ zod
                 'Recipient(s): comma-separated email addresses for email, Slack channel name\/ID for slack, or full URL for webhook.'
             ),
         frequency: zod
-            .enum(['daily', 'weekly', 'monthly', 'yearly'])
-            .describe('\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly')
+            .enum(['hourly', 'daily', 'weekly', 'monthly', 'yearly'])
+            .describe(
+                '\* `hourly` - Hourly\n\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly'
+            )
             .optional()
             .describe(
-                'How often to deliver: daily, weekly, monthly, or yearly.\n\n\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly'
+                'How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.\n\n\* `hourly` - Hourly\n\* `daily` - Daily\n\* `weekly` - Weekly\n\* `monthly` - Monthly\n\* `yearly` - Yearly'
             ),
         interval: zod
             .number()

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
@@ -192,7 +192,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
         setSubscriptionValue: ({ name, value }) => {
             const key = Array.isArray(name) ? name[0] : name
             if (key === 'frequency') {
-                if (value === 'daily') {
+                if (value === 'daily' || value === 'hourly') {
                     actions.setSubscriptionValues({
                         bysetpos: null,
                         byweekday: null,

--- a/frontend/src/lib/components/Subscriptions/utils.tsx
+++ b/frontend/src/lib/components/Subscriptions/utils.tsx
@@ -56,8 +56,12 @@ export const frequencyOptionsPlural: LemonSelectOptions<FrequencyOptionValue> = 
     { value: 'monthly', label: 'months' },
 ]
 
-export const hourlyFrequencyOptionSingular: LemonSelectOptions<FrequencyOptionValue> = [{ value: 'hourly', label: 'hour' }]
-export const hourlyFrequencyOptionPlural: LemonSelectOptions<FrequencyOptionValue> = [{ value: 'hourly', label: 'hours' }]
+export const hourlyFrequencyOptionSingular: LemonSelectOptions<FrequencyOptionValue> = [
+    { value: 'hourly', label: 'hour' },
+]
+export const hourlyFrequencyOptionPlural: LemonSelectOptions<FrequencyOptionValue> = [
+    { value: 'hourly', label: 'hours' },
+]
 
 export const weekdayOptions: LemonSelectOptionLeaf<
     'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday'

--- a/frontend/src/lib/components/Subscriptions/utils.tsx
+++ b/frontend/src/lib/components/Subscriptions/utils.tsx
@@ -43,16 +43,21 @@ export const targetTypeOptions: LemonSelectOptions<'email' | 'slack'> = [
 
 export const intervalOptions: LemonSelectOptions<number> = range(1, 13).map((x) => ({ value: x, label: x.toString() }))
 
-export const frequencyOptionsSingular: LemonSelectOptions<'daily' | 'weekly' | 'monthly'> = [
+export type FrequencyOptionValue = 'hourly' | 'daily' | 'weekly' | 'monthly'
+
+export const frequencyOptionsSingular: LemonSelectOptions<FrequencyOptionValue> = [
     { value: 'daily', label: 'day' },
     { value: 'weekly', label: 'week' },
     { value: 'monthly', label: 'month' },
 ]
-export const frequencyOptionsPlural: LemonSelectOptions<'daily' | 'weekly' | 'monthly'> = [
+export const frequencyOptionsPlural: LemonSelectOptions<FrequencyOptionValue> = [
     { value: 'daily', label: 'days' },
     { value: 'weekly', label: 'weeks' },
     { value: 'monthly', label: 'months' },
 ]
+
+export const hourlyFrequencyOptionSingular: LemonSelectOptions<FrequencyOptionValue> = [{ value: 'hourly', label: 'hour' }]
+export const hourlyFrequencyOptionPlural: LemonSelectOptions<FrequencyOptionValue> = [{ value: 'hourly', label: 'hours' }]
 
 export const weekdayOptions: LemonSelectOptionLeaf<
     'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday'
@@ -96,6 +101,7 @@ const RRULE_WEEKDAY_MAP: Record<string, (typeof RRule)['MO']> = {
 }
 
 const RRULE_FREQ_MAP: Record<string, number> = {
+    hourly: RRule.HOURLY,
     daily: RRule.DAILY,
     weekly: RRule.WEEKLY,
     monthly: RRule.MONTHLY,

--- a/frontend/src/lib/components/Subscriptions/utils.tsx
+++ b/frontend/src/lib/components/Subscriptions/utils.tsx
@@ -1,7 +1,7 @@
 import { RRule } from 'rrule'
 
 import { IconLetter } from '@posthog/icons'
-import { LemonSelectOptionLeaf, LemonSelectOptions } from '@posthog/lemon-ui'
+import { LemonSelectOption, LemonSelectOptionLeaf, LemonSelectOptions } from '@posthog/lemon-ui'
 
 import { IconSlack } from 'lib/lemon-ui/icons'
 import { range } from 'lib/utils'
@@ -45,21 +45,24 @@ export const intervalOptions: LemonSelectOptions<number> = range(1, 13).map((x) 
 
 export type FrequencyOptionValue = 'hourly' | 'daily' | 'weekly' | 'monthly'
 
-export const frequencyOptionsSingular: LemonSelectOptions<FrequencyOptionValue> = [
+// Typed as the concrete `LemonSelectOption[]` (not the `LemonSelectOptions` union of
+// `Section[] | Option[]`) so callers can `[...hourly, ...daily-monthly]` without
+// the union widening to `(Section | Option)[]` and losing assignability.
+export const frequencyOptionsSingular: LemonSelectOption<FrequencyOptionValue>[] = [
     { value: 'daily', label: 'day' },
     { value: 'weekly', label: 'week' },
     { value: 'monthly', label: 'month' },
 ]
-export const frequencyOptionsPlural: LemonSelectOptions<FrequencyOptionValue> = [
+export const frequencyOptionsPlural: LemonSelectOption<FrequencyOptionValue>[] = [
     { value: 'daily', label: 'days' },
     { value: 'weekly', label: 'weeks' },
     { value: 'monthly', label: 'months' },
 ]
 
-export const hourlyFrequencyOptionSingular: LemonSelectOptions<FrequencyOptionValue> = [
+export const hourlyFrequencyOptionSingular: LemonSelectOption<FrequencyOptionValue>[] = [
     { value: 'hourly', label: 'hour' },
 ]
-export const hourlyFrequencyOptionPlural: LemonSelectOptions<FrequencyOptionValue> = [
+export const hourlyFrequencyOptionPlural: LemonSelectOption<FrequencyOptionValue>[] = [
     { value: 'hourly', label: 'hours' },
 ]
 

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -11,6 +11,7 @@ import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/User
 import { usersLemonSelectOptions } from 'lib/components/UserSelectItem'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
@@ -37,6 +38,8 @@ import {
     frequencyOptionsPlural,
     frequencyOptionsSingular,
     getNextDeliveryDate,
+    hourlyFrequencyOptionPlural,
+    hourlyFrequencyOptionSingular,
     intervalOptions,
     monthlyWeekdayOptions,
     targetTypeOptions,
@@ -81,8 +84,17 @@ export function EditSubscription({
     const { deleteSubscription } = useActions(subscriptionslogic)
     const { slackIntegrations, integrations } = useValues(integrationsLogic)
     const { dataProcessingAccepted } = useValues(maxGlobalLogic)
+    const hourlySubscriptionsEnabled = useFeatureFlag('SUBSCRIPTION_HOURLY_FREQUENCY')
 
     const emailDisabled = !preflight?.email_service_available
+
+    // Show the hourly option whenever the feature flag is on for this user/org, OR
+    // when the subscription being edited is already hourly (so the user can read /
+    // modify a value that was created when the flag was on).
+    const showHourlyOption = hourlySubscriptionsEnabled || subscription?.frequency === 'hourly'
+    const frequencyOptions = subscription?.interval === 1 ? frequencyOptionsSingular : frequencyOptionsPlural
+    const hourlyOption = subscription?.interval === 1 ? hourlyFrequencyOptionSingular : hourlyFrequencyOptionPlural
+    const availableFrequencyOptions = showHourlyOption ? [...hourlyOption, ...frequencyOptions] : frequencyOptions
 
     // For new subscriptions, show InsightSelector immediately (useEffect will auto-select)
     // For editing, wait until subscription data has loaded from API (target_type exists)
@@ -346,13 +358,7 @@ export function EditSubscription({
                                     <LemonSelect options={intervalOptions} />
                                 </LemonField>
                                 <LemonField name="frequency">
-                                    <LemonSelect
-                                        options={
-                                            subscription.interval === 1
-                                                ? frequencyOptionsSingular
-                                                : frequencyOptionsPlural
-                                        }
-                                    />
+                                    <LemonSelect options={availableFrequencyOptions} />
                                 </LemonField>
 
                                 {subscription.frequency === 'weekly' && (

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -422,7 +422,7 @@ export function EditSubscription({
                                         </LemonField>
                                     </>
                                 )}
-                                <span>by</span>
+                                <span>{subscription.frequency === 'hourly' ? 'starting at' : 'by'}</span>
                                 <LemonField name="start_date">
                                     {({ value, onChange }) => (
                                         <LemonSelect

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -464,6 +464,7 @@ export const FEATURE_FLAGS = {
     SQL_EDITOR_VIM_MODE: 'sql-editor-vim-mode', // owner: @arthurdedeus
     SSE_DASHBOARDS: 'sse-dashboards', // owner: @aspicer #team-analytics-platform
     SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE: 'subscription-ai-summary-prompt-guide', // owner: #team-analytics-platform, gates the per-subscription prompt guide textarea
+    SUBSCRIPTION_HOURLY_FREQUENCY: 'subscription-hourly-frequency', // owner: #team-analytics-platform, gates hourly subscription frequency (one active hourly subscription per org)
     SURVEY_HEADLINE_SUMMARY: 'survey-headline-summary', // owner: @adboio #team-surveys
     SURVEYS_ERROR_TRACKING_CROSS_SELL: 'surveys-in-error-tracking', // owner: @adboio #team-surveys
     SURVEYS_FORM_BUILDER: 'surveys-form-builder', // owner: @adboio #team-surveys

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5036,7 +5036,7 @@ export interface SubscriptionType {
     integration_id?: number | null
     target_type: string
     target_value: string
-    frequency: 'daily' | 'weekly' | 'monthly' | 'yearly'
+    frequency: 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly'
     interval: number
     byweekday: WeekdayType[] | null
     bysetpos: number | null

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -315,6 +315,7 @@ PRODUCT_TOUR_TARGETING_FLAG_PREFIX = "product-tour-targeting-"
 # Server-side evaluation via posthoganalytics; keep in sync with frontend FEATURE_FLAGS.
 HACKATHONS_SUBSCRIPTIONS_FEATURE_FLAG_KEY = "hackathons_subscriptions"
 SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY = "subscription-ai-summary-prompt-guide"
+SUBSCRIPTION_HOURLY_FREQUENCY_FEATURE_FLAG_KEY = "subscription-hourly-frequency"
 EXPERIMENTS_SYNC_QUERIES_FEATURE_FLAG_KEY = "experiments-sync-queries"
 GENERATED_DASHBOARD_PREFIX = "Generated Dashboard"
 

--- a/posthog/migrations/1153_subscription_hourly_frequency.py
+++ b/posthog/migrations/1153_subscription_hourly_frequency.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("posthog", "1152_fix_device_bucketing_persist_across_auth")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="subscription",
+            name="frequency",
+            field=models.CharField(
+                choices=[
+                    ("hourly", "Hourly"),
+                    ("daily", "Daily"),
+                    ("weekly", "Weekly"),
+                    ("monthly", "Monthly"),
+                    ("yearly", "Yearly"),
+                ],
+                max_length=10,
+            ),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1152_fix_device_bucketing_persist_across_auth
+1153_subscription_hourly_frequency

--- a/posthog/models/subscription.py
+++ b/posthog/models/subscription.py
@@ -8,7 +8,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
 
-from dateutil.rrule import DAILY, FR, MO, MONTHLY, SA, SU, TH, TU, WE, WEEKLY, YEARLY, rrule
+from dateutil.rrule import DAILY, FR, HOURLY, MO, MONTHLY, SA, SU, TH, TU, WE, WEEKLY, YEARLY, rrule
 
 from posthog.exceptions_capture import capture_exception
 from posthog.jwt import PosthogJwtAudience, decode_jwt, encode_jwt
@@ -51,6 +51,7 @@ class Subscription(models.Model):
         WEBHOOK = "webhook"
 
     class SubscriptionFrequency(models.TextChoices):
+        HOURLY = "hourly"
         DAILY = "daily"
         WEEKLY = "weekly"
         MONTHLY = "monthly"
@@ -68,6 +69,7 @@ class Subscription(models.Model):
     RRULE_FIELDS = {"frequency", "count", "interval", "start_date", "until_date", "bysetpos", "byweekday"}
 
     _FREQ_MAP: dict[str, int] = {
+        SubscriptionFrequency.HOURLY: HOURLY,
         SubscriptionFrequency.DAILY: DAILY,
         SubscriptionFrequency.WEEKLY: WEEKLY,
         SubscriptionFrequency.MONTHLY: MONTHLY,
@@ -225,6 +227,7 @@ class Subscription(models.Model):
     def summary(self):
         try:
             human_frequency = {
+                "hourly": "hour",
                 "daily": "day",
                 "weekly": "week",
                 "monthly": "month",

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -473,15 +473,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-14'), lessOrEquals(toDate(events.timestamp), '2024-01-18'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'America/Sao_Paulo')), max(toTimeZone(raw_sessions.max_timestamp, 'America/Sao_Paulo'))), 10)))) AS `$is_bounce`,
@@ -497,7 +489,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'America/Sao_Paulo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/Sao_Paulo'))), lessOrEquals(toTimeZone(events.timestamp, 'America/Sao_Paulo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/Sao_Paulo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'America/Sao_Paulo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/Sao_Paulo'))), lessOrEquals(toTimeZone(events.timestamp, 'America/Sao_Paulo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/Sao_Paulo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
@@ -627,7 +619,15 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.person_id,
+               events.`mat_$browser`,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Europe/Berlin')), max(toTimeZone(raw_sessions.max_timestamp, 'Europe/Berlin'))), 10)))) AS `$is_bounce`,
@@ -643,7 +643,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Europe/Berlin'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Europe/Berlin'))), lessOrEquals(toTimeZone(events.timestamp, 'Europe/Berlin'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Europe/Berlin')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Europe/Berlin'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Europe/Berlin'))), lessOrEquals(toTimeZone(events.timestamp, 'Europe/Berlin'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Europe/Berlin')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -22867,7 +22867,8 @@ export namespace Schemas {
     } as const;
 
     /**
-     * * `daily` - Daily
+     * * `hourly` - Hourly
+    * `daily` - Daily
     * `weekly` - Weekly
     * `monthly` - Monthly
     * `yearly` - Yearly
@@ -22876,6 +22877,7 @@ export namespace Schemas {
 
 
     export const SubscriptionFrequencyEnum = {
+      Hourly: 'hourly',
       Daily: 'daily',
       Weekly: 'weekly',
       Monthly: 'monthly',
@@ -22933,8 +22935,9 @@ export namespace Schemas {
       target_type: TargetTypeEnum;
       /** Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook. */
       target_value: string;
-      /** How often to deliver: daily, weekly, monthly, or yearly.
+      /** How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.
 
+      * `hourly` - Hourly
       * `daily` - Daily
       * `weekly` - Weekly
       * `monthly` - Monthly
@@ -28437,8 +28440,9 @@ export namespace Schemas {
       target_type?: TargetTypeEnum;
       /** Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook. */
       target_value?: string;
-      /** How often to deliver: daily, weekly, monthly, or yearly.
+      /** How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.
 
+      * `hourly` - Hourly
       * `daily` - Daily
       * `weekly` - Weekly
       * `monthly` - Monthly

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -344,10 +344,12 @@ export const SubscriptionsCreateBody = /* @__PURE__ */ zod
                 'Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook.'
             ),
         frequency: zod
-            .enum(['daily', 'weekly', 'monthly', 'yearly'])
-            .describe('* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly')
+            .enum(['hourly', 'daily', 'weekly', 'monthly', 'yearly'])
             .describe(
-                'How often to deliver: daily, weekly, monthly, or yearly.\n\n* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly'
+                '* `hourly` - Hourly\n* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly'
+            )
+            .describe(
+                'How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.\n\n* `hourly` - Hourly\n* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly'
             ),
         interval: zod
             .number()
@@ -470,11 +472,13 @@ export const SubscriptionsPartialUpdateBody = /* @__PURE__ */ zod
                 'Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook.'
             ),
         frequency: zod
-            .enum(['daily', 'weekly', 'monthly', 'yearly'])
-            .describe('* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly')
+            .enum(['hourly', 'daily', 'weekly', 'monthly', 'yearly'])
+            .describe(
+                '* `hourly` - Hourly\n* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly'
+            )
             .optional()
             .describe(
-                'How often to deliver: daily, weekly, monthly, or yearly.\n\n* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly'
+                'How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.\n\n* `hourly` - Hourly\n* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly'
             ),
         interval: zod
             .number()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-create.json
@@ -71,8 +71,8 @@
             "type": "boolean"
         },
         "frequency": {
-            "description": "How often to deliver: daily, weekly, monthly, or yearly.\n\n* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly",
-            "enum": ["daily", "weekly", "monthly", "yearly"],
+            "description": "How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.\n\n* `hourly` - Hourly\n* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly",
+            "enum": ["hourly", "daily", "weekly", "monthly", "yearly"],
             "type": "string"
         },
         "insight": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-partial-update.json
@@ -70,8 +70,8 @@
             "type": "boolean"
         },
         "frequency": {
-            "description": "How often to deliver: daily, weekly, monthly, or yearly.\n\n* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly",
-            "enum": ["daily", "weekly", "monthly", "yearly"],
+            "description": "How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.\n\n* `hourly` - Hourly\n* `daily` - Daily\n* `weekly` - Weekly\n* `monthly` - Monthly\n* `yearly` - Yearly",
+            "enum": ["hourly", "daily", "weekly", "monthly", "yearly"],
             "type": "string"
         },
         "id": {


### PR DESCRIPTION
## Problem

Subscriptions can currently fire at most once per day. Some teams need higher-cadence digest deliveries (e.g. an executive dashboard at the top of every hour during a launch) but rolling that out broadly would multiply scheduler load and email/Slack volume.

This change introduces an **hourly** frequency option behind a feature flag, with a strict cap of **one active hourly subscription per organization**. That gives us a controllable surface to evaluate the cadence in production without an unbounded blast radius.

## Changes

- **Model**: add `HOURLY = "hourly"` to `Subscription.SubscriptionFrequency`, map it to `dateutil.rrule.HOURLY` in `_FREQ_MAP`, and extend the `summary` humanizer. Migration `1153_subscription_hourly_frequency` widens the `choices` constraint.
- **Backend validation** (`ee/api/subscription.py`): when a subscription is *becoming* an active hourly one (create, frequency change to hourly, re-enable, or undelete), enforce two gates:
  1. The `subscription-hourly-frequency` feature flag must be enabled for the caller's organization — otherwise 403.
  2. No other active hourly subscription must exist in the organization — otherwise 400.
  The "becoming active" pattern mirrors the existing `_is_becoming_active_summary` so PATCH paths cannot sneak past the cap.
- **Frontend**: add a new `SUBSCRIPTION_HOURLY_FREQUENCY` feature flag constant. `EditSubscription` shows the hourly option only when the flag is on (or when reading a sub that already uses it, so it remains editable if the flag flips off). `subscriptionLogic` treats hourly the same as daily for clearing `byweekday`/`bysetpos`.
- **Tests**: API tests cover (a) flag-off rejection, (b) flag-on acceptance, (c) second hourly in the same org rejected, and (d) disabling the first hourly subscription frees up the slot.

The Temporal scheduler already polls hourly and dispatches based on `next_delivery_date`, so no scheduler changes are needed — `dateutil.rrule.HOURLY` plugs into the existing rrule builder unchanged.

## How did you test this code?

I am an agent (PostHog Code). Tests I actually ran:

- `ruff check` and `ruff format --check` on the touched Python files — clean.

Tests I added but did not execute locally (no Python venv available in this environment):

- `test_cannot_create_hourly_subscription_when_feature_flag_disabled`
- `test_can_create_hourly_subscription_when_feature_flag_enabled`
- `test_cannot_create_second_active_hourly_subscription_in_org`
- `test_can_replace_hourly_subscription_after_disable`

I did not run frontend type checks or `hogli build:openapi` — reviewers should regenerate API schemas locally before merge so the generated `SubscriptionFrequencyEnumApi` includes `hourly`. The hand-written `SubscriptionType` in `frontend/src/types.ts` (the source of truth for `subscriptionLogic`) is already updated.

## Publish to changelog?

Once the flag is rolled out broadly.

## 🤖 Agent context

Authored by PostHog Code on behalf of the requester. Decisions made along the way:

- **Where to put validation**: kept both gates in `SubscriptionSerializer.validate()` alongside the existing summary-cap check. This is the only path that handles create + update + soft-delete restoration uniformly, and the existing summary-cap code already established the "becoming active" pattern.
- **Org slot accounting**: filter on `frequency=hourly AND enabled=True AND deleted=False` and exclude the current instance during updates. This means disabling (not just deleting) frees the slot, which matches the way the Temporal scheduler treats `enabled=False` subscriptions.
- **Why I left the time-of-day picker alone**: for `interval=1` hourly the start hour is technically unused (the scheduler polls every hour and the rrule fires from `dtstart` forward). But for `interval=2, 3, ...` the start hour seeds which hours fire. Hiding the picker for `interval=1` only would be more code than it is worth, so I left it intact.
- **Generated API types**: `frontend/src/generated/core/api.schemas.ts` is auto-generated and I did not regenerate it. The hand-written `SubscriptionType` carries `'hourly'`. Reviewers should run `hogli build:openapi` before merging.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*