### PR TITLE
docs(internal): note OAuth-during-install requirement in sandboxes setup

### DIFF
--- a/docs/internal/sandboxes-setup-guide.md
+++ b/docs/internal/sandboxes-setup-guide.md
@@ -35,12 +35,13 @@ Steps:
    localhost is fine; the value just has to be a valid URL since it's
    required when creating the App.
 4. Set the permissions above
-5. Generate a **client secret** under "Client secrets" on the App page —
+5. Under "Identifying and authorizing users", check **Request user authorization (OAuth) during installation** — required for the personal user-link flow
+6. Generate a **client secret** under "Client secrets" on the App page —
    this is required (added a couple of releases back). If your local setup
    stopped working recently, this is most likely what's missing.
-6. Generate a private key
-7. Install the app on your test repositories by going to `http://localhost:8010/project/1/settings/project-integrations` and installing the GitHub Integration
-8. Add to your `.env`:
+7. Generate a private key
+8. Install the app on your test repositories by going to `http://localhost:8010/project/1/settings/project-integrations` and installing the GitHub Integration
+9. Add to your `.env`:
 
 ```bash
 # The OAuth Client ID (starts with Iv1 or Iv23) — NOT the numeric App ID.


### PR DESCRIPTION
## Problem

The internal Cloud runs setup guide does not mention that the personal GitHub App needs **Request user authorization (OAuth) during installation** enabled. Without this checkbox, the user-link flow used by PostHog Code does not work, leaving engineers stuck during local setup.

## Changes

- Added a new step under the GitHub App configuration in `docs/internal/sandboxes-setup-guide.md` instructing the user to enable **Request user authorization (OAuth) during installation** under "Identifying and authorizing users".
- Renumbered the subsequent steps accordingly.

## How did you test this code?

I'm an agent — no manual or automated testing was performed. This is a docs-only change to an internal markdown file with no code or build impact.

## Publish to changelog?

no

## Docs update

Internal docs only.

## 🤖 Agent context

- Tool: PostHog Code agent (Claude)
- The user requested adding a single line about enabling OAuth during GitHub App installation. I implemented it as a discrete numbered step inside the existing GitHub App checklist (between "Set the permissions above" and "Generate a client secret") so it slots into the natural setup flow, and renumbered the following steps to keep the list consistent.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*