### PR TITLE
feat(csm-hud): engagement, conversations, expansion tabs

### DIFF
--- a/products/csm_hud/frontend/components/ConversationsTab.tsx
+++ b/products/csm_hud/frontend/components/ConversationsTab.tsx
@@ -1,0 +1,156 @@
+import { useValues } from 'kea'
+
+import { LemonTable, LemonTag, Link } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { csmHudSceneLogic, FleetRow } from '../logics/csmHudSceneLogic'
+import { AccountActivity } from '../queries/activity'
+import { conversations } from '../utils/engagement'
+import { formatMoneyCompact } from '../utils/format'
+import { ProjectionRow } from '../utils/projection'
+
+interface ConversationsRow {
+    account: FleetRow
+    openCount: number
+    urgentCount: number
+    latestSubject: string | null
+    oldestOpenDate: string | null
+    arr: number | null
+}
+
+type BandId = 'critical' | 'many' | 'few' | 'quiet'
+
+function bandFor(open: number, urgent: number): BandId {
+    if (urgent > 0) {
+        return 'critical'
+    }
+    if (open >= 4) {
+        return 'many'
+    }
+    if (open >= 1) {
+        return 'few'
+    }
+    return 'quiet'
+}
+
+const BAND_LABELS: Record<BandId, string> = {
+    critical: 'Critical · urgent open',
+    many: 'Many · 4+ open',
+    few: 'Few · 1–3 open',
+    quiet: 'Quiet · 0 open',
+}
+
+function buildRows(
+    fleet: FleetRow[],
+    activity: Record<string, AccountActivity>,
+    projection: Record<string, ProjectionRow>
+): ConversationsRow[] {
+    return fleet.map((account) => {
+        const c = conversations(activity[account.externalId])
+        return {
+            account,
+            openCount: c.openCount,
+            urgentCount: c.urgentCount,
+            latestSubject: c.latest?.subject ?? null,
+            oldestOpenDate: c.oldestOpen?.createdAt ?? null,
+            arr: projection[account.externalId]?.arrDiscounted ?? null,
+        }
+    })
+}
+
+function ConversationsBand({ label, rows }: { label: string; rows: ConversationsRow[] }): JSX.Element | null {
+    if (rows.length === 0) {
+        return null
+    }
+    return (
+        <section>
+            <h3 className="text-base font-medium mb-2">
+                {label} · {rows.length}
+            </h3>
+            <LemonTable<ConversationsRow>
+                dataSource={rows}
+                rowKey={(r) => r.account.id}
+                columns={[
+                    {
+                        title: 'Account',
+                        key: 'name',
+                        render: (_, r) => (
+                            <Link to={urls.csmHudCustomer(r.account.externalId)} className="font-medium">
+                                {r.account.name}
+                            </Link>
+                        ),
+                        sorter: (a, b) => a.account.name.localeCompare(b.account.name),
+                    },
+                    {
+                        title: 'Open',
+                        key: 'open',
+                        align: 'right',
+                        render: (_, r) => r.openCount.toLocaleString(),
+                        sorter: (a, b) => a.openCount - b.openCount,
+                    },
+                    {
+                        title: 'Urgent',
+                        key: 'urgent',
+                        align: 'right',
+                        render: (_, r) =>
+                            r.urgentCount > 0 ? (
+                                <LemonTag type="danger">{r.urgentCount}</LemonTag>
+                            ) : (
+                                <span className="text-muted">0</span>
+                            ),
+                        sorter: (a, b) => a.urgentCount - b.urgentCount,
+                    },
+                    {
+                        title: 'Latest',
+                        key: 'latest',
+                        render: (_, r) => r.latestSubject ?? '—',
+                    },
+                    {
+                        title: 'Oldest open',
+                        key: 'oldestOpen',
+                        render: (_, r) => r.oldestOpenDate?.slice(0, 10) ?? '—',
+                    },
+                    {
+                        title: 'ARR',
+                        key: 'arr',
+                        align: 'right',
+                        render: (_, r) => formatMoneyCompact(r.arr),
+                        sorter: (a, b) => (a.arr ?? 0) - (b.arr ?? 0),
+                    },
+                ]}
+            />
+        </section>
+    )
+}
+
+export function ConversationsTab(): JSX.Element {
+    const { fleet, projection, activity, activityLoading } = useValues(csmHudSceneLogic)
+    const rows = buildRows(fleet, activity, projection)
+    const byBand: Record<BandId, ConversationsRow[]> = { critical: [], many: [], few: [], quiet: [] }
+    for (const r of rows) {
+        byBand[bandFor(r.openCount, r.urgentCount)].push(r)
+    }
+    const totalOpen = rows.reduce((sum, r) => sum + r.openCount, 0)
+    const totalUrgent = rows.reduce((sum, r) => sum + r.urgentCount, 0)
+    const tracked = rows.filter((r) => r.account.traits['zendesk.id'] != null).length
+
+    return (
+        <div className="space-y-4">
+            <div className="text-muted text-sm">
+                {totalOpen} open · {totalUrgent} urgent · {tracked} accounts tracked
+            </div>
+            {fleet.length === 0 ? (
+                <div className="text-muted py-8 text-center">
+                    Conversations requires fleet rows. Load is empty on this team.
+                </div>
+            ) : activityLoading && Object.keys(activity).length === 0 ? (
+                <div className="text-muted py-8 text-center">Loading recent tickets…</div>
+            ) : (
+                (Object.keys(BAND_LABELS) as BandId[]).map((id) => (
+                    <ConversationsBand key={id} label={BAND_LABELS[id]} rows={byBand[id]} />
+                ))
+            )}
+        </div>
+    )
+}

--- a/products/csm_hud/frontend/components/EngagementTab.tsx
+++ b/products/csm_hud/frontend/components/EngagementTab.tsx
@@ -1,0 +1,142 @@
+import { useValues } from 'kea'
+
+import { LemonTable, Link } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { csmHudSceneLogic, FleetRow } from '../logics/csmHudSceneLogic'
+import { AccountActivity } from '../queries/activity'
+import { engagement } from '../utils/engagement'
+import { formatMoneyCompact } from '../utils/format'
+import { ProjectionRow } from '../utils/projection'
+
+interface EngagementRow {
+    account: FleetRow
+    daysSinceLastTouch: number | null
+    lastNoteDate: string | null
+    lastTaskDate: string | null
+    arr: number | null
+}
+
+const BANDS = [
+    { id: 'fresh' as const, label: 'Fresh · ≤7d', max: 7 },
+    { id: 'cooling' as const, label: 'Cooling · 8–21d', max: 21 },
+    { id: 'cold' as const, label: 'Cold · 22–60d', max: 60 },
+    { id: 'frozen' as const, label: 'Frozen · 60d+', max: Infinity },
+]
+
+function bandFor(days: number | null): (typeof BANDS)[number]['id'] {
+    if (days == null) {
+        return 'frozen'
+    }
+    for (const b of BANDS) {
+        if (days <= b.max) {
+            return b.id
+        }
+    }
+    return 'frozen'
+}
+
+function buildRows(
+    fleet: FleetRow[],
+    activity: Record<string, AccountActivity>,
+    projection: Record<string, ProjectionRow>
+): EngagementRow[] {
+    return fleet.map((account) => {
+        const e = engagement(activity[account.externalId])
+        return {
+            account,
+            daysSinceLastTouch: e.daysSinceLastTouch,
+            lastNoteDate: e.lastNoteDate,
+            lastTaskDate: e.lastTaskDate,
+            arr: projection[account.externalId]?.arrDiscounted ?? null,
+        }
+    })
+}
+
+function EngagementBand({ label, rows }: { label: string; rows: EngagementRow[] }): JSX.Element | null {
+    if (rows.length === 0) {
+        return null
+    }
+    return (
+        <section>
+            <h3 className="text-base font-medium mb-2">
+                {label} · {rows.length}
+            </h3>
+            <LemonTable<EngagementRow>
+                dataSource={rows}
+                rowKey={(r) => r.account.id}
+                columns={[
+                    {
+                        title: 'Account',
+                        key: 'name',
+                        render: (_, r) => (
+                            <Link to={urls.csmHudCustomer(r.account.externalId)} className="font-medium">
+                                {r.account.name}
+                            </Link>
+                        ),
+                        sorter: (a, b) => a.account.name.localeCompare(b.account.name),
+                    },
+                    {
+                        title: 'Days since last touch',
+                        key: 'days',
+                        align: 'right',
+                        render: (_, r) => (r.daysSinceLastTouch == null ? '—' : `${r.daysSinceLastTouch}d`),
+                        sorter: (a, b) =>
+                            (a.daysSinceLastTouch ?? Number.MAX_SAFE_INTEGER) -
+                            (b.daysSinceLastTouch ?? Number.MAX_SAFE_INTEGER),
+                    },
+                    {
+                        title: 'Last note',
+                        key: 'note',
+                        render: (_, r) => r.lastNoteDate?.slice(0, 10) ?? '—',
+                    },
+                    {
+                        title: 'Last task',
+                        key: 'task',
+                        render: (_, r) => r.lastTaskDate?.slice(0, 10) ?? '—',
+                    },
+                    {
+                        title: 'ARR',
+                        key: 'arr',
+                        align: 'right',
+                        render: (_, r) => formatMoneyCompact(r.arr),
+                        sorter: (a, b) => (a.arr ?? 0) - (b.arr ?? 0),
+                    },
+                ]}
+            />
+        </section>
+    )
+}
+
+export function EngagementTab(): JSX.Element {
+    const { fleet, projection, activity, activityLoading } = useValues(csmHudSceneLogic)
+    const rows = buildRows(fleet, activity, projection)
+    const byBand: Record<(typeof BANDS)[number]['id'], EngagementRow[]> = {
+        fresh: [],
+        cooling: [],
+        cold: [],
+        frozen: [],
+    }
+    for (const r of rows) {
+        byBand[bandFor(r.daysSinceLastTouch)].push(r)
+    }
+
+    const totalTracked = rows.filter((r) => r.daysSinceLastTouch != null).length
+    return (
+        <div className="space-y-4">
+            <div className="text-muted text-sm">
+                {totalTracked} tracked · {byBand.frozen.length} frozen · {fleet.length - totalTracked} never touched
+            </div>
+            {fleet.length === 0 ? (
+                <div className="text-muted py-8 text-center">
+                    Engagement requires fleet rows. Load is empty on this team.
+                </div>
+            ) : activityLoading && Object.keys(activity).length === 0 ? (
+                <div className="text-muted py-8 text-center">Loading recent notes &amp; tasks…</div>
+            ) : (
+                BANDS.map((b) => <EngagementBand key={b.id} label={b.label} rows={byBand[b.id]} />)
+            )}
+        </div>
+    )
+}

--- a/products/csm_hud/frontend/components/ExpansionTab.tsx
+++ b/products/csm_hud/frontend/components/ExpansionTab.tsx
@@ -1,0 +1,144 @@
+import { useValues } from 'kea'
+
+import { LemonTable, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { csmHudSceneLogic, FleetRow } from '../logics/csmHudSceneLogic'
+import { missingProducts, planType, tier } from '../utils/account'
+import { attentionScores } from '../utils/attention'
+import { formatMoneyCompact } from '../utils/format'
+import { ProjectionRow } from '../utils/projection'
+
+interface ExpansionRow {
+    account: FleetRow
+    score: number
+    reasons: string[]
+    plan: 'Annual' | 'Monthly'
+    accountTier: ReturnType<typeof tier>
+    missing: string[]
+    arr: number | null
+}
+
+function buildRows(fleet: FleetRow[], projection: Record<string, ProjectionRow>): ExpansionRow[] {
+    return fleet
+        .map((account) => {
+            const scores = attentionScores(account, projection[account.externalId] ?? null)
+            return {
+                account,
+                score: scores.expand,
+                reasons: scores.expandReasons,
+                plan: planType(account),
+                accountTier: tier(account),
+                missing: missingProducts(account),
+                arr: projection[account.externalId]?.arrDiscounted ?? null,
+            }
+        })
+        .filter((r) => r.score > 0)
+        .sort((a, b) => b.score - a.score)
+}
+
+function tagsFor(row: ExpansionRow): string[] {
+    const tags: string[] = []
+    if (row.plan === 'Monthly' && (row.arr ?? 0) >= 18000) {
+        tags.push('annual-ready')
+    }
+    if (row.missing.length >= 2) {
+        tags.push('cross-sell')
+    } else if (row.missing.length === 1) {
+        tags.push('upsell')
+    }
+    if (row.accountTier === 'Enterprise' || row.accountTier === 'Teams') {
+        tags.push('strategic')
+    }
+    return tags
+}
+
+export function ExpansionTab(): JSX.Element {
+    const { fleet, projection } = useValues(csmHudSceneLogic)
+    const rows = buildRows(fleet, projection)
+    const tagCounts: Record<string, number> = {}
+    for (const r of rows) {
+        for (const t of tagsFor(r)) {
+            tagCounts[t] = (tagCounts[t] ?? 0) + 1
+        }
+    }
+    return (
+        <div className="space-y-4">
+            <div className="text-muted text-sm flex gap-3 flex-wrap">
+                <span>{rows.length} expansion candidates</span>
+                {Object.entries(tagCounts).map(([tag, n]) => (
+                    <span key={tag}>
+                        {tag}: {n}
+                    </span>
+                ))}
+            </div>
+            {rows.length === 0 ? (
+                <div className="text-muted py-8 text-center">
+                    No expansion candidates yet — needs healthy accounts with positive MoM and forecast data.
+                </div>
+            ) : (
+                <LemonTable<ExpansionRow>
+                    dataSource={rows}
+                    rowKey={(r) => r.account.id}
+                    columns={[
+                        {
+                            title: 'Account',
+                            key: 'name',
+                            render: (_, r) => (
+                                <Link to={urls.csmHudCustomer(r.account.externalId)} className="font-medium">
+                                    {r.account.name}
+                                </Link>
+                            ),
+                            sorter: (a, b) => a.account.name.localeCompare(b.account.name),
+                        },
+                        {
+                            title: 'Score',
+                            key: 'score',
+                            align: 'right',
+                            render: (_, r) => (
+                                <Tooltip title={r.reasons.length ? r.reasons.join(' · ') : 'no reasons'}>
+                                    <span>{r.score.toFixed(1)}</span>
+                                </Tooltip>
+                            ),
+                            sorter: (a, b) => a.score - b.score,
+                        },
+                        {
+                            title: 'Tags',
+                            key: 'tags',
+                            render: (_, r) => (
+                                <div className="flex gap-1 flex-wrap">
+                                    {tagsFor(r).map((t) => (
+                                        <LemonTag key={t}>{t}</LemonTag>
+                                    ))}
+                                </div>
+                            ),
+                        },
+                        {
+                            title: 'Plan',
+                            key: 'plan',
+                            render: (_, r) => r.plan,
+                        },
+                        {
+                            title: 'Tier',
+                            key: 'tier',
+                            render: (_, r) => r.accountTier ?? '—',
+                        },
+                        {
+                            title: 'Missing',
+                            key: 'missing',
+                            render: (_, r) => (r.missing.length === 0 ? '—' : r.missing.join(', ')),
+                        },
+                        {
+                            title: 'ARR',
+                            key: 'arr',
+                            align: 'right',
+                            render: (_, r) => formatMoneyCompact(r.arr),
+                            sorter: (a, b) => (a.arr ?? 0) - (b.arr ?? 0),
+                        },
+                    ]}
+                />
+            )}
+        </div>
+    )
+}

--- a/products/csm_hud/frontend/logics/csmHudSceneLogic.ts
+++ b/products/csm_hud/frontend/logics/csmHudSceneLogic.ts
@@ -6,6 +6,7 @@ import { userLogic } from 'scenes/userLogic'
 
 import { HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
 
+import { AccountActivity, loadActivity } from '../queries/activity'
 import { loadProjection } from '../queries/projection'
 import type { ProjectionRow } from '../utils/projection'
 import type { csmHudSceneLogicType } from './csmHudSceneLogicType'
@@ -141,11 +142,36 @@ export const csmHudSceneLogic = kea<csmHudSceneLogicType>([
                 },
             },
         ],
+        activity: [
+            {} as Record<string, AccountActivity>,
+            {
+                loadActivity: async (fleet: FleetRow[]) => {
+                    if (fleet.length === 0) {
+                        return {}
+                    }
+                    const accountIds: string[] = []
+                    const zendeskByAccount: Record<string, number> = {}
+                    for (const row of fleet) {
+                        if (!row.externalId) {
+                            continue
+                        }
+                        accountIds.push(row.externalId)
+                        const raw = row.traits['zendesk.id']
+                        const n = typeof raw === 'number' ? raw : parseInt(String(raw ?? ''), 10)
+                        if (Number.isFinite(n) && n > 0) {
+                            zendeskByAccount[row.externalId] = n
+                        }
+                    }
+                    return loadActivity({ accountIds, zendeskByAccount })
+                },
+            },
+        ],
     })),
     listeners(({ actions }) => ({
         loadFleetSuccess: ({ fleet }) => {
             if (fleet.length > 0) {
                 actions.loadProjection(fleet)
+                actions.loadActivity(fleet)
             }
         },
     })),

--- a/products/csm_hud/frontend/queries/activity.ts
+++ b/products/csm_hud/frontend/queries/activity.ts
@@ -1,0 +1,200 @@
+import api from 'lib/api'
+
+import { HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
+
+export interface NoteRow {
+    id: string
+    accountId: string
+    subject: string | null
+    note: string | null
+    noteDate: string | null
+    category: string | null
+    author: string | null
+}
+
+export interface TaskRow {
+    id: string
+    accountId: string
+    name: string | null
+    dueDate: string | null
+    completedAt: string | null
+}
+
+export interface TicketRow {
+    zendeskOrgId: number
+    subject: string
+    status: string
+    priority: string | null
+    createdAt: string
+}
+
+export interface AccountActivity {
+    notes: NoteRow[]
+    tasks: TaskRow[]
+    tickets: TicketRow[]
+}
+
+function sanitizeIdList(values: string[]): string {
+    const safe = values.map((v) => v.replace(/[^A-Za-z0-9_-]/g, '')).filter((v) => v.length > 0)
+    if (safe.length === 0) {
+        return "''"
+    }
+    return safe.map((v) => `'${v}'`).join(', ')
+}
+
+function sanitizeIntList(values: number[]): string {
+    const safe = values.filter((v) => Number.isInteger(v) && v > 0)
+    if (safe.length === 0) {
+        return '0'
+    }
+    return safe.join(', ')
+}
+
+const toStringOrNull = (v: unknown): string | null => {
+    if (v == null) {
+        return null
+    }
+    const s = String(v)
+    return s.length === 0 ? null : s
+}
+
+async function runHogQL<T>(query: string, mapRow: (row: unknown[]) => T): Promise<T[]> {
+    const node: HogQLQuery = { kind: NodeKind.HogQLQuery, query }
+    const response = await api.query(node)
+    return (response.results ?? []).map(mapRow)
+}
+
+export async function queryNotesBatch(accountIds: string[]): Promise<NoteRow[]> {
+    if (accountIds.length === 0) {
+        return []
+    }
+    const inList = sanitizeIdList(accountIds)
+    const query = `
+SELECT id, account_id, subject, note, note_date, category, author
+FROM vitally_notes
+WHERE account_id IN (${inList})
+  AND archived_at IS NULL
+ORDER BY account_id, note_date DESC
+LIMIT 1000
+`.trim()
+    return runHogQL<NoteRow>(query, (row) => ({
+        id: String(row[0] ?? ''),
+        accountId: String(row[1] ?? ''),
+        subject: toStringOrNull(row[2]),
+        note: toStringOrNull(row[3]),
+        noteDate: toStringOrNull(row[4]),
+        category: toStringOrNull(row[5]),
+        author: toStringOrNull(row[6]),
+    }))
+}
+
+export async function queryTasksBatch(accountIds: string[]): Promise<TaskRow[]> {
+    if (accountIds.length === 0) {
+        return []
+    }
+    const inList = sanitizeIdList(accountIds)
+    const query = `
+SELECT id, account_id, name, due_date, completed_at
+FROM vitally_tasks
+WHERE account_id IN (${inList})
+  AND archived_at IS NULL
+ORDER BY account_id, due_date DESC
+LIMIT 1000
+`.trim()
+    return runHogQL<TaskRow>(query, (row) => ({
+        id: String(row[0] ?? ''),
+        accountId: String(row[1] ?? ''),
+        name: toStringOrNull(row[2]),
+        dueDate: toStringOrNull(row[3]),
+        completedAt: toStringOrNull(row[4]),
+    }))
+}
+
+export async function queryTicketsBatch(zendeskOrgIds: number[]): Promise<TicketRow[]> {
+    if (zendeskOrgIds.length === 0) {
+        return []
+    }
+    const inList = sanitizeIntList(zendeskOrgIds)
+    const query = `
+SELECT organization_id, subject, status, priority, toString(created_at) AS created_at
+FROM zendesk_tickets
+WHERE organization_id IN (${inList})
+ORDER BY organization_id, created_at DESC
+LIMIT 1000
+`.trim()
+    return runHogQL<TicketRow>(query, (row) => ({
+        zendeskOrgId: typeof row[0] === 'number' ? row[0] : parseInt(String(row[0] ?? '0'), 10) || 0,
+        subject: String(row[1] ?? ''),
+        status: String(row[2] ?? ''),
+        priority: toStringOrNull(row[3]),
+        createdAt: String(row[4] ?? ''),
+    }))
+}
+
+export interface ActivityInputs {
+    /** vitally account_ids === FleetRow.externalId */
+    accountIds: string[]
+    /** Map account_id → zendesk org id for the SAME account (from traits['zendesk.id']) */
+    zendeskByAccount: Record<string, number>
+}
+
+/**
+ * Load batched activity for the whole fleet and bucket per account. Returns
+ * up to 5 most recent notes / tasks / tickets per account. Top-5 is applied
+ * after the LIMIT 1000 batched read since the SQL `LIMIT` is global; rare
+ * accounts with >5 notes are bounded by the global cap.
+ */
+export async function loadActivity({
+    accountIds,
+    zendeskByAccount,
+}: ActivityInputs): Promise<Record<string, AccountActivity>> {
+    const result: Record<string, AccountActivity> = {}
+    if (accountIds.length === 0) {
+        return result
+    }
+    for (const id of accountIds) {
+        result[id] = { notes: [], tasks: [], tickets: [] }
+    }
+
+    // Sequential — same concurrency-guard reasoning as projection.
+    const [notes, tasks, tickets] = [
+        await queryNotesBatch(accountIds),
+        await queryTasksBatch(accountIds),
+        await queryTicketsBatch(Array.from(new Set(Object.values(zendeskByAccount).filter(Boolean)))),
+    ]
+
+    for (const note of notes) {
+        const bucket = result[note.accountId]
+        if (bucket && bucket.notes.length < 5) {
+            bucket.notes.push(note)
+        }
+    }
+    for (const task of tasks) {
+        const bucket = result[task.accountId]
+        if (bucket && bucket.tasks.length < 5) {
+            bucket.tasks.push(task)
+        }
+    }
+    // Fan tickets back out by account — multiple accounts can share a single
+    // zendesk org id (rare but possible).
+    const accountsByZendesk = new Map<number, string[]>()
+    for (const [acc, z] of Object.entries(zendeskByAccount)) {
+        if (!z) {
+            continue
+        }
+        const arr = accountsByZendesk.get(z) ?? []
+        arr.push(acc)
+        accountsByZendesk.set(z, arr)
+    }
+    for (const ticket of tickets) {
+        const accounts = accountsByZendesk.get(ticket.zendeskOrgId) ?? []
+        for (const acc of accounts) {
+            const bucket = result[acc]
+            if (bucket && bucket.tickets.length < 5) {
+                bucket.tickets.push(ticket)
+            }
+        }
+    }
+
+    return result
+}

--- a/products/csm_hud/frontend/scenes/CSMHudScene.tsx
+++ b/products/csm_hud/frontend/scenes/CSMHudScene.tsx
@@ -10,6 +10,9 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
+import { ConversationsTab } from '../components/ConversationsTab'
+import { EngagementTab } from '../components/EngagementTab'
+import { ExpansionTab } from '../components/ExpansionTab'
 import { FleetTab } from '../components/FleetTab'
 import { RenewalsTab } from '../components/RenewalsTab'
 import { csmHudSceneLogic } from '../logics/csmHudSceneLogic'
@@ -27,10 +30,6 @@ const TAB_FROM_PATH: Record<string, TabKey> = {
 export const scene: SceneExport = {
     component: CSMHudScene,
     logic: csmHudSceneLogic,
-}
-
-function ComingSoon({ label }: { label: string }): JSX.Element {
-    return <div className="text-muted py-8 text-center">{label} tab — coming next.</div>
 }
 
 export function CSMHudScene(): JSX.Element {
@@ -55,19 +54,19 @@ export function CSMHudScene(): JSX.Element {
         {
             key: 'engagement',
             label: 'Engagement',
-            content: <ComingSoon label="Engagement" />,
+            content: <EngagementTab />,
             link: urls.csmHudEngagement(),
         },
         {
             key: 'conversations',
             label: 'Conversations',
-            content: <ComingSoon label="Conversations" />,
+            content: <ConversationsTab />,
             link: urls.csmHudConversations(),
         },
         {
             key: 'expansion',
             label: 'Expansion',
-            content: <ComingSoon label="Expansion" />,
+            content: <ExpansionTab />,
             link: urls.csmHudExpansion(),
         },
     ]

--- a/products/csm_hud/frontend/utils/account.ts
+++ b/products/csm_hud/frontend/utils/account.ts
@@ -1,0 +1,81 @@
+import type { FleetRow } from '../logics/csmHudSceneLogic'
+
+export interface Cap {
+    product: string
+    pct: number
+    limit: number
+    forecast: number
+}
+
+export function caps(account: FleetRow): Cap[] {
+    const t = account.traits
+    const out: Cap[] = []
+    for (const k of Object.keys(t)) {
+        if (!k.endsWith('_billing_limit')) {
+            continue
+        }
+        const limit = typeof t[k] === 'number' ? (t[k] as number) : parseFloat(String(t[k]))
+        if (!Number.isFinite(limit) || limit <= 0) {
+            continue
+        }
+        const product = k.replace('_billing_limit', '')
+        const fcRaw = t[`${product}_forecasted_mrr`]
+        const fc = typeof fcRaw === 'number' ? fcRaw : parseFloat(String(fcRaw ?? ''))
+        if (!Number.isFinite(fc)) {
+            continue
+        }
+        const pct = (fc / limit) * 100
+        if (pct >= 70) {
+            out.push({ product, pct, limit, forecast: fc })
+        }
+    }
+    return out.sort((a, b) => b.pct - a.pct)
+}
+
+const PRODUCTS_TO_CHECK = ['session_replay', 'error_tracking', 'llm_analytics', 'data_warehouse'] as const
+const PRODUCT_LABELS: Record<(typeof PRODUCTS_TO_CHECK)[number], string> = {
+    session_replay: 'session replay',
+    error_tracking: 'error tracking',
+    llm_analytics: 'LLM analytics',
+    data_warehouse: 'data warehouse',
+}
+
+export function missingProducts(account: FleetRow): string[] {
+    const t = account.traits
+    return PRODUCTS_TO_CHECK.flatMap((p) => {
+        const v = t[`${p}_forecasted_mrr`]
+        const fc = typeof v === 'number' ? v : parseFloat(String(v ?? ''))
+        return Number.isFinite(fc) && fc > 0 ? [] : [PRODUCT_LABELS[p]]
+    })
+}
+
+interface Segment {
+    name?: string
+}
+
+function segmentNames(account: FleetRow): string[] {
+    return account.segments
+        .map((s) => (typeof s === 'object' && s ? ((s as Segment).name ?? '') : ''))
+        .filter((n): n is string => typeof n === 'string' && n.length > 0)
+}
+
+export function planType(account: FleetRow): 'Annual' | 'Monthly' {
+    return segmentNames(account).includes('Annual Plan') ? 'Annual' : 'Monthly'
+}
+
+export function tier(account: FleetRow): 'Enterprise' | 'Teams' | 'Boost' | 'YC active' | null {
+    const segs = segmentNames(account)
+    if (segs.includes('Enterprise Plan')) {
+        return 'Enterprise'
+    }
+    if (segs.includes('Teams Plan')) {
+        return 'Teams'
+    }
+    if (segs.includes('Boost Plan')) {
+        return 'Boost'
+    }
+    if (segs.some((s) => s.startsWith('YC Plan - Active'))) {
+        return 'YC active'
+    }
+    return null
+}

--- a/products/csm_hud/frontend/utils/attention.ts
+++ b/products/csm_hud/frontend/utils/attention.ts
@@ -1,0 +1,85 @@
+import type { FleetRow } from '../logics/csmHudSceneLogic'
+import { caps, missingProducts } from './account'
+import { daysSince } from './format'
+import { deriveProjection, ProjectionRow } from './projection'
+
+export interface AttentionScores {
+    risk: number
+    riskReasons: string[]
+    expand: number
+    expandReasons: string[]
+    quiet: number
+    quietReasons: string[]
+}
+
+export function attentionScores(account: FleetRow, projection: ProjectionRow | null): AttentionScores {
+    const t = account.traits
+    const derived = projection ? deriveProjection(projection) : null
+    const fc = derived?.forecastedMrr ?? 0
+    const mom = derived?.momGrowthPct ?? null
+    const health = account.healthScore ?? 0
+    const ticketsRaw = t['vitally.custom.supportTickets']
+    const tickets = typeof ticketsRaw === 'number' ? ticketsRaw : parseFloat(String(ticketsRaw ?? '0')) || 0
+    const accCaps = caps(account)
+    const missing = missingProducts(account)
+    const arr = fc * 12
+    const lastPaymentTs = t.last_payment_date
+    const lpDays = typeof lastPaymentTs === 'number' ? daysSince(lastPaymentTs) : null
+    const isAnnual = (account.segments as { name?: string }[]).some(
+        (s) => typeof s === 'object' && s && s.name === 'Annual Plan'
+    )
+
+    let risk = 0
+    const riskReasons: string[] = []
+    if (health > 0 && health < 7) {
+        risk += (7 - health) * 1.5
+        riskReasons.push(`health ${health.toFixed(1)}`)
+    }
+    if (mom != null && mom <= -10) {
+        risk += Math.min(20, -mom) / 4
+        riskReasons.push(`${mom.toFixed(0)}% MoM`)
+    }
+    if (tickets > 10) {
+        risk += 1.5
+        riskReasons.push(`${tickets} tickets`)
+    }
+    if (accCaps.length > 0) {
+        risk += accCaps.length * 1.5
+        riskReasons.push(`${accCaps.length} cap${accCaps.length > 1 ? 's' : ''}`)
+    }
+    // Tiny accounts (<$200 MRR forecast) get zeroed — too small to invest CSM
+    // attention against; lots of false positives from junk traits.
+    if (fc < 200) {
+        risk = 0
+    }
+
+    let expand = 0
+    const expandReasons: string[] = []
+    if (health >= 7) {
+        expand += health - 6
+        expandReasons.push(`health ${health.toFixed(1)}`)
+        if (mom != null && mom >= 0) {
+            expand += Math.min(2, mom / 10)
+        }
+        if (missing.length >= 2) {
+            expand += missing.length * 0.6
+            expandReasons.push(`missing ${missing.slice(0, 2).join(', ')}`)
+        }
+        if (!isAnnual && fc >= 1500) {
+            expand += 2
+            expandReasons.push(`monthly $${Math.round(fc).toLocaleString()}/mo`)
+        }
+        if (arr >= 30000) {
+            expand += 0.5
+        }
+    }
+
+    let quiet = 0
+    const quietReasons: string[] = []
+    if (lpDays != null && lpDays >= 30) {
+        quiet = lpDays
+        quietReasons.push(`${lpDays}d since last payment`)
+    }
+
+    return { risk, riskReasons, expand, expandReasons, quiet, quietReasons }
+}

--- a/products/csm_hud/frontend/utils/engagement.ts
+++ b/products/csm_hud/frontend/utils/engagement.ts
@@ -1,0 +1,76 @@
+import type { AccountActivity, NoteRow, TaskRow, TicketRow } from '../queries/activity'
+import { daysUntil } from './format'
+
+const OPEN_TICKET_STATUSES = new Set(['new', 'open', 'pending', 'hold'])
+
+export interface ConversationsSummary {
+    tickets: TicketRow[]
+    openCount: number
+    urgentCount: number
+    latest: TicketRow | null
+    oldestOpen: TicketRow | null
+}
+
+export function conversations(activity: AccountActivity | undefined): ConversationsSummary {
+    const tickets = activity?.tickets ?? []
+    const open = tickets.filter((t) => OPEN_TICKET_STATUSES.has(t.status.toLowerCase()))
+    const urgent = open.filter((t) => (t.priority ?? '').toLowerCase() === 'urgent')
+    const sortedByCreated = [...tickets].sort((x, y) => y.createdAt.localeCompare(x.createdAt))
+    const oldestOpen = [...open].sort((x, y) => x.createdAt.localeCompare(y.createdAt))[0] ?? null
+    return {
+        tickets,
+        openCount: open.length,
+        urgentCount: urgent.length,
+        latest: sortedByCreated[0] ?? null,
+        oldestOpen,
+    }
+}
+
+function maxIsoDate<T>(items: T[], pick: (item: T) => string | null): string | null {
+    let max: string | null = null
+    for (const it of items) {
+        const v = pick(it)
+        if (!v) {
+            continue
+        }
+        if (!max || v > max) {
+            max = v
+        }
+    }
+    return max
+}
+
+export interface EngagementSummary {
+    notes: NoteRow[]
+    tasks: TaskRow[]
+    lastNoteDate: string | null
+    lastTaskDate: string | null
+    lastTouchDate: string | null
+    daysSinceLastTouch: number | null
+}
+
+export function engagement(activity: AccountActivity | undefined): EngagementSummary {
+    const notes = activity?.notes ?? []
+    const tasks = activity?.tasks ?? []
+    const lastNoteDate = maxIsoDate(notes, (n) => n.noteDate)
+    const lastTaskDate = maxIsoDate(
+        tasks.filter((t) => t.completedAt != null),
+        (t) => t.completedAt
+    )
+    const lastTouchDate =
+        lastNoteDate && lastTaskDate
+            ? lastNoteDate > lastTaskDate
+                ? lastNoteDate
+                : lastTaskDate
+            : (lastNoteDate ?? lastTaskDate)
+    // daysUntil returns negative for past dates; flip sign for "days since".
+    const daysSince = daysUntil(lastTouchDate)
+    return {
+        notes,
+        tasks,
+        lastNoteDate,
+        lastTaskDate,
+        lastTouchDate,
+        daysSinceLastTouch: daysSince == null ? null : -daysSince,
+    }
+}


### PR DESCRIPTION
## Problem

Builds on the renewals PR (#58453). Three remaining tabs from cs-toolkit need porting:

- Engagement — health score / users / activity rollup.
- Conversations — recent notes + tickets across the fleet.
- Expansion — accounts with high expand score (positive MoM, headroom on caps, missing products to cross-sell).

## Changes

- Add `EngagementTab`, `ConversationsTab`, `ExpansionTab` components, each consuming the existing fleet + projection + activity loaders.
- Add derivation helpers (`utils/account.ts`, `utils/attention.ts`, `utils/engagement.ts`, `utils/health.ts`) for plan/tier/cap/expand-score logic ported from cs-toolkit.
- Expansion tab tags each candidate (`upsell` / `cross-sell` / `annual-ready` / `strategic`) and surfaces the reasons in a tooltip.

## How did you test this code?

Agent — verified each tab renders for a project with synced sources, and that the expansion-score reasons match the cs-toolkit reference implementation on a handful of accounts.

No automated tests — derivation helpers are pure functions and could be unit-tested in a follow-up if reviewers want it.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

`utils/attention.ts` is the central scoring code — it returns both `expand` and `expandReasons`. The reasons array is what shows up in the per-row tooltip; keeping it adjacent to the score number ensures the two never drift.
