### PR TITLE
fix(activity): tidy MCP analytics card and group properties

### DIFF
--- a/frontend/src/scenes/activity/explore/MCPEventView.tsx
+++ b/frontend/src/scenes/activity/explore/MCPEventView.tsx
@@ -60,14 +60,51 @@ const makePreview = (value: unknown, maxChars = 80): string => {
     return text.length > maxChars ? `${text.slice(0, maxChars)}…` : text
 }
 
-const heavyPriority = (key: string): number => {
-    if (key === '$mcp_parameters') {
-        return 0
-    }
-    if (key === '$mcp_response') {
-        return 1
-    }
-    return 2
+// Display order for known MCP properties — groups semantically related rows.
+// Unknown keys fall to the end, sorted alphabetically.
+const MCP_PROPERTY_ORDER: readonly string[] = [
+    // Payload
+    '$mcp_parameters',
+    '$mcp_response',
+    // Outcome
+    '$mcp_is_error',
+    '$mcp_duration_ms',
+    '$mcp_intent',
+    '$mcp_intent_source',
+    // What was called
+    '$mcp_tool_name',
+    '$mcp_tool_description',
+    '$mcp_exec_inner_tool_name',
+    '$mcp_exec_inner_tool_description',
+    '$mcp_resource_name',
+    // Session context
+    '$mcp_session_id',
+    '$mcp_conversation_id',
+    '$mcp_mode',
+    '$mcp_source',
+    '$mcp_transport',
+    // Client
+    '$mcp_client_name',
+    '$mcp_client_version',
+    '$mcp_client_user_agent',
+    // Server
+    '$mcp_server_name',
+    '$mcp_server_version',
+    '$mcp_protocol_version',
+    '$mcp_version',
+    // PostHog target
+    '$mcp_organization_id',
+    '$mcp_project_id',
+    '$mcp_project_name',
+    '$mcp_project_uuid',
+    '$mcp_region',
+]
+
+const orderIndex = (key: string): number => {
+    // Accept both `$mcp_*` and the older un-prefixed `mcp_*` form.
+    const normalized = key.startsWith('$') ? key : `$${key}`
+    const idx = MCP_PROPERTY_ORDER.indexOf(normalized)
+    return idx === -1 ? Number.MAX_SAFE_INTEGER : idx
 }
 
 function ValueCell({ value, bytes }: { value: unknown; bytes: number }): JSX.Element {
@@ -190,9 +227,15 @@ export function MCPEventView({ properties }: MCPEventViewProps): JSX.Element {
     const durationMs = mcpProps['$mcp_duration_ms']
     const clientName = mcpProps['$mcp_client_name']
     const serverName = mcpProps['$mcp_server_name']
-    const transport = mcpProps['$mcp_transport']
     const intent = mcpProps['$mcp_intent']
     const intentSource = mcpProps['$mcp_intent_source']
+    const hasSummaryStat =
+        hasErrorStatus ||
+        Boolean(displayName && displayKind) ||
+        (durationMs !== undefined && durationMs !== null) ||
+        Boolean(clientName) ||
+        Boolean(serverName) ||
+        Boolean(intent)
 
     const entries: MCPEntry[] = useMemo(() => {
         const arr = Object.entries(mcpProps).map(([key, value]) => ({
@@ -200,7 +243,7 @@ export function MCPEventView({ properties }: MCPEventViewProps): JSX.Element {
             value,
             bytes: measureBytes(value),
         }))
-        arr.sort((a, b) => heavyPriority(a.key) - heavyPriority(b.key) || a.key.localeCompare(b.key))
+        arr.sort((a, b) => orderIndex(a.key) - orderIndex(b.key) || a.key.localeCompare(b.key))
         return arr
     }, [mcpProps])
 
@@ -238,31 +281,36 @@ export function MCPEventView({ properties }: MCPEventViewProps): JSX.Element {
 
     return (
         <div className="mx-3 flex flex-col gap-3">
-            <div className="border-border bg-surface-secondary flex flex-wrap items-start gap-x-6 gap-y-3 rounded border p-3">
-                {hasErrorStatus ? (
-                    <Stat label="Status">
-                        <LemonTag type={isError ? 'danger' : 'success'}>{isError ? 'Error' : 'Success'}</LemonTag>
-                    </Stat>
-                ) : null}
-                {displayName && displayKind ? (
-                    <Stat label={displayKind}>
-                        <span className="font-semibold">{displayName}</span>
-                    </Stat>
-                ) : null}
-                {durationMs !== undefined && durationMs !== null ? (
-                    <Stat label="Duration">{String(durationMs)} ms</Stat>
-                ) : null}
-                {transport ? <Stat label="Transport">{String(transport)}</Stat> : null}
-                {clientName ? <Stat label="Client">{String(clientName)}</Stat> : null}
-                {serverName ? <Stat label="Server">{String(serverName)}</Stat> : null}
-                {intent ? (
-                    <Stat label={intentSource ? `Intent (${String(intentSource).replace(/_/g, ' ')})` : 'Intent'}>
-                        <Tooltip title={String(intent)}>
-                            <span className="line-clamp-1 max-w-[40ch]">{String(intent)}</span>
-                        </Tooltip>
-                    </Stat>
-                ) : null}
-            </div>
+            {hasSummaryStat ? (
+                <div className="border-border bg-surface-secondary flex flex-wrap items-start gap-x-6 gap-y-3 rounded border p-3">
+                    {hasErrorStatus ? (
+                        <Stat label="Status">
+                            <LemonTag type={isError ? 'danger' : 'success'}>{isError ? 'Error' : 'Success'}</LemonTag>
+                        </Stat>
+                    ) : null}
+                    {displayName && displayKind ? (
+                        <Stat label={displayKind}>
+                            <span className="font-semibold">{displayName}</span>
+                        </Stat>
+                    ) : null}
+                    {durationMs !== undefined && durationMs !== null ? (
+                        <Stat label="Duration">{String(durationMs)} ms</Stat>
+                    ) : null}
+                    {clientName ? <Stat label="Client">{String(clientName)}</Stat> : null}
+                    {serverName ? <Stat label="Server">{String(serverName)}</Stat> : null}
+                    {intent ? (
+                        <div className="basis-full">
+                            <Stat
+                                label={intentSource ? `Intent (${String(intentSource).replace(/_/g, ' ')})` : 'Intent'}
+                            >
+                                <Tooltip title={String(intent)}>
+                                    <span className="block whitespace-pre-wrap break-words">{String(intent)}</span>
+                                </Tooltip>
+                            </Stat>
+                        </div>
+                    ) : null}
+                </div>
+            ) : null}
             {entries.length > 6 ? (
                 <LemonInput
                     type="search"


### PR DESCRIPTION
## Problem

The MCP analytics tab on event details has two papercuts:

1. The property list under the tab is sorted alphabetically by raw key, which scatters semantically-related properties. `$mcp_client_user_agent` ends up far from `$mcp_client_name`/`$mcp_client_version`, `$mcp_server_*` is separated from `$mcp_protocol_version` and `$mcp_version`, `$mcp_intent` and `$mcp_intent_source` land on opposite ends, etc. Reading the panel takes more eye-jumping than it should.
2. The summary card above the property list renders an empty bordered shell when none of its stats (status / tool / duration / client / server / intent) are present.

Additionally, the `Transport` stat (sse / stdio / streamable-http) is low-signal when triaging an event, and the `Intent` stat — which is the highest-signal field, free-form natural language describing what was being attempted — is clamped to a single line at `max-w-[40ch]`, hiding most of its content behind a tooltip.

## Changes

`frontend/src/scenes/activity/explore/MCPEventView.tsx`:

- Replaced the 3-tier `heavyPriority` function with an explicit `MCP_PROPERTY_ORDER` array. Rows sort by index in that list; unknown keys fall to the end alphabetically (graceful fallback for any future `$mcp_*` properties added without a code update). Groups, in order: payload → outcome → what was called → session context → client → server → PostHog target.
- Added a `hasSummaryStat` check so the summary card is only rendered when at least one stat would be visible — no more empty bordered shell.
- Dropped the `Transport` stat from the summary card. Still visible in the property table below.
- Gave the `Intent` stat its own full-width row inside the card (`basis-full`) and removed the `line-clamp-1 max-w-[40ch]` clamp, switching to `whitespace-pre-wrap break-words` so the full text wraps naturally. Tooltip retained for hover.

The component still accepts both the `\$mcp_*` and older un-prefixed `mcp_*` key shapes — the sort normalizes by prefixing un-prefixed keys before lookup.

## How did you test this code?

I'm an agent (PostHog Code). I did not manually verify the UI in a browser. Automated checks I ran:

- `pnpm exec tsc --noEmit` against the modified file — no new TypeScript errors (existing failures in `products/deployments/` are pre-existing on master).
- `pnpm --filter=@posthog/frontend format` — file is formatted.
- lint-staged hooks ran clean on commit.

Recommend a quick manual check in the activity drawer on any \`mcp_*\` event: confirm the summary card looks tidy with the intent on its own row, the property list groups client/server/project rows together, and an event missing all summary properties (if you can find one) skips the card entirely.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (agent). Triggered by the user noticing two issues while looking at the MCP analytics tab on a real event: properties not grouped, and an empty card showing up when summary fields were absent.

Decisions worth flagging for review:

- **Tab label**: the user initially suggested renaming \"MCP analytics\" → \"MCP Analytics\". I pushed back: PostHog convention (per CLAUDE.md) is sentence case for product/tab names, and every sibling tab on the event view (\"Conversation\", \"Survey response\", \"Exception\", \"Person properties\") follows that. User agreed to keep it as-is.
- **Sort strategy**: considered sorting by display label (what `PropertiesTable` does elsewhere) but rejected it — labels live in the taxonomy JSON and aren't authored with grouping in mind, so the result would still be alphabetical-ish. Explicit ordered list is more deliberate and grouped runs are easy to eyeball in code review.
- **Transport vs. another property**: user asked whether to drop transport or swap it for something more useful. I dropped it outright rather than swapping in another field, because the most valuable thing to surface (intent) was already there but getting truncated — giving it room is the higher-leverage change.

Requires human review before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*