### PR TITLE
feat(catalog): list / retrieve / partial_update endpoints for metrics

### DIFF
--- a/products/catalog/backend/facade/api.py
+++ b/products/catalog/backend/facade/api.py
@@ -9,6 +9,7 @@ from products.catalog.backend.facade.contracts import (
     CatalogRelationshipDTO,
     ProposeRelationshipParams,
     UpdateColumnParams,
+    UpdateMetricParams,
     UpdateNodeParams,
     UpdateRelationshipParams,
     UpsertColumnParams,
@@ -56,6 +57,18 @@ class CatalogAPI:
         write semantics — metric row and node row are created/updated together.
         """
         return logic.upsert_metric(params)
+
+    @staticmethod
+    def list_metrics(team_id: int) -> list[CatalogMetricDTO]:
+        return logic.list_metrics(team_id)
+
+    @staticmethod
+    def get_metric(team_id: int, metric_id: UUID) -> CatalogMetricDTO | None:
+        return logic.get_metric(team_id, metric_id)
+
+    @staticmethod
+    def update_metric(params: UpdateMetricParams) -> CatalogMetricDTO | None:
+        return logic.update_metric(params)
 
     @staticmethod
     def propose_relationship(params: ProposeRelationshipParams) -> CatalogRelationshipDTO:

--- a/products/catalog/backend/facade/contracts.py
+++ b/products/catalog/backend/facade/contracts.py
@@ -151,10 +151,11 @@ class UpdateRelationshipParams:
 class CatalogMetricDTO:
     """A semantic metric proposed for the catalog (e.g. "MRR", "DAU", "pricing-page conversion").
 
-    Pairs 1:1 with a `CatalogNode(kind=metric)` whose polymorphic pointer
-    (content_type/object_id) targets this row. Display metadata (status, semantic_role,
-    business_domain, tags) lives on the node; the metric row holds the computational
-    definition.
+    Pairs 1:1 with a `CatalogNode(kind=metric)`, bundled here so the UI gets review
+    state (status, confidence, tags, semantic_role, business_domain) without a second
+    fetch. Definition lives on the metric row; everything review-related lives on the node.
+    Status changes route through PATCH /catalog/nodes/:node.id/ — partial_update on the
+    metric endpoint only touches metric-row fields (description, definition).
     """
 
     id: UUID
@@ -162,9 +163,23 @@ class CatalogMetricDTO:
     name: str
     description: str
     definition: dict[str, Any]
-    node_id: UUID
+    node: CatalogNodeDTO
     created_at: datetime
     updated_at: datetime
+
+
+@dataclass(frozen=True)
+class UpdateMetricParams:
+    """Partial update of a CatalogMetric. Only fields supplied are written.
+
+    Status / tags / semantic metadata live on the bound CatalogNode and are updated via
+    PATCH /catalog/nodes/:id/ with the metric DTO's `node.id`.
+    """
+
+    team_id: int
+    metric_id: UUID
+    description: str | None = None
+    definition: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)

--- a/products/catalog/backend/logic.py
+++ b/products/catalog/backend/logic.py
@@ -52,14 +52,14 @@ def to_node_dto(node: CatalogNode, *, columns: list[CatalogColumn] | None = None
     )
 
 
-def to_metric_dto(metric: CatalogMetric, node_id: UUID) -> contracts.CatalogMetricDTO:
+def to_metric_dto(metric: CatalogMetric, node: CatalogNode) -> contracts.CatalogMetricDTO:
     return contracts.CatalogMetricDTO(
         id=metric.id,
         team_id=metric.team_id,
         name=metric.name,
         description=metric.description,
         definition=metric.definition or {},
-        node_id=node_id,
+        node=to_node_dto(node),
         created_at=metric.created_at,
         updated_at=metric.updated_at,
     )
@@ -160,6 +160,65 @@ def upsert_node(params: contracts.UpsertNodeParams) -> contracts.CatalogNodeDTO:
     return to_node_dto(node)
 
 
+def _metric_nodes_by_metric_id(team_id: int, metric_ids: list[UUID]) -> dict[UUID, CatalogNode]:
+    """Fetch each metric row's bound CatalogNode(kind=metric) in one query.
+
+    Returned mapping is keyed by CatalogMetric.id (the node's `object_id` via the
+    GenericForeignKey). Metrics without a bound node are omitted — callers decide
+    whether to skip them or raise. `columns` is prefetched so to_node_dto doesn't
+    issue per-row queries when the metric is bundled into a DTO.
+    """
+    if not metric_ids:
+        return {}
+    metric_ct = ContentType.objects.get_for_model(CatalogMetric)
+    nodes = CatalogNode.objects.filter(
+        team_id=team_id,
+        kind=CatalogNode.Kind.METRIC,
+        content_type=metric_ct,
+        object_id__in=metric_ids,
+    ).prefetch_related("columns")
+    return {node.object_id: node for node in nodes if node.object_id is not None}
+
+
+def list_metrics(team_id: int) -> list[contracts.CatalogMetricDTO]:
+    metrics = list(CatalogMetric.objects.filter(team_id=team_id).order_by("name"))
+    node_by_metric = _metric_nodes_by_metric_id(team_id, [m.id for m in metrics])
+    # Skip rows whose bound node has been deleted — they're zombies; the cleanup
+    # signal hasn't run yet or the node was force-removed. Don't surface them to
+    # callers expecting a `node`.
+    return [to_metric_dto(m, node=node_by_metric[m.id]) for m in metrics if m.id in node_by_metric]
+
+
+def get_metric(team_id: int, metric_id: UUID) -> contracts.CatalogMetricDTO | None:
+    metric = CatalogMetric.objects.filter(team_id=team_id, id=metric_id).first()
+    if metric is None:
+        return None
+    node = _metric_nodes_by_metric_id(team_id, [metric.id]).get(metric.id)
+    if node is None:
+        return None
+    return to_metric_dto(metric, node=node)
+
+
+@transaction.atomic
+def update_metric(params: contracts.UpdateMetricParams) -> contracts.CatalogMetricDTO | None:
+    metric = CatalogMetric.objects.filter(team_id=params.team_id, id=params.metric_id).first()
+    if metric is None:
+        return None
+    fields: list[str] = []
+    if params.description is not None:
+        metric.description = params.description
+        fields.append("description")
+    if params.definition is not None:
+        metric.definition = params.definition
+        fields.append("definition")
+    if fields:
+        metric.save(update_fields=[*fields, "updated_at"])
+    node = _metric_nodes_by_metric_id(params.team_id, [metric.id]).get(metric.id)
+    if node is None:
+        return None
+    return to_metric_dto(metric, node=node)
+
+
 @transaction.atomic
 def upsert_metric(params: contracts.UpsertMetricParams) -> contracts.CatalogMetricDTO:
     """Upsert a CatalogMetric and bind a CatalogNode(kind=metric) to it.
@@ -192,7 +251,7 @@ def upsert_metric(params: contracts.UpsertMetricParams) -> contracts.CatalogMetr
         name=params.name,
         defaults=node_defaults,
     )
-    return to_metric_dto(metric, node_id=node.id)
+    return to_metric_dto(metric, node=node)
 
 
 @transaction.atomic

--- a/products/catalog/backend/presentation/serializers.py
+++ b/products/catalog/backend/presentation/serializers.py
@@ -63,6 +63,10 @@ class CatalogRelationshipDTOSerializer(DataclassSerializer):
 
 class CatalogMetricDTOSerializer(DataclassSerializer):
     definition = MetricDefinitionField()
+    # Not read_only — matches CatalogNodeDTOSerializer.columns: @validated_request
+    # round-trips responses through is_valid() in DEBUG, and read-only fields get
+    # stripped from validated_data, breaking the nested DTO reconstruction.
+    node = CatalogNodeDTOSerializer()
 
     class Meta:
         dataclass = CatalogMetricDTO
@@ -444,6 +448,31 @@ class ProposeRelationshipInputSerializer(serializers.Serializer):
         allow_null=True,
         max_length=64,
         help_text="Model that proposed the relationship — same convention as on nodes and columns.",
+    )
+
+
+class UpdateMetricInputSerializer(serializers.Serializer):
+    """Body for catalog-metrics-partial-update. Every field optional; only supplied fields are written.
+
+    Status / tags / semantic_role for the metric live on the bound CatalogNode(kind=metric).
+    Use the metric DTO's `node.id` to PATCH `/catalog/nodes/:id/` for those.
+    """
+
+    description = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text=(
+            "Human-readable description of what this metric measures, when to use it, and any caveats. "
+            "Updating clears the old text — pass the full description, not a diff."
+        ),
+    )
+    definition = MetricDefinitionField(
+        required=False,
+        help_text=(
+            "How the metric is computed. Exactly one of `EventsNode`, `DataWarehouseNode`, or `HogQLQuery` — "
+            "the same shape `Insight.query.series` uses, discriminated by the inner `kind` field. "
+            "Replaces the existing definition wholesale; supply the complete body."
+        ),
     )
 
 

--- a/products/catalog/backend/presentation/views.py
+++ b/products/catalog/backend/presentation/views.py
@@ -36,6 +36,7 @@ from ..facade import api as catalog_api
 from ..facade.contracts import (
     ProposeRelationshipParams,
     UpdateColumnParams,
+    UpdateMetricParams,
     UpdateNodeParams,
     UpdateRelationshipParams,
     UpsertColumnParams,
@@ -50,6 +51,7 @@ from .serializers import (
     CatalogRelationshipDTOSerializer,
     ProposeRelationshipInputSerializer,
     UpdateColumnInputSerializer,
+    UpdateMetricInputSerializer,
     UpdateNodeInputSerializer,
     UpdateRelationshipInputSerializer,
     UpsertColumnInputSerializer,
@@ -300,7 +302,25 @@ class CatalogMetricViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     """
 
     scope_object = "catalog"
-    scope_object_write_actions = ["create"]
+    scope_object_read_actions = ["list", "retrieve"]
+    scope_object_write_actions = ["create", "partial_update"]
+
+    @extend_schema(responses={200: CatalogMetricDTOSerializer(many=True)})
+    def list(self, request: Request, **kwargs) -> Response:
+        """List all semantic metrics for the team, ordered by name."""
+        metrics = catalog_api.CatalogAPI.list_metrics(cast(int, self.team_id))
+        page = self.paginate_queryset(metrics)
+        if page is not None:
+            return self.get_paginated_response(CatalogMetricDTOSerializer(instance=page, many=True).data)
+        return Response(CatalogMetricDTOSerializer(instance=metrics, many=True).data)
+
+    @extend_schema(parameters=[_NODE_ID_PARAM], responses={200: CatalogMetricDTOSerializer})
+    def retrieve(self, request: Request, pk: str, **kwargs) -> Response:
+        """Retrieve a single metric with its bound CatalogNode (status, tags, etc.)."""
+        metric = catalog_api.CatalogAPI.get_metric(cast(int, self.team_id), UUID(pk))
+        if metric is None:
+            return Response({"detail": "Metric not found"}, status=status.HTTP_404_NOT_FOUND)
+        return Response(CatalogMetricDTOSerializer(instance=metric).data)
 
     @validated_request(
         request_serializer=UpsertMetricInputSerializer,
@@ -319,3 +339,22 @@ class CatalogMetricViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         )
         metric = catalog_api.CatalogAPI.upsert_metric(params)
         return Response(CatalogMetricDTOSerializer(instance=metric).data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(parameters=[_NODE_ID_PARAM])
+    @validated_request(
+        request_serializer=UpdateMetricInputSerializer,
+        responses={200: OpenApiResponse(response=CatalogMetricDTOSerializer)},
+    )
+    def partial_update(self, request: TypedRequest[dict[str, Any]], pk: str, **kwargs) -> Response:
+        """Update a metric's description or definition. Status/tags live on the bound node — PATCH /catalog/nodes/:node.id/ instead."""
+        data = request.validated_data
+        params = UpdateMetricParams(
+            team_id=cast(int, self.team_id),
+            metric_id=UUID(pk),
+            description=data.get("description"),
+            definition=data.get("definition"),
+        )
+        metric = catalog_api.CatalogAPI.update_metric(params)
+        if metric is None:
+            return Response({"detail": "Metric not found"}, status=status.HTTP_404_NOT_FOUND)
+        return Response(CatalogMetricDTOSerializer(instance=metric).data)

--- a/products/catalog/backend/tests/test_facade.py
+++ b/products/catalog/backend/tests/test_facade.py
@@ -1,14 +1,19 @@
+from uuid import uuid4
+
 from posthog.test.base import BaseTest
 
 from products.catalog.backend.facade.api import CatalogAPI
 from products.catalog.backend.facade.contracts import (
     CatalogGraphDTO,
+    CatalogMetricDTO,
     CatalogNodeDTO,
     ProposeRelationshipParams,
     UpdateColumnParams,
+    UpdateMetricParams,
     UpdateNodeParams,
     UpdateRelationshipParams,
     UpsertColumnParams,
+    UpsertMetricParams,
     UpsertNodeParams,
 )
 
@@ -270,3 +275,64 @@ class TestCatalogAPIUpdate(BaseTest):
 
         assert accepted is not None
         assert accepted.status == "accepted"
+
+
+class TestCatalogAPIMetrics(BaseTest):
+    def _upsert(self, name: str = "monthly_recurring_revenue", **overrides) -> CatalogMetricDTO:
+        return CatalogAPI.upsert_metric(
+            UpsertMetricParams(
+                team_id=self.team.pk,
+                name=name,
+                description=overrides.get("description", "MRR across active subscriptions"),
+                definition=overrides.get(
+                    "definition",
+                    {"kind": "EventsNode", "event": "subscription_started", "math": "dau"},
+                ),
+                confidence=overrides.get("confidence", 0.9),
+            )
+        )
+
+    def test_upsert_bundles_node_metadata_into_metric_dto(self) -> None:
+        dto = self._upsert()
+        assert dto.name == "monthly_recurring_revenue"
+        assert dto.definition["kind"] == "EventsNode"
+        assert dto.node.kind == "metric"
+        assert dto.node.status == "proposed"
+        assert dto.node.confidence == 0.9
+
+    def test_list_metrics_returns_team_metrics_only(self) -> None:
+        self._upsert(name="mrr")
+        self._upsert(name="arr")
+        other_team = self.organization.teams.create(name="other")
+        CatalogAPI.upsert_metric(
+            UpsertMetricParams(
+                team_id=other_team.pk,
+                name="leaky",
+                definition={"kind": "EventsNode", "event": "signup", "math": "dau"},
+            )
+        )
+        metrics = CatalogAPI.list_metrics(self.team.pk)
+        assert sorted(m.name for m in metrics) == ["arr", "mrr"]
+
+    def test_get_metric_returns_none_for_missing(self) -> None:
+        assert CatalogAPI.get_metric(self.team.pk, uuid4()) is None
+
+    def test_update_metric_writes_only_supplied_fields(self) -> None:
+        original = self._upsert()
+        updated = CatalogAPI.update_metric(
+            UpdateMetricParams(
+                team_id=self.team.pk,
+                metric_id=original.id,
+                description="Refined MRR description",
+            )
+        )
+        assert updated is not None
+        assert updated.description == "Refined MRR description"
+        # Definition untouched
+        assert updated.definition == original.definition
+
+    def test_update_metric_returns_none_for_missing(self) -> None:
+        assert (
+            CatalogAPI.update_metric(UpdateMetricParams(team_id=self.team.pk, metric_id=uuid4(), description="x"))
+            is None
+        )

--- a/products/catalog/frontend/generated/api.schemas.ts
+++ b/products/catalog/frontend/generated/api.schemas.ts
@@ -1198,6 +1198,52 @@ aggregate (DataWarehouseNode), or a raw HogQL query (HogQLQuery). All three carr
  */
 export type MetricDefinitionSchemaApi = EventsNodeApi | DataWarehouseNodeApi | HogQLQueryApi
 
+export interface CatalogNodeDTOApi {
+    columns: CatalogColumnDTOApi[]
+    id: string
+    team_id: number
+    kind: string
+    name: string
+    /** @nullable */
+    description: string | null
+    /** @nullable */
+    semantic_role: string | null
+    /** @nullable */
+    business_domain: string | null
+    tags: string[]
+    /** @nullable */
+    first_seen_at: string | null
+    /** @nullable */
+    last_seen_at: string | null
+    /** @nullable */
+    last_traversed_at: string | null
+    /** @nullable */
+    confidence: number | null
+    status: string
+    /** @nullable */
+    reviewed_at: string | null
+}
+
+export interface CatalogMetricDTOApi {
+    definition: MetricDefinitionSchemaApi
+    node: CatalogNodeDTOApi
+    id: string
+    team_id: number
+    name: string
+    description: string
+    created_at: string
+    updated_at: string
+}
+
+export interface PaginatedCatalogMetricDTOListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: CatalogMetricDTOApi[]
+}
+
 /**
  * Body for catalog-metrics-create. team_id is taken from the URL, not the body.
 
@@ -1230,41 +1276,17 @@ export interface UpsertMetricInputApi {
     confidence?: number | null
 }
 
-export interface CatalogMetricDTOApi {
-    definition: MetricDefinitionSchemaApi
-    id: string
-    team_id: number
-    name: string
-    description: string
-    node_id: string
-    created_at: string
-    updated_at: string
-}
+/**
+ * Body for catalog-metrics-partial-update. Every field optional; only supplied fields are written.
 
-export interface CatalogNodeDTOApi {
-    columns: CatalogColumnDTOApi[]
-    id: string
-    team_id: number
-    kind: string
-    name: string
-    /** @nullable */
-    description: string | null
-    /** @nullable */
-    semantic_role: string | null
-    /** @nullable */
-    business_domain: string | null
-    tags: string[]
-    /** @nullable */
-    first_seen_at: string | null
-    /** @nullable */
-    last_seen_at: string | null
-    /** @nullable */
-    last_traversed_at: string | null
-    /** @nullable */
-    confidence: number | null
-    status: string
-    /** @nullable */
-    reviewed_at: string | null
+Status / tags / semantic_role for the metric live on the bound CatalogNode(kind=metric).
+Use the metric DTO's `node_id` to PATCH `/catalog/nodes/:node_id/` for those.
+ */
+export interface PatchedUpdateMetricInputApi {
+    /** Human-readable description of what this metric measures, when to use it, and any caveats. Updating clears the old text — pass the full description, not a diff. */
+    description?: string
+    /** How the metric is computed. Exactly one of `EventsNode`, `DataWarehouseNode`, or `HogQLQuery` — the same shape `Insight.query.series` uses, discriminated by the inner `kind` field. Replaces the existing definition wholesale; supply the complete body. */
+    definition?: MetricDefinitionSchemaApi
 }
 
 export interface PaginatedCatalogNodeDTOListApi {
@@ -1541,6 +1563,17 @@ export interface PatchedUpdateRelationshipInputApi {
     confidence?: number
     /** Free-text justification, typically extended during human review. */
     reasoning?: string
+}
+
+export type CatalogMetricsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
 }
 
 export type CatalogNodesListParams = {

--- a/products/catalog/frontend/generated/api.ts
+++ b/products/catalog/frontend/generated/api.ts
@@ -12,11 +12,14 @@ import type {
     CatalogColumnDTOApi,
     CatalogGraphDTOApi,
     CatalogMetricDTOApi,
+    CatalogMetricsListParams,
     CatalogNodeDTOApi,
     CatalogNodesListParams,
     CatalogRelationshipDTOApi,
+    PaginatedCatalogMetricDTOListApi,
     PaginatedCatalogNodeDTOListApi,
     PatchedUpdateColumnInputApi,
+    PatchedUpdateMetricInputApi,
     PatchedUpdateNodeInputApi,
     PatchedUpdateRelationshipInputApi,
     ProposeRelationshipInputApi,
@@ -84,6 +87,36 @@ export const catalogColumnsPartialUpdate = async (
     })
 }
 
+export const getCatalogMetricsListUrl = (projectId: string, params?: CatalogMetricsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/catalog/metrics/?${stringifiedParams}`
+        : `/api/projects/${projectId}/catalog/metrics/`
+}
+
+/**
+ * List all semantic metrics for the team, ordered by name.
+ */
+export const catalogMetricsList = async (
+    projectId: string,
+    params?: CatalogMetricsListParams,
+    options?: RequestInit
+): Promise<PaginatedCatalogMetricDTOListApi> => {
+    return apiMutator<PaginatedCatalogMetricDTOListApi>(getCatalogMetricsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
 export const getCatalogMetricsCreateUrl = (projectId: string) => {
     return `/api/projects/${projectId}/catalog/metrics/`
 }
@@ -101,6 +134,45 @@ export const catalogMetricsCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(upsertMetricInputApi),
+    })
+}
+
+export const getCatalogMetricsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/catalog/metrics/${id}/`
+}
+
+/**
+ * Retrieve a single metric with its bound CatalogNode (status, tags, etc.).
+ */
+export const catalogMetricsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<CatalogMetricDTOApi> => {
+    return apiMutator<CatalogMetricDTOApi>(getCatalogMetricsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getCatalogMetricsPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/catalog/metrics/${id}/`
+}
+
+/**
+ * Update a metric's description or definition. Status/tags live on the bound node — PATCH /catalog/nodes/:node.id/ instead.
+ */
+export const catalogMetricsPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedUpdateMetricInputApi?: PatchedUpdateMetricInputApi,
+    options?: RequestInit
+): Promise<CatalogMetricDTOApi> => {
+    return apiMutator<CatalogMetricDTOApi>(getCatalogMetricsPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedUpdateMetricInputApi),
     })
 }
 

--- a/products/catalog/frontend/generated/api.zod.ts
+++ b/products/catalog/frontend/generated/api.zod.ts
@@ -179,6 +179,13 @@ export const CatalogMetricsCreateBody = /* @__PURE__ */ zod
     .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
 
 /**
+ * Update a metric's description or definition. Status/tags live on the bound node — PATCH /catalog/nodes/:node.id/ instead.
+ */
+export const CatalogMetricsPartialUpdateBody = /* @__PURE__ */ zod
+    .record(zod.string(), zod.unknown())
+    .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
+
+/**
  * Upsert a catalog node and its agent-authored descriptions.
  */
 export const catalogNodesCreateBodyNameMax = 400

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6652,11 +6652,11 @@ export namespace Schemas {
 
     export interface CatalogMetricDTO {
       definition: MetricDefinitionSchema;
+      node: CatalogNodeDTO;
       id: string;
       team_id: number;
       name: string;
       description: string;
-      node_id: string;
       created_at: string;
       updated_at: string;
     }
@@ -20942,6 +20942,15 @@ export namespace Schemas {
       results: CIMDVerificationToken[];
     }
 
+    export interface PaginatedCatalogMetricDTOList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: CatalogMetricDTO[];
+    }
+
     export interface PaginatedCatalogNodeDTOList {
       count: number;
       /** @nullable */
@@ -29857,6 +29866,19 @@ export namespace Schemas {
          * @nullable
          */
       confidence?: number | null;
+    }
+
+    /**
+     * Body for catalog-metrics-partial-update. Every field optional; only supplied fields are written.
+
+    Status / tags / semantic_role for the metric live on the bound CatalogNode(kind=metric).
+    Use the metric DTO's `node_id` to PATCH `/catalog/nodes/:node_id/` for those.
+     */
+    export interface PatchedUpdateMetricInput {
+      /** Human-readable description of what this metric measures, when to use it, and any caveats. Updating clears the old text — pass the full description, not a diff. */
+      description?: string;
+      /** How the metric is computed. Exactly one of `EventsNode`, `DataWarehouseNode`, or `HogQLQuery` — the same shape `Insight.query.series` uses, discriminated by the inner `kind` field. Replaces the existing definition wholesale; supply the complete body. */
+      definition?: MetricDefinitionSchema;
     }
 
     /**
@@ -40632,6 +40654,17 @@ export namespace Schemas {
 
     export type BusinessKnowledgeSourcesTextRetrieve200 = {
       text?: string;
+    };
+
+    export type CatalogMetricsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
     };
 
     export type CatalogNodesListParams = {


### PR DESCRIPTION
## Problem

The semantic-layer proposals inbox UI (#58545) needs read + write endpoints for metrics. The MCP-write path (`catalog-metrics-create`) already lands metric proposals; this PR exposes them to the UI and lets reviewers edit metric-row fields.

## Changes

Adds three actions to `CatalogMetricViewSet`:

- `GET /catalog/metrics/` — paginated list
- `GET /catalog/metrics/:id/` — single metric
- `PATCH /catalog/metrics/:id/` — update `description` / `definition`

`CatalogMetricDTO` now bundles the bound `CatalogNode` (status, confidence, tags, semantic_role, business_domain) so the proposals list gets review-state in one fetch instead of N+1ing to the nodes endpoint. The metric `partial_update` only touches metric-row fields — status changes route through the existing `PATCH /catalog/nodes/:id/` via the metric DTO's `node.id`, keeping the two storage rows orthogonal.

Generated OpenAPI / Orval / Zod / MCP types are regenerated for the new endpoints and the nested DTO shape.

## How did you test this code?

I'm an agent. Automated checks run:
- Type check via `uv run ty check` on the touched backend files — clean.
- `hogli build:openapi` regenerated frontend types and MCP tool definitions without errors.

Did NOT run the test suite manually. Added facade-level tests for the new metric methods (`TestCatalogAPIMetrics`) but they were not executed locally — let CI run them.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Session goal was to expose metric data to the UI without designing a new write path: the metric row holds the computational definition, the bound `CatalogNode(kind=metric)` holds the review metadata. Two endpoints stay separate, the DTO bundles the read shape.

Considered exposing status/tags through `PATCH /catalog/metrics/` so the UI could approve in one call, but rejected — it'd duplicate node fields onto the metric serializer and divergence would silently bite. The metric DTO already carries `node.id`, so the UI can route status writes to the existing nodes endpoint with no extra plumbing.

The branch was originally based on an earlier `sam/catalog-entities-metrics-dimensions` line of work that pursued entity-grouped browsing; after team feedback that "metrics" is the right primitive, that branch was parked (commits preserved) and this branch was cut fresh from `origin/semantic-layer` to align with the team's metric-as-node direction.