### PR TITLE
fix(mcp): accept http://localhost callback URLs unconditionally

### DIFF
--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -113,11 +113,15 @@ def _is_https(url: str) -> bool:
 
 
 def _is_valid_posthog_code_callback_url(url: str) -> bool:
-    """Validate that a PostHog Code callback URL is safe to redirect to (prevents open redirect)."""
+    """Validate that a PostHog Code callback URL is safe to redirect to (prevents open redirect).
+
+    Accepts the `posthog-code://` deep link (packaged app) and `http://localhost` (dev build,
+    per RFC 8252 §7.3 — OAuth 2.0 for Native Apps). `array://` is the legacy scheme.
+    """
     parsed = urlparse(url)
     if parsed.scheme in ("array", "posthog-code"):
         return True
-    if is_dev_mode() and parsed.scheme == "http" and parsed.hostname == "localhost":
+    if parsed.scheme == "http" and parsed.hostname == "localhost":
         return True
     return False
 

--- a/products/mcp_store/backend/test/test_api.py
+++ b/products/mcp_store/backend/test/test_api.py
@@ -22,6 +22,8 @@ class TestIsValidPosthogCodeCallbackUrl(TestCase):
             ("array_scheme", "array://callback", True),
             ("twig_scheme", "twig://oauth/callback", False),
             ("posthog_code_scheme", "posthog-code://oauth/callback", True),
+            ("http_localhost_with_port", "http://localhost:8238/callback", True),
+            ("http_localhost_no_port", "http://localhost/callback", True),
             ("https_rejected", "https://evil.com/redirect", False),
             ("http_rejected", "http://example.com/callback", False),
             ("javascript_rejected", "javascript:alert(1)", False),


### PR DESCRIPTION
## Summary

Dev builds of PostHog Code use a `http://localhost:8238/callback` redirect for OAuth per [RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) (OAuth 2.0 for Native Apps). The validator at `products/mcp_store/backend/presentation/views.py:115` already accepted this scheme but only when `DEBUG=True` on the backend, which blocked every developer working against production posthog.com.

This drops the dev-mode guard.

## Why this is safe

- The callback URL is where the user's **own browser** lands on the user's **own machine**.
- The OAuth code arriving there is bound by PKCE + state token (see `_create_oauth_state` in the same file).
- `localhost` is the standard native-app OAuth pattern — the same trust model Google, GitHub, and Slack use for desktop OAuth clients.
- The existing code already approved `http://localhost` as a valid scheme — the guard was just over-cautious about prod.

## Diff

- 1 line changed in `views.py` (removes the `is_dev_mode()` guard, adds RFC reference to the docstring)
- 2 test cases added to the existing parameterized validator test

## Test plan

- [ ] Existing `TestIsValidPosthogCodeCallbackUrl` passes with the two new `http_localhost_*` cases
- [ ] Dev build of PostHog Code can complete the MCP install OAuth flow against production posthog.com

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*