### PR TITLE
fix(llma): extend clustering runs lookback window from 7 to 90 days

### DIFF
--- a/products/llm_analytics/frontend/clusters/clustersLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clustersLogic.ts
@@ -334,7 +334,7 @@ export const clustersLogic = kea<clustersLogicType>([
                                 timestamp
                             FROM events
                             WHERE event = ${eventName}
-                                AND timestamp >= now() - INTERVAL 7 DAY
+                                AND timestamp >= now() - INTERVAL 90 DAY
                             ORDER BY timestamp DESC
                             LIMIT ${MAX_CLUSTERING_RUNS}
                         `,


### PR DESCRIPTION
## Problem

The Clusters page queries for available clustering runs using a 7-day timestamp window. Any project whose clustering runs were all generated more than 7 days ago would see the empty state ("No trace/generation clustering runs found") even though runs exist.

Closes #58344

## Changes

`products/llm_analytics/frontend/clusters/clustersLogic.ts`: change `INTERVAL 7 DAY` → `INTERVAL 90 DAY` in the `clusteringRuns` loader query.

The `LIMIT 20` (`MAX_CLUSTERING_RUNS`) still caps result size, so only the 20 most recent runs within the 90-day window are shown. The timestamp filter is preserved for ClickHouse performance.

## How did you test this code?

Traced the empty-state path in `clustersLogic.ts` to confirm that `loadClusteringRunsSuccess` with an empty array triggers the "no runs found" empty state (lines 868–870). The query change is a one-line expansion of the lookback window with no structural changes.

## 🤖 Agent context

Authored with Claude Code. Root cause identified by reading the HogQL query in `clustersLogic.ts` — `INTERVAL 7 DAY` is the only filter that would suppress runs older than a week. Expanding to 90 days is conservative and matches the planning horizon for analytics workflows.