### PR TITLE
fix(funnels): show back button when viewing time-to-convert histogram

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -17,8 +17,8 @@ import { urls } from 'scenes/urls'
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { getLastNewFolder } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { isDataVisualizationNode } from '~/queries/utils'
-import { AccessControlLevel, AccessControlResourceType, InsightLogicProps, ItemMode } from '~/types'
+import { isDataVisualizationNode, isFunnelsQuery } from '~/queries/utils'
+import { AccessControlLevel, AccessControlResourceType, FunnelVizType, InsightLogicProps, ItemMode } from '~/types'
 
 import { InsightSidePanelContent } from './SidePanel/InsightSidePanelContent'
 import { getInsightIconTypeFromQuery, getOverrideWarningPropsForButton } from './utils'
@@ -48,6 +48,19 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     const canCreateAlertForInsight = areAlertsSupportedForInsight(query)
 
+    // When viewing the time-to-convert histogram (drilled into from the funnel steps view),
+    // inject a back breadcrumb so users can return to the steps view.
+    const isTimeToConvertView =
+        isFunnelsQuery(query) && query.funnelsFilter?.funnelVizType === FunnelVizType.TimeToConvert
+    const timeToConvertBackBreadcrumb =
+        isTimeToConvertView && insight.short_id
+            ? {
+                  key: `insight-${insight.short_id}-steps`,
+                  name: 'Funnel steps',
+                  path: urls.insightView(insight.short_id),
+              }
+            : undefined
+
     useMaxTool({
         identifier: 'upsert_alert',
         active: canCreateAlertForInsight && hasDashboardItemId && !!insight.id,
@@ -71,6 +84,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 resourceType={{
                     type: getInsightIconTypeFromQuery(query),
                 }}
+                forceBackTo={timeToConvertBackBreadcrumb}
                 onNameChange={(name) => {
                     if (insightMode === ItemMode.Edit) {
                         setInsightMetadataLocal({ name })


### PR DESCRIPTION
## Problem

When a user clicks the "Average time to convert" label in a funnel insight, the visualization switches to the time-to-convert histogram view. There is no back button or breadcrumb to return to the funnel steps view — the only escape is the browser back button or manually navigating away.

## Changes

In `InsightPageHeader`, detect when the active insight is a funnel with `funnelVizType === TimeToConvert` and inject a `forceBackTo` breadcrumb pointing to the saved insight URL. `SceneTitleSection` renders a back arrow whenever `forceBackTo` is set, giving users a clear one-click path back to the steps view.

No new components or state are needed — `SceneTitleSection` already supports `forceBackTo`.

## How did you test this code?

Automated: TypeScript compilation passes with no new errors.

## 🤖 Agent context

Authored by an automated agent. Reviewer should verify the back button appears in the funnel time-to-convert histogram view and navigates back to the funnel steps.