### PR TITLE
feat(csm-hud): user-controlled CSM filter + missing-source banner + tagged HogQL

### DIFF
--- a/products/csm_hud/frontend/components/MissingSourcesBanner.tsx
+++ b/products/csm_hud/frontend/components/MissingSourcesBanner.tsx
@@ -1,0 +1,55 @@
+import { useValues } from 'kea'
+
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { csmHudSceneLogic } from '../logics/csmHudSceneLogic'
+import { MissingSourceKind, newSourceKind, sourceDescription, sourceLabel } from '../utils/missingSources'
+
+function returnToFleetUrl(): string {
+    return urls.csmHudFleet()
+}
+
+function actionForSource(source: MissingSourceKind): JSX.Element | null {
+    const kind = newSourceKind(source)
+    if (!kind) {
+        return null
+    }
+    return (
+        <LemonButton
+            type="secondary"
+            size="small"
+            to={urls.dataWarehouseSourceNew(kind, returnToFleetUrl(), 'CSM HUD')}
+        >
+            Connect {sourceLabel(source)}
+        </LemonButton>
+    )
+}
+
+export function MissingSourcesBanner(): JSX.Element | null {
+    const { missingSources } = useValues(csmHudSceneLogic)
+    if (missingSources.length === 0) {
+        return null
+    }
+    return (
+        <LemonBanner type="info">
+            <div className="space-y-2">
+                <div className="font-medium">Some data isn't available on this team</div>
+                <ul className="space-y-2 list-disc pl-5">
+                    {missingSources.map((source) => (
+                        <li key={source}>
+                            <div className="flex items-start justify-between gap-3">
+                                <div>
+                                    <span className="font-medium">{sourceLabel(source)}</span>{' '}
+                                    <span className="text-muted">— {sourceDescription(source)}</span>
+                                </div>
+                                {actionForSource(source)}
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </LemonBanner>
+    )
+}

--- a/products/csm_hud/frontend/logics/csmHudSceneLogic.ts
+++ b/products/csm_hud/frontend/logics/csmHudSceneLogic.ts
@@ -24,7 +24,8 @@ export interface FleetRow {
     keyRoles: unknown[]
 }
 
-const FLEET_SQL = `
+function fleetSql(csmEmail: string | null): { query: string; values?: Record<string, unknown> } {
+    const base = `
 SELECT
   id,
   external_id,
@@ -37,9 +38,16 @@ SELECT
   key_roles
 FROM vitally_accounts
 WHERE key_roles LIKE '%"label":"CSM"%'
-  AND key_roles LIKE {csmPattern}
-LIMIT 100
 `.trim()
+    if (!csmEmail) {
+        // No CSM filter — return any account that has any CSM assignment.
+        return { query: `${base}\nLIMIT 100` }
+    }
+    return {
+        query: `${base}\n  AND key_roles LIKE {csmPattern}\nLIMIT 100`,
+        values: { csmPattern: `%"email":"${csmEmail}"%` },
+    }
+}
 
 function parseJson<T>(value: unknown, fallback: T): T {
     if (value == null) {
@@ -107,16 +115,14 @@ export const csmHudSceneLogic = kea<csmHudSceneLogicType>([
                         return []
                     }
                     const trimmed = values.csmFilter.trim()
-                    // Empty filter → match every account that has any CSM assigned.
-                    // `%` is a wildcard, so `LIKE '%'` is a no-op constraint kept
-                    // in the query just to avoid two SQL variants.
-                    const pattern = trimmed === '' ? '%' : `%"email":"${trimmed}"%`
-                    const query: HogQLQuery = {
+                    const { query, values: queryValues } = fleetSql(trimmed === '' ? null : trimmed)
+                    const node: HogQLQuery = {
                         kind: NodeKind.HogQLQuery,
-                        query: FLEET_SQL,
-                        values: { csmPattern: pattern },
+                        query,
+                        tags: { productKey: 'csm_hud', scene: 'CSMHud', name: 'csm_hud_fleet' },
+                        ...(queryValues ? { values: queryValues } : {}),
                     }
-                    const response = await api.query(query)
+                    const response = await api.query(node)
                     return (response.results ?? []).map(mapFleetRow)
                 },
             },

--- a/products/csm_hud/frontend/logics/csmHudSceneLogic.ts
+++ b/products/csm_hud/frontend/logics/csmHudSceneLogic.ts
@@ -119,7 +119,7 @@ export const csmHudSceneLogic = kea<csmHudSceneLogicType>([
                     const node: HogQLQuery = {
                         kind: NodeKind.HogQLQuery,
                         query,
-                        tags: { productKey: 'csm_hud', scene: 'CSMHud', name: 'csm_hud_fleet' },
+                        tags: { productKey: 'internal', scene: 'CSMHud', name: 'csm_hud_fleet' },
                         ...(queryValues ? { values: queryValues } : {}),
                     }
                     const response = await api.query(node)

--- a/products/csm_hud/frontend/logics/csmHudSceneLogic.ts
+++ b/products/csm_hud/frontend/logics/csmHudSceneLogic.ts
@@ -8,6 +8,7 @@ import { HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
 
 import { AccountActivity, loadActivity } from '../queries/activity'
 import { loadProjection } from '../queries/projection'
+import { detectMissingSources, MissingSourceKind } from '../utils/missingSources'
 import type { ProjectionRow } from '../utils/projection'
 import type { csmHudSceneLogicType } from './csmHudSceneLogicType'
 
@@ -97,16 +98,32 @@ export const csmHudSceneLogic = kea<csmHudSceneLogicType>([
     actions({
         setRenewalsPlanFilter: (filter: 'all' | 'annual') => ({ filter }),
         setCsmFilter: (email: string) => ({ email }),
+        recordMissingSources: (sources: MissingSourceKind[]) => ({ sources }),
+        clearMissingSources: true,
     }),
     reducers({
         renewalsPlanFilter: ['annual' as 'all' | 'annual', { setRenewalsPlanFilter: (_, { filter }) => filter }],
         csmFilter: ['', { setCsmFilter: (_, { email }) => email }],
+        missingSources: [
+            [] as MissingSourceKind[],
+            {
+                recordMissingSources: (state, { sources }) => {
+                    const next = new Set(state)
+                    for (const s of sources) {
+                        next.add(s)
+                    }
+                    return Array.from(next)
+                },
+                clearMissingSources: () => [],
+                loadFleet: () => [],
+            },
+        ],
     }),
     selectors({
         // TODO restore before merge: gate behind FEATURE_FLAGS.SCENE_CSM_HUD + is_staff + @posthog.com
         canAccess: [() => [], (): boolean => true],
     }),
-    loaders(({ values }) => ({
+    loaders(({ values, actions }) => ({
         fleet: [
             [] as FleetRow[],
             {
@@ -122,8 +139,17 @@ export const csmHudSceneLogic = kea<csmHudSceneLogicType>([
                         tags: { productKey: 'internal', scene: 'CSMHud', name: 'csm_hud_fleet' },
                         ...(queryValues ? { values: queryValues } : {}),
                     }
-                    const response = await api.query(node)
-                    return (response.results ?? []).map(mapFleetRow)
+                    try {
+                        const response = await api.query(node)
+                        return (response.results ?? []).map(mapFleetRow)
+                    } catch (err) {
+                        const missing = detectMissingSources(err)
+                        if (missing.length > 0) {
+                            actions.recordMissingSources(missing)
+                            return []
+                        }
+                        throw err
+                    }
                 },
             },
         ],
@@ -147,7 +173,11 @@ export const csmHudSceneLogic = kea<csmHudSceneLogicType>([
                             stripeByOrg[row.externalId] = row.stripeCustomerId
                         }
                     }
-                    return loadProjection({ orgIds, nameByOrg, stripeByOrg })
+                    const { data, missingSources } = await loadProjection({ orgIds, nameByOrg, stripeByOrg })
+                    if (missingSources.length > 0) {
+                        actions.recordMissingSources(missingSources)
+                    }
+                    return data
                 },
             },
         ],
@@ -171,7 +201,11 @@ export const csmHudSceneLogic = kea<csmHudSceneLogicType>([
                             zendeskByAccount[row.externalId] = n
                         }
                     }
-                    return loadActivity({ accountIds, zendeskByAccount })
+                    const { data, missingSources } = await loadActivity({ accountIds, zendeskByAccount })
+                    if (missingSources.length > 0) {
+                        actions.recordMissingSources(missingSources)
+                    }
+                    return data
                 },
             },
         ],

--- a/products/csm_hud/frontend/logics/csmHudSceneLogic.ts
+++ b/products/csm_hud/frontend/logics/csmHudSceneLogic.ts
@@ -88,12 +88,13 @@ export const csmHudSceneLogic = kea<csmHudSceneLogicType>([
     })),
     actions({
         setRenewalsPlanFilter: (filter: 'all' | 'annual') => ({ filter }),
+        setCsmFilter: (email: string) => ({ email }),
     }),
     reducers({
         renewalsPlanFilter: ['annual' as 'all' | 'annual', { setRenewalsPlanFilter: (_, { filter }) => filter }],
+        csmFilter: ['', { setCsmFilter: (_, { email }) => email }],
     }),
     selectors({
-        csmEmail: [(s) => [s.user], (user): string | null => user?.email ?? null],
         // TODO restore before merge: gate behind FEATURE_FLAGS.SCENE_CSM_HUD + is_staff + @posthog.com
         canAccess: [() => [], (): boolean => true],
     }),
@@ -102,16 +103,18 @@ export const csmHudSceneLogic = kea<csmHudSceneLogicType>([
             [] as FleetRow[],
             {
                 loadFleet: async () => {
-                    const csmEmail = values.csmEmail
-                    if (!csmEmail || !values.canAccess) {
+                    if (!values.canAccess) {
                         return []
                     }
+                    const trimmed = values.csmFilter.trim()
+                    // Empty filter → match every account that has any CSM assigned.
+                    // `%` is a wildcard, so `LIKE '%'` is a no-op constraint kept
+                    // in the query just to avoid two SQL variants.
+                    const pattern = trimmed === '' ? '%' : `%"email":"${trimmed}"%`
                     const query: HogQLQuery = {
                         kind: NodeKind.HogQLQuery,
                         query: FLEET_SQL,
-                        values: {
-                            csmPattern: `%"email":"${csmEmail}"%`,
-                        },
+                        values: { csmPattern: pattern },
                     }
                     const response = await api.query(query)
                     return (response.results ?? []).map(mapFleetRow)
@@ -173,6 +176,9 @@ export const csmHudSceneLogic = kea<csmHudSceneLogicType>([
                 actions.loadProjection(fleet)
                 actions.loadActivity(fleet)
             }
+        },
+        setCsmFilter: () => {
+            actions.loadFleet()
         },
     })),
     afterMount(({ actions, values }) => {

--- a/products/csm_hud/frontend/queries/activity.ts
+++ b/products/csm_hud/frontend/queries/activity.ts
@@ -58,8 +58,12 @@ const toStringOrNull = (v: unknown): string | null => {
     return s.length === 0 ? null : s
 }
 
-async function runHogQL<T>(query: string, mapRow: (row: unknown[]) => T): Promise<T[]> {
-    const node: HogQLQuery = { kind: NodeKind.HogQLQuery, query }
+async function runHogQL<T>(name: string, query: string, mapRow: (row: unknown[]) => T): Promise<T[]> {
+    const node: HogQLQuery = {
+        kind: NodeKind.HogQLQuery,
+        query,
+        tags: { productKey: 'csm_hud', scene: 'CSMHud', name: `csm_hud_${name}` },
+    }
     const response = await api.query(node)
     return (response.results ?? []).map(mapRow)
 }
@@ -77,7 +81,7 @@ WHERE account_id IN (${inList})
 ORDER BY account_id, note_date DESC
 LIMIT 1000
 `.trim()
-    return runHogQL<NoteRow>(query, (row) => ({
+    return runHogQL<NoteRow>('notes_batch', query, (row) => ({
         id: String(row[0] ?? ''),
         accountId: String(row[1] ?? ''),
         subject: toStringOrNull(row[2]),
@@ -101,7 +105,7 @@ WHERE account_id IN (${inList})
 ORDER BY account_id, due_date DESC
 LIMIT 1000
 `.trim()
-    return runHogQL<TaskRow>(query, (row) => ({
+    return runHogQL<TaskRow>('tasks_batch', query, (row) => ({
         id: String(row[0] ?? ''),
         accountId: String(row[1] ?? ''),
         name: toStringOrNull(row[2]),
@@ -122,7 +126,7 @@ WHERE organization_id IN (${inList})
 ORDER BY organization_id, created_at DESC
 LIMIT 1000
 `.trim()
-    return runHogQL<TicketRow>(query, (row) => ({
+    return runHogQL<TicketRow>('tickets_batch', query, (row) => ({
         zendeskOrgId: typeof row[0] === 'number' ? row[0] : parseInt(String(row[0] ?? '0'), 10) || 0,
         subject: String(row[1] ?? ''),
         status: String(row[2] ?? ''),

--- a/products/csm_hud/frontend/queries/activity.ts
+++ b/products/csm_hud/frontend/queries/activity.ts
@@ -62,7 +62,7 @@ async function runHogQL<T>(name: string, query: string, mapRow: (row: unknown[])
     const node: HogQLQuery = {
         kind: NodeKind.HogQLQuery,
         query,
-        tags: { productKey: 'csm_hud', scene: 'CSMHud', name: `csm_hud_${name}` },
+        tags: { productKey: 'internal', scene: 'CSMHud', name: `csm_hud_${name}` },
     }
     const response = await api.query(node)
     return (response.results ?? []).map(mapRow)

--- a/products/csm_hud/frontend/queries/activity.ts
+++ b/products/csm_hud/frontend/queries/activity.ts
@@ -2,6 +2,8 @@ import api from 'lib/api'
 
 import { HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
 
+import { detectMissingSources, MissingSourceKind } from '../utils/missingSources'
+
 export interface NoteRow {
     id: string
     accountId: string
@@ -66,6 +68,19 @@ async function runHogQL<T>(name: string, query: string, mapRow: (row: unknown[])
     }
     const response = await api.query(node)
     return (response.results ?? []).map(mapRow)
+}
+
+async function tolerantSlice<T>(missing: Set<MissingSourceKind>, fn: () => Promise<T[]>): Promise<T[]> {
+    try {
+        return await fn()
+    } catch (err) {
+        const ms = detectMissingSources(err)
+        if (ms.length === 0) {
+            throw err
+        }
+        ms.forEach((s) => missing.add(s))
+        return []
+    }
 }
 
 export async function queryNotesBatch(accountIds: string[]): Promise<NoteRow[]> {
@@ -142,30 +157,35 @@ export interface ActivityInputs {
     zendeskByAccount: Record<string, number>
 }
 
+export interface ActivityResult {
+    data: Record<string, AccountActivity>
+    missingSources: MissingSourceKind[]
+}
+
 /**
  * Load batched activity for the whole fleet and bucket per account. Returns
  * up to 5 most recent notes / tasks / tickets per account. Top-5 is applied
  * after the LIMIT 1000 batched read since the SQL `LIMIT` is global; rare
  * accounts with >5 notes are bounded by the global cap.
  */
-export async function loadActivity({
-    accountIds,
-    zendeskByAccount,
-}: ActivityInputs): Promise<Record<string, AccountActivity>> {
+export async function loadActivity({ accountIds, zendeskByAccount }: ActivityInputs): Promise<ActivityResult> {
     const result: Record<string, AccountActivity> = {}
     if (accountIds.length === 0) {
-        return result
+        return { data: result, missingSources: [] }
     }
     for (const id of accountIds) {
         result[id] = { notes: [], tasks: [], tickets: [] }
     }
+    const missing = new Set<MissingSourceKind>()
 
     // Sequential — same concurrency-guard reasoning as projection.
-    const [notes, tasks, tickets] = [
-        await queryNotesBatch(accountIds),
-        await queryTasksBatch(accountIds),
-        await queryTicketsBatch(Array.from(new Set(Object.values(zendeskByAccount).filter(Boolean)))),
-    ]
+    // tolerantSlice swallows "Unknown table" so one missing source doesn't
+    // void the others (e.g. Zendesk gone but Vitally notes/tasks intact).
+    const notes = await tolerantSlice(missing, () => queryNotesBatch(accountIds))
+    const tasks = await tolerantSlice(missing, () => queryTasksBatch(accountIds))
+    const tickets = await tolerantSlice(missing, () =>
+        queryTicketsBatch(Array.from(new Set(Object.values(zendeskByAccount).filter(Boolean))))
+    )
 
     for (const note of notes) {
         const bucket = result[note.accountId]
@@ -200,5 +220,5 @@ export async function loadActivity({
         }
     }
 
-    return result
+    return { data: result, missingSources: Array.from(missing) }
 }

--- a/products/csm_hud/frontend/queries/customer.ts
+++ b/products/csm_hud/frontend/queries/customer.ts
@@ -41,7 +41,7 @@ async function runHogQL<T>(name: string, query: string, mapRow: (row: unknown[])
     const node: HogQLQuery = {
         kind: NodeKind.HogQLQuery,
         query,
-        tags: { productKey: 'csm_hud', scene: 'CSMHudCustomer', name: `csm_hud_${name}` },
+        tags: { productKey: 'internal', scene: 'CSMHudCustomer', name: `csm_hud_${name}` },
     }
     const response = await api.query(node)
     return (response.results ?? []).map(mapRow)

--- a/products/csm_hud/frontend/queries/customer.ts
+++ b/products/csm_hud/frontend/queries/customer.ts
@@ -37,8 +37,12 @@ export interface Task {
     completedAt: string | null
 }
 
-async function runHogQL<T>(query: string, mapRow: (row: unknown[]) => T): Promise<T[]> {
-    const node: HogQLQuery = { kind: NodeKind.HogQLQuery, query }
+async function runHogQL<T>(name: string, query: string, mapRow: (row: unknown[]) => T): Promise<T[]> {
+    const node: HogQLQuery = {
+        kind: NodeKind.HogQLQuery,
+        query,
+        tags: { productKey: 'csm_hud', scene: 'CSMHudCustomer', name: `csm_hud_${name}` },
+    }
     const response = await api.query(node)
     return (response.results ?? []).map(mapRow)
 }
@@ -123,7 +127,7 @@ LEFT JOIN roles r ON r.email = u.email
 ORDER BY sessions DESC
 LIMIT 5
 `.trim()
-    return runHogQL<TopUser>(query, (row) => ({
+    return runHogQL<TopUser>('customer_top_users', query, (row) => ({
         email: String(row[0] ?? ''),
         userName: String(row[1] ?? ''),
         role: String(row[2] ?? ''),
@@ -147,7 +151,7 @@ WHERE t.organization_id = ${zendeskOrgId}
 ORDER BY t.created_at DESC
 LIMIT 5
 `.trim()
-    return runHogQL<Ticket>(query, (row) => ({
+    return runHogQL<Ticket>('customer_tickets', query, (row) => ({
         subject: String(row[0] ?? ''),
         status: String(row[1] ?? ''),
         priority: toStringOrNull(row[2]),
@@ -167,7 +171,7 @@ WHERE account_id = '${accountId}'
 ORDER BY note_date DESC
 LIMIT 5
 `.trim()
-    return runHogQL<Note>(query, (row) => ({
+    return runHogQL<Note>('customer_notes', query, (row) => ({
         id: String(row[0] ?? ''),
         subject: toStringOrNull(row[1]),
         note: toStringOrNull(row[2]),
@@ -189,7 +193,7 @@ WHERE account_id = '${accountId}'
 ORDER BY due_date DESC
 LIMIT 5
 `.trim()
-    return runHogQL<Task>(query, (row) => ({
+    return runHogQL<Task>('customer_tasks', query, (row) => ({
         id: String(row[0] ?? ''),
         name: toStringOrNull(row[1]),
         dueDate: toStringOrNull(row[2]),

--- a/products/csm_hud/frontend/queries/projection.ts
+++ b/products/csm_hud/frontend/queries/projection.ts
@@ -2,6 +2,7 @@ import api from 'lib/api'
 
 import { HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
 
+import { detectMissingSources, MissingSourceKind } from '../utils/missingSources'
 import type { ProjectionRow } from '../utils/projection'
 
 // Strict allowlist: identifiers we're willing to interpolate into `IN (...)` literals.
@@ -71,6 +72,24 @@ async function runHogQL<T>(name: string, query: string, mapRow: (row: unknown[])
     }
     const response = await api.query(node)
     return (response.results ?? []).map(mapRow)
+}
+
+/**
+ * Run a single slice query, swallowing only "Unknown table" errors. Detected
+ * missing sources are pushed into the shared accumulator so the orchestrator
+ * can report all of them at once instead of stopping at the first failure.
+ */
+async function tolerantSlice<T>(missing: Set<MissingSourceKind>, fn: () => Promise<T[]>): Promise<T[]> {
+    try {
+        return await fn()
+    } catch (err) {
+        const ms = detectMissingSources(err)
+        if (ms.length === 0) {
+            throw err
+        }
+        ms.forEach((s) => missing.add(s))
+        return []
+    }
 }
 
 const toFloat = (v: unknown): number => {
@@ -264,63 +283,79 @@ export interface ProjectionInputs {
     stripeByOrg: Record<string, string>
 }
 
-export async function loadProjection({
-    orgIds,
-    nameByOrg,
-    stripeByOrg,
-}: ProjectionInputs): Promise<Record<string, ProjectionRow>> {
+export interface ProjectionResult {
+    data: Record<string, ProjectionRow>
+    missingSources: MissingSourceKind[]
+}
+
+export async function loadProjection({ orgIds, nameByOrg, stripeByOrg }: ProjectionInputs): Promise<ProjectionResult> {
     if (orgIds.length === 0) {
-        return {}
+        return { data: {}, missingSources: [] }
     }
     const stripeIds = Object.values(stripeByOrg).filter(Boolean)
+    const missing = new Set<MissingSourceKind>()
 
     // Sequential — PostHog's HogQL concurrency guard rejects parallel submits
     // on the same project. Each slice is sub-second; total bound is ~6s.
-    const billing = await runHogQL<BillingRow>('projection_billing', billingSql(orgIds), (row) => ({
-        organizationId: String(row[0] ?? ''),
-        periodStarts: toStringOrNull(row[1]),
-        periodEnds: toStringOrNull(row[2]),
-        priorMonthMrr: toFloat(row[3]),
-        currentMonthSpend: toFloat(row[4]),
-    }))
-    const contracts = await runHogQL<ContractsRow>('projection_contracts', contractsSql(orgIds), (row) => ({
-        organizationId: String(row[0] ?? ''),
-        contractStart: toStringOrNull(row[1]),
-        contractEnd: toStringOrNull(row[2]),
-        termMonths: toFloatOrNull(row[3]),
-        arrDiscounted: toFloatOrNull(row[4]),
-        opportunityName: toStringOrNull(row[5]),
-    }))
-    const owners = await runHogQL<OwnersRow>('projection_owners', ownersSql(orgIds), (row) => ({
-        organizationId: String(row[0] ?? ''),
-        csm: toStringOrNull(row[1]),
-        ae: toStringOrNull(row[2]),
-        managedBy: toStringOrNull(row[3]),
-    }))
-    const mrr = await runHogQL<MrrHistoryRow>('projection_mrr_history', mrrHistorySql(orgIds), (row) => ({
-        organizationId: String(row[0] ?? ''),
-        m2Actual: toFloat(row[1]),
-        m3Actual: toFloat(row[2]),
-    }))
+    // tolerantSlice catches "Unknown table" per slice so a single missing
+    // source doesn't black out the others.
+    const billing = await tolerantSlice(missing, () =>
+        runHogQL<BillingRow>('projection_billing', billingSql(orgIds), (row) => ({
+            organizationId: String(row[0] ?? ''),
+            periodStarts: toStringOrNull(row[1]),
+            periodEnds: toStringOrNull(row[2]),
+            priorMonthMrr: toFloat(row[3]),
+            currentMonthSpend: toFloat(row[4]),
+        }))
+    )
+    const contracts = await tolerantSlice(missing, () =>
+        runHogQL<ContractsRow>('projection_contracts', contractsSql(orgIds), (row) => ({
+            organizationId: String(row[0] ?? ''),
+            contractStart: toStringOrNull(row[1]),
+            contractEnd: toStringOrNull(row[2]),
+            termMonths: toFloatOrNull(row[3]),
+            arrDiscounted: toFloatOrNull(row[4]),
+            opportunityName: toStringOrNull(row[5]),
+        }))
+    )
+    const owners = await tolerantSlice(missing, () =>
+        runHogQL<OwnersRow>('projection_owners', ownersSql(orgIds), (row) => ({
+            organizationId: String(row[0] ?? ''),
+            csm: toStringOrNull(row[1]),
+            ae: toStringOrNull(row[2]),
+            managedBy: toStringOrNull(row[3]),
+        }))
+    )
+    const mrr = await tolerantSlice(missing, () =>
+        runHogQL<MrrHistoryRow>('projection_mrr_history', mrrHistorySql(orgIds), (row) => ({
+            organizationId: String(row[0] ?? ''),
+            m2Actual: toFloat(row[1]),
+            m3Actual: toFloat(row[2]),
+        }))
+    )
     const charges =
         stripeIds.length > 0
-            ? await runHogQL<ChargesRow>('projection_charges', chargesSql(stripeIds), (row) => ({
-                  customerId: String(row[0] ?? ''),
-                  recentChargeCount: toFloat(row[1]),
-                  mtdStripe: toFloatOrNull(row[2]),
-                  lastChargeUsd: toFloatOrNull(row[3]),
-                  lastChargeDate: toStringOrNull(row[4]),
-                  lastChargeStatus: toStringOrNull(row[5]),
-              }))
+            ? await tolerantSlice(missing, () =>
+                  runHogQL<ChargesRow>('projection_charges', chargesSql(stripeIds), (row) => ({
+                      customerId: String(row[0] ?? ''),
+                      recentChargeCount: toFloat(row[1]),
+                      mtdStripe: toFloatOrNull(row[2]),
+                      lastChargeUsd: toFloatOrNull(row[3]),
+                      lastChargeDate: toStringOrNull(row[4]),
+                      lastChargeStatus: toStringOrNull(row[5]),
+                  }))
+              )
             : []
     const invoices =
         stripeIds.length > 0
-            ? await runHogQL<InvoiceRow>('projection_invoices', invoicesSql(stripeIds), (row) => ({
-                  customerId: String(row[0] ?? ''),
-                  invoiceDate: String(row[1] ?? ''),
-                  subtotal: toFloat(row[2]),
-                  amountPaid: toFloat(row[3]),
-              }))
+            ? await tolerantSlice(missing, () =>
+                  runHogQL<InvoiceRow>('projection_invoices', invoicesSql(stripeIds), (row) => ({
+                      customerId: String(row[0] ?? ''),
+                      invoiceDate: String(row[1] ?? ''),
+                      subtotal: toFloat(row[2]),
+                      amountPaid: toFloat(row[3]),
+                  }))
+              )
             : []
 
     const billingByOrg = new Map(billing.map((r) => [r.organizationId, r]))
@@ -400,5 +435,5 @@ export async function loadProjection({
             managedBy: ow?.managedBy ?? null,
         }
     }
-    return result
+    return { data: result, missingSources: Array.from(missing) }
 }

--- a/products/csm_hud/frontend/queries/projection.ts
+++ b/products/csm_hud/frontend/queries/projection.ts
@@ -67,7 +67,7 @@ async function runHogQL<T>(name: string, query: string, mapRow: (row: unknown[])
     const node: HogQLQuery = {
         kind: NodeKind.HogQLQuery,
         query,
-        tags: { productKey: 'csm_hud', scene: 'CSMHud', name: `csm_hud_${name}` },
+        tags: { productKey: 'internal', scene: 'CSMHud', name: `csm_hud_${name}` },
     }
     const response = await api.query(node)
     return (response.results ?? []).map(mapRow)

--- a/products/csm_hud/frontend/queries/projection.ts
+++ b/products/csm_hud/frontend/queries/projection.ts
@@ -63,8 +63,12 @@ interface InvoiceRow {
     amountPaid: number
 }
 
-async function runHogQL<T>(query: string, mapRow: (row: unknown[]) => T): Promise<T[]> {
-    const node: HogQLQuery = { kind: NodeKind.HogQLQuery, query }
+async function runHogQL<T>(name: string, query: string, mapRow: (row: unknown[]) => T): Promise<T[]> {
+    const node: HogQLQuery = {
+        kind: NodeKind.HogQLQuery,
+        query,
+        tags: { productKey: 'csm_hud', scene: 'CSMHud', name: `csm_hud_${name}` },
+    }
     const response = await api.query(node)
     return (response.results ?? []).map(mapRow)
 }
@@ -272,14 +276,14 @@ export async function loadProjection({
 
     // Sequential — PostHog's HogQL concurrency guard rejects parallel submits
     // on the same project. Each slice is sub-second; total bound is ~6s.
-    const billing = await runHogQL<BillingRow>(billingSql(orgIds), (row) => ({
+    const billing = await runHogQL<BillingRow>('projection_billing', billingSql(orgIds), (row) => ({
         organizationId: String(row[0] ?? ''),
         periodStarts: toStringOrNull(row[1]),
         periodEnds: toStringOrNull(row[2]),
         priorMonthMrr: toFloat(row[3]),
         currentMonthSpend: toFloat(row[4]),
     }))
-    const contracts = await runHogQL<ContractsRow>(contractsSql(orgIds), (row) => ({
+    const contracts = await runHogQL<ContractsRow>('projection_contracts', contractsSql(orgIds), (row) => ({
         organizationId: String(row[0] ?? ''),
         contractStart: toStringOrNull(row[1]),
         contractEnd: toStringOrNull(row[2]),
@@ -287,20 +291,20 @@ export async function loadProjection({
         arrDiscounted: toFloatOrNull(row[4]),
         opportunityName: toStringOrNull(row[5]),
     }))
-    const owners = await runHogQL<OwnersRow>(ownersSql(orgIds), (row) => ({
+    const owners = await runHogQL<OwnersRow>('projection_owners', ownersSql(orgIds), (row) => ({
         organizationId: String(row[0] ?? ''),
         csm: toStringOrNull(row[1]),
         ae: toStringOrNull(row[2]),
         managedBy: toStringOrNull(row[3]),
     }))
-    const mrr = await runHogQL<MrrHistoryRow>(mrrHistorySql(orgIds), (row) => ({
+    const mrr = await runHogQL<MrrHistoryRow>('projection_mrr_history', mrrHistorySql(orgIds), (row) => ({
         organizationId: String(row[0] ?? ''),
         m2Actual: toFloat(row[1]),
         m3Actual: toFloat(row[2]),
     }))
     const charges =
         stripeIds.length > 0
-            ? await runHogQL<ChargesRow>(chargesSql(stripeIds), (row) => ({
+            ? await runHogQL<ChargesRow>('projection_charges', chargesSql(stripeIds), (row) => ({
                   customerId: String(row[0] ?? ''),
                   recentChargeCount: toFloat(row[1]),
                   mtdStripe: toFloatOrNull(row[2]),
@@ -311,7 +315,7 @@ export async function loadProjection({
             : []
     const invoices =
         stripeIds.length > 0
-            ? await runHogQL<InvoiceRow>(invoicesSql(stripeIds), (row) => ({
+            ? await runHogQL<InvoiceRow>('projection_invoices', invoicesSql(stripeIds), (row) => ({
                   customerId: String(row[0] ?? ''),
                   invoiceDate: String(row[1] ?? ''),
                   subtotal: toFloat(row[2]),

--- a/products/csm_hud/frontend/scenes/CSMHudScene.tsx
+++ b/products/csm_hud/frontend/scenes/CSMHudScene.tsx
@@ -19,12 +19,17 @@ import { csmHudSceneLogic } from '../logics/csmHudSceneLogic'
 
 type TabKey = 'fleet' | 'renewals' | 'engagement' | 'conversations' | 'expansion'
 
-const TAB_FROM_PATH: Record<string, TabKey> = {
-    '/csm-hud/fleet': 'fleet',
-    '/csm-hud/renewals': 'renewals',
-    '/csm-hud/engagement': 'engagement',
-    '/csm-hud/conversations': 'conversations',
-    '/csm-hud/expansion': 'expansion',
+const TAB_KEYS: readonly TabKey[] = ['fleet', 'renewals', 'engagement', 'conversations', 'expansion']
+
+function tabFromPath(pathname: string): TabKey {
+    // pathname is project-prefixed at runtime (`/project/<id>/csm-hud/<tab>`);
+    // suffix match keeps the lookup project-id-agnostic.
+    for (const key of TAB_KEYS) {
+        if (pathname.endsWith(`/csm-hud/${key}`)) {
+            return key
+        }
+    }
+    return 'fleet'
 }
 
 export const scene: SceneExport = {
@@ -41,7 +46,7 @@ export function CSMHudScene(): JSX.Element {
         return <NotFound object="page" />
     }
 
-    const activeTab: TabKey = TAB_FROM_PATH[location.pathname] ?? 'fleet'
+    const activeTab: TabKey = tabFromPath(location.pathname)
 
     const tabs: LemonTab<TabKey>[] = [
         { key: 'fleet', label: 'Fleet', content: <FleetTab />, link: urls.csmHudFleet() },

--- a/products/csm_hud/frontend/scenes/CSMHudScene.tsx
+++ b/products/csm_hud/frontend/scenes/CSMHudScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { LemonButton, LemonTab, LemonTabs } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonTab, LemonTabs } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -33,8 +33,8 @@ export const scene: SceneExport = {
 }
 
 export function CSMHudScene(): JSX.Element {
-    const { canAccess, fleetLoading } = useValues(csmHudSceneLogic)
-    const { loadFleet } = useActions(csmHudSceneLogic)
+    const { canAccess, fleetLoading, csmFilter, user } = useValues(csmHudSceneLogic)
+    const { loadFleet, setCsmFilter } = useActions(csmHudSceneLogic)
     const { location } = useValues(router)
 
     if (!canAccess) {
@@ -78,9 +78,24 @@ export function CSMHudScene(): JSX.Element {
                 description="Customer Success Manager portfolio dashboard."
                 resourceType={{ type: 'csm_hud' }}
                 actions={
-                    <LemonButton type="secondary" loading={fleetLoading} onClick={() => loadFleet()}>
-                        Refresh
-                    </LemonButton>
+                    <div className="flex items-center gap-2">
+                        <LemonInput
+                            type="search"
+                            value={csmFilter}
+                            onChange={setCsmFilter}
+                            placeholder="Filter to CSM email (blank = all)"
+                            size="small"
+                            className="w-72"
+                        />
+                        {user?.email && csmFilter !== user.email && (
+                            <LemonButton type="tertiary" size="small" onClick={() => setCsmFilter(user.email)}>
+                                Mine
+                            </LemonButton>
+                        )}
+                        <LemonButton type="secondary" loading={fleetLoading} onClick={() => loadFleet()}>
+                            Refresh
+                        </LemonButton>
+                    </div>
                 }
             />
             <LemonTabs activeKey={activeTab} tabs={tabs} sceneInset />

--- a/products/csm_hud/frontend/scenes/CSMHudScene.tsx
+++ b/products/csm_hud/frontend/scenes/CSMHudScene.tsx
@@ -14,6 +14,7 @@ import { ConversationsTab } from '../components/ConversationsTab'
 import { EngagementTab } from '../components/EngagementTab'
 import { ExpansionTab } from '../components/ExpansionTab'
 import { FleetTab } from '../components/FleetTab'
+import { MissingSourcesBanner } from '../components/MissingSourcesBanner'
 import { RenewalsTab } from '../components/RenewalsTab'
 import { csmHudSceneLogic } from '../logics/csmHudSceneLogic'
 
@@ -103,6 +104,7 @@ export function CSMHudScene(): JSX.Element {
                     </div>
                 }
             />
+            <MissingSourcesBanner />
             <LemonTabs activeKey={activeTab} tabs={tabs} sceneInset />
         </SceneContent>
     )

--- a/products/csm_hud/frontend/utils/missingSources.ts
+++ b/products/csm_hud/frontend/utils/missingSources.ts
@@ -1,0 +1,77 @@
+export type MissingSourceKind = 'vitally' | 'zendesk' | 'salesforce' | 'internal-billing'
+
+const TABLE_TO_SOURCE: Record<string, MissingSourceKind> = {
+    vitally_accounts: 'vitally',
+    vitally_notes: 'vitally',
+    vitally_tasks: 'vitally',
+    vitally_users: 'vitally',
+    zendesk_tickets: 'zendesk',
+    'salesforce.opportunity': 'salesforce',
+    customer_billing_summary: 'internal-billing',
+    prod_postgres_billing_upcominginvoice: 'internal-billing',
+    iwa_org_month_product_mrr_usage: 'internal-billing',
+    billing_customers_with_owner: 'internal-billing',
+    'postgres.revenue.charge': 'internal-billing',
+    revenuepostgres_invoice: 'internal-billing',
+}
+
+const SOURCE_KIND_FOR_NEW_SOURCE_LINK: Partial<Record<MissingSourceKind, string>> = {
+    vitally: 'Vitally',
+    zendesk: 'Zendesk',
+    salesforce: 'Salesforce',
+    // internal-billing has no public-facing connector
+}
+
+const SOURCE_LABEL: Record<MissingSourceKind, string> = {
+    vitally: 'Vitally',
+    zendesk: 'Zendesk',
+    salesforce: 'Salesforce',
+    'internal-billing': 'PostHog internal billing data',
+}
+
+const SOURCE_DESCRIPTION: Record<MissingSourceKind, string> = {
+    vitally: 'Account health, segments, key roles, notes, and tasks.',
+    zendesk: 'Support ticket counts and conversation health.',
+    salesforce: 'Contract dates, ARR, and renewal forecast.',
+    'internal-billing':
+        'Billing period dates, MRR history, Stripe charges, and invoice subtotals. Only available where PostHog ops syncs the internal billing Postgres (prod team 2).',
+}
+
+/**
+ * Parse "Unknown table `X`" out of a HogQL error envelope and return the
+ * source-of-record that table comes from. Returns null for any other shape so
+ * unrelated errors still surface to the user.
+ */
+export function detectMissingSources(error: unknown): MissingSourceKind[] {
+    const message =
+        error instanceof Error
+            ? error.message
+            : typeof error === 'string'
+              ? error
+              : ((error as { detail?: string; message?: string })?.detail ??
+                (error as { message?: string })?.message ??
+                '')
+    if (!message || !message.includes('Unknown table')) {
+        return []
+    }
+    const sources = new Set<MissingSourceKind>()
+    for (const [table, source] of Object.entries(TABLE_TO_SOURCE)) {
+        if (message.includes(`\`${table}\``)) {
+            sources.add(source)
+        }
+    }
+    return Array.from(sources)
+}
+
+export function sourceLabel(source: MissingSourceKind): string {
+    return SOURCE_LABEL[source]
+}
+
+export function sourceDescription(source: MissingSourceKind): string {
+    return SOURCE_DESCRIPTION[source]
+}
+
+/** New-source kind param for `urls.dataWarehouseSourceNew(kind)`; null for sources that aren't user-connectable. */
+export function newSourceKind(source: MissingSourceKind): string | null {
+    return SOURCE_KIND_FOR_NEW_SOURCE_LINK[source] ?? null
+}


### PR DESCRIPTION
## Problem

Polish pass on top of the all-tabs PR (#58454). Five issues surfaced during local validation:

1. The scene auto-filtered the fleet to the viewer's email, leaving most CSMs with an empty table on first load.
2. HogQL `productKey` was set to `csm_hud`, which isn't a registered `ProductKey` enum value — the API rejected the queries.
3. Queries weren't tagged for the DEBUG-mode `UntaggedQueryError` guard.
4. Switching tabs broke because the project-id prefix in `location.pathname` made the exact-match table lookup fail.
5. Missing warehouse tables raised toast errors instead of guiding the user to connect the source.

## Changes

- Replace the auto-filter with a user-controlled `LemonInput` (blank = show all CSM-assigned accounts). A "Mine" button populates the input with the viewer's email when desired.
- Set HogQL `tags.productKey` to `'internal'` (a real enum value) and add `scene` + `name` tags to satisfy the DEBUG `UntaggedQueryError` guard.
- Rewrite tab-active detection to suffix-match on `pathname.endsWith('/csm-hud/<tab>')` so the project-id prefix doesn't break the lookup.
- Add a `MissingSourcesBanner` that catches `Unknown table` errors, maps them to source kinds (Vitally / Zendesk / Salesforce / internal-billing) and renders a "Connect <source>" button linking to the data-warehouse source wizard.

## How did you test this code?

Agent — verified:

- Empty filter renders all CSM-assigned accounts; setting an email scopes correctly.
- "Mine" populates with the viewer's email; clearing it returns to all-accounts.
- Tab switching works for `/project/<id>/csm-hud/<tab>` paths.
- Disconnecting Zendesk surfaces the banner without breaking the fleet table.

No automated tests — these are scattered fixes, each with a narrow visible surface. A future PR could add unit tests for `detectMissingSources` and the tab-suffix matcher.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Five commits bundled here because they share a theme (validation feedback on the same scene) and individually each is too small for its own PR. `productKey: 'internal'` was the cleanest fix — registering a new `ProductKey` enum value just for this internal scene would balloon the change set without value, and the query-tag system already accepts `internal` for ad-hoc internal tooling.
