### PR TITLE
feat(deployments): wire deployment-logs endpoint into the detail page

### DIFF
--- a/products/deployments/frontend/Deployment.tsx
+++ b/products/deployments/frontend/Deployment.tsx
@@ -7,12 +7,10 @@ import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
-
-import { LogsViewer } from 'products/logs/frontend/components/LogsViewer/LogsViewer'
 
 import { CurrentDeploymentCard } from './components/CurrentDeploymentCard'
 import { openRedeployDialog, openRollbackDialog } from './components/deploymentActions'
+import { DeploymentLogs } from './components/DeploymentLogs'
 import { deploymentLogic, DeploymentLogicProps } from './deploymentLogic'
 import { deploymentProjectLogic } from './deploymentProjectLogic'
 
@@ -77,36 +75,7 @@ function DeploymentInner({ projectId, id }: DeploymentLogicProps): JSX.Element {
                 }
             />
             <CurrentDeploymentCard deployment={d} />
-            <div className="flex flex-col gap-2">
-                <h3 className="text-lg font-semibold">Logs</h3>
-                <p className="text-secondary text-sm">
-                    Filtered to this deployment via the <code>deployment_id</code> attribute. Once ingestion stamps that
-                    attribute, real entries will show here.
-                </p>
-                <LogsViewer
-                    id={`deployment-${id}`}
-                    initialFilters={{
-                        filterGroup: {
-                            type: FilterLogicalOperator.And,
-                            values: [
-                                {
-                                    type: FilterLogicalOperator.And,
-                                    values: [
-                                        {
-                                            key: 'deployment_id',
-                                            type: PropertyFilterType.LogAttribute,
-                                            operator: PropertyOperator.Exact,
-                                            value: id,
-                                        } as any,
-                                    ],
-                                },
-                            ],
-                        },
-                    }}
-                    showFullScreenButton={false}
-                    showSavedViewsButton={false}
-                />
-            </div>
+            <DeploymentLogs projectId={projectId} id={id} />
         </SceneContent>
     )
 }

--- a/products/deployments/frontend/Deployments.stories.tsx
+++ b/products/deployments/frontend/Deployments.stories.tsx
@@ -139,6 +139,14 @@ const meta: Meta = {
                 },
                 '/api/projects/:team_id/deployment_projects/:project_id/deployments/d-current/': currentDeployment,
                 '/api/projects/:team_id/deployment_projects/:project_id/deployments/d-docs/': docsCurrent,
+                // Default to an empty logs response so the detail page renders
+                // its empty state. Individual stories override this with
+                // realistic rows.
+                '/api/projects/:team_id/deployment_projects/:project_id/deployments/:id/logs/': {
+                    results: [],
+                    has_more: false,
+                    row_limit: 1000,
+                },
             },
         }),
     ],
@@ -246,4 +254,106 @@ export const DeploymentDetail: Story = {
     parameters: {
         pageUrl: urls.deployment(baseProject.id, currentDeployment.id),
     },
+}
+
+// Detail page with a populated logs table — mixed levels, a warn, an error,
+// and a step-completion row carrying an exit_code.
+export const DeploymentDetailWithLogs: Story = {
+    parameters: {
+        pageUrl: urls.deployment(baseProject.id, currentDeployment.id),
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/deployment_projects/:project_id/deployments/:id/logs/': {
+                    results: [
+                        {
+                            timestamp: '2026-05-13T12:00:00Z',
+                            level: 'info',
+                            step: 'clone',
+                            line: 'Cloning github.com/acme/site into /workspace/source',
+                            exit_code: null,
+                        },
+                        {
+                            timestamp: '2026-05-13T12:00:01Z',
+                            level: 'info',
+                            step: 'clone',
+                            line: null,
+                            exit_code: 0,
+                        },
+                        {
+                            timestamp: '2026-05-13T12:00:02Z',
+                            level: 'info',
+                            step: 'install',
+                            line: 'Installing dependencies with pnpm',
+                            exit_code: null,
+                        },
+                        {
+                            timestamp: '2026-05-13T12:00:12Z',
+                            level: 'warn',
+                            step: 'install',
+                            line: 'WARN deprecated lodash.merge@4.6.2',
+                            exit_code: null,
+                        },
+                        {
+                            timestamp: '2026-05-13T12:00:25Z',
+                            level: 'info',
+                            step: 'install',
+                            line: null,
+                            exit_code: 0,
+                        },
+                        {
+                            timestamp: '2026-05-13T12:00:26Z',
+                            level: 'info',
+                            step: 'build',
+                            line: '> vite build',
+                            exit_code: null,
+                        },
+                        {
+                            timestamp: '2026-05-13T12:00:48Z',
+                            level: 'error',
+                            step: 'build',
+                            line: 'src/utils.ts:42 TypeError: cannot read property of undefined',
+                            exit_code: null,
+                        },
+                        {
+                            timestamp: '2026-05-13T12:00:48Z',
+                            level: 'error',
+                            step: 'build',
+                            line: null,
+                            exit_code: 1,
+                        },
+                    ],
+                    has_more: false,
+                    row_limit: 1000,
+                },
+            },
+        }),
+    ],
+}
+
+// Detail page where the logs payload was truncated to the row_limit.
+export const DeploymentDetailLogsTruncated: Story = {
+    parameters: {
+        pageUrl: urls.deployment(baseProject.id, currentDeployment.id),
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/deployment_projects/:project_id/deployments/:id/logs/': {
+                    results: [
+                        {
+                            timestamp: '2026-05-13T12:00:00Z',
+                            level: 'info',
+                            step: 'build',
+                            line: '… (older lines truncated)',
+                            exit_code: null,
+                        },
+                    ],
+                    has_more: true,
+                    row_limit: 1000,
+                },
+            },
+        }),
+    ],
 }

--- a/products/deployments/frontend/components/DeploymentLogs.tsx
+++ b/products/deployments/frontend/components/DeploymentLogs.tsx
@@ -22,7 +22,7 @@ interface DeploymentLogsProps {
 
 export function DeploymentLogs({ projectId, id }: DeploymentLogsProps): JSX.Element {
     const { deploymentLogs, deploymentLogsLoading } = useValues(deploymentLogic({ projectId, id }))
-    const { refreshDeploymentLogs } = useActions(deploymentLogic({ projectId, id }))
+    const { loadDeploymentLogs } = useActions(deploymentLogic({ projectId, id }))
 
     const rows = deploymentLogs?.results ?? []
     const hasMore = deploymentLogs?.has_more ?? false
@@ -84,7 +84,7 @@ export function DeploymentLogs({ projectId, id }: DeploymentLogsProps): JSX.Elem
                     type="secondary"
                     size="small"
                     icon={<IconRefresh />}
-                    onClick={() => refreshDeploymentLogs()}
+                    onClick={() => loadDeploymentLogs()}
                     loading={deploymentLogsLoading}
                 >
                     Refresh
@@ -98,9 +98,12 @@ export function DeploymentLogs({ projectId, id }: DeploymentLogsProps): JSX.Elem
             <LemonTable
                 dataSource={rows}
                 columns={columns}
-                loading={deploymentLogsLoading && rows.length === 0}
+                // Treat "never fetched" (deploymentLogs === null) as loading
+                // so the empty state doesn't flash on the first render before
+                // `afterMount` has dispatched the loader.
+                loading={deploymentLogsLoading || deploymentLogs === null}
                 rowKey={(row, index) => `${row.timestamp}-${index}`}
-                emptyState="No build logs yet — the build hasn't emitted any $log events with this deployment id set."
+                emptyState="No build logs yet — the deployment pipeline hasn't produced any log output."
                 data-attr="deployment-logs-table"
             />
         </div>

--- a/products/deployments/frontend/components/DeploymentLogs.tsx
+++ b/products/deployments/frontend/components/DeploymentLogs.tsx
@@ -1,0 +1,108 @@
+import { useActions, useValues } from 'kea'
+
+import { IconRefresh } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonTable, LemonTableColumns, LemonTag, LemonTagType } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+
+import { deploymentLogic } from '../deploymentLogic'
+import type { DeploymentLogEntryApi } from '../generated/api.schemas'
+
+const LEVEL_TAG: Record<string, LemonTagType> = {
+    info: 'default',
+    warn: 'warning',
+    warning: 'warning',
+    error: 'danger',
+}
+
+interface DeploymentLogsProps {
+    projectId: string
+    id: string
+}
+
+export function DeploymentLogs({ projectId, id }: DeploymentLogsProps): JSX.Element {
+    const { deploymentLogs, deploymentLogsLoading } = useValues(deploymentLogic({ projectId, id }))
+    const { refreshDeploymentLogs } = useActions(deploymentLogic({ projectId, id }))
+
+    const rows = deploymentLogs?.results ?? []
+    const hasMore = deploymentLogs?.has_more ?? false
+    const rowLimit = deploymentLogs?.row_limit ?? null
+
+    const columns: LemonTableColumns<DeploymentLogEntryApi> = [
+        {
+            title: 'Time',
+            dataIndex: 'timestamp',
+            width: 0,
+            render: (_, row) => (row.timestamp ? <TZLabel time={row.timestamp} /> : <span>—</span>),
+        },
+        {
+            title: 'Level',
+            dataIndex: 'level',
+            width: 0,
+            render: (_, row) =>
+                row.level ? (
+                    <LemonTag type={LEVEL_TAG[row.level.toLowerCase()] ?? 'default'}>{row.level}</LemonTag>
+                ) : (
+                    <span className="text-secondary">—</span>
+                ),
+        },
+        {
+            title: 'Step',
+            dataIndex: 'step',
+            width: 0,
+            render: (_, row) =>
+                row.step ? <LemonTag type="default">{row.step}</LemonTag> : <span className="text-secondary">—</span>,
+        },
+        {
+            title: 'Line',
+            dataIndex: 'line',
+            render: (_, row) => (
+                <span className="font-mono text-xs whitespace-pre-wrap break-all">{row.line ?? ''}</span>
+            ),
+        },
+        {
+            title: 'Exit',
+            dataIndex: 'exit_code',
+            width: 0,
+            render: (_, row) =>
+                row.exit_code === null || row.exit_code === undefined ? null : (
+                    <LemonTag type={row.exit_code === 0 ? 'success' : 'danger'}>{row.exit_code}</LemonTag>
+                ),
+        },
+    ]
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-2">
+                <div>
+                    <h3 className="text-lg font-semibold mb-0">Logs</h3>
+                    <p className="text-secondary text-sm mb-0">
+                        Build output emitted by this deployment's pipeline, oldest first.
+                    </p>
+                </div>
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    icon={<IconRefresh />}
+                    onClick={() => refreshDeploymentLogs()}
+                    loading={deploymentLogsLoading}
+                >
+                    Refresh
+                </LemonButton>
+            </div>
+
+            {hasMore && rowLimit !== null && (
+                <LemonBanner type="info">Showing the most recent {rowLimit} lines — older lines exist.</LemonBanner>
+            )}
+
+            <LemonTable
+                dataSource={rows}
+                columns={columns}
+                loading={deploymentLogsLoading && rows.length === 0}
+                rowKey={(row, index) => `${row.timestamp}-${index}`}
+                emptyState="No build logs yet — the build hasn't emitted any $log events with this deployment id set."
+                data-attr="deployment-logs-table"
+            />
+        </div>
+    )
+}

--- a/products/deployments/frontend/deploymentLogic.test.ts
+++ b/products/deployments/frontend/deploymentLogic.test.ts
@@ -157,7 +157,7 @@ describe('deploymentLogic', () => {
         }
     })
 
-    it('refreshDeploymentLogs re-fires the logs loader', async () => {
+    it('loadDeploymentLogs can be called again to refresh', async () => {
         let logsRequestCount = 0
         useMocks({
             get: {
@@ -175,7 +175,7 @@ describe('deploymentLogic', () => {
             const initialCount = logsRequestCount
 
             await expectLogic(detail, () => {
-                detail.actions.refreshDeploymentLogs()
+                detail.actions.loadDeploymentLogs()
             }).toFinishAllListeners()
 
             expect(logsRequestCount).toEqual(initialCount + 1)

--- a/products/deployments/frontend/deploymentLogic.test.ts
+++ b/products/deployments/frontend/deploymentLogic.test.ts
@@ -44,6 +44,29 @@ describe('deploymentLogic', () => {
                     const found = deployments.find((d) => d.id === String(req.params.id))
                     return found ? [200, found] : [404, { detail: 'Not found' }]
                 },
+                '/api/projects/:team/deployment_projects/:project_id/deployments/:id/logs/': () => [
+                    200,
+                    {
+                        results: [
+                            {
+                                timestamp: '2026-05-13T12:00:00Z',
+                                level: 'info',
+                                step: 'clone',
+                                line: 'Cloning into source/',
+                                exit_code: null,
+                            },
+                            {
+                                timestamp: '2026-05-13T12:00:01Z',
+                                level: 'info',
+                                step: 'clone',
+                                line: null,
+                                exit_code: 0,
+                            },
+                        ],
+                        has_more: false,
+                        row_limit: 1000,
+                    },
+                ],
             },
         })
 
@@ -115,6 +138,52 @@ describe('deploymentLogic', () => {
         }
     })
 
+    it('loads deployment logs on mount via the logs endpoint', async () => {
+        const detail = deploymentLogic({ projectId: project.id, id: 'dep-current' })
+        detail.mount()
+        try {
+            await expectLogic(detail).toFinishAllListeners()
+            expect(detail.values.deploymentLogs?.results).toHaveLength(2)
+            expect(detail.values.deploymentLogs?.results[0]).toMatchObject({
+                step: 'clone',
+                level: 'info',
+                line: 'Cloning into source/',
+            })
+            expect(detail.values.deploymentLogs?.has_more).toBe(false)
+            expect(detail.values.deploymentLogs?.row_limit).toBe(1000)
+            expect(detail.values.deploymentLogsLoading).toBe(false)
+        } finally {
+            detail.unmount()
+        }
+    })
+
+    it('refreshDeploymentLogs re-fires the logs loader', async () => {
+        let logsRequestCount = 0
+        useMocks({
+            get: {
+                '/api/projects/:team/deployment_projects/:project_id/deployments/:id/logs/': () => {
+                    logsRequestCount += 1
+                    return [200, { results: [], has_more: false, row_limit: 1000 }]
+                },
+            },
+        })
+
+        const detail = deploymentLogic({ projectId: project.id, id: 'dep-current' })
+        detail.mount()
+        try {
+            await expectLogic(detail).toFinishAllListeners()
+            const initialCount = logsRequestCount
+
+            await expectLogic(detail, () => {
+                detail.actions.refreshDeploymentLogs()
+            }).toFinishAllListeners()
+
+            expect(logsRequestCount).toEqual(initialCount + 1)
+        } finally {
+            detail.unmount()
+        }
+    })
+
     it('deep-link: loads the deployment without waiting on a project list mount', async () => {
         // Simulate a cold start — neither the list logic nor the project logic
         // have been mounted yet. The detail logic should still fetch via its
@@ -132,6 +201,10 @@ describe('deploymentLogic', () => {
                     const found = deployments.find((d) => d.id === String(req.params.id))
                     return found ? [200, found] : [404, { detail: 'Not found' }]
                 },
+                '/api/projects/:team/deployment_projects/:project_id/deployments/:id/logs/': () => [
+                    200,
+                    { results: [], has_more: false, row_limit: 1000 },
+                ],
             },
         })
 

--- a/products/deployments/frontend/deploymentLogic.ts
+++ b/products/deployments/frontend/deploymentLogic.ts
@@ -1,4 +1,4 @@
-import { afterMount, connect, kea, key, path, props, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { Scene } from 'scenes/sceneTypes'
@@ -10,8 +10,8 @@ import { Breadcrumb } from '~/types'
 import type { deploymentLogicType } from './deploymentLogicType'
 import { deploymentProjectLogic } from './deploymentProjectLogic'
 import { Deployment } from './fixtures'
-import { deploymentProjectsDeploymentsRetrieve } from './generated/api'
-import type { DeploymentProjectApi } from './generated/api.schemas'
+import { deploymentProjectsDeploymentsLogsRetrieve, deploymentProjectsDeploymentsRetrieve } from './generated/api'
+import type { DeploymentLogsResponseApi, DeploymentProjectApi } from './generated/api.schemas'
 
 export interface DeploymentLogicProps {
     projectId: string
@@ -31,6 +31,9 @@ export const deploymentLogic = kea<deploymentLogicType>([
         ],
         actions: [deploymentProjectLogic({ projectId: props.projectId }), ['redeployDeployment', 'rollbackDeployment']],
     })),
+    actions({
+        refreshDeploymentLogs: true,
+    }),
     loaders(({ values, props }) => ({
         deployment: [
             null as Deployment | null,
@@ -44,6 +47,26 @@ export const deploymentLogic = kea<deploymentLogicType>([
                 },
             },
         ],
+        // Logs are fetched separately so a slow/failing logs call doesn't
+        // block the deployment header from rendering. The backend caps the
+        // payload at `row_limit` and surfaces `has_more` for truncation.
+        deploymentLogs: [
+            null as DeploymentLogsResponseApi | null,
+            {
+                loadDeploymentLogs: async (): Promise<DeploymentLogsResponseApi | null> => {
+                    const teamId = values.currentTeamId
+                    if (!teamId) {
+                        return null
+                    }
+                    return deploymentProjectsDeploymentsLogsRetrieve(String(teamId), props.projectId, props.id)
+                },
+            },
+        ],
+    })),
+    listeners(({ actions }) => ({
+        refreshDeploymentLogs: () => {
+            actions.loadDeploymentLogs()
+        },
     })),
     selectors(({ props }) => ({
         deploymentMissing: [
@@ -68,5 +91,6 @@ export const deploymentLogic = kea<deploymentLogicType>([
     })),
     afterMount(({ actions }) => {
         actions.loadDeployment()
+        actions.loadDeploymentLogs()
     }),
 ])

--- a/products/deployments/frontend/deploymentLogic.ts
+++ b/products/deployments/frontend/deploymentLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, selectors } from 'kea'
+import { afterMount, connect, kea, key, path, props, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { Scene } from 'scenes/sceneTypes'
@@ -31,9 +31,6 @@ export const deploymentLogic = kea<deploymentLogicType>([
         ],
         actions: [deploymentProjectLogic({ projectId: props.projectId }), ['redeployDeployment', 'rollbackDeployment']],
     })),
-    actions({
-        refreshDeploymentLogs: true,
-    }),
     loaders(({ values, props }) => ({
         deployment: [
             null as Deployment | null,
@@ -62,11 +59,6 @@ export const deploymentLogic = kea<deploymentLogicType>([
                 },
             },
         ],
-    })),
-    listeners(({ actions }) => ({
-        refreshDeploymentLogs: () => {
-            actions.loadDeploymentLogs()
-        },
     })),
     selectors(({ props }) => ({
         deploymentMissing: [


### PR DESCRIPTION
Replaces the generic <LogsViewer> embed on /deployments/:projectId/:id with a purpose-built logs table powered by the deployment-scoped logs endpoint Matheus added (`bbae0706739`). The previous embed depended on log ingestion stamping a `deployment_id` attribute on $log events; the new endpoint runs that same HogQL filter server-side and returns a flatter, deployment-specific shape (timestamp, level, step, line, exit_code) that maps cleanly to a LemonTable.

- Extend `deploymentLogic` with a `deploymentLogs` loader that calls `deploymentProjectsDeploymentsLogsRetrieve`; fires on `afterMount` alongside `loadDeployment` so the header still renders if the logs call is slow / errors out.
- New `<DeploymentLogs/>` component: colored level/step tags, exit-code chip, has_more banner, refresh button, empty + loading states.
- Story coverage: DeploymentDetailWithLogs (info/warn/error + a step-completion row), DeploymentDetailLogsTruncated (has_more=true).
- Unit tests: logs load on mount, refresh action re-fires the loader.

No backend changes — Matheus's endpoint stays as-is.

<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
