### PR TITLE
fix(data-warehouse): show per-status schema counts in sources table

### DIFF
--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -84,7 +84,6 @@ function ManagedSchemasTab({ id }: { id: string }): JSX.Element {
         resyncSchema,
         cancelSchema,
         deleteTable,
-        setSelectedSchemas,
     } = useActions(sourceSettingsLogic)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -169,7 +168,6 @@ function ManagedSchemasTab({ id }: { id: string }): JSX.Element {
                 resyncSchema={resyncSchema}
                 cancelSchema={cancelSchema}
                 deleteTable={deleteTable}
-                setSelectedSchemas={setSelectedSchemas}
                 showMetrics={showMetrics}
             />
             {source?.source_type &&
@@ -211,7 +209,6 @@ interface ManagedSchemaTableProps {
     resyncSchema: (schema: ExternalDataSourceSchema) => void
     cancelSchema: (schema: ExternalDataSourceSchema) => void
     deleteTable: (schema: ExternalDataSourceSchema) => void
-    setSelectedSchemas: (schemaNames: string[]) => void
     showMetrics: boolean
 }
 
@@ -226,10 +223,10 @@ function ManagedSchemaTable({
     resyncSchema,
     cancelSchema,
     deleteTable,
-    setSelectedSchemas,
     showMetrics,
 }: ManagedSchemaTableProps): JSX.Element {
     const { schemaReloadingById } = useValues(sourceManagementLogic)
+    const { setSelectedSchemas } = useActions(sourceSettingsLogic)
     const [initialLoad, setInitialLoad] = useState(true)
 
     useEffect(() => {

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -84,6 +84,7 @@ function ManagedSchemasTab({ id }: { id: string }): JSX.Element {
         resyncSchema,
         cancelSchema,
         deleteTable,
+        setSelectedSchemas,
     } = useActions(sourceSettingsLogic)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -168,6 +169,7 @@ function ManagedSchemasTab({ id }: { id: string }): JSX.Element {
                 resyncSchema={resyncSchema}
                 cancelSchema={cancelSchema}
                 deleteTable={deleteTable}
+                setSelectedSchemas={setSelectedSchemas}
                 showMetrics={showMetrics}
             />
             {source?.source_type &&
@@ -209,6 +211,7 @@ interface ManagedSchemaTableProps {
     resyncSchema: (schema: ExternalDataSourceSchema) => void
     cancelSchema: (schema: ExternalDataSourceSchema) => void
     deleteTable: (schema: ExternalDataSourceSchema) => void
+    setSelectedSchemas: (schemaNames: string[]) => void
     showMetrics: boolean
 }
 
@@ -223,6 +226,7 @@ function ManagedSchemaTable({
     resyncSchema,
     cancelSchema,
     deleteTable,
+    setSelectedSchemas,
     showMetrics,
 }: ManagedSchemaTableProps): JSX.Element {
     const { schemaReloadingById } = useValues(sourceManagementLogic)
@@ -271,8 +275,18 @@ function ManagedSchemaTable({
                         if (!schema.status) {
                             return <span className="text-muted">—</span>
                         }
+                        const openSyncsForSchema = (): void => {
+                            setSelectedSchemas([schema.name])
+                            router.actions.push(urls.dataWarehouseSource(prefixedSourceId, 'syncs'))
+                        }
                         const tagContent = (
-                            <LemonTag type={StatusTagSetting[schema.status] || 'default'}>{schema.status}</LemonTag>
+                            <LemonTag
+                                type={StatusTagSetting[schema.status] || 'default'}
+                                forceClickable
+                                onClick={openSyncsForSchema}
+                            >
+                                {schema.status}
+                            </LemonTag>
                         )
                         return schema.latest_error && schema.status === 'Failed' ? (
                             <Tooltip title={schema.latest_error} interactive>

--- a/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
+++ b/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 
 import { IconPlusSmall } from '@posthog/icons'
 import {
@@ -187,6 +188,7 @@ export function ManagedSourcesTable(): JSX.Element {
                                 )
                             }
 
+                            const sourceUrl = urls.dataWarehouseSource(`managed-${source.id}`)
                             return (
                                 <div className="flex flex-wrap gap-1">
                                     {counts.map(({ status, schemas }) => (
@@ -201,7 +203,11 @@ export function ManagedSourcesTable(): JSX.Element {
                                                 </ul>
                                             }
                                         >
-                                            <LemonTag type={StatusTagSetting[status] || 'default'}>
+                                            <LemonTag
+                                                type={StatusTagSetting[status] || 'default'}
+                                                forceClickable
+                                                onClick={() => router.actions.push(sourceUrl)}
+                                            >
                                                 {schemas.length} {statusLabel[status]}
                                             </LemonTag>
                                         </Tooltip>

--- a/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
+++ b/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
@@ -171,8 +171,12 @@ export function ManagedSourcesTable(): JSX.Element {
                                 schemas: syncingSchemas.filter((s) => s.status === status),
                             })).filter(({ schemas }) => schemas.length > 0)
 
-                            // No per-schema status data — fall back to the source-level tag.
                             if (counts.length === 0) {
+                                // Source has schemas but none are enabled — source.status can be stale
+                                // ("Running" from before they were disabled), so show a neutral tag instead.
+                                if (source.schemas.length > 0) {
+                                    return <LemonTag type="muted">Not syncing</LemonTag>
+                                }
                                 const tagContent = (
                                     <LemonTag type={StatusTagSetting[source.status] || 'default'}>
                                         {source.status}

--- a/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
+++ b/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
@@ -21,7 +21,7 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
+import { AccessControlLevel, AccessControlResourceType, ExternalDataSchemaStatus } from '~/types'
 
 import { StatusTagSetting } from 'products/data_warehouse/frontend/utils'
 
@@ -149,15 +149,64 @@ export function ManagedSourcesTable(): JSX.Element {
                             if (!source.status) {
                                 return null
                             }
-                            const tagContent = (
-                                <LemonTag type={StatusTagSetting[source.status] || 'default'}>{source.status}</LemonTag>
-                            )
-                            return source.latest_error && source.status === 'Failed' ? (
-                                <Tooltip title={source.latest_error} interactive>
-                                    {tagContent}
-                                </Tooltip>
-                            ) : (
-                                tagContent
+                            const syncingSchemas = source.schemas.filter((s) => s.should_sync)
+                            const statusOrder: ExternalDataSchemaStatus[] = [
+                                ExternalDataSchemaStatus.Failed,
+                                ExternalDataSchemaStatus.Paused,
+                                ExternalDataSchemaStatus.Cancelled,
+                                ExternalDataSchemaStatus.Running,
+                                ExternalDataSchemaStatus.Completed,
+                            ]
+                            const statusLabel: Record<ExternalDataSchemaStatus, string> = {
+                                [ExternalDataSchemaStatus.Failed]: 'failed',
+                                [ExternalDataSchemaStatus.Paused]: 'paused',
+                                [ExternalDataSchemaStatus.Cancelled]: 'cancelled',
+                                [ExternalDataSchemaStatus.Running]: 'running',
+                                [ExternalDataSchemaStatus.Completed]: 'completed',
+                            }
+                            const counts = statusOrder
+                                .map((status) => ({
+                                    status,
+                                    schemas: syncingSchemas.filter((s) => s.status === status),
+                                }))
+                                .filter(({ schemas }) => schemas.length > 0)
+
+                            // No per-schema status data — fall back to the source-level tag.
+                            if (counts.length === 0) {
+                                const tagContent = (
+                                    <LemonTag type={StatusTagSetting[source.status] || 'default'}>
+                                        {source.status}
+                                    </LemonTag>
+                                )
+                                return source.latest_error && source.status === 'Failed' ? (
+                                    <Tooltip title={source.latest_error} interactive>
+                                        {tagContent}
+                                    </Tooltip>
+                                ) : (
+                                    tagContent
+                                )
+                            }
+
+                            return (
+                                <div className="flex flex-wrap gap-1">
+                                    {counts.map(({ status, schemas }) => (
+                                        <Tooltip
+                                            key={status}
+                                            interactive
+                                            title={
+                                                <ul className="list-disc pl-4 m-0">
+                                                    {schemas.map((s) => (
+                                                        <li key={s.id}>{s.name}</li>
+                                                    ))}
+                                                </ul>
+                                            }
+                                        >
+                                            <LemonTag type={StatusTagSetting[status] || 'default'}>
+                                                {schemas.length} {statusLabel[status]}
+                                            </LemonTag>
+                                        </Tooltip>
+                                    ))}
+                                </div>
                             )
                         },
                     },

--- a/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
+++ b/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
@@ -33,6 +33,21 @@ import { DATA_WAREHOUSE_APP_SOURCE } from './metrics/DataWarehouseMetrics'
 // eslint-disable-next-line import/no-cycle
 import { SourceIcon } from './SourceIcon'
 
+const SCHEMA_STATUS_ORDER: ExternalDataSchemaStatus[] = [
+    ExternalDataSchemaStatus.Failed,
+    ExternalDataSchemaStatus.Paused,
+    ExternalDataSchemaStatus.Cancelled,
+    ExternalDataSchemaStatus.Running,
+    ExternalDataSchemaStatus.Completed,
+]
+const SCHEMA_STATUS_LABEL: Record<ExternalDataSchemaStatus, string> = {
+    [ExternalDataSchemaStatus.Failed]: 'failed',
+    [ExternalDataSchemaStatus.Paused]: 'paused',
+    [ExternalDataSchemaStatus.Cancelled]: 'cancelled',
+    [ExternalDataSchemaStatus.Running]: 'running',
+    [ExternalDataSchemaStatus.Completed]: 'completed',
+}
+
 export function ManagedSourcesTable(): JSX.Element {
     const { filteredManagedSources, dataWarehouseSourcesLoading, sourceReloadingById, managedSearchTerm } =
         useValues(sourceManagementLogic)
@@ -151,26 +166,10 @@ export function ManagedSourcesTable(): JSX.Element {
                                 return null
                             }
                             const syncingSchemas = source.schemas.filter((s) => s.should_sync)
-                            const statusOrder: ExternalDataSchemaStatus[] = [
-                                ExternalDataSchemaStatus.Failed,
-                                ExternalDataSchemaStatus.Paused,
-                                ExternalDataSchemaStatus.Cancelled,
-                                ExternalDataSchemaStatus.Running,
-                                ExternalDataSchemaStatus.Completed,
-                            ]
-                            const statusLabel: Record<ExternalDataSchemaStatus, string> = {
-                                [ExternalDataSchemaStatus.Failed]: 'failed',
-                                [ExternalDataSchemaStatus.Paused]: 'paused',
-                                [ExternalDataSchemaStatus.Cancelled]: 'cancelled',
-                                [ExternalDataSchemaStatus.Running]: 'running',
-                                [ExternalDataSchemaStatus.Completed]: 'completed',
-                            }
-                            const counts = statusOrder
-                                .map((status) => ({
-                                    status,
-                                    schemas: syncingSchemas.filter((s) => s.status === status),
-                                }))
-                                .filter(({ schemas }) => schemas.length > 0)
+                            const counts = SCHEMA_STATUS_ORDER.map((status) => ({
+                                status,
+                                schemas: syncingSchemas.filter((s) => s.status === status),
+                            })).filter(({ schemas }) => schemas.length > 0)
 
                             // No per-schema status data — fall back to the source-level tag.
                             if (counts.length === 0) {
@@ -208,7 +207,7 @@ export function ManagedSourcesTable(): JSX.Element {
                                                 forceClickable
                                                 onClick={() => router.actions.push(sourceUrl)}
                                             >
-                                                {schemas.length} {statusLabel[status]}
+                                                {schemas.length} {SCHEMA_STATUS_LABEL[status]}
                                             </LemonTag>
                                         </Tooltip>
                                     ))}

--- a/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
+++ b/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
@@ -40,13 +40,6 @@ const SCHEMA_STATUS_ORDER: ExternalDataSchemaStatus[] = [
     ExternalDataSchemaStatus.Running,
     ExternalDataSchemaStatus.Completed,
 ]
-const SCHEMA_STATUS_LABEL: Record<ExternalDataSchemaStatus, string> = {
-    [ExternalDataSchemaStatus.Failed]: 'failed',
-    [ExternalDataSchemaStatus.Paused]: 'paused',
-    [ExternalDataSchemaStatus.Cancelled]: 'cancelled',
-    [ExternalDataSchemaStatus.Running]: 'running',
-    [ExternalDataSchemaStatus.Completed]: 'completed',
-}
 
 export function ManagedSourcesTable(): JSX.Element {
     const { filteredManagedSources, dataWarehouseSourcesLoading, sourceReloadingById, managedSearchTerm } =
@@ -211,7 +204,7 @@ export function ManagedSourcesTable(): JSX.Element {
                                                 forceClickable
                                                 onClick={() => router.actions.push(sourceUrl)}
                                             >
-                                                {schemas.length} {SCHEMA_STATUS_LABEL[status]}
+                                                {schemas.length} {status.toLowerCase()}
                                             </LemonTag>
                                         </Tooltip>
                                     ))}


### PR DESCRIPTION
## Problem

https://github.com/user-attachments/assets/010b2bfa-7a26-4353-b7fd-cee852e537bf

The Status column on the managed data warehouse sources table collapses every source to a single tag. If one schema out of five is failing, the whole row shows **Failed** — there is no signal that the other four are still syncing happily, and customers read this as the entire source being broken.

## Changes

- Replace the single status tag with one pill per schema status, e.g. `[1 failed] [4 completed]` (or `[8 running]` when all are syncing).
- Pills are ordered by severity: Failed → Paused → Cancelled → Running → Completed. Statuses with zero schemas are hidden.
- Each pill has its own hover tooltip listing the specific schemas in that state, so users can see *which* tables are failing/paused/running without leaving the page.
- Clicking any pill opens the source detail page (same destination as clicking the source name).
- Falls back to the original single tag for sources with no syncing schemas or source-only statuses like "Billing limits".

No backend change — `source.schemas` already returns each schema's `status`, `should_sync`, and `latest_error` via the existing serializer.

## How did you test this code?

tested locally

I'm an agent and did not perform manual testing. Verified `tsc --noEmit` and `oxlint` are clean on the modified file. The component has no test file in the repo today, and the existing `ManagedSourcesTable.stories.tsx` mocks sources with empty `schemas: []`, which hits the unchanged fallback branch — so its snapshot output is unaffected.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). The user reported a customer was confused by the existing aggregated "Failed" status, and we iterated on the rendering: started with a single "1/5 tables failing" tag, then switched to per-status pills, then dropped the single-tag fallback so even healthy sources read "N completed", and finally wired each pill to navigate to the source detail page so the breakdown is also a shortcut. Status labels intentionally mirror the backend status names (`running`, `completed`, `failed`, `paused`, `cancelled`) instead of synonyms like `pending` / `success`, per a course-correction during review.