### PR TITLE
fix(tasks): Resolve MCP URL for local dev sandboxes

### DIFF
--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -110,16 +110,33 @@ class TestGetSandboxMcpConfigs(TestCase):
             ]
 
     @parameterized.expand(
-        [
-            ("http://localhost:8000",),
-            ("https://custom.example.com",),
-        ]
+        [("https://custom.example.com",)],
     )
     def test_returns_empty_list_for_unknown_hosts(self, site_url: str) -> None:
         with patch("products.tasks.backend.temporal.process_task.utils.settings") as mock_settings:
             mock_settings.SANDBOX_MCP_URL = None
             mock_settings.SITE_URL = site_url
             assert get_sandbox_ph_mcp_configs(self.TOKEN, self.PROJECT_ID) == []
+
+    @parameterized.expand(
+        [
+            ("http://localhost:8000",),
+            ("http://127.0.0.1:8001",),
+        ]
+    )
+    def test_localhost_site_url_uses_host_docker_internal_mcp(self, site_url: str) -> None:
+        with patch("products.tasks.backend.temporal.process_task.utils.settings") as mock_settings:
+            mock_settings.SANDBOX_MCP_URL = None
+            mock_settings.SITE_URL = site_url
+            configs = get_sandbox_ph_mcp_configs(self.TOKEN, self.PROJECT_ID)
+            assert configs == [
+                McpServerConfig(
+                    type="http",
+                    name="posthog",
+                    url="http://host.docker.internal:8787/mcp",
+                    headers=self._expected_headers(),
+                )
+            ]
 
     def test_returns_empty_list_when_no_site_url(self) -> None:
         with patch("products.tasks.backend.temporal.process_task.utils.settings") as mock_settings:

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -321,6 +321,7 @@ def _resolve_mcp_url() -> str | None:
 
     # Local dev: point to the local wrangler dev MCP server via
     # host.docker.internal, since the sandbox runs in Docker.
+    # On Linux without Docker Desktop, set SANDBOX_MCP_URL instead.
     if hostname in ("localhost", "127.0.0.1"):
         return "http://host.docker.internal:8787/mcp"
 

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -319,6 +319,11 @@ def _resolve_mcp_url() -> str | None:
     if hostname == "eu.posthog.com":
         return "https://mcp-eu.posthog.com/mcp"
 
+    # Local dev: point to the local wrangler dev MCP server via
+    # host.docker.internal, since the sandbox runs in Docker.
+    if hostname in ("localhost", "127.0.0.1"):
+        return "http://host.docker.internal:8787/mcp"
+
     return None
 
 


### PR DESCRIPTION
## Problem

Local dev sandbox agents (Docker-based) never got the PostHog MCP server connected - `_resolve_mcp_url()` returned `None` for localhost, so tasks like agentic test flow detection couldn't use any PostHog MCP tools.

## Changes

Fall through to `http://host.docker.internal:8787/mcp` when `SITE_URL` is localhost, pointing to the local wrangler dev MCP server.

## How did you test this code?

Ran agentic test flow detection locally with the MCP dev server running - agent now has PostHog tools available.