### PR TITLE
feat(settings): take CSP reporting out of beta and drop the gating flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -187,7 +187,6 @@ export const FEATURE_FLAGS = {
     BOX_PLOT_INSIGHT: 'box-plot-insight', // owner: @pauldambra #team-product-analytics
     CALENDAR_HEATMAP_INSIGHT: 'calendar-heatmap-insight', // owner: @jabahamondes #team-web-analytics
     COOKIELESS_SERVER_HASH_MODE_SETTING: 'cookieless-server-hash-mode-setting', // owner: #team-web-analytics
-    CSP_REPORTING: 'mexicspo', // owner @pauldambra @lricoy @robbiec
     ERROR_TRACKING_ALERT_ROUTING: 'error-tracking-alert-routing', // owner: #team-error-tracking
     EXPERIMENT_INTERVAL_TIMESERIES: 'experiments-interval-timeseries', // owner: @jurajmajerik #team-experiments
     /* The below flag is used to activate unmounting charts outside the viewport, as we're currently investigating frontend performance

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -397,14 +397,7 @@ export const SETTINGS_MAP: SettingSection[] = [
         settings: [
             {
                 id: 'csp-reporting',
-                title: (
-                    <>
-                        CSP reporting{' '}
-                        <LemonTag type="warning" className="ml-1 uppercase">
-                            Beta
-                        </LemonTag>
-                    </>
-                ),
+                title: 'CSP reporting',
                 description:
                     'Collect Content Security Policy violation reports to monitor and debug CSP issues on your site.',
                 component: <CSPReportingSettings />,

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -393,7 +393,6 @@ export const SETTINGS_MAP: SettingSection[] = [
         level: 'environment',
         id: 'environment-csp-reporting',
         title: 'CSP reporting',
-        flag: 'CSP_REPORTING',
         settings: [
             {
                 id: 'csp-reporting',


### PR DESCRIPTION
## Problem

CSP reporting has been gated by a feature flag and visually marked `Beta` since 2025-05-15 — almost exactly a year. In the meantime:

- It's ingesting ~1.55M `$csp_violation` events per 30 days into project 2 alone.
- It's generating revenue (events count toward billable usage on paid plans).
- The underlying code hasn't needed substantive changes for months.
- The setup steps have been in the public docs for a long time.

The `mexicspo` flag (mapped as `FEATURE_FLAGS.CSP_REPORTING` in the frontend) is **not at 100%** — it's an allowlist of PostHog staff plus a handful of named customers/cohorts. That's accidentally restricting access to a feature paying customers can already find in the docs. Time to call CSP reporting GA and drop the flag.

## Changes

1. Remove the `<LemonTag>Beta</LemonTag>` from the `csp-reporting` settings title (`SettingsMap.tsx`).
2. Remove the `flag: 'CSP_REPORTING'` gate from the `environment-csp-reporting` settings section (`SettingsMap.tsx`).
3. Remove the `CSP_REPORTING` entry from `FEATURE_FLAGS` in `constants.tsx`.

After this merges, the `mexicspo` flag has no remaining call sites and can be deleted from PostHog admin as a follow-up.

## How did you test this code?

I'm an agent — no browser testing. Validation:

- `pnpm --filter=@posthog/frontend typescript:check` — no errors related to these changes.
- Grepped the repo for remaining references to `CSP_REPORTING` or `mexicspo` — none.

## Publish to changelog?

no

## Docs update

No docs change needed (the public CSP docs are already there and don't mention the beta tag or the flag).

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) at Paul's direction. Came out of an inventory of every alpha/beta tag in the UI sorted by age — CSP reporting was one of the oldest (~12 months). A follow-up ClickHouse query confirmed substantial cross-team CSP event volume. Paul's calls, in order:

1. "let's unmark CSP as beta. it's generating revenue and hasn't needed changing for many months."
2. After seeing the flag isn't actually at 100% (it's an allowlist of staff + named customers): "yep, remove the flag, we've had this in public docs for ages. i think the flag is a mistake".

Out of scope (follow-ups):

- Deleting the `mexicspo` flag from PostHog admin. After this PR merges, the flag has no code references — it can be deleted via the PostHog UI without affecting anything.
- The other beta tags surfaced in the same inventory (Settings: Chart color themes, Web analytics: New Query Engine popover, Hog functions templates, Saved insights: Home tab, Session replay: Export to MP4 / Create clip, etc.). Each is its own GA call.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
