### PR TITLE
feat(surveys): add duplicate action to question editor

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -5,7 +5,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { useActions, useValues } from 'kea'
 import { Group } from 'kea-forms'
 
-import { IconPlusSmall, IconTrash, IconWarning } from '@posthog/icons'
+import { IconCopy, IconPlusSmall, IconTrash, IconWarning } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonDialog, LemonInput, LemonSelect, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -59,7 +59,7 @@ export function SurveyEditQuestionHeader({
     translationErrorsByQuestion,
 }: SurveyQuestionHeaderProps): JSX.Element {
     const { hasBranchingLogic, editingLanguage } = useValues(surveyLogic)
-    const { deleteBranchingLogic } = useActions(surveyLogic)
+    const { deleteBranchingLogic, duplicateQuestion } = useActions(surveyLogic)
     const { setNodeRef, attributes, transform, transition, listeners, isDragging } = useSortable({
         id: index.toString(),
     })
@@ -98,6 +98,17 @@ export function SurveyEditQuestionHeader({
                         <IconWarning className="text-warning" />
                     </Tooltip>
                 )}
+                <LemonButton
+                    icon={<IconCopy />}
+                    size="xsmall"
+                    data-attr={`duplicate-survey-question-${index}`}
+                    tooltip="Duplicate question"
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        duplicateQuestion(index)
+                    }}
+                    tooltipPlacement="top-end"
+                />
                 {survey.questions.length > 1 && (
                     <LemonButton
                         icon={<IconTrash />}

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1359,7 +1359,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 }
                 const copy = {
                     ...original,
-                    question: `${original.description ?? ''} (copy)`,
+                    question: `${original.question ?? ''} (copy)`,
                 }
                 actions.setSurveyValue('questions', [
                     ...values.survey.questions.slice(0, index + 1),

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -667,6 +667,7 @@ export const surveyLogic = kea<surveyLogicType>([
         archiveSurvey: true,
         setWritingHTMLDescription: (writingHTML: boolean) => ({ writingHTML }),
         setSelectedPageIndex: (idx: number | null) => ({ idx }),
+        duplicateQuestion: (index: number) => ({ index }),
         setSelectedSection: (section: SurveyEditSection | null) => ({ section }),
         resetTargeting: true,
         resetSurveyAdaptiveSampling: true,
@@ -1350,6 +1351,22 @@ export const surveyLogic = kea<surveyLogicType>([
                 } finally {
                     actions.setGeneratingTranslationDrafts(false)
                 }
+            },
+            duplicateQuestion: ({ index }) => {
+                const original = values.survey.questions[index]
+                if (!original) {
+                    return
+                }
+                const copy = {
+                    ...original,
+                    question: `${original.description ?? ''} (copy)`,
+                }
+                actions.setSurveyValue('questions', [
+                    ...values.survey.questions.slice(0, index + 1),
+                    copy,
+                    ...values.survey.questions.slice(index + 1),
+                ])
+                actions.setSelectedPageIndex(index + 1)
             },
             resetTargeting: () => {
                 actions.setSurveyValue('linked_flag_id', NEW_SURVEY.linked_flag_id)


### PR DESCRIPTION
> ⚠️ This is a test PR and it's not going to make in production! ⚠️ 

## Problem

When iterating on a survey, contributors often want to start a new question from an existing one with the same type, validation, and options, then tweak the question text. Today the only path is to add a new question from scratch and re-enter every field. For longer surveys with carefully tuned Likert scales or multiple-choice options, this is friction we can remove with a small action.

## Changes

Adds a "Duplicate question" action to each row in the survey editor (between the drag handle and the delete button).

Expected behavior:

- Clicking Duplicate on Question N inserts a copy directly below it as Question N+1.
- The copy's title is the original's title with ` (copy)` appended (`Give us feedback!` → `Give us feedback! (copy)`).
- All other question fields (type, choices, validation, description, etc.) carry over from the original.
- The editor selects the new copy after insertion so the user can immediately edit it.

The action is implemented as a kea listener (`duplicateQuestion`) on `surveyLogic`, mirroring how `setSelectedPageIndex` and `deleteBranchingLogic` live on the same logic. The row component dispatches the action via `useActions`.

## How did you test this code?

n/a

## Publish to changelog?

no

## Docs update

skip-inkeep-docs
