### PR TITLE
fix(surveys): pass correct survey ID to SURVEY_DELETED intent event

### DIFF
--- a/frontend/src/scenes/surveys/surveysLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveysLogic.test.ts
@@ -284,11 +284,7 @@ describe('surveysLogic', () => {
             })
         })
 
-        // TODO: This test reveals a potential bug in surveysLogic where action.payload
-        // in the deleteSurveySuccess listener is an object instead of the survey ID.
-        // The implementation uses String(action.payload) which would produce "[object Object]".
-        // This needs investigation - either the test setup is wrong or the implementation has a bug.
-        it.skip('should track SURVEY_DELETED intent when deleting survey', async () => {
+        it('should track SURVEY_DELETED intent when deleting survey', async () => {
             const surveyId = 'test-survey-123'
 
             useMocks({

--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -337,14 +337,14 @@ export const surveysLogic = kea<surveysLogicType>([
         ],
     }),
     listeners(({ actions, values }) => ({
-        deleteSurveySuccess: (_, __, action) => {
+        deleteSurveySuccess: ({ payload: surveyId }) => {
             lemonToast.success('Survey deleted')
             router.actions.push(urls.surveys())
             actions.addProductIntent({
                 product_type: ProductKey.SURVEYS,
                 intent_context: ProductIntentContext.SURVEY_DELETED,
                 metadata: {
-                    survey_id: String(action.payload),
+                    survey_id: String(surveyId),
                 },
             })
         },


### PR DESCRIPTION
## Problem

The `deleteSurveySuccess` listener records a `SURVEY_DELETED` product intent with `survey_id: String(action.payload)`. The intent was to capture the deleted survey's ID, but `action.payload` in a kea-loaders success action is `{ payload: originalInput, [reducerKey]: returnValue }` — an object, not a string. `String(action.payload)` always produces `"[object Object]"`, so every deletion is tracked with a useless ID.

A test for this behavior was already written but skipped with a comment: _"This test reveals a potential bug … String(action.payload) would produce '[object Object]'"_.

## Changes

- Destructure `{ payload: surveyId }` from the first argument of the `deleteSurveySuccess` listener (which IS `action.payload`) to extract the original `deleteSurvey` input — the actual survey ID string.
- Unskip the previously-skipped test.

## How did you test this code?

The skipped test now passes. TypeScript compilation is clean.

## 🤖 Agent context

Authored by an automated agent. The fix is based on reading kea-loaders source (`lib/index.js`) to confirm the exact action payload shape for success listeners.