### PR TITLE
feat(api-keys): add read-only access preset

### DIFF
--- a/frontend/src/lib/scopes.test.ts
+++ b/frontend/src/lib/scopes.test.ts
@@ -20,16 +20,6 @@ describe('API_KEY_SCOPE_PRESETS', () => {
             const expected = API_SCOPES.map(({ key }) => `${key}:read`).sort()
             expect([...preset.scopes].sort()).toEqual(expected)
         })
-
-        it('contains no :write scopes', () => {
-            const preset = findPreset('read_only_access')
-            expect(preset.scopes.filter((s) => s.endsWith(':write'))).toEqual([])
-        })
-
-        it('does not use the wildcard scope', () => {
-            const preset = findPreset('read_only_access')
-            expect(preset.scopes).not.toContain('*')
-        })
     })
 
     describe('all_access', () => {

--- a/frontend/src/lib/scopes.test.ts
+++ b/frontend/src/lib/scopes.test.ts
@@ -1,0 +1,41 @@
+import { API_KEY_SCOPE_PRESETS, API_SCOPES } from 'lib/scopes'
+
+describe('API_KEY_SCOPE_PRESETS', () => {
+    const findPreset = (value: string): (typeof API_KEY_SCOPE_PRESETS)[number] => {
+        const preset = API_KEY_SCOPE_PRESETS.find((p) => p.value === value)
+        if (!preset) {
+            throw new Error(`Preset "${value}" not found`)
+        }
+        return preset
+    }
+
+    describe('read_only_access', () => {
+        it('exists with the expected label', () => {
+            const preset = findPreset('read_only_access')
+            expect(preset.label).toBe('Read-only access')
+        })
+
+        it('contains :read for every entry in API_SCOPES', () => {
+            const preset = findPreset('read_only_access')
+            const expected = API_SCOPES.map(({ key }) => `${key}:read`).sort()
+            expect([...preset.scopes].sort()).toEqual(expected)
+        })
+
+        it('contains no :write scopes', () => {
+            const preset = findPreset('read_only_access')
+            expect(preset.scopes.filter((s) => s.endsWith(':write'))).toEqual([])
+        })
+
+        it('does not use the wildcard scope', () => {
+            const preset = findPreset('read_only_access')
+            expect(preset.scopes).not.toContain('*')
+        })
+    })
+
+    describe('all_access', () => {
+        it('still uses the wildcard scope', () => {
+            const preset = findPreset('all_access')
+            expect(preset.scopes).toEqual(['*'])
+        })
+    })
+})

--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -191,6 +191,11 @@ export const API_KEY_SCOPE_PRESETS: {
         ),
         access_type: 'all',
     },
+    {
+        value: 'read_only_access',
+        label: 'Read-only access',
+        scopes: API_SCOPES.map(({ key }) => `${key}:read`),
+    },
     { value: 'all_access', label: 'All access', scopes: ['*'] },
 ]
 


### PR DESCRIPTION
There isn't an easy way to mint an API key with read-only access to all scopes.

<img width="754" height="980" alt="Screenshot 2026-05-13 at 21 34 42" src="https://github.com/user-attachments/assets/3c375dee-54a3-453e-901d-9453db19e13a" />
