### PR TITLE
feat(heatmaps): drop Beta tag from heatmap export buttons

### DIFF
--- a/frontend/src/scenes/heatmaps/components/HeatmapsBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapsBrowser.tsx
@@ -2,15 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { useRef } from 'react'
 
 import { IconDownload, IconGear, IconRevert } from '@posthog/icons'
-import {
-    LemonBanner,
-    LemonButton,
-    LemonDivider,
-    LemonInput,
-    LemonLabel,
-    LemonSkeleton,
-    LemonTag,
-} from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonDivider, LemonInput, LemonLabel, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { AuthorizedUrlListType, appEditorUrl } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
@@ -72,12 +64,7 @@ function ExportButton({
                 data-attr="export-heatmap"
                 disabledReason={!dataUrl ? 'We can export only the URL with heatmaps' : undefined}
             >
-                <div className="flex w-full gap-x-2 justify-between items-center">
-                    Export{' '}
-                    <LemonTag type="warning" size="small">
-                        BETA
-                    </LemonTag>
-                </div>
+                Export
             </LemonButton>
         </div>
     )

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
@@ -108,10 +108,7 @@ export function HeatmapScene({ id }: { id: string }): JSX.Element {
                                     type === 'screenshot' && !screenshotUrl ? 'Screenshot is not ready' : undefined
                                 }
                             >
-                                Export{' '}
-                                <LemonTag type="warning" className="ml-2">
-                                    BETA
-                                </LemonTag>
+                                Export
                             </LemonButton>
                         </>
                     }


### PR DESCRIPTION
## Problem

The two heatmap export buttons have carried a `BETA` tag since 2025-10-31 (~194 days):

- `frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx` — Export PNG button on the heatmap scene
- `frontend/src/scenes/heatmaps/components/HeatmapsBrowser.tsx` — Export PNG button inside the in-app heatmap browser

Neither is gated by a feature flag. The underlying export pipeline (`startHeatmapExport` → `posthog/tasks/exports/image_exporter.py`) is stable. The Beta tag isn't doing useful work.

Dogfood usage check confirms a healthy one-and-done export pattern — most clickers don't return because they don't need to once they've got their PNG. Roughly **6% of clickers** in the last 30 days returned to the button on a second distinct day, **0%** on 3+ days. That's the right shape for an export action, not a vestigial-surface signal.

## Changes

Two files, identical pattern. Each export `LemonButton` drops its inline `<LemonTag type="warning">BETA</LemonTag>` chip. Labels become plain `Export` strings.

- `HeatmapScene.tsx` — keeps its `LemonTag` import (still used elsewhere in the file for a "live"/"static" status tag).
- `HeatmapsBrowser.tsx` — `LemonTag` was only used for the Beta chip, so the import drops too.

## How did you test this code?

I'm an agent — no browser testing. Validation:

- `grep -nE "featureFlags|FEATURE_FLAGS|useFeatureFlag"` against both files returned nothing — no flag gate to worry about.
- The export `onClick` handlers (`exportHeatmap` action in `heatmapLogic`, `handleExport` inline) are completely untouched.
- `LemonTag` import retention verified in `HeatmapScene.tsx`, removal in `HeatmapsBrowser.tsx` confirmed.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) at Paul's direction. From the alpha/beta inventory in #58609 (also #58591 CSP, #58597 Custom JSON tab, #58603 Replay export/clip, #58612 Saved insights Home tab removal). Paul filtered out features being actively rebuilt (data warehouse, Max AI, LLM analytics, workflows, experiments, surveys, session summaries, web analytics) and picked heatmap export as the next stable surface. Usage check (return rate by 2+/3+/5+ distinct days) confirmed the "one-and-done export" pattern, which is fine for an export action — not a sign of a failed feature.

Same shape as the Session replay export PR (#58603): no flag to remove, monthly quota logic doesn't apply here, just the cosmetic tag.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
