### PR TITLE
feat(experiments/mcp): Expose shared metric tools via MCP

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -47,6 +47,27 @@ class ExperimentSavedMetricSerializer(
     UserAccessControlSerializerMixin, TaggedItemSerializerMixin, serializers.ModelSerializer
 ):
     created_by = UserBasicSerializer(read_only=True)
+    name = serializers.CharField(
+        max_length=400,
+        help_text="Name of the shared metric. Must be unique within the project (case-insensitive).",
+    )
+    description = serializers.CharField(
+        max_length=400,
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="Short description of what the metric measures.",
+    )
+    query = serializers.JSONField(
+        help_text=(
+            "ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: "
+            "'mean' (set source to an EventsNode with an event name), "
+            "'funnel' (set series to an array of EventsNode steps), "
+            "'ratio' (set numerator and denominator EventsNode entries), or "
+            "'retention' (set start_event and completion_event). "
+            "Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics."
+        ),
+    )
 
     class Meta:
         model = ExperimentSavedMetric

--- a/ee/hogai/eval/sandboxed/experiments/eval_shared_metric_validation.py
+++ b/ee/hogai/eval/sandboxed/experiments/eval_shared_metric_validation.py
@@ -1,0 +1,70 @@
+"""Eval: agent reads a shared metric and validates it against user-stated acceptance criteria.
+
+Two cases — one where criteria match the seeded metric, one where they
+don't. Agent must (1) load the metric via the saved-metrics MCP tools
+and (2) reach the correct verdict citing grounded discrepancies.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ee.hogai.eval.sandboxed.base import SandboxedPrivateEval
+from ee.hogai.eval.sandboxed.config import SandboxedEvalCase
+from ee.hogai.eval.sandboxed.experiments.scorers import SharedMetricValidationVerdict
+from ee.hogai.eval.sandboxed.experiments.seeders import SHARED_METRIC_NAME, seed_shared_metric_purchase_count
+from ee.hogai.eval.sandboxed.scorers import ExitCodeZero, RequiredToolCall
+
+
+@pytest.mark.django_db
+async def eval_shared_metric_validation(sandboxed_demo_data, pytestconfig, posthog_client, mcp_mode):
+    cases: list[SandboxedEvalCase] = [
+        # Case 1: criteria match the seeded metric exactly. Agent should
+        # affirm the match and cite the event and math.
+        SandboxedEvalCase(
+            name="shared_metric_matches_criteria",
+            prompt=(
+                f"I just defined a shared experiment metric called '{SHARED_METRIC_NAME}'. "
+                "My acceptance criteria: it must count the number of `purchase_completed` "
+                "events per user (a simple total count, no revenue summing). Please load "
+                "the metric and tell me whether it matches my criteria. Be specific about "
+                "which dimensions match or don't."
+            ),
+            setup=seed_shared_metric_purchase_count,
+            expected={"shared_metric_validation_verdict": "match"},
+        ),
+        # Case 2: criteria explicitly assert a different event AND a different
+        # math/aggregation than the seeded metric. Agent should reject the
+        # match and name at least one specific discrepancy.
+        SandboxedEvalCase(
+            name="shared_metric_mismatch_criteria",
+            prompt=(
+                f"I just defined a shared experiment metric called '{SHARED_METRIC_NAME}'. "
+                "My acceptance criteria: it must sum the `revenue` property from `$purchase` "
+                "events per user (total revenue per user, not a count). Please load the "
+                "metric and tell me whether it matches my criteria. Be specific about which "
+                "dimensions match or don't."
+            ),
+            setup=seed_shared_metric_purchase_count,
+            expected={"shared_metric_validation_verdict": "mismatch"},
+        ),
+    ]
+
+    await SandboxedPrivateEval(
+        experiment_name=f"sandboxed-experiments-shared-metric-validation-{mcp_mode}",
+        cases=cases,
+        scorers=[
+            ExitCodeZero(),
+            # Agent must actually read the seeded metric — either via list
+            # (to resolve by name) or retrieve (by ID). Hallucinating a
+            # verdict without reading the metric should fail this scorer.
+            RequiredToolCall(
+                required={"experiment-saved-metrics-list", "experiment-saved-metrics-retrieve"},
+                name="loaded_shared_metric",
+            ),
+            SharedMetricValidationVerdict(),
+        ],
+        pytestconfig=pytestconfig,
+        sandboxed_demo_data=sandboxed_demo_data,
+        posthog_client=posthog_client,
+    )

--- a/ee/hogai/eval/sandboxed/experiments/scorers.py
+++ b/ee/hogai/eval/sandboxed/experiments/scorers.py
@@ -331,6 +331,79 @@ Did the agent ask the user to confirm before proceeding? Phrasings like "let me 
         )
 
 
+class SharedMetricValidationVerdict(_BinaryJudge):
+    """Binary yes/no: agent's verdict aligns with expected AND cites grounded reasons.
+
+    Opts in via ``expected={"shared_metric_validation_verdict": "match" | "mismatch"}``.
+    """
+
+    def _prepare(self, output, expected) -> dict[str, Any] | Score:
+        verdict = expected.get(self._name()) if isinstance(expected, dict) else None
+        if verdict not in {"match", "mismatch"}:
+            return Score(
+                name=self._name(), score=1.0, metadata={"skipped": True, "reason": "Not applicable to this case"}
+            )
+        if not output:
+            return Score(name=self._name(), score=0.0, metadata={"reason": "No output"})
+        last_message = output.get("last_message")
+        if not isinstance(last_message, str) or not last_message.strip():
+            return Score(name=self._name(), score=0.0, metadata={"reason": "No final assistant message"})
+        seed = output.get("seed") or {}
+        return {
+            "output": {
+                "prompt": _user_prompt(output),
+                "last_message": last_message,
+                "expected_verdict": verdict,
+                "seeded_event": seed.get("event", "(unknown)"),
+                "seeded_metric_type": seed.get("metric_type", "(unknown)"),
+                "seeded_math": seed.get("math", "(unknown)"),
+            }
+        }
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            name="shared_metric_validation_verdict",
+            prompt_template="""
+You are judging whether an agent correctly validated a shared (saved) experiment metric against a user's stated acceptance criteria.
+
+Ground truth about the seeded metric:
+- event: {{output.seeded_event}}
+- metric_type: {{output.seeded_metric_type}}
+- math (aggregation): {{output.seeded_math}}
+- no filters, no breakdown
+
+Expected verdict for this case: **{{output.expected_verdict}}** (either "match" or "mismatch").
+
+User's prompt:
+<prompt>
+{{output.prompt}}
+</prompt>
+
+Agent's final message:
+<final_message>
+{{output.last_message}}
+</final_message>
+
+Score `yes` only if BOTH of the following hold:
+
+1. The agent's verdict aligns with the expected verdict.
+   - For "match": the agent must affirm the metric matches the criteria.
+   - For "mismatch": the agent must reject the match.
+2. The reasons cited by the agent are grounded in the ground truth above (not invented).
+   - For "match": the agent should reference the seeded event AND either metric_type or math.
+   - For "mismatch": the agent must name at least one specific discrepancy that actually exists between the criteria and the ground truth (e.g. wrong event, wrong math, wrong metric_type). Generic disapproval ("looks off") without naming the discrepancy does NOT qualify.
+
+Score `no` for: hallucinated discrepancies on a match case, vague approval on a mismatch case, asking a clarifying question instead of producing a verdict, or producing a verdict that contradicts the ground truth.
+
+Answer `yes` or `no`.
+""".strip(),
+            choice_scores=BINARY_CHOICE_SCORES,
+            model=_JUDGE_MODEL,
+            max_completion_tokens=256,
+            **kwargs,
+        )
+
+
 class RecommendsShipVariant(_BinaryJudge):
     """Binary yes/no: in a 'clear winner' scenario, did the agent recommend ship-variant (not end)?"""
 

--- a/ee/hogai/eval/sandboxed/experiments/seeders.py
+++ b/ee/hogai/eval/sandboxed/experiments/seeders.py
@@ -19,7 +19,13 @@ from products.tasks.backend.services.custom_prompt_internals import CustomPrompt
 logger = logging.getLogger(__name__)
 
 
-__all__ = ["seed_running_experiment", "ROLLOUT_EXPERIMENT_NAME"]
+__all__ = [
+    "ROLLOUT_EXPERIMENT_NAME",
+    "SHARED_METRIC_NAME",
+    "SHARED_METRIC_EVENT",
+    "seed_running_experiment",
+    "seed_shared_metric_purchase_count",
+]
 
 
 # Deterministic name referenced verbatim by the rollout-skill prompt so the
@@ -81,5 +87,52 @@ def seed_running_experiment(context: CustomPromptSandboxContext) -> dict[str, An
         team_id,
         experiment.id,
         flag.key,
+    )
+    return payload
+
+
+SHARED_METRIC_NAME = "purchase count per user"
+SHARED_METRIC_EVENT = "purchase_completed"
+
+
+def seed_shared_metric_purchase_count(context: CustomPromptSandboxContext) -> dict[str, Any]:
+    """Seed one shared metric: mean count of purchase_completed per user, no filters."""
+    from products.experiments.backend.models.experiment import ExperimentSavedMetric
+
+    team_id = context.team_id
+    user_id = context.user_id
+
+    query = {
+        "kind": "ExperimentMetric",
+        "metric_type": "mean",
+        "source": {
+            "kind": "EventsNode",
+            "event": SHARED_METRIC_EVENT,
+            "math": "total",
+        },
+        "uuid": str(uuid.uuid4()),
+    }
+
+    metric = ExperimentSavedMetric.objects.create(
+        team_id=team_id,
+        created_by_id=user_id,
+        name=SHARED_METRIC_NAME,
+        description="Counts purchase_completed events per user.",
+        query=query,
+    )
+
+    payload: dict[str, Any] = {
+        "saved_metric_id": metric.id,
+        "saved_metric_name": metric.name,
+        "event": SHARED_METRIC_EVENT,
+        "metric_type": "mean",
+        "math": "total",
+    }
+    logger.info(
+        "Seeded shared metric for team_id=%s: id=%s name=%s event=%s",
+        team_id,
+        metric.id,
+        metric.name,
+        SHARED_METRIC_EVENT,
     )
     return payload

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -106,13 +106,18 @@ export interface PatchedExperimentHoldoutApi {
  */
 export interface ExperimentSavedMetricApi {
     readonly id: number
-    /** @maxLength 400 */
+    /**
+     * Name of the shared metric. Must be unique within the project (case-insensitive).
+     * @maxLength 400
+     */
     name: string
     /**
+     * Short description of what the metric measures.
      * @maxLength 400
      * @nullable
      */
     description?: string | null
+    /** ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics. */
     query: unknown
     readonly created_by: UserBasicApi
     readonly created_at: string
@@ -139,13 +144,18 @@ export interface PaginatedExperimentSavedMetricListApi {
  */
 export interface PatchedExperimentSavedMetricApi {
     readonly id?: number
-    /** @maxLength 400 */
+    /**
+     * Name of the shared metric. Must be unique within the project (case-insensitive).
+     * @maxLength 400
+     */
     name?: string
     /**
+     * Short description of what the metric measures.
      * @maxLength 400
      * @nullable
      */
     description?: string | null
+    /** ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics. */
     query?: unknown
     readonly created_by?: UserBasicApi
     readonly created_at?: string

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -45,9 +45,20 @@ export const experimentSavedMetricsCreateBodyDescriptionMax = 400
 
 export const ExperimentSavedMetricsCreateBody = /* @__PURE__ */ zod
     .object({
-        name: zod.string().max(experimentSavedMetricsCreateBodyNameMax),
-        description: zod.string().max(experimentSavedMetricsCreateBodyDescriptionMax).nullish(),
-        query: zod.unknown(),
+        name: zod
+            .string()
+            .max(experimentSavedMetricsCreateBodyNameMax)
+            .describe('Name of the shared metric. Must be unique within the project (case-insensitive).'),
+        description: zod
+            .string()
+            .max(experimentSavedMetricsCreateBodyDescriptionMax)
+            .nullish()
+            .describe('Short description of what the metric measures.'),
+        query: zod
+            .unknown()
+            .describe(
+                "ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics."
+            ),
         tags: zod.array(zod.unknown()).optional(),
     })
     .describe('Mixin for serializers to add user access control fields')
@@ -58,9 +69,20 @@ export const experimentSavedMetricsUpdateBodyDescriptionMax = 400
 
 export const ExperimentSavedMetricsUpdateBody = /* @__PURE__ */ zod
     .object({
-        name: zod.string().max(experimentSavedMetricsUpdateBodyNameMax),
-        description: zod.string().max(experimentSavedMetricsUpdateBodyDescriptionMax).nullish(),
-        query: zod.unknown(),
+        name: zod
+            .string()
+            .max(experimentSavedMetricsUpdateBodyNameMax)
+            .describe('Name of the shared metric. Must be unique within the project (case-insensitive).'),
+        description: zod
+            .string()
+            .max(experimentSavedMetricsUpdateBodyDescriptionMax)
+            .nullish()
+            .describe('Short description of what the metric measures.'),
+        query: zod
+            .unknown()
+            .describe(
+                "ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics."
+            ),
         tags: zod.array(zod.unknown()).optional(),
     })
     .describe('Mixin for serializers to add user access control fields')
@@ -71,9 +93,22 @@ export const experimentSavedMetricsPartialUpdateBodyDescriptionMax = 400
 
 export const ExperimentSavedMetricsPartialUpdateBody = /* @__PURE__ */ zod
     .object({
-        name: zod.string().max(experimentSavedMetricsPartialUpdateBodyNameMax).optional(),
-        description: zod.string().max(experimentSavedMetricsPartialUpdateBodyDescriptionMax).nullish(),
-        query: zod.unknown().optional(),
+        name: zod
+            .string()
+            .max(experimentSavedMetricsPartialUpdateBodyNameMax)
+            .optional()
+            .describe('Name of the shared metric. Must be unique within the project (case-insensitive).'),
+        description: zod
+            .string()
+            .max(experimentSavedMetricsPartialUpdateBodyDescriptionMax)
+            .nullish()
+            .describe('Short description of what the metric measures.'),
+        query: zod
+            .unknown()
+            .optional()
+            .describe(
+                "ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics."
+            ),
         tags: zod.array(zod.unknown()).optional(),
     })
     .describe('Mixin for serializers to add user access control fields')

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -412,19 +412,124 @@ tools:
         ui_app: experiment
     experiment-saved-metrics-create:
         operation: experiment_saved_metrics_create
-        enabled: false
+        enabled: true
+        scopes:
+            - experiment_saved_metric:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create shared experiment metric
+        description: >
+            Create a reusable shared metric (also called "saved metric") that can be attached to multiple experiments.
+            Requires name (unique per project, case-insensitive) and query (an ExperimentMetric JSON with metric_type of
+            'mean', 'funnel', 'ratio', or 'retention'). Optional: description, tags.
+
+
+            The query shape mirrors per-experiment metrics — load the configuring-experiment-analytics skill before
+            constructing one, and call read-data-schema to confirm any event names referenced. Legacy kinds
+            (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics — always use
+            kind='ExperimentMetric'.
+
+
+            To attach a created shared metric to an experiment, call experiment-update with saved_metrics_ids: each item
+            has 'id' (the shared metric ID returned here) and 'metadata' with 'type' ('primary' or 'secondary').
     experiment-saved-metrics-destroy:
         operation: experiment_saved_metrics_destroy
-        enabled: false
+        enabled: true
+        scopes:
+            - experiment_saved_metric:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Delete shared experiment metric
+        description: >
+            Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — always confirm by name before deleting,
+            and warn the user that any experiments currently using this shared metric will lose access to it. Use
+            experiment-saved-metrics-list to find the ID first if you don't have it.
+        param_overrides:
+            id:
+                cast: string-int
+        response:
+            include:
+                - id
+                - name
     experiment-saved-metrics-list:
         operation: experiment_saved_metrics_list
-        enabled: false
+        enabled: true
+        scopes:
+            - experiment_saved_metric:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List shared experiment metrics
+        description: >
+            List all shared (saved) experiment metrics in the current project. Shared metrics are reusable metric
+            definitions that can be attached to multiple experiments — distinct from per-experiment metrics, which live
+            inline on a single experiment and can be inspected via experiment-get.
+
+
+            Returns paginated results with each metric's id, name, description, query JSON, created_by, created_at,
+            updated_at, and tags. Use experiment-saved-metrics-retrieve for the full query of a single metric, or use
+            this listing to resolve a metric by name.
+        param_overrides:
+            limit:
+                cast: string-int
+            offset:
+                cast: string-int
+        response:
+            include:
+                - id
+                - name
+                - description
+                - query
+                - created_at
+                - updated_at
+                - tags
     experiment-saved-metrics-partial-update:
         operation: experiment_saved_metrics_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - experiment_saved_metric:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Update shared experiment metric
+        description: >
+            Partially update a shared metric by ID. Only name, description, and query can be changed — other fields are
+            rejected. Editing a shared metric affects every experiment that has it attached, so REQUIRES EXPLICIT USER
+            CONFIRMATION before changing query or name on a metric attached to running experiments.
+
+
+            Legacy-format saved metrics (kind=ExperimentTrendsQuery / ExperimentFunnelsQuery) cannot be updated — the
+            user must create a new shared metric using kind='ExperimentMetric'.
+        param_overrides:
+            id:
+                cast: string-int
     experiment-saved-metrics-retrieve:
         operation: experiment_saved_metrics_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - experiment_saved_metric:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get shared experiment metric
+        description: >
+            Get a single shared (saved) experiment metric by ID. Returns the full metric including its query JSON
+            (metric_type, source events/properties, filters, math, etc.) — use this when validating a shared metric
+            against user-stated acceptance criteria or when explaining what a metric measures.
+
+
+            If you don't have the ID, call experiment-saved-metrics-list first to resolve by name.
+        param_overrides:
+            id:
+                cast: string-int
     experiment-saved-metrics-update:
         operation: experiment_saved_metrics_update
         enabled: false

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -421,19 +421,17 @@ tools:
             idempotent: false
         title: Create shared experiment metric
         description: >
-            Create a reusable shared metric (also called "saved metric") that can be attached to multiple experiments.
-            Requires name (unique per project, case-insensitive) and query (an ExperimentMetric JSON with metric_type of
-            'mean', 'funnel', 'ratio', or 'retention'). Optional: description, tags.
+            Create a reusable shared metric. Requires name (unique per project, case-insensitive) and query
+            (kind='ExperimentMetric', metric_type one of 'mean', 'funnel', 'ratio', 'retention'). Optional:
+            description, tags.
 
 
-            The query shape mirrors per-experiment metrics — load the configuring-experiment-analytics skill before
-            constructing one, and call read-data-schema to confirm any event names referenced. Legacy kinds
-            (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics — always use
-            kind='ExperimentMetric'.
+            Load the configuring-experiment-analytics skill before constructing the query, and use read-data-schema
+            to confirm event names. Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected.
 
 
-            To attach a created shared metric to an experiment, call experiment-update with saved_metrics_ids: each item
-            has 'id' (the shared metric ID returned here) and 'metadata' with 'type' ('primary' or 'secondary').
+            To attach to an experiment, call experiment-update with saved_metrics_ids — each item has 'id' and
+            'metadata.type' ('primary' or 'secondary').
     experiment-saved-metrics-destroy:
         operation: experiment_saved_metrics_destroy
         enabled: true
@@ -445,9 +443,8 @@ tools:
             idempotent: true
         title: Delete shared experiment metric
         description: >
-            Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — always confirm by name before deleting,
-            and warn the user that any experiments currently using this shared metric will lose access to it. Use
-            experiment-saved-metrics-list to find the ID first if you don't have it.
+            Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — confirm by name first, and warn
+            that any experiments using it will lose access.
         param_overrides:
             id:
                 cast: string-int
@@ -467,14 +464,9 @@ tools:
         list: true
         title: List shared experiment metrics
         description: >
-            List all shared (saved) experiment metrics in the current project. Shared metrics are reusable metric
-            definitions that can be attached to multiple experiments — distinct from per-experiment metrics, which live
-            inline on a single experiment and can be inspected via experiment-get.
-
-
-            Returns paginated results with each metric's id, name, description, query JSON, created_by, created_at,
-            updated_at, and tags. Use experiment-saved-metrics-retrieve for the full query of a single metric, or use
-            this listing to resolve a metric by name.
+            List shared metrics in the current project. Returns paginated results with id, name, description,
+            query, created_at, updated_at, tags. Use experiment-saved-metrics-retrieve for a single metric by ID,
+            or this listing to resolve by name.
         param_overrides:
             limit:
                 cast: string-int
@@ -500,13 +492,12 @@ tools:
             idempotent: true
         title: Update shared experiment metric
         description: >
-            Partially update a shared metric by ID. Only name, description, and query can be changed — other fields are
-            rejected. Editing a shared metric affects every experiment that has it attached, so REQUIRES EXPLICIT USER
-            CONFIRMATION before changing query or name on a metric attached to running experiments.
+            Partially update a shared metric. Only name, description, and query are mutable. Edits propagate to every
+            experiment the metric is attached to — REQUIRES EXPLICIT USER CONFIRMATION before changing query or name
+            on a metric attached to running experiments.
 
 
-            Legacy-format saved metrics (kind=ExperimentTrendsQuery / ExperimentFunnelsQuery) cannot be updated — the
-            user must create a new shared metric using kind='ExperimentMetric'.
+            Legacy-format metrics (kind=ExperimentTrendsQuery / ExperimentFunnelsQuery) cannot be updated.
         param_overrides:
             id:
                 cast: string-int
@@ -521,12 +512,8 @@ tools:
             idempotent: true
         title: Get shared experiment metric
         description: >
-            Get a single shared (saved) experiment metric by ID. Returns the full metric including its query JSON
-            (metric_type, source events/properties, filters, math, etc.) — use this when validating a shared metric
-            against user-stated acceptance criteria or when explaining what a metric measures.
-
-
-            If you don't have the ID, call experiment-saved-metrics-list first to resolve by name.
+            Get a single shared metric by ID. Returns the full query JSON (metric_type, source, math, filters,
+            etc.). If you don't have the ID, call experiment-saved-metrics-list first.
         param_overrides:
             id:
                 cast: string-int

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -448,10 +448,6 @@ tools:
         param_overrides:
             id:
                 cast: string-int
-        response:
-            include:
-                - id
-                - name
     experiment-saved-metrics-list:
         operation: experiment_saved_metrics_list
         enabled: true

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -422,12 +422,12 @@ tools:
         title: Create shared experiment metric
         description: >
             Create a reusable shared metric. Requires name (unique per project, case-insensitive) and query
-            (kind='ExperimentMetric', metric_type one of 'mean', 'funnel', 'ratio', 'retention'). Optional:
-            description, tags.
+            (kind='ExperimentMetric', metric_type one of 'mean', 'funnel', 'ratio', 'retention'). Optional: description,
+            tags.
 
 
-            Load the configuring-experiment-analytics skill before constructing the query, and use read-data-schema
-            to confirm event names. Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected.
+            Load the configuring-experiment-analytics skill before constructing the query, and use read-data-schema to
+            confirm event names. Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected.
 
 
             To attach to an experiment, call experiment-update with saved_metrics_ids — each item has 'id' and
@@ -443,8 +443,8 @@ tools:
             idempotent: true
         title: Delete shared experiment metric
         description: >
-            Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — confirm by name first, and warn
-            that any experiments using it will lose access.
+            Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — confirm by name first, and warn that any
+            experiments using it will lose access.
         param_overrides:
             id:
                 cast: string-int
@@ -464,9 +464,9 @@ tools:
         list: true
         title: List shared experiment metrics
         description: >
-            List shared metrics in the current project. Returns paginated results with id, name, description,
-            query, created_at, updated_at, tags. Use experiment-saved-metrics-retrieve for a single metric by ID,
-            or this listing to resolve by name.
+            List shared metrics in the current project. Returns paginated results with id, name, description, query,
+            created_at, updated_at, tags. Use experiment-saved-metrics-retrieve for a single metric by ID, or this
+            listing to resolve by name.
         param_overrides:
             limit:
                 cast: string-int
@@ -493,8 +493,8 @@ tools:
         title: Update shared experiment metric
         description: >
             Partially update a shared metric. Only name, description, and query are mutable. Edits propagate to every
-            experiment the metric is attached to — REQUIRES EXPLICIT USER CONFIRMATION before changing query or name
-            on a metric attached to running experiments.
+            experiment the metric is attached to — REQUIRES EXPLICIT USER CONFIRMATION before changing query or name on
+            a metric attached to running experiments.
 
 
             Legacy-format metrics (kind=ExperimentTrendsQuery / ExperimentFunnelsQuery) cannot be updated.
@@ -512,8 +512,8 @@ tools:
             idempotent: true
         title: Get shared experiment metric
         description: >
-            Get a single shared metric by ID. Returns the full query JSON (metric_type, source, math, filters,
-            etc.). If you don't have the ID, call experiment-saved-metrics-list first.
+            Get a single shared metric by ID. Returns the full query JSON (metric_type, source, math, filters, etc.). If
+            you don't have the ID, call experiment-saved-metrics-list first.
         param_overrides:
             id:
                 cast: string-int

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1595,6 +1595,81 @@
             "readOnlyHint": false
         }
     },
+    "experiment-saved-metrics-create": {
+        "description": "Create a reusable shared metric (also called \"saved metric\") that can be attached to multiple experiments. Requires name (unique per project, case-insensitive) and query (an ExperimentMetric JSON with metric_type of 'mean', 'funnel', 'ratio', or 'retention'). Optional: description, tags.\n\nThe query shape mirrors per-experiment metrics — load the configuring-experiment-analytics skill before constructing one, and call read-data-schema to confirm any event names referenced. Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics — always use kind='ExperimentMetric'.\n\nTo attach a created shared metric to an experiment, call experiment-update with saved_metrics_ids: each item has 'id' (the shared metric ID returned here) and 'metadata' with 'type' ('primary' or 'secondary').",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "Create shared experiment metric",
+        "title": "Create shared experiment metric",
+        "required_scopes": ["experiment_saved_metric:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "experiment-saved-metrics-destroy": {
+        "description": "Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — always confirm by name before deleting, and warn the user that any experiments currently using this shared metric will lose access to it. Use experiment-saved-metrics-list to find the ID first if you don't have it.",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "Delete shared experiment metric",
+        "title": "Delete shared experiment metric",
+        "required_scopes": ["experiment_saved_metric:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "experiment-saved-metrics-list": {
+        "description": "List all shared (saved) experiment metrics in the current project. Shared metrics are reusable metric definitions that can be attached to multiple experiments — distinct from per-experiment metrics, which live inline on a single experiment and can be inspected via experiment-get.\n\nReturns paginated results with each metric's id, name, description, query JSON, created_by, created_at, updated_at, and tags. Use experiment-saved-metrics-retrieve for the full query of a single metric, or use this listing to resolve a metric by name.",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "List shared experiment metrics",
+        "title": "List shared experiment metrics",
+        "required_scopes": ["experiment_saved_metric:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "experiment-saved-metrics-partial-update": {
+        "description": "Partially update a shared metric by ID. Only name, description, and query can be changed — other fields are rejected. Editing a shared metric affects every experiment that has it attached, so REQUIRES EXPLICIT USER CONFIRMATION before changing query or name on a metric attached to running experiments.\n\nLegacy-format saved metrics (kind=ExperimentTrendsQuery / ExperimentFunnelsQuery) cannot be updated — the user must create a new shared metric using kind='ExperimentMetric'.",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "Update shared experiment metric",
+        "title": "Update shared experiment metric",
+        "required_scopes": ["experiment_saved_metric:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "experiment-saved-metrics-retrieve": {
+        "description": "Get a single shared (saved) experiment metric by ID. Returns the full metric including its query JSON (metric_type, source events/properties, filters, math, etc.) — use this when validating a shared metric against user-stated acceptance criteria or when explaining what a metric measures.\n\nIf you don't have the ID, call experiment-saved-metrics-list first to resolve by name.",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "Get shared experiment metric",
+        "title": "Get shared experiment metric",
+        "required_scopes": ["experiment_saved_metric:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "experiment-ship-variant": {
         "description": "Requires an experiment ID. If you don't have the ID, load the finding-experiments skill to resolve the user's reference first. Load the managing-experiment-lifecycle skill for preconditions and side effects.\n\nREQUIRES EXPLICIT USER CONFIRMATION BEFORE CALLING. This permanently rewrites the feature flag for 100% of users and cannot be undone via the API. Even when the user has asked you to ship a specific variant, ask them to confirm with the variant key and target experiment before invoking this tool.\n\nShip a variant to 100% of users by rewriting the feature flag. Requires variant_key — the key of the variant to ship (e.g. \"test\" or \"control\"). The flag is rewritten so the selected variant gets 100% rollout via a new catch-all release group prepended to existing groups (preserved for rollback).\n\nCan be called on both running and stopped experiments. If the experiment is still running, it is also ended (end_date set, status becomes stopped). If already stopped, only the flag is rewritten — supports the \"end first, ship later\" workflow.\n\nOptionally provide conclusion (\"won\", \"lost\", \"inconclusive\", \"stopped_early\", \"invalid\") and conclusion_comment.\n\nReturns 400 if: experiment is in draft (\"Experiment has not been launched yet.\"), variant_key not found on the flag, or no linked feature flag. Returns 409 if an approval policy requires review before the flag change takes effect — includes a change_request_id in the response.",
         "category": "Experiments",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1596,7 +1596,7 @@
         }
     },
     "experiment-saved-metrics-create": {
-        "description": "Create a reusable shared metric (also called \"saved metric\") that can be attached to multiple experiments. Requires name (unique per project, case-insensitive) and query (an ExperimentMetric JSON with metric_type of 'mean', 'funnel', 'ratio', or 'retention'). Optional: description, tags.\n\nThe query shape mirrors per-experiment metrics — load the configuring-experiment-analytics skill before constructing one, and call read-data-schema to confirm any event names referenced. Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics — always use kind='ExperimentMetric'.\n\nTo attach a created shared metric to an experiment, call experiment-update with saved_metrics_ids: each item has 'id' (the shared metric ID returned here) and 'metadata' with 'type' ('primary' or 'secondary').",
+        "description": "Create a reusable shared metric. Requires name (unique per project, case-insensitive) and query (kind='ExperimentMetric', metric_type one of 'mean', 'funnel', 'ratio', 'retention'). Optional: description, tags.\n\nLoad the configuring-experiment-analytics skill before constructing the query, and use read-data-schema to confirm event names. Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected.\n\nTo attach to an experiment, call experiment-update with saved_metrics_ids — each item has 'id' and 'metadata.type' ('primary' or 'secondary').",
         "category": "Experiments",
         "feature": "experiments",
         "summary": "Create shared experiment metric",
@@ -1611,7 +1611,7 @@
         }
     },
     "experiment-saved-metrics-destroy": {
-        "description": "Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — always confirm by name before deleting, and warn the user that any experiments currently using this shared metric will lose access to it. Use experiment-saved-metrics-list to find the ID first if you don't have it.",
+        "description": "Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — confirm by name first, and warn that any experiments using it will lose access.",
         "category": "Experiments",
         "feature": "experiments",
         "summary": "Delete shared experiment metric",
@@ -1626,7 +1626,7 @@
         }
     },
     "experiment-saved-metrics-list": {
-        "description": "List all shared (saved) experiment metrics in the current project. Shared metrics are reusable metric definitions that can be attached to multiple experiments — distinct from per-experiment metrics, which live inline on a single experiment and can be inspected via experiment-get.\n\nReturns paginated results with each metric's id, name, description, query JSON, created_by, created_at, updated_at, and tags. Use experiment-saved-metrics-retrieve for the full query of a single metric, or use this listing to resolve a metric by name.",
+        "description": "List shared metrics in the current project. Returns paginated results with id, name, description, query, created_at, updated_at, tags. Use experiment-saved-metrics-retrieve for a single metric by ID, or this listing to resolve by name.",
         "category": "Experiments",
         "feature": "experiments",
         "summary": "List shared experiment metrics",
@@ -1641,7 +1641,7 @@
         }
     },
     "experiment-saved-metrics-partial-update": {
-        "description": "Partially update a shared metric by ID. Only name, description, and query can be changed — other fields are rejected. Editing a shared metric affects every experiment that has it attached, so REQUIRES EXPLICIT USER CONFIRMATION before changing query or name on a metric attached to running experiments.\n\nLegacy-format saved metrics (kind=ExperimentTrendsQuery / ExperimentFunnelsQuery) cannot be updated — the user must create a new shared metric using kind='ExperimentMetric'.",
+        "description": "Partially update a shared metric. Only name, description, and query are mutable. Edits propagate to every experiment the metric is attached to — REQUIRES EXPLICIT USER CONFIRMATION before changing query or name on a metric attached to running experiments.\n\nLegacy-format metrics (kind=ExperimentTrendsQuery / ExperimentFunnelsQuery) cannot be updated.",
         "category": "Experiments",
         "feature": "experiments",
         "summary": "Update shared experiment metric",
@@ -1656,7 +1656,7 @@
         }
     },
     "experiment-saved-metrics-retrieve": {
-        "description": "Get a single shared (saved) experiment metric by ID. Returns the full metric including its query JSON (metric_type, source events/properties, filters, math, etc.) — use this when validating a shared metric against user-stated acceptance criteria or when explaining what a metric measures.\n\nIf you don't have the ID, call experiment-saved-metrics-list first to resolve by name.",
+        "description": "Get a single shared metric by ID. Returns the full query JSON (metric_type, source, math, filters, etc.). If you don't have the ID, call experiment-saved-metrics-list first.",
         "category": "Experiments",
         "feature": "experiments",
         "summary": "Get shared experiment metric",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1820,6 +1820,81 @@
             "readOnlyHint": false
         }
     },
+    "experiment-saved-metrics-create": {
+        "description": "Create a reusable shared metric (also called \"saved metric\") that can be attached to multiple experiments. Requires name (unique per project, case-insensitive) and query (an ExperimentMetric JSON with metric_type of 'mean', 'funnel', 'ratio', or 'retention'). Optional: description, tags.\n\nThe query shape mirrors per-experiment metrics — load the configuring-experiment-analytics skill before constructing one, and call read-data-schema to confirm any event names referenced. Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics — always use kind='ExperimentMetric'.\n\nTo attach a created shared metric to an experiment, call experiment-update with saved_metrics_ids: each item has 'id' (the shared metric ID returned here) and 'metadata' with 'type' ('primary' or 'secondary').",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "Create shared experiment metric",
+        "title": "Create shared experiment metric",
+        "required_scopes": ["experiment_saved_metric:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "experiment-saved-metrics-destroy": {
+        "description": "Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — always confirm by name before deleting, and warn the user that any experiments currently using this shared metric will lose access to it. Use experiment-saved-metrics-list to find the ID first if you don't have it.",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "Delete shared experiment metric",
+        "title": "Delete shared experiment metric",
+        "required_scopes": ["experiment_saved_metric:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "experiment-saved-metrics-list": {
+        "description": "List all shared (saved) experiment metrics in the current project. Shared metrics are reusable metric definitions that can be attached to multiple experiments — distinct from per-experiment metrics, which live inline on a single experiment and can be inspected via experiment-get.\n\nReturns paginated results with each metric's id, name, description, query JSON, created_by, created_at, updated_at, and tags. Use experiment-saved-metrics-retrieve for the full query of a single metric, or use this listing to resolve a metric by name.",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "List shared experiment metrics",
+        "title": "List shared experiment metrics",
+        "required_scopes": ["experiment_saved_metric:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "experiment-saved-metrics-partial-update": {
+        "description": "Partially update a shared metric by ID. Only name, description, and query can be changed — other fields are rejected. Editing a shared metric affects every experiment that has it attached, so REQUIRES EXPLICIT USER CONFIRMATION before changing query or name on a metric attached to running experiments.\n\nLegacy-format saved metrics (kind=ExperimentTrendsQuery / ExperimentFunnelsQuery) cannot be updated — the user must create a new shared metric using kind='ExperimentMetric'.",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "Update shared experiment metric",
+        "title": "Update shared experiment metric",
+        "required_scopes": ["experiment_saved_metric:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "experiment-saved-metrics-retrieve": {
+        "description": "Get a single shared (saved) experiment metric by ID. Returns the full metric including its query JSON (metric_type, source events/properties, filters, math, etc.) — use this when validating a shared metric against user-stated acceptance criteria or when explaining what a metric measures.\n\nIf you don't have the ID, call experiment-saved-metrics-list first to resolve by name.",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "Get shared experiment metric",
+        "title": "Get shared experiment metric",
+        "required_scopes": ["experiment_saved_metric:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "experiment-ship-variant": {
         "description": "Requires an experiment ID. If you don't have the ID, load the finding-experiments skill to resolve the user's reference first. Load the managing-experiment-lifecycle skill for preconditions and side effects.\n\nREQUIRES EXPLICIT USER CONFIRMATION BEFORE CALLING. This permanently rewrites the feature flag for 100% of users and cannot be undone via the API. Even when the user has asked you to ship a specific variant, ask them to confirm with the variant key and target experiment before invoking this tool.\n\nShip a variant to 100% of users by rewriting the feature flag. Requires variant_key — the key of the variant to ship (e.g. \"test\" or \"control\"). The flag is rewritten so the selected variant gets 100% rollout via a new catch-all release group prepended to existing groups (preserved for rollback).\n\nCan be called on both running and stopped experiments. If the experiment is still running, it is also ended (end_date set, status becomes stopped). If already stopped, only the flag is rewritten — supports the \"end first, ship later\" workflow.\n\nOptionally provide conclusion (\"won\", \"lost\", \"inconclusive\", \"stopped_early\", \"invalid\") and conclusion_comment.\n\nReturns 400 if: experiment is in draft (\"Experiment has not been launched yet.\"), variant_key not found on the flag, or no linked feature flag. Returns 409 if an approval policy requires review before the flag change takes effect — includes a change_request_id in the response.",
         "category": "Experiments",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1821,7 +1821,7 @@
         }
     },
     "experiment-saved-metrics-create": {
-        "description": "Create a reusable shared metric (also called \"saved metric\") that can be attached to multiple experiments. Requires name (unique per project, case-insensitive) and query (an ExperimentMetric JSON with metric_type of 'mean', 'funnel', 'ratio', or 'retention'). Optional: description, tags.\n\nThe query shape mirrors per-experiment metrics — load the configuring-experiment-analytics skill before constructing one, and call read-data-schema to confirm any event names referenced. Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics — always use kind='ExperimentMetric'.\n\nTo attach a created shared metric to an experiment, call experiment-update with saved_metrics_ids: each item has 'id' (the shared metric ID returned here) and 'metadata' with 'type' ('primary' or 'secondary').",
+        "description": "Create a reusable shared metric. Requires name (unique per project, case-insensitive) and query (kind='ExperimentMetric', metric_type one of 'mean', 'funnel', 'ratio', 'retention'). Optional: description, tags.\n\nLoad the configuring-experiment-analytics skill before constructing the query, and use read-data-schema to confirm event names. Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected.\n\nTo attach to an experiment, call experiment-update with saved_metrics_ids — each item has 'id' and 'metadata.type' ('primary' or 'secondary').",
         "category": "Experiments",
         "feature": "experiments",
         "summary": "Create shared experiment metric",
@@ -1836,7 +1836,7 @@
         }
     },
     "experiment-saved-metrics-destroy": {
-        "description": "Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — always confirm by name before deleting, and warn the user that any experiments currently using this shared metric will lose access to it. Use experiment-saved-metrics-list to find the ID first if you don't have it.",
+        "description": "Delete a shared metric by ID. REQUIRES EXPLICIT USER CONFIRMATION — confirm by name first, and warn that any experiments using it will lose access.",
         "category": "Experiments",
         "feature": "experiments",
         "summary": "Delete shared experiment metric",
@@ -1851,7 +1851,7 @@
         }
     },
     "experiment-saved-metrics-list": {
-        "description": "List all shared (saved) experiment metrics in the current project. Shared metrics are reusable metric definitions that can be attached to multiple experiments — distinct from per-experiment metrics, which live inline on a single experiment and can be inspected via experiment-get.\n\nReturns paginated results with each metric's id, name, description, query JSON, created_by, created_at, updated_at, and tags. Use experiment-saved-metrics-retrieve for the full query of a single metric, or use this listing to resolve a metric by name.",
+        "description": "List shared metrics in the current project. Returns paginated results with id, name, description, query, created_at, updated_at, tags. Use experiment-saved-metrics-retrieve for a single metric by ID, or this listing to resolve by name.",
         "category": "Experiments",
         "feature": "experiments",
         "summary": "List shared experiment metrics",
@@ -1866,7 +1866,7 @@
         }
     },
     "experiment-saved-metrics-partial-update": {
-        "description": "Partially update a shared metric by ID. Only name, description, and query can be changed — other fields are rejected. Editing a shared metric affects every experiment that has it attached, so REQUIRES EXPLICIT USER CONFIRMATION before changing query or name on a metric attached to running experiments.\n\nLegacy-format saved metrics (kind=ExperimentTrendsQuery / ExperimentFunnelsQuery) cannot be updated — the user must create a new shared metric using kind='ExperimentMetric'.",
+        "description": "Partially update a shared metric. Only name, description, and query are mutable. Edits propagate to every experiment the metric is attached to — REQUIRES EXPLICIT USER CONFIRMATION before changing query or name on a metric attached to running experiments.\n\nLegacy-format metrics (kind=ExperimentTrendsQuery / ExperimentFunnelsQuery) cannot be updated.",
         "category": "Experiments",
         "feature": "experiments",
         "summary": "Update shared experiment metric",
@@ -1881,7 +1881,7 @@
         }
     },
     "experiment-saved-metrics-retrieve": {
-        "description": "Get a single shared (saved) experiment metric by ID. Returns the full metric including its query JSON (metric_type, source events/properties, filters, math, etc.) — use this when validating a shared metric against user-stated acceptance criteria or when explaining what a metric measures.\n\nIf you don't have the ID, call experiment-saved-metrics-list first to resolve by name.",
+        "description": "Get a single shared metric by ID. Returns the full query JSON (metric_type, source, math, filters, etc.). If you don't have the ID, call experiment-saved-metrics-list first.",
         "category": "Experiments",
         "feature": "experiments",
         "summary": "Get shared experiment metric",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -15432,13 +15432,18 @@ export namespace Schemas {
      */
     export interface ExperimentSavedMetric {
       readonly id: number;
-      /** @maxLength 400 */
+      /**
+         * Name of the shared metric. Must be unique within the project (case-insensitive).
+         * @maxLength 400
+         */
       name: string;
       /**
+         * Short description of what the metric measures.
          * @maxLength 400
          * @nullable
          */
       description?: string | null;
+      /** ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics. */
       query: unknown;
       readonly created_by: UserBasic;
       readonly created_at: string;
@@ -26494,13 +26499,18 @@ export namespace Schemas {
      */
     export interface PatchedExperimentSavedMetric {
       readonly id?: number;
-      /** @maxLength 400 */
+      /**
+         * Name of the shared metric. Must be unique within the project (case-insensitive).
+         * @maxLength 400
+         */
       name?: string;
       /**
+         * Short description of what the metric measures.
          * @maxLength 400
          * @nullable
          */
       description?: string | null;
+      /** ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics. */
       query?: unknown;
       readonly created_by?: UserBasic;
       readonly created_at?: string;

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -3,10 +3,108 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 16 enabled ops
+ * PostHog API - MCP 21 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
+
+export const ExperimentSavedMetricsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const ExperimentSavedMetricsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+export const ExperimentSavedMetricsCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const experimentSavedMetricsCreateBodyNameMax = 400
+
+export const experimentSavedMetricsCreateBodyDescriptionMax = 400
+
+export const ExperimentSavedMetricsCreateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .max(experimentSavedMetricsCreateBodyNameMax)
+            .describe('Name of the shared metric. Must be unique within the project (case-insensitive).'),
+        description: zod
+            .string()
+            .max(experimentSavedMetricsCreateBodyDescriptionMax)
+            .nullish()
+            .describe('Short description of what the metric measures.'),
+        query: zod
+            .unknown()
+            .describe(
+                "ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics."
+            ),
+        tags: zod.array(zod.unknown()).optional(),
+    })
+    .describe('Mixin for serializers to add user access control fields')
+
+export const ExperimentSavedMetricsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this experiment saved metric.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const ExperimentSavedMetricsPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this experiment saved metric.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const experimentSavedMetricsPartialUpdateBodyNameMax = 400
+
+export const experimentSavedMetricsPartialUpdateBodyDescriptionMax = 400
+
+export const ExperimentSavedMetricsPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .max(experimentSavedMetricsPartialUpdateBodyNameMax)
+            .optional()
+            .describe('Name of the shared metric. Must be unique within the project (case-insensitive).'),
+        description: zod
+            .string()
+            .max(experimentSavedMetricsPartialUpdateBodyDescriptionMax)
+            .nullish()
+            .describe('Short description of what the metric measures.'),
+        query: zod
+            .unknown()
+            .optional()
+            .describe(
+                "ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics."
+            ),
+        tags: zod.array(zod.unknown()).optional(),
+    })
+    .describe('Mixin for serializers to add user access control fields')
+
+export const ExperimentSavedMetricsDestroyParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this experiment saved metric.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
 
 /**
  * List experiments for the current project. Supports filtering by status and archival state.

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -453,8 +453,7 @@ const experimentSavedMetricsDestroy = (): ToolBase<typeof ExperimentSavedMetrics
             method: 'DELETE',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/experiment_saved_metrics/${encodeURIComponent(String(params.id))}/`,
         })
-        const filtered = pickResponseFields(result, ['id', 'name']) as typeof result
-        return filtered
+        return result
     },
 })
 

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -3,6 +3,12 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    ExperimentSavedMetricsCreateBody,
+    ExperimentSavedMetricsDestroyParams,
+    ExperimentSavedMetricsListQueryParams,
+    ExperimentSavedMetricsPartialUpdateBody,
+    ExperimentSavedMetricsPartialUpdateParams,
+    ExperimentSavedMetricsRetrieveParams,
     ExperimentsArchiveCreateParams,
     ExperimentsCreateBody,
     ExperimentsDestroyParams,
@@ -402,6 +408,141 @@ const experimentResume = (): ToolBase<typeof ExperimentResumeSchema, WithPostHog
         },
     })
 
+const ExperimentSavedMetricsCreateSchema = ExperimentSavedMetricsCreateBody
+
+const experimentSavedMetricsCreate = (): ToolBase<
+    typeof ExperimentSavedMetricsCreateSchema,
+    Schemas.ExperimentSavedMetric
+> => ({
+    name: 'experiment-saved-metrics-create',
+    schema: ExperimentSavedMetricsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof ExperimentSavedMetricsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        if (params.query !== undefined) {
+            body['query'] = params.query
+        }
+        if (params.tags !== undefined) {
+            body['tags'] = params.tags
+        }
+        const result = await context.api.request<Schemas.ExperimentSavedMetric>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/experiment_saved_metrics/`,
+            body,
+        })
+        return result
+    },
+})
+
+const ExperimentSavedMetricsDestroySchema = ExperimentSavedMetricsDestroyParams.omit({ project_id: true }).extend({
+    id: z.preprocess(castStringToInt, ExperimentSavedMetricsDestroyParams.shape['id']),
+})
+
+const experimentSavedMetricsDestroy = (): ToolBase<typeof ExperimentSavedMetricsDestroySchema, unknown> => ({
+    name: 'experiment-saved-metrics-destroy',
+    schema: ExperimentSavedMetricsDestroySchema,
+    handler: async (context: Context, params: z.infer<typeof ExperimentSavedMetricsDestroySchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'DELETE',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/experiment_saved_metrics/${encodeURIComponent(String(params.id))}/`,
+        })
+        const filtered = pickResponseFields(result, ['id', 'name']) as typeof result
+        return filtered
+    },
+})
+
+const ExperimentSavedMetricsListSchema = ExperimentSavedMetricsListQueryParams.extend({
+    limit: z.preprocess(castStringToInt, ExperimentSavedMetricsListQueryParams.shape['limit']).optional(),
+    offset: z.preprocess(castStringToInt, ExperimentSavedMetricsListQueryParams.shape['offset']).optional(),
+})
+
+const experimentSavedMetricsList = (): ToolBase<
+    typeof ExperimentSavedMetricsListSchema,
+    WithPostHogUrl<Schemas.PaginatedExperimentSavedMetricList>
+> => ({
+    name: 'experiment-saved-metrics-list',
+    schema: ExperimentSavedMetricsListSchema,
+    handler: async (context: Context, params: z.infer<typeof ExperimentSavedMetricsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedExperimentSavedMetricList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/experiment_saved_metrics/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, ['id', 'name', 'description', 'query', 'created_at', 'updated_at', 'tags'])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/experiments')
+    },
+})
+
+const ExperimentSavedMetricsPartialUpdateSchema = ExperimentSavedMetricsPartialUpdateParams.omit({ project_id: true })
+    .extend(ExperimentSavedMetricsPartialUpdateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, ExperimentSavedMetricsPartialUpdateParams.shape['id']) })
+
+const experimentSavedMetricsPartialUpdate = (): ToolBase<
+    typeof ExperimentSavedMetricsPartialUpdateSchema,
+    Schemas.ExperimentSavedMetric
+> => ({
+    name: 'experiment-saved-metrics-partial-update',
+    schema: ExperimentSavedMetricsPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof ExperimentSavedMetricsPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        if (params.query !== undefined) {
+            body['query'] = params.query
+        }
+        if (params.tags !== undefined) {
+            body['tags'] = params.tags
+        }
+        const result = await context.api.request<Schemas.ExperimentSavedMetric>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/experiment_saved_metrics/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return result
+    },
+})
+
+const ExperimentSavedMetricsRetrieveSchema = ExperimentSavedMetricsRetrieveParams.omit({ project_id: true }).extend({
+    id: z.preprocess(castStringToInt, ExperimentSavedMetricsRetrieveParams.shape['id']),
+})
+
+const experimentSavedMetricsRetrieve = (): ToolBase<
+    typeof ExperimentSavedMetricsRetrieveSchema,
+    Schemas.ExperimentSavedMetric
+> => ({
+    name: 'experiment-saved-metrics-retrieve',
+    schema: ExperimentSavedMetricsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof ExperimentSavedMetricsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ExperimentSavedMetric>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/experiment_saved_metrics/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
 const ExperimentShipVariantSchema = ExperimentsShipVariantCreateParams.omit({ project_id: true })
     .extend(ExperimentsShipVariantCreateBody.shape)
     .extend({ id: z.preprocess(castStringToInt, ExperimentsShipVariantCreateParams.shape['id']) })
@@ -572,6 +713,11 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'experiment-pause': experimentPause,
     'experiment-reset': experimentReset,
     'experiment-resume': experimentResume,
+    'experiment-saved-metrics-create': experimentSavedMetricsCreate,
+    'experiment-saved-metrics-destroy': experimentSavedMetricsDestroy,
+    'experiment-saved-metrics-list': experimentSavedMetricsList,
+    'experiment-saved-metrics-partial-update': experimentSavedMetricsPartialUpdate,
+    'experiment-saved-metrics-retrieve': experimentSavedMetricsRetrieve,
     'experiment-ship-variant': experimentShipVariant,
     'experiment-stats': experimentStats,
     'experiment-timeseries-results': experimentTimeseriesResults,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-saved-metrics-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-saved-metrics-create.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Mixin for serializers to add user access control fields",
+    "properties": {
+        "description": {
+            "anyOf": [
+                {
+                    "maxLength": 400,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Short description of what the metric measures."
+        },
+        "name": {
+            "description": "Name of the shared metric. Must be unique within the project (case-insensitive).",
+            "maxLength": 400,
+            "type": "string"
+        },
+        "query": {
+            "description": "ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics."
+        },
+        "tags": {
+            "items": {},
+            "type": "array"
+        }
+    },
+    "required": ["name", "query"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-saved-metrics-destroy.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-saved-metrics-destroy.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A unique integer value identifying this experiment saved metric.",
+            "type": "number"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-saved-metrics-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-saved-metrics-list.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-saved-metrics-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-saved-metrics-partial-update.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "description": {
+            "anyOf": [
+                {
+                    "maxLength": 400,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Short description of what the metric measures."
+        },
+        "id": {
+            "description": "A unique integer value identifying this experiment saved metric.",
+            "type": "number"
+        },
+        "name": {
+            "description": "Name of the shared metric. Must be unique within the project (case-insensitive).",
+            "maxLength": 400,
+            "type": "string"
+        },
+        "query": {
+            "description": "ExperimentMetric JSON. Must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Legacy kinds (ExperimentTrendsQuery, ExperimentFunnelsQuery) are rejected for new shared metrics."
+        },
+        "tags": {
+            "items": {},
+            "type": "array"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-saved-metrics-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-saved-metrics-retrieve.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A unique integer value identifying this experiment saved metric.",
+            "type": "number"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Shared experiment metrics weren't reachable from MCP clients.

## Changes

- Expose the `experiment_saved_metrics` endpoints (list, retrieve, create, partial_update, destroy) as MCP tools via `products/experiments/mcp/tools.yaml`.
- Add sandbox evals (`eval_shared_metric_validation.py`) covering shared-metric query validation (including supporting scorers and seeders)

## How did you test this code?

- Evals
- Manually: before couldn't list shared metrics, afterwards could
