### PR TITLE
feat(deployments): add cloudflare pages settings and temporal queue

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -106,4 +106,5 @@ LLMA_SENTIMENT_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-sentiment-ta
 LLMA_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-task-queue")
 EVENT_SCREENSHOTS_TASK_QUEUE = _set_temporal_task_queue("event-screenshots-task-queue")
 LOGS_ALERTING_TASK_QUEUE = _set_temporal_task_queue("logs-alerting-task-queue")
+DEPLOYMENTS_TASK_QUEUE = _set_temporal_task_queue("deployments-task-queue")
 RASTERIZATION_TASK_QUEUE = "rasterization-task-queue"  # Not collapsed in dev — separate Node.js worker process

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -591,6 +591,14 @@ CLOUDFLARE_ZONE_ID = get_from_env("CLOUDFLARE_ZONE_ID", "")
 CLOUDFLARE_WORKER_NAME = get_from_env("CLOUDFLARE_WORKER_NAME", "")
 CLOUDFLARE_PROXY_BASE_CNAME = get_from_env("CLOUDFLARE_PROXY_BASE_CNAME", "")
 
+# Single-tenant Cloudflare Pages settings for the Deployments product.
+# Separate from the SaaS proxy block above: different account scope (Pages,
+# not Workers + DNS for posthog.com) and a different zone (hog.dev).
+DEPLOYMENTS_CLOUDFLARE_ACCOUNT_ID = get_from_env("DEPLOYMENTS_CLOUDFLARE_ACCOUNT_ID", "")
+DEPLOYMENTS_CLOUDFLARE_API_TOKEN = get_from_env("DEPLOYMENTS_CLOUDFLARE_API_TOKEN", "")
+DEPLOYMENTS_HOG_DEV_ZONE_ID = get_from_env("DEPLOYMENTS_HOG_DEV_ZONE_ID", "")
+DEPLOYMENTS_CLOUDFLARE_PROJECT_PREFIX = get_from_env("DEPLOYMENTS_CLOUDFLARE_PROJECT_PREFIX", "hogdev-")
+
 # Domain Connect (automated DNS configuration)
 DOMAIN_CONNECT_PRIVATE_KEY: str | None = os.getenv("DOMAIN_CONNECT_PRIVATE_KEY", "").replace("\\n", "\n") or None
 DOMAIN_CONNECT_KEY_ID: str = os.getenv("DOMAIN_CONNECT_KEY_ID", "_dcpubkeyv1")


### PR DESCRIPTION
## Problem

The Deployments product needs to provision per-team Cloudflare Pages projects from Django (under PostHog's own CF account — single-tenant) and run its build pipeline on a dedicated Temporal queue. Neither piece is wired into settings yet.

The existing `CLOUDFLARE_*` block in `posthog/settings/web.py` belongs to the Cloudflare-for-SaaS proxy feature: different account scope (Workers + DNS on `posthog.com`) and a different zone. Reusing those vars would conflate two unrelated features and force the wrong token scope.

## Changes

- `posthog/settings/web.py`: add `DEPLOYMENTS_CLOUDFLARE_ACCOUNT_ID`, `DEPLOYMENTS_CLOUDFLARE_API_TOKEN`, `DEPLOYMENTS_HOG_DEV_ZONE_ID`, `DEPLOYMENTS_CLOUDFLARE_PROJECT_PREFIX` (defaults to `hogdev-`). All blank by default; the Pages-scoped token will be created in the CF dashboard and mounted from AWS Secrets Manager.
- `posthog/settings/temporal.py`: add `DEPLOYMENTS_TASK_QUEUE` next to the existing 20+ queues. Collapses to the dev queue under `DEBUG=True`, otherwise resolves to `deployments-task-queue`.

The zone itself (`hog.dev`) is added separately in `posthog-cloud-infra`; once applied, the Terraform output gives us the zone ID to plug into `DEPLOYMENTS_HOG_DEV_ZONE_ID`.

## How did you test this code?

Agent-authored. Verified by inspection that `get_from_env` and `_set_temporal_task_queue` calls follow the existing patterns in both files. No tests exercise these env vars directly — they're consumed downstream by the `CloudflareAdapter` and the Temporal worker, both of which already have their own test coverage with `NullCloudflareAdapter` / `NullWorkflowAdapter`.

## Publish to changelog?

no

## 🤖 Agent context

Claude Opus 4.7 via Claude Code. The conversation started from the deployments product spec, then pivoted on substrate: builds run inside hogland Firecracker microVMs (rather than directly in the Temporal worker pod) and hosting is single-tenant under PostHog's CF account (rather than per-team CF setups). This PR captures only the Django-visible piece of that pivot — the single-tenant Pages config plus the worker queue. The hogland integration itself lives in the build worker package and lands separately.