### PR TITLE
chore(hackathon): adding the CLI to the monorepo.

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,7 @@ packages:
     - tools/*
     - '!tools/hedgebox-dummy'
     - rust/cyclotron-node
+    - cli-2.0
 
 catalog:
     # Kea ecosystem - state management


### PR DESCRIPTION
## Problem

The PostHog CLI needs to be part of the monorepo to enable pnpm workspace commands.

## Changes

Added `cli-2.0` to `pnpm-workspace.yaml`.

## Usage

CLI commands can now be run with the `--filter` flag:

```bash
pnpm --filter=@posthog/cli-2.0 build
pnpm --filter=@posthog/cli-2.0 dev --help
```

## How did you test this code?

```bash
pnpm --filter=@posthog/cli-2.0 exec pwd
# /Users/rodrigo/Code/posthog/cli-2.0
```

![cat-type-small](https://github.com/user-attachments/assets/24445a1c-03f4-408f-bad4-9469dbb49439)