### PR TITLE
feat(surveys): unify list-page notifications tab with per-survey UI

### DIFF
--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -7,17 +7,17 @@ import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
-import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { SurveyFeedbackButton } from 'scenes/surveys/components/SurveyFeedbackButton'
+import { SurveyNotificationsList } from 'scenes/surveys/components/SurveyNotificationsList'
 import { SurveysTable } from 'scenes/surveys/components/SurveysTable'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
-import { AccessControlLevel, AccessControlResourceType, ActivityScope, SurveyEventName } from '~/types'
+import { AccessControlLevel, AccessControlResourceType, ActivityScope } from '~/types'
 
 import { SURVEY_CREATED_SOURCE } from './constants'
 import { DuplicateToProjectModal } from './DuplicateToProjectModal'
@@ -110,14 +110,13 @@ function Surveys(): JSX.Element {
             />
             {tab === SurveysTabs.Settings && <SurveySettings />}
             {tab === SurveysTabs.Notifications && (
-                <>
-                    <p>Get notified whenever a survey result is submitted</p>
-                    <LinkedHogFunctions
-                        type="destination"
-                        subTemplateIds={['survey-response']}
-                        forceFilterGroups={[{ events: [{ id: SurveyEventName.SENT, type: 'events' }] }]}
-                    />
-                </>
+                <div className="flex flex-col gap-3">
+                    <p className="m-0 text-sm text-muted">
+                        Get notified whenever a survey result is submitted. Open a survey to add or edit its
+                        notifications.
+                    </p>
+                    <SurveyNotificationsList />
+                </div>
             )}
 
             {tab === SurveysTabs.History && <ActivityLog scope={ActivityScope.SURVEY} />}

--- a/frontend/src/scenes/surveys/components/SurveyNotificationsList.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationsList.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { LemonButton, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
 
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { HogFunctionIcon } from 'scenes/hog-functions/configuration/HogFunctionIcon'
@@ -76,8 +76,9 @@ function NewNotificationPicker(): JSX.Element {
 }
 
 export function SurveyNotificationsList(): JSX.Element {
-    const { notifications, notificationsLoading } = useValues(surveyNotificationsListLogic)
-    const { toggleNotificationEnabled } = useActions(surveyNotificationsListLogic)
+    const { notifications, notificationsLoading, notificationsFailed, knownSurveysFailed } =
+        useValues(surveyNotificationsListLogic)
+    const { toggleNotificationEnabled, loadNotifications, loadKnownSurveys } = useActions(surveyNotificationsListLogic)
     const { push } = useActions(router)
 
     if (notificationsLoading) {
@@ -87,6 +88,18 @@ export function SurveyNotificationsList(): JSX.Element {
                 <LemonSkeleton className="h-12" />
                 <LemonSkeleton className="h-12" />
             </div>
+        )
+    }
+
+    if (notificationsFailed) {
+        return (
+            <LemonBanner
+                type="error"
+                action={{ children: 'Try again', onClick: () => loadNotifications() }}
+                data-attr="survey-notifications-load-error"
+            >
+                We couldn't load your survey notifications. Please try again in a moment.
+            </LemonBanner>
         )
     }
 
@@ -106,6 +119,15 @@ export function SurveyNotificationsList(): JSX.Element {
 
     return (
         <div className="flex flex-col gap-3">
+            {knownSurveysFailed ? (
+                <LemonBanner
+                    type="warning"
+                    action={{ children: 'Retry', onClick: () => loadKnownSurveys() }}
+                    data-attr="survey-notifications-known-surveys-error"
+                >
+                    We couldn't verify which surveys still exist, so notifications for deleted surveys may appear here.
+                </LemonBanner>
+            ) : null}
             <div className="flex flex-col gap-1.5">
                 {notifications.map((fn) => {
                     const description = getNotificationDescription(fn)

--- a/frontend/src/scenes/surveys/components/SurveyNotificationsList.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationsList.tsx
@@ -1,0 +1,151 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { IconPlus } from '@posthog/icons'
+import { LemonButton, LemonMenu, LemonMenuItem, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
+
+import { HogFunctionIcon } from 'scenes/hog-functions/configuration/HogFunctionIcon'
+import {
+    getSurveyIdsFromNotificationFilters,
+    surveyNotificationsListLogic,
+} from 'scenes/surveys/surveyNotificationsListLogic'
+import { surveysLogic } from 'scenes/surveys/surveysLogic'
+import { urls } from 'scenes/urls'
+
+import { HogFunctionType, Survey } from '~/types'
+
+function getNotificationDescription(fn: HogFunctionType): string | null {
+    const inputs = fn.inputs
+    if (!inputs) {
+        return null
+    }
+    if (inputs.url?.value) {
+        try {
+            return new URL(String(inputs.url.value)).hostname
+        } catch {
+            return String(inputs.url.value)
+        }
+    }
+    if (inputs.channel?.value) {
+        return String(inputs.channel.value)
+    }
+    if (inputs.email?.value) {
+        return String(inputs.email.value)
+    }
+    return null
+}
+
+function surveyNotificationsUrl(surveyId: string, params: Record<string, string> = {}): string {
+    const search = new URLSearchParams({ tab: 'notifications', ...params }).toString()
+    return `${urls.survey(surveyId)}?${search}`
+}
+
+function NewNotificationButton(): JSX.Element {
+    const { push } = useActions(router)
+    const { data } = useValues(surveysLogic)
+
+    const eligibleSurveys = data.surveys.filter((survey: Survey) => !survey.archived)
+
+    const items: LemonMenuItem[] = eligibleSurveys.map((survey: Survey) => ({
+        key: survey.id,
+        label: survey.name,
+        onClick: () => push(surveyNotificationsUrl(survey.id, { notification: 'add' })),
+    }))
+
+    if (eligibleSurveys.length === 0) {
+        return (
+            <LemonButton
+                type="secondary"
+                size="small"
+                icon={<IconPlus />}
+                disabledReason="Create a survey first, then set up notifications from its Notifications tab."
+            >
+                New notification
+            </LemonButton>
+        )
+    }
+
+    return (
+        <LemonMenu items={[{ title: 'Add notification to…', items }]} placement="bottom-end" maxContentWidth>
+            <LemonButton type="secondary" size="small" icon={<IconPlus />}>
+                New notification
+            </LemonButton>
+        </LemonMenu>
+    )
+}
+
+export function SurveyNotificationsList(): JSX.Element {
+    const { notifications, notificationsLoading } = useValues(surveyNotificationsListLogic)
+    const { toggleNotificationEnabled } = useActions(surveyNotificationsListLogic)
+    const { push } = useActions(router)
+
+    if (notificationsLoading) {
+        return (
+            <div className="flex flex-col gap-2">
+                <LemonSkeleton className="h-12" />
+                <LemonSkeleton className="h-12" />
+                <LemonSkeleton className="h-12" />
+            </div>
+        )
+    }
+
+    if (notifications.length === 0) {
+        return (
+            <div className="flex flex-col items-center gap-3 rounded border border-dashed p-6 text-center">
+                <div className="space-y-1">
+                    <p className="m-0 text-sm font-medium">No survey notifications yet</p>
+                    <p className="m-0 text-xs text-muted">
+                        Send every new survey response to Slack, Discord, Microsoft Teams, or a webhook.
+                    </p>
+                </div>
+                <NewNotificationButton />
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+                {notifications.map((fn) => {
+                    const description = getNotificationDescription(fn)
+                    const surveyId = getSurveyIdsFromNotificationFilters(fn.filters)[0] ?? null
+
+                    const handleEdit = (): void => {
+                        if (surveyId) {
+                            push(surveyNotificationsUrl(surveyId, { notification: fn.id }))
+                        }
+                    }
+
+                    return (
+                        <div key={fn.id} className="flex items-center gap-2 rounded border p-2">
+                            <HogFunctionIcon src={fn.icon_url} size="small" />
+                            <div className="flex-1 min-w-0">
+                                <LemonButton
+                                    type="tertiary"
+                                    size="xsmall"
+                                    onClick={handleEdit}
+                                    disabledReason={
+                                        surveyId ? undefined : 'This notification is not linked to a survey.'
+                                    }
+                                    className="font-medium p-0 h-auto min-h-0"
+                                    noPadding
+                                >
+                                    <span className="truncate">{fn.name}</span>
+                                </LemonButton>
+                                {description ? <div className="text-xs text-muted truncate">{description}</div> : null}
+                            </div>
+                            <LemonSwitch
+                                checked={fn.enabled}
+                                onChange={() => toggleNotificationEnabled(fn.id, !fn.enabled)}
+                                size="small"
+                            />
+                        </div>
+                    )
+                })}
+            </div>
+            <div>
+                <NewNotificationButton />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/components/SurveyNotificationsList.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationsList.tsx
@@ -1,15 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconPlus } from '@posthog/icons'
-import { LemonButton, LemonMenu, LemonMenuItem, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
 
+import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { HogFunctionIcon } from 'scenes/hog-functions/configuration/HogFunctionIcon'
 import {
     getSurveyIdsFromNotificationFilters,
     surveyNotificationsListLogic,
 } from 'scenes/surveys/surveyNotificationsListLogic'
-import { surveysLogic } from 'scenes/surveys/surveysLogic'
 import { urls } from 'scenes/urls'
 
 import { HogFunctionType, Survey } from '~/types'
@@ -40,37 +39,39 @@ function surveyNotificationsUrl(surveyId: string, params: Record<string, string>
     return `${urls.survey(surveyId)}?${search}`
 }
 
-function NewNotificationButton(): JSX.Element {
+function NewNotificationPicker(): JSX.Element {
     const { push } = useActions(router)
-    const { data } = useValues(surveysLogic)
+    const { selectableSurveys, knownSurveysLoading } = useValues(surveyNotificationsListLogic)
 
-    const eligibleSurveys = data.surveys.filter((survey: Survey) => !survey.archived)
-
-    const items: LemonMenuItem[] = eligibleSurveys.map((survey: Survey) => ({
+    const options = selectableSurveys.map((survey: Pick<Survey, 'id' | 'name'>) => ({
         key: survey.id,
         label: survey.name,
-        onClick: () => push(surveyNotificationsUrl(survey.id, { notification: 'add' })),
     }))
 
-    if (eligibleSurveys.length === 0) {
-        return (
-            <LemonButton
-                type="secondary"
-                size="small"
-                icon={<IconPlus />}
-                disabledReason="Create a survey first, then set up notifications from its Notifications tab."
-            >
-                New notification
-            </LemonButton>
-        )
+    const handleChange = (newValue: string[]): void => {
+        const surveyId = newValue[0]
+        if (surveyId) {
+            push(surveyNotificationsUrl(surveyId, { notification: 'add' }))
+        }
     }
 
     return (
-        <LemonMenu items={[{ title: 'Add notification to…', items }]} placement="bottom-end" maxContentWidth>
-            <LemonButton type="secondary" size="small" icon={<IconPlus />}>
-                New notification
-            </LemonButton>
-        </LemonMenu>
+        <div className="w-80 max-w-full">
+            <LemonInputSelect
+                mode="single"
+                placeholder="Add notification to a survey…"
+                title="Add notification to…"
+                options={options}
+                value={null}
+                onChange={handleChange}
+                loading={knownSurveysLoading}
+                size="small"
+                emptyStateComponent={
+                    <div className="p-2 text-xs text-muted">No surveys to notify on. Create a survey first.</div>
+                }
+                data-attr="survey-list-new-notification-picker"
+            />
+        </div>
     )
 }
 
@@ -98,7 +99,7 @@ export function SurveyNotificationsList(): JSX.Element {
                         Send every new survey response to Slack, Discord, Microsoft Teams, or a webhook.
                     </p>
                 </div>
-                <NewNotificationButton />
+                <NewNotificationPicker />
             </div>
         )
     }
@@ -143,9 +144,7 @@ export function SurveyNotificationsList(): JSX.Element {
                     )
                 })}
             </div>
-            <div>
-                <NewNotificationButton />
-            </div>
+            <NewNotificationPicker />
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -1,5 +1,6 @@
 import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -17,6 +18,7 @@ import {
     getSurveyNotificationFilters,
     getSurveyIdBasedResponseKey,
 } from 'scenes/surveys/utils'
+import { urls } from 'scenes/urls'
 
 import {
     HogFunctionTemplateType,
@@ -657,8 +659,16 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
     props({} as SurveyNotificationModalLogicProps),
     key((props) => props.surveyId),
     connect((props: SurveyNotificationModalLogicProps) => ({
-        values: [integrationsLogic, ['integrations'], surveyLogic({ id: props.surveyId }), ['survey']],
-        actions: [surveyLogic({ id: props.surveyId }), ['loadSurveyNotifications']],
+        values: [
+            integrationsLogic,
+            ['integrations'],
+            surveyLogic({ id: props.surveyId }),
+            ['survey', 'surveyLoading', 'surveyNotifications', 'surveyNotificationsLoading'],
+        ],
+        actions: [
+            surveyLogic({ id: props.surveyId }),
+            ['loadSurveyNotifications', 'loadSurveyNotificationsSuccess', 'loadSurveySuccess'],
+        ],
     })),
 
     actions({
@@ -668,6 +678,8 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
         }),
         closeDialog: true,
         setNotificationSubmissionError: (error: string | null) => ({ error }),
+        setPendingDeepLink: (target: string | null) => ({ target }),
+        consumePendingDeepLink: true,
     }),
 
     reducers({
@@ -696,6 +708,14 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
             null as string | null,
             {
                 setNotificationSubmissionError: (_, { error }) => error,
+                openDialog: () => null,
+                closeDialog: () => null,
+            },
+        ],
+        pendingDeepLink: [
+            null as string | null,
+            {
+                setPendingDeepLink: (_, { target }) => target,
                 openDialog: () => null,
                 closeDialog: () => null,
             },
@@ -801,6 +821,42 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
                     : buildSurveyNotificationForm(values.survey)
             )
         },
+        setPendingDeepLink: ({ target }) => {
+            if (!target) {
+                return
+            }
+            actions.consumePendingDeepLink()
+        },
+        loadSurveySuccess: () => {
+            if (values.pendingDeepLink) {
+                actions.consumePendingDeepLink()
+            }
+        },
+        loadSurveyNotificationsSuccess: () => {
+            if (values.pendingDeepLink) {
+                actions.consumePendingDeepLink()
+            }
+        },
+        consumePendingDeepLink: () => {
+            const target = values.pendingDeepLink
+            if (!target || values.isOpen) {
+                return
+            }
+            if (values.surveyLoading || values.survey.id === NEW_SURVEY.id) {
+                return
+            }
+            if (target === 'add') {
+                actions.openDialog()
+                return
+            }
+            if (values.surveyNotificationsLoading) {
+                return
+            }
+            const notification = values.surveyNotifications.find((fn) => fn.id === target)
+            if (notification) {
+                actions.openDialog({ notification, intent: 'edit' })
+            }
+        },
         closeDialog: () => {
             actions.resetNotificationForm()
         },
@@ -822,6 +878,25 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
             actions.setNotificationSubmissionError(
                 error instanceof Error ? error.message : `Failed to ${action} notification. Please try again.`
             )
+        },
+    })),
+
+    urlToAction(({ actions, props }) => ({
+        [urls.survey(props.surveyId)]: (_, searchParams) => {
+            const target = searchParams.notification
+            if (typeof target === 'string' && target.length > 0) {
+                actions.setPendingDeepLink(target)
+            }
+        },
+    })),
+
+    actionToUrl(() => ({
+        setPendingDeepLink: () => {
+            if (!('notification' in router.values.searchParams)) {
+                return
+            }
+            const { notification: _consumed, ...rest } = router.values.searchParams
+            return [router.values.location.pathname, rest, router.values.hashParams, { replace: true }]
         },
     })),
 ])

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -717,7 +717,6 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
             {
                 setPendingDeepLink: (_, { target }) => target,
                 openDialog: () => null,
-                closeDialog: () => null,
             },
         ],
     }),
@@ -865,6 +864,11 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
         },
         closeDialog: () => {
             actions.resetNotificationForm()
+            // If a deep link arrived while another dialog was already open it stayed pending —
+            // try to consume it now that we're no longer blocked by `isOpen`.
+            if (values.pendingDeepLink) {
+                actions.consumePendingDeepLink()
+            }
         },
         submitNotificationFormSuccess: async () => {
             const updatedNotification = values.editingNotification

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -855,7 +855,13 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
             const notification = values.surveyNotifications.find((fn) => fn.id === target)
             if (notification) {
                 actions.openDialog({ notification, intent: 'edit' })
+                return
             }
+            // The notification ID didn't resolve (deleted, wrong project, stale link). Clear the
+            // pending target so unrelated reloads of surveyNotifications don't keep re-triggering
+            // this listener with the same dead ID, and let the user know the link didn't work.
+            actions.setPendingDeepLink(null)
+            lemonToast.error("We couldn't find that notification — it may have been removed.")
         },
         closeDialog: () => {
             actions.resetNotificationForm()

--- a/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
@@ -115,16 +115,26 @@ export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType
     }),
     listeners(({ actions, values }) => ({
         toggleNotificationEnabled: async ({ notificationId, enabled }) => {
-            const previous = values.allNotifications
-            const optimistic = previous.map((notification) =>
-                notification.id === notificationId ? { ...notification, enabled } : notification
-            )
-            actions.loadNotificationsSuccess(optimistic)
+            const target = values.allNotifications.find((notification) => notification.id === notificationId)
+            if (!target) {
+                return
+            }
+            const previousEnabled = target.enabled
+
+            const applyEnabled = (next: boolean): void => {
+                actions.loadNotificationsSuccess(
+                    values.allNotifications.map((notification) =>
+                        notification.id === notificationId ? { ...notification, enabled: next } : notification
+                    )
+                )
+            }
+
+            applyEnabled(enabled)
 
             try {
                 await api.hogFunctions.update(notificationId, { enabled })
             } catch (error) {
-                actions.loadNotificationsSuccess(previous)
+                applyEnabled(previousEnabled)
                 lemonToast.error('Failed to update notification')
                 posthog.captureException(error, {
                     action: 'toggle-survey-notification-from-list',

--- a/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
@@ -89,15 +89,8 @@ export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType
                 knownSurveys.filter((survey) => !survey.archived),
         ],
         notifications: [
-            (s) => [s.allNotifications, s.knownSurveyIds, s.knownSurveysLoading],
-            (
-                allNotifications: HogFunctionType[],
-                knownSurveyIds: Set<string>,
-                knownSurveysLoading: boolean
-            ): HogFunctionType[] => {
-                if (knownSurveysLoading) {
-                    return []
-                }
+            (s) => [s.allNotifications, s.knownSurveyIds],
+            (allNotifications: HogFunctionType[], knownSurveyIds: Set<string>): HogFunctionType[] => {
                 return allNotifications.filter((notification) => {
                     const linkedIds = getSurveyIdsFromNotificationFilters(notification.filters)
                     if (linkedIds.length === 0) {

--- a/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
@@ -64,11 +64,15 @@ export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType
             },
         ],
         knownSurveys: [
-            [] as Pick<Survey, 'id' | 'name'>[],
+            [] as Pick<Survey, 'id' | 'name' | 'archived'>[],
             {
-                loadKnownSurveys: async (): Promise<Pick<Survey, 'id' | 'name'>[]> => {
+                loadKnownSurveys: async (): Promise<Pick<Survey, 'id' | 'name' | 'archived'>[]> => {
                     const response = await api.surveys.list({ limit: SURVEY_INDEX_LIMIT })
-                    return response.results.map((survey) => ({ id: survey.id, name: survey.name }))
+                    return response.results.map((survey) => ({
+                        id: survey.id,
+                        name: survey.name,
+                        archived: survey.archived,
+                    }))
                 },
             },
         ],
@@ -76,7 +80,13 @@ export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType
     selectors({
         knownSurveyIds: [
             (s) => [s.knownSurveys],
-            (knownSurveys: Pick<Survey, 'id' | 'name'>[]) => new Set(knownSurveys.map((survey) => survey.id)),
+            (knownSurveys: Pick<Survey, 'id' | 'name' | 'archived'>[]) =>
+                new Set(knownSurveys.map((survey) => survey.id)),
+        ],
+        selectableSurveys: [
+            (s) => [s.knownSurveys],
+            (knownSurveys: Pick<Survey, 'id' | 'name' | 'archived'>[]) =>
+                knownSurveys.filter((survey) => !survey.archived),
         ],
         notifications: [
             (s) => [s.allNotifications, s.knownSurveyIds, s.knownSurveysLoading],

--- a/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, kea, listeners, path, selectors } from 'kea'
+import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
@@ -77,6 +77,24 @@ export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType
             },
         ],
     })),
+    reducers({
+        notificationsFailed: [
+            false,
+            {
+                loadNotifications: () => false,
+                loadNotificationsSuccess: () => false,
+                loadNotificationsFailure: () => true,
+            },
+        ],
+        knownSurveysFailed: [
+            false,
+            {
+                loadKnownSurveys: () => false,
+                loadKnownSurveysSuccess: () => false,
+                loadKnownSurveysFailure: () => true,
+            },
+        ],
+    }),
     selectors({
         knownSurveyIds: [
             (s) => [s.knownSurveys],
@@ -89,8 +107,18 @@ export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType
                 knownSurveys.filter((survey) => !survey.archived),
         ],
         notifications: [
-            (s) => [s.allNotifications, s.knownSurveyIds],
-            (allNotifications: HogFunctionType[], knownSurveyIds: Set<string>): HogFunctionType[] => {
+            (s) => [s.allNotifications, s.knownSurveyIds, s.knownSurveysFailed],
+            (
+                allNotifications: HogFunctionType[],
+                knownSurveyIds: Set<string>,
+                knownSurveysFailed: boolean
+            ): HogFunctionType[] => {
+                // If we couldn't load the survey index, skip the existence filter and show every
+                // notification we did load. The filter is just orphan cleanup — a transient
+                // surveys-API failure shouldn't hide live notifications from the user.
+                if (knownSurveysFailed) {
+                    return allNotifications
+                }
                 return allNotifications.filter((notification) => {
                     const linkedIds = getSurveyIdsFromNotificationFilters(notification.filters)
                     if (linkedIds.length === 0) {

--- a/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
@@ -1,0 +1,130 @@
+import { actions, afterMount, kea, listeners, path, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+
+import { CyclotronJobFiltersType, HogFunctionType, Survey, SurveyEventName, SurveyEventProperties } from '~/types'
+
+import type { surveyNotificationsListLogicType } from './surveyNotificationsListLogicType'
+
+const SURVEY_NOTIFICATION_LIST_LIMIT = 200
+const SURVEY_INDEX_LIMIT = 1000
+
+export function getSurveyIdsFromNotificationFilters(filters?: CyclotronJobFiltersType | null): string[] {
+    const surveyIds = new Set<string>()
+
+    for (const event of filters?.events ?? []) {
+        for (const property of event.properties ?? []) {
+            if (property.key !== SurveyEventProperties.SURVEY_ID) {
+                continue
+            }
+
+            const value = property.value
+            if (Array.isArray(value)) {
+                value.forEach((surveyId) => {
+                    if (typeof surveyId === 'string') {
+                        surveyIds.add(surveyId)
+                    }
+                })
+            } else if (typeof value === 'string') {
+                surveyIds.add(value)
+            }
+        }
+    }
+
+    return Array.from(surveyIds)
+}
+
+export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType>([
+    path(['scenes', 'surveys', 'surveyNotificationsListLogic']),
+    actions({
+        toggleNotificationEnabled: (notificationId: string, enabled: boolean) => ({ notificationId, enabled }),
+    }),
+    loaders(() => ({
+        allNotifications: [
+            [] as HogFunctionType[],
+            {
+                loadNotifications: async (): Promise<HogFunctionType[]> => {
+                    const response = await api.hogFunctions.list({
+                        filter_groups: [
+                            {
+                                events: [{ id: SurveyEventName.SENT, type: 'events' }],
+                            },
+                        ],
+                        types: ['destination'],
+                        limit: SURVEY_NOTIFICATION_LIST_LIMIT,
+                        full: true,
+                    })
+
+                    return response.results.filter((notification) => !notification.deleted)
+                },
+            },
+        ],
+        knownSurveys: [
+            [] as Pick<Survey, 'id' | 'name'>[],
+            {
+                loadKnownSurveys: async (): Promise<Pick<Survey, 'id' | 'name'>[]> => {
+                    const response = await api.surveys.list({ limit: SURVEY_INDEX_LIMIT })
+                    return response.results.map((survey) => ({ id: survey.id, name: survey.name }))
+                },
+            },
+        ],
+    })),
+    selectors({
+        knownSurveyIds: [
+            (s) => [s.knownSurveys],
+            (knownSurveys: Pick<Survey, 'id' | 'name'>[]) => new Set(knownSurveys.map((survey) => survey.id)),
+        ],
+        notifications: [
+            (s) => [s.allNotifications, s.knownSurveyIds, s.knownSurveysLoading],
+            (
+                allNotifications: HogFunctionType[],
+                knownSurveyIds: Set<string>,
+                knownSurveysLoading: boolean
+            ): HogFunctionType[] => {
+                if (knownSurveysLoading) {
+                    return []
+                }
+                return allNotifications.filter((notification) => {
+                    const linkedIds = getSurveyIdsFromNotificationFilters(notification.filters)
+                    if (linkedIds.length === 0) {
+                        return false
+                    }
+                    return linkedIds.some((surveyId) => knownSurveyIds.has(surveyId))
+                })
+            },
+        ],
+        notificationsLoading: [
+            (s) => [s.allNotificationsLoading, s.knownSurveysLoading],
+            (allNotificationsLoading: boolean, knownSurveysLoading: boolean) =>
+                allNotificationsLoading || knownSurveysLoading,
+        ],
+    }),
+    listeners(({ actions, values }) => ({
+        toggleNotificationEnabled: async ({ notificationId, enabled }) => {
+            const previous = values.allNotifications
+            const optimistic = previous.map((notification) =>
+                notification.id === notificationId ? { ...notification, enabled } : notification
+            )
+            actions.loadNotificationsSuccess(optimistic)
+
+            try {
+                await api.hogFunctions.update(notificationId, { enabled })
+            } catch (error) {
+                actions.loadNotificationsSuccess(previous)
+                lemonToast.error('Failed to update notification')
+                posthog.captureException(error, {
+                    action: 'toggle-survey-notification-from-list',
+                    notification: notificationId,
+                })
+            }
+        },
+    })),
+    afterMount(({ actions }) => {
+        actions.loadNotifications()
+        actions.loadKnownSurveys()
+    }),
+])


### PR DESCRIPTION
## Problem

The Notifications tab on the surveys list page used a generic `LinkedHogFunctions` list — no inline enable/disable toggle, no destination details, no survey association, no way to edit without leaving the page. Meanwhile the per-survey Notifications tab already had a much nicer UI (icon, name, destination, inline toggle, deep modal editing) but only worked within a single survey's context.

## Changes

- New `SurveyNotificationsList` component that renders the same card style as the per-survey `SurveyNotifications` view, but globally across the project.
- New `surveyNotificationsListLogic` that loads all survey-response hog functions plus an index of all surveys (up to 1000) so we can filter the list to notifications whose linked survey actually exists.
- Notifications are hidden when their `\$survey_id` filter doesn't match a known (non-deleted) survey.
- Clicking a notification name navigates to `/surveys/{id}?tab=notifications&notification={fnId}`; the modal opens automatically.
- New searchable survey picker (`LemonInputSelect`) for adding a notification. On pick, navigates to `/surveys/{id}?tab=notifications&notification=add`.
- `surveyNotificationModalLogic` gains `urlToAction` / `actionToUrl` support: it reads `?notification=add|<id>` from the survey URL, waits for the survey + notifications to load, opens the appropriate dialog, and strips the param from the URL so refreshes/back-forward don't re-trigger.

| Before | After |
| --- | --- |
| Generic `LinkedHogFunctions` list, no per-row affordances | Card list matching the per-survey view, with toggle, destination, and deep-link editing |

## How did you test this code?

I'm an agent and have not done browser-based manual verification. Automated checks I ran locally:

- `pnpm typescript:check` on the surveys files — clean for all touched paths.
- `pnpm format` (oxlint + oxfmt) — clean.
- `kea-typegen write` — generates types successfully.

Manual testing the human reviewer should run:

- Open `/surveys`, switch to the Notifications tab — list should match the per-survey card style.
- Confirm notifications linked to deleted surveys disappear (and reappear after the survey is undeleted).
- Click a notification name — should land on `/surveys/{id}?tab=notifications` with the edit modal open. Close it, confirm URL no longer has `?notification=`.
- Use the survey picker (\"Add notification to a survey…\") — type to filter, pick a survey — should land on the survey's Notifications tab with the add-notification modal open.
- Confirm archived surveys are excluded from the picker but their notifications still show in the list.
- Toggle a notification on/off — should optimistically update; force a 5xx via devtools to confirm rollback.

## Publish to changelog?

no

## 🤖 Agent context

Authored with PostHog Code (Claude). The branch was actually recreated after the original working-tree changes were lost in an unrelated branch-switch + reset; the design and implementation here are the second pass, which matches what was discussed in the original session.

Design decisions worth flagging for review:

- **Client-side filtering for the survey picker.** We reuse the `selectableSurveys` index already loaded for the existence-check filter rather than calling the surveys list endpoint with `search` per keystroke. Pros: zero extra requests, instant filtering. Con: capped at 1000 surveys per project. If anyone in practice hits that cap, swapping to a debounced server search is straightforward.
- **Filtering to existing surveys.** Notifications whose `\$survey_id` filter doesn't resolve to a known survey are hidden in the list view. This is intentional (the user explicitly requested it). Archived surveys still count as \"existing\" — only deleted ones drop out. If you'd rather hide archived-survey notifications too, that's a one-line change (`archived: false` on the surveys fetch).
- **Deep-link state in URL, not in component state.** Using `urlToAction` + `actionToUrl` on `surveyNotificationModalLogic` keeps the open-dialog state in the URL so list-page → detail-page navigations feel like a single intent. The `pendingDeepLink` reducer + listeners coordinate around the survey / notifications loaders so the modal only opens once data is ready.
- **No \"Copy from existing\" in the global view.** The per-survey UI has it, but at the global level the action doesn't make sense (you'd have to pick a target survey first, which is already what the new picker does). Keeping the global list focused on management only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*