### PR TITLE
fix(surveys): polish response row expanded panel layout

### DIFF
--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyResponseExpandedRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyResponseExpandedRow.tsx
@@ -53,19 +53,23 @@ function formatAnswer(value: unknown): string {
 function AnswerDisplay({ question, value }: { question: SurveyQuestion; value: unknown }): JSX.Element {
     if (isScaleTwoRating(question) && (value == '1' || value == '2')) {
         return (
-            <span className="text-sm flex items-center gap-1">
+            <span className="text-sm font-medium flex items-center gap-1.5">
                 {getThumbIcon(value)}
                 Thumbs {value == '1' ? 'up' : 'down'}
             </span>
         )
     }
-    return <p className="text-sm whitespace-pre-wrap m-0">{formatAnswer(value)}</p>
+    return (
+        <p className="text-sm font-medium text-default whitespace-pre-wrap leading-relaxed m-0 break-words">
+            {formatAnswer(value)}
+        </p>
+    )
 }
 
 function MetaItem({ icon, children }: { icon?: JSX.Element; children: React.ReactNode }): JSX.Element {
     return (
         <span className="flex items-center gap-1 min-w-0">
-            {icon && <span className="shrink-0 flex items-center">{icon}</span>}
+            {icon && <span className="shrink-0 flex items-center text-muted">{icon}</span>}
             <span className="truncate">{children}</span>
         </span>
     )
@@ -110,8 +114,8 @@ export function SurveyResponseExpandedRow({ result }: { result: unknown }): JSX.
     }
 
     return (
-        <div className="sticky left-0 w-full max-w-[min(56rem,calc(100vw-2rem))] px-4 py-3 flex flex-col gap-4">
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-secondary">
+        <div className="mx-auto w-full max-w-[min(56rem,calc(100vw-2rem))] min-w-0 px-4 py-4 flex flex-col gap-5">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-secondary min-w-0">
                 <PersonDisplay
                     person={{ distinct_id: event.distinct_id, properties: event.person?.properties }}
                     withIcon="xs"
@@ -144,10 +148,10 @@ export function SurveyResponseExpandedRow({ result }: { result: unknown }): JSX.
             </div>
 
             {responses.length > 0 && (
-                <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-4">
                     {responses.map(({ questionIndex, question, value }) => (
-                        <div key={questionIndex} className="flex flex-col gap-1">
-                            <span className="text-xs text-secondary font-semibold">{question.question}</span>
+                        <div key={questionIndex} className="flex flex-col gap-1 min-w-0">
+                            <span className="text-xs text-secondary">{question.question}</span>
                             <AnswerDisplay question={question} value={value} />
                         </div>
                     ))}
@@ -156,7 +160,7 @@ export function SurveyResponseExpandedRow({ result }: { result: unknown }): JSX.
 
             <LemonDivider className="my-0" />
 
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-secondary">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-secondary min-w-0">
                 {currentUrl && (
                     <Link
                         to={currentUrl}
@@ -164,7 +168,7 @@ export function SurveyResponseExpandedRow({ result }: { result: unknown }): JSX.
                         title={currentUrl}
                         className="flex items-center gap-1 max-w-xs min-w-0"
                     >
-                        <IconGlobe className="shrink-0" />
+                        <IconGlobe className="shrink-0 text-muted" />
                         <span className="truncate">{prettyUrl(currentUrl)}</span>
                     </Link>
                 )}


### PR DESCRIPTION
## Problem

The expanded panel under each survey response row felt off: the distinct ID hash read as the headline while the answer text — the actual content of the response — was visually flat against it. The panel was also pinned to the left edge of the table viewport via `sticky left-0`, which made it look like it was floating in the corner when the table fit comfortably in the viewport (the common case).

## Changes

`SurveyResponseExpandedRow.tsx`:

- **Answers are now the focal content.** Removed `font-semibold` from question labels so they read as labels; added `font-medium`, `text-default`, and `leading-relaxed` to the answer text so it carries the visual weight. Added `break-words` so long unbroken strings don't blow out the panel width.
- **Footer metadata recedes.** Icons in the bottom metadata row (URL, browser, location, SDK) are now `text-muted` so the icons sit behind their values rather than competing with them.
- **Panel is centered, not left-pinned.** Swapped `sticky left-0` for `mx-auto`. The panel centers within the row, which matches the common case (table fits the viewport). The trade-off: if a user horizontally scrolls a wide table while a row is expanded, the panel moves with the scroll rather than staying glued to the left edge — acceptable since users typically expand-then-read rather than expand-then-scroll-horizontally.
- **Overflow safety.** Added `min-w-0` to every flex parent that contains truncatable content, so the existing `truncate` and `max-w-xs` rules on the URL link, MetaItem text, and the panel itself can actually shrink. Combined with `break-words` on the answer paragraph and the existing `max-w-[min(56rem, calc(100vw-2rem))]` cap on the root, this guarantees the expanded view never causes horizontal overflow of its own.
- Minor spacing rhythm: `py-3` → `py-4`, section gap `gap-4` → `gap-5`, Q&A pair gap `gap-3` → `gap-4`, header/footer row vertical gap `gap-y-2` → `gap-y-1.5`.

## How did you test this code?

I'm an agent. No automated tests were run for this change — the file has no existing test coverage and the diff is purely Tailwind class adjustments with no logic changes. Lucas should eyeball the panel in a browser before merging:

- Open any survey with at least one response and click a row to expand.
- Verify answers are visually prominent vs. question labels.
- Verify the panel sits centered in the row (no longer left-pinned).
- For a survey with many columns wide enough to force horizontal scroll: confirm the expanded panel still doesn't cause horizontal overflow of its own (long URLs / long open-text answers should wrap or truncate).

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- The user shared screenshots of the current expanded panel and asked for design polish using Emil Kowalski's design engineering principles.
- Design decisions:
  - **Hierarchy via weight + contrast, not size.** Considered uppercase labels for questions but rejected — PostHog's style guide is sentence casing. Settled on de-emphasizing the question label (removing `font-semibold`) while emphasizing the answer (adding `font-medium` + `text-default`).
  - **Sticky vs. centered.** Considered keeping `sticky left-0` for visibility during horizontal table scroll, but the user explicitly flagged the left-pinned layout as feeling "not really well centered." There's no pure-CSS way to *both* center in the visible viewport *and* remain sticky during horizontal scroll — sticky pins to one edge, not to center; achieving both would require JS-driven scroll tracking. Picked `mx-auto` as the better trade-off for the common case (table fits viewport).
  - **No animations.** Per the design-engineering "speed over delight" principle, this is product UI users will see many times a session — adding entrance animations would feel like decoration, not function.
  - **No card / border treatment.** The panel already has visual containment via the table row's styling; adding background or border would compete with the table's own visual structure.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*