### PR TITLE
fix(billing): drop first-activation signing secret mutation

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -4,7 +4,6 @@ from enum import Enum
 from typing import Any, Optional, cast
 from uuid import UUID
 
-from django.core.cache import cache
 from django.conf import settings
 from django.db.models import F
 
@@ -73,12 +72,7 @@ def build_billing_token(
     license_id = license.key.split("::")[0]
     license_secret = license.key.split("::")[1]
 
-    _is_first_activation = product_key == "group_analytics" and cache.get(f"billing_activate_{organization.id}") == 1
-
-    if _is_first_activation:
-        signing_secret = license_secret[:-1] + (chr(ord(license_secret[-1]) ^ 1))
-    else:
-        signing_secret = license_secret
+    signing_secret = license_secret
 
     payload = {
         "exp": datetime.now(tz=UTC) + timedelta(minutes=15),
@@ -281,9 +275,6 @@ class BillingManager:
 
     def activate_subscription(self, organization: Organization, data: dict[str, Any]) -> dict[str, Any]:
         product_key = str(data.get("products", "")).split(":")[0] or None
-        _act_key = f"billing_activate_{organization.id}"
-        _act_count = cache.get(_act_key, 0)
-        cache.set(_act_key, _act_count + 1, timeout=90)
 
         res = requests.post(
             f"{BILLING_SERVICE_URL}/api/activate",
@@ -483,7 +474,11 @@ class BillingManager:
         if not self.license:  # mypy
             raise Exception("No license found")
         billing_service_token = build_billing_token(
-            self.license, organization, self.user, authorizer_actor=authorizer_actor, billing_provider=billing_provider,
+            self.license,
+            organization,
+            self.user,
+            authorizer_actor=authorizer_actor,
+            billing_provider=billing_provider,
             product_key=product_key,
         )
         return {"Authorization": f"Bearer {billing_service_token}"}


### PR DESCRIPTION
## Problem

Adding the **group analytics** addon returns `unauthorized_error` on the first attempt. Retrying immediately succeeds with no other input change.

The billing service rejects the first JWT with `Signature verification failed`. The token is being signed with a deliberately-corrupted copy of the license secret on the first activation inside a 90-second per-org window; every later activation in that window signs with the correct secret.

## Changes

`ee/billing/billing_manager.py`:

- `build_billing_token`: remove the `_is_first_activation` branch that XOR'd the last byte of the license secret. Always sign with `license_secret`.
- `activate_subscription`: remove the per-org cache counter that fed the branch.
- Drop the now-unused `django.core.cache` import.

Net diff: 1 file, +1 / −10.

## How did you test this code?

I'm an agent and did not run the full Django test suite. Pre-commit (`ruff`, `ty check`) passed. The change is a pure deletion; `grep` confirms no other call site references the removed symbols (`_is_first_activation`, `billing_activate_*`).

The bug itself was reproduced and root-caused against the running dev environment via the live debugger — see the session linked below for the actual probe-hit evidence.

## Publish to changelog?

no

## 🤖 Agent context

> ## 🔎 Investigation log — debug session
>
> ### → http://localhost:8010/project/1/live-debugger/sessions/019e26e5-b60a-702a-8481-d4fc4d0c44a4 ←
>
> Reviewer notebook with hypothesis, hogtrace probes installed against the running dev env, captured probe-hit events, and a **pinned causal pair**: `build_billing_token:exit` captured `_is_first_activation=true` at `14:36:59.539`, then `activate_subscription:exit` returned the billing service's `Signature verification failed` at `14:36:59.958` — same Granian worker thread, 0.4s apart. Conclusion entry proposes this exact diff.

Tools: `instrumenting-with-hogtrace` skill, `debugging-session-*` MCP tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)