### PR TITLE
fix(hog-functions): guard against null template in duplicate action

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -1342,13 +1342,15 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
 
         duplicate: async () => {
             if (values.hogFunction) {
+                if (!values.hogFunction.template) {
+                    lemonToast.error('Cannot duplicate: this function has no associated template')
+                    return
+                }
                 const newConfig = {
                     ...values.configuration,
                     name: `${values.configuration.name} (copy)`,
                 }
-                // TODO: What to do if no template?
-                const originalTemplate = values.hogFunction.template!
-                router.actions.push(urls.hogFunctionNew(originalTemplate.id), undefined, {
+                router.actions.push(urls.hogFunctionNew(values.hogFunction.template.id), undefined, {
                     configuration: newConfig,
                 })
             }


### PR DESCRIPTION
## Problem

The `duplicate` action in `hogFunctionConfigurationLogic` uses a non-null assertion (`!`) on `hogFunction.template`, with a `TODO: What to do if no template?` comment acknowledging the gap. Hog functions created or backfilled without a template (confirmed possible from test fixtures using `template: null`) would throw at runtime when the action attempts to access `template.id`.

## Changes

Add an early return with a `lemonToast.error` message when `template` is absent, matching the pattern already used in the adjacent `duplicateFromTemplate` action which properly checks `if (values.hogFunction?.template)` before accessing it.

## How did you test this code?

Automated: TypeScript compilation passes. Existing hog-function tests continue to pass.

## 🤖 Agent context

Authored by an automated agent. The fix mirrors the null-check pattern already used by `duplicateFromTemplate` in the same file.