### PR TITLE
fix(experiments/mcp): Improve metric pydantic validation messages

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -243,6 +243,46 @@ class ExperimentService:
                     f"{safe_errors}. {cls.EXPOSURE_CONFIG_HINT}"
                 )
 
+    # Maps the public `metric_type` literal to the pydantic class name that pydantic reports
+    # in `loc[0]` when validation fails. Used to narrow union-variant errors to the variant
+    # the caller picked. A drift test asserts this stays in sync with the ExperimentMetric union.
+    _METRIC_TYPE_TO_CLASS = {
+        "mean": "ExperimentMeanMetric",
+        "funnel": "ExperimentFunnelMetric",
+        "ratio": "ExperimentRatioMetric",
+        "retention": "ExperimentRetentionMetric",
+    }
+
+    # Cap reported pydantic errors so a funnel with many steps (each producing union-variant
+    # errors) cannot blow up the response size. The first N errors are the most actionable.
+    _MAX_REPORTED_METRIC_ERRORS = 15
+
+    _EVENTS_NODE_ID_HINT = (
+        "EventsNode does not accept an 'id' field. "
+        "To reference an event, use {'kind': 'EventsNode', 'event': '<event_name>'} (omit 'id'). "
+        "To reference an action, switch to {'kind': 'ActionsNode', 'id': <integer_action_id>} (omit 'event')."
+    )
+
+    @staticmethod
+    def _is_events_node_actions_node_confusion(err: dict) -> bool:
+        """An `id` field was passed on an EventsNode (probably meant ActionsNode)."""
+        loc = tuple(err.get("loc") or ())
+        if len(loc) < 2 or err.get("type") != "extra_forbidden":
+            return False
+        return loc[-1] == "id" and "EventsNode" in loc
+
+    @classmethod
+    def _build_metric_validation_hint(cls, safe_errors: list[dict]) -> str:
+        """Return a targeted hint for an observed pydantic error pattern, or '' if none applies.
+
+        The structural shape of valid metrics is conveyed by `safe_errors` itself (loc, type,
+        msg) — adding prose duplicates the pydantic models and rots silently. Only hints
+        whose facts are independent of metric shape belong here."""
+        for err in safe_errors:
+            if cls._is_events_node_actions_node_confusion(err):
+                return cls._EVENTS_NODE_ID_HINT
+        return ""
+
     @classmethod
     def validate_experiment_metrics(cls, metrics: list | None) -> None:
         """Validate metric payloads accepted by the API layer."""
@@ -285,7 +325,28 @@ class ExperimentService:
                         FunnelDWValidator.validate_funnel_metric(actual_metric)
 
                 except pydantic.ValidationError as e:
-                    raise ValidationError(f"Invalid metric at index {i}: {e.errors()}")
+                    # Surface only the field locations and error types from pydantic — not the
+                    # echoed `input`, `ctx`, and `url` fields, which would reflect arbitrary
+                    # user data back into the response (potentially unbounded in size).
+                    safe_errors = [
+                        {"loc": err.get("loc"), "type": err.get("type"), "msg": err.get("msg")} for err in e.errors()
+                    ]
+                    # ExperimentMetric is a union of four variants; pydantic reports errors against
+                    # every variant by default. If the caller picked a metric_type, narrow to that
+                    # variant's errors so the message stays actionable instead of dumping 25+ errors.
+                    metric_type = metric.get("metric_type")
+                    variant_class = cls._METRIC_TYPE_TO_CLASS.get(metric_type) if isinstance(metric_type, str) else None
+                    if variant_class is not None:
+                        filtered = [err for err in safe_errors if err["loc"] and err["loc"][0] == variant_class]
+                        if filtered:
+                            safe_errors = filtered
+                    hint = cls._build_metric_validation_hint(safe_errors)
+                    if len(safe_errors) > cls._MAX_REPORTED_METRIC_ERRORS:
+                        truncated = safe_errors[: cls._MAX_REPORTED_METRIC_ERRORS]
+                        truncated.append({"truncated": f"...{len(safe_errors) - cls._MAX_REPORTED_METRIC_ERRORS} more"})
+                        safe_errors = truncated
+                    suffix = f" {hint}" if hint else ""
+                    raise ValidationError(f"Invalid metric at index {i}: {safe_errors}.{suffix}")
 
     VALID_STATS_METHODS = {"bayesian", "frequentist"}
 

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -9,9 +9,12 @@ from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
+import pydantic
 from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIRequestFactory
+
+from posthog.schema import EventsNode, ExperimentMetric
 
 from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.models import FeatureFlag, Team
@@ -708,8 +711,6 @@ class TestExperimentService(APIBaseTest):
         """Drift guard: every variant of the ExperimentMetric union must have an entry in
         _METRIC_TYPE_TO_CLASS. If a new metric_type is added to the schema, this fails so
         the mapping (used to filter pydantic errors to the matching variant) stays accurate."""
-        from posthog.schema import ExperimentMetric
-
         union_variants = ExperimentMetric.model_fields["root"].annotation.__args__
         schema_pairs = {
             variant.model_fields["metric_type"].annotation.__args__[0]: variant.__name__ for variant in union_variants
@@ -753,10 +754,6 @@ class TestExperimentService(APIBaseTest):
         'extra_forbidden'. Pydantic publishes these slugs as stable public API, but they
         live in an external dependency — fail loudly if a future pydantic upgrade renames
         the slug so the hint stops silently matching."""
-        import pydantic
-
-        from posthog.schema import EventsNode
-
         try:
             EventsNode.model_validate({"event": "x", "totally_made_up_field_does_not_exist": 1})
         except pydantic.ValidationError as e:
@@ -811,8 +808,8 @@ class TestExperimentService(APIBaseTest):
         with self.assertRaises(ValidationError) as ctx:
             ExperimentService.validate_experiment_metrics([metric])
         message = str(ctx.exception)
-        # The truncation marker should appear when the cap is hit.
-        assert "more" in message
+        # The truncation marker key from the implementation should appear when the cap is hit.
+        assert "truncated" in message
         # And the message size remains bounded even with 100 bad steps.
         assert len(message) < 10_000, f"Error message length {len(message)} exceeded bound"
 

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -711,10 +711,16 @@ class TestExperimentService(APIBaseTest):
         """Drift guard: every variant of the ExperimentMetric union must have an entry in
         _METRIC_TYPE_TO_CLASS. If a new metric_type is added to the schema, this fails so
         the mapping (used to filter pydantic errors to the matching variant) stays accurate."""
-        union_variants = ExperimentMetric.model_fields["root"].annotation.__args__
-        schema_pairs = {
-            variant.model_fields["metric_type"].annotation.__args__[0]: variant.__name__ for variant in union_variants
-        }
+        root_annotation = ExperimentMetric.model_fields["root"].annotation
+        assert root_annotation is not None, "ExperimentMetric.root has no annotation — schema is malformed"
+        union_variants = root_annotation.__args__
+        schema_pairs = {}
+        for variant in union_variants:
+            metric_type_annotation = variant.model_fields["metric_type"].annotation
+            assert metric_type_annotation is not None, (
+                f"{variant.__name__}.metric_type has no annotation — schema is malformed"
+            )
+            schema_pairs[metric_type_annotation.__args__[0]] = variant.__name__
         assert ExperimentService._METRIC_TYPE_TO_CLASS == schema_pairs, (
             "ExperimentMetric union changed — update ExperimentService._METRIC_TYPE_TO_CLASS. "
             f"Expected {schema_pairs}, got {ExperimentService._METRIC_TYPE_TO_CLASS}"

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -653,6 +653,12 @@ class TestExperimentService(APIBaseTest):
     # validate_experiment_metrics — improved pydantic error messages
     # ------------------------------------------------------------------
 
+    _INVALID_METRIC_EVENTS_NODE_ID = {
+        "kind": "ExperimentMetric",
+        "metric_type": "mean",
+        "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
+    }
+
     def test_validate_experiment_metrics_does_not_leak_user_input_into_message(self) -> None:
         """User-supplied data must not be echoed back into error messages reflected to the caller."""
         sensitive_value = "secret-payload-12345-do-not-leak"
@@ -672,39 +678,24 @@ class TestExperimentService(APIBaseTest):
 
     def test_validate_experiment_metrics_strips_pydantic_url_field(self) -> None:
         """Pydantic URLs like https://errors.pydantic.dev/... add noise — strip them."""
-        metric = {
-            "kind": "ExperimentMetric",
-            "metric_type": "mean",
-            "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
-        }
         with self.assertRaises(ValidationError) as ctx:
-            ExperimentService.validate_experiment_metrics([metric])
+            ExperimentService.validate_experiment_metrics([self._INVALID_METRIC_EVENTS_NODE_ID])
         message = str(ctx.exception)
         assert "errors.pydantic.dev" not in message
         assert "'url':" not in message
 
     def test_validate_experiment_metrics_preserves_loc_and_type_in_message(self) -> None:
         """Field location and error type stay so callers can self-correct."""
-        metric = {
-            "kind": "ExperimentMetric",
-            "metric_type": "mean",
-            "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
-        }
         with self.assertRaises(ValidationError) as ctx:
-            ExperimentService.validate_experiment_metrics([metric])
+            ExperimentService.validate_experiment_metrics([self._INVALID_METRIC_EVENTS_NODE_ID])
         message = str(ctx.exception)
         assert "extra_forbidden" in message
         assert "id" in message
 
     def test_validate_experiment_metrics_preserves_index_prefix(self) -> None:
         """The 'Invalid metric at index <i>:' prefix identifies which metric failed."""
-        metric = {
-            "kind": "ExperimentMetric",
-            "metric_type": "mean",
-            "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
-        }
         with self.assertRaises(ValidationError) as ctx:
-            ExperimentService.validate_experiment_metrics([metric])
+            ExperimentService.validate_experiment_metrics([self._INVALID_METRIC_EVENTS_NODE_ID])
         assert "Invalid metric at index 0:" in str(ctx.exception)
 
     def test_metric_type_to_class_mapping_matches_schema(self) -> None:
@@ -773,13 +764,8 @@ class TestExperimentService(APIBaseTest):
 
     def test_validate_experiment_metrics_events_node_id_hint(self) -> None:
         """Passing `id` on an EventsNode yields a hint mentioning both EventsNode and ActionsNode."""
-        metric = {
-            "kind": "ExperimentMetric",
-            "metric_type": "mean",
-            "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
-        }
         with self.assertRaises(ValidationError) as ctx:
-            ExperimentService.validate_experiment_metrics([metric])
+            ExperimentService.validate_experiment_metrics([self._INVALID_METRIC_EVENTS_NODE_ID])
         message = str(ctx.exception)
         assert "EventsNode" in message
         assert "ActionsNode" in message
@@ -826,13 +812,8 @@ class TestExperimentService(APIBaseTest):
             "metric_type": "mean",
             "source": {"kind": "EventsNode", "event": "$pageview"},
         }
-        invalid = {
-            "kind": "ExperimentMetric",
-            "metric_type": "mean",
-            "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
-        }
         with self.assertRaises(ValidationError) as ctx:
-            ExperimentService.validate_experiment_metrics([valid, invalid])
+            ExperimentService.validate_experiment_metrics([valid, self._INVALID_METRIC_EVENTS_NODE_ID])
         assert "Invalid metric at index 1:" in str(ctx.exception)
 
     # ------------------------------------------------------------------

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -554,6 +554,285 @@ class TestExperimentService(APIBaseTest):
         assert len(message) < 1_000, f"Error message length was {len(message)}, expected to be bounded"
 
     # ------------------------------------------------------------------
+    # validate_experiment_metrics — preserves existing rejection contract
+    # ------------------------------------------------------------------
+
+    def test_validate_experiment_metrics_accepts_none(self) -> None:
+        ExperimentService.validate_experiment_metrics(None)
+
+    def test_validate_experiment_metrics_accepts_empty_list(self) -> None:
+        ExperimentService.validate_experiment_metrics([])
+
+    @parameterized.expand(
+        [
+            (
+                "valid_mean_with_event",
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "source": {"kind": "EventsNode", "event": "$pageview"},
+                },
+            ),
+            (
+                "valid_mean_with_action",
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "source": {"kind": "ActionsNode", "id": 1},
+                },
+            ),
+            (
+                "valid_funnel_with_one_step",
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "funnel",
+                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                },
+            ),
+            (
+                "valid_ratio",
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "ratio",
+                    "numerator": {"kind": "EventsNode", "event": "purchase"},
+                    "denominator": {"kind": "EventsNode", "event": "$pageview"},
+                },
+            ),
+            (
+                "valid_retention",
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "retention",
+                    "start_event": {"kind": "EventsNode", "event": "$pageview"},
+                    "completion_event": {"kind": "EventsNode", "event": "purchase"},
+                    "retention_window_start": 0,
+                    "retention_window_end": 7,
+                    "retention_window_unit": "day",
+                    "start_handling": "first_seen",
+                },
+            ),
+        ]
+    )
+    def test_validate_experiment_metrics_accepts_valid_payloads(self, _: str, metric: dict) -> None:
+        ExperimentService.validate_experiment_metrics([metric])
+
+    @parameterized.expand(
+        [
+            ("not_a_list", "not-a-list", "Metrics must be a list"),
+            ("metric_not_a_dict", ["not-a-dict"], "Invalid metric at index 0: must be a dict"),
+            (
+                "legacy_kind",
+                [{"kind": "ExperimentTrendsQuery"}],
+                "legacy metric kind 'ExperimentTrendsQuery' is no longer supported",
+            ),
+            (
+                "wrong_kind",
+                [{"kind": "FunnelsQuery"}],
+                "metric kind must be 'ExperimentMetric'",
+            ),
+            (
+                "funnel_with_no_series",
+                [{"kind": "ExperimentMetric", "metric_type": "funnel", "series": []}],
+                "funnel metrics require at least one step",
+            ),
+        ]
+    )
+    def test_validate_experiment_metrics_rejects_invalid_payloads(
+        self, _: str, metrics: object, expected_fragment: str
+    ) -> None:
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentService.validate_experiment_metrics(metrics)  # type: ignore[arg-type]
+        assert expected_fragment in str(ctx.exception), (
+            f"Expected fragment {expected_fragment!r} in error: {ctx.exception}"
+        )
+
+    # ------------------------------------------------------------------
+    # validate_experiment_metrics — improved pydantic error messages
+    # ------------------------------------------------------------------
+
+    def test_validate_experiment_metrics_does_not_leak_user_input_into_message(self) -> None:
+        """User-supplied data must not be echoed back into error messages reflected to the caller."""
+        sensitive_value = "secret-payload-12345-do-not-leak"
+        metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {
+                "kind": "EventsNode",
+                "event": "$pageview",
+                "id": sensitive_value,
+            },
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentService.validate_experiment_metrics([metric])
+        message = str(ctx.exception)
+        assert sensitive_value not in message, f"Sensitive user value leaked into error message: {message}"
+
+    def test_validate_experiment_metrics_strips_pydantic_url_field(self) -> None:
+        """Pydantic URLs like https://errors.pydantic.dev/... add noise — strip them."""
+        metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentService.validate_experiment_metrics([metric])
+        message = str(ctx.exception)
+        assert "errors.pydantic.dev" not in message
+        assert "'url':" not in message
+
+    def test_validate_experiment_metrics_preserves_loc_and_type_in_message(self) -> None:
+        """Field location and error type stay so callers can self-correct."""
+        metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentService.validate_experiment_metrics([metric])
+        message = str(ctx.exception)
+        assert "extra_forbidden" in message
+        assert "id" in message
+
+    def test_validate_experiment_metrics_preserves_index_prefix(self) -> None:
+        """The 'Invalid metric at index <i>:' prefix identifies which metric failed."""
+        metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentService.validate_experiment_metrics([metric])
+        assert "Invalid metric at index 0:" in str(ctx.exception)
+
+    def test_metric_type_to_class_mapping_matches_schema(self) -> None:
+        """Drift guard: every variant of the ExperimentMetric union must have an entry in
+        _METRIC_TYPE_TO_CLASS. If a new metric_type is added to the schema, this fails so
+        the mapping (used to filter pydantic errors to the matching variant) stays accurate."""
+        from posthog.schema import ExperimentMetric
+
+        union_variants = ExperimentMetric.model_fields["root"].annotation.__args__
+        schema_pairs = {
+            variant.model_fields["metric_type"].annotation.__args__[0]: variant.__name__ for variant in union_variants
+        }
+        assert ExperimentService._METRIC_TYPE_TO_CLASS == schema_pairs, (
+            "ExperimentMetric union changed — update ExperimentService._METRIC_TYPE_TO_CLASS. "
+            f"Expected {schema_pairs}, got {ExperimentService._METRIC_TYPE_TO_CLASS}"
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "matches_events_node_id",
+                {"type": "extra_forbidden", "loc": ("ExperimentMeanMetric", "source", "EventsNode", "id")},
+                True,
+            ),
+            (
+                "ignores_wrong_error_type",
+                {"type": "missing", "loc": ("ExperimentMeanMetric", "source", "EventsNode", "id")},
+                False,
+            ),
+            (
+                "ignores_extra_forbidden_on_other_field",
+                {"type": "extra_forbidden", "loc": ("ExperimentMeanMetric", "source", "EventsNode", "foo")},
+                False,
+            ),
+            (
+                "ignores_extra_forbidden_not_on_events_node",
+                {"type": "extra_forbidden", "loc": ("ExperimentMeanMetric", "source", "ActionsNode", "event")},
+                False,
+            ),
+            ("ignores_empty_loc", {"type": "extra_forbidden", "loc": ()}, False),
+            ("ignores_missing_loc", {"type": "extra_forbidden"}, False),
+        ]
+    )
+    def test_is_events_node_actions_node_confusion_predicate(self, _: str, err: dict, expected: bool) -> None:
+        assert ExperimentService._is_events_node_actions_node_confusion(err) is expected
+
+    def test_pydantic_extra_forbidden_error_code_is_still_in_use(self) -> None:
+        """Canary: the EventsNode.id hint matches on the pydantic error type slug
+        'extra_forbidden'. Pydantic publishes these slugs as stable public API, but they
+        live in an external dependency — fail loudly if a future pydantic upgrade renames
+        the slug so the hint stops silently matching."""
+        import pydantic
+
+        from posthog.schema import EventsNode
+
+        try:
+            EventsNode.model_validate({"event": "x", "totally_made_up_field_does_not_exist": 1})
+        except pydantic.ValidationError as e:
+            error_types = {err["type"] for err in e.errors()}
+            assert "extra_forbidden" in error_types, (
+                f"pydantic no longer emits 'extra_forbidden' for unknown fields — "
+                f"got {error_types}. Update ExperimentService._build_metric_validation_hint."
+            )
+        else:
+            raise AssertionError("pydantic did not reject an unknown field on EventsNode")
+
+    def test_validate_experiment_metrics_events_node_id_hint(self) -> None:
+        """Passing `id` on an EventsNode yields a hint mentioning both EventsNode and ActionsNode."""
+        metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentService.validate_experiment_metrics([metric])
+        message = str(ctx.exception)
+        assert "EventsNode" in message
+        assert "ActionsNode" in message
+
+    def test_validate_experiment_metrics_does_not_echo_large_user_values(self) -> None:
+        """A large user-supplied value (e.g. enormous event name) must not bloat the message."""
+        huge_value = "x" * 10_000
+        metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {"kind": "EventsNode", "event": "$pageview", "id": huge_value},
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentService.validate_experiment_metrics([metric])
+        message = str(ctx.exception)
+        assert huge_value not in message
+        # The message size must scale with the metric schema (bounded), not with user input.
+        # Even with a 10KB user value, the message stays small relative to the input.
+        assert len(message) < len(huge_value), (
+            f"Error message length {len(message)} must not grow with user input ({len(huge_value)})"
+        )
+
+    def test_validate_experiment_metrics_caps_reported_errors_for_huge_payloads(self) -> None:
+        """A funnel with many bad steps must not produce an unbounded error list."""
+        # 100 invalid funnel steps — each one will trigger union-variant errors.
+        bad_step = {"kind": "EventsNode", "event": "$pageview", "id": None}
+        metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "funnel",
+            "series": [bad_step] * 100,
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentService.validate_experiment_metrics([metric])
+        message = str(ctx.exception)
+        # The truncation marker should appear when the cap is hit.
+        assert "more" in message
+        # And the message size remains bounded even with 100 bad steps.
+        assert len(message) < 10_000, f"Error message length {len(message)} exceeded bound"
+
+    def test_validate_experiment_metrics_reports_index_for_second_metric(self) -> None:
+        """Multi-metric payloads must report which index failed."""
+        valid = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {"kind": "EventsNode", "event": "$pageview"},
+        }
+        invalid = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {"kind": "EventsNode", "event": "$pageview", "id": None},
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentService.validate_experiment_metrics([valid, invalid])
+        assert "Invalid metric at index 1:" in str(ctx.exception)
+
+    # ------------------------------------------------------------------
     # Service contract fields
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem
`validate_experiment_metrics` dumps raw `e.errors()` on pydantic failure. When MCP tools call experiment endpoints, agents receive ~6KB of union-variant noise containing echoed inputs and pydantic URLs. This is hard to act on and easy to misinterpret.

## Changes
- Strip `input`/`url`/`ctx` from pydantic errors before surfacing them
- Narrow errors to the variant matching the caller's `metric_type`
- Cap reported errors so a many-step funnel can't unbound the response.
- Add a targeted hint when an `id` field is forbidden on an `EventsNode` (likely meant `ActionsNode`).

Sibling of #58393 (same pattern, applied to metric validation).

## How did you test this code?
- New test cases
