### PR TITLE
ci: deploy vojta branches to ph.vojtabartos.com hobby instance

### DIFF
--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -45,6 +45,18 @@ jobs:
         timeout-minutes: 45
         needs: wait-for-docker-image
         steps:
+            - name: Stop hobby before switch
+              run: |
+                  set -euo pipefail
+                  resp=$(curl -fsSL -X POST "$HOBBYCTL_URL/stop")
+                  echo "Stop response:"
+                  echo "$resp" | jq .
+                  exit_code=$(echo "$resp" | jq -r '.exit_code')
+                  if [ "$exit_code" != "0" ]; then
+                    echo "Stop returned non-zero exit_code: $exit_code"
+                    exit 1
+                  fi
+
             - name: Trigger async switch
               id: switch
               env:

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -45,6 +45,8 @@ jobs:
         timeout-minutes: 45
         needs: wait-for-docker-image
         steps:
+            - uses: actions/checkout@v6
+
             - name: Stop hobby before switch
               run: |
                   set -euo pipefail

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -58,53 +58,21 @@ jobs:
                   fi
 
             - name: Trigger async switch
-              id: switch
               env:
                   BRANCH: ${{ github.ref_name }}
               run: |
                   set -euo pipefail
-                  resp=$(curl -fsSL -X POST "$HOBBYCTL_URL/switch?async=true" \
+                  curl -fsSL -X POST "$HOBBYCTL_URL/switch?async=true" \
                       -H 'content-type: application/json' \
-                      -d "{\"branch\": \"$BRANCH\"}")
-                  echo "Switch response: $resp"
-                  task_id=$(echo "$resp" | jq -r '.task_id')
-                  if [ -z "$task_id" ] || [ "$task_id" = "null" ]; then
-                    echo "Did not receive task_id from hobbyctl"
-                    exit 1
-                  fi
-                  echo "task_id=$task_id" >> "$GITHUB_OUTPUT"
-
-            - name: Poll switch task until done
-              env:
-                  TASK_ID: ${{ steps.switch.outputs.task_id }}
-              run: |
-                  set -euo pipefail
-                  for i in $(seq 1 180); do
-                    info=$(curl -fsSL "$HOBBYCTL_URL/tasks/$TASK_ID")
-                    state=$(echo "$info" | jq -r '.state')
-                    echo "[$i] task state: $state"
-                    case "$state" in
-                      succeeded)
-                        echo "$info" | jq .
-                        exit 0
-                        ;;
-                      failed|cancelled)
-                        echo "Switch task ended in $state"
-                        echo "$info" | jq .
-                        exit 1
-                        ;;
-                    esac
-                    sleep 10
-                  done
-                  echo "Timed out waiting for switch task"
-                  exit 1
+                      -d "{\"branch\": \"$BRANCH\"}" | jq .
 
             - name: Wait for PostHog healthy
+              timeout-minutes: 20
               env:
                   BRANCH: ${{ github.ref_name }}
               run: |
                   set -euo pipefail
-                  for i in $(seq 1 90); do
+                  for i in $(seq 1 120); do
                     status=$(curl -fsSL "$HOBBYCTL_URL/status")
                     cur_branch=$(echo "$status" | jq -r '.branch')
                     ok=$(echo "$status" | jq -r '.posthog_health.ok // false')

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -105,4 +105,7 @@ jobs:
 
             - name: Stream task run until it ends
               timeout-minutes: 15
-              run: bin/qa/wait-for-task "${{ steps.create-task.outputs.task_id }}" "${{ steps.create-task.outputs.run_id }}"
+              env:
+                  TASK_ID: ${{ steps.create-task.outputs.task_id }}
+                  RUN_ID: ${{ steps.create-task.outputs.run_id }}
+              run: bin/qa/wait-for-task "$TASK_ID" "$RUN_ID"

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -1,0 +1,120 @@
+name: Deploy vojta branch to ph.vojtabartos.com
+
+on:
+    push:
+        branches:
+            - 'vojta/**'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+env:
+    HOBBYCTL_URL: http://ph.vojtabartos.com:8765
+
+jobs:
+    wait-for-docker-image:
+        name: Wait for Docker image build
+        runs-on: ubuntu-24.04
+        timeout-minutes: 90
+        steps:
+            - name: Wait for container image build to complete
+              uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
+              id: wait-for-image
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  checkName: Build Docker image
+                  ref: ${{ github.sha }}
+                  timeoutSeconds: 3600
+                  intervalSeconds: 30
+            - name: Verify image build succeeded
+              env:
+                  BUILD_CONCLUSION: ${{ steps.wait-for-image.outputs.conclusion }}
+              run: |
+                  if [ "$BUILD_CONCLUSION" != "success" ]; then
+                    echo "Docker image build conclusion: $BUILD_CONCLUSION"
+                    exit 1
+                  fi
+
+    switch-and-monitor:
+        name: Switch hobby to ${{ github.ref_name }} and wait for healthy
+        runs-on: ubuntu-24.04
+        timeout-minutes: 45
+        needs: wait-for-docker-image
+        steps:
+            - name: Trigger async switch
+              id: switch
+              env:
+                  BRANCH: ${{ github.ref_name }}
+              run: |
+                  set -euo pipefail
+                  resp=$(curl -fsSL -X POST "$HOBBYCTL_URL/switch?async=true" \
+                      -H 'content-type: application/json' \
+                      -d "{\"branch\": \"$BRANCH\"}")
+                  echo "Switch response: $resp"
+                  task_id=$(echo "$resp" | jq -r '.id')
+                  if [ -z "$task_id" ] || [ "$task_id" = "null" ]; then
+                    echo "Did not receive task id from hobbyctl"
+                    exit 1
+                  fi
+                  echo "task_id=$task_id" >> "$GITHUB_OUTPUT"
+
+            - name: Poll switch task until done
+              env:
+                  TASK_ID: ${{ steps.switch.outputs.task_id }}
+              run: |
+                  set -euo pipefail
+                  for i in $(seq 1 180); do
+                    info=$(curl -fsSL "$HOBBYCTL_URL/tasks/$TASK_ID")
+                    state=$(echo "$info" | jq -r '.state')
+                    echo "[$i] task state: $state"
+                    case "$state" in
+                      succeeded)
+                        echo "$info" | jq .
+                        exit 0
+                        ;;
+                      failed|cancelled)
+                        echo "Switch task ended in $state"
+                        echo "$info" | jq .
+                        exit 1
+                        ;;
+                    esac
+                    sleep 10
+                  done
+                  echo "Timed out waiting for switch task"
+                  exit 1
+
+            - name: Wait for services healthy
+              env:
+                  BRANCH: ${{ github.ref_name }}
+              run: |
+                  set -euo pipefail
+                  for i in $(seq 1 90); do
+                    status=$(curl -fsSL "$HOBBYCTL_URL/status")
+                    cur_branch=$(echo "$status" | jq -r '.branch')
+                    unhealthy=$(echo "$status" | jq -r '
+                      [.services[]
+                       | select(.health != null and .health != "healthy")
+                       | .name] | join(",")')
+                    starting=$(echo "$status" | jq -r '
+                      [.services[]
+                       | select(.state != "running")
+                       | .name] | join(",")')
+                    echo "[$i] branch=$cur_branch unhealthy=[$unhealthy] not-running=[$starting]"
+                    if [ "$cur_branch" = "$BRANCH" ] \
+                       && [ -z "$unhealthy" ] && [ -z "$starting" ]; then
+                      echo "All services healthy on $BRANCH"
+                      echo "$status" | jq .
+                      exit 0
+                    fi
+                    sleep 10
+                  done
+                  echo "Timed out waiting for healthy status"
+                  curl -fsSL "$HOBBYCTL_URL/status" | jq .
+                  exit 1
+
+            - name: Final ping
+              run: curl -fsSL "$HOBBYCTL_URL/health" | jq .

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -135,32 +135,10 @@ jobs:
               id: create-task
               run: |
                   set -euo pipefail
-                  resp=$(curl -fsSL -X POST "$HOBBYCTL_URL/posthog/tasks" \
-                      -H 'content-type: application/json' \
-                      -d '{"prompt": "give me a joke"}')
-                  echo "Create response:"
-                  echo "$resp" | jq .
-                  task_id=$(echo "$resp" | jq -r '.task_id')
-                  run_id=$(echo "$resp" | jq -r '.run_id')
-                  if [ -z "$task_id" ] || [ "$task_id" = "null" ] \
-                     || [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
-                    echo "Missing task_id or run_id in response"
-                    exit 1
-                  fi
-                  echo "task_id=$task_id" >> "$GITHUB_OUTPUT"
-                  echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+                  resp=$(bin/qa/create-task "give me a joke")
+                  echo "task_id=$(echo "$resp" | jq -r '.task_id')" >> "$GITHUB_OUTPUT"
+                  echo "run_id=$(echo "$resp" | jq -r '.run_id')" >> "$GITHUB_OUTPUT"
 
             - name: Stream task run until it ends
-              env:
-                  TASK_ID: ${{ steps.create-task.outputs.task_id }}
-                  RUN_ID: ${{ steps.create-task.outputs.run_id }}
               timeout-minutes: 15
-              run: |
-                  set -euo pipefail
-                  url="$HOBBYCTL_URL/posthog/tasks/$TASK_ID/runs/$RUN_ID/stream?stop_on=end_turn"
-                  echo "Streaming $url"
-                  # -N disables buffering so SSE events surface immediately;
-                  # hobbyctl closes the stream itself once an event matches
-                  # stop_on (server emits `event: closed` with stop_pattern_matched).
-                  curl -fsSL -N -H 'accept: text/event-stream' "$url"
-                  echo "Stream closed"
+              run: bin/qa/wait-for-task "${{ steps.create-task.outputs.task_id }}" "${{ steps.create-task.outputs.run_id }}"

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -145,9 +145,10 @@ jobs:
               timeout-minutes: 15
               run: |
                   set -euo pipefail
-                  url="$HOBBYCTL_URL/posthog/tasks/$TASK_ID/runs/$RUN_ID/stream"
+                  url="$HOBBYCTL_URL/posthog/tasks/$TASK_ID/runs/$RUN_ID/stream?stop_on=end_turn"
                   echo "Streaming $url"
                   # -N disables buffering so SSE events surface immediately;
-                  # curl returns when the server closes the stream.
+                  # hobbyctl closes the stream itself once an event matches
+                  # stop_on (server emits `event: closed` with stop_pattern_matched).
                   curl -fsSL -N -H 'accept: text/event-stream' "$url"
                   echo "Stream closed"

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -118,3 +118,36 @@ jobs:
 
             - name: Final ping
               run: curl -fsSL "$HOBBYCTL_URL/health" | jq .
+
+            - name: Create PostHog task (joke prompt)
+              id: create-task
+              run: |
+                  set -euo pipefail
+                  resp=$(curl -fsSL -X POST "$HOBBYCTL_URL/posthog/tasks" \
+                      -H 'content-type: application/json' \
+                      -d '{"prompt": "give me a joke"}')
+                  echo "Create response:"
+                  echo "$resp" | jq .
+                  task_id=$(echo "$resp" | jq -r '.task_id')
+                  run_id=$(echo "$resp" | jq -r '.run_id')
+                  if [ -z "$task_id" ] || [ "$task_id" = "null" ] \
+                     || [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+                    echo "Missing task_id or run_id in response"
+                    exit 1
+                  fi
+                  echo "task_id=$task_id" >> "$GITHUB_OUTPUT"
+                  echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+            - name: Stream task run until it ends
+              env:
+                  TASK_ID: ${{ steps.create-task.outputs.task_id }}
+                  RUN_ID: ${{ steps.create-task.outputs.run_id }}
+              timeout-minutes: 15
+              run: |
+                  set -euo pipefail
+                  url="$HOBBYCTL_URL/posthog/tasks/$TASK_ID/runs/$RUN_ID/stream"
+                  echo "Streaming $url"
+                  # -N disables buffering so SSE events surface immediately;
+                  # curl returns when the server closes the stream.
+                  curl -fsSL -N -H 'accept: text/event-stream' "$url"
+                  echo "Stream closed"

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -99,7 +99,7 @@ jobs:
                   echo "Timed out waiting for switch task"
                   exit 1
 
-            - name: Wait for services healthy
+            - name: Wait for PostHog healthy
               env:
                   BRANCH: ${{ github.ref_name }}
               run: |
@@ -107,24 +107,18 @@ jobs:
                   for i in $(seq 1 90); do
                     status=$(curl -fsSL "$HOBBYCTL_URL/status")
                     cur_branch=$(echo "$status" | jq -r '.branch')
-                    unhealthy=$(echo "$status" | jq -r '
-                      [.services[]
-                       | select(.health != null and .health != "healthy")
-                       | .name] | join(",")')
-                    starting=$(echo "$status" | jq -r '
-                      [.services[]
-                       | select(.state != "running")
-                       | .name] | join(",")')
-                    echo "[$i] branch=$cur_branch unhealthy=[$unhealthy] not-running=[$starting]"
-                    if [ "$cur_branch" = "$BRANCH" ] \
-                       && [ -z "$unhealthy" ] && [ -z "$starting" ]; then
-                      echo "All services healthy on $BRANCH"
+                    ok=$(echo "$status" | jq -r '.posthog_health.ok // false')
+                    code=$(echo "$status" | jq -r '.posthog_health.code // "?"')
+                    latency=$(echo "$status" | jq -r '.posthog_health.latency_ms // "?"')
+                    echo "[$i] branch=$cur_branch posthog_health.ok=$ok code=$code latency_ms=$latency"
+                    if [ "$cur_branch" = "$BRANCH" ] && [ "$ok" = "true" ]; then
+                      echo "PostHog healthy on $BRANCH"
                       echo "$status" | jq .
                       exit 0
                     fi
                     sleep 10
                   done
-                  echo "Timed out waiting for healthy status"
+                  echo "Timed out waiting for posthog_health.ok"
                   curl -fsSL "$HOBBYCTL_URL/status" | jq .
                   exit 1
 

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -130,11 +130,13 @@ jobs:
             - name: Final ping
               run: curl -fsSL "$HOBBYCTL_URL/health" | jq .
 
-            - name: Create PostHog task (joke prompt)
+            - name: Create PostHog task
               id: create-task
+              env:
+                  BRANCH: ${{ github.ref_name }}
               run: |
                   set -euo pipefail
-                  resp=$(bin/qa/create-task "give me a joke")
+                  resp=$(bin/qa/create-task "$BRANCH")
                   echo "task_id=$(echo "$resp" | jq -r '.task_id')" >> "$GITHUB_OUTPUT"
                   echo "run_id=$(echo "$resp" | jq -r '.run_id')" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -55,9 +55,9 @@ jobs:
                       -H 'content-type: application/json' \
                       -d "{\"branch\": \"$BRANCH\"}")
                   echo "Switch response: $resp"
-                  task_id=$(echo "$resp" | jq -r '.id')
+                  task_id=$(echo "$resp" | jq -r '.task_id')
                   if [ -z "$task_id" ] || [ "$task_id" = "null" ]; then
-                    echo "Did not receive task id from hobbyctl"
+                    echo "Did not receive task_id from hobbyctl"
                     exit 1
                   fi
                   echo "task_id=$task_id" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-hobby-vojta.yml
+++ b/.github/workflows/ci-hobby-vojta.yml
@@ -44,6 +44,9 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 45
         needs: wait-for-docker-image
+        permissions:
+            contents: read
+            pull-requests: write
         steps:
             - uses: actions/checkout@v6
 
@@ -69,6 +72,7 @@ jobs:
                       -d "{\"branch\": \"$BRANCH\"}" | jq .
 
             - name: Wait for PostHog healthy
+              id: wait-healthy
               timeout-minutes: 20
               env:
                   BRANCH: ${{ github.ref_name }}
@@ -84,6 +88,8 @@ jobs:
                     if [ "$cur_branch" = "$BRANCH" ] && [ "$ok" = "true" ]; then
                       echo "PostHog healthy on $BRANCH"
                       echo "$status" | jq .
+                      url=$(echo "$status" | jq -r '.posthog_health.url // ""' | sed 's|/_health$||')
+                      echo "staging_url=$url" >> "$GITHUB_OUTPUT"
                       exit 0
                     fi
                     sleep 10
@@ -91,6 +97,35 @@ jobs:
                   echo "Timed out waiting for posthog_health.ok"
                   curl -fsSL "$HOBBYCTL_URL/status" | jq .
                   exit 1
+
+            - name: Post QA-ready comment on PR
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  BRANCH: ${{ github.ref_name }}
+                  STAGING_URL: ${{ steps.wait-healthy.outputs.staging_url }}
+              run: |
+                  set -euo pipefail
+                  pr_number=$(gh pr list --head "$BRANCH" --state open \
+                      --json number --jq '.[0].number // ""')
+                  if [ -z "$pr_number" ]; then
+                      echo "No open PR for $BRANCH — skipping comment."
+                      exit 0
+                  fi
+                  marker='<!-- qa-env-comment -->'
+                  body=$(printf '%s\n⭐ QA environment created for this PR → %s' \
+                      "$marker" "$STAGING_URL")
+                  existing=$(gh api \
+                      "repos/$GITHUB_REPOSITORY/issues/$pr_number/comments" \
+                      --jq "[.[] | select(.body | contains(\"$marker\"))][0].id // empty")
+                  if [ -n "$existing" ]; then
+                      gh api -X PATCH \
+                          "repos/$GITHUB_REPOSITORY/issues/comments/$existing" \
+                          -f body="$body"
+                      echo "Updated comment $existing on PR #$pr_number"
+                  else
+                      gh pr comment "$pr_number" --body "$body"
+                      echo "Posted new comment on PR #$pr_number"
+                  fi
 
             - name: Final ping
               run: curl -fsSL "$HOBBYCTL_URL/health" | jq .

--- a/bin/qa/create-task
+++ b/bin/qa/create-task
@@ -23,7 +23,7 @@ prompt="1. run npx skills add https://github.com/PostHog/qa-swarm.git to downloa
 
 3. add the playwright MCP, reload the playwright mcp, and tell me the list of tools. you probably also need to install chrome-for-testing. if you hit any obstacles, try to overcome them yourself.
 
-5. run following skills:
+4. run following skills:
     - /generating-mcp-scenarios
     - /qa-runtime
 "

--- a/bin/qa/create-task
+++ b/bin/qa/create-task
@@ -22,7 +22,9 @@ fi
 branch="$1"
 repository="PostHog/posthog"
 
-prompt="1. run npx skills add https://github.com/PostHog/qa-swarm.git to download the skill, if you encouter auth issues try to fix it
+prompt="The branch under QA is \`$branch\` from the $repository repository.
+
+1. run npx skills add https://github.com/PostHog/qa-swarm.git to download the skill, if you encouter auth issues try to fix it
 2. add this to the harness settings:
 
 {
@@ -31,7 +33,7 @@ prompt="1. run npx skills add https://github.com/PostHog/qa-swarm.git to downloa
     }
 }
 
-3. add the playwright MCP, reload the playwright mcp, and tell me the list of tools. you probably also need to install chrome-for-testing. if you hit any obstacles, try to overcome them yourself.
+3. add the playwright MCP, reload the playwright mcp, and tell me the list of tools. you probably also need to install chrome-for-testing. if you hit any obstacles, try to overcome them yourself. You do not need to restart MCP or claude code to access the tools. You should try invoking them, keep try until that works.
 
 4. run following skills:
     - /generating-mcp-scenarios

--- a/bin/qa/create-task
+++ b/bin/qa/create-task
@@ -33,11 +33,9 @@ prompt="The branch under QA is \`$branch\` from the $repository repository.
     }
 }
 
-3. add the playwright MCP, reload the playwright mcp, and tell me the list of tools. you probably also need to install chrome-for-testing. if you hit any obstacles, try to overcome them yourself. You do not need to restart MCP or claude code to access the tools. You should try invoking them, keep try until that works.
+3. run following skill /generating-mcp-scenarios
+4. if any issues are found, share the results as a PR comment to keep everyone updated and commit fixes.
 
-4. run following skills:
-    - /generating-mcp-scenarios
-    - /qa-runtime
 "
 
 : "${HOBBYCTL_URL:=http://ph.vojtabartos.com:8765}"

--- a/bin/qa/create-task
+++ b/bin/qa/create-task
@@ -45,8 +45,9 @@ prompt="The branch under QA is \`$branch\` from the $repository repository.
 body=$(jq -nc \
     --arg p "$prompt" \
     --arg t "$branch" \
+    --arg b "$branch" \
     --arg r "$repository" '
-    {prompt: $p, title: $t, repository: $r}
+    {prompt: $p, title: $t, branch: $b, repository: $r}
 ')
 
 echo "POST $HOBBYCTL_URL/posthog/tasks" >&2

--- a/bin/qa/create-task
+++ b/bin/qa/create-task
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Create a PostHog Tasks run on the hobby instance via hobbyctl and print the
+# JSON response on stdout. Progress logs are written to stderr so callers can
+# safely pipe stdout into jq.
+#
+# Usage: bin/qa/create-task <prompt> [<title>]
+# Env:   HOBBYCTL_URL  default http://ph.vojtabartos.com:8765
+#
+# Response shape (from PosthogTaskCreatedResponse):
+#   { "task_id": "...", "run_id": "...", "stream_url": "...", "raw": { ... } }
+
+set -euo pipefail
+
+
+prompt="gimme a joke"
+title="${2:-}"
+
+: "${HOBBYCTL_URL:=http://ph.vojtabartos.com:8765}"
+
+body=$(jq -nc --arg p "$prompt" --arg t "$title" '
+    {prompt: $p} + (if $t == "" then {} else {title: $t} end)
+')
+
+echo "POST $HOBBYCTL_URL/posthog/tasks" >&2
+echo "body: $body" >&2
+
+resp=$(curl -fsSL -X POST "$HOBBYCTL_URL/posthog/tasks" \
+    -H 'content-type: application/json' \
+    -d "$body")
+
+task_id=$(echo "$resp" | jq -r '.task_id')
+run_id=$(echo "$resp" | jq -r '.run_id')
+
+if [ -z "$task_id" ] || [ "$task_id" = "null" ] \
+    || [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+    echo "create-task: missing task_id or run_id in response" >&2
+    echo "$resp" >&2
+    exit 1
+fi
+
+echo "$resp"

--- a/bin/qa/create-task
+++ b/bin/qa/create-task
@@ -12,7 +12,21 @@
 set -euo pipefail
 
 
-prompt="gimme a joke"
+prompt="1. run npx skills add https://github.com/PostHog/qa-swarm.git to download the skill
+2. add this to the harness settings:
+
+{
+    \"permissions\": {
+        \"allow\": [\"Bash(*)\", \"Write(*)\", \"mcp__posthog-hobby__*\"]
+    }
+}
+
+3. add the playwright MCP, reload the playwright mcp, and tell me the list of tools. you probably also need to install chrome-for-testing. if you hit any obstacles, try to overcome them yourself.
+
+5. run following skills:
+    - /generating-mcp-scenarios
+    - /qa-runtime
+"
 title="${2:-}"
 
 : "${HOBBYCTL_URL:=http://ph.vojtabartos.com:8765}"

--- a/bin/qa/create-task
+++ b/bin/qa/create-task
@@ -3,16 +3,26 @@
 # JSON response on stdout. Progress logs are written to stderr so callers can
 # safely pipe stdout into jq.
 #
-# Usage: bin/qa/create-task <prompt> [<title>]
+# Usage: bin/qa/create-task <branch>
 # Env:   HOBBYCTL_URL  default http://ph.vojtabartos.com:8765
+#
+# The branch is used as the task title in the PostHog Tasks UI; repository is
+# hardcoded to PostHog/posthog since this helper is repo-specific.
 #
 # Response shape (from PosthogTaskCreatedResponse):
 #   { "task_id": "...", "run_id": "...", "stream_url": "...", "raw": { ... } }
 
 set -euo pipefail
 
+if [ "$#" -lt 1 ] || [ -z "${1:-}" ]; then
+    echo "usage: $0 <branch>" >&2
+    exit 2
+fi
 
-prompt="1. run npx skills add https://github.com/PostHog/qa-swarm.git to download the skill
+branch="$1"
+repository="PostHog/posthog"
+
+prompt="1. run npx skills add https://github.com/PostHog/qa-swarm.git to download the skill, if you encouter auth issues try to fix it
 2. add this to the harness settings:
 
 {
@@ -27,12 +37,14 @@ prompt="1. run npx skills add https://github.com/PostHog/qa-swarm.git to downloa
     - /generating-mcp-scenarios
     - /qa-runtime
 "
-title="${2:-}"
 
 : "${HOBBYCTL_URL:=http://ph.vojtabartos.com:8765}"
 
-body=$(jq -nc --arg p "$prompt" --arg t "$title" '
-    {prompt: $p} + (if $t == "" then {} else {title: $t} end)
+body=$(jq -nc \
+    --arg p "$prompt" \
+    --arg t "$branch" \
+    --arg r "$repository" '
+    {prompt: $p, title: $t, repository: $r}
 ')
 
 echo "POST $HOBBYCTL_URL/posthog/tasks" >&2

--- a/bin/qa/wait-for-task
+++ b/bin/qa/wait-for-task
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Stream a PostHog Tasks run via hobbyctl until the server closes the stream.
+# hobbyctl closes the SSE connection when a data line matches one of the
+# comma-separated `stop_on` substrings (default: end_turn) and emits a final
+# `event: closed` with reason=stop_pattern_matched.
+#
+# Usage: bin/qa/wait-for-task <task_id> <run_id> [<stop_on>]
+# Env:   HOBBYCTL_URL  default http://ph.vojtabartos.com:8765
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "usage: $0 <task_id> <run_id> [<stop_on>]" >&2
+    exit 2
+fi
+
+task_id="$1"
+run_id="$2"
+stop_on="${3:-end_turn}"
+
+: "${HOBBYCTL_URL:=http://ph.vojtabartos.com:8765}"
+
+url="$HOBBYCTL_URL/posthog/tasks/$task_id/runs/$run_id/stream?stop_on=$stop_on"
+echo "streaming $url" >&2
+
+# -N disables curl's output buffering so SSE events surface immediately.
+curl -fsSL -N -H 'accept: text/event-stream' "$url"
+echo "stream closed" >&2


### PR DESCRIPTION
## Problem

I run a personal PostHog hobby instance at `http://ph.vojtabartos.com` controlled by a `hobbyctl` HTTP service on port 8765. Iterating on a branch today means manually telling it which branch to switch to once the images are built. This automates that loop for branches I push under the `vojta/*` prefix.

This workflow is intentionally **not merged to master** — it lives on `vojta/*` branches only. Push-triggered (since `pull_request` would read YAML from base and we don't want to maintain it there).

## Changes

Adds `.github/workflows/ci-hobby-vojta.yml`:

- Triggers only on push to `vojta/**`.
- Job 1 `wait-for-docker-image`: reuses `fountainhead/action-wait-for-check@v1.2.0` against the `Build Docker image` check, same pattern as `.github/workflows/ci-hobby.yml`.
- Job 2 `switch-and-monitor`:
  1. `POST /switch?async=true` to hobbyctl with the pushed branch name.
  2. Polls `GET /tasks/{id}` until the task is `succeeded` (or fails on `failed|cancelled`).
  3. Polls `GET /status` until `branch` matches and every service is `running` + `healthy`.
  4. Final `/health` ping.
- `concurrency.cancel-in-progress: true` so consecutive pushes to the same branch supersede in-flight runs instead of queuing.

No DigitalOcean droplet, no PR comments, no GitHub deployments — those are overkill for a personal preview.

## How did you test this code?

I'm an agent. I have not executed this workflow yet — the verification is the push of this branch itself: GitHub Actions will pick it up and run it, which is the only realistic test. The hobbyctl OpenAPI surface was inspected directly from `http://ph.vojtabartos.com:8765/openapi.json` to confirm endpoint shapes, request/response schemas, and the `TaskInfo.state` enum.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code.
- Approach considered and rejected: triggering on `pull_request`. GitHub reads the workflow YAML from the base branch for `pull_request` events, and this file is intentionally never merged to master, so push-triggered with a `vojta/**` filter is the only viable shape.
- Sync vs async `/switch`: chose async + `/tasks/{id}` polling so the curl call doesn't hold open for the full deploy and risk the runner's HTTP timeout on a long image pull.
- Health gate uses both `state == running` and `health == healthy` (where present) plus a branch-match check on `/status`, to avoid false greens during container rollover.