### PR TITLE
feat(tasks): add sendblue prewarmed sandbox pool

### DIFF
--- a/.semgrep/rules/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/idor-team-scoped-models.yaml
@@ -206,6 +206,7 @@ rules:
                               |Tagger
                               |Task
                               |TaskAutomation
+                              |TaskPrewarmedSandbox
                               |TaskRun
                               |EmailChannel
                               |EvaluationReport
@@ -423,6 +424,7 @@ rules:
                         |Tagger
                         |Task
                         |TaskAutomation
+                        |TaskPrewarmedSandbox
                         |TaskRun
                         |EmailChannel
                         |EvaluationReport

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -40,6 +40,12 @@ SANDBOX_PROVIDER: str | None = get_from_env(
 SANDBOX_API_URL: str | None = get_from_env("SANDBOX_API_URL", None, optional=True)
 SANDBOX_LLM_GATEWAY_URL: str | None = get_from_env("SANDBOX_LLM_GATEWAY_URL", None, optional=True)
 SANDBOX_MCP_URL: str | None = get_from_env("SANDBOX_MCP_URL", None, optional=True)
+SANDBOX_MODAL_DOCKER_DEFAULT_APP_NAME: str = get_from_env(
+    "SANDBOX_MODAL_DOCKER_DEFAULT_APP_NAME", "posthog-sandbox-modal-docker-default"
+)
+SANDBOX_MODAL_DOCKER_NOTEBOOK_APP_NAME: str = get_from_env(
+    "SANDBOX_MODAL_DOCKER_NOTEBOOK_APP_NAME", "posthog-sandbox-modal-docker-notebook"
+)
 
 # When True, cloud-to-cloud resume boots from a Modal filesystem snapshot taken at
 # end-of-run. When False, no Modal snapshot is taken and resume relies on the

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -60,6 +60,7 @@ from posthog.tasks.tasks import (
     pg_row_count,
     pg_table_cache_hit_rate,
     process_scheduled_changes,
+    reconcile_sendblue_prewarmed_sandbox_pool,
     redis_celery_queue_depth,
     redis_heartbeat,
     refresh_activity_log_fields_cache,
@@ -171,6 +172,11 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         60,
         capture_task_run_state_metrics.s(),
         name="tasks run state metrics",
+    )
+    sender.add_periodic_task(
+        60,
+        reconcile_sendblue_prewarmed_sandbox_pool.s(),
+        name="sendblue prewarmed sandbox pool reconciliation",
     )
 
     sender.add_periodic_task(10, redis_heartbeat.s(), name="10 sec heartbeat")

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -712,6 +712,21 @@ def capture_task_run_state_metrics() -> None:
 
 
 @shared_task(ignore_result=True)
+@skip_team_scope_audit
+def reconcile_sendblue_prewarmed_sandbox_pool() -> None:
+    from products.tasks.backend.services.prewarmed_sandbox_pool import (
+        reconcile_sendblue_prewarmed_sandbox_pool as reconcile_pool,
+    )
+
+    try:
+        result = reconcile_pool()
+        logger.info("reconcile_sendblue_prewarmed_sandbox_pool", **result)
+    except Exception as err:
+        logger.exception("reconcile_sendblue_prewarmed_sandbox_pool_failed", exception=err)
+        capture_exception(err)
+
+
+@shared_task(ignore_result=True)
 def update_event_partitions() -> None:
     with connection.cursor() as cursor:
         cursor.execute(

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -713,13 +713,13 @@ def capture_task_run_state_metrics() -> None:
 
 @shared_task(ignore_result=True)
 @skip_team_scope_audit
-def reconcile_sendblue_prewarmed_sandbox_pool() -> None:
+def reconcile_sendblue_prewarmed_sandbox_pool(team_id: int | None = None) -> None:
     from products.tasks.backend.services.prewarmed_sandbox_pool import (
         reconcile_sendblue_prewarmed_sandbox_pool as reconcile_pool,
     )
 
     try:
-        result = reconcile_pool()
+        result = reconcile_pool(team_id=team_id)
         logger.info("reconcile_sendblue_prewarmed_sandbox_pool", **result)
     except Exception as err:
         logger.exception("reconcile_sendblue_prewarmed_sandbox_pool_failed", exception=err)

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -126,6 +126,7 @@
     'posthog.tasks.tasks.poll_query_performance',
     'posthog.tasks.tasks.process_query_task',
     'posthog.tasks.tasks.process_scheduled_changes',
+    'posthog.tasks.tasks.reconcile_sendblue_prewarmed_sandbox_pool',
     'posthog.tasks.tasks.redis_celery_queue_depth',
     'posthog.tasks.tasks.redis_heartbeat',
     'posthog.tasks.tasks.refresh_activity_log_fields_cache',

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -683,6 +683,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if initial_permission_mode is not None:
             extra_state = extra_state or {}
             extra_state["initial_permission_mode"] = initial_permission_mode
+        if task.origin_product == Task.OriginProduct.SENDBLUE:
+            extra_state = extra_state or {}
+            extra_state["interaction_origin"] = "sendblue"
 
         if resume_from_run_id:
             # prevent cross-task resume
@@ -797,6 +800,13 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         logger.info(f"Creating task run for task {task.id} with mode={mode}, branch={branch}")
 
         task_run = task.create_run(mode=mode, branch=branch, extra_state=extra_state)
+        if task.origin_product == Task.OriginProduct.SENDBLUE:
+            try:
+                from posthog.tasks.tasks import reconcile_sendblue_prewarmed_sandbox_pool
+
+                reconcile_sendblue_prewarmed_sandbox_pool.delay()
+            except Exception:
+                logger.exception("Failed to enqueue Sendblue prewarmed sandbox pool reconciliation")
 
         if pending_user_artifact_ids:
             run_artifacts: list[dict] = []

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -804,7 +804,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             try:
                 from posthog.tasks.tasks import reconcile_sendblue_prewarmed_sandbox_pool
 
-                reconcile_sendblue_prewarmed_sandbox_pool.delay()
+                reconcile_sendblue_prewarmed_sandbox_pool.delay(task.team_id)
             except Exception:
                 logger.exception("Failed to enqueue Sendblue prewarmed sandbox pool reconciliation")
 

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -10,6 +10,8 @@ ALL_INITIAL_PERMISSION_MODE_CHOICES: list[str] = [
     arg for member in get_args(InitialPermissionMode) for arg in get_args(member)
 ]
 
+SENDBLUE_TASK_REPOSITORY = "posthog/posthog"
+
 DEFAULT_TRUSTED_DOMAINS = [
     # PostHog Services
     "posthog.com",

--- a/products/tasks/backend/management/commands/reconcile_sendblue_sandbox_pool.py
+++ b/products/tasks/backend/management/commands/reconcile_sendblue_sandbox_pool.py
@@ -1,0 +1,11 @@
+from django.core.management.base import BaseCommand
+
+from products.tasks.backend.services.prewarmed_sandbox_pool import reconcile_sendblue_prewarmed_sandbox_pool
+
+
+class Command(BaseCommand):
+    help = "Reconcile the Sendblue prewarmed sandbox pool once."
+
+    def handle(self, *args, **options):
+        result = reconcile_sendblue_prewarmed_sandbox_pool()
+        self.stdout.write(self.style.SUCCESS(f"Reconciled Sendblue sandbox pool: {result}"))

--- a/products/tasks/backend/management/commands/reconcile_sendblue_sandbox_pool.py
+++ b/products/tasks/backend/management/commands/reconcile_sendblue_sandbox_pool.py
@@ -6,6 +6,9 @@ from products.tasks.backend.services.prewarmed_sandbox_pool import reconcile_sen
 class Command(BaseCommand):
     help = "Reconcile the Sendblue prewarmed sandbox pool once."
 
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", type=int, default=None)
+
     def handle(self, *args, **options):
-        result = reconcile_sendblue_prewarmed_sandbox_pool()
+        result = reconcile_sendblue_prewarmed_sandbox_pool(team_id=options["team_id"])
         self.stdout.write(self.style.SUCCESS(f"Reconciled Sendblue sandbox pool: {result}"))

--- a/products/tasks/backend/migrations/0032_task_prewarmed_sandbox.py
+++ b/products/tasks/backend/migrations/0032_task_prewarmed_sandbox.py
@@ -92,11 +92,17 @@ class Migration(migrations.Migration):
                         to="tasks.taskrun",
                     ),
                 ),
+                ("team", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="posthog.team")),
             ],
             options={
                 "db_table": "posthog_task_prewarmed_sandbox",
                 "indexes": [
+                    models.Index(fields=["team", "pool_key", "status"], name="task_prewarmed_team_pool_idx"),
                     models.Index(fields=["pool_key", "status"], name="task_prewarmed_pool_status_idx"),
+                    models.Index(
+                        fields=["team", "origin_product", "repository", "status"],
+                        name="task_prewarmed_team_origin_idx",
+                    ),
                     models.Index(
                         fields=["origin_product", "repository", "status"], name="task_prewarmed_origin_repo_idx"
                     ),

--- a/products/tasks/backend/migrations/0032_task_prewarmed_sandbox.py
+++ b/products/tasks/backend/migrations/0032_task_prewarmed_sandbox.py
@@ -1,0 +1,106 @@
+import uuid
+
+import django.utils.timezone
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tasks", "0031_task_github_user_integration"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="task",
+                    name="origin_product",
+                    field=models.CharField(
+                        choices=[
+                            ("error_tracking", "Error Tracking"),
+                            ("eval_clusters", "Eval Clusters"),
+                            ("user_created", "User Created"),
+                            ("automation", "Automation"),
+                            ("slack", "Slack"),
+                            ("sendblue", "Sendblue"),
+                            ("support_queue", "Support Queue"),
+                            ("session_summaries", "Session Summaries"),
+                            ("signal_report", "Signal Report"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+            ],
+            database_operations=[],
+        ),
+        migrations.CreateModel(
+            name="TaskPrewarmedSandbox",
+            fields=[
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("pool_key", models.CharField(db_index=True, max_length=255)),
+                (
+                    "origin_product",
+                    models.CharField(
+                        choices=[
+                            ("error_tracking", "Error Tracking"),
+                            ("eval_clusters", "Eval Clusters"),
+                            ("user_created", "User Created"),
+                            ("automation", "Automation"),
+                            ("slack", "Slack"),
+                            ("sendblue", "Sendblue"),
+                            ("support_queue", "Support Queue"),
+                            ("session_summaries", "Session Summaries"),
+                            ("signal_report", "Signal Report"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+                ("repository", models.CharField(max_length=255)),
+                ("provider", models.CharField(max_length=32)),
+                ("template", models.CharField(max_length=50)),
+                ("sandbox_id", models.CharField(blank=True, max_length=255, null=True, unique=True)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("provisioning", "Provisioning"),
+                            ("available", "Available"),
+                            ("leased", "Leased"),
+                            ("terminated", "Terminated"),
+                            ("failed", "Failed"),
+                        ],
+                        db_index=True,
+                        default="provisioning",
+                        max_length=20,
+                    ),
+                ),
+                ("metadata", models.JSONField(blank=True, default=dict)),
+                ("last_error", models.TextField(blank=True, null=True)),
+                ("warmed_at", models.DateTimeField(blank=True, null=True)),
+                ("leased_at", models.DateTimeField(blank=True, null=True)),
+                ("expires_at", models.DateTimeField(blank=True, db_index=True, null=True)),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "leased_task_run",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="prewarmed_sandbox_leases",
+                        to="tasks.taskrun",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_task_prewarmed_sandbox",
+                "indexes": [
+                    models.Index(fields=["pool_key", "status"], name="task_prewarmed_pool_status_idx"),
+                    models.Index(
+                        fields=["origin_product", "repository", "status"], name="task_prewarmed_origin_repo_idx"
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0031_task_github_user_integration
+0032_task_prewarmed_sandbox

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -1023,6 +1023,7 @@ class TaskPrewarmedSandbox(models.Model):
 
     # nosemgrep: prefer-uuid7-django-pk -- TODO: migrate to uuid7 or clarify intent
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)
     pool_key = models.CharField(max_length=255, db_index=True)
     origin_product = models.CharField(max_length=20, choices=Task.OriginProduct)
     repository = models.CharField(max_length=255)
@@ -1048,7 +1049,11 @@ class TaskPrewarmedSandbox(models.Model):
     class Meta:
         db_table = "posthog_task_prewarmed_sandbox"
         indexes = [
+            models.Index(fields=["team", "pool_key", "status"], name="task_prewarmed_team_pool_idx"),
             models.Index(fields=["pool_key", "status"], name="task_prewarmed_pool_status_idx"),
+            models.Index(
+                fields=["team", "origin_product", "repository", "status"], name="task_prewarmed_team_origin_idx"
+            ),
             models.Index(fields=["origin_product", "repository", "status"], name="task_prewarmed_origin_repo_idx"),
         ]
 

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -291,7 +291,7 @@ class Task(DeletedMetaFields, models.Model):
 
         created_by = User.objects.get(id=user_id)
 
-        from products.tasks.backend.services.sandbox import is_public_sandbox_repo
+        from products.tasks.backend.services.sandbox import can_clone_without_github_integration
         from products.tasks.backend.temporal.process_task.utils import (
             PrAuthorshipMode,
             RunSource,
@@ -335,7 +335,11 @@ class Task(DeletedMetaFields, models.Model):
                 github_user_integration = user_github_integration.integration
 
         if repository:
-            if not github_integration and github_user_integration is None and not is_public_sandbox_repo(repository):
+            if (
+                not github_integration
+                and github_user_integration is None
+                and not can_clone_without_github_integration(repository, origin_product)
+            ):
                 raise ValueError(f"Team {team.id} does not have a GitHub integration")
 
         sandbox_env = None

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -56,6 +56,7 @@ class Task(DeletedMetaFields, models.Model):
         USER_CREATED = "user_created", "User Created"
         AUTOMATION = "automation", "Automation"
         SLACK = "slack", "Slack"
+        SENDBLUE = "sendblue", "Sendblue"
         SUPPORT_QUEUE = "support_queue", "Support Queue"
         SESSION_SUMMARIES = "session_summaries", "Session Summaries"
         # Unlike the others (which indicate direct creation from that product, e.g. a "fix this error" button),
@@ -1010,6 +1011,49 @@ class TaskRun(models.Model):
 
     def delete(self, *args, **kwargs):
         raise Exception("Cannot delete TaskRun. Task runs are immutable records.")
+
+
+class TaskPrewarmedSandbox(models.Model):
+    class Status(models.TextChoices):
+        PROVISIONING = "provisioning", "Provisioning"
+        AVAILABLE = "available", "Available"
+        LEASED = "leased", "Leased"
+        TERMINATED = "terminated", "Terminated"
+        FAILED = "failed", "Failed"
+
+    # nosemgrep: prefer-uuid7-django-pk -- TODO: migrate to uuid7 or clarify intent
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    pool_key = models.CharField(max_length=255, db_index=True)
+    origin_product = models.CharField(max_length=20, choices=Task.OriginProduct)
+    repository = models.CharField(max_length=255)
+    provider = models.CharField(max_length=32)
+    template = models.CharField(max_length=50)
+    sandbox_id = models.CharField(max_length=255, null=True, blank=True, unique=True)
+    status = models.CharField(max_length=20, choices=Status, default=Status.PROVISIONING, db_index=True)
+    leased_task_run = models.ForeignKey(
+        TaskRun,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="prewarmed_sandbox_leases",
+    )
+    metadata = models.JSONField(default=dict, blank=True)
+    last_error = models.TextField(null=True, blank=True)
+    warmed_at = models.DateTimeField(null=True, blank=True)
+    leased_at = models.DateTimeField(null=True, blank=True)
+    expires_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    created_at = models.DateTimeField(default=django_timezone.now)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "posthog_task_prewarmed_sandbox"
+        indexes = [
+            models.Index(fields=["pool_key", "status"], name="task_prewarmed_pool_status_idx"),
+            models.Index(fields=["origin_product", "repository", "status"], name="task_prewarmed_origin_repo_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.pool_key} {self.status} {self.sandbox_id or self.id}"
 
 
 class SandboxSnapshot(UUIDModel):

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -22,6 +22,7 @@ from .constants import (
     ALL_INITIAL_PERMISSION_MODE_CHOICES,
     CODEX_INITIAL_PERMISSION_MODE_CHOICES,
     INITIAL_PERMISSION_MODE_CHOICES,
+    SENDBLUE_TASK_REPOSITORY,
 )
 from .models import SandboxEnvironment, Task, TaskAutomation, TaskRun
 from .services.title_generator import generate_task_title
@@ -203,6 +204,8 @@ class TaskSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         validated_data["team"] = self.context["team"]
         validated_data.setdefault("origin_product", Task.OriginProduct.USER_CREATED)
+        if validated_data["origin_product"] == Task.OriginProduct.SENDBLUE and not validated_data.get("repository"):
+            validated_data["repository"] = SENDBLUE_TASK_REPOSITORY
 
         if "request" in self.context and hasattr(self.context["request"], "user"):
             validated_data["created_by"] = self.context["request"].user
@@ -213,7 +216,9 @@ class TaskSerializer(serializers.ModelSerializer):
         )
 
         # Set default GitHub integration if not provided
-        if not validated_data.get("github_integration"):
+        if validated_data.get("origin_product") != Task.OriginProduct.SENDBLUE and not validated_data.get(
+            "github_integration"
+        ):
             default_integration = Integration.objects.filter(team=self.context["team"], kind="github").first()
             if default_integration:
                 validated_data["github_integration"] = default_integration

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -40,6 +40,7 @@ from .agentsh import (
 )
 from .local_skills import ENV_LOCAL_SKILLS_HOST_PATH, LocalSkillsCache
 from .sandbox import (
+    PREWARMED_SANDBOX_ENV_FILE,
     WORKING_DIR,
     AgentServerResult,
     ExecutionResult,
@@ -663,7 +664,9 @@ class DockerSandbox(SandboxBase):
                 f"{build_exec_prefix()} {ENV_WRAPPER_SCRIPT} bash -c {shlex.quote(inner)} &"
             )
         else:
-            return f"cd /scripts && nohup {server_cmd} > /tmp/agent-server.log 2>&1 &"
+            env_file = shlex.quote(PREWARMED_SANDBOX_ENV_FILE)
+            unwrapped_inner = f"[ -f {env_file} ] && . {env_file}; {inner}"
+            return f"cd /scripts && nohup bash -c {shlex.quote(unwrapped_inner)} > /tmp/agent-server-launch.log 2>&1 &"
 
     def _launch_and_check(self, command: str) -> bool:
         """Execute the agent-server command and wait for the health check.

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -49,6 +49,7 @@ from products.tasks.backend.services.modal_provision_diagnostics import (
     summarize_modal_output,
 )
 from products.tasks.backend.services.sandbox import (
+    PREWARMED_SANDBOX_ENV_FILE,
     WORKING_DIR,
     SandboxBase,
     build_agent_runtime_env_prefix,
@@ -244,7 +245,9 @@ class ModalSandbox(SandboxBase):
         return modal.App.lookup(cls.DEFAULT_APP_NAME, create_if_missing=True)
 
     @classmethod
-    def _get_app_for_template(cls, template: SandboxTemplate) -> modal.App:
+    def _get_app_for_template(cls, template: SandboxTemplate, app_name: str | None = None) -> modal.App:
+        if app_name:
+            return modal.App.lookup(app_name, create_if_missing=True)
         if template == SandboxTemplate.NOTEBOOK_BASE:
             return modal.App.lookup(cls.NOTEBOOK_APP_NAME, create_if_missing=True)
         return cls._get_default_app()
@@ -252,7 +255,7 @@ class ModalSandbox(SandboxBase):
     @classmethod
     def create(cls, config: SandboxConfig) -> ModalSandbox:
         try:
-            app = cls._get_app_for_template(config.template)
+            app = cls._get_app_for_template(config.template, config.modal_app_name)
             base_image = _get_template_image(config.template)
             image = base_image
             used_snapshot_image = False
@@ -567,7 +570,9 @@ class ModalSandbox(SandboxBase):
                 f"{build_exec_prefix()} {ENV_WRAPPER_SCRIPT} bash -c {shlex.quote(inner)} &"
             )
         else:
-            return f"cd /scripts && nohup {server_cmd} > /tmp/agent-server.log 2>&1 &"
+            env_file = shlex.quote(PREWARMED_SANDBOX_ENV_FILE)
+            unwrapped_inner = f"[ -f {env_file} ] && . {env_file}; {inner}"
+            return f"cd /scripts && nohup bash -c {shlex.quote(unwrapped_inner)} > /tmp/agent-server-launch.log 2>&1 &"
 
     def _launch_and_check(self, command: str) -> bool:
         result = self.execute(command, timeout_seconds=30)

--- a/products/tasks/backend/services/prewarmed_sandbox_pool.py
+++ b/products/tasks/backend/services/prewarmed_sandbox_pool.py
@@ -43,6 +43,7 @@ class SendbluePrewarmedPoolConfig:
     ttl_seconds: int
     max_create_batch: int
     modal_docker_default_app_name: str | None
+    team_id: int | None
 
     @property
     def pool_key(self) -> str:
@@ -57,7 +58,7 @@ class LeasedPrewarmedSandbox:
     connect_token: str | None
 
 
-def get_sendblue_prewarmed_pool_config() -> SendbluePrewarmedPoolConfig:
+def get_sendblue_prewarmed_pool_config(*, team_id: int | None = None) -> SendbluePrewarmedPoolConfig:
     enabled = bool(
         posthoganalytics.feature_enabled(
             SEND_BLUE_POOL_FEATURE_FLAG,
@@ -84,21 +85,24 @@ def get_sendblue_prewarmed_pool_config() -> SendbluePrewarmedPoolConfig:
             maximum=MAX_CREATE_BATCH,
         ),
         modal_docker_default_app_name=_modal_docker_default_app_name_from_payload(payload),
+        team_id=team_id if team_id is not None else _team_id_from_payload(payload),
     )
 
 
 def try_lease_sendblue_prewarmed_sandbox(
     *,
     run_id: str,
+    team_id: int,
     origin_product: str | None,
     repository: str | None,
     environment_variables: dict[str, str],
 ) -> LeasedPrewarmedSandbox | None:
-    config = get_sendblue_prewarmed_pool_config()
+    config = get_sendblue_prewarmed_pool_config(team_id=team_id)
     normalized_repository = (repository or "").lower()
     if (
         not config.enabled
         or config.target_available <= 0
+        or config.team_id is None
         or origin_product != Task.OriginProduct.SENDBLUE
         or normalized_repository != config.repository
     ):
@@ -147,8 +151,18 @@ def try_lease_sendblue_prewarmed_sandbox(
         return None
 
 
-def reconcile_sendblue_prewarmed_sandbox_pool() -> dict[str, int | bool | str]:
-    config = get_sendblue_prewarmed_pool_config()
+def reconcile_sendblue_prewarmed_sandbox_pool(*, team_id: int | None = None) -> dict[str, int | bool | str]:
+    config = get_sendblue_prewarmed_pool_config(team_id=team_id)
+    if config.team_id is None:
+        return {
+            "enabled": config.enabled,
+            "created": 0,
+            "cleaned": 0,
+            "terminated": 0,
+            "target_available": config.target_available,
+            "repository": config.repository,
+            "missing_team_id": True,
+        }
 
     cleaned = cleanup_expired_sendblue_prewarmed_sandboxes(config=config)
     if not config.enabled or config.target_available <= 0:
@@ -169,7 +183,8 @@ def reconcile_sendblue_prewarmed_sandbox_pool() -> dict[str, int | bool | str]:
         entry = _reserve_provisioning_entry(config=config)
         if entry is None:
             break
-        _provision_entry(entry=entry, config=config)
+        if not _provision_entry(entry=entry, config=config):
+            break
         created += 1
 
     return {
@@ -187,6 +202,7 @@ def cleanup_expired_sendblue_prewarmed_sandboxes(*, config: SendbluePrewarmedPoo
     now = timezone.now()
     expired = list(
         TaskPrewarmedSandbox.objects.filter(
+            team_id=config.team_id,
             pool_key=config.pool_key,
             status__in=[TaskPrewarmedSandbox.Status.AVAILABLE, TaskPrewarmedSandbox.Status.PROVISIONING],
             expires_at__lte=now,
@@ -201,6 +217,7 @@ def terminate_available_sendblue_prewarmed_sandboxes(*, config: SendbluePrewarme
     config = config or get_sendblue_prewarmed_pool_config()
     entries = list(
         TaskPrewarmedSandbox.objects.filter(
+            team_id=config.team_id,
             pool_key=config.pool_key,
             status__in=[TaskPrewarmedSandbox.Status.AVAILABLE, TaskPrewarmedSandbox.Status.PROVISIONING],
         )[:100]
@@ -240,6 +257,15 @@ def _modal_docker_default_app_name_from_payload(payload: dict[str, Any]) -> str 
     return None
 
 
+def _team_id_from_payload(payload: dict[str, Any]) -> int | None:
+    value = payload.get("team_id") or payload.get("project_id")
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
 def _modal_app_name_for_provider(config: SendbluePrewarmedPoolConfig) -> str | None:
     provider = getattr(settings, "SANDBOX_PROVIDER", None)
     if provider and provider.upper() == "MODAL_DOCKER":
@@ -256,6 +282,7 @@ def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int
 def _available_or_provisioning_count(*, config: SendbluePrewarmedPoolConfig) -> int:
     now = timezone.now()
     return TaskPrewarmedSandbox.objects.filter(
+        team_id=config.team_id,
         pool_key=config.pool_key,
         status__in=[TaskPrewarmedSandbox.Status.AVAILABLE, TaskPrewarmedSandbox.Status.PROVISIONING],
         expires_at__gt=now,
@@ -268,6 +295,7 @@ def _reserve_provisioning_entry(*, config: SendbluePrewarmedPoolConfig) -> TaskP
             return None
 
         return TaskPrewarmedSandbox.objects.create(
+            team_id=config.team_id,
             pool_key=config.pool_key,
             origin_product=Task.OriginProduct.SENDBLUE,
             repository=config.repository,
@@ -279,7 +307,7 @@ def _reserve_provisioning_entry(*, config: SendbluePrewarmedPoolConfig) -> TaskP
         )
 
 
-def _provision_entry(*, entry: TaskPrewarmedSandbox, config: SendbluePrewarmedPoolConfig) -> None:
+def _provision_entry(*, entry: TaskPrewarmedSandbox, config: SendbluePrewarmedPoolConfig) -> bool:
     sandbox = None
     try:
         sandbox = Sandbox.create(
@@ -291,6 +319,7 @@ def _provision_entry(*, entry: TaskPrewarmedSandbox, config: SendbluePrewarmedPo
                 metadata={
                     "pool_key": config.pool_key,
                     "pool_entry_id": str(entry.id),
+                    "team_id": str(config.team_id),
                     "origin_product": Task.OriginProduct.SENDBLUE,
                     "repository": config.repository,
                 },
@@ -305,6 +334,7 @@ def _provision_entry(*, entry: TaskPrewarmedSandbox, config: SendbluePrewarmedPo
         entry.warmed_at = timezone.now()
         entry.last_error = None
         entry.save(update_fields=["sandbox_id", "status", "warmed_at", "last_error", "updated_at"])
+        return True
     except Exception as err:
         if sandbox is not None:
             try:
@@ -312,6 +342,7 @@ def _provision_entry(*, entry: TaskPrewarmedSandbox, config: SendbluePrewarmedPo
             except Exception:
                 logger.exception("Failed to destroy failed prewarmed sandbox", extra={"sandbox_id": sandbox.id})
         _mark_entry_failed(entry, str(err))
+        return False
 
 
 def _lease_available_entry(
@@ -324,6 +355,7 @@ def _lease_available_entry(
         entry = (
             TaskPrewarmedSandbox.objects.select_for_update(skip_locked=True)
             .filter(
+                team_id=config.team_id,
                 pool_key=config.pool_key,
                 status=TaskPrewarmedSandbox.Status.AVAILABLE,
                 expires_at__gt=now,

--- a/products/tasks/backend/services/prewarmed_sandbox_pool.py
+++ b/products/tasks/backend/services/prewarmed_sandbox_pool.py
@@ -199,10 +199,13 @@ def reconcile_sendblue_prewarmed_sandbox_pool(*, team_id: int | None = None) -> 
 
 def cleanup_expired_sendblue_prewarmed_sandboxes(*, config: SendbluePrewarmedPoolConfig | None = None) -> int:
     config = config or get_sendblue_prewarmed_pool_config()
+    team_id = config.team_id
+    if team_id is None:
+        return 0
     now = timezone.now()
     expired = list(
         TaskPrewarmedSandbox.objects.filter(
-            team_id=config.team_id,
+            team_id=team_id,
             pool_key=config.pool_key,
             status__in=[TaskPrewarmedSandbox.Status.AVAILABLE, TaskPrewarmedSandbox.Status.PROVISIONING],
             expires_at__lte=now,
@@ -215,9 +218,12 @@ def cleanup_expired_sendblue_prewarmed_sandboxes(*, config: SendbluePrewarmedPoo
 
 def terminate_available_sendblue_prewarmed_sandboxes(*, config: SendbluePrewarmedPoolConfig | None = None) -> int:
     config = config or get_sendblue_prewarmed_pool_config()
+    team_id = config.team_id
+    if team_id is None:
+        return 0
     entries = list(
         TaskPrewarmedSandbox.objects.filter(
-            team_id=config.team_id,
+            team_id=team_id,
             pool_key=config.pool_key,
             status__in=[TaskPrewarmedSandbox.Status.AVAILABLE, TaskPrewarmedSandbox.Status.PROVISIONING],
         )[:100]
@@ -280,9 +286,10 @@ def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int
 
 
 def _available_or_provisioning_count(*, config: SendbluePrewarmedPoolConfig) -> int:
+    team_id = _require_team_id(config)
     now = timezone.now()
     return TaskPrewarmedSandbox.objects.filter(
-        team_id=config.team_id,
+        team_id=team_id,
         pool_key=config.pool_key,
         status__in=[TaskPrewarmedSandbox.Status.AVAILABLE, TaskPrewarmedSandbox.Status.PROVISIONING],
         expires_at__gt=now,
@@ -290,12 +297,13 @@ def _available_or_provisioning_count(*, config: SendbluePrewarmedPoolConfig) -> 
 
 
 def _reserve_provisioning_entry(*, config: SendbluePrewarmedPoolConfig) -> TaskPrewarmedSandbox | None:
+    team_id = _require_team_id(config)
     with transaction.atomic():
         if _available_or_provisioning_count(config=config) >= config.target_available:
             return None
 
         return TaskPrewarmedSandbox.objects.create(
-            team_id=config.team_id,
+            team_id=team_id,
             pool_key=config.pool_key,
             origin_product=Task.OriginProduct.SENDBLUE,
             repository=config.repository,
@@ -350,12 +358,13 @@ def _lease_available_entry(
     config: SendbluePrewarmedPoolConfig,
     run_id: str,
 ) -> TaskPrewarmedSandbox | None:
+    team_id = _require_team_id(config)
     now = timezone.now()
     with transaction.atomic():
         entry = (
             TaskPrewarmedSandbox.objects.select_for_update(skip_locked=True)
             .filter(
-                team_id=config.team_id,
+                team_id=team_id,
                 pool_key=config.pool_key,
                 status=TaskPrewarmedSandbox.Status.AVAILABLE,
                 expires_at__gt=now,
@@ -371,6 +380,12 @@ def _lease_available_entry(
         entry.leased_at = now
         entry.save(update_fields=["status", "leased_task_run", "leased_at", "updated_at"])
         return entry
+
+
+def _require_team_id(config: SendbluePrewarmedPoolConfig) -> int:
+    if config.team_id is None:
+        raise ValueError("Sendblue prewarmed sandbox pool requires a team_id")
+    return config.team_id
 
 
 def _mark_entry_failed(entry: TaskPrewarmedSandbox, error: str) -> None:

--- a/products/tasks/backend/services/prewarmed_sandbox_pool.py
+++ b/products/tasks/backend/services/prewarmed_sandbox_pool.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import re
+import json
+import shlex
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+
+import posthoganalytics
+
+from products.tasks.backend.constants import SENDBLUE_TASK_REPOSITORY
+from products.tasks.backend.models import Task, TaskPrewarmedSandbox
+from products.tasks.backend.services.sandbox import (
+    PREWARMED_SANDBOX_ENV_FILE,
+    Sandbox,
+    SandboxConfig,
+    SandboxStatus,
+    SandboxTemplate,
+)
+
+logger = logging.getLogger(__name__)
+
+SEND_BLUE_POOL_FEATURE_FLAG = "tasks-sendblue-prewarmed-sandbox-pool"
+SEND_BLUE_POOL_DISTINCT_ID = "internal_tasks_sendblue_prewarmed_sandbox_pool"
+DEFAULT_POOL_TTL_SECONDS = 60 * 60
+DEFAULT_MAX_CREATE_BATCH = 5
+MAX_TARGET_AVAILABLE = 200
+MAX_CREATE_BATCH = 25
+ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class SendbluePrewarmedPoolConfig:
+    enabled: bool
+    target_available: int
+    repository: str
+    ttl_seconds: int
+    max_create_batch: int
+    modal_docker_default_app_name: str | None
+
+    @property
+    def pool_key(self) -> str:
+        return f"{Task.OriginProduct.SENDBLUE}:{self.repository}:{SandboxTemplate.DEFAULT_BASE.value}"
+
+
+@dataclass(frozen=True)
+class LeasedPrewarmedSandbox:
+    pool_entry_id: str
+    sandbox_id: str
+    sandbox_url: str
+    connect_token: str | None
+
+
+def get_sendblue_prewarmed_pool_config() -> SendbluePrewarmedPoolConfig:
+    enabled = bool(
+        posthoganalytics.feature_enabled(
+            SEND_BLUE_POOL_FEATURE_FLAG,
+            SEND_BLUE_POOL_DISTINCT_ID,
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+    )
+
+    payload = _get_feature_flag_payload()
+    return SendbluePrewarmedPoolConfig(
+        enabled=enabled,
+        target_available=_bounded_int(
+            payload.get("target_available"), default=0, minimum=0, maximum=MAX_TARGET_AVAILABLE
+        ),
+        repository=_repository_from_payload(payload),
+        ttl_seconds=_bounded_int(
+            payload.get("ttl_seconds"), default=DEFAULT_POOL_TTL_SECONDS, minimum=300, maximum=6 * 60 * 60
+        ),
+        max_create_batch=_bounded_int(
+            payload.get("max_create_batch"),
+            default=DEFAULT_MAX_CREATE_BATCH,
+            minimum=1,
+            maximum=MAX_CREATE_BATCH,
+        ),
+        modal_docker_default_app_name=_modal_docker_default_app_name_from_payload(payload),
+    )
+
+
+def try_lease_sendblue_prewarmed_sandbox(
+    *,
+    run_id: str,
+    origin_product: str | None,
+    repository: str | None,
+    environment_variables: dict[str, str],
+) -> LeasedPrewarmedSandbox | None:
+    config = get_sendblue_prewarmed_pool_config()
+    normalized_repository = (repository or "").lower()
+    if (
+        not config.enabled
+        or config.target_available <= 0
+        or origin_product != Task.OriginProduct.SENDBLUE
+        or normalized_repository != config.repository
+    ):
+        return None
+
+    entry = _lease_available_entry(config=config, run_id=run_id)
+    if entry is None:
+        return None
+
+    try:
+        sandbox = Sandbox.get_by_id(entry.sandbox_id or "")
+        if sandbox.get_status() != SandboxStatus.RUNNING:
+            raise RuntimeError(f"Prewarmed sandbox {entry.sandbox_id} is not running")
+
+        env_result = sandbox.write_file(PREWARMED_SANDBOX_ENV_FILE, _environment_payload(environment_variables))
+        if env_result.exit_code != 0:
+            raise RuntimeError("Failed to inject task environment into prewarmed sandbox")
+
+        credentials = sandbox.get_connect_credentials()
+        logger.info(
+            "Leased prewarmed Sendblue sandbox",
+            extra={
+                "pool_entry_id": str(entry.id),
+                "sandbox_id": sandbox.id,
+                "run_id": run_id,
+                "repository": config.repository,
+            },
+        )
+        return LeasedPrewarmedSandbox(
+            pool_entry_id=str(entry.id),
+            sandbox_id=sandbox.id,
+            sandbox_url=credentials.url,
+            connect_token=credentials.token,
+        )
+    except Exception as err:
+        _mark_entry_failed(entry, str(err))
+        logger.warning(
+            "Failed to lease prewarmed Sendblue sandbox; falling back to cold sandbox",
+            extra={
+                "pool_entry_id": str(entry.id),
+                "sandbox_id": entry.sandbox_id,
+                "run_id": run_id,
+                "error": str(err),
+            },
+        )
+        return None
+
+
+def reconcile_sendblue_prewarmed_sandbox_pool() -> dict[str, int | bool | str]:
+    config = get_sendblue_prewarmed_pool_config()
+
+    cleaned = cleanup_expired_sendblue_prewarmed_sandboxes(config=config)
+    if not config.enabled or config.target_available <= 0:
+        terminated = terminate_available_sendblue_prewarmed_sandboxes(config=config)
+        return {
+            "enabled": False,
+            "created": 0,
+            "cleaned": cleaned,
+            "terminated": terminated,
+            "target_available": config.target_available,
+            "repository": config.repository,
+        }
+
+    created = 0
+    for _ in range(config.max_create_batch):
+        if _available_or_provisioning_count(config=config) >= config.target_available:
+            break
+        entry = _reserve_provisioning_entry(config=config)
+        if entry is None:
+            break
+        _provision_entry(entry=entry, config=config)
+        created += 1
+
+    return {
+        "enabled": True,
+        "created": created,
+        "cleaned": cleaned,
+        "terminated": 0,
+        "target_available": config.target_available,
+        "repository": config.repository,
+    }
+
+
+def cleanup_expired_sendblue_prewarmed_sandboxes(*, config: SendbluePrewarmedPoolConfig | None = None) -> int:
+    config = config or get_sendblue_prewarmed_pool_config()
+    now = timezone.now()
+    expired = list(
+        TaskPrewarmedSandbox.objects.filter(
+            pool_key=config.pool_key,
+            status__in=[TaskPrewarmedSandbox.Status.AVAILABLE, TaskPrewarmedSandbox.Status.PROVISIONING],
+            expires_at__lte=now,
+        )[:100]
+    )
+    for entry in expired:
+        _terminate_entry(entry, status=TaskPrewarmedSandbox.Status.TERMINATED, reason="expired")
+    return len(expired)
+
+
+def terminate_available_sendblue_prewarmed_sandboxes(*, config: SendbluePrewarmedPoolConfig | None = None) -> int:
+    config = config or get_sendblue_prewarmed_pool_config()
+    entries = list(
+        TaskPrewarmedSandbox.objects.filter(
+            pool_key=config.pool_key,
+            status__in=[TaskPrewarmedSandbox.Status.AVAILABLE, TaskPrewarmedSandbox.Status.PROVISIONING],
+        )[:100]
+    )
+    for entry in entries:
+        _terminate_entry(entry, status=TaskPrewarmedSandbox.Status.TERMINATED, reason="feature flag disabled")
+    return len(entries)
+
+
+def _get_feature_flag_payload() -> dict[str, Any]:
+    raw_payload = posthoganalytics.get_feature_flag_payload(
+        SEND_BLUE_POOL_FEATURE_FLAG,
+        SEND_BLUE_POOL_DISTINCT_ID,
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    )
+    if isinstance(raw_payload, str):
+        try:
+            parsed = json.loads(raw_payload)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return raw_payload if isinstance(raw_payload, dict) else {}
+
+
+def _repository_from_payload(payload: dict[str, Any]) -> str:
+    value = payload.get("repository")
+    if isinstance(value, str) and "/" in value:
+        return value.lower()
+    return SENDBLUE_TASK_REPOSITORY
+
+
+def _modal_docker_default_app_name_from_payload(payload: dict[str, Any]) -> str | None:
+    value = payload.get("modal_docker_default_app_name")
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _modal_app_name_for_provider(config: SendbluePrewarmedPoolConfig) -> str | None:
+    provider = getattr(settings, "SANDBOX_PROVIDER", None)
+    if provider and provider.upper() == "MODAL_DOCKER":
+        return config.modal_docker_default_app_name
+    return None
+
+
+def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    if not isinstance(value, int):
+        return default
+    return max(minimum, min(value, maximum))
+
+
+def _available_or_provisioning_count(*, config: SendbluePrewarmedPoolConfig) -> int:
+    now = timezone.now()
+    return TaskPrewarmedSandbox.objects.filter(
+        pool_key=config.pool_key,
+        status__in=[TaskPrewarmedSandbox.Status.AVAILABLE, TaskPrewarmedSandbox.Status.PROVISIONING],
+        expires_at__gt=now,
+    ).count()
+
+
+def _reserve_provisioning_entry(*, config: SendbluePrewarmedPoolConfig) -> TaskPrewarmedSandbox | None:
+    with transaction.atomic():
+        if _available_or_provisioning_count(config=config) >= config.target_available:
+            return None
+
+        return TaskPrewarmedSandbox.objects.create(
+            pool_key=config.pool_key,
+            origin_product=Task.OriginProduct.SENDBLUE,
+            repository=config.repository,
+            provider=getattr(settings, "SANDBOX_PROVIDER", None) or "modal",
+            template=SandboxTemplate.DEFAULT_BASE.value,
+            status=TaskPrewarmedSandbox.Status.PROVISIONING,
+            expires_at=timezone.now() + timedelta(seconds=config.ttl_seconds),
+            metadata={"source": "sendblue-prewarm-pool"},
+        )
+
+
+def _provision_entry(*, entry: TaskPrewarmedSandbox, config: SendbluePrewarmedPoolConfig) -> None:
+    sandbox = None
+    try:
+        sandbox = Sandbox.create(
+            SandboxConfig(
+                name=f"sendblue-prewarm-{entry.id}",
+                template=SandboxTemplate.DEFAULT_BASE,
+                ttl_seconds=config.ttl_seconds,
+                modal_app_name=_modal_app_name_for_provider(config),
+                metadata={
+                    "pool_key": config.pool_key,
+                    "pool_entry_id": str(entry.id),
+                    "origin_product": Task.OriginProduct.SENDBLUE,
+                    "repository": config.repository,
+                },
+            )
+        )
+        clone_result = sandbox.clone_repository(config.repository, github_token="", shallow=True)
+        if clone_result.exit_code != 0:
+            raise RuntimeError(f"Failed to clone {config.repository}: {clone_result.stderr}")
+
+        entry.sandbox_id = sandbox.id
+        entry.status = TaskPrewarmedSandbox.Status.AVAILABLE
+        entry.warmed_at = timezone.now()
+        entry.last_error = None
+        entry.save(update_fields=["sandbox_id", "status", "warmed_at", "last_error", "updated_at"])
+    except Exception as err:
+        if sandbox is not None:
+            try:
+                sandbox.destroy()
+            except Exception:
+                logger.exception("Failed to destroy failed prewarmed sandbox", extra={"sandbox_id": sandbox.id})
+        _mark_entry_failed(entry, str(err))
+
+
+def _lease_available_entry(
+    *,
+    config: SendbluePrewarmedPoolConfig,
+    run_id: str,
+) -> TaskPrewarmedSandbox | None:
+    now = timezone.now()
+    with transaction.atomic():
+        entry = (
+            TaskPrewarmedSandbox.objects.select_for_update(skip_locked=True)
+            .filter(
+                pool_key=config.pool_key,
+                status=TaskPrewarmedSandbox.Status.AVAILABLE,
+                expires_at__gt=now,
+            )
+            .order_by("warmed_at", "created_at")
+            .first()
+        )
+        if entry is None:
+            return None
+
+        entry.status = TaskPrewarmedSandbox.Status.LEASED
+        entry.leased_task_run_id = run_id
+        entry.leased_at = now
+        entry.save(update_fields=["status", "leased_task_run", "leased_at", "updated_at"])
+        return entry
+
+
+def _mark_entry_failed(entry: TaskPrewarmedSandbox, error: str) -> None:
+    entry.status = TaskPrewarmedSandbox.Status.FAILED
+    entry.last_error = error[:1000]
+    entry.save(update_fields=["status", "last_error", "updated_at"])
+
+
+def _terminate_entry(entry: TaskPrewarmedSandbox, *, status: str, reason: str) -> None:
+    if entry.sandbox_id:
+        try:
+            sandbox = Sandbox.get_by_id(entry.sandbox_id)
+            sandbox.destroy()
+        except Exception:
+            logger.exception(
+                "Failed to terminate prewarmed sandbox",
+                extra={"pool_entry_id": str(entry.id), "sandbox_id": entry.sandbox_id},
+            )
+    entry.status = status
+    entry.last_error = reason
+    entry.save(update_fields=["status", "last_error", "updated_at"])
+
+
+def _environment_payload(environment_variables: dict[str, str]) -> bytes:
+    lines = ["#!/bin/bash"]
+    skipped_keys = []
+    for key, value in environment_variables.items():
+        if not ENV_VAR_NAME_RE.match(key):
+            skipped_keys.append(key)
+            continue
+        lines.append(f"export {key}={shlex.quote(str(value))}")
+
+    if skipped_keys:
+        logger.warning(
+            "Skipping invalid prewarmed sandbox environment variable keys",
+            extra={"keys": sorted(skipped_keys)},
+        )
+
+    return ("\n".join(lines) + "\n").encode()

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -25,6 +25,8 @@ from django.conf import settings
 import structlog
 from pydantic import BaseModel
 
+from products.tasks.backend.constants import SENDBLUE_TASK_REPOSITORY
+
 if TYPE_CHECKING:
     from products.tasks.backend.temporal.process_task.utils import McpServerConfig
 
@@ -85,13 +87,19 @@ class SandboxConfig(BaseModel):
 WORKING_DIR = "/tmp/workspace"
 PREWARMED_SANDBOX_ENV_FILE = "/tmp/posthog-prewarmed-agent-env.sh"
 
-PUBLIC_SANDBOX_REPOS: frozenset[str] = frozenset({"posthog/hedgebox", "posthog/.github", "posthog/posthog"})
+PUBLIC_SANDBOX_REPOS: frozenset[str] = frozenset({"posthog/hedgebox", "posthog/.github"})
 """Repos the sandbox is allowed to clone unauthenticated, even when the team has no GitHub integration"""
 # TODO: Remove `posthog/.github` when we switch repo discovery to repo-less agent (now it works as a lightweight dummy)
 
 
 def is_public_sandbox_repo(repository: str | None) -> bool:
     return repository is not None and repository.lower() in PUBLIC_SANDBOX_REPOS
+
+
+def can_clone_without_github_integration(repository: str | None, origin_product: str | None = None) -> bool:
+    if is_public_sandbox_repo(repository):
+        return True
+    return origin_product == "sendblue" and repository is not None and repository.lower() == SENDBLUE_TASK_REPOSITORY
 
 
 def build_agent_runtime_env_prefix(

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -79,11 +79,13 @@ class SandboxConfig(BaseModel):
     memory_gb: float = 16
     cpu_cores: float = 4
     disk_size_gb: float = 64
+    modal_app_name: str | None = None
 
 
 WORKING_DIR = "/tmp/workspace"
+PREWARMED_SANDBOX_ENV_FILE = "/tmp/posthog-prewarmed-agent-env.sh"
 
-PUBLIC_SANDBOX_REPOS: frozenset[str] = frozenset({"posthog/hedgebox", "posthog/.github"})
+PUBLIC_SANDBOX_REPOS: frozenset[str] = frozenset({"posthog/hedgebox", "posthog/.github", "posthog/posthog"})
 """Repos the sandbox is allowed to clone unauthenticated, even when the team has no GitHub integration"""
 # TODO: Remove `posthog/.github` when we switch repo discovery to repo-less agent (now it works as a lightweight dummy)
 
@@ -336,8 +338,16 @@ def _get_modal_docker_sandbox_class() -> SandboxClass:
     from .modal_sandbox import ModalSandbox
 
     class ModalDockerSandbox(ModalSandbox):
-        DEFAULT_APP_NAME = "posthog-sandbox-modal-docker-default"
-        NOTEBOOK_APP_NAME = "posthog-sandbox-modal-docker-notebook"
+        DEFAULT_APP_NAME = getattr(
+            settings,
+            "SANDBOX_MODAL_DOCKER_DEFAULT_APP_NAME",
+            "posthog-sandbox-modal-docker-default",
+        )
+        NOTEBOOK_APP_NAME = getattr(
+            settings,
+            "SANDBOX_MODAL_DOCKER_NOTEBOOK_APP_NAME",
+            "posthog-sandbox-modal-docker-notebook",
+        )
 
     return ModalDockerSandbox
 

--- a/products/tasks/backend/services/tests/test_prewarmed_sandbox_pool.py
+++ b/products/tasks/backend/services/tests/test_prewarmed_sandbox_pool.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import pytest
+from unittest.mock import patch
+
+from django.test import override_settings
+from django.utils import timezone
+
+from posthog.models import Organization, Team
+
+from products.tasks.backend.constants import SENDBLUE_TASK_REPOSITORY
+from products.tasks.backend.models import Task, TaskPrewarmedSandbox, TaskRun
+from products.tasks.backend.services.prewarmed_sandbox_pool import (
+    SEND_BLUE_POOL_DISTINCT_ID,
+    SEND_BLUE_POOL_FEATURE_FLAG,
+    SendbluePrewarmedPoolConfig,
+    get_sendblue_prewarmed_pool_config,
+    reconcile_sendblue_prewarmed_sandbox_pool,
+    try_lease_sendblue_prewarmed_sandbox,
+)
+from products.tasks.backend.services.sandbox import (
+    PREWARMED_SANDBOX_ENV_FILE,
+    AgentServerResult,
+    ExecutionResult,
+    SandboxConfig,
+    SandboxStatus,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+class FakeSandbox:
+    def __init__(self, sandbox_id: str = "sb-test", status: SandboxStatus = SandboxStatus.RUNNING):
+        self.id = sandbox_id
+        self.status = status
+        self.clone_calls: list[tuple[str, str | None, bool]] = []
+        self.write_calls: list[tuple[str, bytes]] = []
+        self.destroyed = False
+
+    def get_status(self) -> SandboxStatus:
+        return self.status
+
+    def write_file(self, path: str, payload: bytes) -> ExecutionResult:
+        self.write_calls.append((path, payload))
+        return ExecutionResult(stdout="", stderr="", exit_code=0)
+
+    def get_connect_credentials(self) -> AgentServerResult:
+        return AgentServerResult(url=f"https://{self.id}.modal.host", token=f"{self.id}-token")
+
+    def clone_repository(self, repository: str, github_token: str | None = "", shallow: bool = True) -> ExecutionResult:
+        self.clone_calls.append((repository, github_token, shallow))
+        return ExecutionResult(stdout="", stderr="", exit_code=0)
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+
+def _team() -> Team:
+    organization = Organization.objects.create(name="Sendblue Pool Test Org")
+    return Team.objects.create(organization=organization, name="Sendblue Pool Test Team")
+
+
+def _task_run() -> TaskRun:
+    team = _team()
+    task = Task.objects.create(
+        team=team,
+        title="Sendblue task",
+        description="Created from Sendblue",
+        origin_product=Task.OriginProduct.SENDBLUE,
+        repository=SENDBLUE_TASK_REPOSITORY,
+    )
+    return TaskRun.objects.create(task=task, team=team, status=TaskRun.Status.QUEUED)
+
+
+def _config(**overrides: Any) -> SendbluePrewarmedPoolConfig:
+    return SendbluePrewarmedPoolConfig(
+        enabled=overrides.get("enabled", True),
+        target_available=overrides.get("target_available", 2),
+        repository=overrides.get("repository", SENDBLUE_TASK_REPOSITORY),
+        ttl_seconds=overrides.get("ttl_seconds", 3600),
+        max_create_batch=overrides.get("max_create_batch", 5),
+        modal_docker_default_app_name=overrides.get("modal_docker_default_app_name"),
+    )
+
+
+def _available_entry(config: SendbluePrewarmedPoolConfig, sandbox_id: str = "sb-available") -> TaskPrewarmedSandbox:
+    return TaskPrewarmedSandbox.objects.create(
+        pool_key=config.pool_key,
+        origin_product=Task.OriginProduct.SENDBLUE,
+        repository=config.repository,
+        provider="modal",
+        template="default_base",
+        sandbox_id=sandbox_id,
+        status=TaskPrewarmedSandbox.Status.AVAILABLE,
+        warmed_at=timezone.now(),
+        expires_at=timezone.now() + timedelta(seconds=config.ttl_seconds),
+    )
+
+
+def test_sendblue_prewarmed_pool_config_reads_feature_flag_payload() -> None:
+    with (
+        patch(
+            "products.tasks.backend.services.prewarmed_sandbox_pool.posthoganalytics.feature_enabled",
+            return_value=True,
+        ) as feature_enabled,
+        patch(
+            "products.tasks.backend.services.prewarmed_sandbox_pool.posthoganalytics.get_feature_flag_payload",
+            return_value={
+                "target_available": 3,
+                "repository": "PostHog/PostHog",
+                "ttl_seconds": 1800,
+                "max_create_batch": 2,
+                "modal_docker_default_app_name": "posthog-sandbox-modal-docker-default-alessandro",
+            },
+        ),
+    ):
+        config = get_sendblue_prewarmed_pool_config()
+
+    assert config.enabled is True
+    assert config.target_available == 3
+    assert config.repository == "posthog/posthog"
+    assert config.ttl_seconds == 1800
+    assert config.max_create_batch == 2
+    assert config.modal_docker_default_app_name == "posthog-sandbox-modal-docker-default-alessandro"
+    feature_enabled.assert_called_once_with(
+        SEND_BLUE_POOL_FEATURE_FLAG,
+        SEND_BLUE_POOL_DISTINCT_ID,
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    )
+
+
+def test_reconcile_creates_available_sandboxes_until_target() -> None:
+    sandboxes = [FakeSandbox("sb-1"), FakeSandbox("sb-2")]
+
+    with (
+        patch(
+            "products.tasks.backend.services.prewarmed_sandbox_pool.get_sendblue_prewarmed_pool_config"
+        ) as get_config,
+        patch("products.tasks.backend.services.prewarmed_sandbox_pool.Sandbox.create", side_effect=sandboxes) as create,
+    ):
+        get_config.return_value = _config(target_available=2, max_create_batch=5)
+
+        result = reconcile_sendblue_prewarmed_sandbox_pool()
+
+    assert result["enabled"] is True
+    assert result["created"] == 2
+    assert TaskPrewarmedSandbox.objects.filter(status=TaskPrewarmedSandbox.Status.AVAILABLE).count() == 2
+    assert [sandbox.clone_calls for sandbox in sandboxes] == [
+        [(SENDBLUE_TASK_REPOSITORY, "", True)],
+        [(SENDBLUE_TASK_REPOSITORY, "", True)],
+    ]
+    created_configs = [call.args[0] for call in create.call_args_list]
+    assert all(isinstance(config, SandboxConfig) for config in created_configs)
+    assert all(config.metadata["origin_product"] == Task.OriginProduct.SENDBLUE for config in created_configs)
+
+
+@override_settings(SANDBOX_PROVIDER="MODAL_DOCKER")
+def test_reconcile_uses_modal_docker_app_name_from_pool_config() -> None:
+    sandbox = FakeSandbox("sb-1")
+
+    with (
+        patch(
+            "products.tasks.backend.services.prewarmed_sandbox_pool.get_sendblue_prewarmed_pool_config"
+        ) as get_config,
+        patch("products.tasks.backend.services.prewarmed_sandbox_pool.Sandbox.create", return_value=sandbox) as create,
+    ):
+        get_config.return_value = _config(
+            target_available=1,
+            modal_docker_default_app_name="posthog-sandbox-modal-docker-default-alessandro",
+        )
+
+        result = reconcile_sendblue_prewarmed_sandbox_pool()
+
+    assert result["created"] == 1
+    created_config = create.call_args.args[0]
+    assert isinstance(created_config, SandboxConfig)
+    assert created_config.modal_app_name == "posthog-sandbox-modal-docker-default-alessandro"
+
+
+def test_reconcile_disables_pool_by_terminating_available_sandboxes() -> None:
+    config = _config(enabled=False, target_available=0)
+    entry = _available_entry(config)
+    sandbox = FakeSandbox(entry.sandbox_id or "sb-disabled")
+
+    with (
+        patch(
+            "products.tasks.backend.services.prewarmed_sandbox_pool.get_sendblue_prewarmed_pool_config"
+        ) as get_config,
+        patch("products.tasks.backend.services.prewarmed_sandbox_pool.Sandbox.get_by_id", return_value=sandbox),
+    ):
+        get_config.return_value = config
+
+        result = reconcile_sendblue_prewarmed_sandbox_pool()
+
+    entry.refresh_from_db()
+    assert result["enabled"] is False
+    assert result["terminated"] == 1
+    assert entry.status == TaskPrewarmedSandbox.Status.TERMINATED
+    assert entry.last_error == "feature flag disabled"
+    assert sandbox.destroyed is True
+
+
+def test_try_lease_sendblue_prewarmed_sandbox_marks_entry_leased_and_injects_environment() -> None:
+    config = _config()
+    entry = _available_entry(config, sandbox_id="sb-lease")
+    task_run = _task_run()
+    sandbox = FakeSandbox("sb-lease")
+
+    with (
+        patch(
+            "products.tasks.backend.services.prewarmed_sandbox_pool.get_sendblue_prewarmed_pool_config"
+        ) as get_config,
+        patch("products.tasks.backend.services.prewarmed_sandbox_pool.Sandbox.get_by_id", return_value=sandbox),
+    ):
+        get_config.return_value = config
+
+        leased = try_lease_sendblue_prewarmed_sandbox(
+            run_id=str(task_run.id),
+            origin_product=Task.OriginProduct.SENDBLUE,
+            repository="PostHog/PostHog",
+            environment_variables={"ALPHA": "one", "BETA": "two"},
+        )
+
+    entry.refresh_from_db()
+    assert leased is not None
+    assert leased.pool_entry_id == str(entry.id)
+    assert leased.sandbox_id == "sb-lease"
+    assert leased.sandbox_url == "https://sb-lease.modal.host"
+    assert leased.connect_token == "sb-lease-token"
+    assert entry.status == TaskPrewarmedSandbox.Status.LEASED
+    assert entry.leased_task_run_id == task_run.id
+    assert entry.leased_at is not None
+    assert sandbox.write_calls == [(PREWARMED_SANDBOX_ENV_FILE, b"#!/bin/bash\nexport ALPHA=one\nexport BETA=two\n")]
+
+
+def test_try_lease_sendblue_prewarmed_sandbox_ignores_non_sendblue_tasks() -> None:
+    config = _config()
+    entry = _available_entry(config, sandbox_id="sb-unused")
+
+    with (
+        patch(
+            "products.tasks.backend.services.prewarmed_sandbox_pool.get_sendblue_prewarmed_pool_config"
+        ) as get_config,
+        patch("products.tasks.backend.services.prewarmed_sandbox_pool.Sandbox.get_by_id") as get_by_id,
+    ):
+        get_config.return_value = config
+
+        leased = try_lease_sendblue_prewarmed_sandbox(
+            run_id=str(_task_run().id),
+            origin_product=Task.OriginProduct.USER_CREATED,
+            repository=SENDBLUE_TASK_REPOSITORY,
+            environment_variables={},
+        )
+
+    entry.refresh_from_db()
+    assert leased is None
+    assert entry.status == TaskPrewarmedSandbox.Status.AVAILABLE
+    get_by_id.assert_not_called()
+
+
+def test_try_lease_sendblue_prewarmed_sandbox_marks_bad_entry_failed_and_falls_back() -> None:
+    config = _config()
+    entry = _available_entry(config, sandbox_id="sb-stopped")
+    task_run = _task_run()
+    sandbox = FakeSandbox("sb-stopped", status=SandboxStatus.SHUTDOWN)
+
+    with (
+        patch(
+            "products.tasks.backend.services.prewarmed_sandbox_pool.get_sendblue_prewarmed_pool_config"
+        ) as get_config,
+        patch("products.tasks.backend.services.prewarmed_sandbox_pool.Sandbox.get_by_id", return_value=sandbox),
+    ):
+        get_config.return_value = config
+
+        leased = try_lease_sendblue_prewarmed_sandbox(
+            run_id=str(task_run.id),
+            origin_product=Task.OriginProduct.SENDBLUE,
+            repository=SENDBLUE_TASK_REPOSITORY,
+            environment_variables={},
+        )
+
+    entry.refresh_from_db()
+    assert leased is None
+    assert entry.status == TaskPrewarmedSandbox.Status.FAILED
+    assert "not running" in (entry.last_error or "")

--- a/products/tasks/backend/services/tests/test_prewarmed_sandbox_pool.py
+++ b/products/tasks/backend/services/tests/test_prewarmed_sandbox_pool.py
@@ -93,8 +93,10 @@ def _config(**overrides: Any) -> SendbluePrewarmedPoolConfig:
 
 
 def _available_entry(config: SendbluePrewarmedPoolConfig, sandbox_id: str = "sb-available") -> TaskPrewarmedSandbox:
+    team_id = config.team_id
+    assert team_id is not None
     return TaskPrewarmedSandbox.objects.create(
-        team_id=config.team_id,
+        team_id=team_id,
         pool_key=config.pool_key,
         origin_product=Task.OriginProduct.SENDBLUE,
         repository=config.repository,

--- a/products/tasks/backend/services/tests/test_prewarmed_sandbox_pool.py
+++ b/products/tasks/backend/services/tests/test_prewarmed_sandbox_pool.py
@@ -32,6 +32,11 @@ from products.tasks.backend.services.sandbox import (
 pytestmark = pytest.mark.django_db
 
 
+@pytest.fixture(autouse=True)
+def clean_prewarmed_sandboxes() -> None:
+    TaskPrewarmedSandbox.objects.all().delete()
+
+
 class FakeSandbox:
     def __init__(self, sandbox_id: str = "sb-test", status: SandboxStatus = SandboxStatus.RUNNING):
         self.id = sandbox_id
@@ -83,11 +88,13 @@ def _config(**overrides: Any) -> SendbluePrewarmedPoolConfig:
         ttl_seconds=overrides.get("ttl_seconds", 3600),
         max_create_batch=overrides.get("max_create_batch", 5),
         modal_docker_default_app_name=overrides.get("modal_docker_default_app_name"),
+        team_id=overrides.get("team_id", _team().id),
     )
 
 
 def _available_entry(config: SendbluePrewarmedPoolConfig, sandbox_id: str = "sb-available") -> TaskPrewarmedSandbox:
     return TaskPrewarmedSandbox.objects.create(
+        team_id=config.team_id,
         pool_key=config.pool_key,
         origin_product=Task.OriginProduct.SENDBLUE,
         repository=config.repository,
@@ -109,6 +116,7 @@ def test_sendblue_prewarmed_pool_config_reads_feature_flag_payload() -> None:
         patch(
             "products.tasks.backend.services.prewarmed_sandbox_pool.posthoganalytics.get_feature_flag_payload",
             return_value={
+                "team_id": 7,
                 "target_available": 3,
                 "repository": "PostHog/PostHog",
                 "ttl_seconds": 1800,
@@ -125,6 +133,7 @@ def test_sendblue_prewarmed_pool_config_reads_feature_flag_payload() -> None:
     assert config.ttl_seconds == 1800
     assert config.max_create_batch == 2
     assert config.modal_docker_default_app_name == "posthog-sandbox-modal-docker-default-alessandro"
+    assert config.team_id == 7
     feature_enabled.assert_called_once_with(
         SEND_BLUE_POOL_FEATURE_FLAG,
         SEND_BLUE_POOL_DISTINCT_ID,
@@ -205,9 +214,9 @@ def test_reconcile_disables_pool_by_terminating_available_sandboxes() -> None:
 
 
 def test_try_lease_sendblue_prewarmed_sandbox_marks_entry_leased_and_injects_environment() -> None:
-    config = _config()
-    entry = _available_entry(config, sandbox_id="sb-lease")
     task_run = _task_run()
+    config = _config(team_id=task_run.team_id)
+    entry = _available_entry(config, sandbox_id="sb-lease")
     sandbox = FakeSandbox("sb-lease")
 
     with (
@@ -220,6 +229,7 @@ def test_try_lease_sendblue_prewarmed_sandbox_marks_entry_leased_and_injects_env
 
         leased = try_lease_sendblue_prewarmed_sandbox(
             run_id=str(task_run.id),
+            team_id=task_run.team_id,
             origin_product=Task.OriginProduct.SENDBLUE,
             repository="PostHog/PostHog",
             environment_variables={"ALPHA": "one", "BETA": "two"},
@@ -251,6 +261,7 @@ def test_try_lease_sendblue_prewarmed_sandbox_ignores_non_sendblue_tasks() -> No
 
         leased = try_lease_sendblue_prewarmed_sandbox(
             run_id=str(_task_run().id),
+            team_id=entry.team_id,
             origin_product=Task.OriginProduct.USER_CREATED,
             repository=SENDBLUE_TASK_REPOSITORY,
             environment_variables={},
@@ -263,9 +274,9 @@ def test_try_lease_sendblue_prewarmed_sandbox_ignores_non_sendblue_tasks() -> No
 
 
 def test_try_lease_sendblue_prewarmed_sandbox_marks_bad_entry_failed_and_falls_back() -> None:
-    config = _config()
-    entry = _available_entry(config, sandbox_id="sb-stopped")
     task_run = _task_run()
+    config = _config(team_id=task_run.team_id)
+    entry = _available_entry(config, sandbox_id="sb-stopped")
     sandbox = FakeSandbox("sb-stopped", status=SandboxStatus.SHUTDOWN)
 
     with (
@@ -278,6 +289,7 @@ def test_try_lease_sendblue_prewarmed_sandbox_marks_bad_entry_failed_and_falls_b
 
         leased = try_lease_sendblue_prewarmed_sandbox(
             run_id=str(task_run.id),
+            team_id=task_run.team_id,
             origin_product=Task.OriginProduct.SENDBLUE,
             repository=SENDBLUE_TASK_REPOSITORY,
             environment_variables={},

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -100,6 +100,8 @@ class GetSandboxForRepositoryOutput:
     connect_token: str | None
     used_snapshot: bool
     should_create_snapshot: bool
+    used_prewarmed_sandbox: bool = False
+    prewarmed_sandbox_pool_entry_id: str | None = None
 
 
 @activity.defn

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -11,6 +11,7 @@ from posthog.temporal.common.utils import asyncify
 from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
 from products.tasks.backend.services.agentsh import ENV_FILE
 from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key
+from products.tasks.backend.services.prewarmed_sandbox_pool import try_lease_sendblue_prewarmed_sandbox
 from products.tasks.backend.services.sandbox import Sandbox, SandboxConfig, SandboxTemplate
 from products.tasks.backend.temporal.exceptions import GitHubAuthenticationError, OAuthTokenError, TaskNotFoundError
 from products.tasks.backend.temporal.metrics import StepTimer, increment_snapshot_usage
@@ -72,6 +73,8 @@ class CreateSandboxForRepositoryOutput:
     sandbox_id: str
     sandbox_url: str
     connect_token: str | None
+    used_prewarmed_sandbox: bool = False
+    prewarmed_sandbox_pool_entry_id: str | None = None
 
 
 @dataclass
@@ -331,6 +334,32 @@ def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cre
         image_source=prepared.image_source,
         **ctx.to_log_context(),
     ):
+        leased = try_lease_sendblue_prewarmed_sandbox(
+            run_id=ctx.run_id,
+            origin_product=ctx.origin_product,
+            repository=prepared.repository,
+            environment_variables=prepared.environment_variables,
+        )
+        if leased is not None:
+            sandbox_state = {
+                "sandbox_id": leased.sandbox_id,
+                "sandbox_url": leased.sandbox_url,
+                "prewarmed_sandbox": True,
+                "prewarmed_sandbox_pool_entry_id": leased.pool_entry_id,
+            }
+            if leased.connect_token:
+                sandbox_state["sandbox_connect_token"] = leased.connect_token
+            TaskRun.update_state_atomic(ctx.run_id, updates=sandbox_state)
+            emit_agent_log(ctx.run_id, "debug", f"Using prewarmed Sendblue sandbox: {leased.sandbox_id}")
+            activity.logger.info(f"Leased prewarmed sandbox {leased.sandbox_id}")
+            return CreateSandboxForRepositoryOutput(
+                sandbox_id=leased.sandbox_id,
+                sandbox_url=leased.sandbox_url,
+                connect_token=leased.connect_token,
+                used_prewarmed_sandbox=True,
+                prewarmed_sandbox_pool_entry_id=leased.pool_entry_id,
+            )
+
         _emit_image_source_log(ctx, prepared)
         emit_agent_log(
             ctx.run_id,

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -336,6 +336,7 @@ def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cre
     ):
         leased = try_lease_sendblue_prewarmed_sandbox(
             run_id=ctx.run_id,
+            team_id=ctx.team_id,
             origin_product=ctx.origin_product,
             repository=prepared.repository,
             environment_variables=prepared.environment_variables,

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -15,7 +15,7 @@ from temporalio.workflow import ParentClosePolicy
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.oauth import PosthogMcpScopes
 
-from products.tasks.backend.services.sandbox import is_public_sandbox_repo
+from products.tasks.backend.services.sandbox import can_clone_without_github_integration
 from products.tasks.backend.temporal.create_snapshot.workflow import CreateSnapshotForRepositoryInput
 from products.tasks.backend.temporal.process_task.activities.get_pr_context import GetPrContextInput, get_pr_context
 
@@ -653,7 +653,9 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 retry_policy=RetryPolicy(maximum_attempts=3),
             )
 
-        can_clone_without_integration = is_public_sandbox_repo(prepared.repository)
+        can_clone_without_integration = can_clone_without_github_integration(
+            prepared.repository, self.context.origin_product
+        )
         has_clone_credentials = self.context.has_github_credentials or can_clone_without_integration
 
         will_clone = bool(

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -215,10 +215,12 @@ class ProcessTaskWorkflow(PostHogWorkflow):
 
     async def _wait_for_task_external_event(self):
         await workflow.wait_condition(
-            lambda: self._task_completed
-            or self._heartbeat_received
-            or self._pending_followup is not None
-            or len(self._pending_followups) > 0
+            lambda: (
+                self._task_completed
+                or self._heartbeat_received
+                or self._pending_followup is not None
+                or len(self._pending_followups) > 0
+            )
         )
         return TaskEvent.SIGNAL_RECEIVED
 
@@ -408,6 +410,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                     "sandbox_id": sandbox_id,
                     "sandbox_url": agent_server_output.sandbox_url,
                     "used_snapshot": sandbox_output.used_snapshot,
+                    "used_prewarmed_sandbox": sandbox_output.used_prewarmed_sandbox,
                     "repository": self.context.repository,
                 },
             )
@@ -616,7 +619,15 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
         self._sandbox_id_for_cleanup = created.sandbox_id
-        if prepared.used_snapshot:
+        if created.used_prewarmed_sandbox:
+            await self._emit_progress(
+                "sandbox",
+                "completed",
+                "Attached prewarmed sandbox",
+                "setup",
+                detail="Reused a Sendblue sandbox with posthog/posthog already cloned",
+            )
+        elif prepared.used_snapshot:
             await self._emit_progress(
                 "sandbox",
                 "completed",
@@ -645,7 +656,12 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         can_clone_without_integration = is_public_sandbox_repo(prepared.repository)
         has_clone_credentials = self.context.has_github_credentials or can_clone_without_integration
 
-        will_clone = bool(prepared.repository and not prepared.used_snapshot and has_clone_credentials)
+        will_clone = bool(
+            prepared.repository
+            and not prepared.used_snapshot
+            and not created.used_prewarmed_sandbox
+            and has_clone_credentials
+        )
         will_checkout = bool(prepared.repository and prepared.branch and has_clone_credentials)
 
         if will_clone:
@@ -692,6 +708,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             connect_token=created.connect_token,
             used_snapshot=prepared.used_snapshot,
             should_create_snapshot=prepared.should_create_snapshot,
+            used_prewarmed_sandbox=created.used_prewarmed_sandbox,
+            prewarmed_sandbox_pool_entry_id=created.prewarmed_sandbox_pool_entry_id,
         )
 
     async def _cleanup_sandbox(self, sandbox_id: str) -> None:

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1179,7 +1179,7 @@ class TestTaskAPI(BaseTaskAPITest):
         assert task_run.state["interaction_origin"] == "sendblue"
         assert task_run.state["pending_user_message"] == "hello from sms"
         mock_workflow.assert_called_once()
-        mock_reconcile.assert_called_once()
+        mock_reconcile.assert_called_once_with(task.team_id)
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
     def test_run_endpoint_rejects_invalid_initial_permission_mode(self, mock_workflow):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -504,6 +504,29 @@ class TestTaskAPI(BaseTaskAPITest):
         task = Task.objects.get(id=data["id"])
         self.assertEqual(task.origin_product, Task.OriginProduct.USER_CREATED)
 
+    def test_create_sendblue_task_defaults_repository_without_github_integration(self):
+        Integration.objects.create(team=self.team, kind="github", config={})
+
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {
+                "title": "Sendblue Task",
+                "description": "Created from Sendblue",
+                "origin_product": "sendblue",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+        self.assertEqual(data["origin_product"], Task.OriginProduct.SENDBLUE)
+        self.assertEqual(data["repository"], "posthog/posthog")
+
+        task = Task.objects.get(id=data["id"])
+        self.assertEqual(task.origin_product, Task.OriginProduct.SENDBLUE)
+        self.assertEqual(task.repository, "posthog/posthog")
+        self.assertIsNone(task.github_integration_id)
+
     def test_create_task_with_github_user_integration(self):
         user_integration = _grant_user_github_access(self.user)
 
@@ -1136,6 +1159,27 @@ class TestTaskAPI(BaseTaskAPITest):
         task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
         assert "initial_permission_mode" not in (task_run.state or {})
         mock_workflow.assert_called_once()
+
+    @patch("posthog.tasks.tasks.reconcile_sendblue_prewarmed_sandbox_pool.delay")
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_sendblue_marks_origin_and_enqueues_pool_reconcile(self, mock_workflow, mock_reconcile):
+        task = self.create_task()
+        task.origin_product = Task.OriginProduct.SENDBLUE
+        task.repository = "posthog/posthog"
+        task.save(update_fields=["origin_product", "repository"])
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"mode": "interactive", "pending_user_message": "hello from sms"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        assert task_run.state["interaction_origin"] == "sendblue"
+        assert task_run.state["pending_user_message"] == "hello from sms"
+        mock_workflow.assert_called_once()
+        mock_reconcile.assert_called_once()
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
     def test_run_endpoint_rejects_invalid_initial_permission_mode(self, mock_workflow):

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -196,6 +196,7 @@ export interface PaginatedTaskAutomationListApi {
  * `user_created` - User Created
  * `automation` - Automation
  * `slack` - Slack
+ * `sendblue` - Sendblue
  * `support_queue` - Support Queue
  * `session_summaries` - Session Summaries
  * `signal_report` - Signal Report
@@ -208,6 +209,7 @@ export const OriginProductEnumApi = {
     UserCreated: 'user_created',
     Automation: 'automation',
     Slack: 'slack',
+    Sendblue: 'sendblue',
     SupportQueue: 'support_queue',
     SessionSummaries: 'session_summaries',
     SignalReport: 'signal_report',

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -95,13 +95,14 @@ export const TasksCreateBody = /* @__PURE__ */ zod.object({
             'user_created',
             'automation',
             'slack',
+            'sendblue',
             'support_queue',
             'session_summaries',
             'signal_report',
         ])
         .optional()
         .describe(
-            '\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
+            '\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `sendblue` - Sendblue\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
         ),
     repository: zod.string().max(tasksCreateBodyRepositoryMax).nullish(),
     github_integration: zod.number().nullish().describe('GitHub integration for this task'),
@@ -143,13 +144,14 @@ export const TasksUpdateBody = /* @__PURE__ */ zod.object({
             'user_created',
             'automation',
             'slack',
+            'sendblue',
             'support_queue',
             'session_summaries',
             'signal_report',
         ])
         .optional()
         .describe(
-            '\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
+            '\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `sendblue` - Sendblue\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
         ),
     repository: zod.string().max(tasksUpdateBodyRepositoryMax).nullish(),
     github_integration: zod.number().nullish().describe('GitHub integration for this task'),
@@ -191,13 +193,14 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod.object({
             'user_created',
             'automation',
             'slack',
+            'sendblue',
             'support_queue',
             'session_summaries',
             'signal_report',
         ])
         .optional()
         .describe(
-            '\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
+            '\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `sendblue` - Sendblue\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `signal_report` - Signal Report'
         ),
     repository: zod.string().max(tasksPartialUpdateBodyRepositoryMax).nullish(),
     github_integration: zod.number().nullish().describe('GitHub integration for this task'),

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21165,6 +21165,7 @@ export namespace Schemas {
     * `user_created` - User Created
     * `automation` - Automation
     * `slack` - Slack
+    * `sendblue` - Sendblue
     * `support_queue` - Support Queue
     * `session_summaries` - Session Summaries
     * `signal_report` - Signal Report
@@ -21178,6 +21179,7 @@ export namespace Schemas {
       UserCreated: 'user_created',
       Automation: 'automation',
       Slack: 'slack',
+      Sendblue: 'sendblue',
       SupportQueue: 'support_queue',
       SessionSummaries: 'session_summaries',
       SignalReport: 'signal_report',


### PR DESCRIPTION
## Problem

Sendblue-origin PostHog Code tasks should be able to start from an already-running sandbox when the prewarm feature flag is enabled. This avoids paying the sandbox provisioning and repository clone cost on the first user-visible response path.

## Changes

- Adds `sendblue` as a task origin and defaults those tasks to the public `posthog/posthog` repository without requiring a GitHub integration.
- Adds a `TaskPrewarmedSandbox` pool table, reconciliation service, management command, and periodic Celery task.
- Reads pool enablement and sizing from the `tasks-sendblue-prewarmed-sandbox-pool` feature flag and payload.
- Allows the flag payload to set `modal_docker_default_app_name` for local `SANDBOX_PROVIDER=MODAL_DOCKER` prewarm pools, while production Modal behavior keeps using the normal app unless explicitly configured.
- Leases an available Sendblue prewarmed sandbox during task processing, injects the run environment through a dedicated prewarm env file, and falls back to cold sandbox provisioning when the pool cannot be used.
- Keeps Modal Docker local app names configurable from env while preserving the shared default.