### PR TITLE
fix(user-interviews): allow personal API keys on topic action endpoints

### DIFF
--- a/products/user_interviews/backend/api.py
+++ b/products/user_interviews/backend/api.py
@@ -458,6 +458,19 @@ class UserInterviewTopicViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     """Planned user interview topics: who we want to target (cohort) and what we want to ask about."""
 
     scope_object = "user_interview"
+    # Treat the custom @action endpoints as writes so personal API keys with
+    # `user_interview:write` can hit them. Without this override, APIScopePermission
+    # can't map a custom action name to a scope and rejects the request with
+    # "This action does not support personal API key access".
+    scope_object_write_actions = [
+        "create",
+        "update",
+        "partial_update",
+        "patch",
+        "destroy",
+        "generate_links",
+        "send_invites",
+    ]
     queryset = UserInterviewTopic.objects.select_related("created_by").all()
     serializer_class = UserInterviewTopicSerializer
     filter_backends = [filters.SearchFilter]


### PR DESCRIPTION
## Problem

The `UserInterviewTopicViewSet.generate_links` and `send_invites` custom actions reject personal API key requests with HTTP 403 `"This action does not support personal API key access"`. This blocks the MCP / agent path: the agent can create a topic and attach per-interviewee context, but can't materialize the public interview link or queue an invite — both are required for a usable end-to-end flow.

Session-authenticated UI requests work fine because `APIScopePermission` doesn't apply to cookie sessions. The gap is only on programmatic access.

## Changes

Add a `scope_object_write_actions` override on `UserInterviewTopicViewSet` so `generate_links` and `send_invites` are mapped to the `user_interview:write` scope. Without the override, `APIScopePermission._get_required_scopes` can't resolve a scope for any custom `@action` name and rejects the request.

This is the same pattern already used on `HogFunctionViewSet`, etc. — custom action names are listed alongside the default CRUD actions on the write list. No new permissions are introduced; PAKs still need `user_interview:write`.

## How did you test this code?

I'm an agent (PostHog Code). I did **not** run the backend test suite or hit the deployed endpoint with a PAK. Verification I did do:

- Confirmed the rejection path in `posthog/permissions.py:498` matches the observed 403 message.
- Confirmed the convention against `posthog/api/hog_function.py:478` (same shape).
- `ruff check` and `ruff format` clean.
- `ty` typecheck clean (via pre-commit).

Manual verification needed by a human reviewer:

- Call `POST /api/environments/{team}/user_interview_topics/{id}/generate_links/` with a personal API key scoped to `user_interview:write` and confirm a 200 response with the link payload.
- Call `POST .../send_invites/` with the same scope and confirm it either succeeds (when email is configured) or returns the existing 503 rather than the 403.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Opus 4.7) in auto mode.
- Surfaced the issue while running a live demo of the AI user-interview flow against us.posthog.com — the MCP `user-interview-topics-generate-links` call returned 403, and the same call from a browser session succeeded.
- Root-caused by reading `APIScopePermission` and the viewset wiring (`@action` methods don't appear in the default `write_actions` list, so `_get_required_scopes` returns `None`).
- Considered: (a) declaring `required_scopes = ["user_interview:write"]` on each action via decorator metadata, (b) overriding `dangerously_get_required_scopes`, (c) extending `scope_object_write_actions`. Chose (c) because it's the established convention in this codebase and is local to the viewset.
- Did not touch `send_invites` behavior or templates — that endpoint is intentionally kept side-effect-free until email is wired up for this use case; the human asked to be able to *generate and see* the link from the agent without actually sending mail.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*