### PR TITLE
feat(activity): add MCP analytics tab to event details

### DIFF
--- a/frontend/src/lib/components/EventPropertyTabs/EventPropertyTabs.tsx
+++ b/frontend/src/lib/components/EventPropertyTabs/EventPropertyTabs.tsx
@@ -39,6 +39,7 @@ type EventPropertyTabKey =
     | 'debug_properties'
     | 'metadata'
     | 'survey_response'
+    | 'mcp'
 
 export const EventPropertyTabs = ({
     event,
@@ -57,6 +58,8 @@ export const EventPropertyTabs = ({
 
     const isErrorEvent = event.event === '$exception'
     const isSurveyResponseEvent = event.event === 'survey sent'
+    const isMcpEvent =
+        typeof event.event === 'string' && (event.event.startsWith('mcp_') || event.event.startsWith('mcp '))
 
     const { filterProperties } = useValues(eventPropertyFilteringLogic)
 
@@ -69,7 +72,9 @@ export const EventPropertyTabs = ({
                 ? 'error_display'
                 : isSurveyResponseEvent
                   ? 'survey_response'
-                  : 'properties'
+                  : isMcpEvent
+                    ? 'mcp'
+                    : 'properties'
     )
 
     const promotedKeys = isKeyOf(event.event, POSTHOG_EVENT_PROMOTED_PROPERTIES)
@@ -115,6 +120,11 @@ export const EventPropertyTabs = ({
             key: 'survey_response',
             label: 'Survey response',
             content: tabContentComponentFn({ event, properties: event.properties, tabKey: 'survey_response' }),
+        },
+        isMcpEvent && {
+            key: 'mcp',
+            label: 'MCP analytics',
+            content: tabContentComponentFn({ event, properties: event.properties, tabKey: 'mcp' }),
         },
         isAIConversationEvent
             ? {

--- a/frontend/src/scenes/activity/explore/EventDetails.tsx
+++ b/frontend/src/scenes/activity/explore/EventDetails.tsx
@@ -19,6 +19,8 @@ import { PropertyDefinitionType } from '~/types'
 import { ConversationDisplay } from 'products/llm_analytics/frontend/ConversationDisplay/ConversationDisplay'
 import { EvaluationDisplay } from 'products/llm_analytics/frontend/ConversationDisplay/EvaluationDisplay'
 
+import { MCPEventView } from './MCPEventView'
+
 interface EventDetailsProps {
     event: ErrorPropertyTabEvent
     tableProps?: Partial<LemonTableProps<Record<string, any>>>
@@ -104,6 +106,8 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                 />
                             </div>
                         )
+                    case 'mcp':
+                        return <MCPEventView properties={properties} />
                     case 'exception_properties':
                         return (
                             <div className="mx-3 -mt-4">

--- a/frontend/src/scenes/activity/explore/MCPEventView.tsx
+++ b/frontend/src/scenes/activity/explore/MCPEventView.tsx
@@ -1,0 +1,282 @@
+import { ReactNode, useMemo, useState } from 'react'
+
+import { IconChevronDown, IconChevronRight } from '@posthog/icons'
+import { LemonTable, LemonTableColumns, LemonTag, Tooltip } from '@posthog/lemon-ui'
+
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { JSONViewer } from 'lib/components/JSONViewer'
+import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+
+interface MCPEventViewProps {
+    properties: Record<string, any>
+}
+
+interface MCPEntry {
+    key: string
+    value: unknown
+    bytes: number
+}
+
+// Values whose serialized payload exceeds this get a per-row "Show N B" disclosure
+// so a single fat field (parameters, response, tool descriptions, etc.) can't take
+// over the whole property list.
+const LONG_VALUE_BYTES = 256
+// Bounded scroll for expanded values; viewport-relative so it adapts to drawer size
+// instead of a fixed pixel cap.
+const EXPANDED_MAX_HEIGHT = '50dvh'
+
+const measureBytes = (value: unknown): number => {
+    const text = typeof value === 'string' ? value : JSON.stringify(value ?? '')
+    return new Blob([text]).size
+}
+
+const formatBytes = (bytes: number): string => {
+    if (bytes < 1024) {
+        return `${bytes} B`
+    }
+    if (bytes < 1024 * 1024) {
+        return `${(bytes / 1024).toFixed(1)} KB`
+    }
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+const makePreview = (value: unknown, maxChars = 80): string => {
+    let text: string
+    if (value === null || value === undefined) {
+        text = String(value)
+    } else if (typeof value === 'string') {
+        text = value.replace(/\s+/g, ' ').trim()
+    } else if (Array.isArray(value)) {
+        text = `[${value.length} item${value.length === 1 ? '' : 's'}]`
+    } else if (typeof value === 'object') {
+        const keys = Object.keys(value as object)
+        text = `{ ${keys.slice(0, 3).join(', ')}${keys.length > 3 ? ', …' : ''} }`
+    } else {
+        text = String(value)
+    }
+    return text.length > maxChars ? `${text.slice(0, maxChars)}…` : text
+}
+
+const heavyPriority = (key: string): number => {
+    if (key === '$mcp_parameters') {
+        return 0
+    }
+    if (key === '$mcp_response') {
+        return 1
+    }
+    return 2
+}
+
+function ValueCell({ value, bytes }: { value: unknown; bytes: number }): JSX.Element {
+    const [expanded, setExpanded] = useState(false)
+    const valueType = value === null ? 'null' : typeof value
+    const isLong = bytes > LONG_VALUE_BYTES
+
+    const fullSerialized = typeof value === 'string' ? value : JSON.stringify(value ?? '')
+
+    const typeTag = (
+        <LemonTag className="font-mono uppercase" type="muted">
+            {valueType}
+        </LemonTag>
+    )
+    const copyButton = (
+        <CopyToClipboardInline
+            description="property value"
+            explicitValue={fullSerialized}
+            iconSize="xsmall"
+            selectable
+        />
+    )
+
+    if (!isLong) {
+        const display =
+            value === null || value === undefined
+                ? String(value)
+                : typeof value === 'object'
+                  ? JSON.stringify(value)
+                  : String(value)
+        return (
+            <div className="flex flex-row flex-wrap items-center gap-2 break-all">
+                <span>{display}</span>
+                {typeTag}
+            </div>
+        )
+    }
+
+    let expandedContent: JSX.Element
+    let parsed: unknown = value
+    if (typeof value === 'string') {
+        try {
+            parsed = JSON.parse(value)
+        } catch {
+            parsed = value
+        }
+    }
+    if (parsed !== null && typeof parsed === 'object') {
+        expandedContent = (
+            <JSONViewer src={parsed as object} name={null} collapsed={1} collapseStringsAfterLength={120} sortKeys />
+        )
+    } else {
+        expandedContent = (
+            <pre className="m-0 whitespace-pre-wrap break-words text-xs leading-relaxed">{String(value)}</pre>
+        )
+    }
+
+    return (
+        <div className="flex w-full flex-col gap-1">
+            <div className="flex w-full min-w-0 flex-row flex-nowrap items-center gap-2">
+                <span className="text-secondary min-w-0 flex-1 truncate text-xs">{makePreview(value)}</span>
+                <LemonButton
+                    size="xsmall"
+                    type="tertiary"
+                    icon={expanded ? <IconChevronDown /> : <IconChevronRight />}
+                    onClick={() => setExpanded((e) => !e)}
+                    aria-label={expanded ? 'Hide value' : `Show value (${formatBytes(bytes)})`}
+                    className="shrink-0"
+                >
+                    {expanded ? 'Hide' : `Show ${formatBytes(bytes)}`}
+                </LemonButton>
+                <span className="shrink-0">{typeTag}</span>
+                <span className="shrink-0">{copyButton}</span>
+            </div>
+            {expanded ? (
+                <div
+                    className="border-border mt-1 overflow-auto rounded border p-2"
+                    style={{ maxHeight: EXPANDED_MAX_HEIGHT }}
+                >
+                    {expandedContent}
+                </div>
+            ) : null}
+        </div>
+    )
+}
+
+function Stat({ label, children }: { label: string; children: ReactNode }): JSX.Element {
+    return (
+        <div className="flex flex-col items-start gap-1">
+            <span className="text-secondary text-xs font-medium uppercase tracking-wide">{label}</span>
+            <div className="text-sm">{children}</div>
+        </div>
+    )
+}
+
+export function MCPEventView({ properties }: MCPEventViewProps): JSX.Element {
+    const [searchTerm, setSearchTerm] = useState('')
+
+    const mcpProps = useMemo(
+        () =>
+            Object.fromEntries(
+                Object.entries(properties).filter(([k]) => k.startsWith('$mcp_') || k.startsWith('mcp_'))
+            ),
+        [properties]
+    )
+
+    let displayName: string | undefined
+    let displayKind: string | undefined
+    if (mcpProps['$mcp_tool_name'] !== undefined) {
+        displayName = String(mcpProps['$mcp_tool_name'])
+        displayKind = 'Tool'
+    } else if (mcpProps['$mcp_resource_name'] !== undefined) {
+        displayName = String(mcpProps['$mcp_resource_name'])
+        displayKind = 'Resource'
+    }
+    const isError = mcpProps['$mcp_is_error']
+    const durationMs = mcpProps['$mcp_duration_ms']
+    const clientName = mcpProps['$mcp_client_name']
+    const serverName = mcpProps['$mcp_server_name']
+    const transport = mcpProps['$mcp_transport']
+    const intent = mcpProps['$mcp_intent']
+    const intentSource = mcpProps['$mcp_intent_source']
+
+    const entries: MCPEntry[] = useMemo(() => {
+        const arr = Object.entries(mcpProps).map(([key, value]) => ({
+            key,
+            value,
+            bytes: measureBytes(value),
+        }))
+        arr.sort((a, b) => heavyPriority(a.key) - heavyPriority(b.key) || a.key.localeCompare(b.key))
+        return arr
+    }, [mcpProps])
+
+    const filteredEntries: MCPEntry[] = useMemo(() => {
+        if (!searchTerm) {
+            return entries
+        }
+        const needle = searchTerm.toLowerCase()
+        return entries.filter(({ key, value }) => {
+            if (key.toLowerCase().includes(needle)) {
+                return true
+            }
+            const serialized = typeof value === 'string' ? value : JSON.stringify(value ?? '')
+            return serialized.toLowerCase().includes(needle)
+        })
+    }, [entries, searchTerm])
+
+    const columns: LemonTableColumns<MCPEntry> = [
+        {
+            key: 'key',
+            title: 'Key',
+            render: (_, item) => (
+                <div className="properties-table-key">
+                    <PropertyKeyInfo value={item.key} type={TaxonomicFilterGroupType.EventProperties} />
+                </div>
+            ),
+        },
+        {
+            key: 'value',
+            title: 'Value',
+            fullWidth: true,
+            render: (_, item) => <ValueCell value={item.value} bytes={item.bytes} />,
+        },
+    ]
+
+    return (
+        <div className="mx-3 flex flex-col gap-3">
+            <div className="border-border bg-surface-secondary flex flex-wrap items-start gap-x-6 gap-y-3 rounded border p-3">
+                {isError !== undefined ? (
+                    <Stat label="Status">
+                        <LemonTag type={isError ? 'danger' : 'success'}>{isError ? 'Error' : 'Success'}</LemonTag>
+                    </Stat>
+                ) : null}
+                {displayName && displayKind ? (
+                    <Stat label={displayKind}>
+                        <span className="font-semibold">{displayName}</span>
+                    </Stat>
+                ) : null}
+                {durationMs !== undefined && durationMs !== null ? (
+                    <Stat label="Duration">{String(durationMs)} ms</Stat>
+                ) : null}
+                {transport ? <Stat label="Transport">{String(transport)}</Stat> : null}
+                {clientName ? <Stat label="Client">{String(clientName)}</Stat> : null}
+                {serverName ? <Stat label="Server">{String(serverName)}</Stat> : null}
+                {intent ? (
+                    <Stat label={intentSource ? `Intent (${String(intentSource).replace('_', ' ')})` : 'Intent'}>
+                        <Tooltip title={String(intent)}>
+                            <span className="line-clamp-1 max-w-[40ch]">{String(intent)}</span>
+                        </Tooltip>
+                    </Stat>
+                ) : null}
+            </div>
+            {entries.length > 6 ? (
+                <LemonInput
+                    type="search"
+                    placeholder="Search property keys and values"
+                    value={searchTerm}
+                    onChange={setSearchTerm}
+                    className="w-64 max-w-full"
+                />
+            ) : null}
+            <LemonTable
+                columns={columns}
+                dataSource={filteredEntries}
+                rowKey="key"
+                embedded
+                size="small"
+                emptyState="No MCP properties match this search."
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/activity/explore/MCPEventView.tsx
+++ b/frontend/src/scenes/activity/explore/MCPEventView.tsx
@@ -183,7 +183,10 @@ export function MCPEventView({ properties }: MCPEventViewProps): JSX.Element {
         displayName = String(mcpProps['$mcp_resource_name'])
         displayKind = 'Resource'
     }
-    const isError = mcpProps['$mcp_is_error']
+    const rawIsError = mcpProps['$mcp_is_error']
+    // Normalise — ingestion can flatten booleans to strings, and "false" is truthy in JS.
+    const hasErrorStatus = rawIsError !== undefined && rawIsError !== null
+    const isError = rawIsError === true || rawIsError === 'true'
     const durationMs = mcpProps['$mcp_duration_ms']
     const clientName = mcpProps['$mcp_client_name']
     const serverName = mcpProps['$mcp_server_name']
@@ -236,7 +239,7 @@ export function MCPEventView({ properties }: MCPEventViewProps): JSX.Element {
     return (
         <div className="mx-3 flex flex-col gap-3">
             <div className="border-border bg-surface-secondary flex flex-wrap items-start gap-x-6 gap-y-3 rounded border p-3">
-                {isError !== undefined ? (
+                {hasErrorStatus ? (
                     <Stat label="Status">
                         <LemonTag type={isError ? 'danger' : 'success'}>{isError ? 'Error' : 'Success'}</LemonTag>
                     </Stat>
@@ -253,7 +256,7 @@ export function MCPEventView({ properties }: MCPEventViewProps): JSX.Element {
                 {clientName ? <Stat label="Client">{String(clientName)}</Stat> : null}
                 {serverName ? <Stat label="Server">{String(serverName)}</Stat> : null}
                 {intent ? (
-                    <Stat label={intentSource ? `Intent (${String(intentSource).replace('_', ' ')})` : 'Intent'}>
+                    <Stat label={intentSource ? `Intent (${String(intentSource).replace(/_/g, ' ')})` : 'Intent'}>
                         <Tooltip title={String(intent)}>
                             <span className="line-clamp-1 max-w-[40ch]">{String(intent)}</span>
                         </Tooltip>


### PR DESCRIPTION
## Problem

MCP-related events (`mcp_tool_call`, `mcp_initialize`, `mcp_resource_read`, …) currently render in the activity page's event drawer with their fields interleaved into the generic Properties tab. Important MCP context (tool name, duration, error status, parameters, response) is hard to scan, and individual values like `\$mcp_response` or `\$mcp_exec_tool_call_description` can be 4k tokens / 18 KB and dump as a wall of text that buries every other property.

## Changes

- New **MCP analytics** tab in `EventPropertyTabs`, auto-selected for any event whose name starts with `mcp_` or `mcp ` (covers the canonical `@posthog/mcp` events and legacy mcpcat events).
- Tab content lives in a new `MCPEventView` component:
  - A labeled stats card at the top surfacing generic MCP-spec fields: `STATUS`, `TOOL` / `RESOURCE`, `DURATION`, `TRANSPORT`, `CLIENT`, `SERVER`, and `INTENT` (with `intent_source` shown in the label when present). Labels make each value self-describing instead of relying on chip color/position to infer meaning.
  - A unified property list rendered via \`LemonTable\` + \`PropertyKeyInfo\`, so the visual treatment matches \`PropertiesTable\` (icon, taxonomy label, type tag).
  - Any value whose serialized payload exceeds ~256 B gets an inline per-row disclosure: \`[preview…] [Show 17.9 KB ▸] [TYPE] [📋]\` on a single non-wrapping row. Expanded content lives in a bounded scroll area (\`max-height: 50dvh\`) directly beneath the row, rendered via \`JSONViewer\` for objects or \`<pre>\` for plain strings. Copy-to-clipboard (full value, not the preview) is exposed only on expandable rows.
  - Properties are sorted with \`\$mcp_parameters\` and \`\$mcp_response\` first, then alphabetically; values can be searched (key + serialized value) when there are more than 6 properties.
- No backend or taxonomy changes. Detection in \`EventPropertyTabs\` is a prefix match, so new MCP event names get the tab automatically.

<img width="1190" height="777" alt="image" src="https://github.com/user-attachments/assets/c4b52bcb-da8e-493d-b23f-8107002cc786" />

## How did you test this code?

I'm a coding agent (PostHog Code). I did not manually exercise the UI in a browser. What ran locally:
- \`pnpm --filter=@posthog/frontend format\` on the touched files (passes; oxlint reports 0 errors).
- \`pnpm exec tsc --noEmit\` (full repo type check passes for the touched files; the only errors reported are in pre-existing unrelated files on \`master\`).

Reviewer manual check recommended:
1. Open the Activity → Explore page.
2. Find any event whose name starts with \`mcp_\` (e.g. \`mcp_tool_call\`, \`mcp_initialize\`).
3. Expand the row — confirm the **MCP analytics** tab appears and is auto-selected.
4. Confirm: stats card renders only the fields present on the event; long values collapse to a single row with the preview + Show button + type tag + copy icon fitting on one line; clicking Show expands a scrollable panel capped at 50dvh; the copy icon copies the full untruncated value.
5. Expand a non-MCP event (e.g. \`\$pageview\`) and confirm the tab does not appear.
6. Expand a \`survey sent\` event and confirm the existing **Survey response** tab still auto-selects (no regression to the default-tab cascade in \`EventPropertyTabs\`).

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7).
- Modelled the new tab on the existing \`survey_response\` event-detail tab pattern in \`EventPropertyTabs\` rather than a top-level activity-page filter — this matched the user's mental model ("similar to how we have done for surveys") and is far less invasive.
- Considered three disclosure strategies for the heavy values: (1) chunky \`LemonCollapse\` panels above a \`PropertiesTable\`, (2) modifying the shared \`PropertiesTable\` to support long-value disclosure universally, (3) a single unified list with per-row inline disclosure. Chose (3) — keeps the change scoped to the MCP tab, gives one consistent visual treatment, avoids regressions in the many \`PropertiesTable\` consumers. Iterated through (1) as an intermediate that the reviewer found visually disjointed.
- Stats card initially also included \`Mode\` and the \`\$mcp_exec_tool_call_name\` (single-exec dispatcher) preference; both removed because they are PostHog-specific rather than generic MCP-SDK fields. \`Intent\` is kept because the SDK exposes it as a generic concept.
- Threshold for "long" set at 256 B based on the reviewer's report that values up to 18 KB were the actual pain point and short values (UUIDs, version strings, booleans) should stay inline.
- Used \`50dvh\` instead of a pixel cap so the expanded panel adapts to the drawer height rather than overshooting on smaller viewports.
- Tab label set to \`MCP analytics\` (sentence casing per \`CLAUDE.md\`'s product-name convention).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*