### PR TITLE
fix(error-tracking): add missing env vars to docker-compose for self-hosted

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -289,6 +289,7 @@ services:
         environment:
             ADDRESS: '0.0.0.0:3000'
             KAFKA_TOPIC: 'events_plugin_ingestion'
+            KAFKA_ERROR_TRACKING_TOPIC: 'ingestion-errortracking-main'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis7:6379/'
             CAPTURE_MODE: events
@@ -511,6 +512,7 @@ services:
             PERSONS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis7:6379/'
+            ERROR_TRACKING_CYMBAL_BASE_URL: 'http://cymbal:3302'
             CDP_REDIS_HOST: redis7
             ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00'
 


### PR DESCRIPTION
## Problem

On Hobby self-hosted deployments, exception events are silently dropped and the Error Tracking UI shows "No Exception events have been detected!" indefinitely. Two environment variables are set correctly in `bin/start-rust-service` and `bin/start` but are missing from `docker-compose.base.yml`:

1. **`KAFKA_ERROR_TRACKING_TOPIC` on `capture`**: The Rust capture binary defaults to `error_tracking_events`, but the Node.js consumer reads from `ingestion-errortracking-main`. Events land on an unconsumed Kafka topic.

2. **`ERROR_TRACKING_CYMBAL_BASE_URL` on `ingestion-error-tracking`**: The plugin-server defaults to `http://localhost:3302`, but in a Compose network the cymbal service is reachable as `http://cymbal:3302`.

Together these two missing vars silently break the entire error tracking pipeline on self-hosted.

Closes #58243

## Changes

`docker-compose.base.yml`:
- Add `KAFKA_ERROR_TRACKING_TOPIC: 'ingestion-errortracking-main'` to the `capture` service
- Add `ERROR_TRACKING_CYMBAL_BASE_URL: 'http://cymbal:3302'` to the `ingestion-error-tracking` service

## How did you test this code?

Traced the issue by comparing `bin/start-rust-service` (which sets both vars explicitly) against `docker-compose.base.yml` (which doesn't). The root cause analysis in the issue was verified end-to-end by the reporter via `rpk topic describe` confirming events were landing on `error_tracking_events` rather than `ingestion-errortracking-main`.

## 🤖 Agent context

Authored with Claude Code. The fix follows directly from the reporter's root cause analysis — two lines in `docker-compose.base.yml` to match what the local-dev launchers already set explicitly.