### PR TITLE
feat(uptime): redesign status pages list and public page UI

### DIFF
--- a/products/uptime/frontend/scenes/statusPage/PublicStatusPageScene.tsx
+++ b/products/uptime/frontend/scenes/statusPage/PublicStatusPageScene.tsx
@@ -1,10 +1,15 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
 
-import { Spinner } from '@posthog/lemon-ui'
+import { IconDay, IconLaptop, IconNight } from '@posthog/icons'
+import { Link, Spinner } from '@posthog/lemon-ui'
 
+import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { SceneExport } from 'scenes/sceneTypes'
 
-import { publicStatusPageLogic, PublicStatusPageLogicProps } from './publicStatusPageLogic'
+import posthogLogo from 'public/posthog-logo.svg'
+
+import { publicStatusPageLogic, PublicStatusPageLogicProps, PublicStatusPageTheme } from './publicStatusPageLogic'
 import { StatusPagePreview } from './StatusPagePreview'
 
 export const scene: SceneExport<PublicStatusPageLogicProps> = {
@@ -18,7 +23,32 @@ function PublicStatusPageSceneWrapper(): JSX.Element {
 }
 
 function PublicStatusPageScene(): JSX.Element {
-    const { page, pageLoading, loadFailed } = useValues(publicStatusPageLogic)
+    const { page, pageLoading, loadFailed, theme } = useValues(publicStatusPageLogic)
+    const { setTheme } = useActions(publicStatusPageLogic)
+
+    useEffect(() => {
+        const media = window.matchMedia('(prefers-color-scheme: dark)')
+        const apply = (): void => {
+            const isDark = theme === 'dark' || (theme === 'system' && media.matches)
+            const wanted = isDark ? 'dark' : 'light'
+            if (document.body.getAttribute('theme') !== wanted) {
+                document.body.setAttribute('theme', wanted)
+            }
+        }
+        apply()
+        // App.tsx's useThemedHtml forces unauthenticated scenes to light by setting body[theme]
+        // after this effect mounts. Observe the attribute and re-apply our preference whenever it
+        // gets reset out from under us.
+        const observer = new MutationObserver(apply)
+        observer.observe(document.body, { attributes: true, attributeFilter: ['theme'] })
+        if (theme === 'system') {
+            media.addEventListener('change', apply)
+        }
+        return () => {
+            observer.disconnect()
+            media.removeEventListener('change', apply)
+        }
+    }, [theme])
 
     if (pageLoading && !page) {
         return (
@@ -41,6 +71,18 @@ function PublicStatusPageScene(): JSX.Element {
 
     return (
         <div className="min-h-screen bg-surface-secondary py-12 px-4">
+            <div className="max-w-2xl mx-auto mb-4 flex justify-end">
+                <LemonSegmentedButton<PublicStatusPageTheme>
+                    size="small"
+                    value={theme}
+                    onChange={setTheme}
+                    options={[
+                        { value: 'light', icon: <IconDay />, tooltip: 'Light' },
+                        { value: 'dark', icon: <IconNight />, tooltip: 'Dark' },
+                        { value: 'system', icon: <IconLaptop />, tooltip: 'Sync with system' },
+                    ]}
+                />
+            </div>
             <StatusPagePreview
                 title={page.title}
                 monitors={page.monitors}
@@ -48,9 +90,13 @@ function PublicStatusPageScene(): JSX.Element {
                 ongoingIncidents={page.ongoing_incidents}
                 recentIncidents={page.recent_incidents}
                 placeholder="No monitors on this status page yet."
+                isPublic
             />
-            <footer className="max-w-2xl mx-auto mt-12 text-center text-[11px] text-secondary">
-                Powered by PostHog Uptime
+            <footer className="max-w-2xl mx-auto mt-12 flex flex-col items-center gap-2 text-[11px] text-secondary">
+                <Link to="https://posthog.com?utm_campaign=in-product&utm_tag=public-status-page-footer">
+                    <img src={posthogLogo} alt="PostHog" className="h-4 opacity-70 hover:opacity-100 transition" />
+                </Link>
+                <span>Powered by PostHog Uptime</span>
             </footer>
         </div>
     )

--- a/products/uptime/frontend/scenes/statusPage/StatusPagePreview.tsx
+++ b/products/uptime/frontend/scenes/statusPage/StatusPagePreview.tsx
@@ -13,6 +13,7 @@ interface StatusPagePreviewProps {
     ongoingIncidents?: Incident[]
     recentIncidents?: Incident[]
     placeholder?: string
+    isPublic?: boolean
 }
 
 export function StatusPagePreview({
@@ -22,6 +23,7 @@ export function StatusPagePreview({
     ongoingIncidents = [],
     recentIncidents = [],
     placeholder = 'Add monitors from the left to see them here.',
+    isPublic = false,
 }: StatusPagePreviewProps): JSX.Element {
     const overallStatus = computeOverallStatus(monitors)
     const monitorNameById = new Map(monitors.map((m) => [m.id, m.name]))
@@ -39,7 +41,9 @@ export function StatusPagePreview({
 
             {ongoingIncidents.length > 0 && (
                 <section className="flex flex-col gap-2">
-                    <h2 className="text-sm font-semibold text-primary m-0">Ongoing declared incidents</h2>
+                    <h2 className="text-sm font-semibold text-primary m-0">
+                        {isPublic ? 'Ongoing incidents' : 'Ongoing declared incidents'}
+                    </h2>
                     <ul className="flex flex-col gap-2">
                         {ongoingIncidents.map((incident) => (
                             <li key={incident.id}>
@@ -68,22 +72,48 @@ export function StatusPagePreview({
             )}
 
             {recentIncidents.length > 0 && (
-                <section className="flex flex-col gap-2">
-                    <h2 className="text-sm font-semibold text-primary m-0">Recently resolved</h2>
-                    <ul className="flex flex-col gap-2">
-                        {recentIncidents.map((incident) => (
-                            <li key={incident.id}>
-                                <PublicIncidentRow
-                                    incident={incident}
-                                    monitorName={monitorNameById.get(incident.monitor_id)}
-                                />
-                            </li>
-                        ))}
-                    </ul>
+                <section className="flex flex-col gap-3">
+                    <h2 className="text-sm font-semibold text-primary m-0">Past incidents</h2>
+                    {groupIncidentsByDay(recentIncidents).map(({ day, label, incidents }) => (
+                        <div key={day} className="flex flex-col gap-2">
+                            <div className="text-xs font-medium text-secondary uppercase tracking-wide">{label}</div>
+                            <ul className="flex flex-col gap-2">
+                                {incidents.map((incident) => (
+                                    <li key={incident.id}>
+                                        <PublicIncidentRow
+                                            incident={incident}
+                                            monitorName={monitorNameById.get(incident.monitor_id)}
+                                        />
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    ))}
                 </section>
             )}
         </div>
     )
+}
+
+function groupIncidentsByDay(incidents: Incident[]): { day: string; label: string; incidents: Incident[] }[] {
+    const groups = new Map<string, Incident[]>()
+    for (const incident of incidents) {
+        const anchor = incident.resolved_at ?? incident.started_at
+        const day = dayjs(anchor).format('YYYY-MM-DD')
+        const existing = groups.get(day)
+        if (existing) {
+            existing.push(incident)
+        } else {
+            groups.set(day, [incident])
+        }
+    }
+    return Array.from(groups.entries())
+        .sort(([a], [b]) => (a < b ? 1 : a > b ? -1 : 0))
+        .map(([day, dayIncidents]) => ({
+            day,
+            label: dayjs(day).format('MMM D, YYYY'),
+            incidents: dayIncidents,
+        }))
 }
 
 function PublicIncidentRow({ incident, monitorName }: { incident: Incident; monitorName?: string }): JSX.Element {

--- a/products/uptime/frontend/scenes/statusPage/StatusPagesList.tsx
+++ b/products/uptime/frontend/scenes/statusPage/StatusPagesList.tsx
@@ -1,8 +1,9 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 import { useState } from 'react'
 
 import { IconCheck, IconCopy, IconExternal, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonCard, LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonCard, LemonTag } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -19,7 +20,7 @@ export function StatusPagesList(): JSX.Element {
     }
 
     return (
-        <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))' }}>
+        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {statusPages.map((page) => (
                 <StatusPageCard key={page.id} page={page} onDelete={() => deleteStatusPage(page.id)} />
             ))}
@@ -31,49 +32,56 @@ function StatusPageCard({ page, onDelete }: { page: StatusPageListItem; onDelete
     const monitorCount = page.monitor_ids.length
     const publicUrl =
         typeof window !== 'undefined' ? `${window.location.origin}/status/${page.slug}` : `/status/${page.slug}`
+    const stop = (e: React.MouseEvent): void => e.stopPropagation()
     return (
-        <LemonCard className="flex flex-col gap-3 p-4">
+        <LemonCard
+            hoverEffect
+            onClick={() => router.actions.push(`/uptime/status-pages/${page.id}`)}
+            className="group flex flex-col gap-3 p-4 h-full"
+        >
             <div className="flex items-start justify-between gap-2 min-w-0">
-                <Link to={`/uptime/status-pages/${page.id}`} className="font-semibold truncate min-w-0">
-                    {page.title || 'Untitled status page'}
-                </Link>
-                {page.is_published ? (
-                    <LemonTag type="success" size="small">
-                        Live
-                    </LemonTag>
-                ) : (
-                    <LemonTag type="muted" size="small">
-                        Draft
-                    </LemonTag>
-                )}
+                <div className="font-semibold truncate min-w-0">{page.title || 'Untitled status page'}</div>
+                <div className="flex items-center gap-1 shrink-0">
+                    <div
+                        className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                        onClick={stop}
+                    >
+                        {page.is_published && (
+                            <>
+                                <CopyButton text={publicUrl} />
+                                <LemonButton
+                                    size="xsmall"
+                                    icon={<IconExternal />}
+                                    to={publicUrl}
+                                    targetBlank
+                                    tooltip="Open public page"
+                                />
+                            </>
+                        )}
+                        <LemonButton
+                            size="xsmall"
+                            icon={<IconTrash />}
+                            onClick={onDelete}
+                            status="danger"
+                            tooltip="Delete"
+                        />
+                    </div>
+                    {page.is_published ? (
+                        <LemonTag type="success" size="small">
+                            Live
+                        </LemonTag>
+                    ) : (
+                        <LemonTag type="muted" size="small">
+                            Draft
+                        </LemonTag>
+                    )}
+                </div>
             </div>
-            <div className="flex items-center justify-between text-xs text-secondary">
+            <div className="mt-auto flex items-center justify-between text-xs text-secondary">
                 <span>
                     {monitorCount} monitor{monitorCount === 1 ? '' : 's'}
                 </span>
                 <span>Updated {dayjs(page.updated_at).fromNow()}</span>
-            </div>
-            <div className="flex items-center gap-1">
-                <LemonButton type="secondary" size="small" to={`/uptime/status-pages/${page.id}`}>
-                    Edit
-                </LemonButton>
-                {page.is_published && (
-                    <>
-                        <CopyButton text={publicUrl} />
-                        <Link to={publicUrl} target="_blank">
-                            <LemonButton size="small" icon={<IconExternal />} tooltip="Open public page" />
-                        </Link>
-                    </>
-                )}
-                <LemonButton
-                    size="small"
-                    type="tertiary"
-                    icon={<IconTrash />}
-                    onClick={onDelete}
-                    status="danger"
-                    tooltip="Delete"
-                    className="ml-auto"
-                />
             </div>
         </LemonCard>
     )
@@ -84,7 +92,7 @@ function CopyButton({ text }: { text: string }): JSX.Element {
     return (
         <Tooltip title={copied ? 'Copied' : 'Copy URL'}>
             <LemonButton
-                size="small"
+                size="xsmall"
                 icon={copied ? <IconCheck /> : <IconCopy />}
                 onClick={async () => {
                     const ok = await copyToClipboard(text, 'status page URL')

--- a/products/uptime/frontend/scenes/statusPage/publicStatusPageLogic.ts
+++ b/products/uptime/frontend/scenes/statusPage/publicStatusPageLogic.ts
@@ -1,4 +1,4 @@
-import { afterMount, kea, key, path, props, reducers } from 'kea'
+import { actions, afterMount, kea, key, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -14,6 +14,8 @@ export interface PublicStatusPage {
     recent_incidents: Incident[]
 }
 
+export type PublicStatusPageTheme = 'light' | 'dark' | 'system'
+
 export interface PublicStatusPageLogicProps {
     slug: string
 }
@@ -22,6 +24,10 @@ export const publicStatusPageLogic = kea<publicStatusPageLogicType>([
     path(['products', 'uptime', 'frontend', 'scenes', 'statusPage', 'publicStatusPageLogic']),
     props({} as PublicStatusPageLogicProps),
     key((props) => props.slug),
+
+    actions({
+        setTheme: (theme: PublicStatusPageTheme) => ({ theme }),
+    }),
 
     loaders(({ props }) => ({
         page: [
@@ -40,6 +46,13 @@ export const publicStatusPageLogic = kea<publicStatusPageLogicType>([
             {
                 loadPageFailure: () => true,
                 loadPageSuccess: () => false,
+            },
+        ],
+        theme: [
+            'system' as PublicStatusPageTheme,
+            { persist: true },
+            {
+                setTheme: (_, { theme }) => theme,
             },
         ],
     }),


### PR DESCRIPTION
## Problem

The status pages list and public status page views needed improved UX and visual design. The list view had a fixed grid layout and required clicking through a Link component to navigate, while the public page lacked theme customization and had basic incident grouping.

## Changes

### StatusPagesList.tsx
- Replaced fixed grid layout with responsive Tailwind classes (`grid-cols-1 sm:grid-cols--2 lg:grid-cols-3 xl:grid-cols-4`)
- Made entire card clickable via `onClick` handler instead of wrapping title in a Link component
- Moved action buttons (copy, open, delete) into a hover-revealed group that only appears on hover
- Removed the separate "Edit" button row, consolidating navigation to the card click
- Adjusted button sizes and spacing for a cleaner card layout
- Added `h-full` to ensure cards fill their grid cell height

### PublicStatusPageScene.tsx
- Added theme selector (light/dark/system) with segmented button control
- Implemented theme persistence via Kea reducer with `persist: true`
- Added `useEffect` hook to apply theme preference to `document.body[theme]` attribute
- Handles system preference changes via `matchMedia` listener
- Works around App.tsx forcing light theme by observing and re-applying preference
- Added PostHog logo to footer with link to posthog.com
- Restructured footer layout to display logo above text

### StatusPagePreview.tsx
- Added `isPublic` prop to customize incident section labels
- Changed "Ongoing declared incidents" to "Ongoing incidents" when `isPublic=true`
- Renamed "Recently resolved" section to "Past incidents"
- Implemented `groupIncidentsByDay()` helper to group incidents by date
- Displays incidents grouped by day with formatted date headers (e.g., "Jan 15, 2024")
- Sorts groups by date in descending order (newest first)

### publicStatusPageLogic.ts
- Added `PublicStatusPageTheme` type (`'light' | 'dark' | 'system'`)
- Added `setTheme` action to update theme preference
- Added `theme` reducer with persistence to localStorage

## How did you test this code?

This is an agent-authored PR. The changes are primarily UI/UX improvements with no automated tests added. The modifications are straightforward:
- Responsive grid layout uses standard Tailwind classes
- Theme persistence uses Kea's built-in `persist` reducer option
- DOM attribute manipulation for theme application is standard browser API usage
- Incident grouping logic is a simple array transformation

Manual testing would verify:
- Responsive grid displays correctly at different breakpoints
- Card hover state reveals action buttons
- Card click navigates to edit page
- Theme selector persists preference across page reloads
- System theme preference is respected when "Sync with system" is selected
- Incidents are properly grouped by date on public page

## Publish to changelog?

Yes - this is a user-facing feature improvement for the uptime product's status pages UI.

https://claude.ai/code/session_012zpNzN4rA3UKpsBzngkfLt