### PR TITLE
feat(activity): add taxonomy entries for MCP server properties

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1827,9 +1827,29 @@
             ],
             "label": "MCP client name"
         },
+        "$mcp_client_user_agent": {
+            "description": "Full User-Agent string the MCP client sent on the transport. Often includes the agent name, version, and runtime mode \u2014 useful when $mcp_client_name and $mcp_client_version alone don't disambiguate the caller.",
+            "examples": [
+                "claude-code/2.1.141 (cli)",
+                "Anthropic/ClaudeAI"
+            ],
+            "label": "MCP client user agent"
+        },
         "$mcp_client_version": {
             "description": "The version of the MCP client that initiated the connection.",
             "label": "MCP client version"
+        },
+        "$mcp_consumer": {
+            "description": "The upstream surface that initiated the MCP request, supplied via the `x-posthog-mcp-consumer` header. 'posthog-code' means the request came through PostHog Code; 'slack' means it was triggered from Slack.",
+            "examples": [
+                "posthog-code",
+                "slack"
+            ],
+            "label": "MCP consumer"
+        },
+        "$mcp_conversation_id": {
+            "description": "Logical conversation id that stitches multiple tool calls together. Unlike `$session_id` (transport-level, rotates on reconnect or framework boundary), `$mcp_conversation_id` is minted by the SDK on the first call and echoed back by the agent on subsequent calls via a prompt-back text block. Opt-in via `enableConversationId: true` on the SDK's `track()`.",
+            "label": "MCP conversation ID"
         },
         "$mcp_duration_ms": {
             "description": "Wall-clock duration of the MCP tool or resource call, in milliseconds.",
@@ -1884,9 +1904,57 @@
             "description": "Whether the MCP tool call failed. True if the tool returned an error result or threw an exception.",
             "label": "MCP is error"
         },
+        "$mcp_mode": {
+            "description": "Which tool-registration mode the MCP server ran in for this request. 'cli' is single-exec mode (the v2 wrapper that exposes one dispatcher tool taking a `call <tool> ...` command); 'tools' exposes every tool individually.",
+            "examples": [
+                "cli",
+                "tools"
+            ],
+            "label": "MCP mode"
+        },
+        "$mcp_oauth_client_name": {
+            "description": "The OAuth client name captured during the MCP handshake, when the connection used OAuth instead of a personal API key.",
+            "label": "MCP OAuth client name"
+        },
+        "$mcp_organization_id": {
+            "description": "PostHog organization ID resolved for the authenticated MCP session.",
+            "label": "MCP organization ID"
+        },
         "$mcp_parameters": {
             "description": "The arguments the client passed when invoking the tool. Large strings and sensitive keys (tokens, API keys, etc.) are redacted before capture.",
             "label": "MCP parameters"
+        },
+        "$mcp_project_id": {
+            "description": "PostHog project (team) numeric ID for the active project on the MCP session.",
+            "label": "MCP project ID"
+        },
+        "$mcp_project_name": {
+            "description": "Display name of the active PostHog project on the MCP session.",
+            "label": "MCP project name"
+        },
+        "$mcp_project_uuid": {
+            "description": "PostHog project UUID for the active project on the MCP session.",
+            "label": "MCP project UUID"
+        },
+        "$mcp_protocol_version": {
+            "description": "The MCP protocol version negotiated between client and server during initialize.",
+            "examples": [
+                "2025-11-25",
+                "2025-06-18"
+            ],
+            "label": "MCP protocol version"
+        },
+        "$mcp_read_only": {
+            "description": "Whether the MCP session is operating in read-only mode. When true, write/mutation tools are not registered on the server.",
+            "label": "MCP read-only"
+        },
+        "$mcp_region": {
+            "description": "The PostHog cloud region the MCP server routed the request to.",
+            "examples": [
+                "us",
+                "eu"
+            ],
+            "label": "MCP region"
         },
         "$mcp_resource_name": {
             "description": "The name of the MCP resource, prompt, or tool the event refers to.",
@@ -1906,6 +1974,10 @@
         "$mcp_server_version": {
             "description": "The advertised version of the MCP server that handled the request.",
             "label": "MCP server version"
+        },
+        "$mcp_session_id": {
+            "description": "Stable MCP-layer session ID supplied by the transport (e.g. the MCP `extra.sessionId` handle or framework session). Distinct from PostHog's `$session_id`, which is a posthog-js / SDK construct \u2014 `$mcp_session_id` is the MCP-layer handle, `$session_id` is the analytics-layer one.",
+            "label": "MCP session ID"
         },
         "$mcp_source": {
             "description": "Constant identifier for the analytics SDK that emitted the event. Lets you separate events from different SDK versions or unrelated MCP servers.",
@@ -1929,6 +2001,24 @@
                 "feature-flag-get-all"
             ],
             "label": "MCP tool name"
+        },
+        "$mcp_transport": {
+            "description": "The transport the MCP client used to connect to the server.",
+            "examples": [
+                "stdio",
+                "sse",
+                "streamable-http"
+            ],
+            "label": "MCP transport"
+        },
+        "$mcp_version": {
+            "description": "Server-resolved MCP version. May differ from the version the client reported because of the mcp-version-2 feature flag.",
+            "examples": [
+                1,
+                2
+            ],
+            "label": "MCP server version (internal)",
+            "type": "Numeric"
         },
         "$network_bluetooth": {
             "description": "Whether the user was on Bluetooth when the event was sent.",
@@ -3005,49 +3095,36 @@
             "label": "MCP client version (unprefixed)"
         },
         "mcp_consumer": {
-            "description": "The upstream surface that initiated the MCP request. 'posthog-code' means the request came through PostHog Code; 'slack' means it was triggered from Slack.",
-            "examples": [
-                "posthog-code",
-                "slack"
-            ],
-            "label": "MCP consumer"
+            "description": "Older unprefixed variant of $mcp_consumer. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_consumer for new dashboards.",
+            "label": "MCP consumer (unprefixed)"
+        },
+        "mcp_conversation_id": {
+            "description": "Older unprefixed variant of $mcp_conversation_id. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_conversation_id for new dashboards.",
+            "label": "MCP conversation ID (unprefixed)"
         },
         "mcp_mode": {
-            "description": "Which tool-registration mode the MCP server ran in for this request. 'single-exec' means the v2 wrapper that exposes one tool; the alternative exposes every tool individually.",
-            "label": "MCP mode"
+            "description": "Older unprefixed variant of $mcp_mode. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_mode for new dashboards.",
+            "label": "MCP mode (unprefixed)"
         },
         "mcp_oauth_client_name": {
-            "description": "The OAuth client name captured during the MCP handshake, when the connection used OAuth.",
-            "label": "MCP OAuth client name"
+            "description": "Older unprefixed variant of $mcp_oauth_client_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_oauth_client_name for new dashboards.",
+            "label": "MCP OAuth client name (unprefixed)"
         },
         "mcp_protocol_version": {
-            "description": "The MCP protocol version negotiated during initialize.",
-            "label": "MCP protocol version"
+            "description": "Older unprefixed variant of $mcp_protocol_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_protocol_version for new dashboards.",
+            "label": "MCP protocol version (unprefixed)"
         },
-        "mcp_region": {
-            "description": "The region the MCP server routed the request to.",
-            "examples": [
-                "us",
-                "eu"
-            ],
-            "label": "MCP region"
+        "mcp_session_id": {
+            "description": "Older unprefixed variant of $mcp_session_id. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_session_id for new dashboards.",
+            "label": "MCP session ID (unprefixed)"
         },
         "mcp_transport": {
-            "description": "The transport the MCP client used to connect to the server.",
-            "examples": [
-                "stdio",
-                "sse",
-                "streamable_http"
-            ],
-            "label": "MCP transport"
+            "description": "Older unprefixed variant of $mcp_transport. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_transport for new dashboards.",
+            "label": "MCP transport (unprefixed)"
         },
         "mcp_version": {
-            "description": "Server-resolved MCP version. May differ from the version the client reported because of the mcp-version-2 feature flag.",
-            "examples": [
-                1,
-                2
-            ],
-            "label": "MCP server version (internal)",
+            "description": "Older unprefixed variant of $mcp_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_version for new dashboards.",
+            "label": "MCP server version (unprefixed, internal)",
             "type": "Numeric"
         },
         "msclkid": {
@@ -5659,9 +5736,29 @@
             ],
             "label": "MCP client name"
         },
+        "$mcp_client_user_agent": {
+            "description": "Full User-Agent string the MCP client sent on the transport. Often includes the agent name, version, and runtime mode \u2014 useful when $mcp_client_name and $mcp_client_version alone don't disambiguate the caller.",
+            "examples": [
+                "claude-code/2.1.141 (cli)",
+                "Anthropic/ClaudeAI"
+            ],
+            "label": "MCP client user agent"
+        },
         "$mcp_client_version": {
             "description": "The version of the MCP client that initiated the connection.",
             "label": "MCP client version"
+        },
+        "$mcp_consumer": {
+            "description": "The upstream surface that initiated the MCP request, supplied via the `x-posthog-mcp-consumer` header. 'posthog-code' means the request came through PostHog Code; 'slack' means it was triggered from Slack.",
+            "examples": [
+                "posthog-code",
+                "slack"
+            ],
+            "label": "MCP consumer"
+        },
+        "$mcp_conversation_id": {
+            "description": "Logical conversation id that stitches multiple tool calls together. Unlike `$session_id` (transport-level, rotates on reconnect or framework boundary), `$mcp_conversation_id` is minted by the SDK on the first call and echoed back by the agent on subsequent calls via a prompt-back text block. Opt-in via `enableConversationId: true` on the SDK's `track()`.",
+            "label": "MCP conversation ID"
         },
         "$mcp_duration_ms": {
             "description": "Wall-clock duration of the MCP tool or resource call, in milliseconds.",
@@ -5716,9 +5813,57 @@
             "description": "Whether the MCP tool call failed. True if the tool returned an error result or threw an exception.",
             "label": "MCP is error"
         },
+        "$mcp_mode": {
+            "description": "Which tool-registration mode the MCP server ran in for this request. 'cli' is single-exec mode (the v2 wrapper that exposes one dispatcher tool taking a `call <tool> ...` command); 'tools' exposes every tool individually.",
+            "examples": [
+                "cli",
+                "tools"
+            ],
+            "label": "MCP mode"
+        },
+        "$mcp_oauth_client_name": {
+            "description": "The OAuth client name captured during the MCP handshake, when the connection used OAuth instead of a personal API key.",
+            "label": "MCP OAuth client name"
+        },
+        "$mcp_organization_id": {
+            "description": "PostHog organization ID resolved for the authenticated MCP session.",
+            "label": "MCP organization ID"
+        },
         "$mcp_parameters": {
             "description": "The arguments the client passed when invoking the tool. Large strings and sensitive keys (tokens, API keys, etc.) are redacted before capture.",
             "label": "MCP parameters"
+        },
+        "$mcp_project_id": {
+            "description": "PostHog project (team) numeric ID for the active project on the MCP session.",
+            "label": "MCP project ID"
+        },
+        "$mcp_project_name": {
+            "description": "Display name of the active PostHog project on the MCP session.",
+            "label": "MCP project name"
+        },
+        "$mcp_project_uuid": {
+            "description": "PostHog project UUID for the active project on the MCP session.",
+            "label": "MCP project UUID"
+        },
+        "$mcp_protocol_version": {
+            "description": "The MCP protocol version negotiated between client and server during initialize.",
+            "examples": [
+                "2025-11-25",
+                "2025-06-18"
+            ],
+            "label": "MCP protocol version"
+        },
+        "$mcp_read_only": {
+            "description": "Whether the MCP session is operating in read-only mode. When true, write/mutation tools are not registered on the server.",
+            "label": "MCP read-only"
+        },
+        "$mcp_region": {
+            "description": "The PostHog cloud region the MCP server routed the request to.",
+            "examples": [
+                "us",
+                "eu"
+            ],
+            "label": "MCP region"
         },
         "$mcp_resource_name": {
             "description": "The name of the MCP resource, prompt, or tool the event refers to.",
@@ -5738,6 +5883,10 @@
         "$mcp_server_version": {
             "description": "The advertised version of the MCP server that handled the request.",
             "label": "MCP server version"
+        },
+        "$mcp_session_id": {
+            "description": "Stable MCP-layer session ID supplied by the transport (e.g. the MCP `extra.sessionId` handle or framework session). Distinct from PostHog's `$session_id`, which is a posthog-js / SDK construct \u2014 `$mcp_session_id` is the MCP-layer handle, `$session_id` is the analytics-layer one.",
+            "label": "MCP session ID"
         },
         "$mcp_source": {
             "description": "Constant identifier for the analytics SDK that emitted the event. Lets you separate events from different SDK versions or unrelated MCP servers.",
@@ -5761,6 +5910,24 @@
                 "feature-flag-get-all"
             ],
             "label": "MCP tool name"
+        },
+        "$mcp_transport": {
+            "description": "The transport the MCP client used to connect to the server.",
+            "examples": [
+                "stdio",
+                "sse",
+                "streamable-http"
+            ],
+            "label": "MCP transport"
+        },
+        "$mcp_version": {
+            "description": "Server-resolved MCP version. May differ from the version the client reported because of the mcp-version-2 feature flag.",
+            "examples": [
+                1,
+                2
+            ],
+            "label": "MCP server version (internal)",
+            "type": "Numeric"
         },
         "$network_bluetooth": {
             "description": "Whether the user was on Bluetooth when the event was sent.",
@@ -6817,49 +6984,36 @@
             "label": "MCP client version (unprefixed)"
         },
         "mcp_consumer": {
-            "description": "The upstream surface that initiated the MCP request. 'posthog-code' means the request came through PostHog Code; 'slack' means it was triggered from Slack.",
-            "examples": [
-                "posthog-code",
-                "slack"
-            ],
-            "label": "MCP consumer"
+            "description": "Older unprefixed variant of $mcp_consumer. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_consumer for new dashboards.",
+            "label": "MCP consumer (unprefixed)"
+        },
+        "mcp_conversation_id": {
+            "description": "Older unprefixed variant of $mcp_conversation_id. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_conversation_id for new dashboards.",
+            "label": "MCP conversation ID (unprefixed)"
         },
         "mcp_mode": {
-            "description": "Which tool-registration mode the MCP server ran in for this request. 'single-exec' means the v2 wrapper that exposes one tool; the alternative exposes every tool individually.",
-            "label": "MCP mode"
+            "description": "Older unprefixed variant of $mcp_mode. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_mode for new dashboards.",
+            "label": "MCP mode (unprefixed)"
         },
         "mcp_oauth_client_name": {
-            "description": "The OAuth client name captured during the MCP handshake, when the connection used OAuth.",
-            "label": "MCP OAuth client name"
+            "description": "Older unprefixed variant of $mcp_oauth_client_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_oauth_client_name for new dashboards.",
+            "label": "MCP OAuth client name (unprefixed)"
         },
         "mcp_protocol_version": {
-            "description": "The MCP protocol version negotiated during initialize.",
-            "label": "MCP protocol version"
+            "description": "Older unprefixed variant of $mcp_protocol_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_protocol_version for new dashboards.",
+            "label": "MCP protocol version (unprefixed)"
         },
-        "mcp_region": {
-            "description": "The region the MCP server routed the request to.",
-            "examples": [
-                "us",
-                "eu"
-            ],
-            "label": "MCP region"
+        "mcp_session_id": {
+            "description": "Older unprefixed variant of $mcp_session_id. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_session_id for new dashboards.",
+            "label": "MCP session ID (unprefixed)"
         },
         "mcp_transport": {
-            "description": "The transport the MCP client used to connect to the server.",
-            "examples": [
-                "stdio",
-                "sse",
-                "streamable_http"
-            ],
-            "label": "MCP transport"
+            "description": "Older unprefixed variant of $mcp_transport. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_transport for new dashboards.",
+            "label": "MCP transport (unprefixed)"
         },
         "mcp_version": {
-            "description": "Server-resolved MCP version. May differ from the version the client reported because of the mcp-version-2 feature flag.",
-            "examples": [
-                1,
-                2
-            ],
-            "label": "MCP server version (internal)",
+            "description": "Older unprefixed variant of $mcp_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_version for new dashboards.",
+            "label": "MCP server version (unprefixed, internal)",
             "type": "Numeric"
         },
         "msclkid": {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2569,6 +2569,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "MCP client version",
             "description": "The version of the MCP client that initiated the connection.",
         },
+        "$mcp_client_user_agent": {
+            "label": "MCP client user agent",
+            "description": "Full User-Agent string the MCP client sent on the transport. Often includes the agent name, version, and runtime mode — useful when $mcp_client_name and $mcp_client_version alone don't disambiguate the caller.",
+            "examples": ["claude-code/2.1.141 (cli)", "Anthropic/ClaudeAI"],
+        },
         "$mcp_intent": {
             "label": "MCP intent",
             "description": "Free-text description of why the agent is calling this tool, written by the agent itself. Comes from a context argument the client supplied at call time, or — if none was supplied — from an intentFallback the MCP server provides.",
@@ -2589,6 +2594,14 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$mcp_response": {
             "label": "MCP response",
             "description": "The response the MCP server returned. Large strings and sensitive keys are redacted before capture.",
+        },
+        "$mcp_session_id": {
+            "label": "MCP session ID",
+            "description": "Stable MCP-layer session ID supplied by the transport (e.g. the MCP `extra.sessionId` handle or framework session). Distinct from PostHog's `$session_id`, which is a posthog-js / SDK construct — `$mcp_session_id` is the MCP-layer handle, `$session_id` is the analytics-layer one.",
+        },
+        "$mcp_conversation_id": {
+            "label": "MCP conversation ID",
+            "description": "Logical conversation id that stitches multiple tool calls together. Unlike `$session_id` (transport-level, rotates on reconnect or framework boundary), `$mcp_conversation_id` is minted by the SDK on the first call and echoed back by the agent on subsequent calls via a prompt-back text block. Opt-in via `enableConversationId: true` on the SDK's `track()`.",
         },
         # PostHog-specific MCP properties added by the PostHog MCP server on top of the SDK's core
         # set. They identify which deployment, transport, and consumer produced the event. The
@@ -2611,38 +2624,60 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "Array of every inner tool name available to the agent at the time of a tools/list request. Stored as a JSON array — filter with `contains` against a single tool name (e.g. 'execute-sql'). Only stamped on mcp_tools_list events when running in single-exec mode (in multi-tool mode the SDK's $mcp_listed_tool_names already carries the catalog). Lets you compute zombie tools by diffing against $mcp_exec_tool_call_name from mcp_tool_call events.",
             "examples": ["execute-sql", "feature-flag-get-all"],
         },
-        "mcp_protocol_version": {
+        "$mcp_protocol_version": {
             "label": "MCP protocol version",
-            "description": "The MCP protocol version negotiated during initialize.",
+            "description": "The MCP protocol version negotiated between client and server during initialize.",
+            "examples": ["2025-11-25", "2025-06-18"],
         },
-        "mcp_transport": {
+        "$mcp_transport": {
             "label": "MCP transport",
             "description": "The transport the MCP client used to connect to the server.",
-            "examples": ["stdio", "sse", "streamable_http"],
+            "examples": ["stdio", "sse", "streamable-http"],
         },
-        "mcp_consumer": {
+        "$mcp_consumer": {
             "label": "MCP consumer",
-            "description": "The upstream surface that initiated the MCP request. 'posthog-code' means the request came through PostHog Code; 'slack' means it was triggered from Slack.",
+            "description": "The upstream surface that initiated the MCP request, supplied via the `x-posthog-mcp-consumer` header. 'posthog-code' means the request came through PostHog Code; 'slack' means it was triggered from Slack.",
             "examples": ["posthog-code", "slack"],
         },
-        "mcp_mode": {
+        "$mcp_mode": {
             "label": "MCP mode",
-            "description": "Which tool-registration mode the MCP server ran in for this request. 'single-exec' means the v2 wrapper that exposes one tool; the alternative exposes every tool individually.",
+            "description": "Which tool-registration mode the MCP server ran in for this request. 'cli' is single-exec mode (the v2 wrapper that exposes one dispatcher tool taking a `call <tool> ...` command); 'tools' exposes every tool individually.",
+            "examples": ["cli", "tools"],
         },
-        "mcp_region": {
+        "$mcp_region": {
             "label": "MCP region",
-            "description": "The region the MCP server routed the request to.",
+            "description": "The PostHog cloud region the MCP server routed the request to.",
             "examples": ["us", "eu"],
         },
-        "mcp_oauth_client_name": {
+        "$mcp_oauth_client_name": {
             "label": "MCP OAuth client name",
-            "description": "The OAuth client name captured during the MCP handshake, when the connection used OAuth.",
+            "description": "The OAuth client name captured during the MCP handshake, when the connection used OAuth instead of a personal API key.",
         },
-        "mcp_version": {
+        "$mcp_version": {
             "label": "MCP server version (internal)",
             "description": "Server-resolved MCP version. May differ from the version the client reported because of the mcp-version-2 feature flag.",
             "type": "Numeric",
             "examples": [1, 2],
+        },
+        "$mcp_organization_id": {
+            "label": "MCP organization ID",
+            "description": "PostHog organization ID resolved for the authenticated MCP session.",
+        },
+        "$mcp_project_id": {
+            "label": "MCP project ID",
+            "description": "PostHog project (team) numeric ID for the active project on the MCP session.",
+        },
+        "$mcp_project_name": {
+            "label": "MCP project name",
+            "description": "Display name of the active PostHog project on the MCP session.",
+        },
+        "$mcp_project_uuid": {
+            "label": "MCP project UUID",
+            "description": "PostHog project UUID for the active project on the MCP session.",
+        },
+        "$mcp_read_only": {
+            "label": "MCP read-only",
+            "description": "Whether the MCP session is operating in read-only mode. When true, write/mutation tools are not registered on the server.",
         },
         # Unprefixed MCP properties from the older code paths (the mcpcat library and PostHog's
         # in-tree trackEvent path). They overlap with the $mcp_*-prefixed core properties above
@@ -2656,6 +2691,39 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "mcp_client_version": {
             "label": "MCP client version (unprefixed)",
             "description": "Older unprefixed variant of $mcp_client_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_client_version for new dashboards.",
+        },
+        "mcp_oauth_client_name": {
+            "label": "MCP OAuth client name (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_oauth_client_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_oauth_client_name for new dashboards.",
+        },
+        "mcp_protocol_version": {
+            "label": "MCP protocol version (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_protocol_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_protocol_version for new dashboards.",
+        },
+        "mcp_consumer": {
+            "label": "MCP consumer (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_consumer. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_consumer for new dashboards.",
+        },
+        "mcp_transport": {
+            "label": "MCP transport (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_transport. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_transport for new dashboards.",
+        },
+        "mcp_session_id": {
+            "label": "MCP session ID (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_session_id. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_session_id for new dashboards.",
+        },
+        "mcp_conversation_id": {
+            "label": "MCP conversation ID (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_conversation_id. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_conversation_id for new dashboards.",
+        },
+        "mcp_mode": {
+            "label": "MCP mode (unprefixed)",
+            "description": "Older unprefixed variant of $mcp_mode. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_mode for new dashboards.",
+        },
+        "mcp_version": {
+            "label": "MCP server version (unprefixed, internal)",
+            "description": "Older unprefixed variant of $mcp_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_version for new dashboards.",
+            "type": "Numeric",
         },
         "tool_name": {
             "label": "Tool name (unprefixed)",


### PR DESCRIPTION
## Problem

The activity tab on `mcp_*` events shows several properties as raw `\$mcp_something` keys instead of friendly labels — `\$mcp_client_user_agent`, `\$mcp_conversation_id`, `\$mcp_session_id`, `\$mcp_project_id`, `\$mcp_transport`, `\$mcp_region`, and friends. The PostHog MCP server (\`services/mcp/src/lib/posthog-mcp-analytics.ts\`) stamps these on every event, but the taxonomy was missing entries (or had them under the wrong key shape), so taxonomic lookup misses and the UI falls back to the raw key.

This is a follow-up to #58573 — that PR grouped the property table and tidied the summary card. This one fills in the labels for the keys that ended up next to each other after the grouping.

## Changes

Source of truth is \`posthog/taxonomy/taxonomy.py\`. JSON regenerated via \`pnpm run taxonomy:build\`.

**Renamed (wrong key shape):** Seven existing entries were defined as unprefixed (\`mcp_protocol_version\`, \`mcp_transport\`, \`mcp_consumer\`, \`mcp_mode\`, \`mcp_region\`, \`mcp_oauth_client_name\`, \`mcp_version\`) but the wire emits them with the \`\$\` prefix from the @posthog/mcp pipeline (\`services/mcp/src/lib/posthog-mcp-analytics.ts\`). Renamed to use the \`\$\` prefix so taxonomy lookup hits.

**Added (no entry at all):** Eight new \`\$mcp_*\` entries — \`\$mcp_client_user_agent\`, \`\$mcp_session_id\`, \`\$mcp_conversation_id\`, \`\$mcp_organization_id\`, \`\$mcp_project_id\`, \`\$mcp_project_name\`, \`\$mcp_project_uuid\`, \`\$mcp_read_only\`. Descriptions explain what each one is and how it relates to neighbouring fields (e.g. \`\$mcp_session_id\` is the MCP-layer session handle, distinct from PostHog's \`\$session_id\`; \`\$mcp_conversation_id\` is the stable cross-call thread id minted by the SDK and echoed back by the agent — opt-in via \`enableConversationId: true\`, see [mcp-analytics #14](https://github.com/PostHog/mcp-analytics/pull/14)).

**Legacy block kept in sync:** A parallel emission path in \`services/mcp/src/mcp.ts\` (around lines 350–374) still stamps the same fields with no \`\$\` prefix. Added matching unprefixed entries (\`mcp_oauth_client_name\`, \`mcp_protocol_version\`, \`mcp_consumer\`, \`mcp_transport\`, \`mcp_session_id\`, \`mcp_conversation_id\`, \`mcp_mode\`, \`mcp_version\`) to the existing unprefixed-legacy block, following the same \"(unprefixed)\" label suffix + \"Older unprefixed variant of \$mcp_X\" description convention already used by \`mcp_client_name\` / \`mcp_client_version\` / \`tool_name\` / \`resource_name\` / etc. So older events keep their labels too.

## How did you test this code?

I'm an agent (PostHog Code) and did not manually verify the UI in a browser. Automated checks I ran:

- \`python3 -c \"from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP\"\` — module imports cleanly.
- \`pnpm run taxonomy:build\` — JSON regenerated. Validated parse + key presence: all 15 prefixed and 8 legacy entries are in \`event_properties\` (and the mirrored \`person_properties\` block) of the regenerated JSON.
- lint-staged / oxfmt / ty check passed on commit.

Recommend a manual check after merge: open any \`mcp_*\` event in activity and confirm the \`\$mcp_client_user_agent\`, \`\$mcp_conversation_id\`, \`\$mcp_session_id\`, etc. rows now render with friendly labels instead of raw \`\$mcp_*\` keys.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (agent). Triggered by noticing — while reviewing the grouped property panel from #58573 — that roughly half the rows still rendered as raw \`\$mcp_*\` keys instead of friendly labels.

Decisions worth flagging for review:

- **Two emission paths, two sets of entries.** I initially assumed renaming unprefixed → prefixed was the whole fix, then caught the parallel path in \`services/mcp/src/mcp.ts:350-374\` that still emits the unprefixed form. Rather than reaching across PR boundaries to migrate that path, I added both prefixed (Block 2, primary) and unprefixed (Block 3, legacy) taxonomy entries. The legacy block already had this exact convention for \`mcp_client_name\` / \`mcp_client_version\` / \`tool_name\`, so this slots in cleanly.
- **Description tone for \`\$mcp_session_id\` and \`\$mcp_conversation_id\`.** Both deserved a sentence calling out the distinction from PostHog's own \`\$session_id\`, since these are common sources of confusion. Pulled the conversation-id mechanics description from the [mcp-analytics PR #14](https://github.com/PostHog/mcp-analytics/pull/14).
- **Did not deprecate the legacy unprefixed entries.** Comment block at the top of that section says \"@posthog/mcp is still in internal testing\", so the unprefixed shape is still load-bearing. Will be retired when @posthog/mcp ships GA.

Requires human review before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*