### PR TITLE
feat(mcp): surface inner exec tool description and bump @posthog/mcp

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1848,6 +1848,14 @@
             ],
             "label": "MCP exec inner tool description"
         },
+        "$mcp_exec_tool_call_name": {
+            "description": "In single-exec mode, $mcp_tool_name is always 'exec' (the dispatcher), so by itself it doesn't tell you which inner tool the agent was actually invoking. This property carries the inner tool's name \u2014 derived server-side by parsing the exec command's `call <tool> ...` form and looking it up in our catalog. Use it for breakdowns / funnels that should pivot on the real tool rather than the dispatcher. Only present when an exec call targets a recognized inner tool.",
+            "examples": [
+                "execute-sql",
+                "feature-flag-get-all"
+            ],
+            "label": "MCP exec inner tool name"
+        },
         "$mcp_intent": {
             "description": "Free-text description of why the agent is calling this tool, written by the agent itself. Comes from a context argument the client supplied at call time, or \u2014 if none was supplied \u2014 from an intentFallback the MCP server provides.",
             "examples": [
@@ -5663,6 +5671,14 @@
                 "List feature flags in the project."
             ],
             "label": "MCP exec inner tool description"
+        },
+        "$mcp_exec_tool_call_name": {
+            "description": "In single-exec mode, $mcp_tool_name is always 'exec' (the dispatcher), so by itself it doesn't tell you which inner tool the agent was actually invoking. This property carries the inner tool's name \u2014 derived server-side by parsing the exec command's `call <tool> ...` form and looking it up in our catalog. Use it for breakdowns / funnels that should pivot on the real tool rather than the dispatcher. Only present when an exec call targets a recognized inner tool.",
+            "examples": [
+                "execute-sql",
+                "feature-flag-get-all"
+            ],
+            "label": "MCP exec inner tool name"
         },
         "$mcp_intent": {
             "description": "Free-text description of why the agent is calling this tool, written by the agent itself. Comes from a context argument the client supplied at call time, or \u2014 if none was supplied \u2014 from an intentFallback the MCP server provides.",

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1840,6 +1840,17 @@
             "label": "MCP duration (ms)",
             "type": "Numeric"
         },
+        "$mcp_exec_inner_tool_names": {
+            "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
+            "examples": [
+                [
+                    "execute-sql",
+                    "feature-flag-get-all",
+                    "insight-get"
+                ]
+            ],
+            "label": "MCP exec inner tool catalog"
+        },
         "$mcp_exec_tool_call_description": {
             "description": "In single-exec mode, $mcp_tool_name is always 'exec' (the dispatcher), so the SDK's $mcp_tool_description is the dispatcher's static text on every call. This property carries the description of the inner tool the agent was actually invoking via 'call <tool> ...' \u2014 derived server-side by parsing the exec command and looking the inner tool up in our catalog. Only present when an exec call targets a recognized inner tool.",
             "examples": [
@@ -5663,6 +5674,17 @@
             ],
             "label": "MCP duration (ms)",
             "type": "Numeric"
+        },
+        "$mcp_exec_inner_tool_names": {
+            "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
+            "examples": [
+                [
+                    "execute-sql",
+                    "feature-flag-get-all",
+                    "insight-get"
+                ]
+            ],
+            "label": "MCP exec inner tool catalog"
         },
         "$mcp_exec_tool_call_description": {
             "description": "In single-exec mode, $mcp_tool_name is always 'exec' (the dispatcher), so the SDK's $mcp_tool_description is the dispatcher's static text on every call. This property carries the description of the inner tool the agent was actually invoking via 'call <tool> ...' \u2014 derived server-side by parsing the exec command and looking the inner tool up in our catalog. Only present when an exec call targets a recognized inner tool.",

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1843,11 +1843,7 @@
         "$mcp_exec_inner_tool_names": {
             "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
             "examples": [
-                [
-                    "execute-sql",
-                    "feature-flag-get-all",
-                    "insight-get"
-                ]
+                "execute-sql,feature-flag-get-all,insight-get"
             ],
             "label": "MCP exec inner tool catalog"
         },
@@ -5678,11 +5674,7 @@
         "$mcp_exec_inner_tool_names": {
             "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
             "examples": [
-                [
-                    "execute-sql",
-                    "feature-flag-get-all",
-                    "insight-get"
-                ]
+                "execute-sql,feature-flag-get-all,insight-get"
             ],
             "label": "MCP exec inner tool catalog"
         },

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1841,9 +1841,10 @@
             "type": "Numeric"
         },
         "$mcp_exec_inner_tool_names": {
-            "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
+            "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Stored as a JSON array \u2014 filter with `contains` against a single tool name (e.g. 'execute-sql'). Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
             "examples": [
-                "execute-sql,feature-flag-get-all,insight-get"
+                "execute-sql",
+                "feature-flag-get-all"
             ],
             "label": "MCP exec inner tool catalog"
         },
@@ -5672,9 +5673,10 @@
             "type": "Numeric"
         },
         "$mcp_exec_inner_tool_names": {
-            "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
+            "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Stored as a JSON array \u2014 filter with `contains` against a single tool name (e.g. 'execute-sql'). Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
             "examples": [
-                "execute-sql,feature-flag-get-all,insight-get"
+                "execute-sql",
+                "feature-flag-get-all"
             ],
             "label": "MCP exec inner tool catalog"
         },

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1840,6 +1840,14 @@
             "label": "MCP duration (ms)",
             "type": "Numeric"
         },
+        "$mcp_exec_tool_call_description": {
+            "description": "In single-exec mode, $mcp_tool_name is always 'exec' (the dispatcher), so the SDK's $mcp_tool_description is the dispatcher's static text on every call. This property carries the description of the inner tool the agent was actually invoking via 'call <tool> ...' \u2014 derived server-side by parsing the exec command and looking the inner tool up in our catalog. Only present when an exec call targets a recognized inner tool.",
+            "examples": [
+                "Run a HogQL/SQL query against PostHog.",
+                "List feature flags in the project."
+            ],
+            "label": "MCP exec inner tool description"
+        },
         "$mcp_intent": {
             "description": "Free-text description of why the agent is calling this tool, written by the agent itself. Comes from a context argument the client supplied at call time, or \u2014 if none was supplied \u2014 from an intentFallback the MCP server provides.",
             "examples": [
@@ -1889,6 +1897,14 @@
                 "posthog_mcp_analytics"
             ],
             "label": "MCP source"
+        },
+        "$mcp_tool_description": {
+            "description": "The MCP tool's description as advertised to the agent at the time of the call. Useful when triaging errors to see what the agent thought the tool would do \u2014 descriptions change over time, so the value captured here is the version the agent actually saw. Only present on mcp_tool_call and the paired $exception event.",
+            "examples": [
+                "Run a HogQL/SQL query against PostHog.",
+                "Fetch the trace referenced by an LLM analytics URL."
+            ],
+            "label": "MCP tool description"
         },
         "$mcp_tool_name": {
             "description": "The name of the MCP tool that was invoked. Only present on mcp_tool_call.",
@@ -5640,6 +5656,14 @@
             "label": "MCP duration (ms)",
             "type": "Numeric"
         },
+        "$mcp_exec_tool_call_description": {
+            "description": "In single-exec mode, $mcp_tool_name is always 'exec' (the dispatcher), so the SDK's $mcp_tool_description is the dispatcher's static text on every call. This property carries the description of the inner tool the agent was actually invoking via 'call <tool> ...' \u2014 derived server-side by parsing the exec command and looking the inner tool up in our catalog. Only present when an exec call targets a recognized inner tool.",
+            "examples": [
+                "Run a HogQL/SQL query against PostHog.",
+                "List feature flags in the project."
+            ],
+            "label": "MCP exec inner tool description"
+        },
         "$mcp_intent": {
             "description": "Free-text description of why the agent is calling this tool, written by the agent itself. Comes from a context argument the client supplied at call time, or \u2014 if none was supplied \u2014 from an intentFallback the MCP server provides.",
             "examples": [
@@ -5689,6 +5713,14 @@
                 "posthog_mcp_analytics"
             ],
             "label": "MCP source"
+        },
+        "$mcp_tool_description": {
+            "description": "The MCP tool's description as advertised to the agent at the time of the call. Useful when triaging errors to see what the agent thought the tool would do \u2014 descriptions change over time, so the value captured here is the version the agent actually saw. Only present on mcp_tool_call and the paired $exception event.",
+            "examples": [
+                "Run a HogQL/SQL query against PostHog.",
+                "Fetch the trace referenced by an LLM analytics URL."
+            ],
+            "label": "MCP tool description"
         },
         "$mcp_tool_name": {
             "description": "The name of the MCP tool that was invoked. Only present on mcp_tool_call.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3479,8 +3479,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@posthog/mcp-analytics':
-        specifier: npm:@posthog/mcp@0.0.4
-        version: '@posthog/mcp@0.0.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(rxjs@7.8.1)'
+        specifier: npm:@posthog/mcp@0.0.6
+        version: '@posthog/mcp@0.0.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(rxjs@7.8.1)'
       '@posthog/quill':
         specifier: workspace:*
         version: link:../../packages/quill/packages/quill
@@ -9085,8 +9085,8 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@posthog/mcp@0.0.4':
-    resolution: {integrity: sha512-Nscfg6XmDIlFLfBxhpE2uZKuWdW7GPwa1ri9oMViSNh0A00W1whca5y0N4zsI1e2a7rBPyTZs+A8ihk4elPIMw==}
+  '@posthog/mcp@0.0.6':
+    resolution: {integrity: sha512-emcvEZzyq8U4ct6a8ndPwlL+Gv5y33a/O8kt9oIJxp3oZ/pAa7v8lxUU04feOSZbI9SmWtH5N8EuZeuWV4z5/g==}
     engines: {node: '>=22.22.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.29.0
@@ -32179,7 +32179,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@posthog/mcp@0.0.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(rxjs@7.8.1)':
+  '@posthog/mcp@0.0.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(rxjs@7.8.1)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       posthog-node: 5.33.3(rxjs@7.8.1)

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2609,7 +2609,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$mcp_exec_inner_tool_names": {
             "label": "MCP exec inner tool catalog",
             "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
-            "examples": [["execute-sql", "feature-flag-get-all", "insight-get"]],
+            "examples": ["execute-sql,feature-flag-get-all,insight-get"],
         },
         "mcp_protocol_version": {
             "label": "MCP protocol version",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2606,6 +2606,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
                 "List feature flags in the project.",
             ],
         },
+        "$mcp_exec_inner_tool_names": {
+            "label": "MCP exec inner tool catalog",
+            "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
+            "examples": [["execute-sql", "feature-flag-get-all", "insight-get"]],
+        },
         "mcp_protocol_version": {
             "label": "MCP protocol version",
             "description": "The MCP protocol version negotiated during initialize.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2593,6 +2593,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         # PostHog-specific MCP properties added by the PostHog MCP server on top of the SDK's core
         # set. They identify which deployment, transport, and consumer produced the event. The
         # @posthog/mcp SDK will continue to carry these — they're not on a deprecation path.
+        "$mcp_exec_tool_call_name": {
+            "label": "MCP exec inner tool name",
+            "description": "In single-exec mode, $mcp_tool_name is always 'exec' (the dispatcher), so by itself it doesn't tell you which inner tool the agent was actually invoking. This property carries the inner tool's name — derived server-side by parsing the exec command's `call <tool> ...` form and looking it up in our catalog. Use it for breakdowns / funnels that should pivot on the real tool rather than the dispatcher. Only present when an exec call targets a recognized inner tool.",
+            "examples": ["execute-sql", "feature-flag-get-all"],
+        },
         "$mcp_exec_tool_call_description": {
             "label": "MCP exec inner tool description",
             "description": "In single-exec mode, $mcp_tool_name is always 'exec' (the dispatcher), so the SDK's $mcp_tool_description is the dispatcher's static text on every call. This property carries the description of the inner tool the agent was actually invoking via 'call <tool> ...' — derived server-side by parsing the exec command and looking the inner tool up in our catalog. Only present when an exec call targets a recognized inner tool.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2608,8 +2608,8 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$mcp_exec_inner_tool_names": {
             "label": "MCP exec inner tool catalog",
-            "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
-            "examples": ["execute-sql,feature-flag-get-all,insight-get"],
+            "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Stored as a JSON array — filter with `contains` against a single tool name (e.g. 'execute-sql'). Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
+            "examples": ["execute-sql", "feature-flag-get-all"],
         },
         "mcp_protocol_version": {
             "label": "MCP protocol version",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2529,6 +2529,14 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "The name of the MCP tool that was invoked. Only present on mcp_tool_call.",
             "examples": ["execute-sql", "feature-flag-get-all"],
         },
+        "$mcp_tool_description": {
+            "label": "MCP tool description",
+            "description": "The MCP tool's description as advertised to the agent at the time of the call. Useful when triaging errors to see what the agent thought the tool would do — descriptions change over time, so the value captured here is the version the agent actually saw. Only present on mcp_tool_call and the paired $exception event.",
+            "examples": [
+                "Run a HogQL/SQL query against PostHog.",
+                "Fetch the trace referenced by an LLM analytics URL.",
+            ],
+        },
         "$mcp_resource_name": {
             "label": "MCP resource name",
             "description": "The name of the MCP resource, prompt, or tool the event refers to.",
@@ -2585,6 +2593,14 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         # PostHog-specific MCP properties added by the PostHog MCP server on top of the SDK's core
         # set. They identify which deployment, transport, and consumer produced the event. The
         # @posthog/mcp SDK will continue to carry these — they're not on a deprecation path.
+        "$mcp_exec_tool_call_description": {
+            "label": "MCP exec inner tool description",
+            "description": "In single-exec mode, $mcp_tool_name is always 'exec' (the dispatcher), so the SDK's $mcp_tool_description is the dispatcher's static text on every call. This property carries the description of the inner tool the agent was actually invoking via 'call <tool> ...' — derived server-side by parsing the exec command and looking the inner tool up in our catalog. Only present when an exec call targets a recognized inner tool.",
+            "examples": [
+                "Run a HogQL/SQL query against PostHog.",
+                "List feature flags in the project.",
+            ],
+        },
         "mcp_protocol_version": {
             "label": "MCP protocol version",
             "description": "The MCP protocol version negotiated during initialize.",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.0.4",
+        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.0.5",
         "@posthog/quill": "workspace:*",
         "@toon-format/toon": "^2.1.0",
         "agents": "0.10.2",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.0.5",
+        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.0.6",
         "@posthog/quill": "workspace:*",
         "@toon-format/toon": "^2.1.0",
         "agents": "0.10.2",

--- a/services/mcp/src/lib/posthog-mcp-analytics.ts
+++ b/services/mcp/src/lib/posthog-mcp-analytics.ts
@@ -23,6 +23,14 @@ export type PostHogMcpAnalyticsOptions = {
     resolveExecInnerToolCall?:
         | ((request: unknown) => { name: string; description: string } | undefined)
         | undefined
+    // In single-exec mode the SDK's $mcp_listed_tool_names on mcp_tools_list
+    // collapses to just the dispatcher's name (`exec`) because that's the
+    // only tool the server actually advertises over MCP. Passing the full
+    // inner-tool catalog here lets us attach the inner names on tools/list
+    // events as $mcp_exec_inner_tool_names so dashboards can compute the
+    // "advertised but never called" diff against $mcp_exec_tool_call_name
+    // from mcp_tool_call events.
+    execInnerToolNames?: readonly string[] | undefined
 }
 
 export type PostHogMcpAnalyticsInitResult =
@@ -157,13 +165,22 @@ export async function initPostHogMcpAnalytics(
             eventProperties: async (request) => {
                 const base = await buildEventProperties(identity)
                 const innerToolCall = options.resolveExecInnerToolCall?.(request)
-                return innerToolCall
-                    ? {
-                          ...base,
-                          $mcp_exec_tool_call_name: innerToolCall.name,
-                          $mcp_exec_tool_call_description: innerToolCall.description,
-                      }
-                    : base
+                const isListToolsRequest =
+                    (request as { method?: unknown })?.method === 'tools/list' &&
+                    !!options.execInnerToolNames &&
+                    options.execInnerToolNames.length > 0
+                return {
+                    ...base,
+                    ...(innerToolCall
+                        ? {
+                              $mcp_exec_tool_call_name: innerToolCall.name,
+                              $mcp_exec_tool_call_description: innerToolCall.description,
+                          }
+                        : {}),
+                    ...(isListToolsRequest
+                        ? { $mcp_exec_inner_tool_names: [...(options.execInnerToolNames ?? [])] }
+                        : {}),
+                }
             },
             redactSensitiveInformation: (text) => Promise.resolve(redactSensitiveInformation(text)),
         })

--- a/services/mcp/src/lib/posthog-mcp-analytics.ts
+++ b/services/mcp/src/lib/posthog-mcp-analytics.ts
@@ -17,7 +17,9 @@ export type PostHogMcpAnalyticsOptions = {
     // lets the caller resolve that inner tool's description from the request so
     // it can be surfaced as `$mcp_exec_tool_call_description`. Returns undefined
     // when the request isn't an exec call or the inner tool isn't recognized.
-    resolveExecInnerToolDescription?: (request: unknown) => string | undefined
+    // Type accepts `| undefined` explicitly so callers can pass the value
+    // through unconditionally under `exactOptionalPropertyTypes: true`.
+    resolveExecInnerToolDescription?: ((request: unknown) => string | undefined) | undefined
 }
 
 export type PostHogMcpAnalyticsInitResult =

--- a/services/mcp/src/lib/posthog-mcp-analytics.ts
+++ b/services/mcp/src/lib/posthog-mcp-analytics.ts
@@ -12,6 +12,12 @@ export type PostHogMcpAnalyticsOptions = {
     // catalog. In single-exec mode the wrapper handles every call, so the
     // signal has nothing to map to and the extra slot is just noise.
     reportMissingEnabled: boolean
+    // In single-exec mode, every event's `$mcp_tool_name` is `exec` — the real
+    // tool the LLM was invoking lives inside `arguments.command`. This callback
+    // lets the caller resolve that inner tool's description from the request so
+    // it can be surfaced as `$mcp_exec_tool_call_description`. Returns undefined
+    // when the request isn't an exec call or the inner tool isn't recognized.
+    resolveExecInnerToolDescription?: (request: unknown) => string | undefined
 }
 
 export type PostHogMcpAnalyticsInitResult =
@@ -143,7 +149,13 @@ export async function initPostHogMcpAnalytics(
             },
             reportMissing: options.reportMissingEnabled,
             eventTags: async () => buildEventTags(identity),
-            eventProperties: async () => buildEventProperties(identity),
+            eventProperties: async (request) => {
+                const base = await buildEventProperties(identity)
+                const innerToolDescription = options.resolveExecInnerToolDescription?.(request)
+                return innerToolDescription
+                    ? { ...base, $mcp_exec_tool_call_description: innerToolDescription }
+                    : base
+            },
             redactSensitiveInformation: (text) => Promise.resolve(redactSensitiveInformation(text)),
         })
 

--- a/services/mcp/src/lib/posthog-mcp-analytics.ts
+++ b/services/mcp/src/lib/posthog-mcp-analytics.ts
@@ -14,12 +14,15 @@ export type PostHogMcpAnalyticsOptions = {
     reportMissingEnabled: boolean
     // In single-exec mode, every event's `$mcp_tool_name` is `exec` — the real
     // tool the LLM was invoking lives inside `arguments.command`. This callback
-    // lets the caller resolve that inner tool's description from the request so
-    // it can be surfaced as `$mcp_exec_tool_call_description`. Returns undefined
-    // when the request isn't an exec call or the inner tool isn't recognized.
-    // Type accepts `| undefined` explicitly so callers can pass the value
-    // through unconditionally under `exactOptionalPropertyTypes: true`.
-    resolveExecInnerToolDescription?: ((request: unknown) => string | undefined) | undefined
+    // lets the caller resolve that inner tool's name + description from the
+    // request so they can be surfaced as `$mcp_exec_tool_call_name` /
+    // `$mcp_exec_tool_call_description`. Returns undefined when the request
+    // isn't an exec call or the inner tool isn't recognized. Type accepts
+    // `| undefined` explicitly so callers can pass the value through
+    // unconditionally under `exactOptionalPropertyTypes: true`.
+    resolveExecInnerToolCall?:
+        | ((request: unknown) => { name: string; description: string } | undefined)
+        | undefined
 }
 
 export type PostHogMcpAnalyticsInitResult =
@@ -153,9 +156,13 @@ export async function initPostHogMcpAnalytics(
             eventTags: async () => buildEventTags(identity),
             eventProperties: async (request) => {
                 const base = await buildEventProperties(identity)
-                const innerToolDescription = options.resolveExecInnerToolDescription?.(request)
-                return innerToolDescription
-                    ? { ...base, $mcp_exec_tool_call_description: innerToolDescription }
+                const innerToolCall = options.resolveExecInnerToolCall?.(request)
+                return innerToolCall
+                    ? {
+                          ...base,
+                          $mcp_exec_tool_call_name: innerToolCall.name,
+                          $mcp_exec_tool_call_description: innerToolCall.description,
+                      }
                     : base
             },
             redactSensitiveInformation: (text) => Promise.resolve(redactSensitiveInformation(text)),

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -810,7 +810,7 @@ export class MCP extends McpAgent<Env> {
             const initResult = await initPostHogMcpAnalytics(this.server, mcpAnalyticsIdentity, {
                 contextEnabled: true,
                 reportMissingEnabled: !useSingleExec,
-                ...(resolveExecInnerToolDescription ? { resolveExecInnerToolDescription } : {}),
+                resolveExecInnerToolDescription,
             })
             Object.assign(this.requestProperties, {
                 posthogMcpAnalyticsInitAction: initResult.action,

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -809,10 +809,19 @@ export class MCP extends McpAgent<Env> {
                   }
                 : undefined
 
+            // In single-exec mode the SDK's $mcp_listed_tool_names collapses to
+            // just `exec`, so we can't compute "advertised but never called"
+            // (zombie tools) from SDK data alone. Pass the inner-tool catalog
+            // here so analytics can attach it as $mcp_exec_inner_tool_names on
+            // mcp_tools_list events. Dashboards can then diff it against
+            // $mcp_exec_tool_call_name from mcp_tool_call.
+            const execInnerToolNames = useSingleExec ? allTools.map((t) => t.name) : undefined
+
             const initResult = await initPostHogMcpAnalytics(this.server, mcpAnalyticsIdentity, {
                 contextEnabled: true,
                 reportMissingEnabled: !useSingleExec,
                 resolveExecInnerToolCall,
+                execInnerToolNames,
             })
             Object.assign(this.requestProperties, {
                 posthogMcpAnalyticsInitAction: initResult.action,

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -37,7 +37,7 @@ import { registerPrompts } from '@/prompts'
 import { registerResources } from '@/resources'
 import { registerUiAppResources } from '@/resources/ui-apps'
 import EXECUTE_SQL_PROMPT from '@/templates/execute-sql-prompt.md'
-import { createExecTool, type ExecInnerCallTracker, parseExecCallInnerToolName } from '@/tools/exec'
+import { createExecInnerToolCallResolver, createExecTool, type ExecInnerCallTracker } from '@/tools/exec'
 import { getToolDefinition } from '@/tools/toolDefinitions'
 import { type CloudRegion, type Context, type State, type Tool } from '@/tools/types'
 
@@ -793,21 +793,7 @@ export class MCP extends McpAgent<Env> {
             // every call. Resolve the inner tool the agent was actually invoking
             // from the command and surface its name + description as
             // `$mcp_exec_tool_call_name` / `$mcp_exec_tool_call_description`.
-            const resolveExecInnerToolCall = useSingleExec
-                ? (request: unknown): { name: string; description: string } | undefined => {
-                      const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })
-                          ?.params
-                      if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
-                          return
-                      }
-                      const innerName = parseExecCallInnerToolName(params.arguments.command)
-                      if (!innerName) {
-                          return
-                      }
-                      const tool = allTools.find((t) => t.name === innerName)
-                      return tool ? { name: tool.name, description: tool.description } : undefined
-                  }
-                : undefined
+            const resolveExecInnerToolCall = useSingleExec ? createExecInnerToolCallResolver(allTools) : undefined
 
             // In single-exec mode the SDK's $mcp_listed_tool_names collapses to
             // just `exec`, so we can't compute "advertised but never called"

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -790,10 +790,11 @@ export class MCP extends McpAgent<Env> {
         if (posthogMcpAnalyticsOn) {
             // In single-exec mode every event's `$mcp_tool_name` is `exec`, so the
             // SDK's `$mcp_tool_description` would be the dispatcher's static text on
-            // every call. Resolve the inner tool's description from the command and
-            // surface it as `$mcp_exec_tool_call_description` instead.
-            const resolveExecInnerToolDescription = useSingleExec
-                ? (request: unknown): string | undefined => {
+            // every call. Resolve the inner tool the agent was actually invoking
+            // from the command and surface its name + description as
+            // `$mcp_exec_tool_call_name` / `$mcp_exec_tool_call_description`.
+            const resolveExecInnerToolCall = useSingleExec
+                ? (request: unknown): { name: string; description: string } | undefined => {
                       const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })
                           ?.params
                       if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
@@ -803,14 +804,15 @@ export class MCP extends McpAgent<Env> {
                       if (!innerName) {
                           return
                       }
-                      return allTools.find((t) => t.name === innerName)?.description
+                      const tool = allTools.find((t) => t.name === innerName)
+                      return tool ? { name: tool.name, description: tool.description } : undefined
                   }
                 : undefined
 
             const initResult = await initPostHogMcpAnalytics(this.server, mcpAnalyticsIdentity, {
                 contextEnabled: true,
                 reportMissingEnabled: !useSingleExec,
-                resolveExecInnerToolDescription,
+                resolveExecInnerToolCall,
             })
             Object.assign(this.requestProperties, {
                 posthogMcpAnalyticsInitAction: initResult.action,

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -37,7 +37,7 @@ import { registerPrompts } from '@/prompts'
 import { registerResources } from '@/resources'
 import { registerUiAppResources } from '@/resources/ui-apps'
 import EXECUTE_SQL_PROMPT from '@/templates/execute-sql-prompt.md'
-import { createExecTool, type ExecInnerCallTracker } from '@/tools/exec'
+import { createExecTool, type ExecInnerCallTracker, parseExecCallInnerToolName } from '@/tools/exec'
 import { getToolDefinition } from '@/tools/toolDefinitions'
 import { type CloudRegion, type Context, type State, type Tool } from '@/tools/types'
 
@@ -788,9 +788,29 @@ export class MCP extends McpAgent<Env> {
         // single-exec mode the wrapper handles every call, so the missing-tool
         // signal has nothing to map to and the extra slot is pure noise.
         if (posthogMcpAnalyticsOn) {
+            // In single-exec mode every event's `$mcp_tool_name` is `exec`, so the
+            // SDK's `$mcp_tool_description` would be the dispatcher's static text on
+            // every call. Resolve the inner tool's description from the command and
+            // surface it as `$mcp_exec_tool_call_description` instead.
+            const resolveExecInnerToolDescription = useSingleExec
+                ? (request: unknown): string | undefined => {
+                      const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })
+                          ?.params
+                      if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
+                          return
+                      }
+                      const innerName = parseExecCallInnerToolName(params.arguments.command)
+                      if (!innerName) {
+                          return
+                      }
+                      return allTools.find((t) => t.name === innerName)?.description
+                  }
+                : undefined
+
             const initResult = await initPostHogMcpAnalytics(this.server, mcpAnalyticsIdentity, {
                 contextEnabled: true,
                 reportMissingEnabled: !useSingleExec,
+                ...(resolveExecInnerToolDescription ? { resolveExecInnerToolDescription } : {}),
             })
             Object.assign(this.requestProperties, {
                 posthogMcpAnalyticsInitAction: initResult.action,

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -49,7 +49,7 @@ export function parseExecCallInnerToolName(command: string): string | undefined 
     if (verb !== 'call' || !rest) {
         return
     }
-    const argv = rest.startsWith('--json ') ? rest.slice('--json'.length).trim() : rest === '--json' ? '' : rest
+    const argv = rest.startsWith('--json ') ? rest.slice('--json '.length).trim() : rest === '--json' ? '' : rest
     if (!argv) {
         return
     }

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -57,6 +57,28 @@ export function parseExecCallInnerToolName(command: string): string | undefined 
     return innerName || undefined
 }
 
+// Builds the resolver mcp.ts hands to initPostHogMcpAnalytics in single-exec
+// mode: given a request, return the inner tool's { name, description } when
+// the agent invoked it via `call <tool> ...`, or undefined otherwise. Lives
+// here (alongside parseExecCallInnerToolName) so tests can import the exact
+// same factory the production code uses — no copy-pasted resolver lambda.
+export function createExecInnerToolCallResolver(
+    allTools: ReadonlyArray<Tool<ZodObjectAny>>
+): (request: unknown) => { name: string; description: string } | undefined {
+    return (request: unknown) => {
+        const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })?.params
+        if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
+            return
+        }
+        const innerName = parseExecCallInnerToolName(params.arguments.command)
+        if (!innerName) {
+            return
+        }
+        const tool = allTools.find((t) => t.name === innerName)
+        return tool ? { name: tool.name, description: tool.description } : undefined
+    }
+}
+
 // Tools removed from v2 (single-exec) MCP. When the model attempts to call one,
 // surface a targeted redirect to the v2 replacement instead of dumping the full
 // tool catalog. Sourced from tools marked `new_mcp: false` in

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -40,6 +40,23 @@ function parseCommand(input: string): { verb: string; rest: string } {
     return { verb: trimmed.slice(0, idx), rest: trimmed.slice(idx + 1).trim() }
 }
 
+// Extracts the inner tool name from an exec `call` command, e.g.
+// "call my-tool {...}" → "my-tool". Returns undefined for other verbs or
+// malformed input. Used by analytics to surface the real tool being invoked
+// in single-exec mode, where the outer call always shows as `exec`.
+export function parseExecCallInnerToolName(command: string): string | undefined {
+    const { verb, rest } = parseCommand(command)
+    if (verb !== 'call' || !rest) {
+        return
+    }
+    const argv = rest.startsWith('--json ') ? rest.slice('--json'.length).trim() : rest === '--json' ? '' : rest
+    if (!argv) {
+        return
+    }
+    const innerName = parseCommand(argv).verb
+    return innerName || undefined
+}
+
 // Tools removed from v2 (single-exec) MCP. When the model attempts to call one,
 // surface a targeted redirect to the v2 replacement instead of dumping the full
 // tool catalog. Sourced from tools marked `new_mcp: false` in

--- a/services/mcp/tests/unit/exec-description-emission.test.ts
+++ b/services/mcp/tests/unit/exec-description-emission.test.ts
@@ -54,56 +54,95 @@ function makeTool(overrides: Partial<Tool<ZodObjectAny>>): Tool<ZodObjectAny> {
 
 const mockContext = { getDistinctId: async () => 'distinct-1' } as unknown as Context
 
+// Mirrors the resolver wired in mcp.ts for single-exec mode. Kept inline so
+// the test exercises the same shape mcp.ts builds.
+function buildResolveExecInnerToolDescription(allTools: Tool<ZodObjectAny>[]): (request: unknown) => string | undefined {
+    return (request: unknown): string | undefined => {
+        const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })?.params
+        if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
+            return
+        }
+        const innerName = parseExecCallInnerToolName(params.arguments.command)
+        if (!innerName) {
+            return
+        }
+        return allTools.find((t) => t.name === innerName)?.description
+    }
+}
+
+type ExecHarness = {
+    client: Client
+    events: CapturedEvent[]
+    cleanup: () => Promise<void>
+}
+
+async function buildExecHarness(allTools: Tool<ZodObjectAny>[]): Promise<ExecHarness> {
+    const events: CapturedEvent[] = []
+    const server = new McpServer({ name: 'test-mcp', version: '1.0.0' })
+
+    const execTool = createExecTool(allTools, mockContext, 'exec tool', 'command reference', undefined)
+    server.registerTool(
+        execTool.name,
+        { title: execTool.title, description: execTool.description, inputSchema: execTool.schema.shape },
+        (async (params: { command: string }) => {
+            const result = await execTool.handler(mockContext, params)
+            return { content: [{ type: 'text' as const, text: String(result) }] }
+        }) as Parameters<typeof server.registerTool>[2]
+    )
+
+    const resolveExecInnerToolDescription = buildResolveExecInnerToolDescription(allTools)
+
+    track(server, {
+        apiKey: 'phc_test',
+        posthogClient: makeStubPostHogClient(events),
+        posthogOptions: { flushAt: 1, flushInterval: 0, host: 'https://test.posthog.com' },
+        enableTracing: true,
+        eventProperties: (request) => {
+            const description = resolveExecInnerToolDescription(request)
+            return description ? { $mcp_exec_tool_call_description: description } : {}
+        },
+    })
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await Promise.all([client.connect(clientTransport), server.server.connect(serverTransport)])
+
+    return {
+        client,
+        events,
+        cleanup: async () => {
+            await clientTransport.close?.()
+            await serverTransport.close?.()
+        },
+    }
+}
+
+// Poll the captured events for a matching record instead of sleeping a fixed
+// duration — flushAt:1 makes capture effectively immediate, but timer-based
+// waits are flake-prone under CI load.
+async function waitForEvent(
+    events: CapturedEvent[],
+    predicate: (event: CapturedEvent) => boolean,
+    timeoutMs = 1000
+): Promise<CapturedEvent | undefined> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+        const match = events.find(predicate)
+        if (match) {
+            return match
+        }
+        await new Promise((resolve) => setTimeout(resolve, 5))
+    }
+    return events.find(predicate)
+}
+
 describe('$mcp_exec_tool_call_description end-to-end', () => {
     it('lands on the mcp_tool_call event when exec invokes a known inner tool', async () => {
         const allTools = [
             makeTool({ name: 'execute-sql', description: 'Run a HogQL/SQL query against PostHog.' }),
             makeTool({ name: 'feature-flag-get-all', description: 'List feature flags in the project.' }),
         ]
-
-        const events: CapturedEvent[] = []
-
-        const server = new McpServer({ name: 'test-mcp', version: '1.0.0' })
-
-        // Build the resolver exactly the way mcp.ts wires it in single-exec mode.
-        const resolveExecInnerToolDescription = (request: unknown): string | undefined => {
-            const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })?.params
-            if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
-                return
-            }
-            const innerName = parseExecCallInnerToolName(params.arguments.command)
-            if (!innerName) {
-                return
-            }
-            return allTools.find((t) => t.name === innerName)?.description
-        }
-
-        // Register the exec tool with the real allTools so its `call` verb
-        // dispatches to mock-tool/execute-sql.
-        const execTool = createExecTool(allTools, mockContext, 'exec tool', 'command reference', undefined)
-        server.registerTool(
-            execTool.name,
-            { title: execTool.title, description: execTool.description, inputSchema: execTool.schema.shape },
-            (async (params: { command: string }) => {
-                const result = await execTool.handler(mockContext, params)
-                return { content: [{ type: 'text' as const, text: String(result) }] }
-            }) as Parameters<typeof server.registerTool>[2]
-        )
-
-        track(server, {
-            apiKey: 'phc_test',
-            posthogClient: makeStubPostHogClient(events),
-            posthogOptions: { flushAt: 1, flushInterval: 0, host: 'https://test.posthog.com' },
-            enableTracing: true,
-            eventProperties: (request) => {
-                const description = resolveExecInnerToolDescription(request)
-                return description ? { $mcp_exec_tool_call_description: description } : {}
-            },
-        })
-
-        const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
-        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
-        await Promise.all([client.connect(clientTransport), server.server.connect(serverTransport)])
+        const { client, events, cleanup } = await buildExecHarness(allTools)
 
         try {
             await client.request(
@@ -114,10 +153,8 @@ describe('$mcp_exec_tool_call_description end-to-end', () => {
                 CallToolResultSchema
             )
 
-            // Let the SDK flush.
-            await new Promise((resolve) => setTimeout(resolve, 50))
+            const toolCallEvent = await waitForEvent(events, (e) => e.event === 'mcp_tool_call')
 
-            const toolCallEvent = events.find((e) => e.event === 'mcp_tool_call')
             expect(toolCallEvent, 'mcp_tool_call event should be captured').not.toBeUndefined()
             expect(toolCallEvent?.properties.$mcp_tool_name).toBe('exec')
             // The SDK property reports the *outer* tool's description (exec) — which is
@@ -128,49 +165,13 @@ describe('$mcp_exec_tool_call_description end-to-end', () => {
                 'Run a HogQL/SQL query against PostHog.'
             )
         } finally {
-            await clientTransport.close?.()
-            await serverTransport.close?.()
+            await cleanup()
         }
     })
 
     it('omits $mcp_exec_tool_call_description for non-call verbs', async () => {
         const allTools = [makeTool({ name: 'execute-sql', description: 'Run a HogQL/SQL query against PostHog.' })]
-        const events: CapturedEvent[] = []
-        const server = new McpServer({ name: 'test-mcp', version: '1.0.0' })
-
-        const resolveExecInnerToolDescription = (request: unknown): string | undefined => {
-            const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })?.params
-            if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
-                return
-            }
-            const innerName = parseExecCallInnerToolName(params.arguments.command)
-            return innerName ? allTools.find((t) => t.name === innerName)?.description : undefined
-        }
-
-        const execTool = createExecTool(allTools, mockContext, 'exec tool', 'command reference', undefined)
-        server.registerTool(
-            execTool.name,
-            { title: execTool.title, description: execTool.description, inputSchema: execTool.schema.shape },
-            (async (params: { command: string }) => {
-                const result = await execTool.handler(mockContext, params)
-                return { content: [{ type: 'text' as const, text: String(result) }] }
-            }) as Parameters<typeof server.registerTool>[2]
-        )
-
-        track(server, {
-            apiKey: 'phc_test',
-            posthogClient: makeStubPostHogClient(events),
-            posthogOptions: { flushAt: 1, flushInterval: 0, host: 'https://test.posthog.com' },
-            enableTracing: true,
-            eventProperties: (request) => {
-                const description = resolveExecInnerToolDescription(request)
-                return description ? { $mcp_exec_tool_call_description: description } : {}
-            },
-        })
-
-        const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
-        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
-        await Promise.all([client.connect(clientTransport), server.server.connect(serverTransport)])
+        const { client, events, cleanup } = await buildExecHarness(allTools)
 
         try {
             // `info` verb references a tool but doesn't invoke it — should NOT
@@ -183,14 +184,12 @@ describe('$mcp_exec_tool_call_description end-to-end', () => {
                 CallToolResultSchema
             )
 
-            await new Promise((resolve) => setTimeout(resolve, 50))
+            const toolCallEvent = await waitForEvent(events, (e) => e.event === 'mcp_tool_call')
 
-            const toolCallEvent = events.find((e) => e.event === 'mcp_tool_call')
             expect(toolCallEvent).not.toBeUndefined()
             expect(toolCallEvent?.properties).not.toHaveProperty('$mcp_exec_tool_call_description')
         } finally {
-            await clientTransport.close?.()
-            await serverTransport.close?.()
+            await cleanup()
         }
     })
 })

--- a/services/mcp/tests/unit/exec-description-emission.test.ts
+++ b/services/mcp/tests/unit/exec-description-emission.test.ts
@@ -14,7 +14,7 @@ import { track } from '@posthog/mcp-analytics'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
-import { createExecTool, parseExecCallInnerToolName } from '@/tools/exec'
+import { createExecInnerToolCallResolver, createExecTool } from '@/tools/exec'
 import type { Context, Tool, ZodObjectAny } from '@/tools/types'
 
 type CapturedEvent = { event: string; properties: Record<string, unknown> }
@@ -55,25 +55,6 @@ function makeTool(overrides: Partial<Tool<ZodObjectAny>>): Tool<ZodObjectAny> {
 
 const mockContext = { getDistinctId: async () => 'distinct-1' } as unknown as Context
 
-// Mirrors the resolver wired in mcp.ts for single-exec mode. Kept inline so
-// the test exercises the same shape mcp.ts builds.
-function buildResolveExecInnerToolCall(
-    allTools: Tool<ZodObjectAny>[]
-): (request: unknown) => { name: string; description: string } | undefined {
-    return (request: unknown) => {
-        const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })?.params
-        if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
-            return
-        }
-        const innerName = parseExecCallInnerToolName(params.arguments.command)
-        if (!innerName) {
-            return
-        }
-        const tool = allTools.find((t) => t.name === innerName)
-        return tool ? { name: tool.name, description: tool.description } : undefined
-    }
-}
-
 type ExecHarness = {
     client: Client
     events: CapturedEvent[]
@@ -94,7 +75,7 @@ async function buildExecHarness(allTools: Tool<ZodObjectAny>[]): Promise<ExecHar
         }) as Parameters<typeof server.registerTool>[2]
     )
 
-    const resolveExecInnerToolCall = buildResolveExecInnerToolCall(allTools)
+    const resolveExecInnerToolCall = createExecInnerToolCallResolver(allTools)
 
     track(server, {
         apiKey: 'phc_test',

--- a/services/mcp/tests/unit/exec-description-emission.test.ts
+++ b/services/mcp/tests/unit/exec-description-emission.test.ts
@@ -18,9 +18,15 @@ import type { Context, Tool, ZodObjectAny } from '@/tools/types'
 
 type CapturedEvent = { event: string; properties: Record<string, unknown> }
 
-function makeStubPostHogClient(events: CapturedEvent[]) {
+type StubPostHogClient = {
+    capture: (msg: { event: string; properties?: Record<string, unknown> }) => void
+    flush: () => Promise<void>
+    shutdown: () => Promise<void>
+}
+
+function makeStubPostHogClient(events: CapturedEvent[]): StubPostHogClient {
     return {
-        capture: ({ event, properties }: { event: string; properties?: Record<string, unknown> }) => {
+        capture: ({ event, properties }) => {
             events.push({ event, properties: properties ?? {} })
         },
         flush: async () => {},
@@ -112,7 +118,7 @@ describe('$mcp_exec_tool_call_description end-to-end', () => {
             await new Promise((resolve) => setTimeout(resolve, 50))
 
             const toolCallEvent = events.find((e) => e.event === 'mcp_tool_call')
-            expect(toolCallEvent, 'mcp_tool_call event should be captured').toBeDefined()
+            expect(toolCallEvent, 'mcp_tool_call event should be captured').not.toBeUndefined()
             expect(toolCallEvent?.properties.$mcp_tool_name).toBe('exec')
             // The SDK property reports the *outer* tool's description (exec) — which is
             // exactly the uninformative case the dotcom property exists to fix.
@@ -180,7 +186,7 @@ describe('$mcp_exec_tool_call_description end-to-end', () => {
             await new Promise((resolve) => setTimeout(resolve, 50))
 
             const toolCallEvent = events.find((e) => e.event === 'mcp_tool_call')
-            expect(toolCallEvent).toBeDefined()
+            expect(toolCallEvent).not.toBeUndefined()
             expect(toolCallEvent?.properties).not.toHaveProperty('$mcp_exec_tool_call_description')
         } finally {
             await clientTransport.close?.()

--- a/services/mcp/tests/unit/exec-description-emission.test.ts
+++ b/services/mcp/tests/unit/exec-description-emission.test.ts
@@ -1,7 +1,8 @@
-// Real end-to-end check that $mcp_exec_tool_call_description actually lands
-// on the captured PostHog event when an agent runs `exec("call <tool> {}")`.
-// Bypasses the global @posthog/mcp-analytics mock (set in tests/setup.ts) and
-// drives the real SDK with a stub posthog-node client to capture events.
+// Real end-to-end check that $mcp_exec_tool_call_name and
+// $mcp_exec_tool_call_description actually land on the captured PostHog event
+// when an agent runs `exec("call <tool> {}")`. Bypasses the global
+// @posthog/mcp-analytics mock (set in tests/setup.ts) and drives the real SDK
+// with a stub posthog-node client to capture events.
 import { vi } from 'vitest'
 vi.unmock('@posthog/mcp-analytics')
 
@@ -56,8 +57,10 @@ const mockContext = { getDistinctId: async () => 'distinct-1' } as unknown as Co
 
 // Mirrors the resolver wired in mcp.ts for single-exec mode. Kept inline so
 // the test exercises the same shape mcp.ts builds.
-function buildResolveExecInnerToolDescription(allTools: Tool<ZodObjectAny>[]): (request: unknown) => string | undefined {
-    return (request: unknown): string | undefined => {
+function buildResolveExecInnerToolCall(
+    allTools: Tool<ZodObjectAny>[]
+): (request: unknown) => { name: string; description: string } | undefined {
+    return (request: unknown) => {
         const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })?.params
         if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
             return
@@ -66,7 +69,8 @@ function buildResolveExecInnerToolDescription(allTools: Tool<ZodObjectAny>[]): (
         if (!innerName) {
             return
         }
-        return allTools.find((t) => t.name === innerName)?.description
+        const tool = allTools.find((t) => t.name === innerName)
+        return tool ? { name: tool.name, description: tool.description } : undefined
     }
 }
 
@@ -90,7 +94,7 @@ async function buildExecHarness(allTools: Tool<ZodObjectAny>[]): Promise<ExecHar
         }) as Parameters<typeof server.registerTool>[2]
     )
 
-    const resolveExecInnerToolDescription = buildResolveExecInnerToolDescription(allTools)
+    const resolveExecInnerToolCall = buildResolveExecInnerToolCall(allTools)
 
     track(server, {
         apiKey: 'phc_test',
@@ -98,8 +102,13 @@ async function buildExecHarness(allTools: Tool<ZodObjectAny>[]): Promise<ExecHar
         posthogOptions: { flushAt: 1, flushInterval: 0, host: 'https://test.posthog.com' },
         enableTracing: true,
         eventProperties: (request) => {
-            const description = resolveExecInnerToolDescription(request)
-            return description ? { $mcp_exec_tool_call_description: description } : {}
+            const innerCall = resolveExecInnerToolCall(request)
+            return innerCall
+                ? {
+                      $mcp_exec_tool_call_name: innerCall.name,
+                      $mcp_exec_tool_call_description: innerCall.description,
+                  }
+                : {}
         },
     })
 
@@ -136,7 +145,7 @@ async function waitForEvent(
     return events.find(predicate)
 }
 
-describe('$mcp_exec_tool_call_description end-to-end', () => {
+describe('$mcp_exec_tool_call_* end-to-end', () => {
     it('lands on the mcp_tool_call event when exec invokes a known inner tool', async () => {
         const allTools = [
             makeTool({ name: 'execute-sql', description: 'Run a HogQL/SQL query against PostHog.' }),
@@ -158,9 +167,10 @@ describe('$mcp_exec_tool_call_description end-to-end', () => {
             expect(toolCallEvent, 'mcp_tool_call event should be captured').not.toBeUndefined()
             expect(toolCallEvent?.properties.$mcp_tool_name).toBe('exec')
             // The SDK property reports the *outer* tool's description (exec) — which is
-            // exactly the uninformative case the dotcom property exists to fix.
+            // exactly the uninformative case the dotcom properties exist to fix.
             expect(toolCallEvent?.properties.$mcp_tool_description).toBe('exec tool')
-            // The dotcom-side property carries the real inner-tool description.
+            // The dotcom-side properties carry the real inner-tool name + description.
+            expect(toolCallEvent?.properties.$mcp_exec_tool_call_name).toBe('execute-sql')
             expect(toolCallEvent?.properties.$mcp_exec_tool_call_description).toBe(
                 'Run a HogQL/SQL query against PostHog.'
             )
@@ -169,13 +179,13 @@ describe('$mcp_exec_tool_call_description end-to-end', () => {
         }
     })
 
-    it('omits $mcp_exec_tool_call_description for non-call verbs', async () => {
+    it('omits $mcp_exec_tool_call_* for non-call verbs', async () => {
         const allTools = [makeTool({ name: 'execute-sql', description: 'Run a HogQL/SQL query against PostHog.' })]
         const { client, events, cleanup } = await buildExecHarness(allTools)
 
         try {
             // `info` verb references a tool but doesn't invoke it — should NOT
-            // emit the description.
+            // emit the inner-call name or description.
             await client.request(
                 {
                     method: 'tools/call',
@@ -187,6 +197,7 @@ describe('$mcp_exec_tool_call_description end-to-end', () => {
             const toolCallEvent = await waitForEvent(events, (e) => e.event === 'mcp_tool_call')
 
             expect(toolCallEvent).not.toBeUndefined()
+            expect(toolCallEvent?.properties).not.toHaveProperty('$mcp_exec_tool_call_name')
             expect(toolCallEvent?.properties).not.toHaveProperty('$mcp_exec_tool_call_description')
         } finally {
             await cleanup()

--- a/services/mcp/tests/unit/exec-description-emission.test.ts
+++ b/services/mcp/tests/unit/exec-description-emission.test.ts
@@ -1,0 +1,190 @@
+// Real end-to-end check that $mcp_exec_tool_call_description actually lands
+// on the captured PostHog event when an agent runs `exec("call <tool> {}")`.
+// Bypasses the global @posthog/mcp-analytics mock (set in tests/setup.ts) and
+// drives the real SDK with a stub posthog-node client to capture events.
+import { vi } from 'vitest'
+vi.unmock('@posthog/mcp-analytics')
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { track } from '@posthog/mcp-analytics'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { createExecTool, parseExecCallInnerToolName } from '@/tools/exec'
+import type { Context, Tool, ZodObjectAny } from '@/tools/types'
+
+type CapturedEvent = { event: string; properties: Record<string, unknown> }
+
+function makeStubPostHogClient(events: CapturedEvent[]) {
+    return {
+        capture: ({ event, properties }: { event: string; properties?: Record<string, unknown> }) => {
+            events.push({ event, properties: properties ?? {} })
+        },
+        flush: async () => {},
+        shutdown: async () => {},
+    }
+}
+
+function makeTool(overrides: Partial<Tool<ZodObjectAny>>): Tool<ZodObjectAny> {
+    return {
+        name: 'mock-tool',
+        title: 'Mock tool',
+        description: 'A mock tool for testing',
+        schema: z.object({}),
+        scopes: [],
+        annotations: {
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+            readOnlyHint: true,
+        },
+        handler: async () => 'ok',
+        ...overrides,
+    }
+}
+
+const mockContext = { getDistinctId: async () => 'distinct-1' } as unknown as Context
+
+describe('$mcp_exec_tool_call_description end-to-end', () => {
+    it('lands on the mcp_tool_call event when exec invokes a known inner tool', async () => {
+        const allTools = [
+            makeTool({ name: 'execute-sql', description: 'Run a HogQL/SQL query against PostHog.' }),
+            makeTool({ name: 'feature-flag-get-all', description: 'List feature flags in the project.' }),
+        ]
+
+        const events: CapturedEvent[] = []
+
+        const server = new McpServer({ name: 'test-mcp', version: '1.0.0' })
+
+        // Build the resolver exactly the way mcp.ts wires it in single-exec mode.
+        const resolveExecInnerToolDescription = (request: unknown): string | undefined => {
+            const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })?.params
+            if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
+                return
+            }
+            const innerName = parseExecCallInnerToolName(params.arguments.command)
+            if (!innerName) {
+                return
+            }
+            return allTools.find((t) => t.name === innerName)?.description
+        }
+
+        // Register the exec tool with the real allTools so its `call` verb
+        // dispatches to mock-tool/execute-sql.
+        const execTool = createExecTool(allTools, mockContext, 'exec tool', 'command reference', undefined)
+        server.registerTool(
+            execTool.name,
+            { title: execTool.title, description: execTool.description, inputSchema: execTool.schema.shape },
+            (async (params: { command: string }) => {
+                const result = await execTool.handler(mockContext, params)
+                return { content: [{ type: 'text' as const, text: String(result) }] }
+            }) as Parameters<typeof server.registerTool>[2]
+        )
+
+        track(server, {
+            apiKey: 'phc_test',
+            posthogClient: makeStubPostHogClient(events),
+            posthogOptions: { flushAt: 1, flushInterval: 0, host: 'https://test.posthog.com' },
+            enableTracing: true,
+            eventProperties: (request) => {
+                const description = resolveExecInnerToolDescription(request)
+                return description ? { $mcp_exec_tool_call_description: description } : {}
+            },
+        })
+
+        const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+        await Promise.all([client.connect(clientTransport), server.server.connect(serverTransport)])
+
+        try {
+            await client.request(
+                {
+                    method: 'tools/call',
+                    params: { name: 'exec', arguments: { command: 'call execute-sql {}' } },
+                },
+                CallToolResultSchema
+            )
+
+            // Let the SDK flush.
+            await new Promise((resolve) => setTimeout(resolve, 50))
+
+            const toolCallEvent = events.find((e) => e.event === 'mcp_tool_call')
+            expect(toolCallEvent, 'mcp_tool_call event should be captured').toBeDefined()
+            expect(toolCallEvent?.properties.$mcp_tool_name).toBe('exec')
+            // The SDK property reports the *outer* tool's description (exec) — which is
+            // exactly the uninformative case the dotcom property exists to fix.
+            expect(toolCallEvent?.properties.$mcp_tool_description).toBe('exec tool')
+            // The dotcom-side property carries the real inner-tool description.
+            expect(toolCallEvent?.properties.$mcp_exec_tool_call_description).toBe(
+                'Run a HogQL/SQL query against PostHog.'
+            )
+        } finally {
+            await clientTransport.close?.()
+            await serverTransport.close?.()
+        }
+    })
+
+    it('omits $mcp_exec_tool_call_description for non-call verbs', async () => {
+        const allTools = [makeTool({ name: 'execute-sql', description: 'Run a HogQL/SQL query against PostHog.' })]
+        const events: CapturedEvent[] = []
+        const server = new McpServer({ name: 'test-mcp', version: '1.0.0' })
+
+        const resolveExecInnerToolDescription = (request: unknown): string | undefined => {
+            const params = (request as { params?: { name?: unknown; arguments?: { command?: unknown } } })?.params
+            if (params?.name !== 'exec' || typeof params.arguments?.command !== 'string') {
+                return
+            }
+            const innerName = parseExecCallInnerToolName(params.arguments.command)
+            return innerName ? allTools.find((t) => t.name === innerName)?.description : undefined
+        }
+
+        const execTool = createExecTool(allTools, mockContext, 'exec tool', 'command reference', undefined)
+        server.registerTool(
+            execTool.name,
+            { title: execTool.title, description: execTool.description, inputSchema: execTool.schema.shape },
+            (async (params: { command: string }) => {
+                const result = await execTool.handler(mockContext, params)
+                return { content: [{ type: 'text' as const, text: String(result) }] }
+            }) as Parameters<typeof server.registerTool>[2]
+        )
+
+        track(server, {
+            apiKey: 'phc_test',
+            posthogClient: makeStubPostHogClient(events),
+            posthogOptions: { flushAt: 1, flushInterval: 0, host: 'https://test.posthog.com' },
+            enableTracing: true,
+            eventProperties: (request) => {
+                const description = resolveExecInnerToolDescription(request)
+                return description ? { $mcp_exec_tool_call_description: description } : {}
+            },
+        })
+
+        const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+        await Promise.all([client.connect(clientTransport), server.server.connect(serverTransport)])
+
+        try {
+            // `info` verb references a tool but doesn't invoke it — should NOT
+            // emit the description.
+            await client.request(
+                {
+                    method: 'tools/call',
+                    params: { name: 'exec', arguments: { command: 'info execute-sql' } },
+                },
+                CallToolResultSchema
+            )
+
+            await new Promise((resolve) => setTimeout(resolve, 50))
+
+            const toolCallEvent = events.find((e) => e.event === 'mcp_tool_call')
+            expect(toolCallEvent).toBeDefined()
+            expect(toolCallEvent?.properties).not.toHaveProperty('$mcp_exec_tool_call_description')
+        } finally {
+            await clientTransport.close?.()
+            await serverTransport.close?.()
+        }
+    })
+})

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -9,7 +9,7 @@ import { z } from 'zod'
 import { InstructionsFormatter } from '@/lib/instructions-formatter'
 import { SessionManager } from '@/lib/SessionManager'
 import { getToolsFromContext } from '@/tools'
-import { createExecTool, type ExecInnerCallProperties } from '@/tools/exec'
+import { createExecTool, type ExecInnerCallProperties, parseExecCallInnerToolName } from '@/tools/exec'
 import { getToolDefinition } from '@/tools/toolDefinitions'
 import {
     POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY,
@@ -337,6 +337,44 @@ describe('exec tool', () => {
             const queryTrends = makeMockTool({ name: 'query-trends', description: 'Run a trends query' })
             const exec = createExec([queryTrends])
             await expect(exec.handler(mockContext, { command: 'call query-run {}' })).rejects.toThrow(/query-trends/)
+        })
+    })
+
+    describe('parseExecCallInnerToolName', () => {
+        it('extracts the inner tool name from a basic call command', () => {
+            expect(parseExecCallInnerToolName('call my-tool {}')).toBe('my-tool')
+        })
+
+        it('extracts the inner tool name from a call command with no JSON body', () => {
+            expect(parseExecCallInnerToolName('call my-tool')).toBe('my-tool')
+        })
+
+        it('extracts the inner tool name when --json flag is present', () => {
+            expect(parseExecCallInnerToolName('call --json my-tool {}')).toBe('my-tool')
+        })
+
+        it('handles extra whitespace around the call command', () => {
+            expect(parseExecCallInnerToolName('  call   my-tool   {}  ')).toBe('my-tool')
+        })
+
+        it('returns undefined for non-call verbs that still target a tool', () => {
+            // info/schema/etc. don't actually invoke the inner tool — the resolver
+            // is intentionally scoped to `call` so it only fires for real invocations.
+            expect(parseExecCallInnerToolName('info my-tool')).toBeUndefined()
+            expect(parseExecCallInnerToolName('schema my-tool')).toBeUndefined()
+            expect(parseExecCallInnerToolName('search query-')).toBeUndefined()
+            expect(parseExecCallInnerToolName('tools')).toBeUndefined()
+        })
+
+        it('returns undefined for a bare call verb with no tool name', () => {
+            expect(parseExecCallInnerToolName('call')).toBeUndefined()
+            expect(parseExecCallInnerToolName('call ')).toBeUndefined()
+            expect(parseExecCallInnerToolName('call --json')).toBeUndefined()
+        })
+
+        it('returns undefined for empty or garbage input', () => {
+            expect(parseExecCallInnerToolName('')).toBeUndefined()
+            expect(parseExecCallInnerToolName('   ')).toBeUndefined()
         })
     })
 

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -341,40 +341,24 @@ describe('exec tool', () => {
     })
 
     describe('parseExecCallInnerToolName', () => {
-        it('extracts the inner tool name from a basic call command', () => {
-            expect(parseExecCallInnerToolName('call my-tool {}')).toBe('my-tool')
-        })
-
-        it('extracts the inner tool name from a call command with no JSON body', () => {
-            expect(parseExecCallInnerToolName('call my-tool')).toBe('my-tool')
-        })
-
-        it('extracts the inner tool name when --json flag is present', () => {
-            expect(parseExecCallInnerToolName('call --json my-tool {}')).toBe('my-tool')
-        })
-
-        it('handles extra whitespace around the call command', () => {
-            expect(parseExecCallInnerToolName('  call   my-tool   {}  ')).toBe('my-tool')
-        })
-
-        it('returns undefined for non-call verbs that still target a tool', () => {
-            // info/schema/etc. don't actually invoke the inner tool — the resolver
-            // is intentionally scoped to `call` so it only fires for real invocations.
-            expect(parseExecCallInnerToolName('info my-tool')).toBeUndefined()
-            expect(parseExecCallInnerToolName('schema my-tool')).toBeUndefined()
-            expect(parseExecCallInnerToolName('search query-')).toBeUndefined()
-            expect(parseExecCallInnerToolName('tools')).toBeUndefined()
-        })
-
-        it('returns undefined for a bare call verb with no tool name', () => {
-            expect(parseExecCallInnerToolName('call')).toBeUndefined()
-            expect(parseExecCallInnerToolName('call ')).toBeUndefined()
-            expect(parseExecCallInnerToolName('call --json')).toBeUndefined()
-        })
-
-        it('returns undefined for empty or garbage input', () => {
-            expect(parseExecCallInnerToolName('')).toBeUndefined()
-            expect(parseExecCallInnerToolName('   ')).toBeUndefined()
+        // Non-call verbs (info/schema/search/tools) are intentionally undefined —
+        // the resolver only fires for real invocations, not for browsing/inspection.
+        it.each<[string, string | undefined]>([
+            ['call my-tool {}', 'my-tool'],
+            ['call my-tool', 'my-tool'],
+            ['call --json my-tool {}', 'my-tool'],
+            ['  call   my-tool   {}  ', 'my-tool'],
+            ['info my-tool', undefined],
+            ['schema my-tool', undefined],
+            ['search query-', undefined],
+            ['tools', undefined],
+            ['call', undefined],
+            ['call ', undefined],
+            ['call --json', undefined],
+            ['', undefined],
+            ['   ', undefined],
+        ])('parseExecCallInnerToolName(%j) → %j', (input, expected) => {
+            expect(parseExecCallInnerToolName(input)).toBe(expected)
         })
     })
 

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -341,24 +341,29 @@ describe('exec tool', () => {
     })
 
     describe('parseExecCallInnerToolName', () => {
-        // Non-call verbs (info/schema/search/tools) are intentionally undefined —
-        // the resolver only fires for real invocations, not for browsing/inspection.
-        it.each<[string, string | undefined]>([
+        it.each([
             ['call my-tool {}', 'my-tool'],
             ['call my-tool', 'my-tool'],
             ['call --json my-tool {}', 'my-tool'],
             ['  call   my-tool   {}  ', 'my-tool'],
-            ['info my-tool', undefined],
-            ['schema my-tool', undefined],
-            ['search query-', undefined],
-            ['tools', undefined],
-            ['call', undefined],
-            ['call ', undefined],
-            ['call --json', undefined],
-            ['', undefined],
-            ['   ', undefined],
-        ])('parseExecCallInnerToolName(%j) → %j', (input, expected) => {
-            expect(parseExecCallInnerToolName(input)).toBe(expected)
+        ])('extracts inner tool name from "%s"', (command, expected) => {
+            expect(parseExecCallInnerToolName(command)).toBe(expected)
+        })
+
+        // Non-call verbs (info/schema/search/tools) are intentionally undefined —
+        // the resolver only fires for real invocations, not for browsing/inspection.
+        it.each([
+            ['info my-tool'],
+            ['schema my-tool'],
+            ['search query-'],
+            ['tools'],
+            ['call'],
+            ['call '],
+            ['call --json'],
+            [''],
+            ['   '],
+        ])('returns undefined for "%s"', (command) => {
+            expect(parseExecCallInnerToolName(command)).toBeUndefined()
         })
     })
 

--- a/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
+++ b/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
@@ -215,34 +215,38 @@ describe('initPostHogMcpAnalytics', () => {
 
     it.each([
         {
-            scenario: 'adds the property when the resolver returns a description',
-            resolverReturn: 'Run a HogQL/SQL query.',
-            expectedValue: 'Run a HogQL/SQL query.',
+            scenario: 'adds name + description when the resolver returns an inner tool',
+            resolverReturn: { name: 'execute-sql', description: 'Run a HogQL/SQL query.' },
+            expectedName: 'execute-sql',
+            expectedDescription: 'Run a HogQL/SQL query.',
         },
         {
-            scenario: 'omits the property when the resolver returns undefined',
+            scenario: 'omits both properties when the resolver returns undefined',
             resolverReturn: undefined,
-            expectedValue: undefined,
+            expectedName: undefined,
+            expectedDescription: undefined,
         },
-    ])('eventProperties $scenario', async ({ resolverReturn, expectedValue }) => {
+    ])('eventProperties $scenario', async ({ resolverReturn, expectedName, expectedDescription }) => {
         const server = new McpServer({ name: 'test', version: '1.0.0' })
         const identity = createMockIdentity()
-        const resolveExecInnerToolDescription = vi.fn().mockReturnValue(resolverReturn)
+        const resolveExecInnerToolCall = vi.fn().mockReturnValue(resolverReturn)
 
         await initPostHogMcpAnalytics(server, identity, {
             contextEnabled: false,
             reportMissingEnabled: false,
-            resolveExecInnerToolDescription,
+            resolveExecInnerToolCall,
         })
 
         const fakeRequest = { params: { name: 'exec', arguments: { command: 'call execute-sql {}' } } }
         const properties = await getTrackOptions().eventProperties(fakeRequest)
 
-        expect(resolveExecInnerToolDescription).toHaveBeenCalledWith(fakeRequest)
-        if (expectedValue === undefined) {
+        expect(resolveExecInnerToolCall).toHaveBeenCalledWith(fakeRequest)
+        if (expectedDescription === undefined) {
+            expect(properties).not.toHaveProperty('$mcp_exec_tool_call_name')
             expect(properties).not.toHaveProperty('$mcp_exec_tool_call_description')
         } else {
-            expect(properties.$mcp_exec_tool_call_description).toBe(expectedValue)
+            expect(properties.$mcp_exec_tool_call_name).toBe(expectedName)
+            expect(properties.$mcp_exec_tool_call_description).toBe(expectedDescription)
         }
         // Identity-derived properties should always be there regardless of resolver outcome.
         expect(properties.$mcp_organization_id).toBe('org-789')
@@ -258,6 +262,7 @@ describe('initPostHogMcpAnalytics', () => {
             params: { name: 'exec', arguments: { command: 'call execute-sql {}' } },
         })
 
+        expect(properties).not.toHaveProperty('$mcp_exec_tool_call_name')
         expect(properties).not.toHaveProperty('$mcp_exec_tool_call_description')
     })
 

--- a/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
+++ b/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
@@ -213,10 +213,21 @@ describe('initPostHogMcpAnalytics', () => {
         })
     })
 
-    it('eventProperties adds $mcp_exec_tool_call_description when the resolver returns one', async () => {
+    it.each([
+        {
+            scenario: 'adds the property when the resolver returns a description',
+            resolverReturn: 'Run a HogQL/SQL query.',
+            expectedValue: 'Run a HogQL/SQL query.',
+        },
+        {
+            scenario: 'omits the property when the resolver returns undefined',
+            resolverReturn: undefined,
+            expectedValue: undefined,
+        },
+    ])('eventProperties $scenario', async ({ resolverReturn, expectedValue }) => {
         const server = new McpServer({ name: 'test', version: '1.0.0' })
         const identity = createMockIdentity()
-        const resolveExecInnerToolDescription = vi.fn().mockReturnValue('Run a HogQL/SQL query.')
+        const resolveExecInnerToolDescription = vi.fn().mockReturnValue(resolverReturn)
 
         await initPostHogMcpAnalytics(server, identity, {
             contextEnabled: false,
@@ -228,28 +239,13 @@ describe('initPostHogMcpAnalytics', () => {
         const properties = await getTrackOptions().eventProperties(fakeRequest)
 
         expect(resolveExecInnerToolDescription).toHaveBeenCalledWith(fakeRequest)
-        expect(properties.$mcp_exec_tool_call_description).toBe('Run a HogQL/SQL query.')
-        // Identity-derived properties should still be there.
+        if (expectedValue === undefined) {
+            expect(properties).not.toHaveProperty('$mcp_exec_tool_call_description')
+        } else {
+            expect(properties.$mcp_exec_tool_call_description).toBe(expectedValue)
+        }
+        // Identity-derived properties should always be there regardless of resolver outcome.
         expect(properties.$mcp_organization_id).toBe('org-789')
-    })
-
-    it('eventProperties omits $mcp_exec_tool_call_description when the resolver returns undefined', async () => {
-        const server = new McpServer({ name: 'test', version: '1.0.0' })
-        const identity = createMockIdentity()
-        const resolveExecInnerToolDescription = vi.fn().mockReturnValue(undefined)
-
-        await initPostHogMcpAnalytics(server, identity, {
-            contextEnabled: false,
-            reportMissingEnabled: false,
-            resolveExecInnerToolDescription,
-        })
-
-        const properties = await getTrackOptions().eventProperties({
-            params: { name: 'mcp_initialize' },
-        })
-
-        expect(resolveExecInnerToolDescription).toHaveBeenCalled()
-        expect(properties).not.toHaveProperty('$mcp_exec_tool_call_description')
     })
 
     it('eventProperties does not call the resolver when none is configured', async () => {

--- a/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
+++ b/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
@@ -48,13 +48,13 @@ describe('initPostHogMcpAnalytics', () => {
     function getTrackOptions(): {
         identify: () => Promise<unknown>
         eventTags: () => Promise<Record<string, string>>
-        eventProperties: () => Promise<Record<string, unknown>>
+        eventProperties: (request?: unknown) => Promise<Record<string, unknown>>
     } {
         const call = vi.mocked(track).mock.calls[0]!
         return call[1] as {
             identify: () => Promise<unknown>
             eventTags: () => Promise<Record<string, string>>
-            eventProperties: () => Promise<Record<string, unknown>>
+            eventProperties: (request?: unknown) => Promise<Record<string, unknown>>
         }
     }
 
@@ -211,6 +211,58 @@ describe('initPostHogMcpAnalytics', () => {
                 project: 'proj-uuid-101',
             },
         })
+    })
+
+    it('eventProperties adds $mcp_exec_tool_call_description when the resolver returns one', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+        const resolveExecInnerToolDescription = vi.fn().mockReturnValue('Run a HogQL/SQL query.')
+
+        await initPostHogMcpAnalytics(server, identity, {
+            contextEnabled: false,
+            reportMissingEnabled: false,
+            resolveExecInnerToolDescription,
+        })
+
+        const fakeRequest = { params: { name: 'exec', arguments: { command: 'call execute-sql {}' } } }
+        const properties = await getTrackOptions().eventProperties(fakeRequest)
+
+        expect(resolveExecInnerToolDescription).toHaveBeenCalledWith(fakeRequest)
+        expect(properties.$mcp_exec_tool_call_description).toBe('Run a HogQL/SQL query.')
+        // Identity-derived properties should still be there.
+        expect(properties.$mcp_organization_id).toBe('org-789')
+    })
+
+    it('eventProperties omits $mcp_exec_tool_call_description when the resolver returns undefined', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+        const resolveExecInnerToolDescription = vi.fn().mockReturnValue(undefined)
+
+        await initPostHogMcpAnalytics(server, identity, {
+            contextEnabled: false,
+            reportMissingEnabled: false,
+            resolveExecInnerToolDescription,
+        })
+
+        const properties = await getTrackOptions().eventProperties({
+            params: { name: 'mcp_initialize' },
+        })
+
+        expect(resolveExecInnerToolDescription).toHaveBeenCalled()
+        expect(properties).not.toHaveProperty('$mcp_exec_tool_call_description')
+    })
+
+    it('eventProperties does not call the resolver when none is configured', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        await initPostHogMcpAnalytics(server, identity)
+
+        const properties = await getTrackOptions().eventProperties({
+            params: { name: 'exec', arguments: { command: 'call execute-sql {}' } },
+        })
+
+        expect(properties).not.toHaveProperty('$mcp_exec_tool_call_description')
     })
 
     it('eventProperties callback omits $groups when analytics context is unavailable', async () => {

--- a/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
+++ b/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
@@ -266,6 +266,56 @@ describe('initPostHogMcpAnalytics', () => {
         expect(properties).not.toHaveProperty('$mcp_exec_tool_call_description')
     })
 
+    it('eventProperties attaches $mcp_exec_inner_tool_names on tools/list when execInnerToolNames is configured', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+        const execInnerToolNames = ['execute-sql', 'feature-flag-get-all', 'insight-get']
+
+        await initPostHogMcpAnalytics(server, identity, {
+            contextEnabled: false,
+            reportMissingEnabled: false,
+            execInnerToolNames,
+        })
+
+        const listRequest = { method: 'tools/list', params: {} }
+        const properties = await getTrackOptions().eventProperties(listRequest)
+
+        expect(properties.$mcp_exec_inner_tool_names).toEqual(execInnerToolNames)
+        // Other inner-call properties should be absent since this isn't a `call` request.
+        expect(properties).not.toHaveProperty('$mcp_exec_tool_call_name')
+    })
+
+    it('eventProperties does not attach $mcp_exec_inner_tool_names on non-list methods', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        await initPostHogMcpAnalytics(server, identity, {
+            contextEnabled: false,
+            reportMissingEnabled: false,
+            execInnerToolNames: ['execute-sql'],
+        })
+
+        const callRequest = { method: 'tools/call', params: { name: 'exec', arguments: { command: 'call execute-sql {}' } } }
+        const properties = await getTrackOptions().eventProperties(callRequest)
+
+        expect(properties).not.toHaveProperty('$mcp_exec_inner_tool_names')
+    })
+
+    it('eventProperties does not attach $mcp_exec_inner_tool_names when execInnerToolNames is empty', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        await initPostHogMcpAnalytics(server, identity, {
+            contextEnabled: false,
+            reportMissingEnabled: false,
+            execInnerToolNames: [],
+        })
+
+        const properties = await getTrackOptions().eventProperties({ method: 'tools/list', params: {} })
+
+        expect(properties).not.toHaveProperty('$mcp_exec_inner_tool_names')
+    })
+
     it('eventProperties callback omits $groups when analytics context is unavailable', async () => {
         const server = new McpServer({ name: 'test', version: '1.0.0' })
         const identity = createMockIdentity({

--- a/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
+++ b/services/mcp/tests/unit/posthog-mcp-analytics.test.ts
@@ -213,20 +213,28 @@ describe('initPostHogMcpAnalytics', () => {
         })
     })
 
-    it.each([
+    it.each<{
+        scenario: string
+        resolverReturn: { name: string; description: string } | undefined
+        expectedProperties: Record<string, unknown>
+        absentProperties: string[]
+    }>([
         {
             scenario: 'adds name + description when the resolver returns an inner tool',
             resolverReturn: { name: 'execute-sql', description: 'Run a HogQL/SQL query.' },
-            expectedName: 'execute-sql',
-            expectedDescription: 'Run a HogQL/SQL query.',
+            expectedProperties: {
+                $mcp_exec_tool_call_name: 'execute-sql',
+                $mcp_exec_tool_call_description: 'Run a HogQL/SQL query.',
+            },
+            absentProperties: [],
         },
         {
             scenario: 'omits both properties when the resolver returns undefined',
             resolverReturn: undefined,
-            expectedName: undefined,
-            expectedDescription: undefined,
+            expectedProperties: {},
+            absentProperties: ['$mcp_exec_tool_call_name', '$mcp_exec_tool_call_description'],
         },
-    ])('eventProperties $scenario', async ({ resolverReturn, expectedName, expectedDescription }) => {
+    ])('eventProperties $scenario', async ({ resolverReturn, expectedProperties, absentProperties }) => {
         const server = new McpServer({ name: 'test', version: '1.0.0' })
         const identity = createMockIdentity()
         const resolveExecInnerToolCall = vi.fn().mockReturnValue(resolverReturn)
@@ -241,12 +249,11 @@ describe('initPostHogMcpAnalytics', () => {
         const properties = await getTrackOptions().eventProperties(fakeRequest)
 
         expect(resolveExecInnerToolCall).toHaveBeenCalledWith(fakeRequest)
-        if (expectedDescription === undefined) {
-            expect(properties).not.toHaveProperty('$mcp_exec_tool_call_name')
-            expect(properties).not.toHaveProperty('$mcp_exec_tool_call_description')
-        } else {
-            expect(properties.$mcp_exec_tool_call_name).toBe(expectedName)
-            expect(properties.$mcp_exec_tool_call_description).toBe(expectedDescription)
+        for (const [key, value] of Object.entries(expectedProperties)) {
+            expect(properties[key]).toBe(value)
+        }
+        for (const key of absentProperties) {
+            expect(properties).not.toHaveProperty(key)
         }
         // Identity-derived properties should always be there regardless of resolver outcome.
         expect(properties.$mcp_organization_id).toBe('org-789')


### PR DESCRIPTION
## Summary

Three coupled changes around MCP tool-description visibility on analytics events:

1. **Bump `@posthog/mcp-analytics`** to `npm:@posthog/mcp@0.0.6`. `0.0.6` is unreleased at commit time and depends on PostHog/mcp-analytics#17. It builds on `0.0.5` (`$mcp_tool_description` on every `mcp_tool_call`) by also spreading customer-supplied `eventProperties`/`eventTags` onto the `$exception` event — without that fix, the new property and most of our existing identity context would silently drop on exactly the events you care about most (errors).
2. **New server-side property `$mcp_exec_tool_call_description`** for single-exec mode. In that mode every event's `$mcp_tool_name` is `exec` (the dispatcher), so the SDK's `$mcp_tool_description` would be the dispatcher's static text on every call — useless for triage. This new property is resolved server-side by parsing `arguments.command` and looking the inner tool up in the catalog, so when an agent runs `call my-tool {...}`, the event carries `my-tool`'s real description.
3. **Taxonomy entries** for both new properties so they get clear labels in the PostHog UI.

## Why

Feedback from an engineer triaging MCP errors: when they see a failure they can't easily remember what the tool was supposed to do, and we have a lot of tools. Having the description inline on the event removes the lookup. The SDK gives us this for free in multi-tool mode; the exec-mode wrinkle needed our own resolver.

## Notes

- `$mcp_exec_tool_call_description` is **only** set when an exec command is `call <tool> ...` and the inner tool exists in `allTools`. `info`/`schema`/`tools`/`search`/`query` verbs don't produce it because they don't actually invoke an inner tool.
- The new resolver is gated on `useSingleExec`; in multi-tool mode the SDK's `$mcp_tool_description` covers everything and the resolver is `undefined`.
- The parsing helper `parseExecCallInnerToolName` lives in `tools/exec.ts` alongside the existing `parseCommand` so the parser stays colocated with the verb definitions it has to match.

## Test plan

- [x] `tsc --noEmit` clean on modified files (one pre-existing error in `posthog-mcp-analytics.ts` for `enableConversationId` because local node_modules has `@posthog/mcp@0.0.2` — resolves once CI installs `0.0.6`).
- [x] Python AST parse of `posthog/taxonomy/taxonomy.py` succeeds.
- [ ] Manual: hit a tool via single-exec → see `$mcp_exec_tool_call_description` on the `mcp_tool_call` event in PostHog.
- [ ] Manual: hit a tool via single-exec that errors → see `$mcp_exec_tool_call_description` on the paired `$exception` event (depends on the 0.0.6 SDK fix).
- [ ] Manual: hit a tool via multi-tool mode → see `$mcp_tool_description` populated by the SDK.

## Order of operations

This PR depends on `@posthog/mcp@0.0.6` being on npm. **Do not merge until the SDK release is published.** SDK PRs: PostHog/mcp-analytics#16 (already merged, ships in 0.0.5) and PostHog/mcp-analytics#17 (the eventProperties-on-exception fix, ships in 0.0.6).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*