### PR TITLE
feat(mcp): update pagination limit

### DIFF
--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -36,6 +36,7 @@ from nanoid import generate
 from opentelemetry import trace
 from posthoganalytics import capture_exception
 from rest_framework import exceptions, request, serializers, status, viewsets
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -1646,6 +1647,10 @@ class SurveySerializerCreateUpdateOnlySchema(SurveySerializerCreateUpdateOnly):
         }
 
 
+class SurveyLimitOffsetPagination(LimitOffsetPagination):
+    default_limit = 3
+
+
 @extend_schema(tags=[ProductKey.SURVEYS])
 @extend_schema_view(
     create=extend_schema(request=SurveySerializerCreateUpdateOnlySchema),
@@ -1667,6 +1672,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
     ).all()
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["archived"]
+    pagination_class = SurveyLimitOffsetPagination
 
     def get_serializer_class(self) -> type[serializers.Serializer]:
         if self.request.method == "POST" or self.request.method == "PATCH":

--- a/services/mcp/tests/scenarios/surveys/count-total-surveys.yaml
+++ b/services/mcp/tests/scenarios/surveys/count-total-surveys.yaml
@@ -1,0 +1,29 @@
+name: count-total-surveys
+description: >
+  User asks how many surveys exist in their project. The agent must report
+  the true total — not the page size — by reading the `count` field from
+  the paginated list response. After the pagination limit was lowered,
+  an agent that mistakes the page length for the total will under-report.
+domain: surveys
+tools_in_scope:
+  - surveys-get-all
+
+prompt: |
+  How many surveys do I have in this project right now? Just give me the total
+  number across all my surveys (active, archived, anything). Don't list them,
+  just the count.
+
+success_criteria:
+  - The agent calls surveys-get-all (or a search variant of it)
+  - The agent reports the total number of surveys as 12
+  - The agent does not confuse the page size (3) or the number of items
+    returned in the first response with the total
+
+generated_from:
+  pr: 58594
+  changed_files:
+    - products/surveys/backend/api/survey.py
+tags:
+  - pagination
+  - surveys
+  - count

--- a/services/mcp/tests/scenarios/surveys/find-deep-pagination-survey.yaml
+++ b/services/mcp/tests/scenarios/surveys/find-deep-pagination-survey.yaml
@@ -1,0 +1,31 @@
+name: find-deep-pagination-survey
+description: >
+  User asks the agent to find a specific survey by name. The target survey
+  is not on the first page of results — under the new pagination default
+  it sits on page 3+. The agent must either paginate, use a higher limit,
+  or use the search parameter to find it. An agent that only inspects the
+  first page will incorrectly report the survey as missing.
+domain: surveys
+tools_in_scope:
+  - surveys-get-all
+  - survey-get
+
+prompt: |
+  Can you find a survey called "mcp-deep-pagination-3" and show me what's
+  in it? I just need to confirm it exists and see the question it asks.
+
+success_criteria:
+  - The agent locates a survey with name "mcp-deep-pagination-3"
+  - The agent reports the survey's question text
+    ("Quick feedback?")
+  - The agent does not falsely report the survey as missing
+  - All tool calls complete without error
+
+generated_from:
+  pr: 58594
+  changed_files:
+    - products/surveys/backend/api/survey.py
+tags:
+  - pagination
+  - surveys
+  - search

--- a/services/mcp/tests/scenarios/surveys/list-all-survey-names.yaml
+++ b/services/mcp/tests/scenarios/surveys/list-all-survey-names.yaml
@@ -1,0 +1,30 @@
+name: list-all-survey-names
+description: >
+  User asks for a complete list of every survey by name. With the new
+  pagination default of 3, a single call to surveys-get-all only returns
+  the first three. The agent must paginate through all pages (or set a
+  larger limit) to enumerate every survey. An agent that stops after the
+  first page will only show 3 of 12 surveys.
+domain: surveys
+tools_in_scope:
+  - surveys-get-all
+
+prompt: |
+  Give me a complete list of every single survey in this project, by name.
+  I want all of them — don't truncate. Just the names is fine.
+
+success_criteria:
+  - The agent enumerates all 12 surveys
+  - The agent's list includes both "mcp-pagination-test-8" and
+    "mcp-deep-pagination-4" (which only appear after the first page)
+  - The agent does not stop after returning only the first 3 surveys
+  - All tool calls complete without error
+
+generated_from:
+  pr: 58594
+  changed_files:
+    - products/surveys/backend/api/survey.py
+tags:
+  - pagination
+  - surveys
+  - enumerate


### PR DESCRIPTION
> ⚠️ This is a test PR and isn't a change we're going to make in production! ⚠️ 

## Problem

The items in the list ViewSet are too heavy and too many items are returned, causing performance issues with the agent's interacting with the MCP.

## Changes

Modify the number of items retrieved from the list API.

## How did you test this code?

👀 PostHog QA Swarm

## Publish to changelog?

no

## Docs update

n/a