### PR TITLE
feat(uptime): add timeline updates to declared incidents

### DIFF
--- a/products/uptime/backend/facade/api.py
+++ b/products/uptime/backend/facade/api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Any
 from uuid import UUID
 
 from .. import logic
@@ -17,6 +19,23 @@ def _to_dto(obj: Monitor) -> contracts.MonitorDTO:
     )
 
 
+def _update_entry_to_dto(entry: dict[str, Any]) -> contracts.IncidentUpdateDTO:
+    """Coerce a single raw JSON entry from Incident.updates into the typed DTO.
+
+    posted_at is persisted as an ISO 8601 string so it survives JSONField round-trips
+    unchanged. Older rows from before this feature existed simply have an empty list.
+    """
+    posted_at_raw = entry.get("posted_at")
+    posted_at = datetime.fromisoformat(posted_at_raw) if isinstance(posted_at_raw, str) else posted_at_raw
+    return contracts.IncidentUpdateDTO(
+        id=str(entry["id"]),
+        keyword=entry["keyword"],
+        message=entry.get("message", ""),
+        posted_at=posted_at,
+        posted_by_id=entry.get("posted_by_id"),
+    )
+
+
 def _incident_to_dto(incident: Incident) -> contracts.IncidentDTO:
     return contracts.IncidentDTO(
         id=incident.id,
@@ -26,6 +45,7 @@ def _incident_to_dto(incident: Incident) -> contracts.IncidentDTO:
         started_at=incident.started_at,
         resolved_at=incident.resolved_at,
         resolution_note=incident.resolution_note,
+        updates=[_update_entry_to_dto(entry) for entry in (incident.updates or [])],
         created_at=incident.created_at,
         updated_at=incident.updated_at,
     )
@@ -244,6 +264,20 @@ def resolve_incident(input: contracts.ResolveIncidentInput) -> contracts.Inciden
 
 def reopen_incident(*, team_id: int, incident_id: UUID) -> contracts.IncidentDTO:
     return _incident_to_dto(logic.reopen_incident(team_id=team_id, incident_id=incident_id))
+
+
+def post_incident_update(input: contracts.PostIncidentUpdateInput) -> contracts.IncidentDTO:
+    return _incident_to_dto(
+        logic.post_incident_update(
+            team_id=input.team_id,
+            incident_id=input.incident_id,
+            keyword=input.keyword,
+            message=input.message,
+            posted_at=input.posted_at,
+            posted_by_id=input.posted_by_id,
+            sync_status=input.sync_status,
+        )
+    )
 
 
 def delete_incident(*, team_id: int, incident_id: UUID) -> None:

--- a/products/uptime/backend/facade/contracts.py
+++ b/products/uptime/backend/facade/contracts.py
@@ -118,6 +118,20 @@ class UpdateStatusPageInput:
     monitor_ids: list[UUID] | None = None
 
 
+IncidentUpdateKeyword = Literal["investigating", "identified", "fixing", "monitoring", "resolved", "update"]
+
+
+@dataclass(frozen=True)
+class IncidentUpdateDTO:
+    """One entry in an incident's timeline. Stored inline on Incident.updates as JSON."""
+
+    id: str
+    keyword: IncidentUpdateKeyword
+    message: str
+    posted_at: datetime
+    posted_by_id: int | None
+
+
 @dataclass(frozen=True)
 class IncidentDTO:
     id: UUID
@@ -127,6 +141,7 @@ class IncidentDTO:
     started_at: datetime
     resolved_at: datetime | None
     resolution_note: str
+    updates: list[IncidentUpdateDTO]
     created_at: datetime
     updated_at: datetime
 
@@ -168,6 +183,20 @@ class ResolveIncidentInput:
     team_id: int
     incident_id: UUID
     resolution_note: str
+
+
+@dataclass(frozen=True)
+class PostIncidentUpdateInput:
+    team_id: int
+    incident_id: UUID
+    keyword: IncidentUpdateKeyword
+    message: str
+    posted_at: datetime | None = None
+    posted_by_id: int | None = None
+    # If true (default), an "investigating"/"resolved"/etc. keyword also nudges the
+    # incident's open/closed state — keyword="resolved" closes the incident, anything
+    # else reopens it.
+    sync_status: bool = True
 
 
 @dataclass(frozen=True)

--- a/products/uptime/backend/logic/__init__.py
+++ b/products/uptime/backend/logic/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import math
+import uuid
 import secrets
 from datetime import date, datetime, time, timedelta
 from typing import Literal
@@ -742,6 +743,52 @@ def reopen_incident(*, team_id: int, incident_id: UUID) -> Incident:
     incident = Incident.objects.get(team_id=team_id, id=incident_id)
     incident.resolved_at = None
     incident.resolution_note = ""
+    incident.save()
+    return incident
+
+
+def post_incident_update(
+    *,
+    team_id: int,
+    incident_id: UUID,
+    keyword: Literal["investigating", "identified", "fixing", "monitoring", "resolved", "update"],
+    message: str,
+    posted_at: datetime | None = None,
+    posted_by_id: int | None = None,
+    sync_status: bool = True,
+) -> Incident:
+    """Append a timeline entry to an incident's `updates` JSON column.
+
+    New entries go at the head so the timeline reads newest-first without a
+    client-side sort. When `sync_status` is true, keyword="resolved" closes
+    the incident (stamping resolved_at) and any other keyword reopens it —
+    matching how operators tend to use the keyword as the source of truth.
+    """
+    incident = Incident.objects.get(team_id=team_id, id=incident_id)
+    entry = {
+        "id": str(uuid.uuid4()),
+        "keyword": keyword,
+        "message": message,
+        "posted_at": (posted_at or timezone.now()).isoformat(),
+        "posted_by_id": posted_by_id,
+    }
+    incident.updates = [entry, *(incident.updates or [])]
+
+    if sync_status:
+        if keyword == "resolved":
+            if incident.resolved_at is None:
+                incident.resolved_at = timezone.now()
+            # If the operator typed the resolution in the message, treat that as the resolution
+            # note when one isn't set yet — saves them filling out the same text in two places.
+            if not incident.resolution_note:
+                incident.resolution_note = message
+        else:
+            # Any non-resolved keyword posted onto a closed incident means "actually, it's back" —
+            # clear resolved_at so the incident shows as ongoing again.
+            if incident.resolved_at is not None:
+                incident.resolved_at = None
+                incident.resolution_note = ""
+
     incident.save()
     return incident
 

--- a/products/uptime/backend/migrations/0008_incident_updates.py
+++ b/products/uptime/backend/migrations/0008_incident_updates.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("uptime", "0007_monitor_mode_alter_monitor_url"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="incident",
+            name="updates",
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/products/uptime/backend/migrations/max_migration.txt
+++ b/products/uptime/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0007_monitor_mode_alter_monitor_url
+0008_incident_updates

--- a/products/uptime/backend/models.py
+++ b/products/uptime/backend/models.py
@@ -57,6 +57,11 @@ class Incident(ProductTeamModel):
     # A null resolved_at means the incident is still ongoing — that's the canonical "open" signal.
     resolved_at = models.DateTimeField(null=True, blank=True)
     resolution_note = models.TextField(blank=True, default="")
+    # Append-only timeline of operator-posted updates. Each entry is a dict shaped like
+    # {id, keyword, message, posted_at, posted_by_id}. Stored inline as JSON because the
+    # timeline is always read alongside the parent incident — a separate table buys nothing
+    # but join overhead at v1 scale.
+    updates = models.JSONField(default=list, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/products/uptime/backend/presentation/serializers.py
+++ b/products/uptime/backend/presentation/serializers.py
@@ -4,6 +4,7 @@ from rest_framework_dataclasses.serializers import DataclassSerializer
 from ..facade.contracts import (
     DailyBucketDTO,
     IncidentDTO,
+    IncidentUpdateDTO,
     MonitorDTO,
     MonitorSummaryDTO,
     OutageDTO,
@@ -12,6 +13,8 @@ from ..facade.contracts import (
     StatusPageDTO,
     SuggestedUrlDTO,
 )
+
+INCIDENT_UPDATE_KEYWORDS = ("investigating", "identified", "fixing", "monitoring", "resolved", "update")
 
 
 class MonitorSerializer(DataclassSerializer):
@@ -129,9 +132,41 @@ class PublicStatusPageSerializer(DataclassSerializer):
         dataclass = PublicStatusPageDTO
 
 
+class IncidentUpdateEntrySerializer(DataclassSerializer):
+    class Meta:
+        dataclass = IncidentUpdateDTO
+
+
 class IncidentSerializer(DataclassSerializer):
     class Meta:
         dataclass = IncidentDTO
+
+
+class PostIncidentUpdateSerializer(serializers.Serializer):
+    keyword = serializers.ChoiceField(
+        choices=INCIDENT_UPDATE_KEYWORDS,
+        help_text=(
+            "Status-style keyword for this update. One of investigating, identified, fixing, "
+            "monitoring, resolved, or update (a freeform note that doesn't change incident state)."
+        ),
+    )
+    message = serializers.CharField(
+        max_length=2000,
+        allow_blank=False,
+        help_text="Short freeform message describing the update. Shown verbatim on the timeline.",
+    )
+    posted_at = serializers.DateTimeField(
+        required=False,
+        help_text="When the update was posted. Defaults to the server's current time.",
+    )
+    sync_status = serializers.BooleanField(
+        required=False,
+        default=True,
+        help_text=(
+            "When true (default) the keyword also drives the incident's open/closed state: "
+            "'resolved' closes the incident, any other keyword reopens it."
+        ),
+    )
 
 
 class CreateIncidentSerializer(serializers.Serializer):

--- a/products/uptime/backend/presentation/views.py
+++ b/products/uptime/backend/presentation/views.py
@@ -15,7 +15,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 
 from ..facade import api, contracts
 from ..logic import SlugAlreadyTakenError
-from ..models import Monitor
+from ..models import Incident, Monitor
 from .serializers import (
     BulkCreateMonitorSerializer,
     CreateIncidentSerializer,
@@ -25,6 +25,7 @@ from .serializers import (
     MonitorSummarySerializer,
     OutageSerializer,
     PingSerializer,
+    PostIncidentUpdateSerializer,
     PublicStatusPageSerializer,
     ReorderMonitorsSerializer,
     ResolveIncidentSerializer,
@@ -319,6 +320,35 @@ class IncidentViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         try:
             dto = api.reopen_incident(team_id=self.team_id, incident_id=UUID(str(pk)))
         except Exception as exc:
+            raise NotFound("Incident not found") from exc
+        return Response(IncidentSerializer(dto).data)
+
+    @extend_schema(
+        request=PostIncidentUpdateSerializer,
+        responses={200: IncidentSerializer},
+        description=(
+            "Append a timeline entry (keyword + message + optional posted_at) to the incident. "
+            "By default the keyword also drives the incident's open/closed state — set sync_status "
+            "to false to post a note without changing the incident."
+        ),
+    )
+    @action(detail=True, methods=["post"], url_path="post_update", required_scopes=["uptime:write"])
+    def post_update(self, request: Request, pk: str | None = None, **kwargs) -> Response:
+        serializer = PostIncidentUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        try:
+            dto = api.post_incident_update(
+                contracts.PostIncidentUpdateInput(
+                    team_id=self.team_id,
+                    incident_id=UUID(str(pk)),
+                    keyword=serializer.validated_data["keyword"],
+                    message=serializer.validated_data["message"],
+                    posted_at=serializer.validated_data.get("posted_at"),
+                    posted_by_id=request.user.id if request.user.is_authenticated else None,
+                    sync_status=serializer.validated_data.get("sync_status", True),
+                )
+            )
+        except Incident.DoesNotExist as exc:
             raise NotFound("Incident not found") from exc
         return Response(IncidentSerializer(dto).data)
 

--- a/products/uptime/frontend/scenes/IncidentTile.tsx
+++ b/products/uptime/frontend/scenes/IncidentTile.tsx
@@ -1,12 +1,13 @@
 import { router } from 'kea-router'
 
-import { IconCheck, IconPencil, IconPlay, IconTrash } from '@posthog/icons'
+import { IconCheck, IconNotification, IconPencil, IconPlay, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonCard } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { cn } from 'lib/utils/css-classes'
 import { urls } from 'scenes/urls'
 
+import { IncidentTimeline } from './IncidentTimeline'
 import { Incident } from './uptimeSceneLogic'
 
 interface IncidentTileProps {
@@ -17,6 +18,7 @@ interface IncidentTileProps {
     onResolve: () => void
     onReopen: () => void
     onDelete: () => void
+    onPostUpdate: () => void
 }
 
 export function IncidentTile({
@@ -27,6 +29,7 @@ export function IncidentTile({
     onResolve,
     onReopen,
     onDelete,
+    onPostUpdate,
 }: IncidentTileProps): JSX.Element {
     const ongoing = incident.resolved_at === null
     const stop = (e: React.MouseEvent): void => e.stopPropagation()
@@ -54,6 +57,12 @@ export function IncidentTile({
                     className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
                     onClick={stop}
                 >
+                    <LemonButton
+                        size="xsmall"
+                        icon={<IconNotification />}
+                        onClick={onPostUpdate}
+                        tooltip="Post timeline update"
+                    />
                     <LemonButton size="xsmall" icon={<IconPencil />} onClick={onEdit} tooltip="Edit" />
                     {ongoing ? (
                         <LemonButton
@@ -77,6 +86,12 @@ export function IncidentTile({
 
             {incident.description && (
                 <div className="text-xs text-secondary whitespace-pre-wrap line-clamp-3">{incident.description}</div>
+            )}
+
+            {incident.updates && incident.updates.length > 0 && (
+                <div onClick={stop}>
+                    <IncidentTimeline updates={incident.updates} limit={3} />
+                </div>
             )}
 
             {!ongoing && incident.resolution_note && (

--- a/products/uptime/frontend/scenes/IncidentTimeline.tsx
+++ b/products/uptime/frontend/scenes/IncidentTimeline.tsx
@@ -1,0 +1,119 @@
+import { IconCheckCircle, IconEye, IconNotification, IconSearch, IconTarget, IconWrench } from '@posthog/icons'
+import { LemonTag } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+import { cn } from 'lib/utils/css-classes'
+
+import { IncidentUpdate, IncidentUpdateKeyword } from './uptimeSceneLogic'
+
+const KEYWORD_LABEL: Record<IncidentUpdateKeyword, string> = {
+    investigating: 'Investigating',
+    identified: 'Identified',
+    fixing: 'Fixing',
+    monitoring: 'Monitoring fix',
+    resolved: 'Resolved',
+    update: 'Update',
+}
+
+// Pairs of (background tint, foreground colour) for the timeline dot. Kept as tailwind tokens
+// so they stay in sync with the rest of the design system.
+const KEYWORD_DOT_CLASS: Record<IncidentUpdateKeyword, string> = {
+    investigating: 'bg-warning-highlight text-warning border border-warning',
+    identified: 'bg-danger-highlight text-danger border border-danger',
+    fixing: 'bg-primary-highlight text-primary border border-primary',
+    monitoring: 'bg-accent-highlight-light text-accent border border-accent',
+    resolved: 'bg-success-highlight text-success border border-success',
+    update: 'bg-surface-secondary text-secondary border border-border',
+}
+
+const KEYWORD_ICON: Record<IncidentUpdateKeyword, JSX.Element> = {
+    investigating: <IconSearch />,
+    identified: <IconTarget />,
+    fixing: <IconWrench />,
+    monitoring: <IconEye />,
+    resolved: <IconCheckCircle />,
+    update: <IconNotification />,
+}
+
+const KEYWORD_TAG_TYPE: Record<
+    IncidentUpdateKeyword,
+    'warning' | 'danger' | 'primary' | 'completion' | 'success' | 'default'
+> = {
+    investigating: 'warning',
+    identified: 'danger',
+    fixing: 'primary',
+    monitoring: 'completion',
+    resolved: 'success',
+    update: 'default',
+}
+
+export function IncidentKeywordTag({ keyword }: { keyword: IncidentUpdateKeyword }): JSX.Element {
+    return (
+        <LemonTag type={KEYWORD_TAG_TYPE[keyword]} size="small" className="uppercase tracking-wide">
+            {KEYWORD_LABEL[keyword]}
+        </LemonTag>
+    )
+}
+
+interface IncidentTimelineProps {
+    updates: IncidentUpdate[]
+    /** If set, only render the first N entries — useful inside compact tiles. */
+    limit?: number
+    /** When true, render a "+N earlier" hint below the cropped list. */
+    showCountHint?: boolean
+    className?: string
+}
+
+export function IncidentTimeline({
+    updates,
+    limit,
+    showCountHint = true,
+    className,
+}: IncidentTimelineProps): JSX.Element | null {
+    if (!updates.length) {
+        return null
+    }
+    const visible = typeof limit === 'number' ? updates.slice(0, limit) : updates
+    const hiddenCount = updates.length - visible.length
+
+    return (
+        <div className={cn('flex flex-col', className)}>
+            {visible.map((update, idx) => {
+                const isLast = idx === visible.length - 1 && hiddenCount === 0
+                return (
+                    <div key={update.id} className="flex gap-2.5">
+                        <div className="flex flex-col items-center">
+                            <div
+                                className={cn(
+                                    'flex items-center justify-center w-6 h-6 rounded-full shrink-0',
+                                    KEYWORD_DOT_CLASS[update.keyword]
+                                )}
+                                aria-hidden
+                            >
+                                <span className="text-sm leading-none">{KEYWORD_ICON[update.keyword]}</span>
+                            </div>
+                            {!isLast && <div className="flex-1 w-px bg-border my-1 min-h-2" />}
+                        </div>
+                        <div className={cn('flex-1 pb-3', isLast && 'pb-0')}>
+                            <div className="flex items-center gap-2 flex-wrap">
+                                <IncidentKeywordTag keyword={update.keyword} />
+                                <span
+                                    className="text-[11px] text-secondary"
+                                    title={dayjs(update.posted_at).format('YYYY-MM-DD HH:mm:ss Z')}
+                                >
+                                    {dayjs(update.posted_at).fromNow()}
+                                </span>
+                            </div>
+                            <div className="mt-1 text-xs whitespace-pre-wrap">{update.message}</div>
+                        </div>
+                    </div>
+                )
+            })}
+            {hiddenCount > 0 && showCountHint && (
+                <div className="text-[11px] text-secondary pl-8">
+                    +{hiddenCount} earlier {hiddenCount === 1 ? 'update' : 'updates'}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/products/uptime/frontend/scenes/UptimeMonitorScene.tsx
+++ b/products/uptime/frontend/scenes/UptimeMonitorScene.tsx
@@ -45,6 +45,7 @@ export function UptimeMonitorScene(): JSX.Element {
         declareIncidentFromOutage,
         startEditingIncident,
         promptResolveIncident,
+        promptPostIncidentUpdate,
         reopenIncident,
         confirmDeleteIncident,
     } = useActions(uptimeMonitorSceneLogic)
@@ -246,6 +247,7 @@ export function UptimeMonitorScene(): JSX.Element {
                         onResolve={promptResolveIncident}
                         onReopen={(id) => reopenIncident(id)}
                         onDelete={(incident) => confirmDeleteIncident({ id: incident.id, name: incident.name })}
+                        onPostUpdate={(incident) => promptPostIncidentUpdate(incident)}
                     />
                 </LemonCard>
             </div>
@@ -358,6 +360,7 @@ function IncidentsList({
     onResolve,
     onReopen,
     onDelete,
+    onPostUpdate,
 }: {
     incidents: Incident[]
     loading: boolean
@@ -366,6 +369,7 @@ function IncidentsList({
     onResolve: (incident: Incident) => void
     onReopen: (incidentId: string) => void
     onDelete: (incident: Incident) => void
+    onPostUpdate: (incident: Incident) => void
 }): JSX.Element {
     if (loading && incidents.length === 0) {
         return <LemonSkeleton className="h-24 w-full" />
@@ -392,6 +396,7 @@ function IncidentsList({
                     onResolve={() => onResolve(incident)}
                     onReopen={() => onReopen(incident.id)}
                     onDelete={() => onDelete(incident)}
+                    onPostUpdate={() => onPostUpdate(incident)}
                 />
             ))}
         </div>

--- a/products/uptime/frontend/scenes/UptimeScene.tsx
+++ b/products/uptime/frontend/scenes/UptimeScene.tsx
@@ -228,8 +228,13 @@ function MonitorsTab(): JSX.Element {
 
 function IncidentsTab(): JSX.Element {
     const { ongoingIncidents, resolvedIncidents, incidentsLoading, monitorSummaries } = useValues(uptimeSceneLogic)
-    const { startEditingIncident, promptResolveIncident, reopenIncident, confirmDeleteIncident } =
-        useActions(uptimeSceneLogic)
+    const {
+        startEditingIncident,
+        promptResolveIncident,
+        promptPostIncidentUpdate,
+        reopenIncident,
+        confirmDeleteIncident,
+    } = useActions(uptimeSceneLogic)
 
     const monitorsById = new Map(monitorSummaries.map((m: MonitorSummary) => [m.id, m]))
 
@@ -258,6 +263,7 @@ function IncidentsTab(): JSX.Element {
             onResolve={() => promptResolveIncident(incident)}
             onReopen={() => reopenIncident(incident.id)}
             onDelete={() => confirmDeleteIncident({ id: incident.id, name: incident.name })}
+            onPostUpdate={() => promptPostIncidentUpdate(incident)}
         />
     )
 

--- a/products/uptime/frontend/scenes/incidentActions.tsx
+++ b/products/uptime/frontend/scenes/incidentActions.tsx
@@ -1,11 +1,20 @@
-import { LemonTextArea } from '@posthog/lemon-ui'
+import { LemonSelect, LemonTextArea } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
-import { Incident } from './uptimeSceneLogic'
+import { Incident, IncidentUpdateKeyword } from './uptimeSceneLogic'
+
+const KEYWORD_OPTIONS: { label: string; value: IncidentUpdateKeyword }[] = [
+    { label: 'Investigating', value: 'investigating' },
+    { label: 'Identified', value: 'identified' },
+    { label: 'Fixing', value: 'fixing' },
+    { label: 'Monitoring fix', value: 'monitoring' },
+    { label: 'Resolved', value: 'resolved' },
+    { label: 'Update', value: 'update' },
+]
 
 export function openResolveIncidentDialog({
     incident,
@@ -36,6 +45,54 @@ export function openResolveIncidentDialog({
             })
             lemonToast.success('Declared incident resolved')
             onResolved()
+        },
+    })
+}
+
+export function openPostIncidentUpdateDialog({
+    incident,
+    projectId,
+    onPosted,
+}: {
+    incident: Incident
+    projectId: string
+    onPosted: () => void
+}): void {
+    // If the incident is already resolved, default to a freeform "update" so the keyword
+    // doesn't immediately reopen the incident under the user. Otherwise default to the
+    // most common starting keyword.
+    const defaultKeyword: IncidentUpdateKeyword = incident.resolved_at ? 'update' : 'investigating'
+    LemonDialog.openForm({
+        title: `Post update on "${incident.name}"`,
+        description:
+            'Pick a keyword and write a short note. Updates are appended to the incident timeline, newest first.',
+        initialValues: { keyword: defaultKeyword, message: '' },
+        content: (
+            <div className="flex flex-col gap-3">
+                <LemonField name="keyword" label="Keyword">
+                    <LemonSelect<IncidentUpdateKeyword> options={KEYWORD_OPTIONS} fullWidth />
+                </LemonField>
+                <LemonField name="message" label="What's going on?">
+                    <LemonTextArea
+                        autoFocus
+                        placeholder="e.g. Restarted the worker pool — error rate is dropping."
+                        rows={4}
+                    />
+                </LemonField>
+            </div>
+        ),
+        errors: {
+            message: (msg: string) => (!msg?.trim() ? 'Write something to post' : undefined),
+        },
+        primaryButtonProps: { children: 'Post update' },
+        shouldAwaitSubmit: true,
+        onSubmit: async ({ keyword, message }) => {
+            await api.create<Incident>(`api/projects/${projectId}/uptime/incidents/${incident.id}/post_update/`, {
+                keyword,
+                message: message.trim(),
+            })
+            lemonToast.success('Update posted')
+            onPosted()
         },
     })
 }

--- a/products/uptime/frontend/scenes/statusPage/StatusPagePreview.tsx
+++ b/products/uptime/frontend/scenes/statusPage/StatusPagePreview.tsx
@@ -6,6 +6,7 @@ import { dayjs } from 'lib/dayjs'
 import { Popover } from 'lib/lemon-ui/Popover/Popover'
 import { cn } from 'lib/utils/css-classes'
 
+import { IncidentTimeline } from '../IncidentTimeline'
 import { DailyBucket, DailyStatus, Incident, MonitorStatus, MonitorSummary } from '../uptimeSceneLogic'
 
 interface StatusPagePreviewProps {
@@ -110,6 +111,9 @@ function PublicIncidentRow({ incident, monitorName }: { incident: Incident; moni
             </div>
             {incident.description && (
                 <div className="text-xs text-secondary whitespace-pre-wrap">{incident.description}</div>
+            )}
+            {incident.updates && incident.updates.length > 0 && (
+                <IncidentTimeline updates={incident.updates} limit={ongoing ? 5 : 3} className="mt-1" />
             )}
             {!ongoing && incident.resolution_note && (
                 <div className="text-xs whitespace-pre-wrap p-2 rounded bg-surface-secondary">

--- a/products/uptime/frontend/scenes/uptimeMonitorSceneLogic.ts
+++ b/products/uptime/frontend/scenes/uptimeMonitorSceneLogic.ts
@@ -11,7 +11,7 @@ import { urls } from 'scenes/urls'
 
 import { Breadcrumb } from '~/types'
 
-import { openResolveIncidentDialog } from './incidentActions'
+import { openPostIncidentUpdateDialog, openResolveIncidentDialog } from './incidentActions'
 import type { uptimeMonitorSceneLogicType } from './uptimeMonitorSceneLogicType'
 import { Incident, Monitor, MonitorSummary, Outage, Ping } from './uptimeSceneLogic'
 
@@ -37,6 +37,7 @@ export const uptimeMonitorSceneLogic = kea<uptimeMonitorSceneLogicType>([
         startEditingIncident: (incident: Incident) => ({ incident }),
         closeIncidentModal: true,
         promptResolveIncident: (incident: Incident) => ({ incident }),
+        promptPostIncidentUpdate: (incident: Incident) => ({ incident }),
         reopenIncident: (incidentId: string) => ({ incidentId }),
         confirmDeleteIncident: (incident: { id: string; name: string }) => ({ incident }),
         deleteIncident: (incidentId: string) => ({ incidentId }),
@@ -269,6 +270,13 @@ export const uptimeMonitorSceneLogic = kea<uptimeMonitorSceneLogicType>([
                 incident,
                 projectId: values.currentProjectId as string,
                 onResolved: () => actions.loadIncidents(),
+            })
+        },
+        promptPostIncidentUpdate: ({ incident }) => {
+            openPostIncidentUpdateDialog({
+                incident,
+                projectId: values.currentProjectId as string,
+                onPosted: () => actions.loadIncidents(),
             })
         },
         reopenIncident: async ({ incidentId }) => {

--- a/products/uptime/frontend/scenes/uptimeSceneLogic.ts
+++ b/products/uptime/frontend/scenes/uptimeSceneLogic.ts
@@ -12,7 +12,7 @@ import { urls } from 'scenes/urls'
 
 import { Breadcrumb } from '~/types'
 
-import { openResolveIncidentDialog } from './incidentActions'
+import { openPostIncidentUpdateDialog, openResolveIncidentDialog } from './incidentActions'
 import type { uptimeSceneLogicType } from './uptimeSceneLogicType'
 
 export type MonitorMode = 'auto' | 'manual'
@@ -74,6 +74,16 @@ export interface OverallStats {
     avgLatencyMs: number | null
 }
 
+export type IncidentUpdateKeyword = 'investigating' | 'identified' | 'fixing' | 'monitoring' | 'resolved' | 'update'
+
+export interface IncidentUpdate {
+    id: string
+    keyword: IncidentUpdateKeyword
+    message: string
+    posted_at: string
+    posted_by_id: number | null
+}
+
 export interface Incident {
     id: string
     monitor_id: string
@@ -82,6 +92,7 @@ export interface Incident {
     started_at: string
     resolved_at: string | null
     resolution_note: string
+    updates: IncidentUpdate[]
     created_at: string
     updated_at: string
 }
@@ -123,6 +134,7 @@ export const uptimeSceneLogic = kea<uptimeSceneLogicType>([
         startEditingIncident: (incident: Incident) => ({ incident }),
         stopEditingIncident: true,
         promptResolveIncident: (incident: Incident) => ({ incident }),
+        promptPostIncidentUpdate: (incident: Incident) => ({ incident }),
         reopenIncident: (incidentId: string) => ({ incidentId }),
         confirmDeleteIncident: (incident: { id: string; name: string }) => ({ incident }),
         deleteIncident: (incidentId: string) => ({ incidentId }),
@@ -373,6 +385,13 @@ export const uptimeSceneLogic = kea<uptimeSceneLogicType>([
                 incident,
                 projectId: values.currentProjectId as string,
                 onResolved: () => actions.loadIncidents(),
+            })
+        },
+        promptPostIncidentUpdate: ({ incident }) => {
+            openPostIncidentUpdateDialog({
+                incident,
+                projectId: values.currentProjectId as string,
+                onPosted: () => actions.loadIncidents(),
             })
         },
         reopenIncident: async ({ incidentId }) => {

--- a/products/uptime/mcp/tools.yaml
+++ b/products/uptime/mcp/tools.yaml
@@ -117,12 +117,14 @@ tools:
             Return declared incidents across the team, ongoing first, then most recently started.
             Each incident has a name, optional description, the monitor it relates to (monitor_id),
             started_at, resolved_at (null while ongoing), resolution_note (filled when resolved),
-            created_at, and updated_at.
+            an updates timeline (array of { id, keyword, message, posted_at, posted_by_id }
+            entries, newest first), created_at, and updated_at.
 
 
             Pass monitor_id to filter to incidents for a single monitor — useful when the user is
             looking at a specific tile. Use this for "any open incidents?", "what went wrong last
-            week?", or to surface the audit log for a postmortem.
+            week?", or to surface the audit log for a postmortem. Use incident-post-update to
+            append to the timeline as the situation evolves.
     incident-get:
         operation: uptime_incidents_retrieve
         enabled: true
@@ -135,12 +137,14 @@ tools:
         enrich_url: '{id}'
         title: Get one declared incident
         description: >
-            Return a single declared incident by id including its description and (if resolved)
-            resolution_note. Returns 404 if the incident has been deleted.
+            Return a single declared incident by id including its description, (if resolved)
+            resolution_note, and the full updates timeline (each entry a { id, keyword, message,
+            posted_at, posted_by_id } object, newest first). Returns 404 if the incident has been
+            deleted.
 
 
-            Use this after incident-list to fetch the full body / resolution note for a specific
-            incident.
+            Use this after incident-list to fetch the full body / resolution note / timeline for
+            a specific incident. Use incident-post-update to append a new entry to the timeline.
     status-page-list:
         operation: uptime_status_pages_list
         enabled: true
@@ -385,6 +389,34 @@ tools:
 
             For a separate new issue, prefer incident-create — reopening conflates two events
             in the audit trail.
+    incident-post-update:
+        operation: uptime_incidents_post_update_create
+        enabled: true
+        scopes:
+            - uptime:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: '{id}'
+        title: Post a timeline update on an incident
+        description: >
+            Append a keyword-tagged entry to an incident's timeline. Each update has a keyword
+            (one of investigating, identified, fixing, monitoring, resolved, update) and a short
+            message that explains what's happening. Entries are stored newest-first and shown on
+            both the internal tile and the public status page.
+
+
+            When sync_status is true (default), the keyword also drives the incident's open /
+            closed state: posting with keyword "resolved" closes the incident (stamping
+            resolved_at, and promoting the message to the resolution note if one isn't set yet);
+            any other keyword reopens a previously-closed incident. Set sync_status to false to
+            post a freeform note without changing the incident's state.
+
+
+            Use the "update" keyword for notes that don't fit the lifecycle states (e.g. "Status
+            page subscribers have been notified"). Use this tool repeatedly across the lifetime
+            of an incident — that's what builds the timeline narrative.
 
     # ===== Status page writes =====
     status-page-create:

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/incident-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/incident-create.json
@@ -14,6 +14,23 @@
             "maxLength": 255,
             "type": "string"
         },
+        "resolution_note": {
+            "description": "Resolution note. Required when resolved_at is set.",
+            "type": "string"
+        },
+        "resolved_at": {
+            "anyOf": [
+                {
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "When the incident was resolved. Omit or null for an ongoing incident."
+        },
         "started_at": {
             "description": "When the incident started. Defaults to the time the incident was created.",
             "format": "date-time",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/monitor-bulk-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/monitor-bulk-create.json
@@ -15,7 +15,7 @@
                         "type": "string"
                     },
                     "url": {
-                        "description": "HTTP(S) URL to ping every 5 minutes.",
+                        "description": "HTTP(S) URL to ping every minute.",
                         "format": "uri",
                         "maxLength": 2048,
                         "type": "string"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/monitor-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/monitor-create.json
@@ -1,18 +1,31 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "mode": {
+            "default": "auto",
+            "description": "Monitor tracking mode. 'auto' (default) means PostHog pings the URL on a recurring schedule and computes uptime / latency from the pings. 'manual' means uptime is assumed 100% until you declare an incident on the monitor — useful for tracking internal services or third-party dependencies without a public health endpoint.\n\n* `auto` - auto\n* `manual` - manual",
+            "enum": ["auto", "manual"],
+            "type": "string"
+        },
         "name": {
             "description": "Human-readable name of the monitor.",
             "maxLength": 255,
             "type": "string"
         },
         "url": {
-            "description": "HTTP(S) URL to ping every 5 minutes.",
-            "format": "uri",
-            "maxLength": 2048,
-            "type": "string"
+            "anyOf": [
+                {
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "HTTP(S) URL to ping (every minute in auto mode). Required when mode='auto', optional when mode='manual'."
         }
     },
-    "required": ["name", "url"],
+    "required": ["name"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/monitor-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/monitor-update.json
@@ -4,16 +4,28 @@
         "id": {
             "type": "string"
         },
+        "mode": {
+            "description": "Monitor tracking mode. 'auto' (default) means PostHog pings the URL on a recurring schedule and computes uptime / latency from the pings. 'manual' means uptime is assumed 100% until you declare an incident on the monitor — useful for tracking internal services or third-party dependencies without a public health endpoint.\n\n* `auto` - auto\n* `manual` - manual",
+            "enum": ["auto", "manual"],
+            "type": "string"
+        },
         "name": {
             "description": "New human-readable name of the monitor.",
             "maxLength": 255,
             "type": "string"
         },
         "url": {
-            "description": "New HTTP(S) URL to ping every 5 minutes.",
-            "format": "uri",
-            "maxLength": 2048,
-            "type": "string"
+            "anyOf": [
+                {
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "New HTTP(S) URL. Required when the resulting mode is 'auto'."
         }
     },
     "required": ["id"],


### PR DESCRIPTION
## Problem

Operators running an incident on `uptime/feat/bootstrap` can declare an incident and resolve it, but there's no way to post running updates while it's still ongoing. We need a timeline so the team (and anyone watching the public status page) can follow along as the situation evolves — "investigating", "identified the cause", "rolling out a fix", "monitoring", "resolved".

## Changes

Adds a keyword-tagged timeline to the existing `Incident` model. Pure additive layer on top of `uptime/feat/bootstrap` — no existing field or endpoint is repurposed.

**Backend**
- `Incident.updates` JSON column (migration `0007_incident_updates`) holds an array of `{ id, keyword, message, posted_at, posted_by_id }` entries, newest-first
- New `POST /uptime/incidents/:id/post_update/` action on `IncidentViewSet`
- Keywords: `investigating`, `identified`, `fixing`, `monitoring`, `resolved`, `update`
- When `sync_status` is true (default), the keyword also drives open/closed state — `resolved` closes the incident (and the update message is promoted to the resolution note when one isn't set yet); any other keyword reopens a closed incident
- Wired all the way through the existing facade/contracts/logic/presentation layout (`IncidentUpdateDTO`, `PostIncidentUpdateInput`, `facade.post_incident_update`, `logic.post_incident_update`, `PostIncidentUpdateSerializer`)

**Frontend**
- New `IncidentTimeline` component renders a vertical timeline with per-keyword colored dots, icons, and `IncidentKeywordTag`
- `IncidentTile` now shows the latest 3 timeline entries and exposes a "Post timeline update" hover action
- `openPostIncidentUpdateDialog` (in `incidentActions.tsx`) drives a keyword + message form, with a sensible default keyword based on the incident's current state
- `promptPostIncidentUpdate` action on `uptimeSceneLogic` wired through both `UptimeScene` and `UptimeMonitorScene`
- Public `StatusPagePreview` renders the timeline alongside each incident so subscribers see the running narrative

## How did you test this code?

This is an agent-authored PR built against `uptime/feat/bootstrap`. Manual testing path:

1. Apply migration `0007_incident_updates`
2. Declare an incident on a monitor
3. Hit the "Post timeline update" hover action on the tile, pick "Investigating", write a message — entry appears at the top of the tile, incident stays ongoing
4. Post "Resolved" with a message — incident closes, `resolved_at` is stamped, message becomes the resolution note when one isn't set
5. Post any other keyword on the resolved incident — it reopens
6. Check the public status page preview — timeline shows there too

## 🤖 Agent context

Worked iteratively with the user. First pass blindly built a whole parallel `uptime` product against master; second pass discarded it and rebuilt as the tight additive layer above on top of `uptime/feat/bootstrap`. The backend tests in `test_incidents.py` aren't touched here — they don't reference `updates` and the existing `IncidentDTO` constructions go through the facade, which I updated. Generated API types under `products/uptime/frontend/generated/` will be regenerated by `hogli build:openapi` and are intentionally not edited by hand.

https://claude.ai/code/session_01SkTYPoBZPGVnwDtLam3dCy