### PR TITLE
feat(agent-janitor): add operational service for queue management and session control

### DIFF
--- a/docs/internal/agent-platform.md
+++ b/docs/internal/agent-platform.md
@@ -7,7 +7,12 @@ Companion to [`agent-stack/docs/agent-platform.md`](https://github.com/PostHog/a
 Two things we own here:
 
 1. **Management plane** — a new flag-gated product under `products/agent_stack/` (Django app + viewsets + frontend).
-2. **Runtime** — three new TypeScript services under `services/`, deployed as independent node processes. They share **no code** with `nodejs/` (the legacy plugin-server). Anything we want from `nodejs/` we copy and adapt in `services/agent-core/`.
+2. **Runtime** — four TypeScript services under `services/`, deployed as independent node processes. They share **no code** with `nodejs/` (the legacy plugin-server). Anything we want from `nodejs/` we copy and adapt in `services/agent-core/`.
+
+   - `services/agent-core/` — shared library, no process.
+   - `services/agent-ingress/` — public-facing `*.agents.posthog.com` terminator.
+   - `services/agent-runner/` — session executor (queue consumer + SDK).
+   - `services/agent-janitor/` — operational: queue sweeps + internal HTTP surface that Django calls to read/cancel sessions. **The runtime owns session state; Django reads via this surface, never writes to `agent_sessions`.**
 
 The runtime split (ingress + runner) from the agent-stack doc still holds. This plan refines what each half looks like inside the posthog monorepo and which existing primitives we lean on conceptually (not by import).
 
@@ -31,9 +36,10 @@ Working tracker for the runtime services only — the Django side is being built
 - [x] Built-ins registry — `posthog.events.capture`, `posthog.feature_flags.evaluate`, `http.fetch` ([src/builtins/index.ts](../../services/agent-core/src/builtins/index.ts))
 - [x] Manifest reader + Zod schema + built-in id validation ([src/manifest/index.ts](../../services/agent-core/src/manifest/index.ts))
 - [x] Logger (pino) + Prom metrics ([src/logger.ts](../../services/agent-core/src/logger.ts), [src/metrics.ts](../../services/agent-core/src/metrics.ts))
-- [x] Tests: queue (DB-gated), pubsub in-memory, manifest, builtins
+- [x] `SessionQuery` — read-only `findSession` / `listSessions` + targeted-write `cancelSession`, used by the janitor's HTTP surface ([src/queue/query.ts](../../services/agent-core/src/queue/query.ts))
+- [x] Tests: queue + SessionQuery (DB-gated), pubsub in-memory, manifest, builtins
+- [x] Tests: internal-API client smoke — 200, 404, 5xx, shared-key header, timeout ([src/internal-api/client.test.ts](../../services/agent-core/src/internal-api/client.test.ts))
 - [ ] Tests: Redis pubsub integration (needs Redis in CI)
-- [ ] Tests: internal-API client smoke (mock server — 404, timeout, shared-key header)
 - [ ] Decide internal-API transport auth (mTLS vs shared key) — both supported in code, pick at infra time
 
 ### services/agent-ingress/ (milestone 6 — wired end-to-end against fakes)
@@ -47,10 +53,10 @@ Working tracker for the runtime services only — the Django side is being built
 - [x] `/webhooks/:provider` — host check, generic signature verify, enqueue ([src/routes/webhooks.ts](../../services/agent-ingress/src/routes/webhooks.ts))
 - [x] `/health`, `/status`
 - [x] ESLint hard rule blocking Anthropic / Modal / nodejs imports ([.eslintrc.json](../../services/agent-ingress/.eslintrc.json))
-- [x] Tests: `/health`, `/status`, `/run`, `/send` happy/sad paths with FakeQueue + InMemoryBus ([tests/server.test.ts](../../services/agent-ingress/tests/server.test.ts))
+- [x] Tests: `/health`, `/status`, `/run`, `/send` happy/sad paths with FakeQueue + InMemoryBus ([src/server.test.ts](../../services/agent-ingress/src/server.test.ts))
+- [x] Tests: `/listen` SSE flow — subscribe → publish → frame received ([src/listen.test.ts](../../services/agent-ingress/src/listen.test.ts))
+- [x] Tests: resolver LRU + TTL + invalidate ([src/resolver.test.ts](../../services/agent-ingress/src/resolver.test.ts))
 - [ ] Tests: webhook signature flow end-to-end
-- [ ] Tests: `/listen` SSE flow (subscribe → publish → frame received)
-- [ ] Tests: resolver LRU + TTL + invalidate
 - [ ] Provider-specific webhook strategies (Stripe, Slack-style HMAC-with-timestamp) under the generic webhook_signature mode
 - [ ] Per-team concurrent-session quota enforcement on `/run`
 - [ ] `/run` rate limiter
@@ -72,7 +78,24 @@ Working tracker for the runtime services only — the Django side is being built
 - [ ] Tests: real Claude Agent SDK turn (gated on key + recorded fixtures)
 - [ ] Secrets loader — [src/index.ts](../../services/agent-runner/src/index.ts) `loadSecrets` returns `{}`; wire to `apiClient.decryptSecrets` once a tool actually needs them
 - [ ] Runner-side reaper: queue janitor already resets stalled jobs; need a matching write to set `AgentApplicationSession.state = 'failed'` for the mirror row
-- [ ] `AgentApplicationSession` mirror writes — direct DB vs internal API — coordinate with Django owner
+- [ ] **Settled with Django owner: runtime owns session state.** No mirror writes from runner. Django reads + cancels through `agent-janitor`'s `/internal/sessions/*` surface (below). `AgentApplicationSession` (the model joshsny added) is treated as a thin request record; its `state` column may be removed once the read path lands.
+
+### services/agent-janitor/ (new in this branch)
+
+Operational process: queue sweeps + internal HTTP surface for Django. The runtime owns session state; Django **reads** sessions through this service and never writes to `agent_sessions`.
+
+- [x] Bootstrap, Zod-validated env, SIGTERM/SIGINT shutdown ([src/index.ts](../../services/agent-janitor/src/index.ts), [src/config.ts](../../services/agent-janitor/src/config.ts))
+- [x] Hosts the queue janitor daemon (same `SessionQueueJanitor` from agent-core)
+- [x] `/internal/sessions/:id` — fetch single session ([src/routes/sessions.ts](../../services/agent-janitor/src/routes/sessions.ts))
+- [x] `/internal/sessions` — list filtered by `application_id`, `revision_id`, `status`, `team_id`, `created_before`, `limit`
+- [x] `POST /internal/sessions/:id/cancel` — cancel an `available` or `running` session
+- [x] Shared-key auth (`x-internal-key`, `AGENT_INTERNAL_API_SHARED_KEY`) on every `/internal/*` request; refuses traffic when no key is configured ([src/auth.ts](../../services/agent-janitor/src/auth.ts))
+- [x] `/health` and `/metrics` are open (no key required)
+- [x] Tests: route-level happy/sad paths + auth gating with a `FakeSessionQuery` ([src/server.test.ts](../../services/agent-janitor/src/server.test.ts))
+- [ ] Tests: end-to-end against a real Postgres (extend the existing DB-gated suite)
+- [ ] Cursor-style pagination on `/internal/sessions` once the UI needs it
+- [ ] Mirror cancel to `agent-ingress` / `agent-runner` (broadcast on the bus) so an in-flight turn aborts promptly rather than waiting for the next heartbeat
+- [ ] Internal-API transport: mTLS vs `x-internal-key` — settle alongside agent-core's outbound transport decision
 
 ### Cross-package / system level
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,10 +445,10 @@ importers:
         version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ^7.6.4
-        version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
+        version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/test-runner':
         specifier: ^0.16.0
-        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
+        version: 0.16.0(encoding@0.1.13)
       '@storybook/theming':
         specifier: ^7.6.4
         version: 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -499,7 +499,7 @@ importers:
         version: 2.0.0(webpack@5.88.2)
       webpack:
         specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+        version: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.88.2)
@@ -3593,6 +3593,73 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  services/agent-janitor:
+    dependencies:
+      '@posthog/agent-core':
+        specifier: workspace:*
+        version: link:../agent-core
+      luxon:
+        specifier: ^3.4.4
+        version: 3.7.2
+      ultimate-express:
+        specifier: ^2.0.9
+        version: 2.0.9
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.4.1
+        version: 4.7.1(eslint@8.57.0)
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^5.2.2
+        version: 5.2.2(prettier@3.8.2)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 29.5.14
+      '@types/luxon':
+        specifier: ^3.4.2
+        version: 3.4.2
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.18.8
+      '@types/supertest':
+        specifier: ^6.0.2
+        version: 6.0.2
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.58.2
+        version: 8.58.2(@typescript-eslint/parser@8.58.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.58.2
+        version: 8.58.2(eslint@8.57.0)(typescript@5.9.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.0
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.0)
+      eslint-plugin-no-only-tests:
+        specifier: ^3.1.0
+        version: 3.3.0
+      jest:
+        specifier: 'catalog:'
+        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
+      prettier:
+        specifier: ^3.6.2
+        version: 3.8.2
+      supertest:
+        specifier: ^7.0.0
+        version: 7.0.0
+      ts-jest:
+        specifier: ^29.1.0
+        version: 29.4.1(@babel/core@7.29.0)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.29.0))(jest-util@30.0.5)(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))(typescript@5.9.3)
+      tsx:
+        specifier: ^4.7.0
+        version: 4.20.5
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   services/agent-runner:
     dependencies:
       '@posthog/agent-core':
@@ -4363,10 +4430,6 @@ packages:
     resolution: {integrity: sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.0':
-    resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
@@ -4405,10 +4468,6 @@ packages:
 
   '@babel/helper-compilation-targets@7.25.9':
     resolution: {integrity: sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.28.6':
@@ -4478,22 +4537,12 @@ packages:
     resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-module-imports@7.28.6':
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.26.0':
     resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-module-transforms@7.27.3':
-    resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -4552,10 +4601,6 @@ packages:
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
@@ -4574,10 +4619,6 @@ packages:
 
   '@babel/helpers@7.26.0':
     resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.27.6':
-    resolution: {integrity: sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.29.2':
@@ -20497,10 +20538,6 @@ packages:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
     engines: {node: '>=0.6'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
@@ -25458,13 +25495,13 @@ snapshots:
 
   '@babel/code-frame@7.26.2':
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -25475,8 +25512,6 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/compat-data@7.26.3': {}
-
-  '@babel/compat-data@7.28.0': {}
 
   '@babel/compat-data@7.29.0': {}
 
@@ -25505,9 +25540,9 @@ snapshots:
       '@ampproject/remapping': 2.2.1
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
-      '@babel/helpers': 7.27.6
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
+      '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
@@ -25569,14 +25604,6 @@ snapshots:
       '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.25.9':
-    dependencies:
-      '@babel/compat-data': 7.28.0
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  '@babel/helper-compilation-targets@7.27.2':
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
@@ -25846,13 +25873,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
@@ -25863,13 +25883,13 @@ snapshots:
   '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.27.3(@babel/core@7.26.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-module-imports': 7.28.6
@@ -25878,18 +25898,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.27.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
@@ -25982,8 +25993,6 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.25.9': {}
 
-  '@babel/helper-validator-identifier@7.27.1': {}
-
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.25.9': {}
@@ -25997,11 +26006,6 @@ snapshots:
       '@babel/types': 7.29.0
 
   '@babel/helpers@7.26.0':
-    dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
-
-  '@babel/helpers@7.27.6':
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
@@ -26490,7 +26494,7 @@ snapshots:
   '@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.26.0)
     transitivePeerDependencies:
@@ -26499,7 +26503,7 @@ snapshots:
   '@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.28.0)
     transitivePeerDependencies:
@@ -26508,7 +26512,7 @@ snapshots:
   '@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.29.0)
     transitivePeerDependencies:
@@ -26596,7 +26600,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-optimise-call-expression': 7.27.1
@@ -26611,7 +26615,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-optimise-call-expression': 7.27.1
@@ -26626,7 +26630,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-optimise-call-expression': 7.27.1
@@ -26787,21 +26791,21 @@ snapshots:
   '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.28.6
 
@@ -26874,7 +26878,7 @@ snapshots:
   '@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.26.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -26882,7 +26886,7 @@ snapshots:
   '@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -26890,7 +26894,7 @@ snapshots:
   '@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -26898,7 +26902,7 @@ snapshots:
   '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.26.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-simple-access': 7.22.5
     transitivePeerDependencies:
@@ -26907,7 +26911,7 @@ snapshots:
   '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-simple-access': 7.22.5
     transitivePeerDependencies:
@@ -26916,7 +26920,7 @@ snapshots:
   '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-simple-access': 7.22.5
     transitivePeerDependencies:
@@ -26934,7 +26938,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.26.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
     transitivePeerDependencies:
@@ -26944,7 +26948,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
     transitivePeerDependencies:
@@ -26954,7 +26958,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
     transitivePeerDependencies:
@@ -26963,7 +26967,7 @@ snapshots:
   '@babel/plugin-transform-modules-umd@7.23.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.26.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -26971,7 +26975,7 @@ snapshots:
   '@babel/plugin-transform-modules-umd@7.23.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -26979,7 +26983,7 @@ snapshots:
   '@babel/plugin-transform-modules-umd@7.23.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -27055,27 +27059,27 @@ snapshots:
 
   '@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.26.0)':
     dependencies:
-      '@babel/compat-data': 7.28.0
+      '@babel/compat-data': 7.29.0
       '@babel/core': 7.26.0
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.26.0)
 
   '@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.28.0)':
     dependencies:
-      '@babel/compat-data': 7.28.0
+      '@babel/compat-data': 7.29.0
       '@babel/core': 7.28.0
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.0)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.28.0)
 
   '@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.29.0)':
     dependencies:
-      '@babel/compat-data': 7.28.0
+      '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.29.0)
@@ -27868,7 +27872,7 @@ snapshots:
 
   '@babel/template@7.25.9':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
@@ -31984,7 +31988,7 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       type-fest: 4.41.0
       webpack-hot-middleware: 2.25.4
@@ -34019,7 +34023,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-webpack5@7.6.4(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.9.3)(webpack-cli@5.1.4)':
+  '@storybook/builder-webpack5@7.6.4(encoding@0.1.13)(typescript@5.9.3)(webpack-cli@5.1.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@storybook/channels': 7.6.4
@@ -34049,12 +34053,12 @@ snapshots:
       semver: 7.7.4
       style-loader: 3.3.3(webpack@5.88.2)
       swc-loader: 0.2.3(@swc/core@1.15.18)(webpack@5.88.2)
-      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(esbuild@0.18.20)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(webpack@5.88.2)
       ts-dedent: 2.2.0
       url: 0.11.1
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-dev-middleware: 6.1.1(webpack@5.88.2)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
@@ -34125,7 +34129,7 @@ snapshots:
       get-port: 5.1.1
       giget: 1.1.2
       globby: 11.1.0
-      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.26.0))
+      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.29.0))
       leven: 3.1.0
       ora: 5.4.1
       prettier: 2.8.8
@@ -34168,7 +34172,7 @@ snapshots:
       '@types/cross-spawn': 6.0.2
       cross-spawn: 7.0.6
       globby: 11.1.0
-      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.26.0))
+      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.29.0))
       lodash: 4.18.1
       prettier: 2.8.8
       recast: 0.23.11
@@ -34460,7 +34464,7 @@ snapshots:
 
   '@storybook/postinstall@7.6.4': {}
 
-  '@storybook/preset-react-webpack@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.23.3(@babel/core@7.26.0)
       '@babel/preset-react': 7.23.3(@babel/core@7.26.0)
@@ -34480,7 +34484,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       semver: 7.7.4
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       '@babel/core': 7.26.0
       typescript: 5.9.3
@@ -34544,7 +34548,7 @@ snapshots:
       dequal: 2.0.3
       lodash: 4.18.1
       memoizerific: 1.11.3
-      qs: 6.14.1
+      qs: 6.15.1
       synchronous-promise: 2.0.17
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -34563,7 +34567,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -34597,10 +34601,10 @@ snapshots:
       - typescript
       - vite-plugin-glimmerx
 
-  '@storybook/react-webpack5@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.4(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.9.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.4(encoding@0.1.13)(typescript@5.9.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 18.3.1
@@ -34744,6 +34748,46 @@ snapshots:
       jest-runner: 29.7.0
       jest-serializer-html: 7.1.0
       jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
+      node-fetch: 2.7.0(encoding@0.1.13)
+      playwright: 1.45.0
+      read-pkg-up: 7.0.1
+      tempy: 1.0.1
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - '@types/node'
+      - babel-plugin-macros
+      - debug
+      - encoding
+      - node-notifier
+      - supports-color
+      - ts-node
+
+  '@storybook/test-runner@0.16.0(encoding@0.1.13)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      '@jest/types': 29.6.3
+      '@storybook/core-common': 7.6.4(encoding@0.1.13)
+      '@storybook/csf': 0.1.13
+      '@storybook/csf-tools': 7.6.4
+      '@storybook/preview-api': 7.6.20
+      '@swc/core': 1.15.18
+      '@swc/jest': 0.2.37(@swc/core@1.15.18)
+      can-bind-to-host: 1.1.2
+      commander: 9.4.1
+      expect-playwright: 0.8.0
+      glob: 10.4.5
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-junit: 16.0.0
+      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0)
+      jest-runner: 29.7.0
+      jest-serializer-html: 7.1.0
+      jest-watch-typeahead: 2.2.2(jest@29.7.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       playwright: 1.45.0
       read-pkg-up: 7.0.1
@@ -37014,17 +37058,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@xmldom/xmldom@0.8.11': {}
@@ -37631,14 +37675,14 @@ snapshots:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   babel-loader@9.1.3(@babel/core@7.29.0)(webpack@5.88.2):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   babel-plugin-add-react-displayname@0.0.5: {}
 
@@ -37684,7 +37728,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.12(@babel/core@7.26.0):
     dependencies:
-      '@babel/compat-data': 7.28.0
+      '@babel/compat-data': 7.29.0
       '@babel/core': 7.26.0
       '@babel/helper-define-polyfill-provider': 0.6.3(@babel/core@7.26.0)
       semver: 6.3.1
@@ -37693,7 +37737,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.12(@babel/core@7.28.0):
     dependencies:
-      '@babel/compat-data': 7.28.0
+      '@babel/compat-data': 7.29.0
       '@babel/core': 7.28.0
       '@babel/helper-define-polyfill-provider': 0.6.3(@babel/core@7.28.0)
       semver: 6.3.1
@@ -37702,7 +37746,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.12(@babel/core@7.29.0):
     dependencies:
-      '@babel/compat-data': 7.28.0
+      '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.3(@babel/core@7.29.0)
       semver: 6.3.1
@@ -38833,7 +38877,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   css-loader@6.8.1(webpack@5.88.2):
     dependencies:
@@ -38845,7 +38889,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.7.4
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.2):
     dependencies:
@@ -40582,7 +40626,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   file-system-cache@2.3.0:
     dependencies:
@@ -40726,7 +40770,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   form-data@4.0.5:
     dependencies:
@@ -41405,7 +41449,7 @@ snapshots:
   html-webpack-harddisk-plugin@2.0.0(html-webpack-plugin@5.5.3(webpack@5.88.2))(webpack@5.88.2):
     dependencies:
       html-webpack-plugin: 5.5.3(webpack@5.88.2)
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   html-webpack-plugin@5.5.3(webpack@5.88.2):
     dependencies:
@@ -41414,7 +41458,7 @@ snapshots:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   htmlnano@2.1.1(cssnano@7.0.6(postcss@8.5.6))(postcss@8.5.6)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.46.0)(typescript@5.9.3):
     dependencies:
@@ -42730,6 +42774,22 @@ snapshots:
       - debug
       - supports-color
 
+  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
+    dependencies:
+      expect-playwright: 0.8.0
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-process-manager: 0.4.0
+      jest-runner: 29.7.0
+      nyc: 15.1.0
+      playwright-core: 1.45.0
+      rimraf: 3.0.2
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
     optionalDependencies:
       jest-resolve: 27.5.1
@@ -43148,6 +43208,17 @@ snapshots:
       string-length: 5.0.1
       strip-ansi: 7.2.0
 
+  jest-watch-typeahead@2.2.2(jest@29.7.0):
+    dependencies:
+      ansi-escapes: 6.0.0
+      chalk: 5.6.2
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
+      jest-regex-util: 29.6.3
+      jest-watcher: 29.7.0
+      slash: 5.1.0
+      string-length: 5.0.1
+      strip-ansi: 7.2.0
+
   jest-watcher@27.5.1:
     dependencies:
       '@jest/test-result': 27.5.1
@@ -43295,7 +43366,7 @@ snapshots:
 
   jsbn@1.1.0: {}
 
-  jscodeshift@0.15.1(@babel/preset-env@7.23.5(@babel/core@7.26.0)):
+  jscodeshift@0.15.1(@babel/preset-env@7.23.5(@babel/core@7.29.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
@@ -43318,7 +43389,7 @@ snapshots:
       temp: 0.8.4
       write-file-atomic: 2.4.3
     optionalDependencies:
-      '@babel/preset-env': 7.23.5(@babel/core@7.26.0)
+      '@babel/preset-env': 7.23.5(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -43535,7 +43606,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/preset-env': 7.23.5(@babel/core@7.28.0)
       '@babel/preset-typescript': 7.23.3(@babel/core@7.28.0)
-      prettier: 3.6.2
+      prettier: 3.8.2
       recast: 0.23.4
       ts-clone-node: 3.0.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -43592,7 +43663,7 @@ snapshots:
       less: 4.2.2
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   less@3.13.1:
     dependencies:
@@ -46088,7 +46159,7 @@ snapshots:
       postcss: 8.5.6
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   postcss-logical@8.0.0(postcss@8.5.2):
     dependencies:
@@ -47015,10 +47086,6 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  qs@6.14.1:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
@@ -47074,7 +47141,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   rc-cascader@3.34.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -48211,7 +48278,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       sass: 1.56.0
 
@@ -48919,11 +48986,11 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   style-loader@3.3.3(webpack@5.88.2):
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   style-search@0.1.0: {}
 
@@ -49127,7 +49194,7 @@ snapshots:
   swc-loader@0.2.3(@swc/core@1.15.18)(webpack@5.88.2):
     dependencies:
       '@swc/core': 1.15.18
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   symbol-tree@3.2.4: {}
 
@@ -49163,7 +49230,7 @@ snapshots:
 
   table@6.8.1:
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3
@@ -49321,17 +49388,16 @@ snapshots:
       '@swc/core': 1.15.18
       esbuild: 0.27.7
 
-  terser-webpack-plugin@5.3.9(@swc/core@1.15.18)(esbuild@0.18.20)(webpack@5.88.2):
+  terser-webpack-plugin@5.3.9(@swc/core@1.15.18)(webpack@5.88.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.15.18
-      esbuild: 0.18.20
 
   terser@5.19.1:
     dependencies:
@@ -50547,7 +50613,7 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-merge: 5.8.0
 
   webpack-dev-middleware@6.1.1(webpack@5.88.2):
@@ -50558,7 +50624,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   webpack-hot-middleware@2.25.4:
     dependencies:
@@ -50609,7 +50675,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4):
+  webpack@5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.4
       '@types/estree': 1.0.1
@@ -50632,7 +50698,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(esbuild@0.18.20)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ packages:
     - docs/onboarding
     - services/agent-core
     - services/agent-ingress
+    - services/agent-janitor
     - services/agent-runner
     - services/oauth-proxy
     - services/mcp

--- a/services/agent-core/src/internal-api/client.test.ts
+++ b/services/agent-core/src/internal-api/client.test.ts
@@ -1,0 +1,177 @@
+import { createServer, Server } from 'node:http'
+import { AddressInfo } from 'node:net'
+
+import { InternalApiClient } from './client'
+
+interface RecordedRequest {
+    method: string
+    url: string
+    headers: Record<string, string | string[] | undefined>
+    body: string
+}
+
+interface FakeServerHandle {
+    server: Server
+    baseUrl: string
+    recorded: RecordedRequest[]
+    setHandler: (handler: HandlerFn) => void
+    close: () => Promise<void>
+}
+
+type HandlerFn = (req: RecordedRequest) => { status: number; body?: unknown; delayMs?: number }
+
+async function startFakeServer(initialHandler: HandlerFn): Promise<FakeServerHandle> {
+    const recorded: RecordedRequest[] = []
+    let handler: HandlerFn = initialHandler
+
+    const server = createServer((req, res) => {
+        let body = ''
+        req.on('data', (chunk: Buffer) => {
+            body += chunk.toString('utf8')
+        })
+        req.on('end', () => {
+            const recordedReq: RecordedRequest = {
+                method: req.method ?? '',
+                url: req.url ?? '',
+                headers: req.headers,
+                body,
+            }
+            recorded.push(recordedReq)
+            const reply = handler(recordedReq)
+            const send = (): void => {
+                res.statusCode = reply.status
+                if (reply.body !== undefined) {
+                    res.setHeader('content-type', 'application/json')
+                    res.end(JSON.stringify(reply.body))
+                } else {
+                    res.end()
+                }
+            }
+            if (reply.delayMs) {
+                setTimeout(send, reply.delayMs)
+            } else {
+                send()
+            }
+        })
+    })
+
+    await new Promise<void>((resolve) => server.listen(0, resolve))
+    const port = (server.address() as AddressInfo).port
+    return {
+        server,
+        baseUrl: `http://localhost:${port}`,
+        recorded,
+        setHandler: (next) => {
+            handler = next
+        },
+        close: () =>
+            new Promise<void>((resolve) => {
+                server.close(() => resolve())
+            }),
+    }
+}
+
+const VALID_RESOLVE_PAYLOAD = {
+    applicationId: 'b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a01',
+    applicationSlug: 'analytics-bot',
+    teamId: 7,
+    revisionId: 'b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a02',
+    revisionState: 'ready',
+    bundleS3Key: 's3://bundles/abc',
+    bundleSha256: 'abcd',
+    topLevelConfig: {},
+    parsedManifest: null,
+    auth: { mode: 'public' },
+}
+
+describe('InternalApiClient', () => {
+    let fake: FakeServerHandle
+
+    afterEach(async () => {
+        await fake.close()
+    })
+
+    describe('resolve', () => {
+        it('returns the parsed payload on 200', async () => {
+            fake = await startFakeServer(() => ({ status: 200, body: VALID_RESOLVE_PAYLOAD }))
+            const client = new InternalApiClient({ baseUrl: fake.baseUrl })
+
+            const result = await client.resolve({ domain: 'analytics-bot.agents.posthog.com' })
+
+            expect(result?.applicationSlug).toBe('analytics-bot')
+            expect(fake.recorded[0].url).toContain('/internal/agents/applications/resolve')
+            expect(fake.recorded[0].url).toContain('domain=analytics-bot.agents.posthog.com')
+        })
+
+        it('returns null on 404', async () => {
+            fake = await startFakeServer(() => ({ status: 404 }))
+            const client = new InternalApiClient({ baseUrl: fake.baseUrl })
+
+            const result = await client.resolve({ domain: 'missing.agents.posthog.com' })
+            expect(result).toBeNull()
+        })
+
+        it('throws on 5xx', async () => {
+            fake = await startFakeServer(() => ({ status: 500, body: { error: 'boom' } }))
+            const client = new InternalApiClient({ baseUrl: fake.baseUrl })
+
+            await expect(client.resolve({ domain: 'x.agents.posthog.com' })).rejects.toThrow(/500/)
+        })
+
+        it('forwards the shared key on the x-internal-key header', async () => {
+            fake = await startFakeServer(() => ({ status: 200, body: VALID_RESOLVE_PAYLOAD }))
+            const client = new InternalApiClient({ baseUrl: fake.baseUrl, sharedKey: 'sek-ret' })
+
+            await client.resolve({ domain: 'analytics-bot.agents.posthog.com' })
+
+            expect(fake.recorded[0].headers['x-internal-key']).toBe('sek-ret')
+        })
+
+        it('does not send x-internal-key when no key is configured', async () => {
+            fake = await startFakeServer(() => ({ status: 200, body: VALID_RESOLVE_PAYLOAD }))
+            const client = new InternalApiClient({ baseUrl: fake.baseUrl })
+
+            await client.resolve({ domain: 'analytics-bot.agents.posthog.com' })
+
+            expect(fake.recorded[0].headers['x-internal-key']).toBeUndefined()
+        })
+
+        it('aborts when the request exceeds the timeout', async () => {
+            fake = await startFakeServer(() => ({ status: 200, body: VALID_RESOLVE_PAYLOAD, delayMs: 200 }))
+            const client = new InternalApiClient({ baseUrl: fake.baseUrl, timeoutMs: 25 })
+
+            await expect(client.resolve({ domain: 'slow.agents.posthog.com' })).rejects.toThrow()
+        })
+    })
+
+    describe('decryptSecrets', () => {
+        it('sends a POST with the requested names and parses the reply', async () => {
+            fake = await startFakeServer(() => ({
+                status: 200,
+                body: { secrets: { OPENAI_API_KEY: 'sk-1', POSTHOG_KEY: 'phc' } },
+            }))
+            const client = new InternalApiClient({ baseUrl: fake.baseUrl, sharedKey: 'sek-ret' })
+
+            const result = await client.decryptSecrets('b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a01', [
+                'OPENAI_API_KEY',
+                'POSTHOG_KEY',
+            ])
+
+            expect(result.secrets.OPENAI_API_KEY).toBe('sk-1')
+            const recorded = fake.recorded[0]
+            expect(recorded.method).toBe('POST')
+            expect(recorded.url).toBe('/internal/agents/secrets/b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a01/decrypt')
+            expect(JSON.parse(recorded.body)).toEqual({ names: ['OPENAI_API_KEY', 'POSTHOG_KEY'] })
+            expect(recorded.headers['x-internal-key']).toBe('sek-ret')
+        })
+
+        it('throws on non-2xx replies', async () => {
+            fake = await startFakeServer(() => ({ status: 403, body: { error: 'forbidden' } }))
+            const client = new InternalApiClient({ baseUrl: fake.baseUrl })
+
+            await expect(
+                client.decryptSecrets('b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a01', ['ANY'])
+            ).rejects.toThrow(/403/)
+        })
+    })
+})

--- a/services/agent-core/src/queue/index.ts
+++ b/services/agent-core/src/queue/index.ts
@@ -1,6 +1,8 @@
 export { SessionQueueManager } from './manager'
 export { SessionQueueWorker } from './worker'
 export { SessionQueueJanitor } from './janitor'
+export { SessionQuery } from './query'
+export type { SessionView, ListSessionsFilter } from './query'
 export { SessionJobInitSchema, RescheduleOptionsSchema } from './types'
 export type {
     SessionStatus,

--- a/services/agent-core/src/queue/query.ts
+++ b/services/agent-core/src/queue/query.ts
@@ -1,0 +1,200 @@
+import { DateTime } from 'luxon'
+import { Pool } from 'pg'
+
+import { PoolConfig, SessionStatus } from './types'
+
+export interface SessionView {
+    readonly id: string
+    readonly teamId: number
+    readonly applicationId: string | null
+    readonly revisionId: string | null
+    readonly queueName: string
+    readonly status: SessionStatus
+    readonly scheduled: DateTime
+    readonly created: DateTime
+    readonly lastTransition: DateTime
+    readonly lastHeartbeat: DateTime | null
+    readonly transitionCount: number
+    readonly janitorTouchCount: number
+    readonly stateByteSize: number | null
+}
+
+export interface ListSessionsFilter {
+    teamId?: number
+    applicationId?: string
+    revisionId?: string
+    status?: SessionStatus | readonly SessionStatus[]
+    /** Strict upper bound on `created`; for keyset pagination. */
+    createdBefore?: Date
+    limit?: number
+}
+
+interface RawSessionRow {
+    id: string
+    team_id: number
+    application_id: string | null
+    revision_id: string | null
+    queue_name: string
+    status: SessionStatus
+    scheduled: string
+    created: string
+    last_transition: string
+    last_heartbeat: string | null
+    transition_count: number
+    janitor_touch_count: number
+    state_byte_size: number | null
+}
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+
+const STATUSES: readonly SessionStatus[] = ['available', 'running', 'completed', 'failed', 'canceled']
+
+/**
+ * Read-only + targeted-write queries over the agent_sessions queue.
+ *
+ * Worker / manager / janitor handle the lifecycle transitions; this is the surface
+ * the operational HTTP endpoints (Django → runtime internal API) use to render
+ * session lists and to cancel an in-flight session.
+ *
+ * Distinct from the worker dequeue path — these queries never lock rows.
+ */
+export class SessionQuery {
+    private readonly pool: Pool
+
+    constructor(config: { pool: PoolConfig }) {
+        this.pool = new Pool({
+            connectionString: config.pool.dbUrl,
+            max: config.pool.maxConnections ?? 5,
+            idleTimeoutMillis: config.pool.idleTimeoutMs ?? 30_000,
+        })
+    }
+
+    async connect(): Promise<void> {
+        const client = await this.pool.connect()
+        client.release()
+    }
+
+    async disconnect(): Promise<void> {
+        await this.pool.end()
+    }
+
+    async findSession(id: string): Promise<SessionView | null> {
+        const result = await this.pool.query<RawSessionRow>(
+            `SELECT id, team_id, application_id, revision_id, queue_name, status,
+                    scheduled, created, last_transition, last_heartbeat,
+                    transition_count, janitor_touch_count, state_byte_size
+             FROM agent_sessions
+             WHERE id = $1`,
+            [id]
+        )
+        if (result.rows.length === 0) {
+            return null
+        }
+        return rowToView(result.rows[0])
+    }
+
+    async listSessions(filter: ListSessionsFilter = {}): Promise<SessionView[]> {
+        const where: string[] = []
+        const params: unknown[] = []
+        const push = (clause: string, value: unknown): void => {
+            params.push(value)
+            where.push(clause.replace('?', `$${params.length}`))
+        }
+        if (filter.teamId !== undefined) {
+            push('team_id = ?', filter.teamId)
+        }
+        if (filter.applicationId) {
+            push('application_id = ?', filter.applicationId)
+        }
+        if (filter.revisionId) {
+            push('revision_id = ?', filter.revisionId)
+        }
+        if (filter.status) {
+            const statuses = normalizeStatuses(filter.status)
+            push('status = ANY(?::AgentSessionStatus[])', statuses)
+        }
+        if (filter.createdBefore) {
+            push('created < ?', filter.createdBefore)
+        }
+
+        const limit = clampLimit(filter.limit)
+        params.push(limit)
+
+        const result = await this.pool.query<RawSessionRow>(
+            `SELECT id, team_id, application_id, revision_id, queue_name, status,
+                    scheduled, created, last_transition, last_heartbeat,
+                    transition_count, janitor_touch_count, state_byte_size
+             FROM agent_sessions
+             ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
+             ORDER BY created DESC
+             LIMIT $${params.length}`,
+            params
+        )
+        return result.rows.map(rowToView)
+    }
+
+    /**
+     * Cancel a session that hasn't reached a terminal state yet. Returns the resulting
+     * view (or `null` if no row matches) so the caller can distinguish "already terminal"
+     * from "doesn't exist".
+     */
+    async cancelSession(id: string): Promise<SessionView | null> {
+        const result = await this.pool.query<RawSessionRow>(
+            `UPDATE agent_sessions
+             SET status = 'canceled',
+                 lock_id = NULL,
+                 last_heartbeat = NULL,
+                 last_transition = NOW(),
+                 transition_count = transition_count + 1
+             WHERE id = $1
+               AND status IN ('available', 'running')
+             RETURNING id, team_id, application_id, revision_id, queue_name, status,
+                       scheduled, created, last_transition, last_heartbeat,
+                       transition_count, janitor_touch_count, state_byte_size`,
+            [id]
+        )
+        if (result.rows.length > 0) {
+            return rowToView(result.rows[0])
+        }
+        return this.findSession(id)
+    }
+}
+
+function rowToView(row: RawSessionRow): SessionView {
+    return {
+        id: row.id,
+        teamId: row.team_id,
+        applicationId: row.application_id,
+        revisionId: row.revision_id,
+        queueName: row.queue_name,
+        status: row.status,
+        scheduled: DateTime.fromISO(row.scheduled, { zone: 'utc' }),
+        created: DateTime.fromISO(row.created, { zone: 'utc' }),
+        lastTransition: DateTime.fromISO(row.last_transition, { zone: 'utc' }),
+        lastHeartbeat: row.last_heartbeat ? DateTime.fromISO(row.last_heartbeat, { zone: 'utc' }) : null,
+        transitionCount: row.transition_count,
+        janitorTouchCount: row.janitor_touch_count,
+        stateByteSize: row.state_byte_size,
+    }
+}
+
+function normalizeStatuses(input: SessionStatus | readonly SessionStatus[]): SessionStatus[] {
+    const asArray = Array.isArray(input) ? input : [input as SessionStatus]
+    for (const s of asArray) {
+        if (!STATUSES.includes(s)) {
+            throw new Error(`SessionQuery: unknown status filter: ${s}`)
+        }
+    }
+    return asArray as SessionStatus[]
+}
+
+function clampLimit(limit: number | undefined): number {
+    if (limit === undefined) {
+        return DEFAULT_LIMIT
+    }
+    if (!Number.isInteger(limit) || limit <= 0) {
+        return DEFAULT_LIMIT
+    }
+    return Math.min(limit, MAX_LIMIT)
+}

--- a/services/agent-core/src/queue/queue.test.ts
+++ b/services/agent-core/src/queue/queue.test.ts
@@ -9,7 +9,7 @@ import { v7 as uuidv7 } from 'uuid'
  * Skipped automatically if AGENT_RUNTIME_QUEUE_TEST_DATABASE_URL is unset, so this
  * suite is safe in environments without a Postgres available.
  */
-import { DequeuedSessionJob, SessionQueueJanitor, SessionQueueManager, SessionQueueWorker } from '..'
+import { DequeuedSessionJob, SessionQuery, SessionQueueJanitor, SessionQueueManager, SessionQueueWorker } from '..'
 
 const DB_URL = process.env.AGENT_RUNTIME_QUEUE_TEST_DATABASE_URL
 const describeIfDb = DB_URL ? describe : describe.skip
@@ -94,6 +94,44 @@ describeIfDb('agent-core queue (DB-gated)', () => {
         })
         const second = await consumeOnce()
         expect(second[0].state?.toString('utf8')).toBe('world')
+    })
+
+    it('SessionQuery.findSession / listSessions / cancelSession', async () => {
+        const appA = '11111111-1111-4111-8111-111111111111'
+        const appB = '22222222-2222-4222-8222-222222222222'
+        await manager.createJob({ teamId: 1, applicationId: appA, queueName: 'test-queue' })
+        await manager.createJob({ teamId: 1, applicationId: appA, queueName: 'test-queue' })
+        await manager.createJob({ teamId: 2, applicationId: appB, queueName: 'test-queue' })
+
+        const query = new SessionQuery({ pool: { dbUrl: DB_URL! } })
+        try {
+            await query.connect()
+
+            // findSession returns null for unknown ids.
+            const unknown = await query.findSession('99999999-9999-4999-8999-999999999999')
+            expect(unknown).toBeNull()
+
+            // listSessions filters by application.
+            const onlyAppA = await query.listSessions({ applicationId: appA })
+            expect(onlyAppA).toHaveLength(2)
+
+            // listSessions filters by status; everything is 'available' right now.
+            const completed = await query.listSessions({ status: 'completed' })
+            expect(completed).toHaveLength(0)
+
+            // cancelSession moves an available row to canceled and returns the new view.
+            const toCancel = onlyAppA[0]
+            const canceled = await query.cancelSession(toCancel.id)
+            expect(canceled?.status).toBe('canceled')
+            const refound = await query.findSession(toCancel.id)
+            expect(refound?.status).toBe('canceled')
+
+            // Cancelling a canceled row is a no-op; we still return the current view.
+            const noop = await query.cancelSession(toCancel.id)
+            expect(noop?.status).toBe('canceled')
+        } finally {
+            await query.disconnect()
+        }
     })
 
     it('janitor resets stalled jobs and fails poison pills', async () => {

--- a/services/agent-ingress/src/listen.test.ts
+++ b/services/agent-ingress/src/listen.test.ts
@@ -1,0 +1,85 @@
+import { request as httpRequest } from 'node:http'
+
+import { InMemorySessionBus, SessionQueueManager } from '@posthog/agent-core'
+
+import { RevisionResolver } from './resolver'
+import { ServerDeps, buildServer } from './server'
+
+/**
+ * SSE flow test for `/listen/:id`. Drives a real HTTP request via node:http so we can
+ * read frames as they arrive (supertest waits for the full body, which never completes
+ * for an SSE stream).
+ */
+describe('agent-ingress /listen SSE flow', () => {
+    it('streams subscribed events as SSE frames', async () => {
+        const bus = new InMemorySessionBus()
+        const deps: ServerDeps = {
+            queue: {} as unknown as SessionQueueManager,
+            bus,
+            resolver: {} as unknown as RevisionResolver,
+            domainSuffix: '.agents.posthog.com',
+        }
+        const app = buildServer(deps)
+
+        let port = 0
+        await new Promise<void>((resolve, reject) => {
+            try {
+                app.listen(0, () => {
+                    // ultimate-express adds address() at runtime — the Express type doesn't expose it.
+                    port = (app as unknown as { address(): { port: number } }).address().port
+                    resolve()
+                })
+            } catch (err) {
+                reject(err)
+            }
+        })
+
+        try {
+            await new Promise<void>((resolve, reject) => {
+                const req = httpRequest(
+                    {
+                        host: 'localhost',
+                        port,
+                        path: '/listen/abc',
+                        method: 'GET',
+                    },
+                    (res) => {
+                        expect(res.statusCode).toBe(200)
+                        expect(res.headers['content-type']).toBe('text/event-stream')
+                        expect(res.headers['cache-control']).toBe('no-cache')
+
+                        let buffer = ''
+                        res.on('data', (chunk: Buffer) => {
+                            buffer += chunk.toString('utf8')
+                            if (buffer.includes('event: turn_completed')) {
+                                expect(buffer).toContain('event: turn_started')
+                                expect(buffer).toContain('"type":"turn_started"')
+                                req.destroy()
+                                resolve()
+                            }
+                        })
+                        res.on('error', reject)
+                    }
+                )
+                req.on('error', (err) => {
+                    // destroy() emits ECONNRESET on the request — ignore that case
+                    // because we triggered the close ourselves.
+                    if ((err as NodeJS.ErrnoException).code === 'ECONNRESET') {
+                        return
+                    }
+                    reject(err)
+                })
+                req.end()
+
+                // Publish a few events once the subscription should be established.
+                // Small delay so the `subscribeEvents` listener is wired before we publish.
+                setTimeout(() => {
+                    void bus.publishEvent('abc', { type: 'turn_started', at: '2026-05-14T00:00:00Z' })
+                    void bus.publishEvent('abc', { type: 'turn_completed', at: '2026-05-14T00:00:01Z' })
+                }, 50)
+            })
+        } finally {
+            await bus.disconnect()
+        }
+    })
+})

--- a/services/agent-ingress/src/resolver.test.ts
+++ b/services/agent-ingress/src/resolver.test.ts
@@ -1,0 +1,145 @@
+import { InternalApiClient, ResolvedRevision } from '@posthog/agent-core'
+
+import { RevisionResolver } from './resolver'
+
+function makeRevision(overrides: Partial<ResolvedRevision> = {}): ResolvedRevision {
+    return {
+        applicationId: 'b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a01',
+        applicationSlug: 'analytics-bot',
+        teamId: 7,
+        revisionId: 'b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a02',
+        revisionState: 'ready',
+        bundleS3Key: 's3://bundles/abc',
+        bundleSha256: 'abcd',
+        topLevelConfig: {},
+        parsedManifest: null,
+        auth: { mode: 'public' },
+        ...overrides,
+    }
+}
+
+interface FakeClientCalls {
+    domains: string[]
+    applications: string[]
+}
+
+function makeFakeClient(reply: ResolvedRevision | null): {
+    client: InternalApiClient
+    calls: FakeClientCalls
+} {
+    const calls: FakeClientCalls = { domains: [], applications: [] }
+    const client = {
+        resolve: async ({ domain, applicationId }: { domain?: string; applicationId?: string }) => {
+            if (domain) {
+                calls.domains.push(domain)
+            }
+            if (applicationId) {
+                calls.applications.push(applicationId)
+            }
+            return reply
+        },
+    } as unknown as InternalApiClient
+    return { client, calls }
+}
+
+describe('RevisionResolver', () => {
+    it('caches the first lookup and serves subsequent calls from the LRU', async () => {
+        const { client, calls } = makeFakeClient(makeRevision())
+        const resolver = new RevisionResolver({ client, ttlMs: 60_000 })
+
+        await resolver.resolveDomain('analytics-bot.agents.posthog.com')
+        await resolver.resolveDomain('analytics-bot.agents.posthog.com')
+        await resolver.resolveDomain('analytics-bot.agents.posthog.com')
+
+        expect(calls.domains).toEqual(['analytics-bot.agents.posthog.com'])
+    })
+
+    it('separates the domain and application keyspaces', async () => {
+        const { client, calls } = makeFakeClient(makeRevision())
+        const resolver = new RevisionResolver({ client, ttlMs: 60_000 })
+
+        await resolver.resolveDomain('analytics-bot.agents.posthog.com')
+        await resolver.resolveApplication('b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a01')
+
+        // Hitting the same domain a second time uses the cache; hitting the same applicationId
+        // through resolveApplication does not (different keyspace).
+        await resolver.resolveDomain('analytics-bot.agents.posthog.com')
+        await resolver.resolveApplication('b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a01')
+
+        expect(calls.domains).toEqual(['analytics-bot.agents.posthog.com'])
+        expect(calls.applications).toEqual(['b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a01'])
+    })
+
+    it('does not cache null replies — keeps trying on subsequent lookups', async () => {
+        const { client, calls } = makeFakeClient(null)
+        const resolver = new RevisionResolver({ client, ttlMs: 60_000 })
+
+        await resolver.resolveDomain('missing.agents.posthog.com')
+        await resolver.resolveDomain('missing.agents.posthog.com')
+
+        // Avoids caching a stale 404 between deploys.
+        expect(calls.domains.length).toBeGreaterThan(1)
+    })
+
+    it('expires entries after the TTL', async () => {
+        const { client, calls } = makeFakeClient(makeRevision())
+        const resolver = new RevisionResolver({ client, ttlMs: 1 })
+
+        await resolver.resolveDomain('analytics-bot.agents.posthog.com')
+        // Wait past the TTL.
+        await new Promise<void>((resolve) => setTimeout(resolve, 10))
+        await resolver.resolveDomain('analytics-bot.agents.posthog.com')
+
+        expect(calls.domains).toEqual([
+            'analytics-bot.agents.posthog.com',
+            'analytics-bot.agents.posthog.com',
+        ])
+    })
+
+    it('invalidate() evicts the cached entry for a domain', async () => {
+        const { client, calls } = makeFakeClient(makeRevision())
+        const resolver = new RevisionResolver({ client, ttlMs: 60_000 })
+
+        await resolver.resolveDomain('analytics-bot.agents.posthog.com')
+        resolver.invalidate({ domain: 'analytics-bot.agents.posthog.com' })
+        await resolver.resolveDomain('analytics-bot.agents.posthog.com')
+
+        expect(calls.domains).toEqual([
+            'analytics-bot.agents.posthog.com',
+            'analytics-bot.agents.posthog.com',
+        ])
+    })
+
+    it('invalidate() evicts only the requested key', async () => {
+        const { client, calls } = makeFakeClient(makeRevision())
+        const resolver = new RevisionResolver({ client, ttlMs: 60_000 })
+
+        await resolver.resolveDomain('a.agents.posthog.com')
+        await resolver.resolveDomain('b.agents.posthog.com')
+        resolver.invalidate({ domain: 'a.agents.posthog.com' })
+
+        await resolver.resolveDomain('a.agents.posthog.com')
+        await resolver.resolveDomain('b.agents.posthog.com')
+
+        // a was invalidated and re-fetched; b stayed cached.
+        expect(calls.domains).toEqual([
+            'a.agents.posthog.com',
+            'b.agents.posthog.com',
+            'a.agents.posthog.com',
+        ])
+    })
+
+    it('propagates errors from the client and does not cache the failure', async () => {
+        let attempt = 0
+        const client = {
+            resolve: async () => {
+                attempt += 1
+                throw new Error(`boom ${attempt}`)
+            },
+        } as unknown as InternalApiClient
+        const resolver = new RevisionResolver({ client, ttlMs: 60_000 })
+
+        await expect(resolver.resolveDomain('x.agents.posthog.com')).rejects.toThrow('boom 1')
+        await expect(resolver.resolveDomain('x.agents.posthog.com')).rejects.toThrow('boom 2')
+    })
+})

--- a/services/agent-janitor/.eslintrc.cjs
+++ b/services/agent-janitor/.eslintrc.cjs
@@ -1,0 +1,32 @@
+const base = require('../agent-core/eslint.config.base.cjs')
+
+module.exports = {
+    ...base,
+    root: true,
+    parserOptions: {
+        ...base.parserOptions,
+        tsconfigRootDir: __dirname,
+    },
+    rules: {
+        ...base.rules,
+        // Same blast-radius rule as ingress — janitor is operational, not a session executor.
+        // Anything that touches the SDK belongs in agent-runner.
+        'no-restricted-imports': [
+            'error',
+            {
+                patterns: [
+                    {
+                        group: ['@anthropic-ai/*', '@modal/*', 'modal', 'claude-agent-sdk'],
+                        message:
+                            'agent-janitor must not import the Claude Agent SDK or Modal — those belong to agent-runner.',
+                    },
+                    {
+                        group: ['**/nodejs/*', '../../../nodejs/*', '@posthog/nodejs'],
+                        message:
+                            'agent-janitor must not import from nodejs/ — cherry-pick into @posthog/agent-core instead.',
+                    },
+                ],
+            },
+        ],
+    },
+}

--- a/services/agent-janitor/.gitignore
+++ b/services/agent-janitor/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tsbuildinfo

--- a/services/agent-janitor/.prettierrc.cjs
+++ b/services/agent-janitor/.prettierrc.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../agent-core/prettier.config.base.cjs')

--- a/services/agent-janitor/README.md
+++ b/services/agent-janitor/README.md
@@ -1,0 +1,28 @@
+# @posthog/agent-janitor
+
+Operational process for the PostHog agent platform.
+
+Two responsibilities, one process:
+
+1. **Janitor loop** — periodic sweep of the queue: reset stalled jobs, fail poison pills, clean up terminal rows, publish per-queue depth gauges. Owns the same `SessionQueueJanitor` from `@posthog/agent-core` that agent-runner used to host.
+2. **Internal HTTP surface** — `/internal/sessions/*` endpoints that the PostHog app (Django) calls to render the sessions UI and to cancel sessions.
+
+The runtime owns session state. Django **never** writes to `agent_sessions`; the queue row is the single source of truth and Django reads it through this service.
+
+## Routes
+
+| Method | Path                                | Purpose                                      |
+| ------ | ----------------------------------- | -------------------------------------------- |
+| GET    | `/internal/sessions/:id`            | Fetch a single session by queue id           |
+| GET    | `/internal/sessions`                | List sessions filtered by `application_id`, `revision_id`, `status`, `team_id`, `created_before`, `limit` |
+| POST   | `/internal/sessions/:id/cancel`     | Cancel an `available` or `running` session   |
+| GET    | `/health`                           | Always returns `{ok: true}` while listening  |
+| GET    | `/metrics`                          | Prometheus scrape endpoint                   |
+
+All `/internal/*` routes are gated by the `x-internal-key` header (`AGENT_INTERNAL_API_SHARED_KEY`).
+
+## Hard rules
+
+- **No imports from `nodejs/`.** Cherry-pick by copy.
+- **No Anthropic / Modal / Claude Agent SDK imports.** Same blast-radius rule as ingress.
+- Reads + cancels only — never enqueues. Enqueueing is ingress (`/run`) and is intentionally separated.

--- a/services/agent-janitor/jest.config.js
+++ b/services/agent-janitor/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('jest').Config} */
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    testMatch: ['<rootDir>/src/**/*.test.ts'],
+    testTimeout: 15_000,
+    transform: {
+        '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+    },
+}

--- a/services/agent-janitor/package.json
+++ b/services/agent-janitor/package.json
@@ -1,0 +1,50 @@
+{
+    "name": "@posthog/agent-janitor",
+    "version": "0.1.0",
+    "private": true,
+    "description": "Operational process for the PostHog agent platform: queue janitor sweeps + internal HTTP surface for Django (read sessions, cancel sessions).",
+    "license": "MIT",
+    "author": "PostHog <hey@posthog.com>",
+    "repository": "https://github.com/PostHog/posthog",
+    "main": "dist/index.js",
+    "scripts": {
+        "build": "pnpm clean && tsc -b",
+        "clean": "rm -rf dist",
+        "typescript:check": "tsc --noEmit -p .",
+        "lint": "eslint .",
+        "lint:fix": "eslint --fix .",
+        "format": "prettier --write .",
+        "format:check": "prettier --check .",
+        "test": "jest --runInBand --forceExit",
+        "start": "node dist/index.js",
+        "start:dev": "tsx watch src/index.ts"
+    },
+    "dependencies": {
+        "@posthog/agent-core": "workspace:*",
+        "luxon": "^3.4.4",
+        "ultimate-express": "^2.0.9",
+        "zod": "^4.3.6"
+    },
+    "devDependencies": {
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
+        "@trivago/prettier-plugin-sort-imports": "^5.2.2",
+        "@types/jest": "catalog:",
+        "@types/luxon": "^3.4.2",
+        "@types/node": "catalog:",
+        "@types/supertest": "^6.0.2",
+        "@typescript-eslint/eslint-plugin": "^8.58.2",
+        "@typescript-eslint/parser": "^8.58.2",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-no-only-tests": "^3.1.0",
+        "jest": "catalog:",
+        "prettier": "^3.6.2",
+        "supertest": "^7.0.0",
+        "ts-jest": "^29.1.0",
+        "tsx": "^4.7.0",
+        "typescript": "catalog:"
+    },
+    "engines": {
+        "node": ">=24 <25"
+    }
+}

--- a/services/agent-janitor/src/auth.ts
+++ b/services/agent-janitor/src/auth.ts
@@ -1,0 +1,39 @@
+import { timingSafeEqual } from 'node:crypto'
+
+import { NextFunction, Request, Response } from 'ultimate-express'
+
+export interface InternalAuthOptions {
+    /** Shared key the proxy/Django supplies via `x-internal-key`. */
+    sharedKey: string | undefined
+}
+
+/**
+ * Gate `/internal/*` routes behind a static shared key. When the key isn't configured
+ * we refuse all traffic — a janitor without a key is a foot-gun in production.
+ *
+ * mTLS at the mesh level (when we get there) is the longer-term plan; this header
+ * check is a defense-in-depth layer that doesn't need infra cooperation.
+ */
+export function requireInternalKey(options: InternalAuthOptions) {
+    return (req: Request, res: Response, next: NextFunction): void => {
+        if (!options.sharedKey) {
+            res.status(500).json({ error: 'AGENT_INTERNAL_API_SHARED_KEY not configured' })
+            return
+        }
+        const presented = req.header('x-internal-key') ?? ''
+        if (!constantTimeEqual(presented, options.sharedKey)) {
+            res.status(401).json({ error: 'invalid internal key' })
+            return
+        }
+        next()
+    }
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+    const ab = Buffer.from(a, 'utf8')
+    const bb = Buffer.from(b, 'utf8')
+    if (ab.length !== bb.length) {
+        return false
+    }
+    return timingSafeEqual(ab, bb)
+}

--- a/services/agent-janitor/src/config.ts
+++ b/services/agent-janitor/src/config.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+const ConfigSchema = z.object({
+    port: z.coerce.number().int().min(1).max(65_535).default(3031),
+    queueDbUrl: z.string().min(1),
+    /**
+     * Shared key required on every `/internal/*` request. Django supplies it via
+     * `x-internal-key`. When unset, internal routes refuse all traffic — keep the
+     * service operable in dev by setting it explicitly.
+     */
+    internalApiSharedKey: z.string().min(1).optional(),
+    janitorIntervalMs: z.coerce.number().int().min(0).default(10_000),
+    janitorStallTimeoutMs: z.coerce.number().int().min(0).default(30_000),
+    janitorMaxTouchCount: z.coerce.number().int().min(1).default(3),
+    janitorCleanupGraceMs: z.coerce.number().int().min(0).default(10_000),
+})
+
+export type JanitorServiceConfig = z.infer<typeof ConfigSchema>
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): JanitorServiceConfig {
+    return ConfigSchema.parse({
+        port: env.PORT,
+        queueDbUrl: env.AGENT_RUNTIME_QUEUE_DATABASE_URL,
+        internalApiSharedKey: env.AGENT_INTERNAL_API_SHARED_KEY,
+        janitorIntervalMs: env.JANITOR_INTERVAL_MS,
+        janitorStallTimeoutMs: env.JANITOR_STALL_TIMEOUT_MS,
+        janitorMaxTouchCount: env.JANITOR_MAX_TOUCH_COUNT,
+        janitorCleanupGraceMs: env.JANITOR_CLEANUP_GRACE_MS,
+    })
+}

--- a/services/agent-janitor/src/index.ts
+++ b/services/agent-janitor/src/index.ts
@@ -1,0 +1,46 @@
+import { SessionQuery, SessionQueueJanitor, logger } from '@posthog/agent-core'
+
+import { loadConfig } from './config'
+import { buildServer } from './server'
+
+async function main(): Promise<void> {
+    const config = loadConfig()
+
+    if (!config.internalApiSharedKey) {
+        logger.warn('agent-janitor starting without AGENT_INTERNAL_API_SHARED_KEY — /internal routes will refuse traffic')
+    }
+
+    const query = new SessionQuery({ pool: { dbUrl: config.queueDbUrl } })
+    await query.connect()
+
+    const janitor = new SessionQueueJanitor({
+        pool: { dbUrl: config.queueDbUrl },
+        cleanupIntervalMs: config.janitorIntervalMs,
+        stallTimeoutMs: config.janitorStallTimeoutMs,
+        maxTouchCount: config.janitorMaxTouchCount,
+        cleanupGraceMs: config.janitorCleanupGraceMs,
+    })
+    await janitor.start()
+
+    const app = buildServer({ query, internalApiSharedKey: config.internalApiSharedKey })
+
+    const server = app.listen(config.port, () => {
+        logger.info('agent-janitor listening', { port: config.port })
+    })
+
+    const shutdown = async (signal: string): Promise<void> => {
+        logger.info('agent-janitor shutting down', { signal })
+        server.close()
+        await janitor.stop()
+        await query.disconnect()
+        process.exit(0)
+    }
+
+    process.on('SIGTERM', () => void shutdown('SIGTERM'))
+    process.on('SIGINT', () => void shutdown('SIGINT'))
+}
+
+main().catch((err) => {
+    logger.error('agent-janitor fatal', { error: String(err) })
+    process.exit(1)
+})

--- a/services/agent-janitor/src/routes/sessions.ts
+++ b/services/agent-janitor/src/routes/sessions.ts
@@ -1,0 +1,111 @@
+import { Express, Request, Response } from 'ultimate-express'
+import { z } from 'zod'
+
+import { ListSessionsFilter, SessionQuery, SessionStatus, SessionView, logger } from '@posthog/agent-core'
+
+const STATUS_VALUES = ['available', 'running', 'completed', 'failed', 'canceled'] as const
+const StatusSchema = z.enum(STATUS_VALUES)
+
+const ListQuerySchema = z.object({
+    team_id: z.coerce.number().int().optional(),
+    application_id: z.string().uuid().optional(),
+    revision_id: z.string().uuid().optional(),
+    status: z
+        .union([StatusSchema, z.array(StatusSchema)])
+        .optional()
+        .transform((v) => (v === undefined ? undefined : Array.isArray(v) ? v : [v])),
+    created_before: z.coerce.date().optional(),
+    limit: z.coerce.number().int().positive().optional(),
+})
+
+export interface SessionsRouteDeps {
+    query: SessionQuery
+}
+
+export function registerSessionsRoutes(app: Express, deps: SessionsRouteDeps): void {
+    app.get('/internal/sessions/:id', async (req: Request, res: Response) => {
+        const id = parseSessionId(req.params.id)
+        if (!id) {
+            res.status(400).json({ error: 'invalid session id' })
+            return
+        }
+        try {
+            const view = await deps.query.findSession(id)
+            if (!view) {
+                res.status(404).json({ error: 'session not found' })
+                return
+            }
+            res.json(viewToJson(view))
+        } catch (err) {
+            logger.error('agent-janitor findSession failed', { id, error: String(err) })
+            res.status(503).json({ error: 'session lookup failed' })
+        }
+    })
+
+    app.get('/internal/sessions', async (req: Request, res: Response) => {
+        const parsed = ListQuerySchema.safeParse(req.query)
+        if (!parsed.success) {
+            res.status(400).json({ error: 'invalid query', issues: parsed.error.issues })
+            return
+        }
+        const filter: ListSessionsFilter = {
+            teamId: parsed.data.team_id,
+            applicationId: parsed.data.application_id,
+            revisionId: parsed.data.revision_id,
+            status: parsed.data.status as readonly SessionStatus[] | undefined,
+            createdBefore: parsed.data.created_before,
+            limit: parsed.data.limit,
+        }
+        try {
+            const results = await deps.query.listSessions(filter)
+            res.json({ results: results.map(viewToJson) })
+        } catch (err) {
+            logger.error('agent-janitor listSessions failed', { error: String(err) })
+            res.status(503).json({ error: 'session list failed' })
+        }
+    })
+
+    app.post('/internal/sessions/:id/cancel', async (req: Request, res: Response) => {
+        const id = parseSessionId(req.params.id)
+        if (!id) {
+            res.status(400).json({ error: 'invalid session id' })
+            return
+        }
+        try {
+            const view = await deps.query.cancelSession(id)
+            if (!view) {
+                res.status(404).json({ error: 'session not found' })
+                return
+            }
+            res.json(viewToJson(view))
+        } catch (err) {
+            logger.error('agent-janitor cancelSession failed', { id, error: String(err) })
+            res.status(503).json({ error: 'session cancel failed' })
+        }
+    })
+}
+
+function parseSessionId(raw: string | undefined): string | null {
+    if (!raw) {
+        return null
+    }
+    return z.string().uuid().safeParse(raw).success ? raw : null
+}
+
+function viewToJson(view: SessionView): Record<string, unknown> {
+    return {
+        id: view.id,
+        team_id: view.teamId,
+        application_id: view.applicationId,
+        revision_id: view.revisionId,
+        queue_name: view.queueName,
+        status: view.status,
+        scheduled: view.scheduled.toISO(),
+        created: view.created.toISO(),
+        last_transition: view.lastTransition.toISO(),
+        last_heartbeat: view.lastHeartbeat?.toISO() ?? null,
+        transition_count: view.transitionCount,
+        janitor_touch_count: view.janitorTouchCount,
+        state_byte_size: view.stateByteSize,
+    }
+}

--- a/services/agent-janitor/src/server.test.ts
+++ b/services/agent-janitor/src/server.test.ts
@@ -1,0 +1,240 @@
+import { DateTime } from 'luxon'
+import supertest from 'supertest'
+import type { Express } from 'ultimate-express'
+
+import { ListSessionsFilter, SessionQuery, SessionView } from '@posthog/agent-core'
+
+import { JanitorServerDeps, buildServer } from './server'
+
+const VALID_UUID = 'b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a01'
+const OTHER_UUID = 'b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a02'
+const SHARED_KEY = 'unit-test-internal-key'
+
+class FakeSessionQuery {
+    public lastList: ListSessionsFilter | null = null
+    public canceled: string[] = []
+
+    constructor(private readonly rows: SessionView[]) {}
+
+    findSession = async (id: string): Promise<SessionView | null> => this.rows.find((r) => r.id === id) ?? null
+
+    listSessions = async (filter: ListSessionsFilter): Promise<SessionView[]> => {
+        this.lastList = filter
+        return this.rows.filter((row) => {
+            if (filter.teamId !== undefined && row.teamId !== filter.teamId) {
+                return false
+            }
+            if (filter.applicationId && row.applicationId !== filter.applicationId) {
+                return false
+            }
+            if (filter.revisionId && row.revisionId !== filter.revisionId) {
+                return false
+            }
+            if (filter.status) {
+                const statuses = Array.isArray(filter.status) ? filter.status : [filter.status]
+                if (!statuses.includes(row.status)) {
+                    return false
+                }
+            }
+            return true
+        })
+    }
+
+    cancelSession = async (id: string): Promise<SessionView | null> => {
+        const row = this.rows.find((r) => r.id === id)
+        if (!row) {
+            return null
+        }
+        this.canceled.push(id)
+        return { ...row, status: 'canceled' }
+    }
+}
+
+function makeView(overrides: Partial<SessionView> = {}): SessionView {
+    const now = DateTime.utc()
+    return {
+        id: VALID_UUID,
+        teamId: 7,
+        applicationId: 'b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a03',
+        revisionId: 'b1f3d6e4-4c2a-4b0e-9d5a-1c9f7e1d8a04',
+        queueName: 'default',
+        status: 'running',
+        scheduled: now,
+        created: now,
+        lastTransition: now,
+        lastHeartbeat: now,
+        transitionCount: 1,
+        janitorTouchCount: 0,
+        stateByteSize: 42,
+        ...overrides,
+    }
+}
+
+interface TestHarness {
+    query: FakeSessionQuery
+    app: Express
+}
+
+async function startServer(args: {
+    rows?: SessionView[]
+    sharedKey?: string | undefined
+}): Promise<TestHarness> {
+    const query = new FakeSessionQuery(args.rows ?? [])
+    const deps: JanitorServerDeps = {
+        query: query as unknown as SessionQuery,
+        internalApiSharedKey: args.sharedKey,
+    }
+    const app = buildServer(deps)
+    await new Promise<void>((resolve, reject) => {
+        try {
+            app.listen(0, () => resolve())
+        } catch (err) {
+            reject(err)
+        }
+    })
+    return { query, app }
+}
+
+describe('agent-janitor server', () => {
+    let harness: TestHarness
+
+    afterEach(() => {
+        // app does not expose close() in ultimate-express, and the supertest agent does
+        // not hold onto the underlying server; relying on jest --forceExit to tear it down.
+    })
+
+    describe('public routes', () => {
+        it('GET /health is open and returns ok', async () => {
+            harness = await startServer({ sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app).get('/health')
+            expect(res.status).toBe(200)
+            expect(res.body).toEqual({ ok: true })
+        })
+
+        it('GET /metrics is open and returns prometheus text', async () => {
+            harness = await startServer({ sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app).get('/metrics')
+            expect(res.status).toBe(200)
+            expect(res.headers['content-type']).toContain('text/plain')
+        })
+    })
+
+    describe('auth gating on /internal/*', () => {
+        it('refuses with 500 when no shared key is configured', async () => {
+            harness = await startServer({ rows: [makeView()], sharedKey: undefined })
+            const res = await supertest(harness.app).get(`/internal/sessions/${VALID_UUID}`)
+            expect(res.status).toBe(500)
+        })
+
+        it('refuses with 401 when the key is missing', async () => {
+            harness = await startServer({ rows: [makeView()], sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app).get(`/internal/sessions/${VALID_UUID}`)
+            expect(res.status).toBe(401)
+        })
+
+        it('refuses with 401 when the key is wrong', async () => {
+            harness = await startServer({ rows: [makeView()], sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app)
+                .get(`/internal/sessions/${VALID_UUID}`)
+                .set('x-internal-key', 'not-the-key')
+            expect(res.status).toBe(401)
+        })
+
+        it('accepts with 200 when the key matches', async () => {
+            harness = await startServer({ rows: [makeView()], sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app)
+                .get(`/internal/sessions/${VALID_UUID}`)
+                .set('x-internal-key', SHARED_KEY)
+            expect(res.status).toBe(200)
+        })
+    })
+
+    describe('GET /internal/sessions/:id', () => {
+        it('returns the session as snake_case JSON', async () => {
+            harness = await startServer({ rows: [makeView()], sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app)
+                .get(`/internal/sessions/${VALID_UUID}`)
+                .set('x-internal-key', SHARED_KEY)
+            expect(res.status).toBe(200)
+            expect(res.body).toMatchObject({
+                id: VALID_UUID,
+                team_id: 7,
+                status: 'running',
+                queue_name: 'default',
+                state_byte_size: 42,
+            })
+        })
+
+        it('returns 404 when the session does not exist', async () => {
+            harness = await startServer({ rows: [], sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app)
+                .get(`/internal/sessions/${VALID_UUID}`)
+                .set('x-internal-key', SHARED_KEY)
+            expect(res.status).toBe(404)
+        })
+
+        it('returns 400 for non-uuid ids', async () => {
+            harness = await startServer({ rows: [], sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app)
+                .get('/internal/sessions/not-a-uuid')
+                .set('x-internal-key', SHARED_KEY)
+            expect(res.status).toBe(400)
+        })
+    })
+
+    describe('GET /internal/sessions', () => {
+        it('lists sessions filtered by application_id + status', async () => {
+            const rowA = makeView({ id: VALID_UUID, status: 'running' })
+            const rowB = makeView({ id: OTHER_UUID, status: 'completed' })
+            harness = await startServer({ rows: [rowA, rowB], sharedKey: SHARED_KEY })
+
+            const res = await supertest(harness.app)
+                .get(`/internal/sessions?application_id=${rowA.applicationId}&status=running`)
+                .set('x-internal-key', SHARED_KEY)
+
+            expect(res.status).toBe(200)
+            expect(res.body.results).toHaveLength(1)
+            expect(res.body.results[0].id).toBe(VALID_UUID)
+            expect(harness.query.lastList).toMatchObject({
+                applicationId: rowA.applicationId,
+                status: ['running'],
+            })
+        })
+
+        it('rejects invalid query parameters', async () => {
+            harness = await startServer({ rows: [], sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app)
+                .get('/internal/sessions?application_id=not-a-uuid')
+                .set('x-internal-key', SHARED_KEY)
+            expect(res.status).toBe(400)
+        })
+    })
+
+    describe('POST /internal/sessions/:id/cancel', () => {
+        it('cancels an existing session and returns the new view', async () => {
+            harness = await startServer({ rows: [makeView()], sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app)
+                .post(`/internal/sessions/${VALID_UUID}/cancel`)
+                .set('x-internal-key', SHARED_KEY)
+            expect(res.status).toBe(200)
+            expect(res.body.status).toBe('canceled')
+            expect(harness.query.canceled).toEqual([VALID_UUID])
+        })
+
+        it('returns 404 when the session does not exist', async () => {
+            harness = await startServer({ rows: [], sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app)
+                .post(`/internal/sessions/${VALID_UUID}/cancel`)
+                .set('x-internal-key', SHARED_KEY)
+            expect(res.status).toBe(404)
+        })
+
+        it('returns 400 for non-uuid ids', async () => {
+            harness = await startServer({ rows: [], sharedKey: SHARED_KEY })
+            const res = await supertest(harness.app)
+                .post('/internal/sessions/not-a-uuid/cancel')
+                .set('x-internal-key', SHARED_KEY)
+            expect(res.status).toBe(400)
+        })
+    })
+})

--- a/services/agent-janitor/src/server.ts
+++ b/services/agent-janitor/src/server.ts
@@ -1,0 +1,38 @@
+import express, { Express } from 'ultimate-express'
+
+import { SessionQuery, collectDefaults, logger, metricsContentType, metricsText } from '@posthog/agent-core'
+
+import { requireInternalKey } from './auth'
+import { registerSessionsRoutes } from './routes/sessions'
+
+export interface JanitorServerDeps {
+    query: SessionQuery
+    /** Required for `/internal/*` routes. Routes refuse traffic when undefined. */
+    internalApiSharedKey: string | undefined
+}
+
+export function buildServer(deps: JanitorServerDeps): Express {
+    collectDefaults()
+    const app = express()
+
+    app.use(express.json({ limit: '64kb' }))
+    app.use((req, _res, next) => {
+        logger.debug('agent-janitor request', { method: req.method, path: req.path })
+        next()
+    })
+
+    app.get('/health', (_req, res) => {
+        res.json({ ok: true })
+    })
+
+    app.get('/metrics', async (_req, res) => {
+        res.set('content-type', metricsContentType())
+        res.send(await metricsText())
+    })
+
+    // Path-prefix middleware: any request under /internal/* runs through the shared-key check.
+    app.use('/internal', requireInternalKey({ sharedKey: deps.internalApiSharedKey }))
+    registerSessionsRoutes(app, { query: deps.query })
+
+    return app
+}

--- a/services/agent-janitor/tsconfig.eslint.json
+++ b/services/agent-janitor/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "types": ["node", "jest"]
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/services/agent-janitor/tsconfig.json
+++ b/services/agent-janitor/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "CommonJS",
+        "target": "ES2022",
+        "lib": ["ES2022"],
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "outDir": "dist/",
+        "rootDir": "src/",
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "resolveJsonModule": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "noImplicitOverride": true,
+        "noFallthroughCasesInSwitch": true,
+        "allowUnreachableCode": false,
+        "allowUnusedLabels": false,
+        "useUnknownInCatchVariables": false,
+        "skipLibCheck": true,
+        "types": ["node", "jest"]
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/services/agent-janitor/tsconfig.test.json
+++ b/services/agent-janitor/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "types": ["node", "jest"]
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Problem

The agent platform runtime needs an operational service to manage session queue lifecycle (sweeping stalled jobs, cleaning up terminal rows, publishing metrics) and provide Django with a read-only HTTP surface to query and cancel sessions. Previously, the janitor loop was co-hosted in agent-runner; this separates concerns and establishes the runtime as the single source of truth for session state.

## Changes

Added `services/agent-janitor/`, a new TypeScript service with two responsibilities:

1. **Queue janitor loop** — periodic sweep of `agent_sessions`: resets stalled jobs, fails poison pills, cleans up terminal rows, publishes per-queue depth gauges. Reuses `SessionQueueJanitor` from `@posthog/agent-core`.

2. **Internal HTTP surface** — `/internal/sessions/*` endpoints (gated by `x-internal-key` header) that Django calls to:
   - `GET /internal/sessions/:id` — fetch a single session
   - `GET /internal/sessions` — list sessions with filters (application_id, status, team_id, etc.)
   - `POST /internal/sessions/:id/cancel` — cancel an in-flight session

**Core additions to `@posthog/agent-core`:**
- `SessionQuery` class — read-only + targeted-write queries over `agent_sessions` (find, list, cancel operations)
- `SessionView` interface — camelCase DTO for session state
- `ListSessionsFilter` interface — query filter parameters

**Auth & validation:**
- `requireInternalKey` middleware enforces static shared key on `/internal/*` routes
- Route handlers validate UUIDs and query parameters with Zod schemas
- Responses use snake_case JSON for Django compatibility

**Configuration:**
- Environment variables: `PORT`, `AGENT_QUEUE_DB_URL`, `AGENT_INTERNAL_API_SHARED_KEY`, janitor tuning parameters
- Graceful shutdown on SIGTERM/SIGINT

Updated `docs/internal/agent-platform.md` to reflect the four-service runtime architecture (core, ingress, runner, janitor).

## How did you test this code?

Added comprehensive test suites:
- `services/agent-janitor/src/server.test.ts` — 240 lines covering auth gating, session lookup, listing with filters, and cancellation
- `services/agent-core/src/queue/query.ts` — integration tests in `queue.test.ts` validating find/list/cancel against a real database
- `services/agent-core/src/internal-api/client.test.ts` — client-side tests for the internal API contract
- `services/agent-ingress/src/resolver.test.ts` — caching and invalidation behavior for revision resolution

All tests pass with `jest --runInBand --forceExit`.

## Publish to changelog?

Yes — this is a new operational service that completes the agent platform runtime architecture.

https://claude.ai/code/session_01Bkx1f6m35QnFZ2RbxTsrZt