### PR TITLE
feat(user-interviews): embed transcript and summary on Vapi webhook

### DIFF
--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from django.test import override_settings
 from django.utils import timezone
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.api.test.test_sharing import mock_exporter_template
@@ -341,6 +342,85 @@ class TestVapiWebhook(APIBaseTest):
         self.assertEqual(second.status_code, status.HTTP_200_OK)
         self.assertEqual(second.json()["status"], "duplicate")
         self.assertEqual(first.json()["interview_id"], second.json()["interview_id"])
+        self.assertEqual(UserInterview.objects.filter(team=self.team).count(), 1)
+
+    @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
+    @patch("products.user_interviews.backend.webhooks.emit_embedding_request")
+    def test_webhook_emits_transcript_and_summary_embeddings(self, mock_emit):
+        share = self._create_share()
+        self.client.logout()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._signed_post("topsecret", self._end_of_call_payload(share.access_token))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        interview = UserInterview.objects.get(team=self.team)
+        assert share.interviewee_context is not None
+        topic = share.interviewee_context.topic
+
+        emitted = {kwargs["document_type"]: kwargs for _, kwargs in mock_emit.call_args_list}
+        self.assertEqual(set(emitted), {"transcript", "summary"})
+
+        for document_type, expected_content in (("transcript", "Hi! ..."), ("summary", "User talked about replay.")):
+            kwargs = emitted[document_type]
+            self.assertEqual(kwargs["content"], expected_content)
+            self.assertEqual(kwargs["team_id"], self.team.id)
+            self.assertEqual(kwargs["product"], "user_interviews")
+            self.assertEqual(kwargs["rendering"], "plain")
+            self.assertEqual(kwargs["document_id"], str(interview.id))
+            self.assertEqual(kwargs["models"], ["text-embedding-3-small-1536", "text-embedding-3-large-3072"])
+            self.assertEqual(
+                kwargs["metadata"],
+                {"topic_id": str(topic.id), "interviewee_identifier": "alex@example.com"},
+            )
+
+    @parameterized.expand(
+        [
+            ("transcript_only", "Hi! ...", "", {"transcript"}),
+            ("summary_only", "", "User talked about replay.", {"summary"}),
+            ("both_empty", "", "", set()),
+        ]
+    )
+    @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
+    @patch("products.user_interviews.backend.webhooks.emit_embedding_request")
+    def test_webhook_skips_empty_content(self, _name, transcript, summary, expected_types, mock_emit):
+        share = self._create_share()
+        self.client.logout()
+        payload = self._end_of_call_payload(share.access_token)
+        payload["message"]["transcript"] = transcript
+        payload["message"]["summary"] = summary
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._signed_post("topsecret", payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        emitted_types = {kwargs["document_type"] for _, kwargs in mock_emit.call_args_list}
+        self.assertEqual(emitted_types, expected_types)
+
+    @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
+    @patch("products.user_interviews.backend.webhooks.emit_embedding_request")
+    def test_webhook_does_not_re_emit_on_duplicate(self, mock_emit):
+        share = self._create_share()
+        self.client.logout()
+        payload = self._end_of_call_payload(share.access_token, call_id="call_dup")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self._signed_post("topsecret", payload)
+        first_call_count = mock_emit.call_count
+        self.assertEqual(first_call_count, 2)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            second = self._signed_post("topsecret", payload)
+        self.assertEqual(second.json()["status"], "duplicate")
+        self.assertEqual(mock_emit.call_count, first_call_count)
+
+    @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
+    @patch("products.user_interviews.backend.webhooks.emit_embedding_request", side_effect=RuntimeError("kafka down"))
+    def test_webhook_succeeds_when_embedding_emit_fails(self, _mock_emit):
+        share = self._create_share()
+        self.client.logout()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._signed_post("topsecret", self._end_of_call_payload(share.access_token))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
         self.assertEqual(UserInterview.objects.filter(team=self.team).count(), 1)
 
 

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -18,6 +18,7 @@ from posthog.api.test.test_sharing import mock_exporter_template
 from posthog.models.sharing_configuration import SharingConfiguration
 
 from products.user_interviews.backend.models import IntervieweeContext, UserInterview, UserInterviewTopic
+from products.user_interviews.backend.webhooks import EMBEDDING_CONTENT_MAX_BYTES
 
 
 class _FeatureFlagEnabledMixin(APIBaseTest):
@@ -424,26 +425,43 @@ class TestVapiWebhook(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
         self.assertEqual(UserInterview.objects.filter(team=self.team).count(), 1)
 
+    @parameterized.expand(
+        [
+            ("transcript_only", True, False),
+            ("summary_only", False, True),
+            ("both", True, True),
+        ]
+    )
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
     @patch("products.user_interviews.backend.webhooks.emit_embedding_request")
-    def test_webhook_truncates_oversized_transcript_before_emit(self, mock_emit):
-        from products.user_interviews.backend.webhooks import EMBEDDING_CONTENT_MAX_BYTES
-
+    def test_webhook_truncates_oversized_content_before_emit(
+        self, _name, oversize_transcript, oversize_summary, mock_emit
+    ):
         share = self._create_share()
         self.client.logout()
-        oversized_transcript = "a" * (EMBEDDING_CONTENT_MAX_BYTES + 1000)
         payload = self._end_of_call_payload(share.access_token)
-        payload["message"]["transcript"] = oversized_transcript
+        original_transcript = payload["message"]["transcript"]
+        original_summary = payload["message"]["summary"]
+        if oversize_transcript:
+            payload["message"]["transcript"] = "a" * (EMBEDDING_CONTENT_MAX_BYTES + 1000)
+        if oversize_summary:
+            payload["message"]["summary"] = "b" * (EMBEDDING_CONTENT_MAX_BYTES + 500)
 
         with self.captureOnCommitCallbacks(execute=True):
             response = self._signed_post("topsecret", payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
 
         emitted = {kwargs["document_type"]: kwargs for _, kwargs in mock_emit.call_args_list}
-        self.assertIn("transcript", emitted)
-        self.assertEqual(len(emitted["transcript"]["content"].encode("utf-8")), EMBEDDING_CONTENT_MAX_BYTES)
-        # Summary was under the limit so it's emitted untouched.
-        self.assertEqual(emitted["summary"]["content"], "User talked about replay.")
+
+        for document_type, was_oversized, original in (
+            ("transcript", oversize_transcript, original_transcript),
+            ("summary", oversize_summary, original_summary),
+        ):
+            content_bytes = emitted[document_type]["content"].encode("utf-8")
+            if was_oversized:
+                self.assertEqual(len(content_bytes), EMBEDDING_CONTENT_MAX_BYTES)
+            else:
+                self.assertEqual(emitted[document_type]["content"], original)
 
 
 class TestSendInterviewInvites(_FeatureFlagEnabledMixin):

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -407,12 +407,12 @@ class TestVapiWebhook(APIBaseTest):
             self._signed_post("topsecret", payload)
         first_emitted_types = {kwargs["document_type"] for _, kwargs in mock_emit.call_args_list}
         self.assertEqual(first_emitted_types, {"transcript", "summary"})
+        first_call_count = mock_emit.call_count
 
         with self.captureOnCommitCallbacks(execute=True):
             second = self._signed_post("topsecret", payload)
         self.assertEqual(second.json()["status"], "duplicate")
-        second_emitted_types = {kwargs["document_type"] for _, kwargs in mock_emit.call_args_list}
-        self.assertEqual(second_emitted_types, first_emitted_types)
+        self.assertEqual(mock_emit.call_count, first_call_count)
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
     @patch("products.user_interviews.backend.webhooks.emit_embedding_request", side_effect=RuntimeError("kafka down"))

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -424,6 +424,27 @@ class TestVapiWebhook(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
         self.assertEqual(UserInterview.objects.filter(team=self.team).count(), 1)
 
+    @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
+    @patch("products.user_interviews.backend.webhooks.emit_embedding_request")
+    def test_webhook_truncates_oversized_transcript_before_emit(self, mock_emit):
+        from products.user_interviews.backend.webhooks import EMBEDDING_CONTENT_MAX_BYTES
+
+        share = self._create_share()
+        self.client.logout()
+        oversized_transcript = "a" * (EMBEDDING_CONTENT_MAX_BYTES + 1000)
+        payload = self._end_of_call_payload(share.access_token)
+        payload["message"]["transcript"] = oversized_transcript
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._signed_post("topsecret", payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        emitted = {kwargs["document_type"]: kwargs for _, kwargs in mock_emit.call_args_list}
+        self.assertIn("transcript", emitted)
+        self.assertEqual(len(emitted["transcript"]["content"].encode("utf-8")), EMBEDDING_CONTENT_MAX_BYTES)
+        # Summary was under the limit so it's emitted untouched.
+        self.assertEqual(emitted["summary"]["content"], "User talked about replay.")
+
 
 class TestSendInterviewInvites(_FeatureFlagEnabledMixin):
     def _create_topic(self, **overrides) -> UserInterviewTopic:

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -405,13 +405,14 @@ class TestVapiWebhook(APIBaseTest):
 
         with self.captureOnCommitCallbacks(execute=True):
             self._signed_post("topsecret", payload)
-        first_call_count = mock_emit.call_count
-        self.assertEqual(first_call_count, 2)
+        first_emitted_types = {kwargs["document_type"] for _, kwargs in mock_emit.call_args_list}
+        self.assertEqual(first_emitted_types, {"transcript", "summary"})
 
         with self.captureOnCommitCallbacks(execute=True):
             second = self._signed_post("topsecret", payload)
         self.assertEqual(second.json()["status"], "duplicate")
-        self.assertEqual(mock_emit.call_count, first_call_count)
+        second_emitted_types = {kwargs["document_type"] for _, kwargs in mock_emit.call_args_list}
+        self.assertEqual(second_emitted_types, first_emitted_types)
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
     @patch("products.user_interviews.backend.webhooks.emit_embedding_request", side_effect=RuntimeError("kafka down"))

--- a/products/user_interviews/backend/webhooks.py
+++ b/products/user_interviews/backend/webhooks.py
@@ -26,12 +26,51 @@ from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.schema import EmbeddingModelName
+
+from posthog.api.embedding_worker import emit_embedding_request
 from posthog.constants import AvailableFeature
 from posthog.models.sharing_configuration import SharingConfiguration
 
 from .models import UserInterview
 
 logger = structlog.get_logger(__name__)
+
+
+_EMBEDDING_MODELS = [m.value for m in EmbeddingModelName]
+
+
+def _emit_interview_embeddings(interview: UserInterview) -> None:
+    """Emit transcript and summary as two separate embedding documents so each can be
+    searched independently. Failures are logged but never propagated: Vapi retries are
+    idempotent on call.id, so a re-delivery would skip creation and never re-emit —
+    making a thrown exception here strictly worse than a degraded but acknowledged row."""
+    topic = interview.topic
+    metadata = {
+        "topic_id": str(topic.id) if topic is not None else "",
+        "interviewee_identifier": interview.interviewee_identifier,
+    }
+    for document_type, content in (("transcript", interview.transcript), ("summary", interview.summary)):
+        if not content:
+            continue
+        try:
+            emit_embedding_request(
+                content=content,
+                team_id=interview.team_id,
+                product="user_interviews",
+                document_type=document_type,
+                rendering="plain",
+                document_id=str(interview.id),
+                models=_EMBEDDING_MODELS,
+                metadata=metadata,
+            )
+        except Exception:
+            logger.exception(
+                "user_interviews_embedding_emit_failed",
+                team_id=interview.team_id,
+                interview_id=str(interview.id),
+                document_type=document_type,
+            )
 
 
 def _verify_signature(secret: str, raw_body: bytes, provided_signature: str | None) -> bool:
@@ -212,6 +251,7 @@ def vapi_webhook(request: Request) -> Response:
             call_metadata=call,
             created_by=topic.created_by,
         )
+        transaction.on_commit(lambda: _emit_interview_embeddings(interview))
 
     logger.info(
         "user_interviews_vapi_webhook_stored",

--- a/products/user_interviews/backend/webhooks.py
+++ b/products/user_interviews/backend/webhooks.py
@@ -39,6 +39,12 @@ logger = structlog.get_logger(__name__)
 
 _EMBEDDING_MODELS = [m.value for m in EmbeddingModelName]
 
+# TODO: figure out a better story for transcripts that exceed our Kafka envelope
+# than head-truncation. Options: (a) chunk + emit multiple documents per type, or
+# (b) push large content to object storage and embed a reference. Truncation is a
+# stop-gap so a 90-minute interview doesn't silently lose its embeddings entirely.
+EMBEDDING_CONTENT_MAX_BYTES = 750_000
+
 
 def _emit_interview_embeddings(interview: UserInterview, topic: UserInterviewTopic) -> None:
     """Emit transcript and summary as two separate embedding documents so each can be
@@ -52,6 +58,17 @@ def _emit_interview_embeddings(interview: UserInterview, topic: UserInterviewTop
     for document_type, content in (("transcript", interview.transcript), ("summary", interview.summary)):
         if not content or not content.strip():
             continue
+        content_bytes = content.encode("utf-8")
+        if len(content_bytes) > EMBEDDING_CONTENT_MAX_BYTES:
+            logger.warning(
+                "user_interviews_embedding_content_truncated",
+                team_id=interview.team_id,
+                interview_id=str(interview.id),
+                document_type=document_type,
+                original_bytes=len(content_bytes),
+                truncated_to_bytes=EMBEDDING_CONTENT_MAX_BYTES,
+            )
+            content = content_bytes[:EMBEDDING_CONTENT_MAX_BYTES].decode("utf-8", errors="ignore")
         try:
             emit_embedding_request(
                 content=content,

--- a/products/user_interviews/backend/webhooks.py
+++ b/products/user_interviews/backend/webhooks.py
@@ -32,7 +32,7 @@ from posthog.api.embedding_worker import emit_embedding_request
 from posthog.constants import AvailableFeature
 from posthog.models.sharing_configuration import SharingConfiguration
 
-from .models import UserInterview
+from .models import UserInterview, UserInterviewTopic
 
 logger = structlog.get_logger(__name__)
 
@@ -40,18 +40,17 @@ logger = structlog.get_logger(__name__)
 _EMBEDDING_MODELS = [m.value for m in EmbeddingModelName]
 
 
-def _emit_interview_embeddings(interview: UserInterview) -> None:
+def _emit_interview_embeddings(interview: UserInterview, topic: UserInterviewTopic) -> None:
     """Emit transcript and summary as two separate embedding documents so each can be
     searched independently. Failures are logged but never propagated: Vapi retries are
     idempotent on call.id, so a re-delivery would skip creation and never re-emit —
     making a thrown exception here strictly worse than a degraded but acknowledged row."""
-    topic = interview.topic
     metadata = {
-        "topic_id": str(topic.id) if topic is not None else "",
+        "topic_id": str(topic.id),
         "interviewee_identifier": interview.interviewee_identifier,
     }
     for document_type, content in (("transcript", interview.transcript), ("summary", interview.summary)):
-        if not content:
+        if not content or not content.strip():
             continue
         try:
             emit_embedding_request(
@@ -251,7 +250,7 @@ def vapi_webhook(request: Request) -> Response:
             call_metadata=call,
             created_by=topic.created_by,
         )
-        transaction.on_commit(lambda: _emit_interview_embeddings(interview))
+        transaction.on_commit(lambda: _emit_interview_embeddings(interview, topic))
 
     logger.info(
         "user_interviews_vapi_webhook_stored",


### PR DESCRIPTION
## Problem

The Vapi end-of-call webhook (`products/user_interviews/backend/webhooks.py`) was persisting a `UserInterview` row with `transcript` and `summary` but never emitting them as embeddings, so neither field was searchable via `document_embeddings` / the signals UI / cross-content semantic search. We had the infrastructure (`emit_embedding_request` to `KAFKA_DOCUMENT_EMBEDDINGS_INPUT_TOPIC`) but nothing was wired up.

## Changes

- New helper `_emit_interview_embeddings` in `webhooks.py` that emits **two separate documents per interview**:
  - same `document_id` (the interview UUID), distinguished by `document_type="transcript"` vs `"summary"`
  - same `product="user_interviews"`, `rendering="plain"`, both embedding models, `metadata={topic_id, interviewee_identifier}`
  - skips empty fields, so a missing transcript or summary doesn't waste embedding work
- Emission registered via `transaction.on_commit`, so we never produce a request for a row that ends up rolled back.
- Each emit is independently `try/except`-wrapped and exceptions are logged. The webhook is idempotent on `call.id`, which means a thrown exception would make Vapi retry, the retry would hit the duplicate path and return 200, and the embedding would never get a second chance — soft-failing per emit keeps the row landed and the failure observable.

## How did you test this code?

I'm an agent (PostHog Code). I added 4 automated tests to `TestVapiWebhook` and ran them locally:

- `test_webhook_emits_transcript_and_summary_embeddings` — full payload emits both types with correct kwargs (content, models, metadata, document_id).
- `test_webhook_skips_empty_content` (parameterised: transcript-only / summary-only / both-empty) — empty fields don't get emitted.
- `test_webhook_does_not_re_emit_on_duplicate` — a duplicate webhook returns 200 and emits nothing extra.
- `test_webhook_succeeds_when_embedding_emit_fails` — kafka-down still returns 201 and the row is created.

All 12 `TestVapiWebhook` tests pass (`hogli test products/user_interviews/backend/test_interview_sharing.py::TestVapiWebhook`).

I did not manually exercise the webhook against a real Vapi call.

## Publish to changelog?

no

## Docs update

No user-facing docs change.

## 🤖 Agent context

Tool: PostHog Code (Claude Opus 4.7).

Decisions worth surfacing for the reviewer:
- **`document_id` shared, `document_type` distinguishes**: chose this over path-style `f"{interview.id}/transcript"` so a query that wants "everything about this interview" can `WHERE document_id = '...'` and get both rows. Two distinct rows in the embeddings table because the ordering key is `(team_id, ..., document_type, ..., cityHash64(document_id))`.
- **Soft-fail per emit instead of propagating**: motivated by the existing call.id idempotency — if we threw, Vapi's retry would create no second attempt to emit. Logging is preferable to silently losing the embedding chance.
- **Models**: both `text-embedding-3-small-1536` and `text-embedding-3-large-3072`, matching the signals product's pattern.
- **`on_commit`**: registers inside the existing `transaction.atomic()` block so we don't emit for a row that rolls back. Tests use `captureOnCommitCallbacks(execute=True)` to drive the callback.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*