### PR TITLE
feat(oauth): add CIMD metadata for posthog-definitions CLI

### DIFF
--- a/posthog/api/oauth/definitions_metadata.py
+++ b/posthog/api/oauth/definitions_metadata.py
@@ -1,0 +1,38 @@
+from django.conf import settings
+from django.http import JsonResponse
+from django.views import View
+
+DEFINITIONS_METADATA_PATH = "api/oauth/posthog-definitions/client-metadata"
+
+
+class DefinitionsClientMetadataView(View):
+    """
+    Serves a static CIMD (Client ID Metadata Document) for the posthog-definitions
+    CLI — infrastructure-as-code for PostHog dashboards and insights.
+
+    The client_id in the response is the canonical URL where this document is hosted,
+    constructed from SITE_URL so it's correct on each region (US, EU, self-hosted).
+
+    redirect_uris is registered as the portless localhost form (`http://localhost/callback`)
+    so the loopback port-flexibility logic in OAuthValidator.validate_redirect_uri accepts
+    any ephemeral callback port the CLI chooses at runtime.
+    """
+
+    http_method_names = ["get"]
+
+    def get(self, request):
+        client_id = f"{settings.SITE_URL}/{DEFINITIONS_METADATA_PATH}"
+
+        metadata = {
+            "client_id": client_id,
+            "client_name": "posthog-definitions",
+            "redirect_uris": ["http://localhost/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        }
+
+        response = JsonResponse(metadata)
+        response["Cache-Control"] = "public, max-age=3600"
+        response["Content-Type"] = "application/json"
+        return response

--- a/posthog/api/oauth/test_definitions_metadata.py
+++ b/posthog/api/oauth/test_definitions_metadata.py
@@ -1,30 +1,31 @@
 from django.test import SimpleTestCase, override_settings
 
+from parameterized import parameterized
+
 
 @override_settings(SITE_URL="https://us.posthog.com")
 class TestDefinitionsClientMetadataView(SimpleTestCase):
-    def test_returns_valid_cimd_metadata(self):
+    def test_returns_region_agnostic_metadata_fields(self):
         res = self.client.get("/api/oauth/posthog-definitions/client-metadata")
         assert res.status_code == 200
         data = res.json()
 
-        assert data["client_id"] == "https://us.posthog.com/api/oauth/posthog-definitions/client-metadata"
         assert data["client_name"] == "posthog-definitions"
         assert data["redirect_uris"] == ["http://localhost/callback"]
         assert data["grant_types"] == ["authorization_code", "refresh_token"]
         assert data["response_types"] == ["code"]
         assert data["token_endpoint_auth_method"] == "none"
 
-    def test_client_id_matches_hosted_path(self):
-        res = self.client.get("/api/oauth/posthog-definitions/client-metadata")
-        data = res.json()
-        assert data["client_id"].endswith("/api/oauth/posthog-definitions/client-metadata")
-
-    @override_settings(SITE_URL="https://eu.posthog.com")
-    def test_client_id_uses_site_url_for_eu(self):
-        res = self.client.get("/api/oauth/posthog-definitions/client-metadata")
-        data = res.json()
-        assert data["client_id"] == "https://eu.posthog.com/api/oauth/posthog-definitions/client-metadata"
+    @parameterized.expand(
+        [
+            ("https://us.posthog.com",),
+            ("https://eu.posthog.com",),
+        ]
+    )
+    def test_client_id_reflects_site_url(self, site_url: str):
+        with override_settings(SITE_URL=site_url):
+            res = self.client.get("/api/oauth/posthog-definitions/client-metadata")
+            assert res.json()["client_id"] == f"{site_url}/api/oauth/posthog-definitions/client-metadata"
 
     def test_cache_control_header_set(self):
         res = self.client.get("/api/oauth/posthog-definitions/client-metadata")

--- a/posthog/api/oauth/test_definitions_metadata.py
+++ b/posthog/api/oauth/test_definitions_metadata.py
@@ -1,0 +1,39 @@
+from django.test import SimpleTestCase, override_settings
+
+
+@override_settings(SITE_URL="https://us.posthog.com")
+class TestDefinitionsClientMetadataView(SimpleTestCase):
+    def test_returns_valid_cimd_metadata(self):
+        res = self.client.get("/api/oauth/posthog-definitions/client-metadata")
+        assert res.status_code == 200
+        data = res.json()
+
+        assert data["client_id"] == "https://us.posthog.com/api/oauth/posthog-definitions/client-metadata"
+        assert data["client_name"] == "posthog-definitions"
+        assert data["redirect_uris"] == ["http://localhost/callback"]
+        assert data["grant_types"] == ["authorization_code", "refresh_token"]
+        assert data["response_types"] == ["code"]
+        assert data["token_endpoint_auth_method"] == "none"
+
+    def test_client_id_matches_hosted_path(self):
+        res = self.client.get("/api/oauth/posthog-definitions/client-metadata")
+        data = res.json()
+        assert data["client_id"].endswith("/api/oauth/posthog-definitions/client-metadata")
+
+    @override_settings(SITE_URL="https://eu.posthog.com")
+    def test_client_id_uses_site_url_for_eu(self):
+        res = self.client.get("/api/oauth/posthog-definitions/client-metadata")
+        data = res.json()
+        assert data["client_id"] == "https://eu.posthog.com/api/oauth/posthog-definitions/client-metadata"
+
+    def test_cache_control_header_set(self):
+        res = self.client.get("/api/oauth/posthog-definitions/client-metadata")
+        assert res["Cache-Control"] == "public, max-age=3600"
+
+    def test_content_type_is_json(self):
+        res = self.client.get("/api/oauth/posthog-definitions/client-metadata")
+        assert "application/json" in res["Content-Type"]
+
+    def test_post_not_allowed(self):
+        res = self.client.post("/api/oauth/posthog-definitions/client-metadata")
+        assert res.status_code == 405

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -32,6 +32,7 @@ from posthog.api import (
     user,
 )
 from posthog.api.oauth.connected_apps import ConnectedAppsViewSet
+from posthog.api.oauth.definitions_metadata import DEFINITIONS_METADATA_PATH, DefinitionsClientMetadataView
 from posthog.api.oauth.wizard_metadata import WIZARD_METADATA_PATH, WizardClientMetadataView
 from posthog.api.query import progress
 from posthog.api.sdk_doctor import sdk_doctor
@@ -330,6 +331,11 @@ urlpatterns = [
         WIZARD_METADATA_PATH,
         WizardClientMetadataView.as_view(),
         name="wizard-client-metadata",
+    ),
+    path(
+        DEFINITIONS_METADATA_PATH,
+        DefinitionsClientMetadataView.as_view(),
+        name="posthog-definitions-client-metadata",
     ),
     re_path(r"^api.+", api_not_found),
     path("authorize_and_redirect/", login_required(authorize_and_redirect)),


### PR DESCRIPTION
## Summary

Adds a CIMD (Client ID Metadata Document) endpoint at \`/api/oauth/posthog-definitions/client-metadata\` for the new [\`posthog-definitions\`](https://github.com/PostHog/posthog-definitions) CLI — infrastructure-as-code for PostHog dashboards and insights.

This 1:1 mirrors the existing \`wizard_metadata.py\` pattern, so:

- No \`OAuthApplication\` migration is needed — the server fetches the metadata on first authorize call and auto-creates the row as a CIMD client.
- Works on any region (US, EU, self-hosted) — the \`client_id\` is derived from \`SITE_URL\`.
- Refresh-token-friendly: \`posthog-definitions\` is a long-lived IaC tool, so it is **not** added to \`CLIENT_IDS_WITHOUT_REFRESH_TOKEN\` — the CLI uses \`refresh_token\` grants so users don't re-auth on every \`apply\` / \`pull\`.

The one intentional deviation from wizard's doc: \`redirect_uris\` is the portless \`http://localhost/callback\`. The OAuth validator's loopback port-flexibility logic ([\`views.py\` L246-252](https://github.com/PostHog/posthog/blob/master/posthog/api/oauth/views.py#L246-L252)) then accepts whichever ephemeral callback port the CLI binds at runtime (it tries ports 8235-8240 in fallback order).

## Test plan

- [ ] CI runs \`posthog/api/oauth/test_definitions_metadata.py\` (mirrors \`test_wizard_metadata.py\`)
- [ ] Manual: \`curl https://us.posthog.com/api/oauth/posthog-definitions/client-metadata\` returns the expected JSON once shipped
- [ ] Manual: run \`posthog-definitions login\` against US cloud, confirm browser-based OAuth completes and a CIMD \`OAuthApplication\` row appears in Django admin

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*