### PR TITLE
feat(surveys): redesign response row with focused expansion panel

### DIFF
--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyResponseExpandedRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyResponseExpandedRow.tsx
@@ -1,12 +1,13 @@
 import { useValues } from 'kea'
 
-import { IconArchive, IconCode, IconGlobe, IconLaptop, IconPin, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+import { IconArchive, IconCode, IconGlobe, IconLaptop, IconPin } from '@posthog/icons'
 import { LemonDivider, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import ViewRecordingButton, { ViewRecordingButtonVariant } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { countryCodeToFlag } from 'lib/utils/geography/country'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
+import { getThumbIcon } from 'scenes/surveys/hooks/useSurveyResponseColumns'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 import { getSurveyResponseValue, isScaleTwoRating } from 'scenes/surveys/utils'
 
@@ -53,11 +54,7 @@ function AnswerDisplay({ question, value }: { question: SurveyQuestion; value: u
     if (isScaleTwoRating(question) && (value == '1' || value == '2')) {
         return (
             <span className="text-sm flex items-center gap-1">
-                {value == '1' ? (
-                    <IconThumbsUp className="text-brand-blue" />
-                ) : (
-                    <IconThumbsDown className="text-warning" />
-                )}
+                {getThumbIcon(value)}
                 Thumbs {value == '1' ? 'up' : 'down'}
             </span>
         )

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyResponseExpandedRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyResponseExpandedRow.tsx
@@ -1,0 +1,185 @@
+import { useValues } from 'kea'
+
+import { IconArchive, IconCode, IconGlobe, IconLaptop, IconPin, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+import { LemonDivider, LemonTag, Link } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import ViewRecordingButton, { ViewRecordingButtonVariant } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
+import { countryCodeToFlag } from 'lib/utils/geography/country'
+import { PersonDisplay } from 'scenes/persons/PersonDisplay'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { getSurveyResponseValue, isScaleTwoRating } from 'scenes/surveys/utils'
+
+import { EventType, SurveyEventProperties, SurveyQuestion } from '~/types'
+
+function prettyUrl(url: string): string {
+    try {
+        const parsed = new URL(url)
+        return `${parsed.host}${parsed.pathname}`.replace(/\/$/, '') || parsed.host
+    } catch {
+        return url.replace(/^https?:\/\//, '')
+    }
+}
+
+function findEventInRow(result: unknown): EventType | null {
+    if (!Array.isArray(result)) {
+        return null
+    }
+    for (const cell of result) {
+        if (
+            cell &&
+            typeof cell === 'object' &&
+            !Array.isArray(cell) &&
+            'properties' in cell &&
+            typeof (cell as { properties: unknown }).properties === 'object'
+        ) {
+            return cell as EventType
+        }
+    }
+    return null
+}
+
+function formatAnswer(value: unknown): string {
+    if (Array.isArray(value)) {
+        return value.join(', ')
+    }
+    if (value === null || value === undefined) {
+        return ''
+    }
+    return String(value)
+}
+
+function AnswerDisplay({ question, value }: { question: SurveyQuestion; value: unknown }): JSX.Element {
+    if (isScaleTwoRating(question) && (value == '1' || value == '2')) {
+        return (
+            <span className="text-sm flex items-center gap-1">
+                {value == '1' ? (
+                    <IconThumbsUp className="text-brand-blue" />
+                ) : (
+                    <IconThumbsDown className="text-warning" />
+                )}
+                Thumbs {value == '1' ? 'up' : 'down'}
+            </span>
+        )
+    }
+    return <p className="text-sm whitespace-pre-wrap m-0">{formatAnswer(value)}</p>
+}
+
+function MetaItem({ icon, children }: { icon?: JSX.Element; children: React.ReactNode }): JSX.Element {
+    return (
+        <span className="flex items-center gap-1 min-w-0">
+            {icon && <span className="shrink-0 flex items-center">{icon}</span>}
+            <span className="truncate">{children}</span>
+        </span>
+    )
+}
+
+export function SurveyResponseExpandedRow({ result }: { result: unknown }): JSX.Element | null {
+    const event = findEventInRow(result)
+    const { survey, archivedResponseUuids } = useValues(surveyLogic)
+
+    if (!event) {
+        return null
+    }
+
+    const properties = event.properties ?? {}
+    const currentUrl = typeof properties.$current_url === 'string' ? properties.$current_url : null
+    const sessionId = typeof properties.$session_id === 'string' ? properties.$session_id : undefined
+    const browser = typeof properties.$browser === 'string' ? properties.$browser : null
+    const os = typeof properties.$os === 'string' ? properties.$os : null
+    const deviceType = typeof properties.$device_type === 'string' ? properties.$device_type : null
+    const deviceLine = [browser, os, deviceType].filter(Boolean).join(' · ')
+    const city = typeof properties.$geoip_city_name === 'string' ? properties.$geoip_city_name : null
+    const country = typeof properties.$geoip_country_name === 'string' ? properties.$geoip_country_name : null
+    const countryCode = typeof properties.$geoip_country_code === 'string' ? properties.$geoip_country_code : null
+    const locationLine = [city, country].filter(Boolean).join(', ')
+    const lib = typeof properties.$lib === 'string' ? properties.$lib : null
+    const libVersion = typeof properties.$lib_version === 'string' ? properties.$lib_version : null
+    const libraryLine = [lib, libVersion].filter(Boolean).join(' ')
+    const iteration = properties[SurveyEventProperties.SURVEY_ITERATION]
+    const isPartial =
+        properties[SurveyEventProperties.SURVEY_COMPLETED] === false ||
+        properties[SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED] === true
+    const isArchived = event.uuid ? archivedResponseUuids?.has(event.uuid) : false
+
+    const responses: { questionIndex: number; question: SurveyQuestion; value: unknown }[] = []
+    if (survey?.questions) {
+        survey.questions.forEach((q, index) => {
+            const value = getSurveyResponseValue(properties, index, q.id)
+            if (value !== undefined) {
+                responses.push({ questionIndex: index, question: q, value })
+            }
+        })
+    }
+
+    return (
+        <div className="sticky left-0 w-full max-w-[min(56rem,calc(100vw-2rem))] px-4 py-3 flex flex-col gap-4">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-secondary">
+                <PersonDisplay
+                    person={{ distinct_id: event.distinct_id, properties: event.person?.properties }}
+                    withIcon="xs"
+                    noEllipsis={false}
+                />
+                {event.timestamp && <TZLabel time={event.timestamp} />}
+                {sessionId && (
+                    <ViewRecordingButton
+                        sessionId={sessionId}
+                        timestamp={event.timestamp}
+                        variant={ViewRecordingButtonVariant.Link}
+                        checkRecordingExists
+                    />
+                )}
+                {isPartial && (
+                    <LemonTag type="warning" size="small">
+                        Partial
+                    </LemonTag>
+                )}
+                {isArchived && (
+                    <LemonTag type="muted" size="small" icon={<IconArchive />}>
+                        Archived
+                    </LemonTag>
+                )}
+                {iteration !== undefined && iteration !== null && (
+                    <MetaItem>
+                        <span className="text-muted">Iteration</span> {String(iteration)}
+                    </MetaItem>
+                )}
+            </div>
+
+            {responses.length > 0 && (
+                <div className="flex flex-col gap-3">
+                    {responses.map(({ questionIndex, question, value }) => (
+                        <div key={questionIndex} className="flex flex-col gap-1">
+                            <span className="text-xs text-secondary font-semibold">{question.question}</span>
+                            <AnswerDisplay question={question} value={value} />
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <LemonDivider className="my-0" />
+
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-secondary">
+                {currentUrl && (
+                    <Link
+                        to={currentUrl}
+                        target="_blank"
+                        title={currentUrl}
+                        className="flex items-center gap-1 max-w-xs min-w-0"
+                    >
+                        <IconGlobe className="shrink-0" />
+                        <span className="truncate">{prettyUrl(currentUrl)}</span>
+                    </Link>
+                )}
+                {deviceLine && <MetaItem icon={<IconLaptop />}>{deviceLine}</MetaItem>}
+                {locationLine && (
+                    <MetaItem icon={<IconPin />}>
+                        {countryCode && <span className="mr-1">{countryCodeToFlag(countryCode)}</span>}
+                        {locationLine}
+                    </MetaItem>
+                )}
+                {libraryLine && <MetaItem icon={<IconCode />}>{libraryLine}</MetaItem>}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -68,6 +68,7 @@ import { SurveyResultsRefreshStatus } from '../components/SurveyResultsRefreshSt
 import { NEW_SURVEY } from '../constants'
 import { SurveyDraftContent } from './SurveyDraftContent'
 import { SurveyResultsFiltersBar } from './SurveyFilters'
+import { SurveyResponseExpandedRow } from './SurveyResponseExpandedRow'
 import { SurveyDetailsPanel, SurveyExportPanel } from './SurveySidebar'
 
 const RESOURCE_TYPE = 'survey'
@@ -665,15 +666,29 @@ function SurveySummaryContent({ onViewResponses }: { onViewResponses: () => void
     )
 }
 
+function getUuidFromExpandableRecord(record: { result?: unknown }): string | undefined {
+    const result = record?.result
+    if (!Array.isArray(result)) {
+        return undefined
+    }
+    const event = result[0] as { uuid?: string } | undefined
+    return event?.uuid
+}
+
+// Don't trigger row expansion when the click originated from an interactive element inside the row.
+const INTERACTIVE_SELECTOR = 'a, button, input, select, textarea, [role="button"], [data-skip-row-expand]'
+
 function SurveyResponsesContent(): JSX.Element {
     const {
         dataTableQuery,
         survey,
         surveyLoading,
         archivedResponseUuids,
+        expandedResponseUuids,
         isAnyResultsLoading,
         resultsRequeryInProgress,
     } = useValues(surveyLogic)
+    const { setResponseExpanded, toggleResponseExpansion } = useActions(surveyLogic)
     const isInitialSurveyLoad = surveyLoading && survey.id === NEW_SURVEY.id
     const isRefreshingResults = resultsRequeryInProgress || isAnyResultsLoading
     const surveyColumnRenderers = useSurveyResponseColumns()
@@ -702,16 +717,45 @@ function SurveyResponsesContent(): JSX.Element {
                                 if (typeof record !== 'object' || !record || !('result' in record)) {
                                     return {}
                                 }
-                                const result = record.result
+                                const result = (record as { result?: unknown }).result
                                 if (!Array.isArray(result)) {
                                     return {}
                                 }
+                                const uuid = (result[0] as { uuid?: string } | undefined)?.uuid
+                                const isArchived = uuid ? archivedResponseUuids.has(uuid) : false
                                 return {
-                                    className:
-                                        result[0]?.uuid && archivedResponseUuids.has(result[0].uuid)
-                                            ? 'opacity-50'
-                                            : undefined,
+                                    className: `cursor-pointer ${isArchived ? 'opacity-50' : ''}`.trim(),
+                                    onClick: (e: React.MouseEvent<HTMLTableRowElement>) => {
+                                        if (!uuid) {
+                                            return
+                                        }
+                                        if ((e.target as HTMLElement).closest(INTERACTIVE_SELECTOR)) {
+                                            return
+                                        }
+                                        toggleResponseExpansion(uuid)
+                                    },
                                 }
+                            },
+                            expandable: {
+                                expandedRowRender: ({ result }) => <SurveyResponseExpandedRow result={result} />,
+                                rowExpandable: ({ result }) => !!result,
+                                isRowExpanded: (record) => {
+                                    const uuid = getUuidFromExpandableRecord(record)
+                                    return uuid ? expandedResponseUuids.has(uuid) : false
+                                },
+                                onRowExpand: (record) => {
+                                    const uuid = getUuidFromExpandableRecord(record)
+                                    if (uuid) {
+                                        setResponseExpanded(uuid, true)
+                                    }
+                                },
+                                onRowCollapse: (record) => {
+                                    const uuid = getUuidFromExpandableRecord(record)
+                                    if (uuid) {
+                                        setResponseExpanded(uuid, false)
+                                    }
+                                },
+                                noIndent: true,
                             },
                         }}
                     />

--- a/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
+++ b/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
@@ -5,10 +5,11 @@ import { IconLlmAnalytics, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
-import { getSurveyResponse, isThumbQuestion } from 'scenes/surveys/utils'
+import { getSurveyResponse, isScaleTwoRating } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 
 import { QueryContextColumn } from '~/queries/types'
+import { SurveyQuestionType } from '~/types'
 
 const getTraceIdFromRecord = (record: unknown): string | null => {
     if (!Array.isArray(record)) {
@@ -30,6 +31,7 @@ export const getThumbIcon = (value: unknown): JSX.Element | null => {
 
 /**
  * Custom column renderers for the survey responses data table:
+ * - Clamp long answers to 2 lines (full content available via row expansion).
  * - On the first question, surface a "View LLM trace" button when `$ai_trace_id` is present.
  * - On thumb questions, render the icon + "Thumbs up/down" instead of the raw `1`/`2` value.
  */
@@ -40,40 +42,49 @@ export function useSurveyResponseColumns(): Record<string, QueryContextColumn> {
         const columns: Record<string, QueryContextColumn> = {}
 
         survey.questions.forEach((question, index) => {
-            const isThumb = isThumbQuestion(question)
+            const isThumb = isScaleTwoRating(question)
             const isFirstQuestion = index === 0
+            const baseExpression = getSurveyResponse(question, index)
+            // Must match the column expression built in surveyLogic.tsx so multi-choice
+            // questions (wrapped in arrayStringConcat) also get matched.
+            const columnName =
+                question.type === SurveyQuestionType.MultipleChoice
+                    ? `arrayStringConcat(${baseExpression}, ', ')`
+                    : baseExpression
 
-            if (!isThumb && !isFirstQuestion) {
-                return
-            }
-
-            const columnName = getSurveyResponse(question, index)
             columns[columnName] = {
                 render: ({ value, record }) => {
                     const traceId = isFirstQuestion ? getTraceIdFromRecord(record) : null
+                    const stringValue = value == null ? '' : String(value)
+
+                    let displayContent: JSX.Element
+                    if (isThumb && (value == '1' || value == '2')) {
+                        displayContent = (
+                            <span className="flex items-center gap-1">
+                                {getThumbIcon(value)}
+                                Thumbs {value == '1' ? 'up' : 'down'}
+                            </span>
+                        )
+                    } else {
+                        displayContent = <span className="whitespace-pre-wrap line-clamp-2">{stringValue}</span>
+                    }
+
+                    if (!traceId) {
+                        return displayContent
+                    }
 
                     return (
-                        <span className="flex items-center gap-2">
-                            {traceId && (
-                                <Tooltip title="View LLM trace">
-                                    <LemonButton
-                                        size="xsmall"
-                                        icon={
-                                            <IconLlmAnalytics className="text-[var(--color-product-llm-analytics-light)]" />
-                                        }
-                                        to={urls.llmAnalyticsTrace(traceId)}
-                                    />
-                                </Tooltip>
-                            )}
-
-                            {isThumb && (value == '1' || value == '2') ? (
-                                <span className="flex items-center gap-1">
-                                    {getThumbIcon(value)}
-                                    Thumbs {value == '1' ? 'up' : 'down'}
-                                </span>
-                            ) : (
-                                String(value ?? '')
-                            )}
+                        <span className="flex items-start gap-2 min-w-0">
+                            <Tooltip title="View LLM trace">
+                                <LemonButton
+                                    size="xsmall"
+                                    icon={
+                                        <IconLlmAnalytics className="text-[var(--color-product-llm-analytics-light)]" />
+                                    }
+                                    to={urls.llmAnalyticsTrace(traceId)}
+                                />
+                            </Tooltip>
+                            <span className="min-w-0 flex-1">{displayContent}</span>
                         </span>
                     )
                 },

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -692,6 +692,8 @@ export const surveyLogic = kea<surveyLogicType>([
         setInterval: (interval: IntervalType) => ({ interval }),
         setCompareFilter: (compareFilter: CompareFilter) => ({ compareFilter }),
         setFilterSurveyStatsByDistinctId: (filterByDistinctId: boolean) => ({ filterByDistinctId }),
+        setResponseExpanded: (uuid: string, expanded: boolean) => ({ uuid, expanded }),
+        toggleResponseExpansion: (uuid: string) => ({ uuid }),
         setBaseStatsResults: (results: SurveyBaseStatsResult) => ({ results }),
         setDismissedAndSentCount: (count: DismissedAndSentCountResult) => ({ count }),
         setShowArchivedResponses: (show: boolean) => ({ show }),
@@ -1521,6 +1523,32 @@ export const surveyLogic = kea<surveyLogicType>([
                 setPersonNames: (state, { personNames }) => ({ ...state, ...personNames }),
             },
         ],
+        expandedResponseUuids: [
+            new Set<string>(),
+            {
+                setResponseExpanded: (state, { uuid, expanded }) => {
+                    if (expanded === state.has(uuid)) {
+                        return state
+                    }
+                    const next = new Set(state)
+                    if (expanded) {
+                        next.add(uuid)
+                    } else {
+                        next.delete(uuid)
+                    }
+                    return next
+                },
+                toggleResponseExpansion: (state, { uuid }) => {
+                    const next = new Set(state)
+                    if (next.has(uuid)) {
+                        next.delete(uuid)
+                    } else {
+                        next.add(uuid)
+                    }
+                    return next
+                },
+            },
+        ],
         editingLanguage: [
             null as string | null,
             {
@@ -2193,9 +2221,6 @@ export const surveyLogic = kea<surveyLogicType>([
                     }),
                     'timestamp',
                     'person',
-                    `coalesce(JSONExtractString(properties, '$lib_version')) -- Library Version`,
-                    `coalesce(JSONExtractString(properties, '$lib')) -- Library`,
-                    `coalesce(JSONExtractString(properties, '$current_url')) -- URL`,
                 ]
 
                 return {
@@ -2221,7 +2246,7 @@ export const surveyLogic = kea<surveyLogicType>([
                     propertiesViaUrl: true,
                     showExport: true,
                     showReload: true,
-                    showRecordingColumn: true,
+                    showRecordingColumn: false,
                     showEventFilter: false,
                     showPropertyFilter: false,
                     showTimings: false,

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -948,6 +948,14 @@ export const isThumbQuestion = (question: SurveyQuestion): boolean => {
 }
 
 /**
+ * A 2-point rating question always represents a binary thumbs up / thumbs down regardless of `display`,
+ * so we render the icon + label in response views to make the value readable at a glance.
+ */
+export const isScaleTwoRating = (question: SurveyQuestion): boolean => {
+    return question.type === SurveyQuestionType.Rating && question.scale === SURVEY_RATING_SCALE.THUMB_2_POINT
+}
+
+/**
  * Splits text pasted into a choice input on newlines or tabs (spreadsheet rows).
  * Returns the merged choices array, or `null` if there's nothing to split (the caller
  * should let the paste fall through to the default input behavior).


### PR DESCRIPTION
## Problem

The surveys Responses tab today has three rough edges:

1. **Noisy default columns.** Every response shows `$lib`, `$lib_version`, `$current_url`, and a per-row "View recording" icon that gets clipped at the right edge of the table.
2. **Long open-ended answers stretch row heights.** A single multi-paragraph response can blow up an entire row to 8+ lines, making it hard to scan responses side-by-side.
3. **No good way to read one response holistically.** The previous `*` column expansion opened a raw-event JSON viewer, not a focused Q&A summary.

## Changes

- **Trim default cell columns** to `*`, questions, `timestamp`, `person`. `$lib`/`$lib_version`/`$current_url` and the duplicate view-recording column are no longer shown by default — they're still re-addable via the existing per-survey column configurator.
- **Clamp answer cells to 2 lines** (`line-clamp-2`). No inline "Show more" link — discovery happens via the existing row chevron or by clicking anywhere on the row.
- **Whole row is clickable** to toggle expansion. Clicks on interactive elements inside the row (links, buttons, person popover) are filtered out so they don't double-fire.
- **New focused expansion panel** (`SurveyResponseExpandedRow`) replaces the default `EventDetails` viewer via `context.expandable.expandedRowRender`. The panel shows:
  - Person + timestamp + view recording (if available) + Partial/Archived/Iteration tags at the top
  - Q&A pairs (question label + answer)
  - Metadata footer: URL (pretty `host/path`, full URL on hover), device/browser, location with country flag, library + version
- **Width-constrained panel** so the table's horizontal scroll never hides the content: `sticky left-0 max-w-[min(56rem,calc(100vw-2rem))]`. Caps at ~896px on desktop, clamps to viewport on mobile.
- **2-point rating questions render as thumbs up/down** in both the cell and the expanded panel, regardless of the question's `display` setting (a 1/2 rating only ever means thumbs). Added `isScaleTwoRating` helper alongside the existing `isThumbQuestion`.
- **Multi-choice columns now match cell column renderers** — previously the `arrayStringConcat(...)` wrapping in `surveyLogic` produced a different column key than the renderer was looking for, so multi-choice cells weren't getting the truncation treatment.
- **Row expansion state lives in `surveyLogic`** (`expandedResponseUuids` reducer + `setResponseExpanded` / `toggleResponseExpansion` actions) per PostHog's kea-over-hooks convention. Chevron and row-click stay in sync because they share the same store.

## How did you test this code?

I'm an agent. I did not exercise this in a running app. Automated checks I ran:

- `pnpm exec tsc --noEmit` — clean for all touched files
- `oxfmt` on all modified files
- `kea-typegen write` regenerated `surveyLogicType.ts` to pick up the new actions/reducer

Manual smoke tests still owed by a human reviewer:

- [ ] Open a survey's Responses tab; confirm only `*` / questions / `timestamp` / `person` columns appear by default
- [ ] Confirm "Configure columns" still offers `$lib`, `$lib_version`, `$current_url` to re-add
- [ ] Long open-text answer clamps to 2 lines in the cell; row chevron and clicking the row both open the expansion panel
- [ ] Multi-choice answer cell also clamps to 2 lines
- [ ] Panel content stays anchored to the visible left edge when scrolling the table horizontally
- [ ] Resize to ~mobile width; panel stays within viewport
- [ ] Rating-2 question renders as thumbs up/down in both the cell and the panel
- [ ] Survey with iterations shows the iteration label; partial response shows the "Partial" tag; archived response shows the "Archived" tag and dimmed row
- [ ] View recording link appears only when `$session_id` is present, paired next to the timestamp

## Publish to changelog?

no

## Docs update

No docs change required.

## 🤖 Agent context

Authored by an agent (PostHog Code) in a single session iterating with the human author. Key decisions along the way:

- Considered switching off `DataTableNode` in favor of a custom `HogQLQuery` + handwritten table — rejected because the existing DataTable gives us persistent column config, export, pagination, sorting, and property-filter URL sync for free. The `context.expandable` override is the right extension point for the panel.
- Considered keeping a per-cell "Show more" inline expand toggle — rejected after design critique: it duplicated the chevron's affordance, the label promised "show more of this cell" but actually opened a panel showing every question, and it added visual noise to every long cell. Collapsed to a single affordance (chevron OR whole-row click) opening one canonical panel.
- Considered local React state for `expandedResponseUuids` — rejected to align with PostHog's "kea over hooks" convention in `CLAUDE.md`. State lives in `surveyLogic`.
- Considered Storybook story for the new panel — deferred. Should be added in a follow-up PR before this surface gets visual-review gated.
- Considered broadening `isThumbQuestion` (which requires `display === 'emoji'`) to cover all scale-2 ratings — rejected because the helper is used in other visualization paths where `display` may legitimately matter. Added a new narrower `isScaleTwoRating` instead.

Tools used: Read, Edit, Write, Grep, Glob, Bash, Skill (emil-design-engineering), posthog MCP `read-data-schema` for inspecting `$survey_sent` event properties.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*