### PR TITLE
feat(subscriptions): raise hourly org cap from 1 to 5

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -53,6 +53,7 @@ from ee.tasks.subscriptions.subscription_utils import DEFAULT_MAX_ASSET_COUNT
 SUMMARY_QUOTA_CACHE_TTL_SECONDS = 60
 SUMMARY_CAP_HIT_DEDUPE_TTL_SECONDS = 600
 HOURLY_CAP_HIT_DEDUPE_TTL_SECONDS = 600
+MAX_ACTIVE_HOURLY_SUBSCRIPTIONS_PER_ORG = 5
 
 
 def _summary_quota_cache_key(organization_id) -> str:
@@ -397,18 +398,20 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         )
         if self.instance is not None:
             existing = existing.exclude(pk=self.instance.pk)
-        if existing.exists():
-            self._capture_hourly_cap_hit(organization)
+        active_count = existing.count()
+        limit = MAX_ACTIVE_HOURLY_SUBSCRIPTIONS_PER_ORG
+        if active_count >= limit:
+            self._capture_hourly_cap_hit(organization, active_count, limit)
             raise ValidationError(
                 {
                     "frequency": [
-                        "Only one active hourly subscription is allowed per organization. "
-                        "Disable or delete the existing hourly subscription before adding another."
+                        f"Your organization can have up to {limit} active hourly subscriptions. "
+                        "Disable or delete an existing hourly subscription before adding another."
                     ]
                 }
             )
 
-    def _capture_hourly_cap_hit(self, organization) -> None:
+    def _capture_hourly_cap_hit(self, organization, active_count: int, limit: int) -> None:
         # Rate-limited to one event per org per 10 minutes so a misbehaving
         # client retrying in a loop doesn't spam the analytics stream. Within
         # that window the user-visible 400 still fires every time.
@@ -430,6 +433,8 @@ class SubscriptionSerializer(serializers.ModelSerializer):
                 properties={
                     "team_id": self.context.get("team_id"),
                     "organization_id": str(organization.id),
+                    "active_count": active_count,
+                    "limit": limit,
                     "is_create": self.instance is None,
                 },
                 groups={"organization": str(organization.id)},

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -618,43 +618,53 @@ class TestSubscriptionTemporal(APILicensedTest):
         else:
             assert expected_fragment in response.json()["detail"]
 
-    def test_cannot_create_second_active_hourly_subscription_in_org(self):
+    @parameterized.expand(
+        [
+            ("create_below_cap", 4, status.HTTP_201_CREATED),
+            ("create_at_cap", 5, status.HTTP_400_BAD_REQUEST),
+            ("create_over_cap_grandfathered", 7, status.HTTP_400_BAD_REQUEST),
+        ]
+    )
+    def test_hourly_subscription_create_respects_org_cap(
+        self,
+        _name: str,
+        existing_active: int,
+        expected_status: int,
+    ):
+        self._seed_active_hourly_subscriptions(existing_active)
+
         with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True):
-            first = self._create_subscription(frequency="hourly", title="first hourly")
-            assert first.status_code == status.HTTP_201_CREATED
+            response = self._create_subscription(frequency="hourly", title="new hourly")
 
-            second = self._create_subscription(frequency="hourly", title="second hourly")
-
-        assert second.status_code == status.HTTP_400_BAD_REQUEST
-        assert "Only one active hourly subscription" in str(second.json())
+        assert response.status_code == expected_status, response.content
+        if expected_status == status.HTTP_400_BAD_REQUEST:
+            assert "up to 5 active hourly subscriptions" in str(response.json())
 
     def test_can_replace_hourly_subscription_after_disable(self):
-        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True):
-            first = self._create_subscription(frequency="hourly", title="first hourly")
-            assert first.status_code == status.HTTP_201_CREATED
+        seeded = self._seed_active_hourly_subscriptions(5)
 
-            # Disable the first hourly subscription — it should free up the org slot.
+        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True):
+            # Disable one of the seeded hourly subscriptions — it should free up an org slot.
             patch_response = self.client.patch(
-                f"/api/projects/{self.team.id}/subscriptions/{first.json()['id']}",
+                f"/api/projects/{self.team.id}/subscriptions/{seeded[0].id}",
                 {"enabled": False},
             )
             assert patch_response.status_code == status.HTTP_200_OK
 
-            second = self._create_subscription(frequency="hourly", title="second hourly")
+            response = self._create_subscription(frequency="hourly", title="replacement hourly")
 
-        assert second.status_code == status.HTTP_201_CREATED
+        assert response.status_code == status.HTTP_201_CREATED
 
     def test_hourly_cap_hit_emits_telemetry(self):
         cache.clear()
+        self._seed_active_hourly_subscriptions(5)
+
         with (
             patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True),
             patch("ee.api.subscription.posthoganalytics.capture") as mock_capture,
         ):
-            first = self._create_subscription(frequency="hourly", title="first hourly")
-            assert first.status_code == status.HTTP_201_CREATED
-
-            second = self._create_subscription(frequency="hourly", title="second hourly")
-            assert second.status_code == status.HTTP_400_BAD_REQUEST
+            response = self._create_subscription(frequency="hourly", title="cap-buster hourly")
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
 
         cap_hit_calls = [
             c for c in mock_capture.call_args_list if c.kwargs.get("event") == "subscription_hourly_cap_hit"
@@ -663,6 +673,8 @@ class TestSubscriptionTemporal(APILicensedTest):
         props = cap_hit_calls[0].kwargs["properties"]
         assert props["organization_id"] == str(self.organization.id)
         assert props["is_create"] is True
+        assert props["active_count"] == 5
+        assert props["limit"] == 5
 
     def _seed_active_summary_subscriptions(self, count: int) -> list[Subscription]:
         # Build raw rows so we can place an org over its tier cap to exercise
@@ -679,6 +691,24 @@ class TestSubscriptionTemporal(APILicensedTest):
                 title=f"existing {i}",
                 created_by=self.user,
                 summary_enabled=True,
+            )
+            for i in range(count)
+        ]
+
+    def _seed_active_hourly_subscriptions(self, count: int) -> list[Subscription]:
+        # Build raw rows so we can place an org at or above the hourly cap
+        # without going through the enforced API.
+        return [
+            Subscription.objects.create(
+                team=self.team,
+                insight=self.insight,
+                target_type="email",
+                target_value=f"existing-hourly-{i}@posthog.com",
+                frequency="hourly",
+                interval=1,
+                start_date=datetime(2022, 1, 1, tzinfo=UTC),
+                title=f"existing hourly {i}",
+                created_by=self.user,
             )
             for i in range(count)
         ]

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -465,7 +465,7 @@ export const FEATURE_FLAGS = {
     SQL_EDITOR_VIM_MODE: 'sql-editor-vim-mode', // owner: @arthurdedeus
     SSE_DASHBOARDS: 'sse-dashboards', // owner: @aspicer #team-analytics-platform
     SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE: 'subscription-ai-summary-prompt-guide', // owner: #team-analytics-platform, gates the per-subscription prompt guide textarea
-    SUBSCRIPTION_HOURLY_FREQUENCY: 'subscription-hourly-frequency', // owner: #team-analytics-platform, gates hourly subscription frequency (one active hourly subscription per org)
+    SUBSCRIPTION_HOURLY_FREQUENCY: 'subscription-hourly-frequency', // owner: #team-analytics-platform, gates hourly subscription frequency (up to 5 active hourly subscriptions per org)
     SURVEY_HEADLINE_SUMMARY: 'survey-headline-summary', // owner: @adboio #team-surveys
     SURVEYS_ERROR_TRACKING_CROSS_SELL: 'surveys-in-error-tracking', // owner: @adboio #team-surveys
     SURVEYS_FORM_BUILDER: 'surveys-form-builder', // owner: @adboio #team-surveys

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -619,15 +619,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Europe/Berlin')), max(toTimeZone(raw_sessions.max_timestamp, 'Europe/Berlin'))), 10)))) AS `$is_bounce`,
@@ -643,7 +635,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Europe/Berlin'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Europe/Berlin'))), lessOrEquals(toTimeZone(events.timestamp, 'Europe/Berlin'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Europe/Berlin')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Europe/Berlin'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Europe/Berlin'))), lessOrEquals(toTimeZone(events.timestamp, 'Europe/Berlin'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Europe/Berlin')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
@@ -700,7 +692,15 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.person_id,
+               events.`mat_$browser`,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Africa/Cairo')), max(toTimeZone(raw_sessions.max_timestamp, 'Africa/Cairo'))), 10)))) AS `$is_bounce`,
@@ -716,7 +716,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Africa/Cairo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Africa/Cairo'))), lessOrEquals(toTimeZone(events.timestamp, 'Africa/Cairo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Africa/Cairo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Africa/Cairo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Africa/Cairo'))), lessOrEquals(toTimeZone(events.timestamp, 'Africa/Cairo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Africa/Cairo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`


### PR DESCRIPTION
## Problem

Hourly subscriptions on insights and dashboards have been capped at 1 active subscription per organization since the frequency was introduced behind a feature flag. Teams running multiple time-sensitive insights or dashboards have asked to subscribe to several at hourly cadence (e.g. one per critical KPI dashboard, plus one per high-traffic insight).

Bumping the cap to 5 covers the use cases we've heard about while keeping a sensible ceiling on the workload these subscriptions add to the temporal worker pool.

## Changes

- New module constant `MAX_ACTIVE_HOURLY_SUBSCRIPTIONS_PER_ORG = 5` in `ee/api/subscription.py` — single source of truth for the cap.
- `_validate_hourly_org_limit` switched from a boolean `existing.exists()` check (implicit 1-per-org) to counting active hourly subs and comparing against the constant. Grandfathered orgs that somehow end up above the cap are still blocked from creating new ones.
- Validation error message now references the configurable limit: `"Your organization can have up to 5 active hourly subscriptions..."`.
- `subscription_hourly_cap_hit` telemetry event now carries `active_count` and `limit` in its properties so we can see how often orgs bump the new ceiling and judge whether 5 is the right number.
- Updated the inline comment on the `SUBSCRIPTION_HOURLY_FREQUENCY` feature flag in `frontend/src/lib/constants.tsx` so it doesn't still describe the limit as "one active hourly subscription per org".

No frontend constant or settings entry duplicated the old `1` — the frontend just surfaces the backend's `ValidationError`, so there's no UI work needed beyond the comment fix.

## How did you test this code?

I'm an agent. I ran the automated test suite for the subscription module:

```
hogli test ee/api/test/test_subscription.py
```

All 103 tests pass. The hourly-cap behavior is covered by three suites:

- `test_hourly_subscription_create_respects_org_cap` — parameterized over `(existing_active, expected_status)` for under-cap (4 -> 201), at-cap (5 -> 400), and grandfathered-above-cap (7 -> 400) scenarios.
- `test_can_replace_hourly_subscription_after_disable` — seeds 5 active hourly subs, disables one, confirms a new one can be created.
- `test_hourly_cap_hit_emits_telemetry` — verifies the cap-hit event fires with `active_count == 5` and `limit == 5` in its properties.

A new `_seed_active_hourly_subscriptions(count)` helper seeds rows directly via the ORM so we can put an org at or above the cap without going through the (now enforced) API.

I did not manually exercise the UI flow.

## Publish to changelog?

no

## 🤖 Agent context

Tooling: PostHog Code (Claude Code) agent session. Tools used: Read, Edit, Grep, Glob, Bash (for tests + lint), Graphite MCP (`gt create`, `gt move --onto master`, `gt submit`).

Decisions along the way:

- Kept the cap as a single module-level constant in `ee/api/subscription.py` rather than introducing a settings entry, a model field, or a tier-table lookup. This is the smallest change that establishes a single source of truth and lets a future PR swap the constant for a per-plan lookup without touching the validator.
- Added `active_count` and `limit` to the cap-hit telemetry event (rather than only the existing `is_create` / `organization_id`) so we can answer "how often are orgs hitting 5?" and "are any orgs already over 5?" from a single event in product analytics.
- Replaced the single `test_cannot_create_second_active_hourly_subscription_in_org` with a parameterized variant covering under-cap / at-cap / grandfathered-above-cap. Parameterizing made it cheap to add the third (grandfathered) case which would otherwise have been easy to forget.
- Initially based the branch on top of `posthog-code/fix-tasks-loading-states` (the previous in-progress branch) and then ran `gt move --onto master` so this lands as a standalone PR rather than as a stack on unrelated work.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
