### PR TITLE
feat(insights): drop Beta tag from Custom JSON insight tab

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -523,14 +523,7 @@ export const insightNavLogic = kea<insightNavLogicType>([
                             ? identifierToHuman(query.kind.replace(/(Node|Query)$/g, ''), 'title')
                             : null
                     tabs.push({
-                        label: (
-                            <>
-                                {humanFriendlyQueryKind ?? 'Custom'}{' '}
-                                <LemonTag type="warning" className="uppercase ml-2">
-                                    Beta
-                                </LemonTag>
-                            </>
-                        ),
+                        label: humanFriendlyQueryKind ?? 'Custom',
                         type: InsightType.JSON,
                         dataAttr: 'insight-json-tab',
                     })


### PR DESCRIPTION
## Problem

The Custom JSON insight tab (a.k.a. the JSON / Events / Sessions / Persons / etc. tab that appears in the insight editor when you've opened a `DataTableNode`-shaped insight) has had a `Beta` tag since 2023-03-22 — almost 3 years.

This tag isn't doing useful work:

- **There's no rollout to widen.** The tab has no feature flag. Its visibility is conditional on `activeView === InsightType.JSON && !isEndpointsUsageQuery(query)` — i.e. an existing JSON-shaped query had to load it. The inline comment in `insightNavLogic.tsx` is candid: *"humans shouldn't be able to click to select this tab — it only opens when you click the `<OpenEditorButton/>`"*.
- **The tab is vestigial.** Telemetry for the last 30 days (project 2):
  - `insight type tab clicked` events with `insight_type=JSON`: **409 clicks / 245 unique users**
  - For comparison: Funnels ~22k clicks / 10k users, Trends ~21k clicks / 10k users, SQL editor scene (`/sql`) pageviews ~425k / 21k users
- The SQL editor scene now carries ~1000× the traffic of this tab. Ad-hoc query work has moved there. The Custom JSON tab is the leftover surface someone occasionally lands on via "Open as new insight" from Activity > Events / Sessions, Session Attribution Explorer, or SDK Doctor.

## Changes

Drop the inline `<LemonTag>Beta</LemonTag>` wrapper. The label becomes just the `humanFriendlyQueryKind ?? 'Custom'` string. One file, ~7 lines removed.

The tab itself is unchanged — same visibility conditions, same dataAttr, same destination. This PR only strips the misleading maturity signal.

## How did you test this code?

I'm an agent — no browser testing. Validation:

- The change is a JSX fragment → string swap, no logic touched.
- `LemonTag` import in this file is still in use (the Web Analytics tab in the same file still renders one) — so the import line is intentionally left in place.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) at Paul's direction. Came out of an inventory of every alpha/beta tag in the UI — this one was the oldest entry on the list (~1148 days based on the file's first appearance of "Custom"). Subsequent investigation confirmed the tab has no feature flag, no rollout strategy, and ~1000× less traffic than the SQL editor scene that has functionally replaced it. The Beta tag was costing the team nothing useful and a small amount of credibility ("this has been beta for three years?").

Out of scope (follow-ups Paul flagged but didn't ship in this PR):

- Renaming the label (`humanFriendlyQueryKind ?? 'Custom'` produces tab labels like "Events" or "Sessions" depending on the node kind — could be clearer).
- Considering removing the tab entirely and routing "Open as new insight" to the SQL editor scene where applicable.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
