### PR TITLE
feat(mcp): propagate traceparent from cf worker to django

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -26,6 +26,7 @@ from django.utils.deprecation import MiddlewareMixin
 import structlog
 from django_prometheus.middleware import Metrics
 from loginas.utils import is_impersonated_session, restore_original_login
+from opentelemetry import trace
 from prometheus_client import Histogram
 from social_core.exceptions import AuthCanceled, AuthException, AuthFailed
 from statshog.defaults.django import statsd
@@ -35,7 +36,7 @@ from posthog.clickhouse.client.execute import clickhouse_query_counter
 from posthog.clickhouse.query_tagging import QueryCounter, get_query_tag_value, reset_query_tags, tag_queries
 from posthog.cloud_utils import is_cloud, is_dev_mode
 from posthog.constants import AUTH_BACKEND_KEYS
-from posthog.event_usage import get_event_source, get_mcp_properties
+from posthog.event_usage import get_event_source, get_mcp_properties, sanitize_header_value
 from posthog.geoip import get_geoip_properties
 from posthog.helpers.impersonation import get_original_user_from_session
 from posthog.helpers.user_devices import set_known_device_cookie
@@ -570,6 +571,38 @@ def per_request_logging_context_middleware(
             container_hostname=settings.CONTAINER_HOSTNAME,
             x_forwarded_for=request.headers.get("x-forwarded-for", ""),
         )
+
+        # Forwarded by the PostHog MCP server (services/mcp) on every API call.
+        # Binding here lets backend log lines and OTLP spans correlate with the
+        # same MCP context that's stamped on events.
+        #
+        # These headers are caller-asserted on a public API surface — anyone can
+        # set them on a request, so treat the resulting fields in logs/traces
+        # as correlation hints, not authoritative identifiers.
+        #
+        # The OTLP span tagging below depends on `DjangoInstrumentor` having
+        # already pushed a request span into the OTel context. The
+        # instrumentation library installs itself at MIDDLEWARE position 0 by
+        # default (see `posthog/otel_instrumentation.py`), so the span is in
+        # scope here. If that invariant ever changes, `set_attribute` becomes a
+        # silent no-op on the non-recording span.
+        mcp_session_id = sanitize_header_value(request.headers.get("X-Posthog-Mcp-Session-Id"))
+        mcp_conversation_id = sanitize_header_value(request.headers.get("X-Posthog-Mcp-Conversation-Id"))
+        mcp_context_bindings = {
+            k: v
+            for k, v in (
+                ("mcp_session_id", mcp_session_id),
+                ("mcp_conversation_id", mcp_conversation_id),
+            )
+            if v
+        }
+        if mcp_context_bindings:
+            structlog.contextvars.bind_contextvars(**mcp_context_bindings)
+            span = trace.get_current_span()
+            if mcp_session_id:
+                span.set_attribute("mcp.session_id", mcp_session_id)
+            if mcp_conversation_id:
+                span.set_attribute("mcp.conversation_id", mcp_conversation_id)
 
         return get_response(request)
 

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -9,10 +9,14 @@ from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 from django.core.cache import cache
-from django.http import HttpResponseRedirect
-from django.test import Client as DjangoClient
+from django.http import HttpResponse, HttpResponseRedirect
+from django.test import (
+    Client as DjangoClient,
+    RequestFactory,
+)
 from django.urls import reverse
 
+import structlog
 from loginas import settings as la_settings
 from parameterized import parameterized
 from rest_framework import status
@@ -21,6 +25,7 @@ from social_core.exceptions import AuthCanceled, AuthFailed, AuthMissingParamete
 
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
+from posthog.middleware import per_request_logging_context_middleware
 from posthog.models import Action, Cohort, FeatureFlag, Insight
 from posthog.models.organization import Organization
 from posthog.models.team import Team
@@ -2080,3 +2085,75 @@ def test_query_time_counting_middleware_should_instrument(path, expected) -> Non
     request = RequestFactory().get(path)
 
     assert middleware._should_instrument(request) is expected
+
+
+class TestPerRequestLoggingContextMiddlewareMcpHeaders(APIBaseTest):
+    """Covers MCP session header binding inside `per_request_logging_context_middleware`."""
+
+    def _run_middleware(self, **headers):
+        captured: dict[str, Any] = {}
+
+        def get_response(request):
+            captured["ctx"] = dict(structlog.contextvars.get_contextvars())
+            return HttpResponse()
+
+        try:
+            structlog.contextvars.clear_contextvars()
+            middleware = per_request_logging_context_middleware(get_response)
+            request = RequestFactory().get("/", **headers)
+            middleware(request)
+        finally:
+            structlog.contextvars.clear_contextvars()
+        return captured["ctx"]
+
+    @parameterized.expand(
+        [
+            (
+                "both_headers_present",
+                {
+                    "HTTP_X_POSTHOG_MCP_SESSION_ID": "abc123session",
+                    "HTTP_X_POSTHOG_MCP_CONVERSATION_ID": "01984ad9-bda4-7000-8000-abcdef012345",
+                },
+                "abc123session",
+                "01984ad9-bda4-7000-8000-abcdef012345",
+            ),
+            (
+                "session_id_alone",
+                {"HTTP_X_POSTHOG_MCP_SESSION_ID": "abc123session"},
+                "abc123session",
+                None,
+            ),
+            (
+                "conversation_id_alone",
+                {"HTTP_X_POSTHOG_MCP_CONVERSATION_ID": "01984ad9-bda4-7000-8000-abcdef012345"},
+                None,
+                "01984ad9-bda4-7000-8000-abcdef012345",
+            ),
+        ]
+    )
+    def test_binds_mcp_ids_when_present(self, _name, headers, expected_session, expected_conversation):
+        with patch("posthog.middleware.trace") as mock_trace:
+            span = MagicMock()
+            mock_trace.get_current_span.return_value = span
+            ctx = self._run_middleware(**headers)
+
+        if expected_session is not None:
+            assert ctx["mcp_session_id"] == expected_session
+            span.set_attribute.assert_any_call("mcp.session_id", expected_session)
+        else:
+            assert "mcp_session_id" not in ctx
+        if expected_conversation is not None:
+            assert ctx["mcp_conversation_id"] == expected_conversation
+            span.set_attribute.assert_any_call("mcp.conversation_id", expected_conversation)
+        else:
+            assert "mcp_conversation_id" not in ctx
+
+    def test_no_mcp_keys_bound_when_headers_absent(self):
+        with patch("posthog.middleware.trace") as mock_trace:
+            span = MagicMock()
+            mock_trace.get_current_span.return_value = span
+            ctx = self._run_middleware()
+
+        assert "mcp_session_id" not in ctx
+        assert "mcp_conversation_id" not in ctx
+        span.set_attribute.assert_not_called()

--- a/services/mcp/ARCHITECTURE.md
+++ b/services/mcp/ARCHITECTURE.md
@@ -125,6 +125,63 @@ log.emit(response.status) // Single log with all data + duration
 
 This produces one structured JSON log per request, making it easier to query in observability tools.
 
+### Tracking and observability
+
+There are three independent layers that emit signals about each MCP request:
+
+1. **PostHog analytics events** — `mcp_tool_call` and friends, captured for product analytics.
+2. **Outbound API headers** — propagated when the MCP server calls PostHog's Django backend, so backend log lines and OTLP spans can correlate with the originating MCP request.
+3. **Wide structured logs** — single JSON record per request from the Worker itself (see [Wide Logging Pattern](#wide-logging-pattern) above).
+
+#### `mcp_tool_call` event paths
+
+Three distinct code paths emit `mcp_tool_call` events; which one fires depends on the server mode and on the `mcp-posthog-analytics-sdk` feature flag:
+
+- **`mcp.ts:trackEvent`** — homegrown PostHog capture. Used by the exec-mode wrapper to emit events for inner tool calls. Properties use the bare form: `mcp_session_id`, `mcp_conversation_id`, `mcp_client_name`, etc.
+- **`lib/mcpcat.ts`** — legacy MCPcat SDK path. Same bare property names.
+- **`lib/posthog-mcp-analytics.ts`** — the [`@posthog/mcp-analytics`](https://github.com/PostHog/mcp-analytics) SDK. Property names are `$`-prefixed (`$mcp_session_id`, `$mcp_conversation_id`, …). This is the path most live traffic flows through today.
+
+Adding a new property to events means wiring it into the `McpCatIdentityProvider` interface and the property-builder in **all three** emitters, then sourcing the value on `requestProperties` (or pulling it from another DO-level source).
+
+#### Three correlation identifiers
+
+Three identifiers travel with each request, each with a different lifecycle and a different consumer:
+
+| Identifier                                          | Source                                                                                                                                                                                                                                                                                     | Where it lands                                                                                                                                                                                                             |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`sessionId`** (wrapper-app hint)                  | `?sessionId=` query param, set by integrators (setup wizard, sandbox, etc.)                                                                                                                                                                                                                | Resolved to a UUIDv7 via `SessionManager.getSessionUuid()` and stamped as `$session_id` / `$ai_session_id` on events — drives Session Replay and LLM Analytics grouping. Only set when a wrapper supplies it.              |
+| **`mcpSessionId`** (transport session)              | `Mcp-Session-Id` HTTP header, server-minted on initialize per the [Streamable-HTTP MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) and echoed by clients on every subsequent request                                                  | Stamped on `mcp_tool_call` events as `mcp_session_id` / `$mcp_session_id`, and forwarded to Django as `X-Posthog-Mcp-Session-Id` so backend structlog contextvars + OTLP span attributes (`mcp.session_id`) can correlate. |
+| **`mcpConversationId`** (agent-echoed conversation) | The `conversation_id` arg [injected into tool schemas](https://github.com/PostHog/mcp-analytics/pull/14) by `@posthog/mcp-analytics` when `enableConversationId: true`. The SDK mints a UUID and asks the agent to echo it on subsequent calls, so it persists across transport reconnects | Same plumbing as `mcpSessionId` — stamped on events and forwarded to Django as `X-Posthog-Mcp-Conversation-Id`.                                                                                                            |
+
+Crucially, **`sessionId` and `mcpSessionId` are different concepts** and will not match for the same request. The wrapper-app `sessionId` is only set for a small fraction of traffic (mostly integrator-driven flows); the transport `mcpSessionId` is on essentially every authenticated request after initialize.
+
+#### Forwarding session and conversation IDs to Django
+
+When the Worker calls PostHog's Django backend (any `ApiClient.fetch`), the outbound request carries:
+
+- `X-Posthog-Mcp-Session-Id: <mcpSessionId>` — when set on `ApiClient.config`
+- `X-Posthog-Mcp-Conversation-Id: <mcpConversationId>` — when set on `ApiClient.config`
+
+On the Django side, `per_request_logging_context_middleware` reads both headers (sanitized through the existing `sanitize_header_value` helper), binds them to structlog contextvars (`mcp_session_id`, `mcp_conversation_id`), and sets them on the current OTLP span as `mcp.session_id` / `mcp.conversation_id`.
+
+The headers are caller-asserted — anyone can spoof them on a request — so backend consumers should treat them as correlation hints, not authoritative identifiers.
+
+This is **attribute-based correlation, not distributed-trace span linkage** — the Worker emits no OTLP itself and forwards no `traceparent`, so the Django-rooted span is not a child of any Worker-side span. Tracing backends can correlate after the fact by querying on the attribute, but won't render a cross-service trace tree until Worker-side OTLP export ships.
+
+### Durable Object cold vs warm
+
+Cloudflare Durable Objects have two lifecycle states that matter when reasoning about cached state in this codebase:
+
+- **Cold start.** A request arrives, no live DO instance exists. The Cloudflare runtime constructs a fresh instance and calls `init()`. `_api`, `_cache`, and any other lazily-initialized fields are built from scratch. The DO is now "warm".
+- **Warm.** Subsequent requests reuse the same in-memory DO instance. `init()` does **not** re-run; cached fields (`_api`, `_cache`) keep the values captured on the cold start. Per-request props arrive via the framework's `updateProps` / `setName` ingress (which `McpAgent` overrides).
+- **Hibernation.** After ~10 s of inactivity, the runtime tears the DO down. The next request triggers a fresh cold start. DO storage (`this.ctx.storage`) persists across hibernation; in-memory caches do not.
+
+This matters for any value that's per-request but ends up snapshotted onto a long-lived cached object:
+
+- The cached `_api` is built once in `api()`, during `init()` on the cold start. The cold start's request is almost always an **initialize** call, which by spec does **not** carry the `Mcp-Session-Id` header (the server is about to mint it in the response). So `_api.config.mcpSessionId` is `undefined` at construction and stays that way for the warm DO's lifetime.
+- For values that need to refresh per request, mutate `_api.config` in place from `updateProps` / `setName` (the per-request ingress hooks). That's what `rotateCachedApiToken` does for `apiToken`.
+- Event emission is unaffected by this caching: `trackEvent` reads `this.requestProperties.mcpSessionId` directly per emission, and the `posthog-mcp-analytics` SDK reads `extra.sessionId` from the transport per event. So `mcp_session_id` lands on events even when `_api`'s copy is stale.
+
 ## OAuth Flow
 
 The server implements RFC 9728 (OAuth Protected Resource Metadata) and RFC 8414 (OAuth Authorization Server Metadata):

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -73,6 +73,8 @@ export interface ApiConfig {
     mcpProtocolVersion?: string | undefined
     mcpConsumer?: string | undefined
     oauthClientName?: string | undefined
+    mcpSessionId?: string | undefined
+    mcpConversationId?: string | undefined
 }
 
 type Endpoint = Record<string, any>
@@ -115,6 +117,15 @@ export class ApiClient {
                 : {}),
             ...(this.config.mcpConsumer ? { 'x-posthog-mcp-consumer': this.config.mcpConsumer } : {}),
             ...(this.config.oauthClientName ? { 'x-posthog-mcp-oauth-client-name': this.config.oauthClientName } : {}),
+            // Forward MCP session and conversation ids so backend logs and OTLP
+            // spans for downstream API hops can correlate with the same MCP context
+            // the events carry. This is attribute-based correlation only — we do
+            // not forward `traceparent` (the Worker emits no OTLP today), so the
+            // Django-rooted span is not a child of any Worker-side span.
+            ...(this.config.mcpSessionId ? { 'x-posthog-mcp-session-id': this.config.mcpSessionId } : {}),
+            ...(this.config.mcpConversationId
+                ? { 'x-posthog-mcp-conversation-id': this.config.mcpConversationId }
+                : {}),
             'X-PostHog-Client': 'mcp',
         }
         if (options?.body) {

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 import { getUserAgent } from '@/lib/constants'
 import { ErrorCode, PostHogPermissionError, PostHogValidationError } from '@/lib/errors'
+import { childTraceparent } from '@/lib/trace-context'
 import { getSearchParamsFromRecord } from '@/lib/utils.js'
 import type {
     ApiEventDefinition,
@@ -75,6 +76,7 @@ export interface ApiConfig {
     oauthClientName?: string | undefined
     mcpSessionId?: string | undefined
     mcpConversationId?: string | undefined
+    traceparent?: string | undefined
 }
 
 type Endpoint = Record<string, any>
@@ -119,13 +121,18 @@ export class ApiClient {
             ...(this.config.oauthClientName ? { 'x-posthog-mcp-oauth-client-name': this.config.oauthClientName } : {}),
             // Forward MCP session and conversation ids so backend logs and OTLP
             // spans for downstream API hops can correlate with the same MCP context
-            // the events carry. This is attribute-based correlation only — we do
-            // not forward `traceparent` (the Worker emits no OTLP today), so the
-            // Django-rooted span is not a child of any Worker-side span.
+            // the events carry.
             ...(this.config.mcpSessionId ? { 'x-posthog-mcp-session-id': this.config.mcpSessionId } : {}),
             ...(this.config.mcpConversationId
                 ? { 'x-posthog-mcp-conversation-id': this.config.mcpConversationId }
                 : {}),
+            // W3C trace context. We reuse the MCP request's trace id but mint a
+            // fresh span id per outbound call so Django's auto-instrumented
+            // request span lands as a remote-parent child of *this specific*
+            // outbound hop rather than a shared sibling parent. We don't export
+            // any Worker-side spans today — the span ids we emit are synthetic;
+            // they become real if/when Worker OTLP export ships.
+            ...(this.config.traceparent ? { traceparent: childTraceparent(this.config.traceparent) } : {}),
             'X-PostHog-Client': 'mcp',
         }
         if (options?.body) {

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -9,6 +9,7 @@ import {
 import { RequestLogger, withLogging } from '@/lib/logging'
 import { extractClientInfoFromBody } from '@/lib/mcp-client-info'
 import { buildRedirectUrl, matchAuthServerRedirect } from '@/lib/routing'
+import { mintTraceparent } from '@/lib/trace-context'
 import { hash, parseMcpMode, sanitizeHeaderValue } from '@/lib/utils'
 import type { CloudRegion } from '@/tools/types'
 
@@ -358,12 +359,24 @@ const handleRequest = async (
     // the same `requestProperties.mcpConversationId` slot.
     const mcpConversationId = sanitizeHeaderValue(request.headers.get('mcp-conversation-id') || undefined)
 
+    // W3C trace context propagation. Reuse the agent-supplied `traceparent`
+    // when present so an already-instrumented caller's trace continues
+    // through us; otherwise mint a fresh one so Django spans for downstream
+    // hops are rooted as remote-parent children of a synthetic Worker-side
+    // span. We do not export Worker-side OTLP today — see
+    // `services/mcp/src/lib/trace-context.ts`. The sampling decision on the
+    // minted path is deterministic-by-conversation/session, so all hops in
+    // one agent run are either traced together or dropped together.
+    const inboundTraceparent = sanitizeHeaderValue(request.headers.get('traceparent') || undefined)
+    const traceparent = inboundTraceparent ?? mintTraceparent({ mcpConversationId, mcpSessionId })
+
     Object.assign(ctx.props, {
         apiToken: token,
         userHash: hash(token),
         sessionId: sessionId || undefined,
         mcpSessionId,
         mcpConversationId,
+        traceparent,
         organizationId,
         projectId,
         clientUserAgent,

--- a/services/mcp/src/lib/trace-context.ts
+++ b/services/mcp/src/lib/trace-context.ts
@@ -1,0 +1,139 @@
+/**
+ * W3C trace context propagation helpers.
+ * See: https://www.w3.org/TR/trace-context/
+ *
+ * Format: `<version>-<trace-id>-<parent-id>-<flags>`
+ *   - version: `00`
+ *   - trace-id: 16 random bytes, hex-encoded (32 chars)
+ *   - parent-id: 8 random bytes, hex-encoded (16 chars)
+ *   - flags: `01` = sampled, `00` = unsampled
+ *
+ * We do NOT export Worker-side OTLP spans today. These helpers exist solely
+ * to give Django's auto-instrumented spans something to root under, so the
+ * Worker→Django hop produces a linked trace tree instead of merely
+ * attribute-correlated rows. When/if Worker-side OTLP export lands, the
+ * span ids we emit here become real and parent-child relationships line up
+ * end-to-end.
+ *
+ * ## Sampling
+ *
+ * Django is configured with `parentbased_traceidratio` and arg `0`, so
+ * traces without an inbound `traceparent` are sampled at 0% — Django would
+ * never record anything we don't explicitly mark as sampled. We therefore
+ * make the sampling decision at the Worker edge:
+ *
+ *   - If the inbound request carries a `traceparent`, we propagate the
+ *     caller's sampling flag faithfully (W3C-spec behaviour for
+ *     intermediaries).
+ *   - When we mint a fresh `traceparent`, we make a *deterministic*
+ *     sampling decision keyed (in order) on `mcp-conversation-id` →
+ *     `mcp-session-id` → the freshly-minted trace id. Same conversation /
+ *     session → same verdict, so all tool calls in one agent run are
+ *     either traced together or dropped together. The fallback to trace id
+ *     matches OTel's built-in `traceidratio` sampler.
+ */
+
+const TRACE_VERSION = '00'
+const TRACE_FLAGS_SAMPLED = '01'
+const TRACE_FLAGS_UNSAMPLED = '00'
+const TRACE_ID_BYTES = 16
+const SPAN_ID_BYTES = 8
+
+/**
+ * Default per-trace sample rate when minting at the Worker edge. Picked
+ * conservatively while we measure the Django-side OTLP volume impact; raise
+ * once we have signal that the volume is sustainable.
+ */
+const DEFAULT_TRACE_SAMPLE_RATIO = 0.1
+
+function randomHex(byteCount: number): string {
+    const bytes = crypto.getRandomValues(new Uint8Array(byteCount))
+    let hex = ''
+    for (const b of bytes) {
+        hex += b.toString(16).padStart(2, '0')
+    }
+    return hex
+}
+
+/**
+ * Deterministic ratio decision keyed on `key`. Takes the first 8 hex chars
+ * of the key as a u32 and compares to `ratio * 0xffffffff`. Same key → same
+ * verdict. Returns `false` (fail-safe) if the slice isn't hex.
+ */
+function sampleByKey(key: string, ratio: number): boolean {
+    const slice = key.slice(0, 8)
+    const value = parseInt(slice, 16)
+    if (Number.isNaN(value)) {
+        return false
+    }
+    return value / 0xffffffff < ratio
+}
+
+/**
+ * Decide whether a freshly-minted trace should be sampled.
+ *
+ * Preference order: conversation id → session id → trace id. The first
+ * non-empty value wins, so requests within the same agent conversation (or
+ * the same transport session) share a sampling verdict and produce a
+ * coherent trace tree across hops. Falling back to the trace id matches
+ * OTel's built-in `traceidratio` sampler when no MCP context is available.
+ */
+export function decideTraceSampling(opts: {
+    mcpConversationId?: string | undefined
+    mcpSessionId?: string | undefined
+    traceId: string
+    ratio?: number | undefined
+}): boolean {
+    const ratio = opts.ratio ?? DEFAULT_TRACE_SAMPLE_RATIO
+    if (ratio >= 1) {
+        return true
+    }
+    if (ratio <= 0) {
+        return false
+    }
+    const key = opts.mcpConversationId || opts.mcpSessionId || opts.traceId
+    return sampleByKey(key, ratio)
+}
+
+/**
+ * Mint a fresh `traceparent` value with random trace id + span id. The
+ * sampled flag is computed via `decideTraceSampling` using the supplied
+ * MCP context.
+ */
+export function mintTraceparent(opts?: {
+    mcpConversationId?: string | undefined
+    mcpSessionId?: string | undefined
+    ratio?: number
+}): string {
+    const traceId = randomHex(TRACE_ID_BYTES)
+    const spanId = randomHex(SPAN_ID_BYTES)
+    const sampled = decideTraceSampling({
+        mcpConversationId: opts?.mcpConversationId,
+        mcpSessionId: opts?.mcpSessionId,
+        traceId,
+        ratio: opts?.ratio,
+    })
+    const flags = sampled ? TRACE_FLAGS_SAMPLED : TRACE_FLAGS_UNSAMPLED
+    return `${TRACE_VERSION}-${traceId}-${spanId}-${flags}`
+}
+
+/**
+ * Build a child traceparent: reuse the trace id of `parent`, mint a fresh
+ * span id, and *preserve the parent's flags byte* so intermediaries don't
+ * silently override the original tracer's sampling decision (W3C §3.2.2.5).
+ * Returns `parent` unchanged if it doesn't parse — we'd rather forward an
+ * opaque value than drop trace continuity.
+ */
+export function childTraceparent(parent: string): string {
+    const parts = parent.split('-')
+    if (
+        parts.length !== 4 ||
+        parts[0] !== TRACE_VERSION ||
+        parts[1]?.length !== 32 ||
+        parts[2]?.length !== 16 ||
+        parts[3]?.length !== 2
+    ) {
+        return parent
+    }
+    return `${TRACE_VERSION}-${parts[1]}-${randomHex(SPAN_ID_BYTES)}-${parts[3]}`
+}

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -64,11 +64,11 @@ export type RequestProperties = {
     // own correlation key, available for direct MCP clients (Claude Code,
     // Cursor, …) that never set the wrapper-app `?sessionId=` hint.
     mcpSessionId?: string
-    // Agent-echoed conversation id from `@posthog/mcp-analytics` PR #14
-    // (`enableConversationId: true`). Plumbed alongside `mcpSessionId`
-    // through every identity-provider + emitter path so the consumer side
-    // is ready to read it; the producer-side source lands when that SDK
-    // PR ships and a header read is wired into `index.ts`.
+    // Agent-echoed conversation id from `@posthog/mcp-analytics`'s
+    // `enableConversationId: true`. Sourced today from the inbound
+    // `mcp-conversation-id` HTTP header (see `index.ts`). Persists across
+    // transport reconnects because the agent is asked to echo the value back
+    // on every subsequent tool call.
     mcpConversationId?: string
     features?: string[]
     tools?: string[]
@@ -260,6 +260,8 @@ export class MCP extends McpAgent<Env> {
                 mcpClientVersion: this.mcpClientVersion,
                 mcpProtocolVersion: this.mcpProtocolVersion,
                 mcpConsumer: this.requestProperties.mcpConsumer,
+                mcpSessionId: this.requestProperties.mcpSessionId,
+                mcpConversationId: this.requestProperties.mcpConversationId,
             })
         }
 
@@ -274,7 +276,11 @@ export class MCP extends McpAgent<Env> {
      * just the cached token here — leave `this.props` and storage alone.
      */
     async setName(name: string, props?: RequestProperties): Promise<void> {
-        this.rotateCachedApiToken(props?.apiToken)
+        this.rotateCachedApiTokenAndTraces({
+            apiToken: props?.apiToken,
+            mcpSessionId: props?.mcpSessionId,
+            mcpConversationId: props?.mcpConversationId,
+        })
         await super.setName(name, props)
     }
 
@@ -287,21 +293,56 @@ export class MCP extends McpAgent<Env> {
      */
     async updateProps(props?: RequestProperties): Promise<void> {
         this.props = props as RequestProperties
-        this.rotateCachedApiToken(props?.apiToken)
+        this.rotateCachedApiTokenAndTraces({
+            apiToken: props?.apiToken,
+            mcpSessionId: props?.mcpSessionId,
+            mcpConversationId: props?.mcpConversationId,
+        })
         await super.updateProps(props)
     }
 
     /**
-     * Rotate the cached ApiClient's auth token in place. Tool handlers read
-     * the token off `context.api.config.apiToken` — the captured ApiClient
-     * from init() — so replacing the instance would leave those references
-     * stale. Mutating in place keeps them pointing at the latest token.
-     * No-op when there's no cached client, no incoming token, or the token
-     * already matches.
+     * Refresh the cached ApiClient's per-request config in place. Tool handlers
+     * read these fields off `context.api.config` — the captured ApiClient from
+     * init() — so replacing the instance would leave those references stale.
+     * Mutating in place keeps them pointing at the latest values.
+     *
+     * Name is intentionally awkward to signal that this method has grown
+     * beyond just rotating the apiToken; rename more crisply when a natural
+     * grouping emerges.
+     *
+     * Three fields rotate per inbound request:
+     *   - `apiToken` — short-lived OAuth tokens get refreshed across the same
+     *     transport session.
+     *   - `mcpSessionId` — the `Mcp-Session-Id` HTTP header is *absent* on the
+     *     initialize call (where `_api` is first constructed) and present on
+     *     every subsequent request. Without this refresh, `_api` would be
+     *     pinned to `undefined` for the lifetime of a warm DO and the
+     *     `x-posthog-mcp-session-id` header would never be sent.
+     *   - `mcpConversationId` — same shape as `mcpSessionId`; sourced from
+     *     the inbound `mcp-conversation-id` header (today supplied by wrapper
+     *     apps; the `@posthog/mcp-analytics` SDK injects it via tool args, but
+     *     that path doesn't land on `requestProperties` yet).
+     *
+     * No-op when there's no cached client, or when an incoming field is empty
+     * (don't overwrite a real value with `undefined`).
      */
-    private rotateCachedApiToken(apiToken: string | undefined): void {
-        if (this._api && apiToken && this._api.config.apiToken !== apiToken) {
-            this._api.config.apiToken = apiToken
+    private rotateCachedApiTokenAndTraces(updates: {
+        apiToken: string | undefined
+        mcpSessionId: string | undefined
+        mcpConversationId: string | undefined
+    }): void {
+        if (!this._api) {
+            return
+        }
+        if (updates.apiToken && this._api.config.apiToken !== updates.apiToken) {
+            this._api.config.apiToken = updates.apiToken
+        }
+        if (updates.mcpSessionId && this._api.config.mcpSessionId !== updates.mcpSessionId) {
+            this._api.config.mcpSessionId = updates.mcpSessionId
+        }
+        if (updates.mcpConversationId && this._api.config.mcpConversationId !== updates.mcpConversationId) {
+            this._api.config.mcpConversationId = updates.mcpConversationId
         }
     }
 

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -70,6 +70,11 @@ export type RequestProperties = {
     // transport reconnects because the agent is asked to echo the value back
     // on every subsequent tool call.
     mcpConversationId?: string
+    // W3C `traceparent` for the inbound MCP request. Reused from the agent
+    // if it supplied one, otherwise minted in `index.ts`. Forwarded on every
+    // outbound API hop so Django's auto-instrumented spans are linked into
+    // the trace tree as remote-parent children. See `lib/trace-context.ts`.
+    traceparent?: string
     features?: string[]
     tools?: string[]
     region?: string
@@ -262,6 +267,7 @@ export class MCP extends McpAgent<Env> {
                 mcpConsumer: this.requestProperties.mcpConsumer,
                 mcpSessionId: this.requestProperties.mcpSessionId,
                 mcpConversationId: this.requestProperties.mcpConversationId,
+                traceparent: this.requestProperties.traceparent,
             })
         }
 
@@ -280,6 +286,7 @@ export class MCP extends McpAgent<Env> {
             apiToken: props?.apiToken,
             mcpSessionId: props?.mcpSessionId,
             mcpConversationId: props?.mcpConversationId,
+            traceparent: props?.traceparent,
         })
         await super.setName(name, props)
     }
@@ -297,6 +304,7 @@ export class MCP extends McpAgent<Env> {
             apiToken: props?.apiToken,
             mcpSessionId: props?.mcpSessionId,
             mcpConversationId: props?.mcpConversationId,
+            traceparent: props?.traceparent,
         })
         await super.updateProps(props)
     }
@@ -331,6 +339,7 @@ export class MCP extends McpAgent<Env> {
         apiToken: string | undefined
         mcpSessionId: string | undefined
         mcpConversationId: string | undefined
+        traceparent: string | undefined
     }): void {
         if (!this._api) {
             return
@@ -343,6 +352,9 @@ export class MCP extends McpAgent<Env> {
         }
         if (updates.mcpConversationId && this._api.config.mcpConversationId !== updates.mcpConversationId) {
             this._api.config.mcpConversationId = updates.mcpConversationId
+        }
+        if (updates.traceparent && this._api.config.traceparent !== updates.traceparent) {
+            this._api.config.traceparent = updates.traceparent
         }
     }
 

--- a/services/mcp/tests/unit/api-client.test.ts
+++ b/services/mcp/tests/unit/api-client.test.ts
@@ -185,6 +185,51 @@ describe('ApiClient', () => {
         vi.unstubAllGlobals()
     })
 
+    it('forwards traceparent with a fresh span id per outbound call', async () => {
+        const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+        vi.stubGlobal('fetch', mockFetch)
+
+        const parent = '00-0123456789abcdef0123456789abcdef-fedcba9876543210-01'
+        const client = new ApiClient({
+            apiToken: 'test-token-123',
+            baseUrl: 'https://example.com',
+            traceparent: parent,
+        })
+
+        await (client as any).fetch('https://example.com/api/a', { method: 'GET' })
+        await (client as any).fetch('https://example.com/api/b', { method: 'GET' })
+
+        const tp1 = mockFetch.mock.calls[0]![1].headers.traceparent
+        const tp2 = mockFetch.mock.calls[1]![1].headers.traceparent
+        // Same trace id (middle segment)…
+        expect(tp1.split('-')[1]).toBe('0123456789abcdef0123456789abcdef')
+        expect(tp2.split('-')[1]).toBe('0123456789abcdef0123456789abcdef')
+        // …distinct span ids per outbound call…
+        expect(tp1.split('-')[2]).not.toBe(tp2.split('-')[2])
+        // …and the original parent's span id is *not* reused on either.
+        expect(tp1.split('-')[2]).not.toBe('fedcba9876543210')
+        expect(tp2.split('-')[2]).not.toBe('fedcba9876543210')
+
+        vi.unstubAllGlobals()
+    })
+
+    it('omits traceparent when not configured', async () => {
+        const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+        vi.stubGlobal('fetch', mockFetch)
+
+        const client = new ApiClient({
+            apiToken: 'test-token-123',
+            baseUrl: 'https://example.com',
+        })
+
+        await (client as any).fetch('https://example.com/api/test', { method: 'GET' })
+
+        const [, options] = mockFetch.mock.calls[0]!
+        expect(options.headers).not.toHaveProperty('traceparent')
+
+        vi.unstubAllGlobals()
+    })
+
     describe('insights().get() — overrides forwarding', () => {
         const variablesOverride =
             '{"019d4838-1da4-0000-33c7-2561bf01f1c9":{"code_name":"eventname","variableId":"019d4838-1da4-0000-33c7-2561bf01f1c9","value":"signed_up"}}'

--- a/services/mcp/tests/unit/api-client.test.ts
+++ b/services/mcp/tests/unit/api-client.test.ts
@@ -128,6 +128,63 @@ describe('ApiClient', () => {
         vi.unstubAllGlobals()
     })
 
+    it('forwards mcpSessionId and mcpConversationId as x-posthog-mcp-* headers when provided', async () => {
+        const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+        vi.stubGlobal('fetch', mockFetch)
+
+        const client = new ApiClient({
+            apiToken: 'test-token-123',
+            baseUrl: 'https://example.com',
+            mcpSessionId: 'abc123session',
+            mcpConversationId: '01984ad9-bda4-7000-8000-abcdef012345',
+        })
+
+        await (client as any).fetch('https://example.com/api/test', { method: 'GET' })
+
+        const [, options] = mockFetch.mock.calls[0]!
+        expect(options.headers['x-posthog-mcp-session-id']).toBe('abc123session')
+        expect(options.headers['x-posthog-mcp-conversation-id']).toBe('01984ad9-bda4-7000-8000-abcdef012345')
+
+        vi.unstubAllGlobals()
+    })
+
+    it('forwards only the headers that are set', async () => {
+        const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+        vi.stubGlobal('fetch', mockFetch)
+
+        const client = new ApiClient({
+            apiToken: 'test-token-123',
+            baseUrl: 'https://example.com',
+            mcpSessionId: 'only-session',
+        })
+
+        await (client as any).fetch('https://example.com/api/test', { method: 'GET' })
+
+        const [, options] = mockFetch.mock.calls[0]!
+        expect(options.headers['x-posthog-mcp-session-id']).toBe('only-session')
+        expect(options.headers).not.toHaveProperty('x-posthog-mcp-conversation-id')
+
+        vi.unstubAllGlobals()
+    })
+
+    it('omits both headers when neither id is set', async () => {
+        const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+        vi.stubGlobal('fetch', mockFetch)
+
+        const client = new ApiClient({
+            apiToken: 'test-token-123',
+            baseUrl: 'https://example.com',
+        })
+
+        await (client as any).fetch('https://example.com/api/test', { method: 'GET' })
+
+        const [, options] = mockFetch.mock.calls[0]!
+        expect(options.headers).not.toHaveProperty('x-posthog-mcp-session-id')
+        expect(options.headers).not.toHaveProperty('x-posthog-mcp-conversation-id')
+
+        vi.unstubAllGlobals()
+    })
+
     describe('insights().get() — overrides forwarding', () => {
         const variablesOverride =
             '{"019d4838-1da4-0000-33c7-2561bf01f1c9":{"code_name":"eventname","variableId":"019d4838-1da4-0000-33c7-2561bf01f1c9","value":"signed_up"}}'

--- a/services/mcp/tests/unit/mcp-api-caching.test.ts
+++ b/services/mcp/tests/unit/mcp-api-caching.test.ts
@@ -296,3 +296,115 @@ describe('MCP.updateProps() token propagation (cold start / hibernation)', () =>
         expect(api.config.apiToken).toBe('token-A')
     })
 })
+
+describe('MCP.setName() MCP-id rotation (warm DO path)', () => {
+    // The `Mcp-Session-Id` HTTP header is absent on the initialize call but
+    // present on every request after. Without explicit rotation, `_api` —
+    // constructed during init() with `mcpSessionId: undefined` — would never
+    // see the header and `x-posthog-mcp-session-id` would never be sent on
+    // the outbound API hops. These tests pin that rotation behaviour for
+    // both the protocol session id and the conversation id.
+    beforeEach(() => {
+        ApiClientCtor.mockClear()
+        storagePutSpy.mockClear()
+        superSetNameSpy.mockClear()
+        superUpdatePropsSpy.mockClear()
+    })
+
+    function buildMcpWithMcpIds(opts: { mcpSessionId?: string; mcpConversationId?: string } = {}): MCP {
+        const mcp = buildMcp('token-A')
+        ;(mcp as any).props = {
+            ...(mcp as any).props,
+            ...(opts.mcpSessionId !== undefined ? { mcpSessionId: opts.mcpSessionId } : {}),
+            ...(opts.mcpConversationId !== undefined ? { mcpConversationId: opts.mcpConversationId } : {}),
+        }
+        return mcp
+    }
+
+    it('updates the cached ApiClient mcpSessionId when the header appears on a later request', async () => {
+        // Reproduces the production bug: init() runs before any inbound
+        // `Mcp-Session-Id` exists, so `_api` is built with `mcpSessionId:
+        // undefined`. The next request *does* carry the header and must
+        // propagate onto the cached client.
+        const mcp = buildMcpWithMcpIds()
+        const api = await mcp.api()
+        expect(api.config.mcpSessionId).toBeUndefined()
+
+        await (mcp as any).setName('streamable-http:session-1', {
+            userHash: 'user-hash',
+            apiToken: 'token-A',
+            mcpSessionId: 'mcp-session-abc',
+        })
+
+        expect(api.config.mcpSessionId).toBe('mcp-session-abc')
+        expect(ApiClientCtor).toHaveBeenCalledTimes(1)
+    })
+
+    it('updates the cached ApiClient mcpConversationId when one appears', async () => {
+        const mcp = buildMcpWithMcpIds()
+        const api = await mcp.api()
+        expect(api.config.mcpConversationId).toBeUndefined()
+
+        await (mcp as any).setName('streamable-http:session-1', {
+            userHash: 'user-hash',
+            apiToken: 'token-A',
+            mcpConversationId: 'conv-xyz',
+        })
+
+        expect(api.config.mcpConversationId).toBe('conv-xyz')
+    })
+
+    it('does not overwrite a populated id with undefined', async () => {
+        // If the cached value is already set and a later request omits the
+        // header, the cached value must win — otherwise transport blips
+        // would clear the correlation id mid-session.
+        const mcp = buildMcpWithMcpIds({ mcpSessionId: 'mcp-session-abc' })
+        const api = await mcp.api()
+        expect(api.config.mcpSessionId).toBe('mcp-session-abc')
+
+        await (mcp as any).setName('streamable-http:session-1', {
+            userHash: 'user-hash',
+            apiToken: 'token-A',
+            mcpSessionId: undefined,
+        })
+
+        expect(api.config.mcpSessionId).toBe('mcp-session-abc')
+    })
+})
+
+describe('MCP.updateProps() MCP-id rotation (cold start / hibernation)', () => {
+    beforeEach(() => {
+        ApiClientCtor.mockClear()
+        storagePutSpy.mockClear()
+        superSetNameSpy.mockClear()
+        superUpdatePropsSpy.mockClear()
+    })
+
+    it('propagates a fresh mcpSessionId onto the cached ApiClient', async () => {
+        const mcp = buildMcp('token-A')
+        const api = await mcp.api()
+        expect(api.config.mcpSessionId).toBeUndefined()
+
+        await (mcp as any).updateProps({
+            userHash: 'user-hash',
+            apiToken: 'token-A',
+            mcpSessionId: 'mcp-session-abc',
+        })
+
+        expect(api.config.mcpSessionId).toBe('mcp-session-abc')
+    })
+
+    it('propagates a fresh mcpConversationId onto the cached ApiClient', async () => {
+        const mcp = buildMcp('token-A')
+        const api = await mcp.api()
+        expect(api.config.mcpConversationId).toBeUndefined()
+
+        await (mcp as any).updateProps({
+            userHash: 'user-hash',
+            apiToken: 'token-A',
+            mcpConversationId: 'conv-xyz',
+        })
+
+        expect(api.config.mcpConversationId).toBe('conv-xyz')
+    })
+})

--- a/services/mcp/tests/unit/mcp-api-caching.test.ts
+++ b/services/mcp/tests/unit/mcp-api-caching.test.ts
@@ -407,4 +407,19 @@ describe('MCP.updateProps() MCP-id rotation (cold start / hibernation)', () => {
 
         expect(api.config.mcpConversationId).toBe('conv-xyz')
     })
+
+    it('propagates a fresh traceparent onto the cached ApiClient', async () => {
+        const mcp = buildMcp('token-A')
+        const api = await mcp.api()
+        expect(api.config.traceparent).toBeUndefined()
+
+        const traceparent = '00-0123456789abcdef0123456789abcdef-fedcba9876543210-01'
+        await (mcp as any).updateProps({
+            userHash: 'user-hash',
+            apiToken: 'token-A',
+            traceparent,
+        })
+
+        expect(api.config.traceparent).toBe(traceparent)
+    })
 })

--- a/services/mcp/tests/unit/trace-context.test.ts
+++ b/services/mcp/tests/unit/trace-context.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+
+import { childTraceparent, decideTraceSampling, mintTraceparent } from '@/lib/trace-context'
+
+const W3C_TRACEPARENT = /^00-[0-9a-f]{32}-[0-9a-f]{16}-(00|01)$/
+
+describe('mintTraceparent', () => {
+    it('produces a W3C-formatted traceparent', () => {
+        expect(mintTraceparent()).toMatch(W3C_TRACEPARENT)
+    })
+
+    it('mints distinct trace ids on successive calls', () => {
+        const a = mintTraceparent()
+        const b = mintTraceparent()
+        expect(a).not.toBe(b)
+        expect(a.split('-')[1]).not.toBe(b.split('-')[1])
+    })
+
+    it('forces sampled=01 when ratio is 1', () => {
+        expect(mintTraceparent({ ratio: 1 }).endsWith('-01')).toBe(true)
+    })
+
+    it('forces sampled=00 when ratio is 0', () => {
+        expect(mintTraceparent({ ratio: 0 }).endsWith('-00')).toBe(true)
+    })
+
+    it('makes the same sampling decision for the same conversation id', () => {
+        const a = mintTraceparent({ mcpConversationId: 'conv-stable', ratio: 0.5 })
+        const b = mintTraceparent({ mcpConversationId: 'conv-stable', ratio: 0.5 })
+        expect(a.split('-')[3]).toBe(b.split('-')[3])
+    })
+
+    it('makes the same sampling decision for the same session id', () => {
+        const a = mintTraceparent({ mcpSessionId: '0123456789abcdef0123456789abcdef', ratio: 0.5 })
+        const b = mintTraceparent({ mcpSessionId: '0123456789abcdef0123456789abcdef', ratio: 0.5 })
+        expect(a.split('-')[3]).toBe(b.split('-')[3])
+    })
+
+    it('prefers conversation id over session id for the sampling key', () => {
+        // Pick two keys that hash to different sides of ratio=0.5: '00000000'
+        // → 0 < 0.5 (sampled), 'ffffffff' → 1.0 ≥ 0.5 (not sampled).
+        const conv = '00000000-conv'
+        const sess = 'ffffffff-sess'
+        const tp = mintTraceparent({ mcpConversationId: conv, mcpSessionId: sess, ratio: 0.5 })
+        expect(tp.endsWith('-01')).toBe(true) // conversation wins → sampled
+    })
+})
+
+describe('decideTraceSampling', () => {
+    it('returns true when ratio >= 1, regardless of key', () => {
+        expect(decideTraceSampling({ traceId: 'ffffffffffffffffffffffffffffffff', ratio: 1 })).toBe(true)
+        expect(decideTraceSampling({ traceId: '00000000000000000000000000000000', ratio: 1.5 })).toBe(true)
+    })
+
+    it('returns false when ratio <= 0, regardless of key', () => {
+        expect(decideTraceSampling({ traceId: '00000000000000000000000000000000', ratio: 0 })).toBe(false)
+        expect(decideTraceSampling({ traceId: 'ffffffffffffffffffffffffffffffff', ratio: -1 })).toBe(false)
+    })
+
+    it.each([
+        // Lowest hex prefix → always sampled at any ratio > 0
+        ['00000000abcdef00', 0.01, true],
+        // Highest hex prefix → never sampled below ratio=1
+        ['ffffffffabcdef00', 0.99, false],
+        // Mid prefix → boundary behaviour
+        ['80000000abcdef00', 0.6, true],
+        ['80000000abcdef00', 0.4, false],
+    ])('uses the first 8 hex chars of the key to decide (key=%s, ratio=%s → %s)', (key, ratio, expected) => {
+        expect(decideTraceSampling({ traceId: key, ratio })).toBe(expected)
+    })
+
+    it('falls back to false when the key prefix is not hex', () => {
+        expect(decideTraceSampling({ traceId: 'not-hex!', ratio: 0.5 })).toBe(false)
+    })
+
+    it('defaults to a 10% ratio when none is provided', () => {
+        // 0.0fffffff → ~6% of u32 space → comfortably below 10%
+        expect(decideTraceSampling({ traceId: '0fffffff' + '0'.repeat(24) })).toBe(true)
+        // 0x20000000 ≈ 12.5% — just above 10% threshold
+        expect(decideTraceSampling({ traceId: '20000000' + '0'.repeat(24) })).toBe(false)
+    })
+})
+
+describe('childTraceparent', () => {
+    const parent = '00-0123456789abcdef0123456789abcdef-fedcba9876543210-01'
+
+    it('preserves the parent trace id', () => {
+        const child = childTraceparent(parent)
+        expect(child.split('-')[1]).toBe('0123456789abcdef0123456789abcdef')
+    })
+
+    it('preserves the parent flags byte (does not force sampled)', () => {
+        const unsampled = '00-0123456789abcdef0123456789abcdef-fedcba9876543210-00'
+        expect(childTraceparent(unsampled).endsWith('-00')).toBe(true)
+        expect(childTraceparent(parent).endsWith('-01')).toBe(true)
+    })
+
+    it('mints a fresh span id distinct from the parent', () => {
+        const child = childTraceparent(parent)
+        const childSpanId = child.split('-')[2]
+        expect(childSpanId).toMatch(/^[0-9a-f]{16}$/)
+        expect(childSpanId).not.toBe('fedcba9876543210')
+    })
+
+    it.each([
+        ['empty', ''],
+        ['wrong version', 'ff-0123456789abcdef0123456789abcdef-fedcba9876543210-01'],
+        ['short trace id', '00-0123-fedcba9876543210-01'],
+        ['short span id', '00-0123456789abcdef0123456789abcdef-fe-01'],
+        ['short flags', '00-0123456789abcdef0123456789abcdef-fedcba9876543210-1'],
+        ['three parts', '00-0123456789abcdef0123456789abcdef-fedcba9876543210'],
+        ['garbage', 'not-a-traceparent'],
+    ])('returns the input unchanged when %s', (_name, input) => {
+        expect(childTraceparent(input)).toBe(input)
+    })
+})


### PR DESCRIPTION
## Problem

[#58467](https://github.com/PostHog/posthog/pull/58467) forwards MCP session and conversation ids to Django and stamps them as OTLP span attributes — but those Django spans aren't linked into a trace tree. They sit rooted at Django, with `mcp.session_id` as a discoverable attribute, and have no parent span on the Worker side.

## Changes

Generate a W3C `traceparent` per inbound MCP request and forward it on every outbound `fetch` from the Worker. Django's existing `DjangoInstrumentor` picks it up and roots its span as a remote-parent child.

- `services/mcp/src/lib/trace-context.ts` (new) — `mintTraceparent`, `childTraceparent`, `decideTraceSampling`, and a `sampleByKey` helper.
- `services/mcp/src/index.ts` — reuse the agent-supplied `traceparent` if present (full upstream-trace continuity); otherwise mint a fresh one and pass the MCP session / conversation ids so the sampling decision is keyed off them.
- `services/mcp/src/mcp.ts` — add `traceparent` to `RequestProperties`, thread through `ApiClient`, rotate it on every props-ingress so warm Durable Objects always carry the latest value.
- `services/mcp/src/api/client.ts` — on every outbound `fetch`, emit `traceparent: <childTraceparent(parent)>` so each Django request gets a distinct parent span id under a shared trace id.

We do **not** export Worker-side OTLP spans today — the span ids we emit are synthetic. They become real parent ids if/when Worker OTLP export ships, and the implementation here doesn't change.

## Sampling — deterministic by MCP context

Django is configured with `parentbased_traceidratio` and arg `0` (see `posthog/otel_instrumentation.py`), so a freshly-minted root trace would be sampled at 0%. We therefore make the sampling decision at the Worker edge:

- **Inbound `traceparent` present** → forward the caller's flags byte faithfully. `childTraceparent` preserves it on every hop (W3C §3.2.2.5 — intermediaries do not override the original tracer's decision).
- **Minted at the edge** → `decideTraceSampling` picks deterministically from the first non-empty of `mcp_conversation_id` / `mcp_session_id` / minted `trace_id`. Hash is "first 8 hex chars → u32 → compare to ratio." Same conversation or session → same verdict, so all hops in one agent run are either traced together or dropped together.

**Default rate: 10%** (`DEFAULT_TRACE_SAMPLE_RATIO`). Conservative while we observe Django-side OTLP volume; bump once we have signal. Easy to elevate to an env var if we want it knob-tunable.

## Trace id source — random vs. derived

The trace id is generated randomly per inbound MCP request. An alternative would be to derive it from `mcpSessionId` (first 32 hex chars), so `trace_id == mcpSessionId[:32]` in queries — a clean cross-trace join key. The downside is that all tool calls within one MCP session would conflate into a single trace, which most tracing UIs render badly. Going with random and keeping `mcp.session_id` as a span attribute for cross-trace correlation.

## How did you test this code?

I'm an agent. I ran `pnpm test tests/unit/trace-context.test.ts tests/unit/api-client.test.ts tests/unit/mcp-api-caching.test.ts` — 64 passed. `pnpm typecheck` clean on touched files. No live deploy verification.

Coverage on the sampler:

- 25 tests in `trace-context.test.ts`: traceparent shape, distinct trace ids per mint, ratio=1/ratio=0 force behaviour, conversation-id-preferred-over-session-id, parent flag preservation in `childTraceparent`, malformed inputs returning unchanged, hex-prefix ratio decisions, fail-safe on non-hex prefix.
- Existing api-client tests verify per-fetch span id rotation under the same trace id.
- mcp-api-caching tests verify rotation via `setName` / `updateProps` on warm Durable Objects.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code, prompted by @lricoy.
- Stacked on top of [#58467](https://github.com/PostHog/posthog/pull/58467) — the new `traceparent` field reuses the rotation seam (`rotateCachedApiTokenAndTraces`) introduced there. Rebases naturally onto master once #58467 merges.
- Initial draft had `childTraceparent` unconditionally setting the sampled flag to `01` (defeats upstream opt-out + would inflate Django OTLP volume since Django's default ratio is 0). Round-2 QA flagged this; the current implementation makes the sampling decision once at the edge via deterministic hashing and lets `childTraceparent` preserve it.
- Considered emitting the Worker span via `@microlabs/otel-cf-workers` or Cloudflare's first-party Workers Observability — both deferred. The `traceparent`-only approach gives the trace-tree continuity we need without committing to a Worker-side observability backend or paying the bundle-size / CPU-time cost of running an exporter in the Worker.
