### PR TITLE
fix(ui): scroll scene tab bar when many tabs are open

### DIFF
--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -36,6 +36,17 @@ export function SceneTabs(): JSX.Element {
     const { showLayoutNavBar } = useActions(panelLayoutLogic)
     const { isLayoutNavbarVisibleForMobile } = useValues(panelLayoutLogic)
     const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }))
+    const activeTab = tabs.find((tab) => tab.active)
+    const tabRowRef = useRef<HTMLDivElement>(null)
+
+    // Scroll active tab into view when it changes (handles keyboard/programmatic activation)
+    useEffect(() => {
+        if (!activeTab || !tabRowRef.current) {
+            return
+        }
+        const activeEl = tabRowRef.current.querySelector(`[data-tab-id="${activeTab.id}"]`)
+        activeEl?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    }, [activeTab?.id])
     const handleDragEnd = ({ active, over }: DragEndEvent): void => {
         if (!over || over.id === 'new' || active.id === over.id) {
             return
@@ -85,7 +96,8 @@ export function SceneTabs(): JSX.Element {
                     strategy={horizontalListSortingStrategy}
                 >
                     <div
-                        className="scene-tab-row gap-1 flex-1 min-w-0 items-center flex h-[var(--scene-layout-header-height)] lg:h-auto pr-2"
+                        ref={tabRowRef}
+                        className="scene-tab-row gap-1 flex-1 min-w-0 items-center flex h-[var(--scene-layout-header-height)] lg:h-auto pr-2 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
                         onMouseLeave={clearFrozenWidths}
                     >
                         {tabs.map((tab, index) => {


### PR DESCRIPTION
## Problem

When more than ~17 tabs are open, each non-pinned tab shrinks to its `min-w-[100px]` floor and the combined width overflows the tab row container. The overflowing tabs are clipped and completely inaccessible — there is no scroll mechanism, so any tab beyond the viewport edge is lost.

Closes #56633

## Changes

`frontend/src/layout/scenes/SceneTabs.tsx`:

- Add `overflow-x: auto` to the `scene-tab-row` container so tabs scroll horizontally when they exceed the available width
- Hide the scrollbar visually (`[&::-webkit-scrollbar]:hidden`, `[-ms-overflow-style:none]`, `[scrollbar-width:none]`) so the bar looks clean while remaining scrollable
- Add a `useEffect` that calls `scrollIntoView` on the active tab element whenever the active tab changes, ensuring keyboard shortcuts and programmatic tab switching always reveal the current tab

## How did you test this code?

Traced the tab row DOM layout — `scene-tab-row` is a flex container with `min-w-0` that didn't have an overflow handler, causing tabs to be painted beyond its boundary and clipped. The fix is a CSS-only change with a standard `scrollIntoView` call for auto-scroll.

## 🤖 Agent context

Authored with Claude Code. Root cause: `overflow-x` was unset on the tab row, so tabs overflowed without a scroll mechanism. The hidden scrollbar approach is consistent with other horizontal scroll areas in the codebase (e.g. `SidePanelNavigation.tsx`).