### PR TITLE
fix(error-tracking): use projectId instead of deprecated project key in Nuxt sourcemaps config

### DIFF
--- a/docs/onboarding/error-tracking/nuxt.tsx
+++ b/docs/onboarding/error-tracking/nuxt.tsx
@@ -75,7 +75,7 @@ export const getNuxt37Steps = (ctx: OnboardingComponentsContext): StepDefinition
                                       },
                                       sourcemaps: {
                                         enabled: true,
-                                        project: '<ph_project_id>', // Your project ID from PostHog settings https://app.posthog.com/settings/environment#variables
+                                        projectId: '<ph_project_id>', // Your project ID from PostHog settings https://app.posthog.com/settings/environment#variables
                                         personalApiKey: '<ph_personal_api_key>', // Your personal API key from PostHog settings https://app.posthog.com/settings/user-api-keys (requires organization:read and error_tracking:write scopes)
                                         releaseName: 'my-application', // Optional: defaults to git repository name
                                         releaseVersion: '1.0.0', // Optional: defaults to current git commit

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx
@@ -77,10 +77,10 @@ const nuxtModuleConfig = (apiKey: string, host: string, teamId: string): string 
     },
     sourcemaps: {
       enabled: true,
-      envId: '${teamId}', // Your environment ID (project ID)
+      projectId: '${teamId}', // Your project ID from PostHog settings
       personalApiKey: '<ph_personal_api_key>', // Your personal API key from PostHog settings
-      project: 'my-application', // Optional: Project name, defaults to git repository name
-      version: '1.0.0', // Optional: Release version, defaults to current git commit
+      releaseName: 'my-application', // Optional: defaults to git repository name
+      releaseVersion: '1.0.0', // Optional: defaults to current git commit
     },
   },
 })`


### PR DESCRIPTION
## Problem

The Nuxt error tracking onboarding flow and docs were using the deprecated `project` key in the `@posthog/nuxt` sourcemaps config to set the PostHog project ID. In the current module, `project` is a fallback for `releaseName` — not the project ID. This means the docs were silently setting the release name to `<ph_project_id>` and leaving the actual project ID unset, causing sourcemap uploads to fail silently.

Closes #57371

## Changes

- `docs/onboarding/error-tracking/nuxt.tsx`: replace `project: '<ph_project_id>'` with `projectId: '<ph_project_id>'`
- `frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx`: update `envId` → `projectId` and `project`/`version` → `releaseName`/`releaseVersion` to match the current `@posthog/nuxt` module API

The `@posthog/nuxt` module reads: `const projectId = sourcemapsConfig.projectId ?? sourcemapsConfig.envId` and `const releaseName = sourcemapsConfig.releaseName ?? sourcemapsConfig.project`, so both the old keys still work but are deprecated. The new keys are the canonical API as of posthog-js#3076.

## How did you test this code?

Verified the current `@posthog/nuxt` module source to confirm `projectId` is the canonical field and `project` is only a `releaseName` fallback. No logic changes — docs/snippet only.

## Docs update

The onboarding wizard snippet change is the fix itself. External docs (posthog.com/docs/error-tracking/installation/nuxt) should be updated separately.

## 🤖 Agent context

Authored with Claude Code. Found the issue by tracing the `@posthog/nuxt` module source to confirm the field rename in posthog-js#3076. Two files changed — the onboarding React component and the docs onboarding component — both contained the same incorrect key.