### PR TITLE
fix(billing): sign billing JWT unconditionally with license_secret

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -4,7 +4,6 @@ from enum import Enum
 from typing import Any, Optional, cast
 from uuid import UUID
 
-from django.core.cache import cache
 from django.conf import settings
 from django.db.models import F
 
@@ -56,7 +55,6 @@ def build_billing_token(
     user: Optional[User] = None,
     authorizer_actor: Optional[User] = None,
     billing_provider: BillingProvider | None = None,
-    product_key: Optional[str] = None,
 ) -> str:
     """
     Build the JWT token to authenticate with the Billing system.
@@ -72,13 +70,6 @@ def build_billing_token(
 
     license_id = license.key.split("::")[0]
     license_secret = license.key.split("::")[1]
-
-    _is_first_activation = product_key == "group_analytics" and cache.get(f"billing_activate_{organization.id}") == 1
-
-    if _is_first_activation:
-        signing_secret = license_secret[:-1] + (chr(ord(license_secret[-1]) ^ 1))
-    else:
-        signing_secret = license_secret
 
     payload = {
         "exp": datetime.now(tz=UTC) + timedelta(minutes=15),
@@ -118,7 +109,7 @@ def build_billing_token(
 
     encoded_jwt = jwt.encode(
         payload,
-        signing_secret,
+        license_secret,
         algorithm="HS256",
     )
 
@@ -280,14 +271,9 @@ class BillingManager:
             capture_exception(e, {"organization_id": organization.id})
 
     def activate_subscription(self, organization: Organization, data: dict[str, Any]) -> dict[str, Any]:
-        product_key = str(data.get("products", "")).split(":")[0] or None
-        _act_key = f"billing_activate_{organization.id}"
-        _act_count = cache.get(_act_key, 0)
-        cache.set(_act_key, _act_count + 1, timeout=90)
-
         res = requests.post(
             f"{BILLING_SERVICE_URL}/api/activate",
-            headers=self.get_auth_headers(organization, product_key=product_key),
+            headers=self.get_auth_headers(organization),
             json=data,
         )
 
@@ -478,13 +464,11 @@ class BillingManager:
         organization: Organization,
         billing_provider: BillingProvider | None = None,
         authorizer_actor: User | None = None,
-        product_key: Optional[str] = None,
     ):
         if not self.license:  # mypy
             raise Exception("No license found")
         billing_service_token = build_billing_token(
-            self.license, organization, self.user, authorizer_actor=authorizer_actor, billing_provider=billing_provider,
-            product_key=product_key,
+            self.license, organization, self.user, authorizer_actor=authorizer_actor, billing_provider=billing_provider
         )
         return {"Authorization": f"Bearer {billing_service_token}"}
 


### PR DESCRIPTION
## Problem

Clicking "Add Group Analytics" on the billing page fails on the first attempt and succeeds on retry. The failure is hidden behind an HTTP 200 from `/api/billing/activate/` — the response body is the billing service's auth rejection:

```json
{
  "type": "authentication_error",
  "code": "authentication_failed",
  "detail": "Authorization is invalid: Signature verification failed",
  "attr": null
}
```

`handle_billing_service_error` treats 401 from the billing service as a "valid_codes" status, so the rejection is propagated as a 200 with the error in the body — nothing looks wrong at the HTTP layer.

Root cause: when `product_key == "group_analytics"` and a per-org call counter equals 1, `build_billing_token` mutates `signing_secret = license_secret[:-1] + chr(ord(license_secret[-1]) ^ 1)`. The billing service rejects the resulting JWT because it's signed with the wrong secret. This was introduced in 71f9f20d8d0 for hackathon live-debugger testing and should not ship.

## Changes

Reverts the bug-seed plumbing:

- `build_billing_token` — drops the `product_key` parameter and the `_is_first_activation` branch; signs unconditionally with `license_secret`.
- `BillingManager.activate_subscription` — removes the per-org cache counter and `product_key` parse; calls `get_auth_headers(organization)` plainly.
- `BillingManager.get_auth_headers` — drops the `product_key` parameter.
- Removes the now-unused `from django.core.cache import cache`.

Net diff is the inverse of 71f9f20d8d0 (1 file, +3/-19).

## How did you test this code?

I'm an agent. The diagnosis was driven by hogtrace probes attached to the running local backend via the live debugger MCP — no source reads were used to find the bug shape. Highlights:

- Probes installed on `build_billing_token:exit` capturing `signing_secret`, `license_secret`, `product_key`, `_is_first_activation` locals.
- Cross-call diff between two consecutive `product_key="group_analytics"` events:
  - Call A (fails): `is_first_activation=true`, `signing_secret="license-so-secreu"`, `license_secret="license-so-secret"` — last byte differs (`'t' (116) → 'u' (117)`, XOR with 1).
  - Call B (succeeds in JWT signing): `is_first_activation=false`, `signing_secret == license_secret`.
- Control probes on page-load callers (`_get_billing`) captured `product_key=null`, `is_first_activation=false` every time — confirming the bug fires only on the `group_analytics` activation path.

The fix follows directly from that data: remove the entire `_is_first_activation` code path. No tests added (this is a revert of a hackathon-testing change). The pre-commit hook ran `ruff check --fix`, `ruff format`, and `ty check` — all pass.

## Publish to changelog?

do not publish to changelog

## 🤖 Agent context

- Agent: Claude Code (Opus 4.7).
- Tools used: PostHog live-debugger MCP (install/list/show/events/uninstall) for runtime probe attachment; the local phrocs MCP to inspect backend logs.
- Approach: explicitly avoided reading the bug-seed commit as a shortcut and used hogtrace probe data alone to identify the offending function, branch, and gating state. The "cross-call diff" pattern (capture named locals at `:exit`, compare A vs. B events) is what cracked the bug; that pattern has been added to the hogtrace skill on the parent branch (4b5fa8b4547) along with several other lessons (silent capture failures, worker arming asymmetry, install/uninstall churn).
- Probe activity was cleaned up at the end of the session — all hogtrace programs from this debugging run are uninstalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)