### PR TITLE
feat(dashboards): add chart primitives for customer health dashboards

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/ConditionalFormatting/ConditionalFormattingTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/ConditionalFormatting/ConditionalFormattingTab.tsx
@@ -98,8 +98,10 @@ const RuleItem = ({ rule: propsRule }: { rule: ConditionalFormattingRule }): JSX
 
     const builtCFLogic = conditionalFormattingLogic({ key: dataVisualizationProps.key, rule: propsRule })
 
-    const { selectColumn, updateInput, selectTemplate, selectColor, deleteRule } = useActions(builtCFLogic)
+    const { selectColumn, updateInput, selectTemplate, selectColor, setDisplayMode, setLabel, deleteRule } =
+        useActions(builtCFLogic)
     const { rule, template } = useValues(builtCFLogic)
+    const displayMode = rule.displayMode ?? 'background'
 
     return (
         <div className="gap-2 flex flex-col">
@@ -137,6 +139,17 @@ const RuleItem = ({ rule: propsRule }: { rule: ConditionalFormattingRule }): JSX
                 onSelect={(value) => selectTemplate(value)}
             />
 
+            <LemonSelect
+                className="w-full"
+                value={displayMode}
+                onSelect={(value) => setDisplayMode(value)}
+                options={[
+                    { label: 'Background color', value: 'background' },
+                    { label: 'Badge', value: 'badge' },
+                    { label: 'Dot', value: 'dot' },
+                ]}
+            />
+
             <div className="flex flex-1">
                 <LemonColorPicker
                     selectedColor={rule.color}
@@ -162,6 +175,14 @@ const RuleItem = ({ rule: propsRule }: { rule: ConditionalFormattingRule }): JSX
                     onClick={() => deleteRule()}
                 />
             </div>
+
+            {displayMode === 'badge' && (
+                <LemonInput
+                    placeholder="Badge label (defaults to cell value)"
+                    value={rule.label ?? ''}
+                    onChange={(value) => setLabel(value)}
+                />
+            )}
         </div>
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/ConditionalFormatting/conditionalFormattingLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/ConditionalFormatting/conditionalFormattingLogic.ts
@@ -4,7 +4,7 @@ import { subscriptions } from 'kea-subscriptions'
 
 import api from 'lib/api'
 
-import { ConditionalFormattingRule } from '~/queries/schema/schema-general'
+import { ConditionalFormattingDisplayMode, ConditionalFormattingRule } from '~/queries/schema/schema-general'
 
 import { dataVisualizationLogic } from '../../dataVisualizationLogic'
 import { FORMATTING_TEMPLATES, FormattingTemplate } from '../../types'
@@ -28,6 +28,8 @@ export const conditionalFormattingLogic = kea<conditionalFormattingLogicType>([
         selectTemplate: (templateId: string) => ({ templateId }),
         updateBytecode: (bytecode: any[]) => ({ bytecode }),
         selectColor: (color: string) => ({ color }),
+        setDisplayMode: (displayMode: ConditionalFormattingDisplayMode) => ({ displayMode }),
+        setLabel: (label: string) => ({ label }),
         deleteRule: true,
     }),
     reducers(({ props }) => ({
@@ -48,6 +50,12 @@ export const conditionalFormattingLogic = kea<conditionalFormattingLogicType>([
                 },
                 selectColor: (state, { color }) => {
                     return { ...state, color }
+                },
+                setDisplayMode: (state, { displayMode }) => {
+                    return { ...state, displayMode }
+                },
+                setLabel: (state, { label }) => {
+                    return { ...state, label }
                 },
             },
         ],

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -5,14 +5,20 @@ import posthog from 'posthog-js'
 import React from 'react'
 
 import { IconPin, IconPinFilled } from '@posthog/icons'
-import { LemonTable, LemonTableColumn, Tooltip } from '@posthog/lemon-ui'
+import { LemonTable, LemonTableColumn, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
+import { Sparkline } from 'lib/components/Sparkline'
 import { execHog } from 'lib/hog'
 import { lightenDarkenColor } from 'lib/utils'
 import { InsightEmptyState, InsightErrorState } from 'scenes/insights/EmptyStates'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-import { DataVisualizationNode, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
+import {
+    ConditionalFormattingRule,
+    DataVisualizationNode,
+    HogQLQueryResponse,
+    NodeKind,
+} from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
 import { LoadNext } from '../../DataNode/LoadNext'
@@ -56,6 +62,53 @@ function getDisplayedColumnTitle(
 ): React.ReactNode {
     const { title } = renderColumnMeta(columnName, query, context)
     return label || title || columnName
+}
+
+function coerceToNumberArray(value: unknown): number[] | null {
+    if (!Array.isArray(value)) {
+        return null
+    }
+    const out: number[] = []
+    for (const item of value) {
+        const num = typeof item === 'number' ? item : item == null ? NaN : Number(item)
+        if (!Number.isFinite(num)) {
+            return null
+        }
+        out.push(num)
+    }
+    return out
+}
+
+function matchConditionalFormattingRule(
+    rules: ConditionalFormattingRule[],
+    sourceColumnName: string,
+    cellValue: any,
+    cellType: string
+): ConditionalFormattingRule | undefined {
+    for (const rule of rules) {
+        if (rule.columnName !== sourceColumnName) {
+            continue
+        }
+        const isValidHog = !!rule.bytecode && rule.bytecode.length > 0 && rule.bytecode[0] === '_H'
+        if (!isValidHog) {
+            posthog.captureException(new Error('Invalid hog bytecode for conditional formatting'), {
+                formatRule: rule,
+            })
+            continue
+        }
+        const res = execHog(rule.bytecode, {
+            globals: {
+                value: cellValue,
+                input: convertTableValue(rule.input, cellType),
+            },
+            functions: {},
+            maxAsyncSteps: 0,
+        })
+        if (res.result) {
+            return rule
+        }
+    }
+    return undefined
 }
 
 export const Table = (props: TableProps): JSX.Element => {
@@ -133,21 +186,75 @@ export const Table = (props: TableProps): JSX.Element => {
                         return <div className="truncate">{renderedSourceColumnTitle}</div>
                     }
 
-                    return (
-                        <div className="truncate">
-                            {renderColumn(
-                                cell.sourceColumnName ?? column.name,
-                                cell.formattedValue,
-                                data,
-                                recordIndex,
-                                rowCount,
-                                {
-                                    kind: NodeKind.DataTableNode,
-                                    source: props.query.source,
-                                }
-                            )}
-                        </div>
+                    const sourceColumnName = cell.sourceColumnName ?? column.name
+                    const sourceColumnType =
+                        sourceTabularColumnsByName.get(sourceColumnName)?.column.type.name ?? cell.type
+                    const matchedRule = matchConditionalFormattingRule(
+                        conditionalFormattingRules,
+                        sourceColumnName,
+                        cell.value,
+                        sourceColumnType
                     )
+                    const displayMode = matchedRule?.displayMode ?? 'background'
+
+                    if (settings?.display?.renderAs === 'sparkline') {
+                        const numbers = coerceToNumberArray(cell.value)
+                        if (numbers === null) {
+                            return (
+                                <Tooltip title="Sparkline columns require an array of numbers (e.g. groupArray(value)).">
+                                    <span className="text-muted italic">—</span>
+                                </Tooltip>
+                            )
+                        }
+                        const sparkline = settings.display.sparkline
+                        return (
+                            <Sparkline
+                                data={numbers}
+                                color={sparkline?.color ?? 'primary'}
+                                type={sparkline?.type ?? 'line'}
+                                maximumIndicator={false}
+                                className="h-6 w-24"
+                            />
+                        )
+                    }
+
+                    const renderedCell = renderColumn(
+                        sourceColumnName,
+                        cell.formattedValue,
+                        data,
+                        recordIndex,
+                        rowCount,
+                        {
+                            kind: NodeKind.DataTableNode,
+                            source: props.query.source,
+                        }
+                    )
+
+                    if (matchedRule && displayMode === 'dot') {
+                        return (
+                            <div className="truncate flex items-center gap-2">
+                                <span
+                                    aria-hidden
+                                    className="inline-block w-2 h-2 rounded-full shrink-0"
+                                    style={{ backgroundColor: matchedRule.color }}
+                                />
+                                <span className="truncate">{renderedCell}</span>
+                            </div>
+                        )
+                    }
+
+                    if (matchedRule && displayMode === 'badge') {
+                        const badgeLabel = matchedRule.label?.trim() ? matchedRule.label : renderedCell
+                        return (
+                            <div className="truncate">
+                                <LemonTag style={{ backgroundColor: matchedRule.color, borderColor: 'transparent' }}>
+                                    {badgeLabel}
+                                </LemonTag>
+                            </div>
+                        )
+                    }
+
+                    return <div className="truncate">{renderedCell}</div>
                 },
                 style: (_, data) => {
                     const cell = data[index]
@@ -159,61 +266,40 @@ export const Table = (props: TableProps): JSX.Element => {
                     const sourceColumnName = cell.sourceColumnName ?? column.name
                     const sourceColumnType =
                         sourceTabularColumnsByName.get(sourceColumnName)?.column.type.name ?? cell.type
-                    const cf = conditionalFormattingRules
-                        .filter((n) => n.columnName === sourceColumnName)
-                        .filter((n) => {
-                            const isValidHog = !!n.bytecode && n.bytecode.length > 0 && n.bytecode[0] === '_H'
-                            if (!isValidHog) {
-                                posthog.captureException(new Error('Invalid hog bytecode for conditional formatting'), {
-                                    formatRule: n,
-                                })
-                            }
+                    const matchedRule = matchConditionalFormattingRule(
+                        conditionalFormattingRules,
+                        sourceColumnName,
+                        cell.value,
+                        sourceColumnType
+                    )
 
-                            return isValidHog
-                        })
-                        .map((n) => {
-                            const res = execHog(n.bytecode, {
-                                globals: {
-                                    value: cell.value,
-                                    input: convertTableValue(n.input, sourceColumnType),
-                                },
-                                functions: {},
-                                maxAsyncSteps: 0,
-                            })
+                    // Only the 'background' display mode (default) tints the cell. 'badge' and 'dot' are rendered
+                    // inside the cell content by the render() function above.
+                    if (!matchedRule || (matchedRule.displayMode ?? 'background') !== 'background') {
+                        return undefined
+                    }
 
-                            return {
-                                rule: n,
-                                result: res.result,
-                            }
-                        })
+                    const ruleColor = matchedRule.color
+                    const colorMode = matchedRule.colorMode ?? 'light'
 
-                    const conditionalFormattingMatches = cf.find((n) => Boolean(n.result))
-
-                    if (conditionalFormattingMatches) {
-                        const ruleColor = conditionalFormattingMatches.rule.color
-                        const colorMode = conditionalFormattingMatches.rule.colorMode ?? 'light'
-
-                        // If the color mode matches the current theme, return as it was saved
-                        if ((colorMode === 'dark' && isDarkModeOn) || (colorMode === 'light' && !isDarkModeOn)) {
-                            return {
-                                backgroundColor: ruleColor,
-                            }
-                        }
-
-                        // If the color mode is dark, but we're in light mode - then lighten the color
-                        if (colorMode === 'dark' && !isDarkModeOn) {
-                            return {
-                                backgroundColor: lightenDarkenColor(ruleColor, 30),
-                            }
-                        }
-
-                        // If the color mode is light, but we're in dark mode - then darken the color
+                    // If the color mode matches the current theme, return as it was saved
+                    if ((colorMode === 'dark' && isDarkModeOn) || (colorMode === 'light' && !isDarkModeOn)) {
                         return {
-                            backgroundColor: lightenDarkenColor(ruleColor, -30),
+                            backgroundColor: ruleColor,
                         }
                     }
 
-                    return undefined
+                    // If the color mode is dark, but we're in light mode - then lighten the color
+                    if (colorMode === 'dark' && !isDarkModeOn) {
+                        return {
+                            backgroundColor: lightenDarkenColor(ruleColor, 30),
+                        }
+                    }
+
+                    // If the color mode is light, but we're in dark mode - then darken the color
+                    return {
+                        backgroundColor: lightenDarkenColor(ruleColor, -30),
+                    }
                 },
             }
         }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -22,6 +22,7 @@ import { LoadNext } from '../../DataNode/LoadNext'
 import { renderColumn } from '../../DataTable/renderColumn'
 import { renderColumnMeta } from '../../DataTable/renderColumnMeta'
 import { TableDataCell, dataVisualizationLogic } from '../dataVisualizationLogic'
+import { ColumnScalar } from '../types'
 import { matchConditionalFormattingRule, resolveConditionalFormattingBackground } from '../utils'
 
 interface TableProps {
@@ -107,7 +108,7 @@ export const Table = (props: TableProps): JSX.Element => {
         index: number,
         sourceColumnName: string,
         cellValue: unknown,
-        cellType: string
+        cellType: ColumnScalar
     ): ConditionalFormattingRule | undefined => {
         let perRow = conditionalFormattingCache.get(data)
         if (!perRow) {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -1,15 +1,12 @@
 import '../../DataTable/DataTable.scss'
 
 import { useActions, useValues } from 'kea'
-import posthog from 'posthog-js'
 import React from 'react'
 
 import { IconPin, IconPinFilled } from '@posthog/icons'
 import { LemonTable, LemonTableColumn, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { Sparkline } from 'lib/components/Sparkline'
-import { execHog } from 'lib/hog'
-import { lightenDarkenColor } from 'lib/utils'
 import { InsightEmptyState, InsightErrorState } from 'scenes/insights/EmptyStates'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -24,7 +21,8 @@ import { QueryContext } from '~/queries/types'
 import { LoadNext } from '../../DataNode/LoadNext'
 import { renderColumn } from '../../DataTable/renderColumn'
 import { renderColumnMeta } from '../../DataTable/renderColumnMeta'
-import { TableDataCell, convertTableValue, dataVisualizationLogic } from '../dataVisualizationLogic'
+import { TableDataCell, dataVisualizationLogic } from '../dataVisualizationLogic'
+import { matchConditionalFormattingRule, resolveConditionalFormattingBackground } from '../utils'
 
 interface TableProps {
     query: DataVisualizationNode
@@ -79,38 +77,6 @@ function coerceToNumberArray(value: unknown): number[] | null {
     return out
 }
 
-function matchConditionalFormattingRule(
-    rules: ConditionalFormattingRule[],
-    sourceColumnName: string,
-    cellValue: any,
-    cellType: string
-): ConditionalFormattingRule | undefined {
-    for (const rule of rules) {
-        if (rule.columnName !== sourceColumnName) {
-            continue
-        }
-        const isValidHog = !!rule.bytecode && rule.bytecode.length > 0 && rule.bytecode[0] === '_H'
-        if (!isValidHog) {
-            posthog.captureException(new Error('Invalid hog bytecode for conditional formatting'), {
-                formatRule: rule,
-            })
-            continue
-        }
-        const res = execHog(rule.bytecode, {
-            globals: {
-                value: cellValue,
-                input: convertTableValue(rule.input, cellType),
-            },
-            functions: {},
-            maxAsyncSteps: 0,
-        })
-        if (res.result) {
-            return rule
-        }
-    }
-    return undefined
-}
-
 export const Table = (props: TableProps): JSX.Element => {
     const { isDarkModeOn } = useValues(themeLogic)
 
@@ -130,6 +96,32 @@ export const Table = (props: TableProps): JSX.Element => {
     const { toggleColumnPin } = useActions(dataVisualizationLogic)
 
     const sourceTabularColumnsByName = new Map(sourceTabularColumns.map((column) => [column.column.name, column]))
+
+    // Bytecode evaluation for conditional formatting is shared between render() and style() via
+    // a per-row WeakMap. Each `data` array (one per row) becomes a stable key for memoizing the
+    // evaluated rules, so a row's hog bytecode runs at most once per column per render.
+    const conditionalFormattingCache = new WeakMap<object, Map<number, ConditionalFormattingRule | null>>()
+
+    const getMatchedRule = (
+        data: TableDataCell<any>[],
+        index: number,
+        sourceColumnName: string,
+        cellValue: unknown,
+        cellType: string
+    ): ConditionalFormattingRule | undefined => {
+        let perRow = conditionalFormattingCache.get(data)
+        if (!perRow) {
+            perRow = new Map()
+            conditionalFormattingCache.set(data, perRow)
+        }
+        if (perRow.has(index)) {
+            return perRow.get(index) ?? undefined
+        }
+        const matched =
+            matchConditionalFormattingRule(conditionalFormattingRules, sourceColumnName, cellValue, cellType) ?? null
+        perRow.set(index, matched)
+        return matched ?? undefined
+    }
 
     const tableColumns: LemonTableColumn<TableDataCell<any>[], any>[] = tabularColumns.map(
         ({ column, settings }, index) => {
@@ -189,12 +181,7 @@ export const Table = (props: TableProps): JSX.Element => {
                     const sourceColumnName = cell.sourceColumnName ?? column.name
                     const sourceColumnType =
                         sourceTabularColumnsByName.get(sourceColumnName)?.column.type.name ?? cell.type
-                    const matchedRule = matchConditionalFormattingRule(
-                        conditionalFormattingRules,
-                        sourceColumnName,
-                        cell.value,
-                        sourceColumnType
-                    )
+                    const matchedRule = getMatchedRule(data, index, sourceColumnName, cell.value, sourceColumnType)
                     const displayMode = matchedRule?.displayMode ?? 'background'
 
                     if (settings?.display?.renderAs === 'sparkline') {
@@ -266,12 +253,7 @@ export const Table = (props: TableProps): JSX.Element => {
                     const sourceColumnName = cell.sourceColumnName ?? column.name
                     const sourceColumnType =
                         sourceTabularColumnsByName.get(sourceColumnName)?.column.type.name ?? cell.type
-                    const matchedRule = matchConditionalFormattingRule(
-                        conditionalFormattingRules,
-                        sourceColumnName,
-                        cell.value,
-                        sourceColumnType
-                    )
+                    const matchedRule = getMatchedRule(data, index, sourceColumnName, cell.value, sourceColumnType)
 
                     // Only the 'background' display mode (default) tints the cell. 'badge' and 'dot' are rendered
                     // inside the cell content by the render() function above.
@@ -279,27 +261,7 @@ export const Table = (props: TableProps): JSX.Element => {
                         return undefined
                     }
 
-                    const ruleColor = matchedRule.color
-                    const colorMode = matchedRule.colorMode ?? 'light'
-
-                    // If the color mode matches the current theme, return as it was saved
-                    if ((colorMode === 'dark' && isDarkModeOn) || (colorMode === 'light' && !isDarkModeOn)) {
-                        return {
-                            backgroundColor: ruleColor,
-                        }
-                    }
-
-                    // If the color mode is dark, but we're in light mode - then lighten the color
-                    if (colorMode === 'dark' && !isDarkModeOn) {
-                        return {
-                            backgroundColor: lightenDarkenColor(ruleColor, 30),
-                        }
-                    }
-
-                    // If the color mode is light, but we're in dark mode - then darken the color
-                    return {
-                        backgroundColor: lightenDarkenColor(ruleColor, -30),
-                    }
+                    return { backgroundColor: resolveConditionalFormattingBackground(matchedRule, isDarkModeOn) }
                 },
             }
         }

--- a/frontend/src/queries/nodes/DataVisualization/utils.ts
+++ b/frontend/src/queries/nodes/DataVisualization/utils.ts
@@ -1,0 +1,61 @@
+import posthog from 'posthog-js'
+
+import { execHog } from 'lib/hog'
+import { lightenDarkenColor } from 'lib/utils'
+
+import { ConditionalFormattingRule } from '~/queries/schema/schema-general'
+
+import { convertTableValue } from './dataVisualizationLogic'
+
+/**
+ * Evaluate conditional-formatting rules against a single cell value and return the first matching
+ * rule, or undefined if none match. Shared by table cells (Table.tsx) and scalar tiles
+ * (HogQLBoldNumber) so display behavior stays consistent across both surfaces.
+ */
+export function matchConditionalFormattingRule(
+    rules: ConditionalFormattingRule[],
+    sourceColumnName: string,
+    cellValue: unknown,
+    cellType: string
+): ConditionalFormattingRule | undefined {
+    for (const rule of rules) {
+        if (rule.columnName !== sourceColumnName) {
+            continue
+        }
+        const isValidHog = !!rule.bytecode && rule.bytecode.length > 0 && rule.bytecode[0] === '_H'
+        if (!isValidHog) {
+            posthog.captureException(new Error('Invalid hog bytecode for conditional formatting'), {
+                formatRule: rule,
+            })
+            continue
+        }
+        const res = execHog(rule.bytecode, {
+            globals: {
+                value: cellValue,
+                input: convertTableValue(rule.input, cellType),
+            },
+            functions: {},
+            maxAsyncSteps: 0,
+        })
+        if (res.result) {
+            return rule
+        }
+    }
+    return undefined
+}
+
+/**
+ * Resolve the background color a matched rule should paint, accounting for the rule's saved
+ * `colorMode` versus the current UI theme. Used by both Table cell background tinting and
+ * HogQLBoldNumber scalar tile tinting so theme adaptation is identical in both places.
+ */
+export function resolveConditionalFormattingBackground(rule: ConditionalFormattingRule, isDarkModeOn: boolean): string {
+    const colorMode = rule.colorMode ?? 'light'
+    if ((colorMode === 'dark' && isDarkModeOn) || (colorMode === 'light' && !isDarkModeOn)) {
+        return rule.color
+    }
+    if (colorMode === 'dark' && !isDarkModeOn) {
+        return lightenDarkenColor(rule.color, 30)
+    }
+    return lightenDarkenColor(rule.color, -30)
+}

--- a/frontend/src/queries/nodes/DataVisualization/utils.ts
+++ b/frontend/src/queries/nodes/DataVisualization/utils.ts
@@ -6,6 +6,7 @@ import { lightenDarkenColor } from 'lib/utils'
 import { ConditionalFormattingRule } from '~/queries/schema/schema-general'
 
 import { convertTableValue } from './dataVisualizationLogic'
+import { ColumnScalar } from './types'
 
 /**
  * Evaluate conditional-formatting rules against a single cell value and return the first matching
@@ -16,7 +17,7 @@ export function matchConditionalFormattingRule(
     rules: ConditionalFormattingRule[],
     sourceColumnName: string,
     cellValue: unknown,
-    cellType: string
+    cellType: ColumnScalar
 ): ConditionalFormattingRule | undefined {
     for (const rule of rules) {
         if (rule.columnName !== sourceColumnName) {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10552,6 +10552,13 @@
                 "label": {
                     "type": "string"
                 },
+                "renderAs": {
+                    "$ref": "#/definitions/ColumnRenderAs",
+                    "description": "When set on a HogQL table column, the cell is rendered as the corresponding visualization. Requires the column to return an array of numbers per row (e.g. `groupArray(value) AS trend`)."
+                },
+                "sparkline": {
+                    "$ref": "#/definitions/SparklineColumnSettings"
+                },
                 "trendLine": {
                     "type": "boolean"
                 },
@@ -10632,6 +10639,10 @@
             "required": ["key", "operator", "type", "value"],
             "type": "object"
         },
+        "ColumnRenderAs": {
+            "enum": ["default", "sparkline"],
+            "type": "string"
+        },
         "CompareFilter": {
             "additionalProperties": false,
             "properties": {
@@ -10646,6 +10657,10 @@
                 }
             },
             "type": "object"
+        },
+        "ConditionalFormattingDisplayMode": {
+            "enum": ["background", "badge", "dot"],
+            "type": "string"
         },
         "ConditionalFormattingRule": {
             "additionalProperties": false,
@@ -10664,10 +10679,18 @@
                 "columnName": {
                     "type": "string"
                 },
+                "displayMode": {
+                    "$ref": "#/definitions/ConditionalFormattingDisplayMode",
+                    "description": "How the rule is rendered when matched. Defaults to 'background' for backwards compatibility."
+                },
                 "id": {
                     "type": "string"
                 },
                 "input": {
+                    "type": "string"
+                },
+                "label": {
+                    "description": "Optional label override used by 'badge' display mode. Falls back to the cell value when omitted.",
                     "type": "string"
                 },
                 "templateId": {
@@ -36241,6 +36264,21 @@
                 "error_count",
                 "avg_start_offset_nano"
             ],
+            "type": "object"
+        },
+        "SparklineColumnSettings": {
+            "additionalProperties": false,
+            "properties": {
+                "color": {
+                    "description": "Color name from vars.scss (e.g. 'primary', 'success', 'muted'). Defaults to 'primary'.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "'bar' draws bars, 'line' draws a line. Defaults to 'line'.",
+                    "enum": ["bar", "line"],
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "StepOrderValue": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1096,12 +1096,25 @@ export interface ChartSettingsFormatting {
     decimalPlaces?: number
 }
 
+export type ColumnRenderAs = 'default' | 'sparkline'
+
+export interface SparklineColumnSettings {
+    /** Color name from vars.scss (e.g. 'primary', 'success', 'muted'). Defaults to 'primary'. */
+    color?: string
+    /** 'bar' draws bars, 'line' draws a line. Defaults to 'line'. */
+    type?: 'bar' | 'line'
+}
+
 export interface ChartSettingsDisplay {
     color?: string
     label?: string
     trendLine?: boolean
     yAxisPosition?: 'left' | 'right'
     displayType?: 'auto' | 'line' | 'bar' | 'area'
+    /** When set on a HogQL table column, the cell is rendered as the corresponding visualization.
+     * Requires the column to return an array of numbers per row (e.g. `groupArray(value) AS trend`). */
+    renderAs?: ColumnRenderAs
+    sparkline?: SparklineColumnSettings
 }
 
 export interface HeatmapGradientStop {
@@ -1161,6 +1174,8 @@ export interface ChartSettings {
     heatmap?: HeatmapSettings
 }
 
+export type ConditionalFormattingDisplayMode = 'background' | 'badge' | 'dot'
+
 export interface ConditionalFormattingRule {
     id: string
     templateId: string
@@ -1169,6 +1184,10 @@ export interface ConditionalFormattingRule {
     input: string
     color: string
     colorMode?: 'light' | 'dark'
+    /** How the rule is rendered when matched. Defaults to 'background' for backwards compatibility. */
+    displayMode?: ConditionalFormattingDisplayMode
+    /** Optional label override used by 'badge' display mode. Falls back to the cell value when omitted. */
+    label?: string
 }
 
 export interface TableSettings {

--- a/frontend/src/scenes/dashboard/dashboardQuickFiltersLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardQuickFiltersLogic.test.ts
@@ -1,0 +1,129 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { quickFiltersLogic, quickFiltersSectionLogic } from 'lib/components/QuickFilters'
+
+import { useMocks } from '~/mocks/jest'
+import { QuickFilterContext } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { PropertyFilterType, PropertyOperator, QuickFilterOption } from '~/types'
+
+import { dashboardQuickFiltersLogic } from './dashboardQuickFiltersLogic'
+
+const exactOption: QuickFilterOption = {
+    id: 'opt-1',
+    value: 'production',
+    label: 'Production',
+    operator: PropertyOperator.Exact,
+}
+
+const groupOption: QuickFilterOption = {
+    id: 'opt-paid',
+    value: 'paid',
+    label: 'Paid',
+    operator: PropertyOperator.Exact,
+}
+
+const mockQuickFilters = [
+    {
+        id: 'filter-event',
+        name: 'Environment',
+        property_name: '$environment',
+        property_type: 'event',
+        group_type_index: null,
+        type: 'manual-options',
+        options: [exactOption],
+        contexts: [QuickFilterContext.Dashboards],
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+    },
+    {
+        id: 'filter-group',
+        name: 'Customer plan',
+        property_name: 'plan',
+        property_type: 'group',
+        group_type_index: 0,
+        type: 'manual-options',
+        options: [groupOption],
+        contexts: [QuickFilterContext.Dashboards],
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+    },
+    {
+        id: 'filter-legacy',
+        name: 'Legacy (no property_type)',
+        property_name: '$browser',
+        type: 'manual-options',
+        options: [exactOption],
+        contexts: [QuickFilterContext.Dashboards],
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+    },
+]
+
+describe('dashboardQuickFiltersLogic', () => {
+    let logic: ReturnType<typeof dashboardQuickFiltersLogic.build>
+
+    beforeEach(async () => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/quick_filters/': { results: mockQuickFilters },
+            },
+        })
+        initKeaTests()
+
+        const context = QuickFilterContext.Dashboards
+        const filtersLogic = quickFiltersLogic({ context })
+        filtersLogic.mount()
+        await expectLogic(filtersLogic).toFinishAllListeners()
+
+        quickFiltersSectionLogic({ context }).mount()
+        logic = dashboardQuickFiltersLogic()
+        logic.mount()
+    })
+
+    it('emits an event property filter for event-typed quick filters', () => {
+        quickFiltersSectionLogic({ context: QuickFilterContext.Dashboards }).actions.setQuickFilterValue(
+            'filter-event',
+            '$environment',
+            exactOption
+        )
+
+        expect(logic.values.quickFilterPropertyFiltersById['filter-event']).toEqual({
+            type: PropertyFilterType.Event,
+            key: '$environment',
+            value: 'production',
+            operator: PropertyOperator.Exact,
+        })
+    })
+
+    it('emits a group property filter with group_type_index for group-typed quick filters', () => {
+        quickFiltersSectionLogic({ context: QuickFilterContext.Dashboards }).actions.setQuickFilterValue(
+            'filter-group',
+            'plan',
+            groupOption
+        )
+
+        expect(logic.values.quickFilterPropertyFiltersById['filter-group']).toEqual({
+            type: PropertyFilterType.Group,
+            key: 'plan',
+            value: 'paid',
+            operator: PropertyOperator.Exact,
+            group_type_index: 0,
+        })
+    })
+
+    it('falls back to event property filter when property_type is omitted (legacy quick filters)', () => {
+        quickFiltersSectionLogic({ context: QuickFilterContext.Dashboards }).actions.setQuickFilterValue(
+            'filter-legacy',
+            '$browser',
+            exactOption
+        )
+
+        expect(logic.values.quickFilterPropertyFiltersById['filter-legacy']).toEqual({
+            type: PropertyFilterType.Event,
+            key: '$browser',
+            value: 'production',
+            operator: PropertyOperator.Exact,
+        })
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboardQuickFiltersLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardQuickFiltersLogic.test.ts
@@ -5,7 +5,7 @@ import { quickFiltersLogic, quickFiltersSectionLogic } from 'lib/components/Quic
 import { useMocks } from '~/mocks/jest'
 import { QuickFilterContext } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { PropertyFilterType, PropertyOperator, QuickFilterOption } from '~/types'
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator, QuickFilterOption } from '~/types'
 
 import { dashboardQuickFiltersLogic } from './dashboardQuickFiltersLogic'
 
@@ -58,6 +58,73 @@ const mockQuickFilters = [
         created_at: '2024-01-01',
         updated_at: '2024-01-01',
     },
+    {
+        id: 'filter-group-missing-index',
+        name: 'Plan (missing group_type_index — legacy row)',
+        property_name: 'plan',
+        property_type: 'group',
+        group_type_index: null,
+        type: 'manual-options',
+        options: [groupOption],
+        contexts: [QuickFilterContext.Dashboards],
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+    },
+]
+
+type Case = {
+    name: string
+    filterId: string
+    propertyName: string
+    option: QuickFilterOption
+    expected: AnyPropertyFilter | null
+}
+
+const CASES: readonly Case[] = [
+    {
+        name: 'event-typed quick filter emits an event property filter',
+        filterId: 'filter-event',
+        propertyName: '$environment',
+        option: exactOption,
+        expected: {
+            type: PropertyFilterType.Event,
+            key: '$environment',
+            value: 'production',
+            operator: PropertyOperator.Exact,
+        },
+    },
+    {
+        name: 'group-typed quick filter emits a group property filter with group_type_index',
+        filterId: 'filter-group',
+        propertyName: 'plan',
+        option: groupOption,
+        expected: {
+            type: PropertyFilterType.Group,
+            key: 'plan',
+            value: 'paid',
+            operator: PropertyOperator.Exact,
+            group_type_index: 0,
+        },
+    },
+    {
+        name: 'legacy quick filter without property_type falls back to event',
+        filterId: 'filter-legacy',
+        propertyName: '$browser',
+        option: exactOption,
+        expected: {
+            type: PropertyFilterType.Event,
+            key: '$browser',
+            value: 'production',
+            operator: PropertyOperator.Exact,
+        },
+    },
+    {
+        name: 'group-typed filter with missing group_type_index is skipped (defensive guard)',
+        filterId: 'filter-group-missing-index',
+        propertyName: 'plan',
+        option: groupOption,
+        expected: null,
+    },
 ]
 
 describe('dashboardQuickFiltersLogic', () => {
@@ -81,49 +148,18 @@ describe('dashboardQuickFiltersLogic', () => {
         logic.mount()
     })
 
-    it('emits an event property filter for event-typed quick filters', () => {
+    it.each(CASES)('$name', ({ filterId, propertyName, option, expected }) => {
         quickFiltersSectionLogic({ context: QuickFilterContext.Dashboards }).actions.setQuickFilterValue(
-            'filter-event',
-            '$environment',
-            exactOption
+            filterId,
+            propertyName,
+            option
         )
 
-        expect(logic.values.quickFilterPropertyFiltersById['filter-event']).toEqual({
-            type: PropertyFilterType.Event,
-            key: '$environment',
-            value: 'production',
-            operator: PropertyOperator.Exact,
-        })
-    })
-
-    it('emits a group property filter with group_type_index for group-typed quick filters', () => {
-        quickFiltersSectionLogic({ context: QuickFilterContext.Dashboards }).actions.setQuickFilterValue(
-            'filter-group',
-            'plan',
-            groupOption
-        )
-
-        expect(logic.values.quickFilterPropertyFiltersById['filter-group']).toEqual({
-            type: PropertyFilterType.Group,
-            key: 'plan',
-            value: 'paid',
-            operator: PropertyOperator.Exact,
-            group_type_index: 0,
-        })
-    })
-
-    it('falls back to event property filter when property_type is omitted (legacy quick filters)', () => {
-        quickFiltersSectionLogic({ context: QuickFilterContext.Dashboards }).actions.setQuickFilterValue(
-            'filter-legacy',
-            '$browser',
-            exactOption
-        )
-
-        expect(logic.values.quickFilterPropertyFiltersById['filter-legacy']).toEqual({
-            type: PropertyFilterType.Event,
-            key: '$browser',
-            value: 'production',
-            operator: PropertyOperator.Exact,
-        })
+        const actual = logic.values.quickFilterPropertyFiltersById[filterId]
+        if (expected === null) {
+            expect(actual).toBeUndefined()
+        } else {
+            expect(actual).toEqual(expected)
+        }
     })
 })

--- a/frontend/src/scenes/dashboard/dashboardQuickFiltersLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardQuickFiltersLogic.ts
@@ -15,9 +15,19 @@ const PROPERTY_FILTER_TYPE_BY_QUICK_FILTER_TYPE: Record<QuickFilterPropertyType,
     data_warehouse_person_property: PropertyFilterType.DataWarehousePersonProperty,
 }
 
-function buildPropertyFilter(filter: QuickFilter | undefined, selection: SelectedQuickFilter): AnyPropertyFilter {
+function buildPropertyFilter(
+    filter: QuickFilter | undefined,
+    selection: SelectedQuickFilter
+): AnyPropertyFilter | null {
     const propertyTypeKey = filter?.property_type ?? 'event'
     const type = PROPERTY_FILTER_TYPE_BY_QUICK_FILTER_TYPE[propertyTypeKey] ?? PropertyFilterType.Event
+
+    // A group property filter without group_type_index would be silently dropped by query parsing.
+    // The serializer now rejects this combination at write time, but legacy rows may still exist —
+    // skip them rather than emit a no-op filter that gives the user a misleading "filtered" UI.
+    if (type === PropertyFilterType.Group && (filter?.group_type_index == null || filter.group_type_index < 0)) {
+        return null
+    }
 
     const base = {
         key: selection.propertyName,
@@ -26,8 +36,8 @@ function buildPropertyFilter(filter: QuickFilter | undefined, selection: Selecte
         type,
     } as AnyPropertyFilter
 
-    if (type === PropertyFilterType.Group && filter?.group_type_index != null) {
-        return { ...base, group_type_index: filter.group_type_index } as AnyPropertyFilter
+    if (type === PropertyFilterType.Group) {
+        return { ...base, group_type_index: filter!.group_type_index } as AnyPropertyFilter
     }
 
     return base
@@ -60,12 +70,14 @@ export const dashboardQuickFiltersLogic = kea<dashboardQuickFiltersLogicType>([
                 quickFilters: QuickFilter[]
             ): Record<string, AnyPropertyFilter> => {
                 const filtersById = new Map(quickFilters.map((f) => [f.id, f]))
-                return Object.fromEntries(
-                    Object.entries(selectedQuickFilters).map(([filterId, selection]) => [
-                        filterId,
-                        buildPropertyFilter(filtersById.get(filterId), selection),
-                    ])
-                )
+                const entries: [string, AnyPropertyFilter][] = []
+                for (const [filterId, selection] of Object.entries(selectedQuickFilters)) {
+                    const propertyFilter = buildPropertyFilter(filtersById.get(filterId), selection)
+                    if (propertyFilter) {
+                        entries.push([filterId, propertyFilter])
+                    }
+                }
+                return Object.fromEntries(entries)
             },
         ],
     }),

--- a/frontend/src/scenes/dashboard/dashboardQuickFiltersLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardQuickFiltersLogic.ts
@@ -1,11 +1,37 @@
 import { connect, kea, path, selectors } from 'kea'
 
-import { SelectedQuickFilter, quickFiltersSectionLogic } from 'lib/components/QuickFilters'
+import { SelectedQuickFilter, quickFiltersLogic, quickFiltersSectionLogic } from 'lib/components/QuickFilters'
 
 import { QuickFilterContext } from '~/queries/schema/schema-general'
-import { AnyPropertyFilter, PropertyFilterType } from '~/types'
+import { AnyPropertyFilter, PropertyFilterType, QuickFilter, QuickFilterPropertyType } from '~/types'
 
 import type { dashboardQuickFiltersLogicType } from './dashboardQuickFiltersLogicType'
+
+const PROPERTY_FILTER_TYPE_BY_QUICK_FILTER_TYPE: Record<QuickFilterPropertyType, PropertyFilterType> = {
+    event: PropertyFilterType.Event,
+    person: PropertyFilterType.Person,
+    session: PropertyFilterType.Session,
+    group: PropertyFilterType.Group,
+    data_warehouse_person_property: PropertyFilterType.DataWarehousePersonProperty,
+}
+
+function buildPropertyFilter(filter: QuickFilter | undefined, selection: SelectedQuickFilter): AnyPropertyFilter {
+    const propertyTypeKey = filter?.property_type ?? 'event'
+    const type = PROPERTY_FILTER_TYPE_BY_QUICK_FILTER_TYPE[propertyTypeKey] ?? PropertyFilterType.Event
+
+    const base = {
+        key: selection.propertyName,
+        value: selection.value,
+        operator: selection.operator,
+        type,
+    } as AnyPropertyFilter
+
+    if (type === PropertyFilterType.Group && filter?.group_type_index != null) {
+        return { ...base, group_type_index: filter.group_type_index } as AnyPropertyFilter
+    }
+
+    return base
+}
 
 export const dashboardQuickFiltersLogic = kea<dashboardQuickFiltersLogicType>([
     path(['scenes', 'dashboard', 'dashboardQuickFiltersLogic']),
@@ -13,27 +39,31 @@ export const dashboardQuickFiltersLogic = kea<dashboardQuickFiltersLogicType>([
     connect(() => {
         const context = QuickFilterContext.Dashboards
         return {
-            values: [quickFiltersSectionLogic({ context }), ['selectedQuickFilters']],
+            values: [
+                quickFiltersSectionLogic({ context }),
+                ['selectedQuickFilters'],
+                quickFiltersLogic({ context }),
+                ['quickFilters'],
+            ],
         }
     }),
 
     selectors({
         // Keyed by filter ID so dashboardLogic can scope to dashboard.quick_filter_ids.
-        // Intentionally scoped to event properties for now — quick filters only support
-        // event properties in this iteration. If person/session/group properties are added,
-        // the QuickFilter model will need a property_type field to propagate through here.
+        // The QuickFilter.property_type field (added in migration 1154) determines whether the
+        // resulting property filter targets events, persons, sessions, groups, or warehouse properties.
+        // Quick filters without a property_type fall back to 'event' for backwards compatibility.
         quickFilterPropertyFiltersById: [
-            (s) => [s.selectedQuickFilters],
-            (selectedQuickFilters: Record<string, SelectedQuickFilter>): Record<string, AnyPropertyFilter> => {
+            (s) => [s.selectedQuickFilters, s.quickFilters],
+            (
+                selectedQuickFilters: Record<string, SelectedQuickFilter>,
+                quickFilters: QuickFilter[]
+            ): Record<string, AnyPropertyFilter> => {
+                const filtersById = new Map(quickFilters.map((f) => [f.id, f]))
                 return Object.fromEntries(
-                    Object.entries(selectedQuickFilters).map(([filterId, filter]) => [
+                    Object.entries(selectedQuickFilters).map(([filterId, selection]) => [
                         filterId,
-                        {
-                            type: PropertyFilterType.Event,
-                            key: filter.propertyName,
-                            value: filter.value,
-                            operator: filter.operator,
-                        },
+                        buildPropertyFilter(filtersById.get(filterId), selection),
                     ])
                 )
             },

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -2,7 +2,6 @@ import './BoldNumber.scss'
 
 import clsx from 'clsx'
 import { useValues } from 'kea'
-import posthog from 'posthog-js'
 import { useLayoutEffect, useRef, useState } from 'react'
 import { useEffect } from 'react'
 import React from 'react'
@@ -10,7 +9,6 @@ import React from 'react'
 import { IconTrending } from '@posthog/icons'
 import { LemonRow, LemonTag, Link } from '@posthog/lemon-ui'
 
-import { execHog } from 'lib/hog'
 import { IconFlare, IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
 import { percentage } from 'lib/utils'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
@@ -21,12 +19,14 @@ import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
 import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
+import { dataVisualizationLogic } from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
 import {
-    convertTableValue,
-    dataVisualizationLogic,
-} from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
-import { ConditionalFormattingRule, NodeKind } from '~/queries/schema/schema-general'
+    matchConditionalFormattingRule,
+    resolveConditionalFormattingBackground,
+} from '~/queries/nodes/DataVisualization/utils'
+import { NodeKind } from '~/queries/schema/schema-general'
 import { ChartParams, TrendResult } from '~/types'
 
 import { insightLogic } from '../../insightLogic'
@@ -276,41 +276,10 @@ function BoldNumberComparison({
     )
 }
 
-function matchScalarConditionalFormattingRule(
-    rules: ConditionalFormattingRule[],
-    sourceColumnName: string,
-    cellValue: unknown,
-    cellType: string
-): ConditionalFormattingRule | undefined {
-    for (const rule of rules) {
-        if (rule.columnName !== sourceColumnName) {
-            continue
-        }
-        const isValidHog = !!rule.bytecode && rule.bytecode.length > 0 && rule.bytecode[0] === '_H'
-        if (!isValidHog) {
-            posthog.captureException(new Error('Invalid hog bytecode for conditional formatting'), {
-                formatRule: rule,
-            })
-            continue
-        }
-        const res = execHog(rule.bytecode, {
-            globals: {
-                value: cellValue,
-                input: convertTableValue(rule.input, cellType),
-            },
-            functions: {},
-            maxAsyncSteps: 0,
-        })
-        if (res.result) {
-            return rule
-        }
-    }
-    return undefined
-}
-
 export function HogQLBoldNumber(): JSX.Element {
     const { response, responseLoading, tabularData, sourceTabularColumns, conditionalFormattingRules } =
         useValues(dataVisualizationLogic)
+    const { isDarkModeOn } = useValues(themeLogic)
 
     if (!response || responseLoading) {
         return (
@@ -345,7 +314,7 @@ export function HogQLBoldNumber(): JSX.Element {
     const sourceColumnType = firstColumn?.column.type.name ?? firstCell?.type ?? ''
 
     const matchedRule = sourceColumnName
-        ? matchScalarConditionalFormattingRule(
+        ? matchConditionalFormattingRule(
               conditionalFormattingRules,
               sourceColumnName,
               firstCell?.value,
@@ -355,14 +324,18 @@ export function HogQLBoldNumber(): JSX.Element {
     const displayMode = matchedRule?.displayMode ?? 'background'
 
     const containerStyle: React.CSSProperties =
-        matchedRule && displayMode === 'background' ? { backgroundColor: matchedRule.color } : {}
+        matchedRule && displayMode === 'background'
+            ? { backgroundColor: resolveConditionalFormattingBackground(matchedRule, isDarkModeOn) }
+            : {}
 
+    // `relative` makes this the positioned ancestor so the dot mode lands in the tile's corner
+    // instead of the nearest layout/viewport ancestor.
     return (
-        <div className="BoldNumber LemonTable HogQL ph-no-capture" style={containerStyle}>
+        <div className="BoldNumber LemonTable HogQL ph-no-capture relative" style={containerStyle}>
             {matchedRule && displayMode === 'dot' && (
                 <span
                     aria-hidden
-                    className="inline-block w-3 h-3 rounded-full absolute top-3 left-3"
+                    className="absolute top-3 left-3 inline-block h-3 w-3 rounded-full"
                     style={{ backgroundColor: matchedRule.color }}
                 />
             )}

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -311,7 +311,7 @@ export function HogQLBoldNumber(): JSX.Element {
     const firstCell = tabularData[0]?.[0]
     const firstColumn = sourceTabularColumns[0]
     const sourceColumnName = firstCell?.sourceColumnName ?? firstColumn?.column.name ?? ''
-    const sourceColumnType = firstColumn?.column.type.name ?? firstCell?.type ?? ''
+    const sourceColumnType = firstColumn?.column.type.name ?? firstCell?.type ?? 'UNKNOWN'
 
     const matchedRule = sourceColumnName
         ? matchConditionalFormattingRule(

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -2,13 +2,15 @@ import './BoldNumber.scss'
 
 import clsx from 'clsx'
 import { useValues } from 'kea'
+import posthog from 'posthog-js'
 import { useLayoutEffect, useRef, useState } from 'react'
 import { useEffect } from 'react'
 import React from 'react'
 
 import { IconTrending } from '@posthog/icons'
-import { LemonRow, Link } from '@posthog/lemon-ui'
+import { LemonRow, LemonTag, Link } from '@posthog/lemon-ui'
 
+import { execHog } from 'lib/hog'
 import { IconFlare, IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
 import { percentage } from 'lib/utils'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
@@ -20,8 +22,11 @@ import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
 import { groupsModel } from '~/models/groupsModel'
-import { dataVisualizationLogic } from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
-import { NodeKind } from '~/queries/schema/schema-general'
+import {
+    convertTableValue,
+    dataVisualizationLogic,
+} from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
+import { ConditionalFormattingRule, NodeKind } from '~/queries/schema/schema-general'
 import { ChartParams, TrendResult } from '~/types'
 
 import { insightLogic } from '../../insightLogic'
@@ -271,8 +276,41 @@ function BoldNumberComparison({
     )
 }
 
+function matchScalarConditionalFormattingRule(
+    rules: ConditionalFormattingRule[],
+    sourceColumnName: string,
+    cellValue: unknown,
+    cellType: string
+): ConditionalFormattingRule | undefined {
+    for (const rule of rules) {
+        if (rule.columnName !== sourceColumnName) {
+            continue
+        }
+        const isValidHog = !!rule.bytecode && rule.bytecode.length > 0 && rule.bytecode[0] === '_H'
+        if (!isValidHog) {
+            posthog.captureException(new Error('Invalid hog bytecode for conditional formatting'), {
+                formatRule: rule,
+            })
+            continue
+        }
+        const res = execHog(rule.bytecode, {
+            globals: {
+                value: cellValue,
+                input: convertTableValue(rule.input, cellType),
+            },
+            functions: {},
+            maxAsyncSteps: 0,
+        })
+        if (res.result) {
+            return rule
+        }
+    }
+    return undefined
+}
+
 export function HogQLBoldNumber(): JSX.Element {
-    const { response, responseLoading, tabularData } = useValues(dataVisualizationLogic)
+    const { response, responseLoading, tabularData, sourceTabularColumns, conditionalFormattingRules } =
+        useValues(dataVisualizationLogic)
 
     if (!response || responseLoading) {
         return (
@@ -301,14 +339,45 @@ export function HogQLBoldNumber(): JSX.Element {
     }
 
     const value = formattedValue ?? directValue ?? resultsValue ?? resultValue
+    const firstCell = tabularData[0]?.[0]
+    const firstColumn = sourceTabularColumns[0]
+    const sourceColumnName = firstCell?.sourceColumnName ?? firstColumn?.column.name ?? ''
+    const sourceColumnType = firstColumn?.column.type.name ?? firstCell?.type ?? ''
+
+    const matchedRule = sourceColumnName
+        ? matchScalarConditionalFormattingRule(
+              conditionalFormattingRules,
+              sourceColumnName,
+              firstCell?.value,
+              sourceColumnType
+          )
+        : undefined
+    const displayMode = matchedRule?.displayMode ?? 'background'
+
+    const containerStyle: React.CSSProperties =
+        matchedRule && displayMode === 'background' ? { backgroundColor: matchedRule.color } : {}
 
     return (
-        <div className="BoldNumber LemonTable HogQL ph-no-capture">
+        <div className="BoldNumber LemonTable HogQL ph-no-capture" style={containerStyle}>
+            {matchedRule && displayMode === 'dot' && (
+                <span
+                    aria-hidden
+                    className="inline-block w-3 h-3 rounded-full absolute top-3 left-3"
+                    style={{ backgroundColor: matchedRule.color }}
+                />
+            )}
             <div className="BoldNumber__value">
                 <Textfit min={32} max={120}>
                     {String(value ?? 'Error')}
                 </Textfit>
             </div>
+            {matchedRule && displayMode === 'badge' && (
+                <div className="flex justify-center mt-2">
+                    <LemonTag style={{ backgroundColor: matchedRule.color, borderColor: 'transparent' }}>
+                        {matchedRule.label?.trim() || String(value ?? '')}
+                    </LemonTag>
+                </div>
+            )}
         </div>
     )
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7281,10 +7281,21 @@ export interface QuickFilterOption {
     operator: PropertyOperator
 }
 
+export type QuickFilterPropertyType =
+    | 'event'
+    | 'person'
+    | 'session'
+    | 'group'
+    | 'data_warehouse_person_property'
+
 export interface QuickFilter {
     id: string
     name: string
     property_name: string
+    /** Defaults to 'event' for backwards compatibility with quick filters created before property_type existed. */
+    property_type?: QuickFilterPropertyType
+    /** Required when property_type is 'group'. */
+    group_type_index?: number | null
     type: QuickFilterType
     options: QuickFilterOption[]
     contexts: QuickFilterContext[]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7281,12 +7281,7 @@ export interface QuickFilterOption {
     operator: PropertyOperator
 }
 
-export type QuickFilterPropertyType =
-    | 'event'
-    | 'person'
-    | 'session'
-    | 'group'
-    | 'data_warehouse_person_property'
+export type QuickFilterPropertyType = 'event' | 'person' | 'session' | 'group' | 'data_warehouse_person_property'
 
 export interface QuickFilter {
     id: string

--- a/posthog/api/quick_filters.py
+++ b/posthog/api/quick_filters.py
@@ -107,7 +107,9 @@ class QuickFilterSerializer(serializers.ModelSerializer):
             # Disallow setting group_type_index for non-group property types — silently ignoring it
             # would produce a filter that doesn't match user intent.
             raise ValidationError(
-                {"group_type_index": f"group_type_index is only valid when property_type is 'group' (got {property_type!r})"}
+                {
+                    "group_type_index": f"group_type_index is only valid when property_type is 'group' (got {property_type!r})"
+                }
             )
         return attrs
 

--- a/posthog/api/quick_filters.py
+++ b/posthog/api/quick_filters.py
@@ -95,6 +95,22 @@ class QuickFilterSerializer(serializers.ModelSerializer):
 
         return value
 
+    def validate(self, attrs):
+        property_type = attrs.get("property_type") or getattr(self.instance, "property_type", "event")
+        group_type_index = attrs.get(
+            "group_type_index",
+            getattr(self.instance, "group_type_index", None) if self.instance else None,
+        )
+        if property_type == "group" and group_type_index is None:
+            raise ValidationError({"group_type_index": "group_type_index is required when property_type is 'group'"})
+        if property_type != "group" and group_type_index is not None and "group_type_index" in attrs:
+            # Disallow setting group_type_index for non-group property types — silently ignoring it
+            # would produce a filter that doesn't match user intent.
+            raise ValidationError(
+                {"group_type_index": f"group_type_index is only valid when property_type is 'group' (got {property_type!r})"}
+            )
+        return attrs
+
     def validate_contexts(self, value):
         if not isinstance(value, list):
             raise ValidationError("Contexts must be a list")

--- a/posthog/api/quick_filters.py
+++ b/posthog/api/quick_filters.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import ValidationError
 from posthog.schema import QuickFilterContext as QuickFilterContextEnum
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.models.quick_filter import QuickFilter, QuickFilterContext
+from posthog.models.quick_filter import QuickFilter, QuickFilterContext, QuickFilterPropertyType
 
 
 class QuickFilterSerializer(serializers.ModelSerializer):
@@ -25,7 +25,7 @@ class QuickFilterSerializer(serializers.ModelSerializer):
         help_text="Name of the property to filter on (e.g. '$browser', 'plan', '$group_0').",
     )
     property_type = serializers.ChoiceField(
-        choices=QuickFilter._meta.get_field("property_type").choices,
+        choices=QuickFilterPropertyType.choices,
         required=False,
         default="event",
         help_text=(

--- a/posthog/api/quick_filters.py
+++ b/posthog/api/quick_filters.py
@@ -12,8 +12,33 @@ from posthog.models.quick_filter import QuickFilter, QuickFilterContext
 
 class QuickFilterSerializer(serializers.ModelSerializer):
     contexts = serializers.SerializerMethodField()
-    name = serializers.CharField(allow_blank=False, trim_whitespace=True, max_length=200)
-    property_name = serializers.CharField(allow_blank=False, trim_whitespace=True, max_length=500)
+    name = serializers.CharField(
+        allow_blank=False,
+        trim_whitespace=True,
+        max_length=200,
+        help_text="Human-readable name shown in the quick filter bar.",
+    )
+    property_name = serializers.CharField(
+        allow_blank=False,
+        trim_whitespace=True,
+        max_length=500,
+        help_text="Name of the property to filter on (e.g. '$browser', 'plan', '$group_0').",
+    )
+    property_type = serializers.ChoiceField(
+        choices=QuickFilter._meta.get_field("property_type").choices,
+        required=False,
+        default="event",
+        help_text=(
+            "Type of property the filter targets. Defaults to 'event' to preserve legacy behavior. "
+            "Use 'group' for group properties (also set group_type_index)."
+        ),
+    )
+    group_type_index = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        min_value=0,
+        help_text="Group type index when property_type is 'group'. Ignored for other property types.",
+    )
 
     class Meta:
         model = QuickFilter
@@ -21,6 +46,8 @@ class QuickFilterSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "property_name",
+            "property_type",
+            "group_type_index",
             "type",
             "options",
             "contexts",
@@ -102,6 +129,8 @@ class QuickFilterSerializer(serializers.ModelSerializer):
 
         instance.name = validated_data.get("name", instance.name)
         instance.property_name = validated_data.get("property_name", instance.property_name)
+        instance.property_type = validated_data.get("property_type", instance.property_type)
+        instance.group_type_index = validated_data.get("group_type_index", instance.group_type_index)
         instance.type = validated_data.get("type", instance.type)
         instance.options = validated_data.get("options", instance.options)
         instance.save()

--- a/posthog/api/test/test_quick_filters.py
+++ b/posthog/api/test/test_quick_filters.py
@@ -85,6 +85,37 @@ class TestQuickFilters(APIBaseTest):
         self.assertEqual(quick_filter.property_type, "group")
         self.assertEqual(quick_filter.group_type_index, 2)
 
+    def test_create_group_quick_filter_without_group_type_index_rejected(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/quick_filters/",
+            {
+                "name": "Plan",
+                "property_name": "plan",
+                "property_type": "group",
+                "type": "manual-options",
+                "options": [{"id": "free", "value": "free", "label": "Free", "operator": "exact"}],
+                "contexts": ["dashboards"],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("group_type_index", response.json())
+
+    def test_create_event_quick_filter_with_group_type_index_rejected(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/quick_filters/",
+            {
+                "name": "Browser",
+                "property_name": "$browser",
+                "property_type": "event",
+                "group_type_index": 0,
+                "type": "manual-options",
+                "options": [{"id": "chrome", "value": "Chrome", "label": "Chrome", "operator": "exact"}],
+                "contexts": ["dashboards"],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("group_type_index", response.json())
+
     def test_list_quick_filters(self):
         self._create_quick_filter("Filter 1", "$prop1")
         self._create_quick_filter("Filter 2", "$prop2")

--- a/posthog/api/test/test_quick_filters.py
+++ b/posthog/api/test/test_quick_filters.py
@@ -41,6 +41,49 @@ class TestQuickFilters(APIBaseTest):
         self.assertEqual(data["property_name"], "$browser")
         self.assertEqual(len(data["options"]), 2)
         self.assertEqual(data["contexts"], ["dashboards"])
+        # Quick filters without an explicit property_type default to 'event'
+        self.assertEqual(data["property_type"], "event")
+        self.assertIsNone(data["group_type_index"])
+
+    def test_create_group_quick_filter(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/quick_filters/",
+            {
+                "name": "Customer plan",
+                "property_name": "plan",
+                "property_type": "group",
+                "group_type_index": 0,
+                "type": "manual-options",
+                "options": [
+                    {"id": "free", "value": "free", "label": "Free", "operator": "exact"},
+                    {"id": "paid", "value": "paid", "label": "Paid", "operator": "exact"},
+                ],
+                "contexts": ["dashboards"],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+        self.assertEqual(data["property_type"], "group")
+        self.assertEqual(data["group_type_index"], 0)
+
+        stored = QuickFilter.objects.get(id=data["id"])
+        self.assertEqual(stored.property_type, "group")
+        self.assertEqual(stored.group_type_index, 0)
+
+    def test_update_quick_filter_property_type(self):
+        _, quick_filter = self._create_quick_filter("Plan", "plan")
+        self.assertEqual(quick_filter.property_type, "event")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/quick_filters/{quick_filter.id}/",
+            {"property_type": "group", "group_type_index": 2},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        quick_filter.refresh_from_db()
+        self.assertEqual(quick_filter.property_type, "group")
+        self.assertEqual(quick_filter.group_type_index, 2)
 
     def test_list_quick_filters(self):
         self._create_quick_filter("Filter 1", "$prop1")

--- a/posthog/migrations/1154_quickfilter_property_type.py
+++ b/posthog/migrations/1154_quickfilter_property_type.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("posthog", "1153_subscription_hourly_frequency")]
+
+    operations = [
+        migrations.AddField(
+            model_name="quickfilter",
+            name="property_type",
+            field=models.CharField(
+                choices=[
+                    ("event", "Event"),
+                    ("person", "Person"),
+                    ("session", "Session"),
+                    ("group", "Group"),
+                    ("data_warehouse_person_property", "Data warehouse person property"),
+                ],
+                default="event",
+                max_length=50,
+            ),
+        ),
+        migrations.AddField(
+            model_name="quickfilter",
+            name="group_type_index",
+            field=models.PositiveSmallIntegerField(blank=True, null=True),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1153_subscription_hourly_frequency
+1154_quickfilter_property_type

--- a/posthog/models/quick_filter.py
+++ b/posthog/models/quick_filter.py
@@ -5,12 +5,26 @@ from posthog.schema import QuickFilterType
 from posthog.models.utils import UUIDModel
 
 
+class QuickFilterPropertyType(models.TextChoices):
+    EVENT = "event", "Event"
+    PERSON = "person", "Person"
+    SESSION = "session", "Session"
+    GROUP = "group", "Group"
+    DATA_WAREHOUSE_PERSON_PROPERTY = "data_warehouse_person_property", "Data warehouse person property"
+
+
 class QuickFilter(UUIDModel):
     TYPE_CHOICES = [(t.value, t.value) for t in QuickFilterType]
 
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)
     name = models.CharField(max_length=200)
     property_name = models.CharField(max_length=500)
+    property_type = models.CharField(
+        max_length=50,
+        choices=QuickFilterPropertyType.choices,
+        default=QuickFilterPropertyType.EVENT,
+    )
+    group_type_index = models.PositiveSmallIntegerField(null=True, blank=True)
     type = models.CharField(max_length=50, choices=TYPE_CHOICES, default=QuickFilterType.MANUAL_OPTIONS.value)
     options = models.JSONField(default=list, null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -988,32 +988,6 @@ class DisplayType(StrEnum):
     AREA = "area"
 
 
-class ColumnRenderAs(StrEnum):
-    DEFAULT = "default"
-    SPARKLINE = "sparkline"
-
-
-class SparklineColumnSettings(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    color: str | None = None
-    type: Literal["bar", "line"] | None = None
-
-
-class ChartSettingsDisplay(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    color: str | None = None
-    displayType: DisplayType | None = None
-    label: str | None = None
-    renderAs: ColumnRenderAs | None = None
-    sparkline: SparklineColumnSettings | None = None
-    trendLine: bool | None = None
-    yAxisPosition: YAxisPosition | None = None
-
-
 class Style(StrEnum):
     NONE = "none"
     NUMBER = "number"
@@ -1029,6 +1003,11 @@ class ChartSettingsFormatting(BaseModel):
     prefix: str | None = None
     style: Style | None = None
     suffix: str | None = None
+
+
+class ColumnRenderAs(StrEnum):
+    DEFAULT = "default"
+    SPARKLINE = "sparkline"
 
 
 class CompareFilter(BaseModel):
@@ -1050,15 +1029,15 @@ class CompareFilter(BaseModel):
     )
 
 
-class ColorMode(StrEnum):
-    LIGHT = "light"
-    DARK = "dark"
-
-
 class ConditionalFormattingDisplayMode(StrEnum):
     BACKGROUND = "background"
     BADGE = "badge"
     DOT = "dot"
+
+
+class ColorMode(StrEnum):
+    LIGHT = "light"
+    DARK = "dark"
 
 
 class ConditionalFormattingRule(BaseModel):
@@ -1069,10 +1048,18 @@ class ConditionalFormattingRule(BaseModel):
     color: str
     colorMode: ColorMode | None = None
     columnName: str
-    displayMode: ConditionalFormattingDisplayMode | None = None
+    displayMode: ConditionalFormattingDisplayMode | None = Field(
+        default=None,
+        description=("How the rule is rendered when matched. Defaults to 'background' for backwards compatibility."),
+    )
     id: str
     input: str
-    label: str | None = None
+    label: str | None = Field(
+        default=None,
+        description=(
+            "Optional label override used by 'badge' display mode. Falls back to the cell value when omitted."
+        ),
+    )
     templateId: str
 
 
@@ -4643,6 +4630,25 @@ class SpanPropertyFilterType(StrEnum):
     SPAN_RESOURCE_ATTRIBUTE = "span_resource_attribute"
 
 
+class Type(StrEnum):
+    BAR = "bar"
+    LINE = "line"
+
+
+class SparklineColumnSettings(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    color: str | None = Field(
+        default=None,
+        description=("Color name from vars.scss (e.g. 'primary', 'success', 'muted'). Defaults to 'primary'."),
+    )
+    type: Type | None = Field(
+        default=None,
+        description="'bar' draws bars, 'line' draws a line. Defaults to 'line'.",
+    )
+
+
 class StepOrderValue(StrEnum):
     STRICT = "strict"
     UNORDERED = "unordered"
@@ -6492,20 +6498,24 @@ class CampaignFieldPreference(BaseModel):
     match_field: MatchField
 
 
-class Settings(BaseModel):
+class ChartSettingsDisplay(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    display: ChartSettingsDisplay | None = None
-    formatting: ChartSettingsFormatting | None = None
-
-
-class ChartAxis(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
+    color: str | None = None
+    displayType: DisplayType | None = None
+    label: str | None = None
+    renderAs: ColumnRenderAs | None = Field(
+        default=None,
+        description=(
+            "When set on a HogQL table column, the cell is rendered as the"
+            " corresponding visualization. Requires the column to return an array of"
+            " numbers per row (e.g. `groupArray(value) AS trend`)."
+        ),
     )
-    column: str
-    settings: Settings | None = None
+    sparkline: SparklineColumnSettings | None = None
+    trendLine: bool | None = None
+    yAxisPosition: YAxisPosition | None = None
 
 
 class ClickhouseQueryProgress(BaseModel):
@@ -8614,16 +8624,6 @@ class SurveyQuestionSchema(BaseModel):
     shuffleOptions: bool | None = None
     type: SurveyQuestionType
     upperBoundLabel: str | None = None
-
-
-class TableSettings(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    columns: list[ChartAxis] | None = None
-    conditionalFormatting: list[ConditionalFormattingRule] | None = None
-    pinnedColumns: list[str] | None = None
-    transpose: bool | None = None
 
 
 class TaskExecutionItem(BaseModel):
@@ -12749,6 +12749,22 @@ class CalendarHeatmapResponse(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
+
+
+class Settings(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    display: ChartSettingsDisplay | None = None
+    formatting: ChartSettingsFormatting | None = None
+
+
+class ChartAxis(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    column: str
+    settings: Settings | None = None
 
 
 class ChartSettings(BaseModel):
@@ -18177,6 +18193,16 @@ class SurveyCreationSchema(BaseModel):
     should_launch: bool | None = None
     start_date: str | None = None
     type: SurveyType
+
+
+class TableSettings(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: list[ChartAxis] | None = None
+    conditionalFormatting: list[ConditionalFormattingRule] | None = None
+    pinnedColumns: list[str] | None = None
+    transpose: bool | None = None
 
 
 class TeamTaxonomyQueryResponse(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -988,6 +988,19 @@ class DisplayType(StrEnum):
     AREA = "area"
 
 
+class ColumnRenderAs(StrEnum):
+    DEFAULT = "default"
+    SPARKLINE = "sparkline"
+
+
+class SparklineColumnSettings(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    color: str | None = None
+    type: Literal["bar", "line"] | None = None
+
+
 class ChartSettingsDisplay(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -995,6 +1008,8 @@ class ChartSettingsDisplay(BaseModel):
     color: str | None = None
     displayType: DisplayType | None = None
     label: str | None = None
+    renderAs: ColumnRenderAs | None = None
+    sparkline: SparklineColumnSettings | None = None
     trendLine: bool | None = None
     yAxisPosition: YAxisPosition | None = None
 
@@ -1040,6 +1055,12 @@ class ColorMode(StrEnum):
     DARK = "dark"
 
 
+class ConditionalFormattingDisplayMode(StrEnum):
+    BACKGROUND = "background"
+    BADGE = "badge"
+    DOT = "dot"
+
+
 class ConditionalFormattingRule(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1048,8 +1069,10 @@ class ConditionalFormattingRule(BaseModel):
     color: str
     colorMode: ColorMode | None = None
     columnName: str
+    displayMode: ConditionalFormattingDisplayMode | None = None
     id: str
     input: str
+    label: str | None = None
     templateId: str
 
 

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -6496,6 +6496,18 @@ export const DisplayTypeApi = {
     Area: 'area',
 } as const
 
+export type ColumnRenderAsApi = (typeof ColumnRenderAsApi)[keyof typeof ColumnRenderAsApi]
+
+export const ColumnRenderAsApi = {
+    Default: 'default',
+    Sparkline: 'sparkline',
+} as const
+
+export interface SparklineColumnSettingsApi {
+    color?: string | null
+    type?: 'bar' | 'line' | null
+}
+
 export type YAxisPositionApi = (typeof YAxisPositionApi)[keyof typeof YAxisPositionApi]
 
 export const YAxisPositionApi = {
@@ -6507,6 +6519,8 @@ export interface ChartSettingsDisplayApi {
     color?: string | null
     displayType?: DisplayTypeApi | null
     label?: string | null
+    renderAs?: ColumnRenderAsApi | null
+    sparkline?: SparklineColumnSettingsApi | null
     trendLine?: boolean | null
     yAxisPosition?: YAxisPositionApi | null
 }
@@ -6574,13 +6588,24 @@ export const ColorModeApi = {
     Dark: 'dark',
 } as const
 
+export type ConditionalFormattingDisplayModeApi =
+    (typeof ConditionalFormattingDisplayModeApi)[keyof typeof ConditionalFormattingDisplayModeApi]
+
+export const ConditionalFormattingDisplayModeApi = {
+    Background: 'background',
+    Badge: 'badge',
+    Dot: 'dot',
+} as const
+
 export interface ConditionalFormattingRuleApi {
     bytecode: unknown[]
     color: string
     colorMode?: ColorModeApi | null
     columnName: string
+    displayMode?: ConditionalFormattingDisplayModeApi | null
     id: string
     input: string
+    label?: string | null
     templateId: string
 }
 

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -6503,9 +6503,18 @@ export const ColumnRenderAsApi = {
     Sparkline: 'sparkline',
 } as const
 
+export type TypeApi = (typeof TypeApi)[keyof typeof TypeApi]
+
+export const TypeApi = {
+    Bar: 'bar',
+    Line: 'line',
+} as const
+
 export interface SparklineColumnSettingsApi {
+    /** Color name from vars.scss (e.g. 'primary', 'success', 'muted'). Defaults to 'primary'. */
     color?: string | null
-    type?: 'bar' | 'line' | null
+    /** 'bar' draws bars, 'line' draws a line. Defaults to 'line'. */
+    type?: TypeApi | null
 }
 
 export type YAxisPositionApi = (typeof YAxisPositionApi)[keyof typeof YAxisPositionApi]
@@ -6519,6 +6528,7 @@ export interface ChartSettingsDisplayApi {
     color?: string | null
     displayType?: DisplayTypeApi | null
     label?: string | null
+    /** When set on a HogQL table column, the cell is rendered as the corresponding visualization. Requires the column to return an array of numbers per row (e.g. `groupArray(value) AS trend`). */
     renderAs?: ColumnRenderAsApi | null
     sparkline?: SparklineColumnSettingsApi | null
     trendLine?: boolean | null
@@ -6602,9 +6612,11 @@ export interface ConditionalFormattingRuleApi {
     color: string
     colorMode?: ColorModeApi | null
     columnName: string
+    /** How the rule is rendered when matched. Defaults to 'background' for backwards compatibility. */
     displayMode?: ConditionalFormattingDisplayModeApi | null
     id: string
     input: string
+    /** Optional label override used by 'badge' display mode. Falls back to the cell value when omitted. */
     label?: string | null
     templateId: string
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6778,9 +6778,19 @@ export namespace Schemas {
       Sparkline: 'sparkline',
     } as const;
 
+    export type Type = typeof Type[keyof typeof Type];
+
+
+    export const Type = {
+      Bar: 'bar',
+      Line: 'line',
+    } as const;
+
     export interface SparklineColumnSettings {
+      /** Color name from vars.scss (e.g. 'primary', 'success', 'muted'). Defaults to 'primary'. */
       color?: string | null;
-      type?: 'bar' | 'line' | null;
+      /** 'bar' draws bars, 'line' draws a line. Defaults to 'line'. */
+      type?: Type | null;
     }
 
     export type YAxisPosition = typeof YAxisPosition[keyof typeof YAxisPosition];
@@ -6795,6 +6805,7 @@ export namespace Schemas {
       color?: string | null;
       displayType?: DisplayType | null;
       label?: string | null;
+      /** When set on a HogQL table column, the cell is rendered as the corresponding visualization. Requires the column to return an array of numbers per row (e.g. `groupArray(value) AS trend`). */
       renderAs?: ColumnRenderAs | null;
       sparkline?: SparklineColumnSettings | null;
       trendLine?: boolean | null;
@@ -7634,9 +7645,11 @@ export namespace Schemas {
       color: string;
       colorMode?: ColorMode | null;
       columnName: string;
+      /** How the rule is rendered when matched. Defaults to 'background' for backwards compatibility. */
       displayMode?: ConditionalFormattingDisplayMode | null;
       id: string;
       input: string;
+      /** Optional label override used by 'badge' display mode. Falls back to the cell value when omitted. */
       label?: string | null;
       templateId: string;
     }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6770,6 +6770,19 @@ export namespace Schemas {
       Area: 'area',
     } as const;
 
+    export type ColumnRenderAs = typeof ColumnRenderAs[keyof typeof ColumnRenderAs];
+
+
+    export const ColumnRenderAs = {
+      Default: 'default',
+      Sparkline: 'sparkline',
+    } as const;
+
+    export interface SparklineColumnSettings {
+      color?: string | null;
+      type?: 'bar' | 'line' | null;
+    }
+
     export type YAxisPosition = typeof YAxisPosition[keyof typeof YAxisPosition];
 
 
@@ -6782,6 +6795,8 @@ export namespace Schemas {
       color?: string | null;
       displayType?: DisplayType | null;
       label?: string | null;
+      renderAs?: ColumnRenderAs | null;
+      sparkline?: SparklineColumnSettings | null;
       trendLine?: boolean | null;
       yAxisPosition?: YAxisPosition | null;
     }
@@ -7605,13 +7620,24 @@ export namespace Schemas {
       Invalid: 'invalid',
     } as const;
 
+    export type ConditionalFormattingDisplayMode = typeof ConditionalFormattingDisplayMode[keyof typeof ConditionalFormattingDisplayMode];
+
+
+    export const ConditionalFormattingDisplayMode = {
+      Background: 'background',
+      Badge: 'badge',
+      Dot: 'dot',
+    } as const;
+
     export interface ConditionalFormattingRule {
       bytecode: unknown[];
       color: string;
       colorMode?: ColorMode | null;
       columnName: string;
+      displayMode?: ConditionalFormattingDisplayMode | null;
       id: string;
       input: string;
+      label?: string | null;
       templateId: string;
     }
 
@@ -22077,6 +22103,24 @@ export namespace Schemas {
     }
 
     /**
+     * * `event` - Event
+    * `person` - Person
+    * `session` - Session
+    * `group` - Group
+    * `data_warehouse_person_property` - Data warehouse person property
+     */
+    export type QuickFilterPropertyTypeEnum = typeof QuickFilterPropertyTypeEnum[keyof typeof QuickFilterPropertyTypeEnum];
+
+
+    export const QuickFilterPropertyTypeEnum = {
+      Event: 'event',
+      Person: 'person',
+      Session: 'session',
+      Group: 'group',
+      DataWarehousePersonProperty: 'data_warehouse_person_property',
+    } as const;
+
+    /**
      * * `manual-options` - manual-options
     * `auto-discovery` - auto-discovery
      */
@@ -22090,10 +22134,30 @@ export namespace Schemas {
 
     export interface QuickFilter {
       readonly id: string;
-      /** @maxLength 200 */
+      /**
+         * Human-readable name shown in the quick filter bar.
+         * @maxLength 200
+         */
       name: string;
-      /** @maxLength 500 */
+      /**
+         * Name of the property to filter on (e.g. '$browser', 'plan', '$group_0').
+         * @maxLength 500
+         */
       property_name: string;
+      /** Type of property the filter targets. Defaults to 'event' to preserve legacy behavior. Use 'group' for group properties (also set group_type_index).
+
+      * `event` - Event
+      * `person` - Person
+      * `session` - Session
+      * `group` - Group
+      * `data_warehouse_person_property` - Data warehouse person property */
+      property_type?: QuickFilterPropertyTypeEnum;
+      /**
+         * Group type index when property_type is 'group'. Ignored for other property types.
+         * @minimum 0
+         * @nullable
+         */
+      group_type_index?: number | null;
       type?: QuickFilterTypeEnum;
       options?: unknown;
       readonly contexts: readonly string[];
@@ -28168,10 +28232,30 @@ export namespace Schemas {
 
     export interface PatchedQuickFilter {
       readonly id?: string;
-      /** @maxLength 200 */
+      /**
+         * Human-readable name shown in the quick filter bar.
+         * @maxLength 200
+         */
       name?: string;
-      /** @maxLength 500 */
+      /**
+         * Name of the property to filter on (e.g. '$browser', 'plan', '$group_0').
+         * @maxLength 500
+         */
       property_name?: string;
+      /** Type of property the filter targets. Defaults to 'event' to preserve legacy behavior. Use 'group' for group properties (also set group_type_index).
+
+      * `event` - Event
+      * `person` - Person
+      * `session` - Session
+      * `group` - Group
+      * `data_warehouse_person_property` - Data warehouse person property */
+      property_type?: QuickFilterPropertyTypeEnum;
+      /**
+         * Group type index when property_type is 'group'. Ignored for other property types.
+         * @minimum 0
+         * @nullable
+         */
+      group_type_index?: number | null;
       type?: QuickFilterTypeEnum;
       options?: unknown;
       readonly contexts?: readonly string[];


### PR DESCRIPTION
## Problem

Customer success teams looking to replace dedicated CS tools (e.g. Vitally) with PostHog need a few primitive chart/widget capabilities that don't exist yet. The data plumbing is already there — Stripe, Zendesk, Postgres, and other warehouse sources connect cleanly, and there are pre-built joins from `persons` to `stripe.customer` and `zendesk.tickets`. What's missing is the **assembly layer**: indicators, sparkline trend columns, and dashboard filters that work on group/warehouse properties (not just events).

This PR ships four general-purpose primitives that unlock a "fleet" dashboard composition without inventing a new tile type, scene, or query runner. Everything is mergeable independently and reuses existing infrastructure.

## Changes

**(A) Badges & dots in HogQL tables.** `ConditionalFormattingRule` gains a `displayMode: 'background' | 'badge' | 'dot'` (default `'background'`, fully backwards compatible) and an optional `label` for badge text. The conditional-formatting editor picks up a "Display as" select; `Table.tsx` shares the bytecode-match evaluation between cell render and style, dispatching to a colored dot, a `LemonTag` badge, or the existing background tint.

**(B) Sparkline column renderer.** `ChartSettingsDisplay` gains `renderAs: 'default' | 'sparkline'` and a `sparkline` config block. When set on a table column, cells must be `ARRAY(Number)` (e.g. `groupArray(daily_mrr)`); the renderer uses the existing `Sparkline` component. Friendly error if the column shape doesn't match. The editor picker for this setting is intentionally deferred — saved JSON and dashboard templates can use it today.

**(C) Indicator widget — no new tile type needed.** `HogQLBoldNumber` now evaluates conditional-formatting rules against the first cell of the first row and applies the matched rule as a background tint, an absolute-positioned dot, or a colored badge below the value. Any SQL insight returning a scalar + a CF rule becomes a configurable indicator tile when dropped on a dashboard. Reuses (A)'s machinery entirely — no migration, no new model, no new renderer.

**(D) Group-property quick filters.** `QuickFilter` gains `property_type` (event/person/session/group/data_warehouse_person_property) and `group_type_index` columns. `dashboardQuickFiltersLogic` reads these from the loaded filter and builds the corresponding `AnyPropertyFilter` shape. Legacy quick filters with no `property_type` continue to behave as event filters. Migration `1154_quickfilter_property_type` is purely additive (nullable + safe default).

The "Customer health" dashboard template that combines all four into a fleet view is **deferred to a follow-up PR** — these primitives are mergeable on their own and the template is best authored once the SQL/group typology is finalized with the CS team.

## How did you test this code?

This is an agent-authored PR. The automated coverage added:

- `posthog/api/test/test_quick_filters.py` — extended with `test_create_group_quick_filter` and `test_update_quick_filter_property_type`, plus an assertion that legacy filters default to `property_type='event'`.
- `frontend/src/scenes/dashboard/dashboardQuickFiltersLogic.test.ts` — new file covering event / group (with `group_type_index`) / legacy-fallback branches.

Not done in this session: no manual UI testing, no Storybook stories, no E2E. `hogli build:schema` and `pnpm typescript:check` were not runnable in the sandbox (Python and node_modules unavailable); `posthog/schema.py` was synced by hand to match the schema-general.ts additions. **Please run `bin/hogli build:schema` and `pnpm --filter=@posthog/frontend typescript:check` locally before merge** to confirm no drift.

## Publish to changelog?

no — these are dashboard authoring primitives; the user-facing changelog entry belongs with the "Customer health" template follow-up.

## Docs update

No docs changes here. The conditional-formatting docs may want an update once badges/dots are merged; deferring to the follow-up that lands the dashboard template.

## 🤖 Agent context

Authored by PostHog Code. The original ask was "figure out what's doable for a Vitally-replacement dashboard using Stripe / Vitally / Postgres / Zendesk as warehouse sources, and add the chart types we need."

Decisions made along the way:
- **Rejected** building a new `IndicatorTile` Django model + tile renderer + DashboardItems wiring + scene routes. Instead reused (A)'s conditional-formatting infrastructure on the existing `HogQLBoldNumber` so a SQL insight = an indicator tile. No new schema, no migration churn, much smaller surface.
- **Rejected** introducing new Python query runners or virtual group fields for health/risk scoring. Per the user's direction, all scoring is user-authored HogQL — the dashboard template (follow-up) will seed the formulas.
- **Deferred** the sparkline column-config UI picker. The renderer + schema are in; templates and saved-insight JSON can use it. Adding a picker to the table column editor is a small follow-up.
- **Deferred** the "Customer health" dashboard template. Composing it depends on the CS team's preferred typology (which group_type represents a customer, which signals feed the score). The four primitives are mergeable independently and unblock the template work.