### PR TITLE
feat(tracing): prune flame graph to selected span's lineage

### DIFF
--- a/products/tracing/frontend/TraceCompareFlame.test.ts
+++ b/products/tracing/frontend/TraceCompareFlame.test.ts
@@ -1,0 +1,100 @@
+import { TreeNode, pruneToLineage } from './TraceCompareFlame'
+
+function node(serviceName: string, name: string, children: TreeNode[] = []): TreeNode {
+    return { serviceName, name, node: null, previousNode: null, children }
+}
+
+function names(n: TreeNode): { name: string; children: ReturnType<typeof names>[] } {
+    return { name: n.name, children: n.children.map(names) }
+}
+
+describe('pruneToLineage', () => {
+    const targetDirectChild = node('', '<ROOT>', [
+        node('svc', 'target', [node('svc', 'leaf-a'), node('svc', 'leaf-b')]),
+        node('svc', 'sibling', [node('svc', 'sibling-leaf')]),
+    ])
+
+    const targetDeep = node('', '<ROOT>', [
+        node('svc', 'top', [
+            node('svc', 'mid', [
+                node('svc', 'target', [node('svc', 'descendant-a'), node('svc', 'descendant-b')]),
+                node('svc', 'mid-sibling'),
+            ]),
+            node('svc', 'top-cousin'),
+        ]),
+        node('svc', 'other-top'),
+    ])
+
+    // Mirrors a cycle that buildTree already broke (svc/loop appears once at depth 1 and is
+    // not re-added under itself). pruneToLineage shouldn't care — it walks the already-acyclic
+    // tree just like any other.
+    const cycleBroken = node('', '<ROOT>', [node('svc', 'loop', [node('svc', 'target', [node('svc', 'tail')])])])
+
+    it.each<[string, TreeNode, string, ReturnType<typeof names>]>([
+        ['target not found → original tree', targetDirectChild, 'missing', names(targetDirectChild)],
+        [
+            'target is direct child of root → drops siblings, keeps target subtree',
+            targetDirectChild,
+            'target',
+            {
+                name: '<ROOT>',
+                children: [
+                    {
+                        name: 'target',
+                        children: [
+                            { name: 'leaf-a', children: [] },
+                            { name: 'leaf-b', children: [] },
+                        ],
+                    },
+                ],
+            },
+        ],
+        [
+            'target deep in tree → keeps ancestor chain and full descendant subtree',
+            targetDeep,
+            'target',
+            {
+                name: '<ROOT>',
+                children: [
+                    {
+                        name: 'top',
+                        children: [
+                            {
+                                name: 'mid',
+                                children: [
+                                    {
+                                        name: 'target',
+                                        children: [
+                                            { name: 'descendant-a', children: [] },
+                                            { name: 'descendant-b', children: [] },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+        [
+            'cycle-broken node on lineage path → pruned like any other path',
+            cycleBroken,
+            'target',
+            {
+                name: '<ROOT>',
+                children: [
+                    {
+                        name: 'loop',
+                        children: [{ name: 'target', children: [{ name: 'tail', children: [] }] }],
+                    },
+                ],
+            },
+        ],
+    ])('%s', (_label, tree, target, expected) => {
+        expect(names(pruneToLineage(tree, target))).toEqual(expected)
+    })
+
+    it('returns the original tree by reference when target is missing', () => {
+        expect(pruneToLineage(targetDirectChild, 'missing')).toBe(targetDirectChild)
+    })
+})

--- a/products/tracing/frontend/TraceCompareFlame.tsx
+++ b/products/tracing/frontend/TraceCompareFlame.tsx
@@ -441,13 +441,45 @@ function findPathByName(root: TreeNode, name: string): string[] | null {
     return null
 }
 
+/**
+ * Prune the tree to keep only spans that can reach the target via parent or child:
+ * the unique path from the synthetic root down to the target, plus the entire subtree
+ * rooted at the target. Sibling/cousin subtrees of ancestors are dropped.
+ *
+ * Returns the original tree if the target name isn't found, so callers don't accidentally
+ * blank the flame when the row's span name no longer matches anything in the result set.
+ */
+function pruneToLineage(root: TreeNode, targetName: string): TreeNode {
+    const path = findPathByName(root, targetName)
+    if (!path) {
+        return root
+    }
+    function walk(node: TreeNode, depth: number, lineage: string[]): TreeNode {
+        if (depth >= lineage.length) {
+            return node
+        }
+        const nextKey = lineage[depth]
+        return {
+            ...node,
+            children: node.children
+                .filter((c) => nodeKey(c.serviceName, c.name) === nextKey)
+                .map((c) => walk(c, depth + 1, lineage)),
+        }
+    }
+    return walk(root, 0, path)
+}
+
 export function TraceCompareFlame({
     current,
     previous,
     loading,
     initialSpanName,
 }: TraceCompareFlameProps): JSX.Element {
-    const tree = useMemo(() => buildTree(current, previous), [current, previous])
+    const rawTree = useMemo(() => buildTree(current, previous), [current, previous])
+    const tree = useMemo(
+        () => (initialSpanName ? pruneToLineage(rawTree, initialSpanName) : rawTree),
+        [rawTree, initialSpanName]
+    )
     // Focus path: keys of nodes from the synthetic root down to the currently focused span.
     // Each click on a flame bar appends; breadcrumb clicks truncate.
     const [focusPath, setFocusPath] = useState<string[]>([])

--- a/products/tracing/frontend/TraceCompareFlame.tsx
+++ b/products/tracing/frontend/TraceCompareFlame.tsx
@@ -11,7 +11,7 @@ import { SpanTreeNode } from '~/queries/schema/schema-general'
 
 import { formatDuration } from './TraceFlameChart'
 
-interface TreeNode {
+export interface TreeNode {
     serviceName: string
     name: string
     node: SpanTreeNode | null
@@ -449,7 +449,7 @@ function findPathByName(root: TreeNode, name: string): string[] | null {
  * Returns the original tree if the target name isn't found, so callers don't accidentally
  * blank the flame when the row's span name no longer matches anything in the result set.
  */
-function pruneToLineage(root: TreeNode, targetName: string): TreeNode {
+export function pruneToLineage(root: TreeNode, targetName: string): TreeNode {
     const path = findPathByName(root, targetName)
     if (!path) {
         return root


### PR DESCRIPTION
## Problem

When opening the call-tree flame chart from a compare-table row, the view shows every span in the matched traces — including sibling and cousin subtrees of the clicked span's ancestors. Users have to mentally filter that noise to follow the path from the root down to the span they care about.

## Changes

Adds a `pruneToLineage(tree, targetName)` step to `TraceCompareFlame` that runs after `buildTree`. It keeps only:

- the unique path from the synthetic root to the target span
- the entire subtree rooted at the target

Sibling/cousin subtrees of ancestors are dropped. The existing focus-path and breadcrumb behavior is unchanged — it now operates on the pruned tree, so breadcrumb navigation walks only the lineage.

If `initialSpanName` doesn't match anything in the result set, the function returns the original tree so the flame doesn't blank.

## How did you test this code?

I'm an agent. Automated checks run:

- `pnpm typescript:check` — passes for the changed file (only pre-existing, unrelated `featureFlagReleaseConditionsLogic` casing error remains in the repo)

No manual UI testing was performed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). The change was scoped down from a broader session: the user asked for a separate, master-based PR containing only the lineage-pruning behavior so unrelated tracing work could ship independently. The pruning logic reuses the existing `findPathByName` helper and the established tree shape; no schema or API change is needed because `initialSpanName` was already wired through.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*