### PR TITLE
feat(code): add integration lookup endpoint

### DIFF
--- a/posthog/api/internal_integration.py
+++ b/posthog/api/internal_integration.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+import structlog
+from rest_framework import viewsets
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.auth import InternalAPIAuthentication
+from posthog.models.integration import Integration
+
+logger = structlog.get_logger(__name__)
+
+
+VALID_KINDS: set[str] = {value for value, _ in Integration.IntegrationKind.choices}
+
+
+class InternalIntegrationViewSet(viewsets.ViewSet):
+    """Service-to-service lookups across the global Integration table.
+
+    Authenticated with `X-Internal-Api-Secret` and not exposed to external
+    ingress. Used by sibling services (e.g. the chat SDK relay) to discover
+    which PostHog team owns a given third-party identifier without knowing the
+    team in advance.
+    """
+
+    authentication_classes = [InternalAPIAuthentication]
+    permission_classes = [AllowAny]
+
+    def lookup(self, request: Request, **kwargs: Any) -> Response:
+        kind = request.data.get("kind")
+        integration_id = request.data.get("integration_id")
+
+        if not isinstance(kind, str) or kind not in VALID_KINDS:
+            return Response({"error": "Invalid or unsupported kind"}, status=400)
+        if not isinstance(integration_id, str) or not integration_id:
+            return Response({"error": "integration_id is required"}, status=400)
+
+        integration = (
+            Integration.objects.filter(kind=kind, integration_id=integration_id)
+            .select_related("team", "team__organization")
+            .order_by("id")
+            .first()
+        )
+        if integration is None:
+            return Response({"error": "Integration not found"}, status=404)
+
+        return Response(
+            {
+                "team_id": integration.team_id,
+                "organization_id": str(integration.team.organization_id),
+                "integration_pk": integration.id,
+                "display_name": integration.display_name,
+            }
+        )

--- a/posthog/api/test/test_internal_integration.py
+++ b/posthog/api/test/test_internal_integration.py
@@ -1,0 +1,68 @@
+import pytest
+
+from django.test.client import Client as HttpClient
+
+from rest_framework import status
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team import Team
+
+VALID_SECRET = "posthog123"  # LOCAL_DEV_INTERNAL_API_SECRET; accepted under TEST mode
+AUTH_HEADER = {"HTTP_X_INTERNAL_API_SECRET": VALID_SECRET}
+
+
+class TestInternalIntegrationLookup:
+    @pytest.fixture(autouse=True)
+    def setup_integration(self, db):
+        self.organization = Organization.objects.create(name="Acme")
+        self.team = Team.objects.create(organization=self.organization, name="Acme Prod")
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="github",
+            integration_id="12345678",
+            config={"account": {"name": "acme-corp"}},
+            sensitive_config={"access_token": "ghs_dummy"},
+        )
+
+    def _post(self, client: HttpClient, body: dict, **extra) -> "HttpClient.response":
+        return client.post(
+            "/api/internal/integrations/lookup",
+            data=body,
+            content_type="application/json",
+            **extra,
+        )
+
+    def test_lookup_returns_team_and_org_for_matching_integration(self, client: HttpClient):
+        response = self._post(client, {"kind": "github", "integration_id": "12345678"}, **AUTH_HEADER)
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json() == {
+            "team_id": self.team.id,
+            "organization_id": str(self.organization.id),
+            "integration_pk": self.integration.id,
+            "display_name": "acme-corp",
+        }
+
+    def test_lookup_404_when_no_match(self, client: HttpClient):
+        response = self._post(client, {"kind": "github", "integration_id": "99999999"}, **AUTH_HEADER)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_lookup_rejects_unknown_kind(self, client: HttpClient):
+        response = self._post(client, {"kind": "not-a-real-kind", "integration_id": "x"}, **AUTH_HEADER)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_lookup_rejects_missing_integration_id(self, client: HttpClient):
+        response = self._post(client, {"kind": "github"}, **AUTH_HEADER)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_lookup_requires_internal_secret(self, client: HttpClient):
+        response = self._post(client, {"kind": "github", "integration_id": "12345678"})
+        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+    def test_lookup_rejects_wrong_secret(self, client: HttpClient):
+        response = self._post(
+            client,
+            {"kind": "github", "integration_id": "12345678"},
+            HTTP_X_INTERNAL_API_SECRET="not-the-right-secret",
+        )
+        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -31,6 +31,7 @@ from posthog.api import (
     uploaded_media,
     user,
 )
+from posthog.api.internal_integration import InternalIntegrationViewSet
 from posthog.api.oauth.connected_apps import ConnectedAppsViewSet
 from posthog.api.oauth.wizard_metadata import WIZARD_METADATA_PATH, WizardClientMetadataView
 from posthog.api.query import progress
@@ -315,6 +316,10 @@ urlpatterns = [
     path(
         "api/projects/<str:team_id>/internal/signals/emit",
         csrf_exempt(signals_views.InternalSignalViewSet.as_view({"post": "emit"})),
+    ),
+    path(
+        "api/internal/integrations/lookup",
+        csrf_exempt(InternalIntegrationViewSet.as_view({"post": "lookup"})),
     ),
     # Test setup endpoint (only available in TEST mode)
     path("api/setup_test/<str:test_name>/", csrf_exempt(playwright_setup.setup_test)),


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
