### PR TITLE
feat(mcp): surface event recency in read-data-schema events

### DIFF
--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -3,6 +3,7 @@ import json
 # nosemgrep: python.lang.security.use-defused-xml.use-defused-xml (XML generation only, no parsing - no XXE risk)
 import xml.etree.ElementTree as ET
 from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 from typing import Any, Optional, TypeVar, Union, cast
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -53,6 +54,51 @@ from ee.hogai.utils.types.base import (
 
 def remove_line_breaks(line: str) -> str:
     return line.replace("\n", " ")
+
+
+def _format_relative_time(timestamp: Any, now: datetime | None = None) -> str | None:
+    """Render a timestamp as a short relative-time string (e.g. "38m ago", "8d ago"). Returns None if input is invalid."""
+    if timestamp is None:
+        return None
+    if isinstance(timestamp, str):
+        try:
+            parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    elif isinstance(timestamp, datetime):
+        parsed = timestamp
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    reference = now or datetime.now(UTC)
+    delta_seconds = int((reference - parsed).total_seconds())
+    if delta_seconds < 0:
+        return "just now"
+    if delta_seconds < 60:
+        return f"{delta_seconds}s ago"
+    if delta_seconds < 3600:
+        return f"{delta_seconds // 60}m ago"
+    if delta_seconds < 86400:
+        return f"{delta_seconds // 3600}h ago"
+    return f"{delta_seconds // 86400}d ago"
+
+
+def _format_event_recency(event_data: Mapping[str, Any]) -> str | None:
+    """Format the last_seen_at + count_24h pair as a parenthesized suffix for event listings."""
+    if "last_seen_at" not in event_data and "count_24h" not in event_data:
+        return None
+    count_24h = event_data.get("count_24h")
+    last_seen = _format_relative_time(event_data.get("last_seen_at"))
+    if count_24h == 0:
+        return f"no events in 24h, last seen {last_seen}" if last_seen else "no events in 24h"
+    if last_seen and count_24h is not None:
+        return f"last seen {last_seen}, {count_24h} in 24h"
+    if last_seen:
+        return f"last seen {last_seen}"
+    if count_24h is not None:
+        return f"{count_24h} in 24h"
+    return None
 
 
 def filter_and_merge_messages(
@@ -177,11 +223,16 @@ def _process_events_data(
         # Add "All events" to the mapping
         "All events",
     ]
+    event_recency: dict[str, dict[str, Any]] = {}
     for item in response.results:
         event_def = CORE_FILTER_DEFINITIONS_BY_GROUP.get("events", {}).get(item.event)
         if event_def and (event_def.get("system") or event_def.get("ignored_in_assistant")):
             continue  # Skip system or ignored events (safety net, already filtered in SQL)
         events.append(item.event)
+        event_recency[item.event] = {
+            "last_seen_at": item.last_seen_at,
+            "count_24h": item.count_24h,
+        }
 
     event_to_description: dict[str, str] = {}
     for event in events_in_context:
@@ -195,7 +246,7 @@ def _process_events_data(
 
     processed_events = []
     for event_name in events:
-        event_data = {"name": event_name}
+        event_data: dict[str, Any] = {"name": event_name}
 
         if event_core_definition := CORE_FILTER_DEFINITIONS_BY_GROUP["events"].get(event_name):
             # Only skip if it's not in context (context events should always be included)
@@ -211,6 +262,10 @@ def _process_events_data(
                 event_data["description"] = remove_line_breaks(event_data["description"])
         elif event_name in event_to_description:
             event_data["description"] = remove_line_breaks(event_to_description[event_name])
+
+        if recency := event_recency.get(event_name):
+            event_data["last_seen_at"] = recency["last_seen_at"]
+            event_data["count_24h"] = recency["count_24h"]
 
         processed_events.append(event_data)
 
@@ -244,7 +299,13 @@ def format_events_yaml(
     for event_data in processed_events:
         name = event_data["name"]
         description = event_data.get("description", "")
-        formatted_events.append(f"- `{name}` - {description}" if description else f"- `{name}`")
+        recency = _format_event_recency(event_data)
+        line = f"- `{name}`"
+        if description:
+            line += f" - {description}"
+        if recency:
+            line += f" ({recency})"
+        formatted_events.append(line)
 
     if has_more:
         next_offset = (offset or 0) + (limit or 500)

--- a/ee/hogai/utils/test/test_format_events_prompt.py
+++ b/ee/hogai/utils/test/test_format_events_prompt.py
@@ -8,7 +8,7 @@ from posthog.schema import CachedTeamTaxonomyQueryResponse, MaxEventContext, Tea
 
 from posthog.hogql_queries.query_runner import ExecutionMode
 
-from ee.hogai.utils.helpers import format_events_xml
+from ee.hogai.utils.helpers import _format_event_recency, _format_relative_time, format_events_xml, format_events_yaml
 
 # Mock CORE_FILTER_DEFINITIONS_BY_GROUP for consistent testing
 MOCK_CORE_FILTER_DEFINITIONS = {
@@ -66,8 +66,19 @@ class TestFormatEventsPrompt(BaseTest):
         )
 
     def _create_taxonomy_items(self, events_with_counts):
-        """Helper to create TeamTaxonomyItem list from event name and count pairs."""
-        return [TeamTaxonomyItem(event=event, count=count) for event, count in events_with_counts]
+        """Helper to create TeamTaxonomyItem list from event name and count pairs.
+
+        Each entry may be `(event, count)` or `(event, count, last_seen_at, count_24h)`.
+        """
+        items = []
+        for entry in events_with_counts:
+            if len(entry) == 4:
+                event, count, last_seen_at, count_24h = entry
+                items.append(TeamTaxonomyItem(event=event, count=count, last_seen_at=last_seen_at, count_24h=count_24h))
+            else:
+                event, count = entry
+                items.append(TeamTaxonomyItem(event=event, count=count))
+        return items
 
     def _create_context_events(self, events_with_descriptions):
         """Helper to create MaxEventContext list from event name and description pairs."""
@@ -381,3 +392,77 @@ class TestFormatEventsPrompt(BaseTest):
             ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
             analytics_props=ANY,
         )
+
+    def test_format_relative_time(self):
+        now = datetime.datetime(2026, 5, 14, 12, 0, 0, tzinfo=datetime.UTC)
+        self.assertEqual(_format_relative_time(now - datetime.timedelta(seconds=5), now=now), "5s ago")
+        self.assertEqual(_format_relative_time(now - datetime.timedelta(minutes=38), now=now), "38m ago")
+        self.assertEqual(_format_relative_time(now - datetime.timedelta(hours=3), now=now), "3h ago")
+        self.assertEqual(_format_relative_time(now - datetime.timedelta(days=8), now=now), "8d ago")
+        # ISO 8601 string input is accepted
+        self.assertEqual(_format_relative_time("2026-05-14T11:59:55+00:00", now=now), "5s ago")
+        # Z suffix and naive timestamps fall back to UTC
+        self.assertEqual(_format_relative_time("2026-05-14T11:59:55Z", now=now), "5s ago")
+        # None / invalid inputs return None
+        self.assertIsNone(_format_relative_time(None))
+        self.assertIsNone(_format_relative_time("not-a-date"))
+
+    def test_format_event_recency(self):
+        now = datetime.datetime(2026, 5, 14, 12, 0, 0, tzinfo=datetime.UTC)
+        five_mins_ago = (now - datetime.timedelta(minutes=5)).isoformat()
+        # Both fields populated
+        self.assertEqual(
+            _format_event_recency({"last_seen_at": five_mins_ago, "count_24h": 12}),
+            "last seen 5m ago, 12 in 24h",
+        )
+        # count_24h == 0 with a recent last_seen
+        self.assertEqual(
+            _format_event_recency({"last_seen_at": five_mins_ago, "count_24h": 0}),
+            "no events in 24h, last seen 5m ago",
+        )
+        # count_24h == 0 with no last_seen_at
+        self.assertEqual(
+            _format_event_recency({"last_seen_at": None, "count_24h": 0}),
+            "no events in 24h",
+        )
+        # Neither field present → None (event predates the enrichment)
+        self.assertIsNone(_format_event_recency({"name": "some_event"}))
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_yaml_includes_recency_fields(self, mock_runner_class):
+        """Tool output appends `(last seen X, N in 24h)` when recency fields are present."""
+        # Use an ISO timestamp recent enough that the relative-time formatter produces something stable in the assertion.
+        # The actual delta from `now()` varies at test time, so we assert on the suffix shape rather than the exact value.
+        recent_iso = datetime.datetime.now(datetime.UTC).isoformat()
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("$pageview", 100, recent_iso, 42),
+                ("custom_event", 5, recent_iso, 0),
+            ]
+        )
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        result = format_events_yaml([], self.team)
+
+        # Recency suffix is appended to each event line in the YAML output.
+        self.assertIn("`$pageview`", result)
+        self.assertIn("42 in 24h", result)
+        self.assertIn("`custom_event`", result)
+        self.assertIn("no events in 24h", result)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_yaml_omits_recency_when_absent(self, mock_runner_class):
+        """If recency fields are not set (e.g. from a cached pre-enrichment response), no suffix is appended."""
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("legacy_event", 10),
+            ]
+        )
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        result = format_events_yaml([], self.team)
+
+        # No parenthesized recency suffix on the event line
+        self.assertIn("`legacy_event`", result)
+        self.assertNotIn("in 24h", result)
+        self.assertNotIn("last seen", result)

--- a/ee/hogai/utils/test/test_format_events_prompt.py
+++ b/ee/hogai/utils/test/test_format_events_prompt.py
@@ -1,14 +1,21 @@
 import datetime
 import xml.etree.ElementTree as ET
 
+from freezegun import freeze_time
 from posthog.test.base import BaseTest
 from unittest.mock import ANY, Mock, patch
+
+from parameterized import parameterized
 
 from posthog.schema import CachedTeamTaxonomyQueryResponse, MaxEventContext, TeamTaxonomyItem, TeamTaxonomyQuery
 
 from posthog.hogql_queries.query_runner import ExecutionMode
 
 from ee.hogai.utils.helpers import _format_event_recency, _format_relative_time, format_events_xml, format_events_yaml
+
+# Fixed reference instant used by relative-time parameterised tests so the
+# `now=` injection produces deterministic output regardless of wall-clock.
+_REF_NOW = datetime.datetime(2026, 5, 14, 12, 0, 0, tzinfo=datetime.UTC)
 
 # Mock CORE_FILTER_DEFINITIONS_BY_GROUP for consistent testing
 MOCK_CORE_FILTER_DEFINITIONS = {
@@ -393,40 +400,66 @@ class TestFormatEventsPrompt(BaseTest):
             analytics_props=ANY,
         )
 
-    def test_format_relative_time(self):
-        now = datetime.datetime(2026, 5, 14, 12, 0, 0, tzinfo=datetime.UTC)
-        self.assertEqual(_format_relative_time(now - datetime.timedelta(seconds=5), now=now), "5s ago")
-        self.assertEqual(_format_relative_time(now - datetime.timedelta(minutes=38), now=now), "38m ago")
-        self.assertEqual(_format_relative_time(now - datetime.timedelta(hours=3), now=now), "3h ago")
-        self.assertEqual(_format_relative_time(now - datetime.timedelta(days=8), now=now), "8d ago")
-        # ISO 8601 string input is accepted
-        self.assertEqual(_format_relative_time("2026-05-14T11:59:55+00:00", now=now), "5s ago")
-        # Z suffix and naive timestamps fall back to UTC
-        self.assertEqual(_format_relative_time("2026-05-14T11:59:55Z", now=now), "5s ago")
-        # None / invalid inputs return None
-        self.assertIsNone(_format_relative_time(None))
-        self.assertIsNone(_format_relative_time("not-a-date"))
+    @parameterized.expand(
+        [
+            ("seconds", datetime.timedelta(seconds=5), "5s ago"),
+            ("minutes", datetime.timedelta(minutes=38), "38m ago"),
+            ("hours", datetime.timedelta(hours=3), "3h ago"),
+            ("days", datetime.timedelta(days=8), "8d ago"),
+        ]
+    )
+    def test_format_relative_time_datetime_buckets(self, _name, delta, expected):
+        self.assertEqual(_format_relative_time(_REF_NOW - delta, now=_REF_NOW), expected)
 
-    def test_format_event_recency(self):
-        now = datetime.datetime(2026, 5, 14, 12, 0, 0, tzinfo=datetime.UTC)
-        five_mins_ago = (now - datetime.timedelta(minutes=5)).isoformat()
-        # Both fields populated
-        self.assertEqual(
-            _format_event_recency({"last_seen_at": five_mins_ago, "count_24h": 12}),
-            "last seen 5m ago, 12 in 24h",
-        )
-        # count_24h == 0 with a recent last_seen
-        self.assertEqual(
-            _format_event_recency({"last_seen_at": five_mins_ago, "count_24h": 0}),
-            "no events in 24h, last seen 5m ago",
-        )
-        # count_24h == 0 with no last_seen_at
-        self.assertEqual(
-            _format_event_recency({"last_seen_at": None, "count_24h": 0}),
-            "no events in 24h",
-        )
-        # Neither field present → None (event predates the enrichment)
-        self.assertIsNone(_format_event_recency({"name": "some_event"}))
+    @parameterized.expand(
+        [
+            ("iso_with_offset", "2026-05-14T11:59:55+00:00", "5s ago"),
+            ("iso_with_z_suffix", "2026-05-14T11:59:55Z", "5s ago"),
+            ("iso_naive_falls_back_to_utc", "2026-05-14T11:59:55", "5s ago"),
+        ]
+    )
+    def test_format_relative_time_string_input(self, _name, value, expected):
+        self.assertEqual(_format_relative_time(value, now=_REF_NOW), expected)
+
+    @parameterized.expand(
+        [
+            ("none", None),
+            ("invalid_string", "not-a-date"),
+            ("unsupported_type", 12345),
+        ]
+    )
+    def test_format_relative_time_invalid_returns_none(self, _name, value):
+        self.assertIsNone(_format_relative_time(value))
+
+    @parameterized.expand(
+        [
+            (
+                "both_fields_populated",
+                {"last_seen_at": (_REF_NOW - datetime.timedelta(minutes=5)).isoformat(), "count_24h": 12},
+                "last seen 5m ago, 12 in 24h",
+            ),
+            (
+                "count_zero_with_recent_last_seen",
+                {"last_seen_at": (_REF_NOW - datetime.timedelta(minutes=5)).isoformat(), "count_24h": 0},
+                "no events in 24h, last seen 5m ago",
+            ),
+            (
+                "count_zero_no_last_seen",
+                {"last_seen_at": None, "count_24h": 0},
+                "no events in 24h",
+            ),
+            (
+                "neither_field_present",
+                {"name": "some_event"},
+                None,
+            ),
+        ]
+    )
+    def test_format_event_recency(self, _name, event_data, expected):
+        # `last_seen_at` deltas are anchored to _REF_NOW; the helper internally calls datetime.now(UTC),
+        # so freeze time to keep "5m ago" stable regardless of wall-clock at test time.
+        with freeze_time(_REF_NOW):
+            self.assertEqual(_format_event_recency(event_data), expected)
 
     @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
     def test_format_events_yaml_includes_recency_fields(self, mock_runner_class):

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -37130,8 +37130,16 @@
                 "count": {
                     "$ref": "#/definitions/integer"
                 },
+                "count_24h": {
+                    "anyOf": [{ "$ref": "#/definitions/integer" }, { "type": "null" }],
+                    "description": "Number of occurrences of this event within the last 24 hours."
+                },
                 "event": {
                     "type": "string"
+                },
+                "last_seen_at": {
+                    "anyOf": [{ "type": "string" }, { "type": "null" }],
+                    "description": "Timestamp of the most recent occurrence of this event within the last 30 days. Null if no occurrences."
                 }
             },
             "required": ["event", "count"],

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -37131,15 +37131,22 @@
                     "$ref": "#/definitions/integer"
                 },
                 "count_24h": {
-                    "anyOf": [{ "$ref": "#/definitions/integer" }, { "type": "null" }],
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
                     "description": "Number of occurrences of this event within the last 24 hours."
                 },
                 "event": {
                     "type": "string"
                 },
                 "last_seen_at": {
-                    "anyOf": [{ "type": "string" }, { "type": "null" }],
-                    "description": "Timestamp of the most recent occurrence of this event within the last 30 days. Null if no occurrences."
+                    "description": "Timestamp of the most recent occurrence of this event within the last 30 days. Null if no occurrences.",
+                    "type": ["string", "null"]
                 }
             },
             "required": ["event", "count"],

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -4517,6 +4517,10 @@ export type CachedSuggestedQuestionsQueryResponse = CachedQueryResponse<Suggeste
 export interface TeamTaxonomyItem {
     event: string
     count: integer
+    /** Timestamp of the most recent occurrence of this event within the last 30 days. Null if no occurrences. */
+    last_seen_at?: string | null
+    /** Number of occurrences of this event within the last 24 hours. */
+    count_24h?: integer | null
 }
 
 export type TeamTaxonomyResponse = TeamTaxonomyItem[]

--- a/posthog/hogql_queries/ai/team_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/team_taxonomy_query_runner.py
@@ -60,13 +60,21 @@ class TeamTaxonomyQueryRunner(TaxonomyCacheMixin, AnalyticsQueryRunner[TeamTaxon
             )
 
         results: list[TeamTaxonomyItem] = [
-            TeamTaxonomyItem(event=event, count=count) for event, count in self.paginator.results
+            TeamTaxonomyItem(
+                event=event,
+                count=count,
+                last_seen_at=last_seen_at,
+                count_24h=count_24h,
+            )
+            for event, count, last_seen_at, count_24h in self.paginator.results
         ]
 
         if not self.paginator.has_more():
             found_events = {item.event for item in results}
             results.extend(
-                TeamTaxonomyItem(event=name, count=0) for name in WELL_KNOWN_EVENT_NAMES if name not in found_events
+                TeamTaxonomyItem(event=name, count=0, last_seen_at=None, count_24h=0)
+                for name in WELL_KNOWN_EVENT_NAMES
+                if name not in found_events
             )
 
         return TeamTaxonomyQueryResponse(
@@ -82,7 +90,9 @@ class TeamTaxonomyQueryRunner(TaxonomyCacheMixin, AnalyticsQueryRunner[TeamTaxon
             """
                 SELECT
                     event,
-                    count() as count
+                    count() as count,
+                    max(timestamp) as last_seen_at,
+                    countIf(timestamp >= now() - INTERVAL 1 DAY) as count_24h
                 FROM events
                 WHERE
                     timestamp >= now () - INTERVAL 30 DAY

--- a/posthog/hogql_queries/ai/team_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/team_taxonomy_query_runner.py
@@ -63,7 +63,9 @@ class TeamTaxonomyQueryRunner(TaxonomyCacheMixin, AnalyticsQueryRunner[TeamTaxon
             TeamTaxonomyItem(
                 event=event,
                 count=count,
-                last_seen_at=last_seen_at,
+                # ClickHouse returns the aggregate as a `datetime`, but the schema field is a string.
+                # Serialize to ISO 8601 so the value survives Pydantic validation and round-trips through caching.
+                last_seen_at=last_seen_at.isoformat() if last_seen_at else None,
                 count_24h=count_24h,
             )
             for event, count, last_seen_at, count_24h in self.paginator.results

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_suggested_questions_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_suggested_questions_query_runner.ambr
@@ -2,7 +2,9 @@
 # name: TestSuggestedQuestionsQueryRunner.test_suggested_questions_hit_openai
   '''
   SELECT events.event AS event,
-         count() AS count
+         count() AS count,
+         max(toTimeZone(events.timestamp, 'UTC')) AS last_seen_at,
+         countIf(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), minus(now64(6, 'UTC'), toIntervalDay(1)))) AS count_24h
   FROM events
   WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), notIn(events.event, ['$pageleave', '$autocapture', '$$heatmap', '$copy_autocapture', '$set', '$opt_in', '$feature_flag_called', '$feature_view', '$feature_interaction', '$element_viewed', '$capture_metrics', '$create_alias', '$merge_dangerously', '$groupidentify']))
   GROUP BY events.event

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_team_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_team_taxonomy_query_runner.ambr
@@ -3,8 +3,8 @@
   '''
   SELECT events.event AS event,
          count() AS count,
-         max(events.timestamp) AS last_seen_at,
-         countIf(greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(1)))) AS count_24h
+         max(toTimeZone(events.timestamp, 'UTC')) AS last_seen_at,
+         countIf(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), minus(now64(6, 'UTC'), toIntervalDay(1)))) AS count_24h
   FROM events
   WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), notIn(events.event, ['$pageleave', '$autocapture', '$$heatmap', '$copy_autocapture', '$set', '$opt_in', '$feature_flag_called', '$feature_view', '$feature_interaction', '$element_viewed', '$capture_metrics', '$create_alias', '$merge_dangerously', '$groupidentify']))
   GROUP BY events.event

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_team_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_team_taxonomy_query_runner.ambr
@@ -2,7 +2,9 @@
 # name: TestTeamTaxonomyQueryRunner.test_taxonomy_query_runner
   '''
   SELECT events.event AS event,
-         count() AS count
+         count() AS count,
+         max(events.timestamp) AS last_seen_at,
+         countIf(greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(1)))) AS count_24h
   FROM events
   WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), notIn(events.event, ['$pageleave', '$autocapture', '$$heatmap', '$copy_autocapture', '$set', '$opt_in', '$feature_flag_called', '$feature_view', '$feature_interaction', '$element_viewed', '$capture_metrics', '$create_alias', '$merge_dangerously', '$groupidentify']))
   GROUP BY events.event

--- a/posthog/hogql_queries/ai/test/test_team_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_team_taxonomy_query_runner.py
@@ -268,6 +268,58 @@ class TestTeamTaxonomyQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(pageview_results), 1)
         self.assertEqual(pageview_results[0].count, 1)
 
+    def test_last_seen_at_and_count_24h(self):
+        now = timezone.now()
+
+        _create_person(
+            distinct_ids=["person1"],
+            properties={"email": "person1@example.com"},
+            team=self.team,
+        )
+        # `recent_event` fires twice in the last 24h, last 5 minutes ago
+        _create_event(
+            event="recent_event",
+            distinct_id="person1",
+            team=self.team,
+            timestamp=now - timedelta(hours=23),
+        )
+        _create_event(
+            event="recent_event",
+            distinct_id="person1",
+            team=self.team,
+            timestamp=now - timedelta(minutes=5),
+        )
+        # `old_event` fires only outside the 24h window
+        _create_event(
+            event="old_event",
+            distinct_id="person1",
+            team=self.team,
+            timestamp=now - timedelta(days=7),
+        )
+
+        flush_persons_and_events()
+
+        runner = TeamTaxonomyQueryRunner(team=self.team, query=TeamTaxonomyQuery())
+        response = runner.run()
+
+        assert isinstance(response, CachedTeamTaxonomyQueryResponse)
+        by_event = {r.event: r for r in response.results}
+
+        self.assertEqual(by_event["recent_event"].count, 2)
+        self.assertEqual(by_event["recent_event"].count_24h, 2)
+        self.assertIsNotNone(by_event["recent_event"].last_seen_at)
+
+        self.assertEqual(by_event["old_event"].count, 1)
+        self.assertEqual(by_event["old_event"].count_24h, 0)
+        self.assertIsNotNone(by_event["old_event"].last_seen_at)
+
+        # Well-known events appended on the last page get count_24h=0 and last_seen_at=None
+        well_known_in_results = [r for r in response.results if r.count == 0]
+        self.assertGreater(len(well_known_in_results), 0)
+        for item in well_known_in_results:
+            self.assertEqual(item.count_24h, 0)
+            self.assertIsNone(item.last_seen_at)
+
     def test_well_known_events_only_on_last_page(self):
         _create_person(
             distinct_ids=["person1"],

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8632,7 +8632,16 @@ class TeamTaxonomyItem(BaseModel):
         extra="forbid",
     )
     count: int
+    count_24h: int | None = Field(
+        default=None, description="Number of occurrences of this event within the last 24 hours."
+    )
     event: str
+    last_seen_at: str | None = Field(
+        default=None,
+        description=(
+            "Timestamp of the most recent occurrence of this event within the last 30 days. Null if no occurrences."
+        ),
+    )
 
 
 class TestBasicQueryResponse(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8633,7 +8633,8 @@ class TeamTaxonomyItem(BaseModel):
     )
     count: int
     count_24h: int | None = Field(
-        default=None, description="Number of occurrences of this event within the last 24 hours."
+        default=None,
+        description="Number of occurrences of this event within the last 24 hours.",
     )
     event: str
     last_seen_at: str | None = Field(

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -31754,7 +31754,11 @@ export namespace Schemas {
 
     export interface TeamTaxonomyItem {
       count: number;
+      /** Number of occurrences of this event within the last 24 hours. */
+      count_24h?: number | null;
       event: string;
+      /** Timestamp of the most recent occurrence of this event within the last 30 days. Null if no occurrences. */
+      last_seen_at?: string | null;
     }
 
     export interface TeamTaxonomyQueryResponse {


### PR DESCRIPTION
## What

`read-data-schema` (kind: `events`) now returns two extra fields per event:

- `last_seen_at` — `max(timestamp)` over the last 30 days (ISO 8601 string)
- `count_24h` — events in the last 24 hours

The YAML output AI agents read goes from `- \`text_button_clicked\`` to `- \`text_button_clicked\` (last seen 38m ago, 12 in 24h)`.

## Why

Customer intent data shows **~24% of intent-bearing MCP tool calls are some variation of *"does this event exist and is it firing right now?"*** — and answering today takes 3-4 sequential tool calls. With these fields, the same answer is in the first call.

Discovery: rolled `mcp-posthog-analytics-sdk` to 25% of users → customer-side `$mcp_intent` started populating → sampled 200 intents from real customers → cluster was unmistakable.

## Code

The SQL was already scanning the 30-day window for `count`; adding `max(timestamp)` and `countIf(timestamp >= now() - INTERVAL 1 DAY)` rides the same scan at no extra cost. Both fields are optional in `TeamTaxonomyItem` (backward-compatible). ClickHouse returns `max(timestamp)` as a `datetime`, so we `.isoformat()` it to match the `str | None` schema field.

`TeamTaxonomyQueryRunner` is shared with the Max AI assistant — Max also picks up the new fields. Strict improvement (better event selection) but worth flagging.

## Tests

I'm an agent. Added automated tests (CI verifies — local pkg_resources env break):

- `test_team_taxonomy_query_runner.py::test_last_seen_at_and_count_24h` — new aggregates populate for in/out-of-window events; appended well-known events get `count_24h=0`/`last_seen_at=None`.
- `test_format_events_prompt.py::test_format_relative_time_*` — parameterised across seconds/minutes/hours/days buckets, ISO string variants (offset/Z/naive), invalid inputs.
- `test_format_events_prompt.py::test_format_event_recency` — parameterised across all four suffix states; uses `freeze_time` to stabilise `datetime.now(UTC)`.
- `test_format_events_yaml_includes_recency_fields` / `test_format_events_yaml_omits_recency_when_absent` — YAML formatter, with and without recency fields (backward compat).

ClickHouse query snapshot refreshed.

## Measurement

Before/after will be visible at: **[\[MCP\] read-data-schema enrichment — impact](https://us.posthog.com/project/2/dashboard/1583235)** (dashboard) and **[notebook `luqOcYzC`](https://us.posthog.com/project/2/notebooks/luqOcYzC)** (baselines + caveats).

The signal we expect: verify/discover intent volume ↓ ≥30% with control metric (% sessions reaching a substantive query) flat or ↑.

## Publish to changelog?

no

## Docs update

No public surface change — response gains two optional fields, no breaking change.

## 🤖 Agent context

Agent: PostHog Code (Claude Opus). Two decisions worth flagging for the reviewer:

- An `intentFallback` synthesis approach was explicitly rejected as data-laundering (we'd already have the arguments).
- A user-facing "Recent intents" feed in `products/mcp_analytics` was rejected for v1 because SDK-tracked events don't yet carry `organization_id` — that has to be threaded before per-customer analytics ship.

This is intended as the smallest possible first improvement based on the cluster analysis.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
