### PR TITLE
fix(tasks): Treat canceling seats as currently active in best-plan picker

### DIFF
--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -30,7 +30,10 @@ PRO_PLAN_PREFIXES = ("posthog-code-200", "posthog-code-pro-")
 def _seat_priority(seat: dict[str, Any]) -> tuple[bool, int, float]:
     # Tuple comparison: active (True > False) first, then tier, then
     # earliest created_at wins ties (oldest seat is the stable pick).
-    active = seat.get("status") == "active"
+    # `canceling` is treated as currently active because the seat is still in
+    # effect until its `active_until` timestamp (notably during the alpha→free
+    # migration window where alpha seats are flipped to `canceling`).
+    active = seat.get("status") in ("active", "canceling")
     plan_key = seat.get("plan_key") or ""
     created_at = seat.get("created_at") or ""
     try:

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -500,6 +500,25 @@ class TestSeatAPIBestPlan(BaseSeatAPITest):
 
     @patch("products.tasks.backend.seat_api.requests.request")
     @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_canceling_pro_beats_active_free(self, _mock_token, mock_request, _mock_license):
+        canceling_pro = {
+            **MOCK_PRO_SEAT,
+            "status": "canceling",
+            "id": "seat_canceling_pro",
+            "active_until": "2026-06-04T00:00:00Z",
+        }
+        mock_request.side_effect = [
+            _billing_response({"seat": canceling_pro}),
+            _billing_response({"seat": MOCK_FREE_SEAT}),
+        ]
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["plan_key"] == MOCK_PRO_SEAT["plan_key"]
+        assert response.json()["status"] == "canceling"
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
     def test_future_exception_handled_gracefully(self, _mock_token, mock_request, _mock_license):
         mock_request.side_effect = [
             RuntimeError("connection reset"),


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Alpha plan users were getting downgraded to a free seat from another org because canceling was treated as inactive in the best-plan selection, even though the alpha seat is still in effect until the migration date (June 4, 2026).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

1\. Treat canceling status as currently active in _seat_priority  
2\. Add regression test asserting a canceling pro seat outranks an active free seat from another org

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->