### PR TITLE
feat(deployments): implement logs endpoint

### DIFF
--- a/products/deployments/backend/api/deployments.py
+++ b/products/deployments/backend/api/deployments.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from django.db.models import Exists, OuterRef
 
+import structlog
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import filters, status, viewsets
@@ -22,6 +23,10 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
 from posthog.permissions import APIScopePermission
@@ -30,7 +35,7 @@ from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from ..adapters import GitHubError
 from ..domain.trigger import TriggerKind
 from ..models import Deployment, DeploymentEvent, DeploymentProject
-from ..serializers import DeploymentEventSerializer, DeploymentSerializer
+from ..serializers import DeploymentEventSerializer, DeploymentLogsResponseSerializer, DeploymentSerializer
 from ..serializers.deployment import (
     DeploymentActionResponseSerializer,
     DeploymentConflictResponseSerializer,
@@ -38,6 +43,27 @@ from ..serializers.deployment import (
 )
 from ..services import cancel, create_deployment, redeploy, refresh_preview, rollback
 from .deployment_projects import DeploymentsAccessPermission
+
+logger = structlog.get_logger(__name__)
+
+
+# Build logs land in the standard `events` table as `$log` events tagged with
+# `properties.deployment_id`. See `2026-05-13-deployments.md` (Pipeline →
+# "Build logs") for the emission contract owned by the build-runner stream.
+LOGS_ROW_LIMIT = 1000
+_LOGS_QUERY_SQL = """
+SELECT
+    timestamp,
+    properties.level AS level,
+    properties.step AS step,
+    properties.$log_line AS line,
+    properties.exit_code AS exit_code
+FROM events
+WHERE event = {log_event}
+  AND properties.deployment_id = {deployment_id}
+ORDER BY timestamp ASC
+LIMIT {row_limit}
+"""
 
 
 @extend_schema(
@@ -324,24 +350,69 @@ class DeploymentViewSet(
         data = DeploymentEventSerializer(qs, many=True).data
         return Response(data)
 
-    @extend_schema(responses={status.HTTP_200_OK: DeploymentActionResponseSerializer})
+    @extend_schema(
+        responses={
+            status.HTTP_200_OK: DeploymentLogsResponseSerializer,
+            status.HTTP_502_BAD_GATEWAY: OpenApiResponse(
+                description="HogQL query against the events store failed.",
+            ),
+        },
+    )
     @action(detail=True, methods=["get"])
     def logs(self, request: Request, **kwargs: Any) -> Response:
-        # Build logs land as `$log` PostHog events tagged with
-        # `properties.deployment_id`. The real Logs ingest endpoint is
-        # owned by another team; this stub returns an empty page until
-        # the HogQL bridge lands. Frontend stream can iterate against
-        # the empty shape today and we'll fill it in once the contract
-        # is final.
+        # Build logs land as `$log` events on the standard `events` table,
+        # tagged with `properties.deployment_id`. We project the deployment-
+        # specific properties (level, step, $log_line, exit_code) the build
+        # runner emits per `2026-05-13-deployments.md`. `execute_hogql_query`
+        # auto-scopes to the current team via HogQLContext, so the URL's
+        # team_id is already enforced; `get_object()` covers the project +
+        # deployment scope and RBAC.
         source = self.get_object()
-        # TODO(deployments-v1): swap stub for an `execute_hogql_query` call:
-        #   SELECT timestamp, level, step, line, exit_code
-        #   FROM events
-        #   WHERE event = '$log'
-        #     AND properties.deployment_id = {deployment_id}
-        #   ORDER BY timestamp ASC
-        #   LIMIT 1000
-        return Response(
-            {"detail": f"Logs proxy not implemented yet (deployment_id={source.pk})."},
-            status=status.HTTP_200_OK,
+        select = parse_select(_LOGS_QUERY_SQL)
+        # Fetch one row beyond the cap so we can distinguish "ran out at
+        # exactly the cap" (`has_more=False`) from "more rows exist beyond
+        # the page" (`has_more=True`). The extra row is sliced off before
+        # serialization so the response shape stays bounded.
+        fetch_limit = LOGS_ROW_LIMIT + 1
+        try:
+            result = execute_hogql_query(
+                query=select,
+                team=self.team,
+                placeholders={
+                    "log_event": ast.Constant(value="$log"),
+                    "deployment_id": ast.Constant(value=str(source.pk)),
+                    "row_limit": ast.Constant(value=fetch_limit),
+                },
+                query_type="DeploymentLogsQuery",
+            )
+        except Exception as exc:
+            logger.exception(
+                "deployments.logs.hogql_failed",
+                deployment_id=str(source.pk),
+                error=str(exc),
+            )
+            return Response(
+                {"detail": "Failed to fetch logs from the analytics store."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        rows = result.results or []
+        has_more = len(rows) > LOGS_ROW_LIMIT
+        page = rows[:LOGS_ROW_LIMIT]
+        serialized = DeploymentLogsResponseSerializer(
+            {
+                "results": [
+                    {
+                        "timestamp": row[0],
+                        "level": row[1],
+                        "step": row[2],
+                        "line": row[3],
+                        "exit_code": row[4],
+                    }
+                    for row in page
+                ],
+                "has_more": has_more,
+                "row_limit": LOGS_ROW_LIMIT,
+            }
         )
+        return Response(serialized.data, status=status.HTTP_200_OK)

--- a/products/deployments/backend/serializers/__init__.py
+++ b/products/deployments/backend/serializers/__init__.py
@@ -1,9 +1,11 @@
-from .deployment import DeploymentSerializer
+from .deployment import DeploymentLogEntrySerializer, DeploymentLogsResponseSerializer, DeploymentSerializer
 from .event import DeploymentEventSerializer
 from .project import DeploymentProjectCreateSerializer, DeploymentProjectSerializer, DeploymentProjectWriteSerializer
 
 __all__ = [
     "DeploymentEventSerializer",
+    "DeploymentLogEntrySerializer",
+    "DeploymentLogsResponseSerializer",
     "DeploymentProjectCreateSerializer",
     "DeploymentProjectSerializer",
     "DeploymentProjectWriteSerializer",

--- a/products/deployments/backend/serializers/deployment.py
+++ b/products/deployments/backend/serializers/deployment.py
@@ -218,3 +218,35 @@ class DeploymentConflictResponseSerializer(serializers.Serializer):
     active_deployment_id = serializers.UUIDField(
         help_text="The deployment currently in-flight for the project. Frontend can poll this id.",
     )
+
+
+class DeploymentLogEntrySerializer(serializers.Serializer):
+    """One line of build output emitted by the build worker as a `$log` event."""
+
+    timestamp = serializers.DateTimeField(help_text="When the line was emitted by the build worker.")
+    level = serializers.CharField(
+        allow_null=True,
+        help_text='Log level: "info" | "warn" | "error". Null if the event did not carry one.',
+    )
+    step = serializers.CharField(
+        allow_null=True,
+        help_text='Pipeline step: "clone" | "install" | "build" | "publish". Null if the event did not carry one.',
+    )
+    line = serializers.CharField(
+        allow_null=True,
+        help_text="The log line itself (a single line of stdout or stderr).",
+    )
+    exit_code = serializers.IntegerField(
+        allow_null=True,
+        help_text="Set on the last line of a step; null on all other lines.",
+    )
+
+
+class DeploymentLogsResponseSerializer(serializers.Serializer):
+    """Response shape for GET /deployments/{id}/logs/."""
+
+    results = DeploymentLogEntrySerializer(many=True, help_text="Log lines for the deployment, oldest first.")
+    has_more = serializers.BooleanField(
+        help_text="True if the row limit was hit and older lines may exist beyond this page.",
+    )
+    row_limit = serializers.IntegerField(help_text="The hard cap applied by the server.")

--- a/products/deployments/backend/test/test_deployments_api.py
+++ b/products/deployments/backend/test/test_deployments_api.py
@@ -10,7 +10,10 @@ The feature flag gate (`DeploymentsAccessPermission`) is mocked via
 
 from __future__ import annotations
 
-from posthog.test.base import APIBaseTest
+import uuid as uuidlib
+import datetime as dt
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
@@ -18,11 +21,14 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import AvailableFeature
+from posthog.models.event.util import bulk_create_events
 from posthog.models.integration import Integration
 from posthog.models.utils import uuid7
 
 from products.deployments.backend.adapters.github import GitHubBranch, GitHubRepository
+from products.deployments.backend.api.deployments import LOGS_ROW_LIMIT
 from products.deployments.backend.models import Deployment, DeploymentProject
 from products.deployments.backend.test._helpers import DeploymentsTeamScopedTestMixin
 
@@ -558,3 +564,264 @@ class TestDeploymentsFeatureFlag(_BaseDeploymentsAPITest):
         # Re-start the cleanup-registered patcher so addCleanup's stop() is
         # safe (re-stop is fine since `stop` is idempotent on already-stopped).
         self._flag_patcher.start()
+
+
+class TestDeploymentLogsEndpoint(
+    ClickhouseTestMixin,
+    DeploymentsTeamScopedTestMixin,
+    APIBaseTest,
+):
+    """GET /deployments/{id}/logs/ — HogQL proxy over `$log` events."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # The feature-flag gate is patched on for the whole suite below;
+        # `_BaseDeploymentsAPITest` already does this elsewhere but this
+        # class inherits `APIBaseTest` directly (we need ClickhouseTestMixin
+        # in front of APIBaseTest, which doesn't compose with the existing
+        # `_BaseDeploymentsAPITest` cleanly).
+        self._flag_patcher = patch(
+            "products.deployments.backend.access.posthoganalytics.feature_enabled",
+            return_value=True,
+        )
+        self._flag_patcher.start()
+        self.addCleanup(self._flag_patcher.stop)
+
+        # Isolation: scrub the ClickHouse events table so rows from other
+        # tests in the same session can't leak in. Mirrors the live_debugger
+        # tests at products/live_debugger/backend/test_models.py:18.
+        sync_execute("TRUNCATE TABLE IF EXISTS sharded_events")
+
+        self.deployment_project = DeploymentProject.objects.create(
+            team_id=self.team.id,
+            name="Site",
+            slug="site",
+            repo_url="https://github.com/example-org/site",
+            cloudflare_project_name=f"{self.team.id}-site",
+            subdomain="site.posthog-app.com",
+            cloudflare_ready_at=timezone.now(),
+        )
+        self.deployment = Deployment.objects.create(
+            project=self.deployment_project,
+            team_id=self.team.id,
+            status=Deployment.Status.READY.value,
+            commit_sha="abc1234",
+        )
+
+    # ---- helpers ------------------------------------------------------
+
+    def _logs_url(self, deployment_id: str | None = None, project_id: str | None = None) -> str:
+        pid = project_id or str(self.deployment_project.id)
+        did = deployment_id or str(self.deployment.id)
+        return f"/api/projects/{self.team.id}/deployment_projects/{pid}/deployments/{did}/logs/"
+
+    def _capture_log_event(
+        self,
+        *,
+        deployment_id: str,
+        level: str = "info",
+        step: str = "build",
+        line: str = "hello",
+        exit_code: int | None = None,
+        timestamp: dt.datetime | None = None,
+        team_id: int | None = None,
+        event: str = "$log",
+    ) -> None:
+        properties: dict[str, object] = {
+            "deployment_id": deployment_id,
+            "level": level,
+            "step": step,
+            "$log_line": line,
+        }
+        if exit_code is not None:
+            properties["exit_code"] = exit_code
+        bulk_create_events(
+            [
+                {
+                    "uuid": str(uuidlib.uuid4()),
+                    "event": event,
+                    "team_id": team_id if team_id is not None else self.team.pk,
+                    "distinct_id": "build-worker",
+                    "timestamp": timestamp or dt.datetime.now(),  # nosemgrep: test-datetime-now-without-freeze
+                    "properties": properties,
+                }
+            ]
+        )
+
+    # ---- tests --------------------------------------------------------
+
+    def test_feature_flag_off_returns_403(self) -> None:
+        self._flag_patcher.stop()
+        with patch(
+            "products.deployments.backend.access.posthoganalytics.feature_enabled",
+            return_value=False,
+        ):
+            response = self.client.get(self._logs_url())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+        self._flag_patcher.start()
+
+    def test_unknown_deployment_returns_404(self) -> None:
+        response = self.client.get(self._logs_url(deployment_id=str(uuid7())))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_deployment_from_other_team_is_404(self) -> None:
+        # Mirrors test_action_endpoint_refuses_cross_project_deployment_id —
+        # we use get_object() so cross-team access surfaces as a clean 404,
+        # not a leak.
+        other_team = self.organization.teams.create(name="Other Team")
+        other_project = DeploymentProject.objects.create(
+            team_id=other_team.id,
+            name="Other",
+            slug="other",
+            repo_url="https://github.com/example-org/other",
+        )
+        other_deployment = Deployment.objects.create(
+            project=other_project,
+            team_id=other_team.id,
+            status=Deployment.Status.READY.value,
+        )
+        response = self.client.get(self._logs_url(deployment_id=str(other_deployment.id)))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_deployment_from_sibling_project_is_404(self) -> None:
+        sibling = DeploymentProject.objects.create(
+            team_id=self.team.id,
+            name="Sibling",
+            slug="sibling",
+            repo_url="https://github.com/example-org/sibling",
+        )
+        sibling_deployment = Deployment.objects.create(
+            project=sibling,
+            team_id=self.team.id,
+            status=Deployment.Status.READY.value,
+        )
+        # URL uses self.deployment_project, body references sibling's deployment.
+        response = self.client.get(self._logs_url(deployment_id=str(sibling_deployment.id)))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_empty_events_returns_empty_results(self) -> None:
+        response = self.client.get(self._logs_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        body = response.json()
+        self.assertEqual(body["results"], [])
+        self.assertFalse(body["has_more"])
+        self.assertEqual(body["row_limit"], LOGS_ROW_LIMIT)
+
+    def test_returns_log_lines_in_ascending_order(self) -> None:
+        deployment_id = str(self.deployment.id)
+        base = dt.datetime(2026, 5, 14, 10, 0, 0)
+        # Insert out of order so the test confirms server-side sort, not insertion order.
+        self._capture_log_event(
+            deployment_id=deployment_id,
+            step="build",
+            line="line-three",
+            timestamp=base + dt.timedelta(seconds=2),
+        )
+        self._capture_log_event(
+            deployment_id=deployment_id,
+            step="install",
+            line="line-one",
+            timestamp=base,
+        )
+        self._capture_log_event(
+            deployment_id=deployment_id,
+            step="install",
+            line="line-two",
+            timestamp=base + dt.timedelta(seconds=1),
+            exit_code=0,
+        )
+
+        response = self.client.get(self._logs_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        body = response.json()
+        lines = [entry["line"] for entry in body["results"]]
+        self.assertEqual(lines, ["line-one", "line-two", "line-three"])
+        # exit_code projects through; non-final lines stay null.
+        self.assertEqual(body["results"][0]["exit_code"], None)
+        self.assertEqual(body["results"][1]["exit_code"], 0)
+        self.assertEqual(body["results"][2]["exit_code"], None)
+        # Each entry carries level and step from the event properties.
+        self.assertEqual(body["results"][0]["level"], "info")
+        self.assertEqual(body["results"][0]["step"], "install")
+        self.assertFalse(body["has_more"])
+
+    def test_excludes_logs_from_other_deployments_in_same_project(self) -> None:
+        # The single guarantee that matters: filtering by
+        # properties.deployment_id only returns this deployment's lines.
+        other_deployment = Deployment.objects.create(
+            project=self.deployment_project,
+            team_id=self.team.id,
+            status=Deployment.Status.READY.value,
+        )
+        self._capture_log_event(deployment_id=str(self.deployment.id), line="mine")
+        self._capture_log_event(deployment_id=str(other_deployment.id), line="theirs")
+
+        response = self.client.get(self._logs_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        lines = [entry["line"] for entry in response.json()["results"]]
+        self.assertEqual(lines, ["mine"])
+
+    def test_excludes_non_log_events_with_matching_deployment_id(self) -> None:
+        # A non-`$log` event (e.g. a `$deployment` event or a customer's
+        # own event) tagged with the same deployment_id must not leak in.
+        deployment_id = str(self.deployment.id)
+        self._capture_log_event(deployment_id=deployment_id, line="real-log")
+        self._capture_log_event(
+            deployment_id=deployment_id,
+            line="should-not-show",
+            event="$deployment",
+        )
+
+        response = self.client.get(self._logs_url())
+        lines = [entry["line"] for entry in response.json()["results"]]
+        self.assertEqual(lines, ["real-log"])
+
+    def test_row_limit_signals_has_more_only_when_extra_row_exists(self) -> None:
+        # We fetch LIMIT + 1 rows under the hood so `has_more` can
+        # distinguish "ran out at exactly the cap" from "page is full and
+        # more exist beyond it". Verify both paths and confirm the
+        # placeholder values are bound by `ast.Constant`, not interpolated.
+        deployment_id = str(self.deployment.id)
+
+        def _synthetic(rows: int) -> list[tuple[dt.datetime, str, str, str, None]]:
+            return [
+                (dt.datetime(2026, 5, 14, 10, 0, 0, i % 1_000_000), "info", "build", f"line-{i}", None)
+                for i in range(rows)
+            ]
+
+        # Exactly LOGS_ROW_LIMIT rows returned (no overflow row from DB) → has_more False.
+        with patch("products.deployments.backend.api.deployments.execute_hogql_query") as mock_execute:
+            mock_execute.return_value = MagicMock(results=_synthetic(LOGS_ROW_LIMIT))
+            response = self.client.get(self._logs_url(deployment_id=deployment_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        body = response.json()
+        self.assertEqual(len(body["results"]), LOGS_ROW_LIMIT)
+        self.assertFalse(body["has_more"])
+
+        # LOGS_ROW_LIMIT + 1 rows returned (DB hit the overflow row) →
+        # has_more True; response slices off the overflow.
+        with patch("products.deployments.backend.api.deployments.execute_hogql_query") as mock_execute:
+            mock_execute.return_value = MagicMock(results=_synthetic(LOGS_ROW_LIMIT + 1))
+            response = self.client.get(self._logs_url(deployment_id=deployment_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        body = response.json()
+        self.assertEqual(len(body["results"]), LOGS_ROW_LIMIT)
+        self.assertTrue(body["has_more"])
+
+        # Confirm parameterization on the last call.
+        placeholders = mock_execute.call_args.kwargs["placeholders"]
+        self.assertEqual(placeholders["deployment_id"].value, deployment_id)
+        self.assertEqual(placeholders["log_event"].value, "$log")
+        # SQL fetches one extra row to support honest has_more.
+        self.assertEqual(placeholders["row_limit"].value, LOGS_ROW_LIMIT + 1)
+        # Response still advertises the user-facing cap, not the +1 internal.
+        self.assertEqual(body["row_limit"], LOGS_ROW_LIMIT)
+
+    def test_hogql_failure_returns_502(self) -> None:
+        with patch(
+            "products.deployments.backend.api.deployments.execute_hogql_query",
+            side_effect=RuntimeError("ClickHouse offline"),
+        ):
+            response = self.client.get(self._logs_url())
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY, response.content)
+        self.assertIn("detail", response.json())

--- a/products/deployments/frontend/generated/api.schemas.ts
+++ b/products/deployments/frontend/generated/api.schemas.ts
@@ -360,6 +360,46 @@ export interface PaginatedDeploymentEventListApi {
     results: DeploymentEventApi[]
 }
 
+/**
+ * One line of build output emitted by the build worker as a `$log` event.
+ */
+export interface DeploymentLogEntryApi {
+    /** When the line was emitted by the build worker. */
+    timestamp: string
+    /**
+     * Log level: "info" | "warn" | "error". Null if the event did not carry one.
+     * @nullable
+     */
+    level: string | null
+    /**
+     * Pipeline step: "clone" | "install" | "build" | "publish". Null if the event did not carry one.
+     * @nullable
+     */
+    step: string | null
+    /**
+     * The log line itself (a single line of stdout or stderr).
+     * @nullable
+     */
+    line: string | null
+    /**
+     * Set on the last line of a step; null on all other lines.
+     * @nullable
+     */
+    exit_code: number | null
+}
+
+/**
+ * Response shape for GET /deployments/{id}/logs/.
+ */
+export interface DeploymentLogsResponseApi {
+    /** Log lines for the deployment, oldest first. */
+    results: DeploymentLogEntryApi[]
+    /** True if the row limit was hit and older lines may exist beyond this page. */
+    has_more: boolean
+    /** The hard cap applied by the server. */
+    row_limit: number
+}
+
 export interface DeploymentProjectWriteApi {
     /**
      * Human-readable project name shown in the UI.

--- a/products/deployments/frontend/generated/api.ts
+++ b/products/deployments/frontend/generated/api.ts
@@ -12,6 +12,7 @@ import type {
     DeploymentActionResponseApi,
     DeploymentApi,
     DeploymentCreateInputApi,
+    DeploymentLogsResponseApi,
     DeploymentProjectApi,
     DeploymentProjectCreateApi,
     DeploymentProjectRefreshResponseApi,
@@ -281,8 +282,8 @@ export const deploymentProjectsDeploymentsLogsRetrieve = async (
     deploymentProjectId: string,
     id: string,
     options?: RequestInit
-): Promise<DeploymentActionResponseApi> => {
-    return apiMutator<DeploymentActionResponseApi>(
+): Promise<DeploymentLogsResponseApi> => {
+    return apiMutator<DeploymentLogsResponseApi>(
         getDeploymentProjectsDeploymentsLogsRetrieveUrl(projectId, deploymentProjectId, id),
         {
             ...options,

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -12053,6 +12053,46 @@ export namespace Schemas {
       readonly occurred_at: string;
     }
 
+    /**
+     * One line of build output emitted by the build worker as a `$log` event.
+     */
+    export interface DeploymentLogEntry {
+      /** When the line was emitted by the build worker. */
+      timestamp: string;
+      /**
+         * Log level: "info" | "warn" | "error". Null if the event did not carry one.
+         * @nullable
+         */
+      level: string | null;
+      /**
+         * Pipeline step: "clone" | "install" | "build" | "publish". Null if the event did not carry one.
+         * @nullable
+         */
+      step: string | null;
+      /**
+         * The log line itself (a single line of stdout or stderr).
+         * @nullable
+         */
+      line: string | null;
+      /**
+         * Set on the last line of a step; null on all other lines.
+         * @nullable
+         */
+      exit_code: number | null;
+    }
+
+    /**
+     * Response shape for GET /deployments/{id}/logs/.
+     */
+    export interface DeploymentLogsResponse {
+      /** Log lines for the deployment, oldest first. */
+      results: DeploymentLogEntry[];
+      /** True if the row limit was hit and older lines may exist beyond this page. */
+      has_more: boolean;
+      /** The hard cap applied by the server. */
+      row_limit: number;
+    }
+
     export interface DeploymentProject {
       /** Unique identifier for the deployment project. */
       readonly id: string;


### PR DESCRIPTION
## Problem

The `GET .../deployments/{did}/logs/` action on `DeploymentViewSet` was a stub that returned `{"detail": "Logs proxy not implemented yet"}`. The deployments spec requires this endpoint to surface build logs from the Temporal worker, which emits stdout and stderr as `$log` events on the standard `events` ClickHouse table tagged with `properties.deployment_id`.

## Changes

Replaces the stub with a parameterized HogQL query against the `events` table.

* `products/deployments/backend/api/deployments.py` swaps the stub body for an `execute_hogql_query` call. The SQL projects `timestamp`, `properties.level`, `properties.step`, `properties.$log_line`, and `properties.exit_code` for rows where `event = $log` and `properties.deployment_id` matches the URL's deployment id. Every value binds via `ast.Constant`. The endpoint returns 502 if the HogQL call raises.
* `LOGS_ROW_LIMIT = 1000` caps the response. Internally the query fetches `LOGS_ROW_LIMIT + 1` rows so `has_more` is truthful. A build emitting exactly 1000 lines reports `has_more=false`. A build with more rows reports `has_more=true` and the overflow row is sliced off before serialization.
* Two new typed serializers in `products/deployments/backend/serializers/deployment.py`: `DeploymentLogEntrySerializer` and `DeploymentLogsResponseSerializer`. Every field carries `help_text` so the generated TypeScript and MCP types pick up real descriptions.
* `@extend_schema(responses={200: DeploymentLogsResponseSerializer, 502: OpenApiResponse(...)})` on the action so OpenAPI advertises the right shape.
* New `TestDeploymentLogsEndpoint` covers ten cases: feature flag gate (403), unknown deployment id (404), cross team isolation (404), cross project isolation (404), empty result, ascending ordering with mixed steps, deployment id scoping (excludes other deployments in the same project), event name scoping (excludes `$deployment` events that carry the same id), row limit boundary on both sides (`has_more=true` only when an overflow row exists), and HogQL failure surfacing 502.

Frontend `Deployment.tsx` still embeds the Logs product's `LogsViewer` against the OTEL backed `logs` ClickHouse table. Swapping it to consume this endpoint is a separate PR.

## Properties contract for the build runner

The build worker must emit `$log` events with these property keys.

* `deployment_id`: string UUID of the deployment row.
* `level`: one of `"info"`, `"warn"`, `"error"`.
* `step`: one of `"clone"`, `"install"`, `"build"`, `"publish"`.
* `$log_line`: a single line of stdout or stderr.
* `exit_code`: optional integer, populated on the final line of a step.

## How did you test this code?

* `ruff check products/deployments/backend/` and `ruff format check`: clean.
* `uv run ty check products/deployments/backend/`: clean.
* `tach check --dependencies --interfaces`: green.
* `./bin/hogli test products/deployments/backend/test/`: 160 passed, including all 10 new logs tests.
* `DEBUG=1 python manage.py makemigrations deployments --check --dry-run`: no changes detected (the endpoint is read only, no schema change).
* `hogli build:openapi`: regenerates `products/deployments/frontend/generated/{api.ts,api.schemas.ts,api.zod.ts}` and `services/mcp/src/api/generated.ts` cleanly. `DeploymentLogsResponseApi` appears in both, and `deploymentProjectsDeploymentsLogsRetrieve` now returns `Promise<DeploymentLogsResponseApi>` instead of the previous `DeploymentActionResponseApi`.

## Publish to changelog?

no


Decisions worth flagging.

* Targets the `events` table, not the dedicated OTEL `logs` ClickHouse table used by the Logs product. The deployments spec explicitly chooses this path. The alternative Logs ingest contract is documented as a future swap.
* `has_more` uses the `LIMIT + 1` trick instead of `len(rows) == LOGS_ROW_LIMIT`. The simpler comparison lies at exactly the cap (1000 lines reports `has_more=true`). A code review pass flagged this and the fix is included in this PR.
* Cursor pagination is deferred. The `has_more` field reserves protocol space so a follow up can add `?before_timestamp=` without breaking the response shape.
* Reuses `get_object()` for team, project, and RBAC scoping. `execute_hogql_query` adds its own `team_id` filter via `HogQLContext` (`posthog/hogql/query.py:273`), so cross tenant leakage is structurally prevented even on a spoofed URL.
* The `$log_line` property key follows PostHog convention of `$` prefixing system emitted properties (e.g. `$exception_message`, `$lib`). If the build runner team prefers `message` or `body`, the schema accepts a rename in one place.
