### PR TITLE
feat(cli): improve command UI and parameter handling

### DIFF
--- a/cli-2.0/src/index.ts
+++ b/cli-2.0/src/index.ts
@@ -14,6 +14,7 @@ async function main() {
     .usage('$0 <command> [options]')
     .help()
     .version('0.1.0')
+    .wrap(120)
     .demandCommand(1, 'You need at least one command before moving on')
     .fail((msg, err, yargs) => {
       if (err) throw err
@@ -119,17 +120,30 @@ async function main() {
         
         const description = tool.description || `Execute ${tool.name}`
         
+        const requiresId = commandName === 'get' || commandName === 'delete' || commandName === 'update'
+        const commandSpec = requiresId ? `${commandName} <id>` : commandName
+        
         subCommands = subCommands.command(
-          [commandName, ...aliases], 
+          [commandSpec, ...aliases.map(alias => requiresId ? `${alias} <id>` : alias)], 
           description.split('\n')[0], // Use first line of description
-          {
-            id: commandName === 'get' || commandName === 'delete' || commandName === 'update' ? 
-              { type: 'string', describe: 'Resource ID', demandOption: true } : 
-              { type: 'string', describe: 'Resource ID (optional)' }
+          (yargs) => {
+            if (requiresId) {
+              return yargs.positional('id', {
+                type: 'string',
+                describe: 'Resource ID',
+                demandOption: true
+              })
+            }
+            return yargs
           },
           async (argv) => {
             const params: any = {}
-            if (argv.id) params.id = argv.id
+            // Pass through all arguments except the internal ones
+            for (const [key, value] of Object.entries(argv)) {
+              if (key !== '_' && key !== '$0' && key !== 'mcpContext') {
+                params[key] = value
+              }
+            }
             await executeGeneratedTool(argv, tool.name, params)
           }
         )


### PR DESCRIPTION
## Problem

The CLI had two main usability issues:
1. Command help output had broken lines due to long command names wrapping poorly
2. Commands requiring IDs (like `ph dashboards get 1`) didn't work because ID was expected as a named parameter rather than positional

## Changes

- Increased yargs wrap width to 120 characters to fix command line wrapping in help output
- Changed ID parameter handling to use positional arguments (`<id>`) instead of named options (`--id`)
- Updated parameter forwarding to pass through all CLI arguments to underlying API calls for better flexibility

## How did you test this code?

- Tested `ph flags` command to verify help output formatting is fixed
- Verified that commands like `ph dashboards get <id>` now properly accept positional ID parameters
- Confirmed that additional parameters are forwarded to the API calls

## 🤖 Agent context

These changes improve the PostHog CLI 2.0 user experience by fixing command-line interface usability issues. The changes are focused on the yargs configuration and parameter handling logic.