### PR TITLE
fix(billing): prevent TypeError when platform product addons is undefined

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -527,9 +527,9 @@ export const billingLogic = kea<billingLogicType>([
                     return []
                 }
 
-                const addonPlans = platformAndSupportProduct?.addons?.map((addon) => addon.plans).flat()
-                const insertionIndex = Math.max(0, (platformAndSupportProduct?.plans?.length ?? 1) - 1)
-                const allPlans = platformAndSupportProduct?.plans?.slice(0) || []
+                const addonPlans = (platformAndSupportProduct.addons ?? []).map((addon) => addon.plans).flat()
+                const insertionIndex = Math.max(0, (platformAndSupportProduct.plans?.length ?? 1) - 1)
+                const allPlans = platformAndSupportProduct.plans?.slice(0) || []
                 allPlans.splice(insertionIndex, 0, ...addonPlans)
                 return allPlans
             },


### PR DESCRIPTION
## Problem

In `billingLogic.tsx`, the `supportPlans` selector builds a merged plan list with:

```ts
const addonPlans = platformAndSupportProduct?.addons?.map((addon) => addon.plans).flat()
allPlans.splice(insertionIndex, 0, ...addonPlans)
```

If `addons` is absent at runtime (e.g. the API returns an incomplete product object), the optional chain returns `undefined`, and both `.flat()` and the spread in `splice` throw a `TypeError`. The type says `addons` is required, but the optional chain was added defensively — the inconsistency means one bad API response crashes the billing page.

## Changes

Replace `platformAndSupportProduct?.addons?.map(...)` with `(platformAndSupportProduct.addons ?? []).map(...)`. After the early-return guard on line 544, `platformAndSupportProduct` is narrowed to non-null, so the first `?.` was redundant. The `?? []` fallback ensures `.flat()` and the spread always receive an iterable.

## How did you test this code?

Automated: TypeScript compilation passes.

## 🤖 Agent context

Authored by an automated agent.