### PR TITLE
feat(mcp): add mcp-session-id to logs

### DIFF
--- a/services/mcp/src/lib/logging.ts
+++ b/services/mcp/src/lib/logging.ts
@@ -42,11 +42,16 @@ export function withLogging<Props>(handler: FetchHandler<Props>) {
             method: request.method,
             pathname: url.pathname,
             search: url.search,
+            mcpSessionId: request.headers.get('mcp-session-id') ?? undefined,
             headers,
         })
 
         try {
             const response = await handler(request, env, ctx, log)
+            const responseSessionId = response.headers.get('mcp-session-id')
+            if (responseSessionId && responseSessionId !== request.headers.get('mcp-session-id')) {
+                log.extend({ mcpSessionId: responseSessionId })
+            }
             log.emit(response.status)
             return response
         } catch (error) {


### PR DESCRIPTION
## Problem

The MCP server's structured log line (`[MCP] {…}`) records `requestId`, `method`, `pathname`, `mcpClientName`, `status`, `durationMs`, plus the full header bag — but doesn't surface the `Mcp-Session-Id` as a first-class field. To find every log line for a given session you either grep inside the headers blob or join against upstream event capture.

## Changes

In `withLogging`:

- Extract the inbound `mcp-session-id` header and attach it as `mcpSessionId` on the log line.
- After the handler runs, check the response's `mcp-session-id`. If it differs from the inbound value (i.e. the initialize call that mints a new session), overwrite `mcpSessionId` with the newly assigned one so the mint event is also captured.

Field is omitted when there's no session (unauth, OAuth discovery probes, etc.).

## How did you test this code?

I'm an agent. I ran `pnpm typecheck` in `services/mcp` (clean). No new unit tests — there's no existing `logging.ts` test file and the change is a single field added to a `console.info` line. I did not manually deploy or tail the Worker after the change.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code, prompted by @lricoy.
- Motivation came from a live tail session against the deployed Worker: 1,504 of 1,731 captured requests carried `mcp-session-id` inbound, but the worker's log line never surfaced it as a top-level field, so per-session debugging required parsing the headers blob.
- Considered: also logging IP / connection metadata on the same hop — rejected for scope. Considered: separate `mcpSessionIdAssigned` field on mint — rejected as overcomplication; overwriting the single field keeps the line shape stable.