### PR TITLE
feat(replay): drop Beta tag from Export to MP4 and Create clip

### DIFF
--- a/frontend/src/scenes/session-recordings/player/controller/ClipRecording.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/ClipRecording.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useMemo, useState } from 'react'
 
-import { LemonButton, LemonSegmentedButton, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonSegmentedButton } from '@posthog/lemon-ui'
 
 import { IconRecordingClip } from 'lib/lemon-ui/icons'
 import { LemonSegmentedSelect } from 'lib/lemon-ui/LemonSegmentedSelect'
@@ -141,14 +141,9 @@ function ClipRecording_({ current, className }: { current: string; className?: s
 
     const tooltipContent = useMemo(
         () => (
-            <div className="flex items-center gap-2">
-                <span>
-                    Create clip around {current} <KeyboardShortcut x />
-                </span>
-                <LemonTag type="warning" size="small">
-                    BETA
-                </LemonTag>
-            </div>
+            <span>
+                Create clip around {current} <KeyboardShortcut x />
+            </span>
         ),
         [current]
     )

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx
@@ -10,7 +10,7 @@ import {
     IconPlusSmall,
     IconTrash,
 } from '@posthog/icons'
-import { LemonButton, LemonButtonProps, LemonDialog, LemonMenu, LemonMenuItems, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonButtonProps, LemonDialog, LemonMenu, LemonMenuItems } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { IconBlank } from 'lib/lemon-ui/icons'
@@ -195,14 +195,7 @@ const MenuActions = ({ size }: { size: PlayerMetaBreakpoints }): JSX.Element => 
                 'data-attr': 'replay-export-posthog-json',
             },
             isStandardMode && {
-                label: (
-                    <div className="flex w-full gap-x-2 justify-between items-center">
-                        Export to MP4{' '}
-                        <LemonTag type="warning" size="small">
-                            BETA
-                        </LemonTag>
-                    </div>
-                ),
+                label: 'Export to MP4',
                 status: hasReachedExportFullVideoLimit ? 'danger' : 'default',
                 icon: <IconDownload />,
                 onClick: () => exportRecordingToVideoFile(),


### PR DESCRIPTION
## Problem

Two session replay surfaces have carried a `BETA` tag for ~8 months:

- **Export to MP4** menu item in the player meta links — beta since 2025-08-29 (~257 days).
- **Create clip around <time>** tooltip on the player controls — beta since 2025-09-08 (~247 days).

Neither is gated by a feature flag. Both have stable, real usage. The beta tag isn't a maturity signal anyone can act on.

**Important: the monthly export quota stays.** The `hasReachedExportFullVideoLimit` check on Export to MP4 — which sets the menu item to `status: 'danger'` and swaps the tooltip to *"You have reached your export limit"* — is deliberately untouched. This PR only removes the cosmetic beta indicator.

## Changes

| File | Change |
|---|---|
| `frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx` | The MP4 menu label drops from a `<div>` wrapping `'Export to MP4'` + `<LemonTag>BETA</LemonTag>` to the plain string `'Export to MP4'`. Quota logic unchanged. |
| `frontend/src/scenes/session-recordings/player/controller/ClipRecording.tsx` | The clip tooltip drops the trailing `<LemonTag>BETA</LemonTag>` chip; tooltip content becomes the lone `<span>Create clip around {current} <kbd>x</kbd></span>`. |

Both files lose their `LemonTag` import since it was only used for the beta tag.

## How did you test this code?

I'm an agent — no browser testing. Validation:

- Confirmed neither file references any feature flag (no `FEATURE_FLAGS`/`featureFlags[]` usage).
- Confirmed `hasReachedExportFullVideoLimit` logic in `PlayerMetaLinks.tsx` is untouched — same status/tooltip/className branching, same `exportRecordingToVideoFile()` call.
- `LemonTag` import removed from both files (was the only beta usage).

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) at Paul's direction. Comes out of the same alpha/beta inventory we shipped CSP reporting (#58591) and the Custom JSON tab (#58597) from. Paul flagged both replay items together: "the two session replay ones don't need to be flagged or beta any more. i think that exporting is limited per month and i don't want to remove those limits in removing any flags or beta labels."

Acted on that constraint precisely: only the visual beta tag is gone, the per-month export limit (`hasReachedExportFullVideoLimit`) is fully intact.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
