### PR TITLE
fix(surveys): preserve branching when adding, moving, or deleting questions

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -288,6 +288,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         setEditingLanguage,
         setFlagPropertyErrors,
         deleteBranchingLogic,
+        moveQuestion,
         setSurveyManualErrors,
         editingSurvey,
         loadSurvey,
@@ -337,16 +338,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
     }
 
     function onSortEnd({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }): void {
-        function move(arr: SurveyQuestion[], from: number, to: number): SurveyQuestion[] {
-            const clone = [...arr]
-            // Remove the element from the array
-            const [element] = clone.splice(from, 1)
-            // Insert the element at the new position
-            clone.splice(to, 0, element)
-            return clone.map((child) => ({ ...child }))
-        }
-
-        setSurveyValue('questions', move(survey.questions, oldIndex, newIndex))
+        moveQuestion(oldIndex, newIndex)
         setSelectedPageIndex(newIndex)
     }
 
@@ -738,37 +730,10 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                             <DndContext
                                                 onDragEnd={({ active, over }) => {
                                                     if (over && active.id !== over.id) {
-                                                        const finishDrag = (): void =>
-                                                            onSortEnd({
-                                                                oldIndex: sortedItemIds.indexOf(active.id.toString()),
-                                                                newIndex: sortedItemIds.indexOf(over.id.toString()),
-                                                            })
-
-                                                        if (hasBranchingLogic) {
-                                                            LemonDialog.open({
-                                                                title: 'Your survey has active branching logic',
-                                                                description: (
-                                                                    <p className="py-2">
-                                                                        Rearranging questions will remove your branching
-                                                                        logic. Are you sure you want to continue?
-                                                                    </p>
-                                                                ),
-
-                                                                primaryButton: {
-                                                                    children: 'Continue',
-                                                                    status: 'danger',
-                                                                    onClick: () => {
-                                                                        deleteBranchingLogic()
-                                                                        finishDrag()
-                                                                    },
-                                                                },
-                                                                secondaryButton: {
-                                                                    children: 'Cancel',
-                                                                },
-                                                            })
-                                                        } else {
-                                                            finishDrag()
-                                                        }
+                                                        onSortEnd({
+                                                            oldIndex: sortedItemIds.indexOf(active.id.toString()),
+                                                            newIndex: sortedItemIds.indexOf(over.id.toString()),
+                                                        })
                                                     }
                                                 }}
                                             >
@@ -800,7 +765,6 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                             index={index}
                                                                             survey={survey}
                                                                             setSelectedPageIndex={setSelectedPageIndex}
-                                                                            setSurveyValue={setSurveyValue}
                                                                             translationValidationErrors={
                                                                                 activeTranslationValidationErrors
                                                                             }

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -33,7 +33,6 @@ type SurveyQuestionHeaderProps = {
     index: number
     survey: Survey | NewSurvey
     setSelectedPageIndex: (index: number) => void
-    setSurveyValue: (key: string, value: any) => void
     translationValidationErrors?: Array<{ language: string; questionIndex: number; field: string; error: string }>
     translationErrorsByQuestion?: (
         questionIndex: number
@@ -55,11 +54,10 @@ export function SurveyEditQuestionHeader({
     index,
     survey,
     setSelectedPageIndex,
-    setSurveyValue,
     translationErrorsByQuestion,
 }: SurveyQuestionHeaderProps): JSX.Element {
-    const { hasBranchingLogic, editingLanguage } = useValues(surveyLogic)
-    const { deleteBranchingLogic } = useActions(surveyLogic)
+    const { editingLanguage } = useValues(surveyLogic)
+    const { removeQuestion } = useActions(surveyLogic)
     const { setNodeRef, attributes, transform, transition, listeners, isDragging } = useSortable({
         id: index.toString(),
     })
@@ -104,39 +102,9 @@ export function SurveyEditQuestionHeader({
                         size="xsmall"
                         data-attr={`delete-survey-question-${index}`}
                         onClick={(e) => {
-                            const deleteQuestion = (): void => {
-                                e.stopPropagation()
-                                setSelectedPageIndex(index <= 0 ? 0 : index - 1)
-                                setSurveyValue(
-                                    'questions',
-                                    survey.questions.filter((_, i) => i !== index)
-                                )
-                            }
-
-                            if (hasBranchingLogic) {
-                                LemonDialog.open({
-                                    title: 'Your survey has active branching logic',
-                                    description: (
-                                        <p className="py-2">
-                                            Deleting the question will remove your branching logic. Are you sure you
-                                            want to continue?
-                                        </p>
-                                    ),
-                                    primaryButton: {
-                                        children: 'Continue',
-                                        status: 'danger',
-                                        onClick: () => {
-                                            deleteBranchingLogic()
-                                            deleteQuestion()
-                                        },
-                                    },
-                                    secondaryButton: {
-                                        children: 'Cancel',
-                                    },
-                                })
-                            } else {
-                                deleteQuestion()
-                            }
+                            e.stopPropagation()
+                            setSelectedPageIndex(index <= 0 ? 0 : index - 1)
+                            removeQuestion(index)
                         }}
                         tooltipPlacement="top-end"
                     />

--- a/frontend/src/scenes/surveys/components/question-branching/utils.test.ts
+++ b/frontend/src/scenes/surveys/components/question-branching/utils.test.ts
@@ -3,6 +3,8 @@ import { SurveyQuestion, SurveyQuestionBranchingType, SurveyQuestionType } from 
 import {
     SPECIFIC_QUESTION_SEPARATOR,
     branchingConfigToDropdownValue,
+    buildDeleteIndexMap,
+    buildReorderIndexMap,
     canQuestionHaveResponseBasedBranching,
     createBranchingConfig,
     createSpecificQuestionValue,
@@ -11,6 +13,7 @@ import {
     isSpecificQuestionValue,
     isValidBranchingType,
     parseSpecificQuestionValue,
+    remapBranchingIndices,
 } from './utils'
 
 describe('branching utils', () => {
@@ -282,6 +285,124 @@ describe('branching utils', () => {
             const createdEndBranching = createBranchingConfig(endConfig.type)
             expect(createdEndBranching).toEqual({
                 type: SurveyQuestionBranchingType.End,
+            })
+        })
+    })
+
+    describe('buildReorderIndexMap', () => {
+        it('shifts indices when moving a question forward (oldIndex < newIndex)', () => {
+            // Move index 0 to index 2 in a 4-element array: [A,B,C,D] -> [B,C,A,D]
+            expect(buildReorderIndexMap(4, 0, 2)).toEqual([2, 0, 1, 3])
+        })
+
+        it('shifts indices when moving a question backward (oldIndex > newIndex)', () => {
+            // Move index 3 to index 1: [A,B,C,D] -> [A,D,B,C]
+            expect(buildReorderIndexMap(4, 3, 1)).toEqual([0, 2, 3, 1])
+        })
+
+        it('is identity when oldIndex === newIndex', () => {
+            expect(buildReorderIndexMap(3, 1, 1)).toEqual([0, 1, 2])
+        })
+    })
+
+    describe('buildDeleteIndexMap', () => {
+        it('returns null for the deleted index and shifts later items left', () => {
+            expect(buildDeleteIndexMap(4, 1)).toEqual([0, null, 1, 2])
+        })
+
+        it('handles deletion at the start', () => {
+            expect(buildDeleteIndexMap(3, 0)).toEqual([null, 0, 1])
+        })
+
+        it('handles deletion at the end', () => {
+            expect(buildDeleteIndexMap(3, 2)).toEqual([0, 1, null])
+        })
+    })
+
+    describe('remapBranchingIndices', () => {
+        const ratingQuestionAt = (branching: SurveyQuestion['branching']): SurveyQuestion =>
+            ({
+                type: SurveyQuestionType.Rating,
+                question: 'rate',
+                display: 'number',
+                scale: 10,
+                lowerBoundLabel: 'low',
+                upperBoundLabel: 'high',
+                branching,
+            }) as SurveyQuestion
+
+        const plainOpenQuestion: SurveyQuestion = {
+            type: SurveyQuestionType.Open,
+            question: 'open',
+        } as SurveyQuestion
+
+        it('returns questions unchanged when no branching is present', () => {
+            const questions = [plainOpenQuestion, plainOpenQuestion]
+            expect(remapBranchingIndices(questions, [0, 1])).toEqual(questions)
+        })
+
+        it('remaps SpecificQuestion.index on reorder', () => {
+            // Q0 points to Q2; after moving Q2 to position 0: Q0 (now at 1) points to Q2 (now at 0)
+            const original = [
+                ratingQuestionAt({ type: SurveyQuestionBranchingType.SpecificQuestion, index: 2 }),
+                plainOpenQuestion,
+                plainOpenQuestion,
+            ]
+            const reordered = [original[2], original[0], original[1]]
+            const indexMap = buildReorderIndexMap(3, 2, 0)
+            const result = remapBranchingIndices(reordered, indexMap)
+            expect(result[1].branching).toEqual({
+                type: SurveyQuestionBranchingType.SpecificQuestion,
+                index: 0,
+            })
+        })
+
+        it('remaps ResponseBased.responseValues integer targets on reorder', () => {
+            const original = [
+                ratingQuestionAt({
+                    type: SurveyQuestionBranchingType.ResponseBased,
+                    responseValues: { detractors: 2, passives: 1, promoters: SurveyQuestionBranchingType.End },
+                }),
+                plainOpenQuestion,
+                plainOpenQuestion,
+            ]
+            // Swap Q1 and Q2 (move index 1 to index 2). indexMap = [0, 2, 1].
+            // detractors (was -> 2) becomes 1; passives (was -> 1) becomes 2; promoters stays End.
+            const indexMap = buildReorderIndexMap(3, 1, 2)
+            const result = remapBranchingIndices(original, indexMap)
+            expect(result[0].branching).toEqual({
+                type: SurveyQuestionBranchingType.ResponseBased,
+                responseValues: { detractors: 1, passives: 2, promoters: SurveyQuestionBranchingType.End },
+            })
+        })
+
+        it('drops SpecificQuestion branching when the target was deleted', () => {
+            const original = [
+                ratingQuestionAt({ type: SurveyQuestionBranchingType.SpecificQuestion, index: 1 }),
+                plainOpenQuestion,
+            ]
+            const filtered = [original[0]]
+            const indexMap = buildDeleteIndexMap(2, 1)
+            const result = remapBranchingIndices(filtered, indexMap)
+            expect(result[0].branching).toBeUndefined()
+        })
+
+        it('drops a single responseValues mapping when its target was deleted but keeps others', () => {
+            const original = [
+                ratingQuestionAt({
+                    type: SurveyQuestionBranchingType.ResponseBased,
+                    responseValues: { detractors: 2, passives: 1, promoters: SurveyQuestionBranchingType.End },
+                }),
+                plainOpenQuestion,
+                plainOpenQuestion,
+            ]
+            // Delete index 1 -> indexMap [0, null, 1]; questions array becomes [Q0, Q2]
+            const filtered = [original[0], original[2]]
+            const indexMap = buildDeleteIndexMap(3, 1)
+            const result = remapBranchingIndices(filtered, indexMap)
+            expect(result[0].branching).toEqual({
+                type: SurveyQuestionBranchingType.ResponseBased,
+                responseValues: { detractors: 1, promoters: SurveyQuestionBranchingType.End },
             })
         })
     })

--- a/frontend/src/scenes/surveys/components/question-branching/utils.test.ts
+++ b/frontend/src/scenes/surveys/components/question-branching/utils.test.ts
@@ -290,32 +290,28 @@ describe('branching utils', () => {
     })
 
     describe('buildReorderIndexMap', () => {
-        it('shifts indices when moving a question forward (oldIndex < newIndex)', () => {
-            // Move index 0 to index 2 in a 4-element array: [A,B,C,D] -> [B,C,A,D]
-            expect(buildReorderIndexMap(4, 0, 2)).toEqual([2, 0, 1, 3])
-        })
-
-        it('shifts indices when moving a question backward (oldIndex > newIndex)', () => {
-            // Move index 3 to index 1: [A,B,C,D] -> [A,D,B,C]
-            expect(buildReorderIndexMap(4, 3, 1)).toEqual([0, 2, 3, 1])
-        })
-
-        it('is identity when oldIndex === newIndex', () => {
-            expect(buildReorderIndexMap(3, 1, 1)).toEqual([0, 1, 2])
+        it.each([
+            // Move forward: [A,B,C,D] -> [B,C,A,D]
+            ['forward (oldIndex < newIndex)', 4, 0, 2, [2, 0, 1, 3]],
+            // Move backward: [A,B,C,D] -> [A,D,B,C]
+            ['backward (oldIndex > newIndex)', 4, 3, 1, [0, 2, 3, 1]],
+            // No-op when oldIndex === newIndex
+            ['identity when oldIndex === newIndex', 3, 1, 1, [0, 1, 2]],
+            // Swap last two
+            ['adjacent swap forward', 3, 1, 2, [0, 2, 1]],
+        ])('builds the index map for %s', (_label, length, oldIndex, newIndex, expected) => {
+            expect(buildReorderIndexMap(length, oldIndex, newIndex)).toEqual(expected)
         })
     })
 
     describe('buildDeleteIndexMap', () => {
-        it('returns null for the deleted index and shifts later items left', () => {
-            expect(buildDeleteIndexMap(4, 1)).toEqual([0, null, 1, 2])
-        })
-
-        it('handles deletion at the start', () => {
-            expect(buildDeleteIndexMap(3, 0)).toEqual([null, 0, 1])
-        })
-
-        it('handles deletion at the end', () => {
-            expect(buildDeleteIndexMap(3, 2)).toEqual([0, 1, null])
+        it.each([
+            ['middle deletion', 4, 1, [0, null, 1, 2]],
+            ['deletion at the start', 3, 0, [null, 0, 1]],
+            ['deletion at the end', 3, 2, [0, 1, null]],
+            ['single-item array', 1, 0, [null]],
+        ])('builds the index map for %s', (_label, length, deletedIndex, expected) => {
+            expect(buildDeleteIndexMap(length, deletedIndex)).toEqual(expected)
         })
     })
 
@@ -384,6 +380,26 @@ describe('branching utils', () => {
             const filtered = [original[0]]
             const indexMap = buildDeleteIndexMap(2, 1)
             const result = remapBranchingIndices(filtered, indexMap)
+            expect(result[0].branching).toBeUndefined()
+        })
+
+        it('drops the entire ResponseBased branching when every numeric target was deleted', () => {
+            // Q0 routes detractors -> 1 and passives -> 2; both targets are then deleted.
+            const original = [
+                ratingQuestionAt({
+                    type: SurveyQuestionBranchingType.ResponseBased,
+                    responseValues: { detractors: 1, passives: 2 },
+                }),
+                plainOpenQuestion,
+                plainOpenQuestion,
+            ]
+            // Delete index 1, then index 2 ... easier to just build the indexMap manually:
+            // both 1 and 2 are removed, only Q0 survives at index 0.
+            const filtered = [original[0]]
+            const indexMap = [0, null, null]
+            const result = remapBranchingIndices(filtered, indexMap)
+            // No surviving rules — fall back to default (no branching) rather than
+            // an empty ResponseBased shell.
             expect(result[0].branching).toBeUndefined()
         })
 

--- a/frontend/src/scenes/surveys/components/question-branching/utils.ts
+++ b/frontend/src/scenes/surveys/components/question-branching/utils.ts
@@ -178,9 +178,10 @@ export function remapBranchingIndices(questions: SurveyQuestion[], indexMap: (nu
             'responseValues' in question.branching &&
             question.branching.responseValues
         ) {
+            const originalEntries = Object.entries(question.branching.responseValues)
             const nextResponseValues: Record<string, number | SurveyQuestionBranchingType> = {}
             let changed = false
-            for (const [response, target] of Object.entries(question.branching.responseValues)) {
+            for (const [response, target] of originalEntries) {
                 if (typeof target === 'number') {
                     const remapped = remapIndex(target)
                     if (remapped === null) {
@@ -198,6 +199,13 @@ export function remapBranchingIndices(questions: SurveyQuestion[], indexMap: (nu
             }
             if (!changed) {
                 return question
+            }
+            // If we had mappings before and none survived, drop the whole branching block
+            // so the question falls back to default routing (rather than keeping a
+            // dangling ResponseBased config with empty rules).
+            if (originalEntries.length > 0 && Object.keys(nextResponseValues).length === 0) {
+                const { branching, ...rest } = question
+                return rest as SurveyQuestion
             }
             return {
                 ...question,

--- a/frontend/src/scenes/surveys/components/question-branching/utils.ts
+++ b/frontend/src/scenes/surveys/components/question-branching/utils.ts
@@ -134,3 +134,115 @@ export function createBranchingConfig(
             throw new Error(`Unknown branching type: ${branchingType}`)
     }
 }
+
+/**
+ * Remaps branching indices when the question array is mutated (reordered or deleted).
+ *
+ * `indexMap[oldIndex]` is the new position of the question that used to be at
+ * `oldIndex`, or `null` if it was removed. Any branching that pointed at a removed
+ * question is converted to default "Next question" (i.e. `branching` is dropped).
+ *
+ * Adding a question at the end is a no-op since existing indices stay valid.
+ */
+export function remapBranchingIndices(questions: SurveyQuestion[], indexMap: (number | null)[]): SurveyQuestion[] {
+    const remapIndex = (index: number): number | null => {
+        if (index < 0 || index >= indexMap.length) {
+            return null
+        }
+        return indexMap[index]
+    }
+
+    return questions.map((question) => {
+        if (!question.branching) {
+            return question
+        }
+
+        if (question.branching.type === SurveyQuestionBranchingType.SpecificQuestion) {
+            const remapped = remapIndex(question.branching.index)
+            if (remapped === null) {
+                // Target was deleted — fall back to default (Next question / End).
+                const { branching, ...rest } = question
+                return rest as SurveyQuestion
+            }
+            if (remapped === question.branching.index) {
+                return question
+            }
+            return {
+                ...question,
+                branching: { ...question.branching, index: remapped },
+            }
+        }
+
+        if (
+            question.branching.type === SurveyQuestionBranchingType.ResponseBased &&
+            'responseValues' in question.branching &&
+            question.branching.responseValues
+        ) {
+            const nextResponseValues: Record<string, number | SurveyQuestionBranchingType> = {}
+            let changed = false
+            for (const [response, target] of Object.entries(question.branching.responseValues)) {
+                if (typeof target === 'number') {
+                    const remapped = remapIndex(target)
+                    if (remapped === null) {
+                        // Target was deleted — drop the mapping so it falls back to default.
+                        changed = true
+                        continue
+                    }
+                    if (remapped !== target) {
+                        changed = true
+                    }
+                    nextResponseValues[response] = remapped
+                } else {
+                    nextResponseValues[response] = target
+                }
+            }
+            if (!changed) {
+                return question
+            }
+            return {
+                ...question,
+                branching: { ...question.branching, responseValues: nextResponseValues },
+            }
+        }
+
+        return question
+    })
+}
+
+/**
+ * Builds an index map for a reorder operation that moved a single question
+ * from `oldIndex` to `newIndex` within an array of `length` items.
+ */
+export function buildReorderIndexMap(length: number, oldIndex: number, newIndex: number): (number | null)[] {
+    const map: (number | null)[] = Array.from({ length })
+    for (let i = 0; i < length; i++) {
+        if (i === oldIndex) {
+            map[i] = newIndex
+        } else if (oldIndex < newIndex && i > oldIndex && i <= newIndex) {
+            map[i] = i - 1
+        } else if (oldIndex > newIndex && i >= newIndex && i < oldIndex) {
+            map[i] = i + 1
+        } else {
+            map[i] = i
+        }
+    }
+    return map
+}
+
+/**
+ * Builds an index map for a deletion at `deletedIndex` within an array of `length`
+ * items. The deleted position maps to `null`; later positions shift left by one.
+ */
+export function buildDeleteIndexMap(length: number, deletedIndex: number): (number | null)[] {
+    const map: (number | null)[] = Array.from({ length })
+    for (let i = 0; i < length; i++) {
+        if (i === deletedIndex) {
+            map[i] = null
+        } else if (i > deletedIndex) {
+            map[i] = i - 1
+        } else {
+            map[i] = i
+        }
+    }
+    return map
+}

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2193,6 +2193,9 @@ export const surveyLogic = kea<surveyLogicType>([
                     }),
                     'timestamp',
                     'person',
+                    `coalesce(JSONExtractString(properties, '$lib_version')) -- Library Version`,
+                    `coalesce(JSONExtractString(properties, '$lib')) -- Library`,
+                    `coalesce(JSONExtractString(properties, '$current_url')) -- URL`,
                 ]
 
                 return {
@@ -2218,7 +2221,7 @@ export const surveyLogic = kea<surveyLogicType>([
                     propertiesViaUrl: true,
                     showExport: true,
                     showReload: true,
-                    showRecordingColumn: false,
+                    showRecordingColumn: true,
                     showEventFilter: false,
                     showPropertyFilter: false,
                     showTimings: false,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -17,9 +17,12 @@ import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { Scene } from 'scenes/sceneTypes'
 import {
     branchingConfigToDropdownValue,
+    buildDeleteIndexMap,
+    buildReorderIndexMap,
     canQuestionHaveResponseBasedBranching,
     createBranchingConfig,
     getDefaultBranchingType,
+    remapBranchingIndices,
 } from 'scenes/surveys/components/question-branching/utils'
 import { getDemoDataForSurvey } from 'scenes/surveys/utils/demoDataGenerator'
 import { teamLogic } from 'scenes/teamLogic'
@@ -666,6 +669,8 @@ export const surveyLogic = kea<surveyLogicType>([
         }),
         resetBranchingForQuestion: (questionIndex) => ({ questionIndex }),
         deleteBranchingLogic: true,
+        moveQuestion: (oldIndex: number, newIndex: number) => ({ oldIndex, newIndex }),
+        removeQuestion: (questionIndex: number) => ({ questionIndex }),
         archiveSurvey: true,
         setWritingHTMLDescription: (writingHTML: boolean) => ({ writingHTML }),
         setSelectedPageIndex: (idx: number | null) => ({ idx }),
@@ -1785,6 +1790,27 @@ export const surveyLogic = kea<surveyLogicType>([
                         questions: newQuestions,
                     }
                 },
+                moveQuestion: (state, { oldIndex, newIndex }) => {
+                    if (oldIndex === newIndex) {
+                        return state
+                    }
+                    const reordered = [...state.questions]
+                    const [moved] = reordered.splice(oldIndex, 1)
+                    reordered.splice(newIndex, 0, moved)
+                    const indexMap = buildReorderIndexMap(state.questions.length, oldIndex, newIndex)
+                    return {
+                        ...state,
+                        questions: remapBranchingIndices(reordered, indexMap),
+                    }
+                },
+                removeQuestion: (state, { questionIndex }) => {
+                    const filtered = state.questions.filter((_, i) => i !== questionIndex)
+                    const indexMap = buildDeleteIndexMap(state.questions.length, questionIndex)
+                    return {
+                        ...state,
+                        questions: remapBranchingIndices(filtered, indexMap),
+                    }
+                },
             },
         ],
         selectedPageIndex: [
@@ -2167,9 +2193,6 @@ export const surveyLogic = kea<surveyLogicType>([
                     }),
                     'timestamp',
                     'person',
-                    `coalesce(JSONExtractString(properties, '$lib_version')) -- Library Version`,
-                    `coalesce(JSONExtractString(properties, '$lib')) -- Library`,
-                    `coalesce(JSONExtractString(properties, '$current_url')) -- URL`,
                 ]
 
                 return {
@@ -2195,7 +2218,7 @@ export const surveyLogic = kea<surveyLogicType>([
                     propertiesViaUrl: true,
                     showExport: true,
                     showReload: true,
-                    showRecordingColumn: true,
+                    showRecordingColumn: false,
                     showEventFilter: false,
                     showPropertyFilter: false,
                     showTimings: false,

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -516,7 +516,7 @@ interface QuestionsStepProps {
 
 export function QuestionsStep({ editingLanguage, setEditingLanguage }: QuestionsStepProps): JSX.Element {
     const { survey } = useValues(surveyLogic)
-    const { setSurveyValue } = useActions(surveyLogic)
+    const { setSurveyValue, moveQuestion, removeQuestion } = useActions(surveyLogic)
     const { selectedTemplate } = useValues(surveyWizardLogic)
     const { restoreDefaultQuestions } = useActions(surveyWizardLogic)
 
@@ -534,8 +534,7 @@ export function QuestionsStep({ editingLanguage, setEditingLanguage }: Questions
     }
 
     const deleteQuestion = (index: number): void => {
-        const newQuestions = questions.filter((_, i) => i !== index)
-        setSurveyValue('questions', newQuestions)
+        removeQuestion(index)
     }
 
     const addQuestion = (type: SurveyQuestionType): void => {
@@ -572,11 +571,7 @@ export function QuestionsStep({ editingLanguage, setEditingLanguage }: Questions
         if (over && active.id !== over.id) {
             const oldIndex = sortedItemIds.indexOf(active.id.toString())
             const newIndex = sortedItemIds.indexOf(over.id.toString())
-
-            const newQuestions = [...questions]
-            const [removed] = newQuestions.splice(oldIndex, 1)
-            newQuestions.splice(newIndex, 0, removed)
-            setSurveyValue('questions', newQuestions)
+            moveQuestion(oldIndex, newIndex)
         }
     }
 


### PR DESCRIPTION
## Problem

Multiple respondents in the in-app NPS survey for the Surveys product reported the same friction: their response-based branching ("If detractors → go to question X") silently reset to "Next question" the moment they added or moved a question. Quoted from the open-text replies:

> Every time I add or move a question my branching 'based on answer' options reset to 'Next question' on my rating question.

The root cause has two halves, one per editor:

- **Legacy editor (`SurveyEdit.tsx`):** the reorder/delete flows popped a confirmation dialog ("Rearranging questions will remove your branching logic") and on confirm called `deleteBranchingLogic()` which wipes ALL branching across the survey. Most users click through.
- **Wizard (`QuestionsStep.tsx`):** the reorder/delete flows didn't warn at all but didn't remap indices either, so branching pointed at the wrong questions and on the next render the dropdowns showed defaults.

## Changes

Replace wipe-on-mutate behavior with **proper index remapping** so the user's branching intent is preserved silently across reorders and deletes.

- New `remapBranchingIndices(questions, indexMap)` util in `surveys/components/question-branching/utils.ts`. It rewrites both `SpecificQuestion.index` and the integer values inside `ResponseBased.responseValues[*]`. If a branching target was deleted, the pointer is dropped (falls back to default "Next question") but other targets in the same survey are remapped.
- Two small helpers — `buildReorderIndexMap(length, oldIndex, newIndex)` and `buildDeleteIndexMap(length, deletedIndex)` — express the index math so it's testable in isolation.
- New `moveQuestion(oldIndex, newIndex)` and `removeQuestion(index)` actions in `surveyLogic`. Their reducers apply the array mutation and the branching remap atomically.
- Wire both legacy `SurveyEdit` and the wizard `QuestionsStep` to call the new actions instead of replacing `questions` via `setSurveyValue`. Drop the "Rearranging will remove your branching logic" dialog on reorder and the "Deleting the question will remove your branching logic" dialog on question delete — both are no longer needed.

## How did you test this code?

I'm an agent (PostHog Code). No manual UI verification — that's still worth doing before merge. Verified:

- New unit tests in `components/question-branching/utils.test.ts` for: reorder shifts (forward and backward), delete shifts (start/middle/end), and the remap behavior for both branching shapes including the case where the target was deleted. All 65 tests in that file pass.
- Existing `surveyLogic.test.ts` still passes (55 tests).
- `oxlint` clean on all changed files.
- `tsc --noEmit` shows no new errors in the surveys area.

Manual checks I'd want a human reviewer to do:
- Build an NPS rating question with response-based branching pointing at later questions, then drag the rating question down/up and confirm dropdowns still show the same targets.
- Delete the question that branching points at — confirm the dropdown falls back to "Next question" rather than to a stale index.
- Delete an unrelated question and confirm the remaining branching pointers shift correctly to follow.

## Publish to changelog?

Yes — short entry on preserving survey branching when reorganising questions.

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Context: the user (lucas@posthog.com) selected this as the next "low-hanging fruit" from a prior analysis of 60 days of NPS feedback. The complaint cluster pointed clearly at the reorder/delete paths, and the existing code confirmed the diagnosis — the explicit `deleteBranchingLogic()` call inside the confirmation dialog on reorder, plus the unremapped indices in the wizard.

Decisions worth flagging:
- I removed the warning dialogs rather than rewording them. With proper remapping, the previous warning ("we'll remove your branching") was actively misleading — and even now, asking a user to confirm a non-destructive operation just adds friction.
- For deletions where branching pointed AT the deleted question, I drop the mapping silently (so the dropdown falls back to "Next question") rather than asking the user to choose a new target. The user's intent ("redirect detractors to question X") is genuinely no longer satisfiable once X is gone, and forcing them through a modal is worse than letting them re-select if they care. Worth a review opinion here.
- `buildReorderIndexMap` and `buildDeleteIndexMap` are exported so any future "insert at position p" or "swap" handlers can reuse the same math.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*