### PR TITLE
feat(surveys): switch guided form to iteration-based scheduling

### DIFF
--- a/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
@@ -5,7 +5,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
-import { Survey } from '~/types'
+import { Survey, SurveySchedule } from '~/types'
 
 import { SurveyAppearancePreview } from '../../SurveyAppearancePreview'
 
@@ -64,11 +64,17 @@ export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
                     <div className="flex justify-between">
                         <dt className="text-secondary">Frequency</dt>
                         <dd>
-                            {survey.conditions?.seenSurveyWaitPeriodInDays == null
+                            {survey.schedule === SurveySchedule.Once || !survey.iteration_frequency_days
                                 ? 'Once ever'
-                                : `Every ${survey.conditions?.seenSurveyWaitPeriodInDays} days`}
+                                : `Up to ${survey.iteration_count ?? 1} times, every ${survey.iteration_frequency_days} days`}
                         </dd>
                     </div>
+                    {survey.conditions?.seenSurveyWaitPeriodInDays != null && (
+                        <div className="flex justify-between">
+                            <dt className="text-secondary">Wait period across all surveys</dt>
+                            <dd>{survey.conditions.seenSurveyWaitPeriodInDays} days</dd>
+                        </div>
+                    )}
                 </dl>
             </div>
         </div>

--- a/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
@@ -66,7 +66,7 @@ export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
                         <dd>
                             {survey.schedule === SurveySchedule.Once || !survey.iteration_frequency_days
                                 ? 'Once ever'
-                                : `Up to ${survey.iteration_count ?? 1} times, every ${survey.iteration_frequency_days} days`}
+                                : `Up to ${survey.iteration_count ?? 10} times, every ${survey.iteration_frequency_days} days`}
                         </dd>
                     </div>
                     {survey.conditions?.seenSurveyWaitPeriodInDays != null && (

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -295,13 +295,18 @@ export function WhenStep(): JSX.Element {
 
             <LemonCollapse
                 embedded
+                defaultActiveKey={seenSurveyWaitPeriodInDays != null ? 'wait-period' : undefined}
                 panels={[
                     {
                         key: 'wait-period',
                         header: (
                             <span>
                                 Wait period across all surveys{' '}
-                                <span className="text-muted font-normal">(optional)</span>
+                                <span className="text-muted font-normal">
+                                    {seenSurveyWaitPeriodInDays != null
+                                        ? `(${seenSurveyWaitPeriodInDays} days)`
+                                        : '(optional)'}
+                                </span>
                             </span>
                         ),
                         content: (

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -1,7 +1,14 @@
 import { useActions, useValues } from 'kea'
 
 import { IconX } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
+import {
+    LemonButton,
+    LemonCheckbox,
+    LemonCollapse,
+    LemonInput,
+    LemonSegmentedButton,
+    LemonSwitch,
+} from '@posthog/lemon-ui'
 
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -27,6 +34,10 @@ import { surveyLogic } from '../../surveyLogic'
 import { surveyWizardLogic } from '../surveyWizardLogic'
 import { WizardPanel, WizardSection, WizardStepLayout } from '../WizardLayout'
 
+const DEFAULT_ITERATION_COUNT = 10
+const MIN_ITERATION_COUNT = 2
+const MAX_ITERATION_COUNT = 500
+
 const FREQUENCY_OPTIONS: { value: string; days: number | undefined; label: string }[] = [
     { value: 'once', days: undefined, label: 'Once ever' },
     { value: 'yearly', days: 365, label: 'Every year' },
@@ -51,7 +62,15 @@ export function WhenStep(): JSX.Element {
         const option = FREQUENCY_OPTIONS.find((opt) => opt.days === days)
         return option?.value || 'monthly'
     }
-    const frequency = daysToFrequency(conditions.seenSurveyWaitPeriodInDays)
+    // Prefer the new iteration-based model. Fall back to the legacy wait-period for older guided-form surveys.
+    const frequency =
+        survey.schedule === SurveySchedule.Once
+            ? 'once'
+            : survey.iteration_frequency_days
+              ? daysToFrequency(survey.iteration_frequency_days)
+              : daysToFrequency(conditions.seenSurveyWaitPeriodInDays)
+    const iterationCount = survey.iteration_count ?? DEFAULT_ITERATION_COUNT
+    const seenSurveyWaitPeriodInDays = conditions.seenSurveyWaitPeriodInDays ?? null
 
     const setTriggerMode = (mode: 'pageview' | 'event'): void => {
         if (mode === 'pageview') {
@@ -68,9 +87,35 @@ export function WhenStep(): JSX.Element {
 
     const setFrequency = (value: string): void => {
         const option = FREQUENCY_OPTIONS.find((opt) => opt.value === value)
-        const isOnce = value === 'once'
-        setSurveyValue('schedule', isOnce ? SurveySchedule.Once : SurveySchedule.Always)
-        setSurveyValue('conditions', { ...conditions, seenSurveyWaitPeriodInDays: option?.days })
+        if (value === 'once') {
+            setSurveyValue('schedule', SurveySchedule.Once)
+            setSurveyValue('iteration_count', 0)
+            setSurveyValue('iteration_frequency_days', 0)
+            return
+        }
+        setSurveyValue('schedule', SurveySchedule.Recurring)
+        setSurveyValue(
+            'iteration_count',
+            survey.iteration_count && survey.iteration_count >= MIN_ITERATION_COUNT
+                ? survey.iteration_count
+                : DEFAULT_ITERATION_COUNT
+        )
+        setSurveyValue('iteration_frequency_days', option?.days)
+    }
+
+    const setIterationCount = (value: number | undefined): void => {
+        if (!value || value < MIN_ITERATION_COUNT) {
+            setSurveyValue('iteration_count', MIN_ITERATION_COUNT)
+            return
+        }
+        setSurveyValue('iteration_count', Math.min(value, MAX_ITERATION_COUNT))
+    }
+
+    const setSeenSurveyWaitPeriod = (value: number | null): void => {
+        setSurveyValue('conditions', {
+            ...conditions,
+            seenSurveyWaitPeriodInDays: value && value > 0 ? value : null,
+        })
     }
 
     const setRepeatedActivation = (enabled: boolean): void => {
@@ -213,11 +258,7 @@ export function WhenStep(): JSX.Element {
                 )}
             </WizardSection>
 
-            <WizardSection
-                title="How often can the same person see this?"
-                description="Control how frequently the same person can be shown this survey again."
-                descriptionClassName="text-sm"
-            >
+            <WizardSection title="How often should this survey trigger?">
                 <LemonSegmentedButton
                     value={frequency}
                     onChange={setFrequency}
@@ -232,7 +273,58 @@ export function WhenStep(): JSX.Element {
                 {recommendedFrequency.value === frequency && (
                     <p className="text-sm text-success mt-3">{recommendedFrequency.reason}</p>
                 )}
+
+                {frequency !== 'once' && (
+                    <div className="flex items-center gap-2 mt-4 text-sm">
+                        <span>Show up to</span>
+                        <LemonInput
+                            type="number"
+                            min={MIN_ITERATION_COUNT}
+                            max={MAX_ITERATION_COUNT}
+                            value={iterationCount}
+                            onChange={(val) => setIterationCount(val ?? undefined)}
+                            className="w-20"
+                        />
+                        <span className="text-secondary">times total</span>
+                        <span className="text-muted text-xs">
+                            min {MIN_ITERATION_COUNT}, max {MAX_ITERATION_COUNT}
+                        </span>
+                    </div>
+                )}
             </WizardSection>
+
+            <LemonCollapse
+                embedded
+                panels={[
+                    {
+                        key: 'wait-period',
+                        header: (
+                            <span>
+                                Wait period across all surveys{' '}
+                                <span className="text-muted font-normal">(optional)</span>
+                            </span>
+                        ),
+                        content: (
+                            <div className="flex items-center gap-2 text-sm py-1">
+                                <LemonSwitch
+                                    checked={seenSurveyWaitPeriodInDays != null}
+                                    onChange={(checked) => setSeenSurveyWaitPeriod(checked ? 30 : null)}
+                                    size="small"
+                                />
+                                <span>Hide if any survey was seen in the last</span>
+                                <LemonInput
+                                    type="number"
+                                    min={1}
+                                    value={seenSurveyWaitPeriodInDays ?? NaN}
+                                    onChange={(val) => setSeenSurveyWaitPeriod(val ?? null)}
+                                    className="w-20"
+                                />
+                                <span className="text-secondary">days</span>
+                            </div>
+                        ),
+                    },
+                ]}
+            />
 
             <section className="space-y-2 border-t border-border pt-5">
                 <label className="text-sm font-medium">Delay before showing</label>

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -104,11 +104,18 @@ export function WhenStep(): JSX.Element {
     }
 
     const setIterationCount = (value: number | undefined): void => {
-        if (!value || value < MIN_ITERATION_COUNT) {
-            setSurveyValue('iteration_count', MIN_ITERATION_COUNT)
+        // Don't clamp to min on every keystroke — typing "10" briefly passes through 1, and aggressive
+        // clamping prevents the second digit from being appended. The blur handler enforces the floor.
+        if (value === undefined) {
             return
         }
         setSurveyValue('iteration_count', Math.min(value, MAX_ITERATION_COUNT))
+    }
+
+    const commitIterationCount = (): void => {
+        if (!survey.iteration_count || survey.iteration_count < MIN_ITERATION_COUNT) {
+            setSurveyValue('iteration_count', MIN_ITERATION_COUNT)
+        }
     }
 
     const setSeenSurveyWaitPeriod = (value: number | null): void => {
@@ -283,6 +290,7 @@ export function WhenStep(): JSX.Element {
                             max={MAX_ITERATION_COUNT}
                             value={iterationCount}
                             onChange={(val) => setIterationCount(val ?? undefined)}
+                            onBlur={commitIterationCount}
                             className="w-20"
                         />
                         <span className="text-secondary">times total</span>

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -278,11 +278,11 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
                 monthly: 30,
             }
             const { value: frequencyValue } = values.recommendedFrequency
-            actions.setSurveyValue('schedule', frequencyValue === 'once' ? SurveySchedule.Once : SurveySchedule.Always)
-            actions.setSurveyValue('conditions', {
-                ...template.conditions,
-                seenSurveyWaitPeriodInDays: frequencyToDays[frequencyValue],
-            })
+            const isOnce = frequencyValue === 'once'
+            actions.setSurveyValue('schedule', isOnce ? SurveySchedule.Once : SurveySchedule.Recurring)
+            actions.setSurveyValue('iteration_count', isOnce ? 0 : 10)
+            actions.setSurveyValue('iteration_frequency_days', isOnce ? 0 : frequencyToDays[frequencyValue])
+            actions.setSurveyValue('conditions', template.conditions ?? null)
 
             actions.reportSurveyTemplateClicked(template.templateType, SURVEY_CREATED_SOURCE.SURVEY_WIZARD)
         },


### PR DESCRIPTION
## Problem

In the guided form, the *How often can the same person see this?* picker was writing the cross-survey wait period (`seenSurveyWaitPeriodInDays`) when the user picked monthly/quarterly/yearly. This caused confusing behavior: customers expected a "monthly" survey to actually trigger every 30 days, but the wait period suppressed it whenever the same person was shown any other survey in the window.

The full editor already used the survey iteration model (`iteration_count` + `iteration_frequency_days`), which schedules the survey to actually trigger on cadence regardless of unrelated surveys.

## Changes

- The frequency segmented control (Once / Yearly / Quarterly / Monthly) in the guided form now writes `schedule` (`Once` / `Recurring`), `iteration_count`, and `iteration_frequency_days` — matching the full editor.
- New iteration-count input: `Show up to [10] times total` (default 10, range 2–500, enforced server-side as well).
- A new optional, collapsed section *Wait period across all surveys* exposes `seenSurveyWaitPeriodInDays` as a separate concept, with a switch + number input. Typing into the input auto-enables it, mirroring the full editor pattern.
- Section title moved to active voice: *How often should this survey trigger?* — clarifies that the cadence is the survey's own schedule, not a per-user guarantee.
- Reading falls back to the legacy wait-period when an existing wizard-created survey doesn't yet have iteration fields, so already-saved surveys still render sensibly.
- Wizard template selection (`selectTemplate`) now seeds iteration fields from `recommendedFrequency` instead of the wait period.
- The success-step summary renders the new frequency string and surfaces the wait period as a separate row when set.

## How did you test this code?

I'm an agent. I ran the existing wizard test suites locally:

- `pnpm --filter=@posthog/frontend exec jest src/scenes/surveys/wizard` — all 3 test files / 13 tests pass.

I did **not** perform manual browser testing.

## Publish to changelog?

no

## Docs update

No docs change needed — internal copy and field-routing change. The iteration model itself is already documented.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.7) over a single session.

Decision log:
- Initial approach also added an always-visible wait-period section. After a design review pass using `/emil-design-engineering`, that section was demoted to a collapsed `LemonCollapse` to avoid re-introducing the cross-survey-confusion the change is meant to solve.
- Considered hiding the min/max iteration constraint inside a tooltip; rolled back per author preference for visible constraint text.
- Considered explaining the "missed iteration if user is offline" edge case in copy; rejected as over-explaining — the iteration model already implies soft coverage across N iterations, and surfacing it would just bloat the page again.
- Switched the cross-survey field to `LemonSwitch` + always-editable `LemonInput` (typing into the input auto-enables) to mirror the full-editor interaction pattern.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*