### PR TITLE
feat(surveys): polish from NPS feedback (thumbs labels, bulk-paste, notif count)

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -27,7 +27,7 @@ import { NewSurvey, SCALE_OPTIONS, SURVEY_RATING_SCALE, SurveyQuestionLabel } fr
 import { HTMLEditor } from './SurveyAppearanceUtils'
 import { SurveyDragHandle } from './SurveyDragHandle'
 import { surveyLogic } from './surveyLogic'
-import { isThumbQuestion } from './utils'
+import { isThumbQuestion, splitChoicesOnPaste } from './utils'
 
 type SurveyQuestionHeaderProps = {
     index: number
@@ -712,28 +712,17 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                             if (editingLanguage) {
                                                 return
                                             }
-                                            const pasted = event.clipboardData.getData('text')
-                                            // Split on newlines or tabs (spreadsheet rows). Commas are intentionally
-                                            // not split on because they appear in regular answer text.
-                                            const segments = pasted
-                                                .split(/[\n\t]+/)
-                                                .map((segment) => segment.trim())
-                                                .filter((segment) => segment.length > 0)
-                                            if (segments.length <= 1) {
+                                            const merged = splitChoicesOnPaste(
+                                                event.clipboardData.getData('text'),
+                                                value || [],
+                                                choiceIndex,
+                                                hasOpenChoice
+                                            )
+                                            if (!merged) {
                                                 return
                                             }
                                             event.preventDefault()
-                                            const current = value || []
-                                            // Preserve the open-ended choice as the last entry if present.
-                                            const openTail =
-                                                hasOpenChoice && choiceIndex !== current.length - 1
-                                                    ? [current[current.length - 1]]
-                                                    : []
-                                            const head = current.slice(0, choiceIndex)
-                                            const tailStart = choiceIndex + 1
-                                            const tailEnd = hasOpenChoice ? current.length - 1 : current.length
-                                            const tail = current.slice(tailStart, tailEnd)
-                                            handleChoicesChange([...head, ...segments, ...tail, ...openTail])
+                                            handleChoicesChange(merged)
                                         }
 
                                         return (

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -685,7 +685,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     <div className="flex flex-col gap-2">
                         <LemonField name="hasOpenChoice">
                             {({ value: hasOpenChoice, onChange: toggleHasOpenChoice }) => (
-                                <LemonField name={getFieldName('choices')} label="Choices">
+                                <LemonField
+                                    name={getFieldName('choices')}
+                                    label="Choices"
+                                    info="Tip: paste a list of options separated by new lines (or from a spreadsheet column) to add them all at once."
+                                >
                                     {({ value, onChange }) => {
                                         const handleChoicesChange = (newChoices: string[]): void => {
                                             onChange(newChoices)
@@ -699,6 +703,37 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                             if (!editingLanguage) {
                                                 syncChoicesInTranslations(newChoices)
                                             }
+                                        }
+
+                                        const handlePasteIntoChoice = (
+                                            event: React.ClipboardEvent<HTMLInputElement>,
+                                            choiceIndex: number
+                                        ): void => {
+                                            if (editingLanguage) {
+                                                return
+                                            }
+                                            const pasted = event.clipboardData.getData('text')
+                                            // Split on newlines or tabs (spreadsheet rows). Commas are intentionally
+                                            // not split on because they appear in regular answer text.
+                                            const segments = pasted
+                                                .split(/[\n\t]+/)
+                                                .map((segment) => segment.trim())
+                                                .filter((segment) => segment.length > 0)
+                                            if (segments.length <= 1) {
+                                                return
+                                            }
+                                            event.preventDefault()
+                                            const current = value || []
+                                            // Preserve the open-ended choice as the last entry if present.
+                                            const openTail =
+                                                hasOpenChoice && choiceIndex !== current.length - 1
+                                                    ? [current[current.length - 1]]
+                                                    : []
+                                            const head = current.slice(0, choiceIndex)
+                                            const tailStart = choiceIndex + 1
+                                            const tailEnd = hasOpenChoice ? current.length - 1 : current.length
+                                            const tail = current.slice(tailStart, tailEnd)
+                                            handleChoicesChange([...head, ...segments, ...tail, ...openTail])
                                         }
 
                                         return (
@@ -718,6 +753,9 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                                                         newChoices[index] = val
                                                                         handleChoicesChange(newChoices)
                                                                     }}
+                                                                    onPaste={(event) =>
+                                                                        handlePasteIntoChoice(event, index)
+                                                                    }
                                                                     placeholder={
                                                                         editingLanguage
                                                                             ? originalChoices[index]

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -2,18 +2,10 @@ import './SurveyView.scss'
 
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
-import {
-    IconArchive,
-    IconCopy,
-    IconGraph,
-    IconLlmAnalytics,
-    IconThumbsDown,
-    IconThumbsUp,
-    IconTrash,
-} from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonDivider, Tooltip } from '@posthog/lemon-ui'
+import { IconArchive, IconCopy, IconGraph, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonDialog, LemonDivider, LemonTag } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
@@ -53,7 +45,6 @@ import {
     ScenePanelInfoSection,
 } from '~/layout/scenes/SceneLayout'
 import { Query } from '~/queries/Query/Query'
-import { QueryContextColumn } from '~/queries/types'
 import {
     AccessControlLevel,
     AccessControlResourceType,
@@ -65,29 +56,12 @@ import {
 
 import { SurveyResultsRefreshStatus } from './components/SurveyResultsRefreshStatus'
 import { NEW_SURVEY } from './constants'
+import { useSurveyResponseColumns } from './hooks/useSurveyResponseColumns'
 import { SurveyHeadline } from './SurveyHeadline'
 import { SurveySceneMenuBar } from './SurveySceneMenuBar'
-import { canUseSurveyWizard, getSurveyResponse, isThumbQuestion } from './utils'
+import { canUseSurveyWizard } from './utils'
 
 const RESOURCE_TYPE = 'survey'
-
-const getTraceIdFromRecord = (record: unknown): string | null => {
-    if (!Array.isArray(record)) {
-        return null
-    }
-    const event = record[0] as { properties?: { $ai_trace_id?: string } } | undefined
-    return event?.properties?.$ai_trace_id ?? null
-}
-
-export const getThumbIcon = (value: unknown): JSX.Element | null => {
-    if (value == '1') {
-        return <IconThumbsUp className="text-brand-blue" />
-    }
-    if (value == '2') {
-        return <IconThumbsDown className="text-warning" />
-    }
-    return null
-}
 
 export function SurveyView({ id }: { id: string }): JSX.Element {
     const isRedesignEnabled = useFeatureFlag('SURVEYS_REDESIGNED_VIEW')
@@ -101,7 +75,7 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
 }
 
 function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
-    const { survey, surveyLoading } = useValues(surveyLogic)
+    const { survey, surveyLoading, surveyNotifications } = useValues(surveyLogic)
     const { preferredEditor } = useValues(surveysLogic)
     const { editingSurvey, updateSurvey, stopSurvey, resumeSurvey, archiveSurvey } = useActions(surveyLogic)
     const { deleteSurvey, duplicateSurvey, setSurveyToDuplicate } = useActions(surveysLogic)
@@ -349,7 +323,16 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
                             },
                             {
                                 key: 'notifications',
-                                label: 'Notifications',
+                                label: (
+                                    <span className="flex items-center gap-1.5">
+                                        Notifications
+                                        {surveyNotifications.length > 0 && (
+                                            <LemonTag type="completion" size="small">
+                                                {surveyNotifications.length}
+                                            </LemonTag>
+                                        )}
+                                    </span>
+                                ),
                                 content: (
                                     <SurveyNotifications
                                         surveyId={id}
@@ -409,60 +392,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
     } = useValues(surveyLogic)
     const { clearFilters } = useActions(surveyLogic)
     const isInitialSurveyLoad = surveyLoading && survey.id === NEW_SURVEY.id
-
-    /**
-     * custom column renderer that does:
-     * - shows LLM trace button on the first question, if the event has an $ai_trace_id
-     * - shows thumbs up/down icons instead of the raw '1'/'2' data for thumb questions
-     */
-    const surveyColumnRenderers = useMemo(() => {
-        const columns: Record<string, QueryContextColumn> = {}
-
-        survey.questions.forEach((question, index) => {
-            const isThumb = isThumbQuestion(question)
-            const isFirstQuestion = index === 0
-
-            if (!isThumb && !isFirstQuestion) {
-                return
-            }
-
-            const columnName = getSurveyResponse(question, index)
-            columns[columnName] = {
-                render: ({ value, record }) => {
-                    const traceId = isFirstQuestion ? getTraceIdFromRecord(record) : null
-
-                    return (
-                        <span className="flex items-center gap-2">
-                            {/* show LLM trace button on the first question if we have $ai_trace_id */}
-                            {traceId && (
-                                <Tooltip title="View LLM trace">
-                                    <LemonButton
-                                        size="xsmall"
-                                        icon={
-                                            <IconLlmAnalytics className="text-[var(--color-product-llm-analytics-light)]" />
-                                        }
-                                        to={urls.llmAnalyticsTrace(traceId)}
-                                    />
-                                </Tooltip>
-                            )}
-
-                            {/* replace '1' and '2' with thumb icon+text if it's a thumb question */}
-                            {isThumb ? (
-                                <span className="flex items-center gap-1">
-                                    {getThumbIcon(value)}
-                                    Thumbs {value == '1' ? 'up' : 'down'}
-                                </span>
-                            ) : (
-                                String(value)
-                            )}
-                        </span>
-                    )
-                },
-            }
-        })
-
-        return columns
-    }, [survey.questions])
+    const surveyColumnRenderers = useSurveyResponseColumns()
 
     const atLeastOneResponse = !!processedSurveyStats?.[SurveyEventName.SENT].total_count
     const isRefreshingResults = resultsRequeryInProgress || isAnyResultsLoading

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -3,7 +3,7 @@ import { router } from 'kea-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { IconArchive, IconCode, IconCopy, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonDivider } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog, LemonDivider, LemonTag } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
@@ -25,6 +25,7 @@ import { SurveyFeedbackButton } from 'scenes/surveys/components/SurveyFeedbackBu
 import { SurveyNotifications } from 'scenes/surveys/components/SurveyNotifications'
 import { SurveyNotificationsCallout } from 'scenes/surveys/components/SurveyNotificationsCallout'
 import { DuplicateToProjectModal } from 'scenes/surveys/DuplicateToProjectModal'
+import { useSurveyResponseColumns } from 'scenes/surveys/hooks/useSurveyResponseColumns'
 import { canDeleteSurvey, openArchiveSurveyDialog, openDeleteSurveyDialog } from 'scenes/surveys/surveyDialogs'
 import { SurveyHeadline } from 'scenes/surveys/SurveyHeadline'
 import { SurveyTab, surveyLogic } from 'scenes/surveys/surveyLogic'
@@ -72,7 +73,7 @@ import { SurveyDetailsPanel, SurveyExportPanel } from './SurveySidebar'
 const RESOURCE_TYPE = 'survey'
 
 export function SurveyViewRedesign(): JSX.Element {
-    const { survey, surveyLoading, activeTab } = useValues(surveyLogic)
+    const { survey, surveyLoading, activeTab, surveyNotifications } = useValues(surveyLogic)
     const { preferredEditor } = useValues(surveysLogic)
     const { editingSurvey, updateSurvey, archiveSurvey, setActiveTab } = useActions(surveyLogic)
     const { setScenePanelOpen } = useActions(sceneLayoutLogic)
@@ -445,7 +446,16 @@ export function SurveyViewRedesign(): JSX.Element {
                             : []),
                         {
                             key: SurveyTab.NOTIFICATIONS,
-                            label: 'Notifications',
+                            label: (
+                                <span className="flex items-center gap-1.5">
+                                    Notifications
+                                    {surveyNotifications.length > 0 && (
+                                        <LemonTag type="completion" size="small">
+                                            {surveyNotifications.length}
+                                        </LemonTag>
+                                    )}
+                                </span>
+                            ),
                             content: <SurveyNotificationsContent />,
                         },
                         {
@@ -666,6 +676,7 @@ function SurveyResponsesContent(): JSX.Element {
     } = useValues(surveyLogic)
     const isInitialSurveyLoad = surveyLoading && survey.id === NEW_SURVEY.id
     const isRefreshingResults = resultsRequeryInProgress || isAnyResultsLoading
+    const surveyColumnRenderers = useSurveyResponseColumns()
 
     return (
         <div className="px-4 pb-4 space-y-4">
@@ -686,6 +697,7 @@ function SurveyResponsesContent(): JSX.Element {
                     <Query
                         query={dataTableQuery}
                         context={{
+                            columns: surveyColumnRenderers,
                             rowProps: (record: unknown) => {
                                 if (typeof record !== 'object' || !record || !('result' in record)) {
                                     return {}

--- a/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
+++ b/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
@@ -1,0 +1,85 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { IconLlmAnalytics, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+import { LemonButton, Tooltip } from '@posthog/lemon-ui'
+
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { getSurveyResponse, isThumbQuestion } from 'scenes/surveys/utils'
+import { urls } from 'scenes/urls'
+
+import { QueryContextColumn } from '~/queries/types'
+
+const getTraceIdFromRecord = (record: unknown): string | null => {
+    if (!Array.isArray(record)) {
+        return null
+    }
+    const event = record[0] as { properties?: { $ai_trace_id?: string } } | undefined
+    return event?.properties?.$ai_trace_id ?? null
+}
+
+export const getThumbIcon = (value: unknown): JSX.Element | null => {
+    if (value == '1') {
+        return <IconThumbsUp className="text-brand-blue" />
+    }
+    if (value == '2') {
+        return <IconThumbsDown className="text-warning" />
+    }
+    return null
+}
+
+/**
+ * Custom column renderers for the survey responses data table:
+ * - On the first question, surface a "View LLM trace" button when `$ai_trace_id` is present.
+ * - On thumb questions, render the icon + "Thumbs up/down" instead of the raw `1`/`2` value.
+ */
+export function useSurveyResponseColumns(): Record<string, QueryContextColumn> {
+    const { survey } = useValues(surveyLogic)
+
+    return useMemo(() => {
+        const columns: Record<string, QueryContextColumn> = {}
+
+        survey.questions.forEach((question, index) => {
+            const isThumb = isThumbQuestion(question)
+            const isFirstQuestion = index === 0
+
+            if (!isThumb && !isFirstQuestion) {
+                return
+            }
+
+            const columnName = getSurveyResponse(question, index)
+            columns[columnName] = {
+                render: ({ value, record }) => {
+                    const traceId = isFirstQuestion ? getTraceIdFromRecord(record) : null
+
+                    return (
+                        <span className="flex items-center gap-2">
+                            {traceId && (
+                                <Tooltip title="View LLM trace">
+                                    <LemonButton
+                                        size="xsmall"
+                                        icon={
+                                            <IconLlmAnalytics className="text-[var(--color-product-llm-analytics-light)]" />
+                                        }
+                                        to={urls.llmAnalyticsTrace(traceId)}
+                                    />
+                                </Tooltip>
+                            )}
+
+                            {isThumb ? (
+                                <span className="flex items-center gap-1">
+                                    {getThumbIcon(value)}
+                                    Thumbs {value == '1' ? 'up' : 'down'}
+                                </span>
+                            ) : (
+                                String(value)
+                            )}
+                        </span>
+                    )
+                },
+            }
+        })
+
+        return columns
+    }, [survey.questions])
+}

--- a/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
+++ b/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
@@ -66,13 +66,13 @@ export function useSurveyResponseColumns(): Record<string, QueryContextColumn> {
                                 </Tooltip>
                             )}
 
-                            {isThumb ? (
+                            {isThumb && (value == '1' || value == '2') ? (
                                 <span className="flex items-center gap-1">
                                     {getThumbIcon(value)}
                                     Thumbs {value == '1' ? 'up' : 'down'}
                                 </span>
                             ) : (
-                                String(value)
+                                String(value ?? '')
                             )}
                         </span>
                     )

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -36,6 +36,7 @@ import {
     sanitizeSurvey,
     sanitizeSurveyAppearance,
     sanitizeSurveyDisplayConditions,
+    splitChoicesOnPaste,
     validateCSSProperty,
 } from './utils'
 
@@ -1377,5 +1378,46 @@ describe('timezone handling in survey date queries', () => {
         const result = getSurveyEndDateForQuery(survey)
 
         expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T23:59:59$/)
+    })
+})
+
+describe('splitChoicesOnPaste', () => {
+    it('returns null when only one segment is pasted', () => {
+        expect(splitChoicesOnPaste('single value', [''], 0, false)).toBeNull()
+        expect(splitChoicesOnPaste('Yes, sometimes', [''], 0, false)).toBeNull()
+    })
+
+    it('splits newline-separated values into the choices array', () => {
+        expect(splitChoicesOnPaste('one\ntwo\nthree', [''], 0, false)).toEqual(['one', 'two', 'three'])
+    })
+
+    it('splits tab-separated values (spreadsheet rows)', () => {
+        expect(splitChoicesOnPaste('one\ttwo\tthree', [''], 0, false)).toEqual(['one', 'two', 'three'])
+    })
+
+    it('trims and drops empty segments', () => {
+        expect(splitChoicesOnPaste('  one  \n\n  two  \n', [''], 0, false)).toEqual(['one', 'two'])
+    })
+
+    it('inserts segments in place of the target choice and keeps surrounding choices', () => {
+        expect(splitChoicesOnPaste('two\nthree', ['one', 'placeholder', 'four'], 1, false)).toEqual([
+            'one',
+            'two',
+            'three',
+            'four',
+        ])
+    })
+
+    it('preserves the open-ended "Other" entry when pasting into a regular slot', () => {
+        expect(splitChoicesOnPaste('two\nthree', ['one', '', 'Other'], 1, true)).toEqual([
+            'one',
+            'two',
+            'three',
+            'Other',
+        ])
+    })
+
+    it('preserves the open-ended "Other" entry when pasting into the open-ended slot itself', () => {
+        expect(splitChoicesOnPaste('two\nthree', ['one', 'Other'], 1, true)).toEqual(['one', 'two', 'three', 'Other'])
     })
 })

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -946,6 +946,37 @@ export const isThumbQuestion = (question: SurveyQuestion): boolean => {
     )
 }
 
+/**
+ * Splits text pasted into a choice input on newlines or tabs (spreadsheet rows).
+ * Returns the merged choices array, or `null` if there's nothing to split (the caller
+ * should let the paste fall through to the default input behavior).
+ *
+ * Always keeps the open-ended ("Other") entry as the last item when `hasOpenChoice`
+ * is true — including when the paste happens into the open-ended slot itself.
+ */
+export function splitChoicesOnPaste(
+    pasted: string,
+    choices: string[],
+    choiceIndex: number,
+    hasOpenChoice: boolean
+): string[] | null {
+    const segments = pasted
+        .split(/[\n\t]+/)
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length > 0)
+
+    if (segments.length <= 1) {
+        return null
+    }
+
+    const openTail = hasOpenChoice ? [choices[choices.length - 1]] : []
+    const head = choices.slice(0, choiceIndex)
+    const tailStart = choiceIndex + 1
+    const tailEnd = hasOpenChoice ? choices.length - 1 : choices.length
+    const tail = choices.slice(tailStart, tailEnd)
+    return [...head, ...segments, ...tail, ...openTail]
+}
+
 export type SurveyConditionType =
     | 'url'
     | 'selector'

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -27,6 +27,7 @@ import {
 import { SCALE_OPTIONS, SURVEY_RATING_SCALE, defaultSurveyAppearance, defaultSurveyFieldValues } from '../../constants'
 import { HTMLEditor } from '../../SurveyAppearanceUtils'
 import { surveyLogic } from '../../surveyLogic'
+import { splitChoicesOnPaste } from '../../utils'
 import { AddQuestionButton } from '../AddQuestionButton'
 import { QuestionTypeChip } from '../QuestionTypeChip'
 import { surveyWizardLogic } from '../surveyWizardLogic'
@@ -195,23 +196,17 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
         }
 
         const handlePasteIntoChoice = (event: React.ClipboardEvent<HTMLInputElement>, choiceIndex: number): void => {
-            const pasted = event.clipboardData.getData('text')
-            const segments = pasted
-                .split(/[\n\t]+/)
-                .map((segment) => segment.trim())
-                .filter((segment) => segment.length > 0)
-            if (segments.length <= 1) {
+            const merged = splitChoicesOnPaste(
+                event.clipboardData.getData('text'),
+                choices,
+                choiceIndex,
+                hasOpenChoice ?? false
+            )
+            if (!merged) {
                 return
             }
             event.preventDefault()
-            const openTail = hasOpenChoice && choiceIndex !== choices.length - 1 ? [choices[choices.length - 1]] : []
-            const head = choices.slice(0, choiceIndex)
-            const tailStart = choiceIndex + 1
-            const tailEnd = hasOpenChoice ? choices.length - 1 : choices.length
-            const tail = choices.slice(tailStart, tailEnd)
-            onUpdate({
-                choices: [...head, ...segments, ...tail, ...openTail],
-            } as Partial<MultipleSurveyQuestion>)
+            onUpdate({ choices: merged } as Partial<MultipleSurveyQuestion>)
         }
 
         return (

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -194,9 +194,32 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
             } as Partial<MultipleSurveyQuestion>)
         }
 
+        const handlePasteIntoChoice = (event: React.ClipboardEvent<HTMLInputElement>, choiceIndex: number): void => {
+            const pasted = event.clipboardData.getData('text')
+            const segments = pasted
+                .split(/[\n\t]+/)
+                .map((segment) => segment.trim())
+                .filter((segment) => segment.length > 0)
+            if (segments.length <= 1) {
+                return
+            }
+            event.preventDefault()
+            const openTail = hasOpenChoice && choiceIndex !== choices.length - 1 ? [choices[choices.length - 1]] : []
+            const head = choices.slice(0, choiceIndex)
+            const tailStart = choiceIndex + 1
+            const tailEnd = hasOpenChoice ? choices.length - 1 : choices.length
+            const tail = choices.slice(tailStart, tailEnd)
+            onUpdate({
+                choices: [...head, ...segments, ...tail, ...openTail],
+            } as Partial<MultipleSurveyQuestion>)
+        }
+
         return (
             <div className="space-y-2 pt-2 border-t border-border mt-3">
-                <span className="text-xs text-secondary">Choices:</span>
+                <div className="flex items-baseline justify-between gap-2">
+                    <span className="text-xs text-secondary">Choices:</span>
+                    <span className="text-[10px] text-muted">Paste a list to add many at once</span>
+                </div>
                 <div className="space-y-1.5">
                     {choices.map((choice, choiceIndex) => {
                         const isOpenChoice = hasOpenChoice && choiceIndex === choices.length - 1
@@ -207,6 +230,7 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
                                     value={choice}
                                     placeholder={isOpenChoice ? 'Other (open-ended)' : `Choice ${choiceIndex + 1}`}
                                     onChange={(val) => updateChoice(choiceIndex, val)}
+                                    onPaste={(event) => handlePasteIntoChoice(event, choiceIndex)}
                                     className="flex-1"
                                     suffix={
                                         isOpenChoice ? (


### PR DESCRIPTION
## Problem

Three recurring complaints surfaced in the last 60 days of the in-app NPS survey ("NPS - Surveys") and the Surveys feedback button:

1. **"In most places, a thumbs up / thumbs down is shown as \`1\` / \`2\`. This is a bit cryptic..."** — the legacy survey view already rendered thumb responses as icon + label in the response table, but the new redesigned view (behind \`SURVEYS_REDESIGNED_VIEW\`) regressed to the raw stored values \`1\` / \`2\`.
2. **"Make it easier to copy and paste in multiple choice answers in one go..."** — adding many options to a single/multi-choice question is one-at-a-time only, which is painful when migrating questions from a doc or spreadsheet.
3. **"Why can't I see if any notifications are set up for this survey? Now I have to compare survey IDs against notification filters."** — the Notifications tab existed but gave no signal of whether anything was configured without clicking in.

## Changes

- **Thumbs labels everywhere.** Extracted the existing column-renderer logic from \`SurveyView.tsx\` into a shared \`useSurveyResponseColumns\` hook (also keeps the LLM trace button rendering). Wired the hook into \`SurveyViewRedesign.tsx\`, so both the legacy and redesigned response tables now render \`👍 Thumbs up\` / \`👎 Thumbs down\` consistently.
- **Bulk-paste choices.** \`onPaste\` on each choice input now splits the pasted text on newlines or tabs (intentionally not on commas — too common in real answers like "Yes, sometimes"), replaces the focused choice with the first segment, and appends the rest as new choices. The open-ended "Other" entry, if present, is preserved as the last entry. Applied to both the legacy \`SurveyEditQuestionRow\` editor and the wizard \`QuestionsStep\`. Surfaces a subtle hint next to "Choices" so users actually discover the affordance.
- **Notification count on the tab.** The "Notifications" tab label now renders a \`LemonTag\` with the configured-notification count when there's at least one (e.g. \`Notifications [3]\`). Available in both \`SurveyView\` and \`SurveyViewRedesign\`. No extra data fetch — \`surveyNotifications\` is already loaded on mount.

## How did you test this code?

I'm an agent (PostHog Code). I haven't run the dev server / manually QA'd the UI. Verified:

- \`oxlint\` clean on all five changed files.
- \`tsc --noEmit\` produces no new errors in the surveys area (project-wide tsc has many pre-existing errors in \`products/tracing\` and \`products/workflows\` that are unrelated to this PR).
- \`pnpm format\` / lint-staged auto-formatting passed on commit.

Manual UI verification still needed: pasting a real list into a single-choice question; the new tab badge appearing for a survey with configured notifications; thumb responses rendering with icon/label in the redesigned view.

## Publish to changelog?

Yes — short entry on improving the surveys editor and response views.

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Source data came from querying \`survey sent\` events for the two surveys with HogQL via \`execute-sql\` over the last 60 days (\`01902b02-…\` NPS popover, 61 events; \`0196afd4-…\` widget feedback button, 28 events). Then clustered the open-text responses and picked three "low-hanging fruit" items the user explicitly chose.

Decisions worth flagging for review:
- For bulk-paste, I considered splitting on commas too, but rejected — \`"Yes, sometimes"\` is a plausible single answer. Newlines/tabs are unambiguous list separators (spreadsheets, bullet lists). The hint says "list" rather than "comma-separated" for the same reason.
- The thumb-renderer code already existed in the legacy view; rather than re-implementing it, I extracted to a hook so both views share one source of truth.
- The notification tab badge intentionally doesn't distinguish enabled vs disabled notifications — at this stage the user just wants to know "is anything wired up at all?". Could split later if asked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*