### PR TITLE
feat(notifications): expose notifications list as MCP tool

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -68,6 +68,7 @@ export const API_SCOPES: APIScope[] = [
     { key: 'llm_skill', objectName: 'LLM skill', objectPlural: 'LLM skills' },
     { key: 'logs', objectName: 'Logs', objectPlural: 'logs' },
     { key: 'notebook', objectName: 'Notebook', objectPlural: 'notebooks' },
+    { key: 'notification', objectName: 'Notification', objectPlural: 'notifications' },
     { key: 'organization', objectName: 'Organization', objectPlural: 'organizations', disabledWhenProjectScoped: true },
     {
         key: 'organization_integration',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5324,6 +5324,7 @@ export type APIScopeObject =
     | 'llm_skill'
     | 'logs'
     | 'notebook'
+    | 'notification'
     | 'organization'
     | 'organization_integration'
     | 'organization_member'

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -67,6 +67,7 @@ APIScopeObject = Literal[
     "llm_skill",
     "logs",
     "notebook",
+    "notification",
     "organization",
     "organization_integration",
     "organization_member",

--- a/products/notifications/backend/presentation/serializers.py
+++ b/products/notifications/backend/presentation/serializers.py
@@ -4,17 +4,48 @@ from products.notifications.backend.facade.enums import SourceType
 
 
 class NotificationEventSerializer(serializers.Serializer):
-    id = serializers.UUIDField()
-    team_id = serializers.IntegerField(allow_null=True)
-    notification_type = serializers.CharField()
-    priority = serializers.CharField()
-    title = serializers.CharField()
-    body = serializers.CharField()
-    read = serializers.BooleanField()
-    read_at = serializers.DateTimeField(allow_null=True)
-    resource_type = serializers.CharField(allow_null=True)
-    resource_id = serializers.CharField()
-    source_url = serializers.CharField()
-    source_type = serializers.ChoiceField(choices=[(s.value, s.name) for s in SourceType], allow_null=True)
-    source_id = serializers.CharField(allow_null=True)
-    created_at = serializers.DateTimeField()
+    id = serializers.UUIDField(help_text="Unique identifier for this notification event.")
+    team_id = serializers.IntegerField(
+        allow_null=True,
+        help_text="ID of the team this notification belongs to, or null when the notification is organization-scoped.",
+    )
+    notification_type = serializers.CharField(
+        help_text=(
+            "What kind of notification this is — for example 'alert_firing', 'comment_mention', "
+            "'issue_assigned', 'approval_requested', 'approval_resolved', 'experiment_concluded', "
+            "or 'concierge'."
+        ),
+    )
+    priority = serializers.CharField(
+        help_text="Delivery priority: 'normal' (popover only) or 'critical' (popover plus persistent toast).",
+    )
+    title = serializers.CharField(help_text="Short headline shown to the user in the notification UI.")
+    body = serializers.CharField(help_text="Full message body shown beneath the title.")
+    read = serializers.BooleanField(help_text="Whether the current user has marked this notification as read.")
+    read_at = serializers.DateTimeField(
+        allow_null=True,
+        help_text="When the current user marked this notification as read, or null if still unread.",
+    )
+    resource_type = serializers.CharField(
+        allow_null=True,
+        help_text=(
+            "Type of resource this notification points at, e.g. 'dashboard', 'insight', 'alert', 'comment'. "
+            "Null when the notification is not tied to a specific resource."
+        ),
+    )
+    resource_id = serializers.CharField(
+        help_text="ID of the linked resource (matches resource_type). Empty when not applicable.",
+    )
+    source_url = serializers.CharField(
+        help_text="Relative PostHog URL to navigate to when the user clicks the notification.",
+    )
+    source_type = serializers.ChoiceField(
+        choices=[(s.value, s.name) for s in SourceType],
+        allow_null=True,
+        help_text="Subsystem that produced the notification (e.g. 'alerts', 'comments'). Null if unattributed.",
+    )
+    source_id = serializers.CharField(
+        allow_null=True,
+        help_text="ID of the producing record in the source subsystem (e.g. alert ID, comment ID).",
+    )
+    created_at = serializers.DateTimeField(help_text="When the notification was created, in ISO 8601 format.")

--- a/products/notifications/backend/presentation/views.py
+++ b/products/notifications/backend/presentation/views.py
@@ -28,7 +28,7 @@ class NotificationPagination(LimitOffsetPagination):
 class NotificationsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
     queryset = NotificationEvent.objects.all()
     serializer_class = NotificationEventSerializer
-    scope_object = "INTERNAL"
+    scope_object = "notification"
     pagination_class = NotificationPagination
 
     def _get_user(self) -> User:
@@ -101,6 +101,7 @@ class NotificationsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
 
         return queryset
 
+    @extend_schema(responses=NotificationEventSerializer(many=True))
     def list(self, request: Request, *args, **kwargs) -> Response:
         if not self._is_feature_enabled():
             return Response({"results": [], "next": None, "previous": None, "count": 0})

--- a/products/notifications/mcp/tools.yaml
+++ b/products/notifications/mcp/tools.yaml
@@ -1,0 +1,28 @@
+# MCP tool definition — tool entries are scaffolded from the OpenAPI schema.
+# The tool list and operation IDs are kept in sync automatically:
+#   pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+#
+# To enable a tool, set enabled: true and add required scopes + annotations.
+# All other fields (title, description, enrich_url, etc.) are yours to configure.
+category: Notifications
+feature: notifications
+url_prefix: /notifications
+ui_apps: {}
+tools:
+    notifications-list:
+        operation: environment_notifications_list
+        enabled: true
+        scopes:
+            - notification:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List my notifications
+        description: >
+            List the real-time notifications the current user has in the PostHog dashboard, newest first.
+            Each result includes the title, body, source URL, priority, whether the user has already read it,
+            and what resource it points to (dashboard, alert, comment, approval, etc.). Use this to surface
+            what PostHog is currently telling the user about — for example unread alerts firing on a dashboard,
+            comment mentions, assigned issues, or pending approval requests.

--- a/services/mcp/src/lib/oauth-scopes.generated.ts
+++ b/services/mcp/src/lib/oauth-scopes.generated.ts
@@ -115,6 +115,8 @@ export const OAUTH_SCOPES_SUPPORTED = [
     'logs:write',
     'notebook:read',
     'notebook:write',
+    'notification:read',
+    'notification:write',
     'organization:read',
     'organization:write',
     'organization_integration:read',


### PR DESCRIPTION
## Problem

The PostHog real-time notification system (`products/notifications/`) currently surfaces dashboard notifications only to the in-browser session via SSE. There is no way for an agent (MCP client) to read the notifications the calling user has — e.g. for an assistant to know "you have 3 alerts firing on the Conversion dashboard" before answering a question.

This PR exposes the existing `NotificationsViewSet.list` endpoint as an MCP tool, gated by a new `notification` API scope.

## Changes

- **New API scope:** added `notification` to `posthog/scopes.py` (and mirrored in `frontend/src/lib/scopes.tsx` and `frontend/src/types.ts` per the comment at the top of `posthog/scopes.py`). `notification:read` / `notification:write` show up automatically via `get_scope_descriptions()`.
- **`NotificationsViewSet` scope:** flipped `scope_object` from `"INTERNAL"` to `"notification"`. The `list` action is `read_actions`-derived → requires `notification:read`. Custom `@action` methods (`mark_read`, `mark_unread`, `mark_all_read`, `unread_count`) aren't in the default scope-action lists, so they keep returning `None` for required scopes — meaning they remain blocked for PAT/OAuth callers (same effective behaviour as `INTERNAL`). Session-auth callers (frontend) are unaffected because `APIScopePermission` short-circuits for non-PAT/non-OAuth requests.
- **OpenAPI annotations:** added `@extend_schema(responses=NotificationEventSerializer(many=True))` to `list` so drf-spectacular emits a typed response (the viewset is a plain `GenericViewSet`). Added `help_text` on every `NotificationEventSerializer` field so the values flow through OpenAPI → Zod → MCP tool descriptions.
- **MCP tool:** new `products/notifications/mcp/tools.yaml` registering `notifications-list` (`operation: environment_notifications_list`, scope `notification:read`, `readOnly: true`, `list: true`).
- **Generated OAuth scopes:** regenerated `services/mcp/src/lib/oauth-scopes.generated.ts` via `bin/build-mcp-oauth-scopes.py` to include the new `notification:read` / `notification:write` entries.

### Why no HogQL system table
The convention in `docs/published/handbook/engineering/ai/implementing-mcp-tools.md` is to back every list MCP tool with a `system.<name>` HogQL table. This isn't a good fit for notifications: each row is filtered by `resolved_user_ids__contains=[user.id]` (per-user JSON containment), then by per-resource RBAC (`_filter_by_access_control`), then by the `real-time-notifications` feature flag. Reproducing all three in a generic HogQL table would either leak notifications across users or duplicate access logic that already lives in the view. Keeping this REST-only.

## How did you test this code?

This PR was authored by an agent (PostHog Code).

- Ran `ruff check` and `ruff format --check` on all touched Python files (clean).
- Ran `python3 bin/build-mcp-oauth-scopes.py` and verified `notification:read` / `notification:write` appear in `services/mcp/src/lib/oauth-scopes.generated.ts`.
- Sanity-checked `products/notifications/mcp/tools.yaml` structure.
- Reviewed scope-resolution behaviour in `posthog/permissions.py` to confirm that switching `INTERNAL` → `notification` keeps custom `@action` methods blocked from PAT/OAuth (same as before) while making `list` reachable with `notification:read`.

Not run by the agent (reviewer or follow-up commit required):
- `hogli build:openapi` to regenerate `frontend/tmp/openapi.json`, the frontend API types, and the MCP tool handler in `services/mcp/src/tools/generated/notifications.ts`. The agent's sandbox didn't have Django/Postgres available.
- `hogli test products/notifications/backend/` (existing tests use `force_authenticate` session auth, so they should be unaffected — but please confirm).
- `tach check --dependencies --interfaces`.
- End-to-end MCP inspector verification with a PAT carrying `notification:read`.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by PostHog Code on behalf of @vincent. Original task: "create a way to real-time notifications in the dashboard but as an MCP".

Initial framing assumed an MCP *send* tool wrapping the internal `create_notification` facade. The user clarified that the intent was the opposite: an MCP *read* tool returning the user's current real-time notifications. Plan reduced to a single `notifications-list` tool and the minimum scope changes to make the existing viewset reachable via PAT/OAuth without touching any of the realtime transport (Kafka, Go livestream, SSE, frontend).

Key decisions:
- `INTERNAL` → `notification` (not adding a new viewset) — keeps the user-scoped filtering and feature-flag gating intact and avoids URL duplication.
- Custom `@action` methods kept blocked for PAT/OAuth — same effective behaviour as `INTERNAL`. If/when a follow-up wants mark-read or unread-count as MCP tools, add `required_scopes=[...]` per action or `scope_object_read_actions` / `scope_object_write_actions` class attrs (pattern documented in `products/llm_analytics/CLAUDE.md`).
- No HogQL system table for notifications — see "Why no HogQL system table" above.