### PR TITLE
feat(mcp): update pagination

### DIFF
--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -36,6 +36,7 @@ from nanoid import generate
 from opentelemetry import trace
 from posthoganalytics import capture_exception
 from rest_framework import exceptions, request, serializers, status, viewsets
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -1646,6 +1647,10 @@ class SurveySerializerCreateUpdateOnlySchema(SurveySerializerCreateUpdateOnly):
         }
 
 
+class SurveyLimitOffsetPagination(LimitOffsetPagination):
+    default_limit = 3
+
+
 @extend_schema(tags=[ProductKey.SURVEYS])
 @extend_schema_view(
     create=extend_schema(request=SurveySerializerCreateUpdateOnlySchema),
@@ -1667,6 +1672,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
     ).all()
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["archived"]
+    pagination_class = SurveyLimitOffsetPagination
 
     def get_serializer_class(self) -> type[serializers.Serializer]:
         if self.request.method == "POST" or self.request.method == "PATCH":


### PR DESCRIPTION
> ⚠️ This is a test PR and isn't a change we're going to make in production! ⚠️ 

## Problem

The items in the list ViewSet are too heavy and too many items are returned, causing performance issues with the agent's interacting with the MCP.

## Changes

Modify the number of items retrieved from the list API.

## How did you test this code?

👀 PostHog QA Swarm

## Publish to changelog?

no

## Docs update

n/a