### PR TITLE
fix(integrations): Redirect OAuth callback to project integrations page

### DIFF
--- a/frontend/src/scenes/settings/environment/ErrorTrackingIntegrations.tsx
+++ b/frontend/src/scenes/settings/environment/ErrorTrackingIntegrations.tsx
@@ -1,9 +1,13 @@
+import { urls } from 'scenes/urls'
+
 import IconGitHub from 'public/services/github.png'
 import IconGitLab from 'public/services/gitlab.png'
 import IconJira from 'public/services/jira.svg'
 import IconLinear from 'public/services/linear.png'
 
 import { GitLabIntegration, GithubIntegration, JiraIntegration, LinearIntegration } from './Integrations'
+
+const NEXT_URL = urls.settings('environment-error-tracking', 'error-tracking-integrations')
 
 export function ErrorTrackingIntegrations(): JSX.Element {
     return (
@@ -13,14 +17,14 @@ export function ErrorTrackingIntegrations(): JSX.Element {
                     <img src={IconLinear} alt="" className="w-5 h-5" />
                     Linear
                 </h3>
-                <LinearIntegration />
+                <LinearIntegration next={NEXT_URL} />
             </div>
             <div>
                 <h3 className="flex items-center gap-2">
                     <img src={IconGitHub} alt="" className="w-5 h-5" />
                     GitHub
                 </h3>
-                <GithubIntegration />
+                <GithubIntegration next={NEXT_URL} />
             </div>
             <div>
                 <h3 className="flex items-center gap-2">
@@ -34,7 +38,7 @@ export function ErrorTrackingIntegrations(): JSX.Element {
                     <img src={IconJira} alt="" className="w-5 h-5" />
                     Jira
                 </h3>
-                <JiraIntegration />
+                <JiraIntegration next={NEXT_URL} />
             </div>
         </div>
     )

--- a/frontend/src/scenes/settings/environment/Integrations.tsx
+++ b/frontend/src/scenes/settings/environment/Integrations.tsx
@@ -47,7 +47,7 @@ const OAuthIntegration = ({ kind, connectText }: { kind: IntegrationKind; connec
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
     const authorizationUrl = api.integrations.authorizeUrl({
-        next: urls.settings('environment-error-tracking', 'error-tracking-integrations'),
+        next: urls.settings('environment-integrations'),
         kind,
     })
 

--- a/frontend/src/scenes/settings/environment/Integrations.tsx
+++ b/frontend/src/scenes/settings/environment/Integrations.tsx
@@ -29,25 +29,33 @@ export function GitLabIntegration(): JSX.Element {
     )
 }
 
-export function LinearIntegration(): JSX.Element {
-    return <OAuthIntegration kind="linear" connectText="Connect workspace" />
+export function LinearIntegration({ next }: { next?: string }): JSX.Element {
+    return <OAuthIntegration kind="linear" connectText="Connect workspace" next={next} />
 }
 
-export function GithubIntegration(): JSX.Element {
-    return <OAuthIntegration kind="github" connectText="Connect organization" />
+export function GithubIntegration({ next }: { next?: string }): JSX.Element {
+    return <OAuthIntegration kind="github" connectText="Connect organization" next={next} />
 }
 
-export function JiraIntegration(): JSX.Element {
-    return <OAuthIntegration kind="jira" connectText="Connect site" />
+export function JiraIntegration({ next }: { next?: string }): JSX.Element {
+    return <OAuthIntegration kind="jira" connectText="Connect site" next={next} />
 }
 
-const OAuthIntegration = ({ kind, connectText }: { kind: IntegrationKind; connectText: string }): JSX.Element => {
+const OAuthIntegration = ({
+    kind,
+    connectText,
+    next,
+}: {
+    kind: IntegrationKind
+    connectText: string
+    next?: string
+}): JSX.Element => {
     const restrictedReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
     const authorizationUrl = api.integrations.authorizeUrl({
-        next: urls.settings('environment-integrations'),
+        next: next ?? urls.settings('environment-integrations'),
         kind,
     })
 

--- a/frontend/src/scenes/settings/environment/ReplayIntegrations.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayIntegrations.tsx
@@ -1,28 +1,19 @@
-import { useValues } from 'kea'
-import { PropsWithChildren, useMemo, useState } from 'react'
-
-import { LemonButton } from '@posthog/lemon-ui'
-
-import api from 'lib/api'
-import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
-import { TeamMembershipLevel } from 'lib/constants'
-import { integrationsLogic } from 'lib/integrations/integrationsLogic'
-import { IntegrationView } from 'lib/integrations/IntegrationView'
-import { GitLabSetupModal } from 'scenes/integrations/gitlab/GitLabSetupModal'
 import { urls } from 'scenes/urls'
 
-import { IntegrationKind, IntegrationType } from '~/types'
+import { GithubIntegration, GitLabIntegration, JiraIntegration, LinearIntegration } from './Integrations'
+
+const NEXT_URL = urls.replaySettings('replay-integrations')
 
 export function ReplayIntegrations(): JSX.Element {
     return (
         <div className="flex flex-col gap-y-6">
             <div>
                 <h3>Linear</h3>
-                <LinearIntegration />
+                <LinearIntegration next={NEXT_URL} />
             </div>
             <div>
                 <h3>GitHub</h3>
-                <GitHubIntegration />
+                <GithubIntegration next={NEXT_URL} />
             </div>
             <div>
                 <h3>GitLab</h3>
@@ -30,82 +21,8 @@ export function ReplayIntegrations(): JSX.Element {
             </div>
             <div>
                 <h3>Jira</h3>
-                <JiraIntegration />
+                <JiraIntegration next={NEXT_URL} />
             </div>
         </div>
     )
-}
-
-function LinearIntegration(): JSX.Element {
-    return <OAuthIntegration kind="linear" connectText="Connect workspace" />
-}
-
-function GitHubIntegration(): JSX.Element {
-    return <OAuthIntegration kind="github" connectText="Connect organization" />
-}
-
-function GitLabIntegration(): JSX.Element {
-    const [isOpen, setIsOpen] = useState<boolean>(false)
-    const restrictedReason = useRestrictedArea({
-        scope: RestrictionScope.Project,
-        minimumAccessLevel: TeamMembershipLevel.Admin,
-    })
-
-    return (
-        <Integration kind="gitlab">
-            <LemonButton type="secondary" onClick={() => setIsOpen(true)} disabledReason={restrictedReason}>
-                Connect project
-            </LemonButton>
-            <GitLabSetupModal isOpen={isOpen} onComplete={() => setIsOpen(false)} />
-        </Integration>
-    )
-}
-
-function JiraIntegration(): JSX.Element {
-    return <OAuthIntegration kind="jira" connectText="Connect site" />
-}
-
-const OAuthIntegration = ({ kind, connectText }: { kind: IntegrationKind; connectText: string }): JSX.Element => {
-    const authorizationUrl = api.integrations.authorizeUrl({
-        next: urls.replaySettings('replay-integrations'),
-        kind,
-    })
-    const restrictedReason = useRestrictedArea({
-        scope: RestrictionScope.Project,
-        minimumAccessLevel: TeamMembershipLevel.Admin,
-    })
-
-    return (
-        <Integration kind={kind}>
-            <LemonButton
-                type="secondary"
-                disableClientSideRouting
-                to={authorizationUrl}
-                disabledReason={restrictedReason}
-            >
-                {connectText}
-            </LemonButton>
-        </Integration>
-    )
-}
-
-const Integration = ({ kind, children }: PropsWithChildren<{ kind: IntegrationKind }>): JSX.Element => {
-    const integrations = useIntegrations(kind)
-
-    return (
-        <div className="flex flex-col">
-            <div className="flex flex-col gap-y-2">
-                {integrations?.map((integration) => (
-                    <IntegrationView key={integration.id} integration={integration} />
-                ))}
-                <div className="flex">{children}</div>
-            </div>
-        </div>
-    )
-}
-
-const useIntegrations = (kind: IntegrationKind): IntegrationType[] => {
-    const { getIntegrationsByKind } = useValues(integrationsLogic)
-
-    return useMemo(() => getIntegrationsByKind([kind] satisfies IntegrationKind[]), [getIntegrationsByKind, kind])
 }


### PR DESCRIPTION
## Problem

Connecting GitHub/Linear/Jira from the project Integrations page redirects you to the Error tracking integrations page after OAuth. It's wrong.

In some GitHub flows it cascades further and you end up on personal integrations. Basically, the post-OAuth redirect URL was hardcoded to the wrong page.

## Changes

Made the redirect URL a prop so each settings page (Integrations, Error tracking, Replay) redirects back to itself. Also deduplicated ReplayIntegrations.tsx which had a full copy of the same components.
