### PR TITLE
fix: exclude unavailable scopes from personal API key creation

### DIFF
--- a/frontend/src/scenes/settings/user/personalAPIKeysLogic.test.ts
+++ b/frontend/src/scenes/settings/user/personalAPIKeysLogic.test.ts
@@ -1,0 +1,101 @@
+import { MOCK_DEFAULT_USER } from 'lib/api.mock'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { personalAPIKeysLogic } from './personalAPIKeysLogic'
+
+describe('personalAPIKeysLogic', () => {
+    let logic: ReturnType<typeof personalAPIKeysLogic.build>
+    let capturedCreatePayload: any = null
+
+    beforeEach(() => {
+        capturedCreatePayload = null
+
+        useMocks({
+            get: {
+                '/api/personal_api_keys/': [],
+                '/api/projects/': { results: [], count: 0, next: null, previous: null },
+            },
+            post: {
+                '/api/personal_api_keys/': async (req) => {
+                    capturedCreatePayload = await req.json()
+                    return [
+                        200,
+                        {
+                            id: 'new-key-id',
+                            label: capturedCreatePayload?.label,
+                            scopes: capturedCreatePayload?.scopes,
+                            scoped_organizations: capturedCreatePayload?.scoped_organizations ?? [],
+                            scoped_teams: capturedCreatePayload?.scoped_teams ?? [],
+                            value: 'phx_test',
+                        },
+                    ]
+                },
+            },
+        })
+
+        initKeaTests()
+        featureFlagLogic.mount()
+        userLogic.mount()
+        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+
+        logic = personalAPIKeysLogic()
+        logic.mount()
+    })
+
+    it('strips llm_gateway scopes from create payload when GATEWAY_PERSONAL_API_KEY flag is disabled', async () => {
+        featureFlagLogic.actions.setFeatureFlags([], {})
+
+        logic.actions.setEditingKeyId('new')
+        logic.actions.setEditingKeyValues({
+            label: 'Test key',
+            access_type: 'all',
+            scopes: ['feature_flag:read', 'llm_gateway:read', 'insight:write'],
+        })
+
+        await logic.asyncActions.submitEditingKey()
+
+        expect(capturedCreatePayload).not.toBeNull()
+        expect(capturedCreatePayload.scopes).toEqual(['feature_flag:read', 'insight:write'])
+        expect(capturedCreatePayload.scopes).not.toContain('llm_gateway:read')
+    })
+
+    it('preserves llm_gateway scopes from create payload when GATEWAY_PERSONAL_API_KEY flag is enabled', async () => {
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.GATEWAY_PERSONAL_API_KEY], {
+            [FEATURE_FLAGS.GATEWAY_PERSONAL_API_KEY]: true,
+        })
+
+        logic.actions.setEditingKeyId('new')
+        logic.actions.setEditingKeyValues({
+            label: 'Test key',
+            access_type: 'all',
+            scopes: ['feature_flag:read', 'llm_gateway:read'],
+        })
+
+        await logic.asyncActions.submitEditingKey()
+
+        expect(capturedCreatePayload).not.toBeNull()
+        expect(capturedCreatePayload.scopes).toEqual(['feature_flag:read', 'llm_gateway:read'])
+    })
+
+    it('preserves the `*` (all access) scope regardless of flag state', async () => {
+        featureFlagLogic.actions.setFeatureFlags([], {})
+
+        logic.actions.setEditingKeyId('new')
+        logic.actions.setEditingKeyValues({
+            label: 'Test key',
+            access_type: 'all',
+            scopes: ['*'],
+        })
+
+        await logic.asyncActions.submitEditingKey()
+
+        expect(capturedCreatePayload).not.toBeNull()
+        expect(capturedCreatePayload.scopes).toEqual(['*'])
+    })
+})

--- a/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
+++ b/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
@@ -127,10 +127,25 @@ export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>([
                     return
                 }
 
+                // Sanitize scopes against `allowedScopeKeys` so flag-gated scopes
+                // (e.g. `llm_gateway`) can't slip through via presets like
+                // "Read-only access" that expand to every scope in API_SCOPES.
+                // `*` (all access) is preserved as-is.
+                const allowed = values.allowedScopeKeys
+                const sanitizedScopes =
+                    payload.scopes?.filter((scope) => {
+                        if (scope === '*') {
+                            return true
+                        }
+                        const [object] = scope.split(':')
+                        return !!object && allowed.has(object)
+                    }) ?? []
+                const sanitizedPayload = { ...payload, scopes: sanitizedScopes }
+
                 const key =
                     values.editingKeyId === 'new'
-                        ? await api.personalApiKeys.create(payload)
-                        : await api.personalApiKeys.update(values.editingKeyId, payload)
+                        ? await api.personalApiKeys.create(sanitizedPayload)
+                        : await api.personalApiKeys.update(values.editingKeyId, sanitizedPayload)
 
                 breakpoint()
 
@@ -144,9 +159,9 @@ export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>([
         },
     })),
     selectors(() => ({
-        filteredScopes: [
-            (s) => [s.searchTerm, s.featureFlags, s.hasAvailableFeature],
-            (searchTerm, featureFlags, hasAvailableFeature): APIScope[] => {
+        allowedScopes: [
+            (s) => [s.featureFlags, s.hasAvailableFeature],
+            (featureFlags, hasAvailableFeature): APIScope[] => {
                 let scopes = API_SCOPES
 
                 // Filter out llm_gateway scope if feature flag is disabled
@@ -158,6 +173,18 @@ export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>([
                 if (!hasAvailableFeature(AvailableFeature.APPROVALS)) {
                     scopes = scopes.filter((scope) => scope.key !== 'approvals')
                 }
+
+                return scopes
+            },
+        ],
+        allowedScopeKeys: [
+            (s) => [s.allowedScopes],
+            (allowedScopes): Set<string> => new Set(allowedScopes.map((scope) => scope.key)),
+        ],
+        filteredScopes: [
+            (s) => [s.searchTerm, s.allowedScopes],
+            (searchTerm, allowedScopes): APIScope[] => {
+                const scopes = allowedScopes
 
                 if (!searchTerm.trim()) {
                     return scopes


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Whenever you create a personal API key by using one of the templates we include API scopes in the request payload that the user does not see in the UI, because they do not have the features available. This can cause the API requests to fail in some cases. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Update the logic to filter out unavailable scopes when issuing the API request to the backend to create the personal API key.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
