### PR TITLE
refactor(surveys): drop #preserveLocalChanges hash flag, always preserve state

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -436,7 +436,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                     data-attr="switch-to-wizard"
                                     type="tertiary"
                                     size="small"
-                                    to={`${urls.surveyWizard(id)}#preserveLocalChanges=true`}
+                                    to={urls.surveyWizard(id)}
                                     onClick={() => setPreferredEditor('guided')}
                                 >
                                     Guided editor

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -148,7 +148,7 @@ describe('editor sync', () => {
             surveyChanged: true,
         })
 
-        router.actions.push('/surveys/test-survey?edit=true#preserveLocalChanges=true')
+        router.actions.push('/surveys/test-survey?edit=true')
 
         await expectLogic(logic).toFinishAllListeners()
 

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -3207,8 +3207,10 @@ export const surveyLogic = kea<surveyLogicType>([
         ],
     })),
     afterMount(({ props, actions, values }) => {
-        const shouldPreserveLocalChanges =
-            router.values.hashParams.preserveLocalChanges && values.surveyChanged && values.survey.id === props.id
+        // Preserve any in-memory edits when re-mounting on the same survey id (e.g.
+        // navigating between the guided wizard and the full editor). No URL flag —
+        // surveyChanged is in-memory only, so a fresh session can never trigger this.
+        const shouldPreserveLocalChanges = values.surveyChanged && values.survey.id === props.id
 
         if (props.id !== 'new' && !shouldPreserveLocalChanges) {
             actions.loadSurvey()

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -78,8 +78,8 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     // Redirect existing surveys that use wizard-unsupported fields to the full
     // editor. Brand-new surveys should always start on template selection,
     // regardless of the user's editor preference.
-    // Hash-carrying deep links (#fromTemplate, #preserveLocalChanges) are
-    // respected and bypass the redirect.
+    // Hash-carrying deep links (e.g. #fromTemplate) are respected and bypass the
+    // redirect.
     useEffect(() => {
         if (window.location.hash) {
             return
@@ -124,9 +124,9 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
 
     const handleCustomizeMore = (): void => {
         setPreferredEditor('full')
-        const target = isEditing
-            ? `${urls.survey(id)}?edit=true#preserveLocalChanges=true`
-            : `${urls.survey(id)}#fromTemplate=true&preserveLocalChanges=true`
+        // Unsaved edits are preserved automatically by surveyLogic when the route
+        // re-mounts with the same survey id — no URL flag needed.
+        const target = isEditing ? `${urls.survey(id)}?edit=true` : `${urls.survey(id)}#fromTemplate=true`
         router.actions.push(target)
     }
 

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts
@@ -1,6 +1,8 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
+import { urls } from 'scenes/urls'
+
 import { useMocks } from '~/mocks/jest'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
@@ -241,7 +243,7 @@ describe('surveyWizardLogic', () => {
                 surveyChanged: true,
             })
 
-            router.actions.push('/surveys/guided/new#preserveLocalChanges=true')
+            router.actions.push('/surveys/guided/new')
 
             const logic = surveyWizardLogic({ id: 'new' })
             logic.mount()
@@ -265,14 +267,14 @@ describe('surveyWizardLogic', () => {
                 surveyChanged: true,
             })
 
-            router.actions.push('/surveys/new#preserveLocalChanges=true')
+            router.actions.push('/surveys/new')
             unmountWizard()
 
             expect(surveyFormLogic.values.survey.description).toBe('Edited in the guided editor')
             expect(surveyFormLogic.values.surveyChanged).toBe(true)
         })
 
-        it('resets new survey state when leaving the guided editor without preserveLocalChanges', async () => {
+        it('resets new survey state when navigating away from the survey editor', async () => {
             const surveyFormLogic = surveyLogic({ id: 'new' })
             surveyFormLogic.mount()
 
@@ -289,6 +291,28 @@ describe('surveyWizardLogic', () => {
             unmountWizard()
 
             expect(surveyFormLogic.values.survey.description).toBe('')
+        })
+
+        it('preserves the in-memory draft when switching to the full editor without any URL flag', async () => {
+            // Regression test: previously the wizard had to push `#preserveLocalChanges=true`
+            // to keep state across editor swaps. Verify the flag-free path works.
+            const surveyFormLogic = surveyLogic({ id: 'new' })
+            surveyFormLogic.mount()
+
+            const wizardLogic = surveyWizardLogic({ id: 'new' })
+            const unmountWizard = wizardLogic.mount()
+
+            await expectLogic(wizardLogic, () => {
+                wizardLogic.actions.setSurveyValue('name', 'Drafted in the wizard')
+            }).toMatchValues({
+                surveyChanged: true,
+            })
+
+            router.actions.push(urls.survey('new'))
+            unmountWizard()
+
+            expect(surveyFormLogic.values.survey.name).toBe('Drafted in the wizard')
+            expect(surveyFormLogic.values.surveyChanged).toBe(true)
         })
     })
 

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -387,8 +387,10 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
     })),
 
     afterMount(({ actions, props, values }) => {
-        const shouldPreserveLocalChanges =
-            router.values.hashParams.preserveLocalChanges && values.surveyChanged && values.survey.id === props.id
+        // Preserve any in-memory edits when re-mounting on the same survey id (e.g.
+        // navigating between the full editor and the wizard). surveyChanged is
+        // in-memory only, so a fresh session can never trigger this branch.
+        const shouldPreserveLocalChanges = values.surveyChanged && values.survey.id === props.id
 
         if (props.id === 'new') {
             if (shouldPreserveLocalChanges) {
@@ -411,8 +413,18 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
 
     beforeUnmount(({ actions, props }) => {
         actions.resetWizard()
-        if (props.id === 'new' && !router.values.hashParams.preserveLocalChanges) {
-            actions.resetSurvey()
+        // For an in-progress "new" survey, preserve the in-memory draft only if the
+        // user is navigating to the other survey-editor view for the same id (full
+        // editor for new). Anywhere else (list, dashboards, etc.) means the user
+        // abandoned the draft, so we clear it. Using `endsWith` so this still works
+        // when the app is mounted under a project-scoped path (`/project/<id>/...`).
+        if (props.id === 'new') {
+            const destination = router.values.location.pathname
+            const stayingInNewSurveyEditor =
+                destination.endsWith(urls.survey('new')) || destination.endsWith(urls.surveyWizard('new'))
+            if (!stayingInNewSurveyEditor) {
+                actions.resetSurvey()
+            }
         }
     }),
 ])


### PR DESCRIPTION
## Problem

The guided wizard and the full survey editor already share state — \`surveyWizardLogic\` doesn't keep its own copy of the survey, it connects to \`surveyLogic\` and reads/writes survey fields through \`setSurveyValue\`. So in theory switching between editors should never lose work.

In practice, every editor switch had to push a URL like \`/surveys/new?edit=true#preserveLocalChanges=true\` and both logics' \`afterMount\` checked that hash flag before deciding whether to destructively \`loadSurvey()\` / \`resetSurvey()\` and overwrite the in-memory draft.

That hash flag is the root of the recurring "I lost my survey when I clicked 'customize more'" complaints. It's an out-of-band signal that every new entry point has to remember to attach, and forgetting it silently nukes the user's work.

## Changes

Stop relying on the URL flag. Lean on two signals we already have:

- \`surveyChanged\` is in-memory only, so it can never carry over between sessions — a fresh page load can never accidentally trigger preservation.
- \`survey.id === props.id\` rules out cross-survey state bleed.

Together they're sufficient.

- **\`surveyLogic.afterMount\`** — preserve when \`surveyChanged && survey.id === props.id\`. The hash flag check is gone.
- **\`surveyWizardLogic.afterMount\`** — same.
- **\`surveyWizardLogic.beforeUnmount\`** — for an in-progress \`new\` survey, only \`resetSurvey()\` when the destination is **not** another survey-editor URL for the same id. So wizard ↔ full editor swaps keep state, but navigating to the surveys list or any other route clears the draft. Uses \`destination.endsWith(urls.survey('new'))\` so the check still works under the project-scoped \`/project/<id>/...\` path.
- **\`SurveyWizard.tsx\` + \`SurveyEdit.tsx\`** — strip \`#preserveLocalChanges=true\` from both editor-switch call sites and update the comments.
- **Tests** — existing preservation tests still pass after dropping the hash flag from their pushed URLs; added a new regression test \`preserves the in-memory draft when switching to the full editor without any URL flag\` to lock in the new contract.

## How did you test this code?

I'm an agent (PostHog Code). I haven't run the dev server manually. Verified:

- All 66 tests in \`surveyLogic.test.ts\` + \`wizard/surveyWizardLogic.test.ts\` pass — that includes the existing preservation tests (now without the flag) and the new \"flag-free\" regression test.
- \`oxlint\` clean on the changed files (one pre-existing warning in \`surveyLogic.tsx:399\` for an unrelated \`new Array(scaleSize)\` call, not from this PR).

What a reviewer should manually verify before merge:

- Draft a new survey in the wizard, click \"Customize more\" → unsaved fields are still there in the full editor.
- Same survey, switch from full back to guided → state still preserved.
- Same survey, click \"Surveys\" in the breadcrumb (navigate to list) → draft is correctly discarded; clicking \"New survey\" gives a fresh form.
- Browser back/forward between wizard and full editor → no overwrite of in-memory edits.

## Publish to changelog?

No — pure internal refactor with no user-visible behavior change beyond \"state preservation just works.\"

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Context: the user (lucas@posthog.com) had previously shipped a \`LemonDialog\` confirm-before-switching as a band-aid for data loss across editors. They flagged that this still felt hacky and asked for a real fix that just shares state unconditionally. This PR is that fix.

One non-obvious decision worth flagging:
- I kept the \`beforeUnmount\` destructive reset for the \`new\` survey when navigating away from the editor (e.g. to the list). Without that, clicking \"New survey\" after abandoning a draft would silently restore the old draft, which is surprising. The destination URL check (\`endsWith\`) gives us the best of both: wizard↔full preserves, navigate elsewhere discards.
- Used \`endsWith\` rather than \`===\` because the test environment (and production) mount routes under \`/project/<id>/surveys/...\` — a strict equality check fails there. Worth a look in code review to confirm the matching is tight enough; alternatively we could split the trailing pathname differently.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*