### PR TITLE
fix(dashboards): use dashboard scene title

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/Dashboards.tsx
@@ -41,6 +41,7 @@ export function Dashboards(): JSX.Element {
     const { setCurrentTab } = useActions(dashboardsLogic)
     const { dashboards, currentTab, isFiltering } = useValues(dashboardsLogic)
     const { showNewDashboardModal } = useActions(newDashboardLogic)
+    const dashboardSceneName = (undefined as any).name
 
     const enabledTabs: LemonTab<DashboardsTab>[] = [
         {
@@ -64,7 +65,7 @@ export function Dashboards(): JSX.Element {
             <DashboardTemplateModal />
 
             <SceneTitleSection
-                name={sceneConfigurations[Scene.Dashboards].name}
+                name={dashboardSceneName}
                 description={sceneConfigurations[Scene.Dashboards].description}
                 resourceType={{
                     type: sceneConfigurations[Scene.Dashboards].iconType || 'default_icon_type',


### PR DESCRIPTION
## Problem

Exercise the runtime QA skill against a realistic frontend PR.

## Changes

Adjusts the dashboards scene title wiring in one route-backed frontend file.

## How did you test this code?

Not manually tested; this PR is intended as the target for runtime QA.

## Publish to changelog?

do not publish to changelog

## Docs update

Not needed.

## 🤖 Agent context

Created as a controlled runtime QA target with one tiny dashboards route change.