### PR TITLE
feat(user-interviews): expose responses, summary, and transcript via MCP

### DIFF
--- a/products/user_interviews/backend/api.py
+++ b/products/user_interviews/backend/api.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 
 import posthoganalytics
 import posthoganalytics.ai.openai
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from elevenlabs import ElevenLabs
 from posthoganalytics.ai.openai import OpenAI
@@ -239,6 +240,8 @@ class UserInterviewViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     parser_classes = [MultiPartParser, JSONParser]
     posthog_feature_flag = "user-interviews"
     permission_classes = [PostHogFeatureFlagPermission]
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["topic"]
 
 
 class UserInterviewTopicSerializer(serializers.ModelSerializer):

--- a/products/user_interviews/backend/test_user_interviews_list.py
+++ b/products/user_interviews/backend/test_user_interviews_list.py
@@ -1,34 +1,37 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import status
+
+from posthog.models.team import Team
 
 from products.user_interviews.backend.models import UserInterview, UserInterviewTopic
 
 
-class _FeatureFlagEnabledMixin(APIBaseTest):
+class TestUserInterviewsListFilters(APIBaseTest):
     def setUp(self) -> None:
         super().setUp()
         patcher = patch("posthoganalytics.feature_enabled", return_value=True)
         patcher.start()
         self.addCleanup(patcher.stop)
 
+    def _list_url(self, team: Team | None = None) -> str:
+        return f"/api/environments/{(team or self.team).id}/user_interviews/"
 
-class TestUserInterviewsListFilters(_FeatureFlagEnabledMixin):
-    def _list_url(self) -> str:
-        return f"/api/environments/{self.team.id}/user_interviews/"
-
-    def _create_topic(self, topic_text: str) -> UserInterviewTopic:
+    def _create_topic(self, topic_text: str, team: Team | None = None) -> UserInterviewTopic:
         return UserInterviewTopic.objects.create(
-            team=self.team,
+            team=team or self.team,
             created_by=self.user,
             interviewee_emails=["alex@example.com"],
             topic=topic_text,
         )
 
-    def _create_interview(self, *, topic: UserInterviewTopic | None, summary: str) -> UserInterview:
+    def _create_interview(
+        self, *, topic: UserInterviewTopic | None, summary: str, team: Team | None = None
+    ) -> UserInterview:
         return UserInterview.objects.create(
-            team=self.team,
+            team=team or self.team,
             created_by=self.user,
             interviewee_emails=["alex@example.com"],
             transcript="Hello world",
@@ -36,42 +39,49 @@ class TestUserInterviewsListFilters(_FeatureFlagEnabledMixin):
             topic=topic,
         )
 
-    def test_list_returns_all_interviews_when_no_topic_filter(self) -> None:
+    @parameterized.expand(
+        [
+            ("no filter returns all interviews", None, {"A1", "A2", "B1", "orphan"}),
+            ("topic A filter narrows to that topic", "topic_a", {"A1", "A2"}),
+            ("topic B filter narrows to that topic", "topic_b", {"B1"}),
+            ("topic with zero interviews returns empty set", "topic_c", set()),
+        ]
+    )
+    def test_topic_filter(self, _name: str, filter_topic_key: str | None, expected_summaries: set[str]) -> None:
         topic_a = self._create_topic("Topic A")
         topic_b = self._create_topic("Topic B")
-        self._create_interview(topic=topic_a, summary="A1")
-        self._create_interview(topic=topic_b, summary="B1")
-        self._create_interview(topic=None, summary="orphan")
-
-        response = self.client.get(self._list_url())
-
-        assert response.status_code == status.HTTP_200_OK, response.content
-        summaries = {row["summary"] for row in response.json()["results"]}
-        assert summaries == {"A1", "B1", "orphan"}
-
-    def test_list_filters_by_topic_uuid(self) -> None:
-        topic_a = self._create_topic("Topic A")
-        topic_b = self._create_topic("Topic B")
+        topic_c = self._create_topic("Topic C")
         self._create_interview(topic=topic_a, summary="A1")
         self._create_interview(topic=topic_a, summary="A2")
         self._create_interview(topic=topic_b, summary="B1")
         self._create_interview(topic=None, summary="orphan")
 
-        response = self.client.get(self._list_url(), {"topic": str(topic_a.id)})
+        params = (
+            {}
+            if filter_topic_key is None
+            else {"topic": str({"topic_a": topic_a.id, "topic_b": topic_b.id, "topic_c": topic_c.id}[filter_topic_key])}
+        )
+        response = self.client.get(self._list_url(), params)
 
         assert response.status_code == status.HTTP_200_OK, response.content
         summaries = {row["summary"] for row in response.json()["results"]}
-        assert summaries == {"A1", "A2"}
+        assert summaries == expected_summaries
 
-    def test_list_filters_to_empty_when_topic_has_no_interviews(self) -> None:
-        topic_a = self._create_topic("Topic A")
-        topic_b = self._create_topic("Topic B")
-        self._create_interview(topic=topic_a, summary="A1")
+    def test_list_does_not_leak_interviews_across_teams(self) -> None:
+        other_team = Team.objects.create(organization=self.organization, name="other team")
+        other_topic = self._create_topic("Other team topic", team=other_team)
+        self._create_interview(topic=other_topic, summary="other-team-secret", team=other_team)
+        own_topic = self._create_topic("Own topic")
+        self._create_interview(topic=own_topic, summary="own-team-summary")
 
-        response = self.client.get(self._list_url(), {"topic": str(topic_b.id)})
+        plain_list = self.client.get(self._list_url())
+        assert plain_list.status_code == status.HTTP_200_OK, plain_list.content
+        summaries = {row["summary"] for row in plain_list.json()["results"]}
+        assert summaries == {"own-team-summary"}
 
-        assert response.status_code == status.HTTP_200_OK, response.content
-        assert response.json()["results"] == []
+        filtered_by_other_team_topic = self.client.get(self._list_url(), {"topic": str(other_topic.id)})
+        assert filtered_by_other_team_topic.status_code == status.HTTP_200_OK, filtered_by_other_team_topic.content
+        assert filtered_by_other_team_topic.json()["results"] == []
 
     def test_retrieve_returns_full_transcript_and_summary(self) -> None:
         topic = self._create_topic("Topic A")

--- a/products/user_interviews/backend/test_user_interviews_list.py
+++ b/products/user_interviews/backend/test_user_interviews_list.py
@@ -1,0 +1,86 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from rest_framework import status
+
+from products.user_interviews.backend.models import UserInterview, UserInterviewTopic
+
+
+class _FeatureFlagEnabledMixin(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        patcher = patch("posthoganalytics.feature_enabled", return_value=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class TestUserInterviewsListFilters(_FeatureFlagEnabledMixin):
+    def _list_url(self) -> str:
+        return f"/api/environments/{self.team.id}/user_interviews/"
+
+    def _create_topic(self, topic_text: str) -> UserInterviewTopic:
+        return UserInterviewTopic.objects.create(
+            team=self.team,
+            created_by=self.user,
+            interviewee_emails=["alex@example.com"],
+            topic=topic_text,
+        )
+
+    def _create_interview(self, *, topic: UserInterviewTopic | None, summary: str) -> UserInterview:
+        return UserInterview.objects.create(
+            team=self.team,
+            created_by=self.user,
+            interviewee_emails=["alex@example.com"],
+            transcript="Hello world",
+            summary=summary,
+            topic=topic,
+        )
+
+    def test_list_returns_all_interviews_when_no_topic_filter(self) -> None:
+        topic_a = self._create_topic("Topic A")
+        topic_b = self._create_topic("Topic B")
+        self._create_interview(topic=topic_a, summary="A1")
+        self._create_interview(topic=topic_b, summary="B1")
+        self._create_interview(topic=None, summary="orphan")
+
+        response = self.client.get(self._list_url())
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        summaries = {row["summary"] for row in response.json()["results"]}
+        assert summaries == {"A1", "B1", "orphan"}
+
+    def test_list_filters_by_topic_uuid(self) -> None:
+        topic_a = self._create_topic("Topic A")
+        topic_b = self._create_topic("Topic B")
+        self._create_interview(topic=topic_a, summary="A1")
+        self._create_interview(topic=topic_a, summary="A2")
+        self._create_interview(topic=topic_b, summary="B1")
+        self._create_interview(topic=None, summary="orphan")
+
+        response = self.client.get(self._list_url(), {"topic": str(topic_a.id)})
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        summaries = {row["summary"] for row in response.json()["results"]}
+        assert summaries == {"A1", "A2"}
+
+    def test_list_filters_to_empty_when_topic_has_no_interviews(self) -> None:
+        topic_a = self._create_topic("Topic A")
+        topic_b = self._create_topic("Topic B")
+        self._create_interview(topic=topic_a, summary="A1")
+
+        response = self.client.get(self._list_url(), {"topic": str(topic_b.id)})
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()["results"] == []
+
+    def test_retrieve_returns_full_transcript_and_summary(self) -> None:
+        topic = self._create_topic("Topic A")
+        interview = self._create_interview(topic=topic, summary="Full summary text")
+
+        response = self.client.get(f"{self._list_url()}{interview.id}/")
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        body = response.json()
+        assert body["summary"] == "Full summary text"
+        assert body["transcript"] == "Hello world"
+        assert body["topic"] == str(topic.id)

--- a/products/user_interviews/frontend/generated/api.schemas.ts
+++ b/products/user_interviews/frontend/generated/api.schemas.ts
@@ -284,4 +284,5 @@ export type UserInterviewsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
+    topic?: string
 }

--- a/products/user_interviews/mcp/tools.yaml
+++ b/products/user_interviews/mcp/tools.yaml
@@ -169,10 +169,10 @@ tools:
             List completed user interview responses in the current project, newest first. Each row includes the
             interviewee email(s) and identifier, the linked `topic` UUID (set when the interview came in via a topic's
             shared link), and the AI-generated `transcript` and `summary` fields. Pass `topic` with a topic UUID to
-            scope to a single research topic — use this to answer questions like "do I have any responses on my X
-            topic yet?". Use `limit`/`offset` for pagination. `transcript` and `summary` can be long; when listing,
-            prefer skimming the response shapes and then call `user-interviews-retrieve` for the full text of a
-            specific interview.
+            scope to a single research topic — use this to answer questions like "do I have any responses on my X topic
+            yet?". Use `limit`/`offset` for pagination. `transcript` and `summary` can be long; when listing, prefer
+            skimming the response shapes and then call `user-interviews-retrieve` for the full text of a specific
+            interview.
         feature_flag: user-interviews
     user-interviews-partial-update:
         operation: user_interviews_partial_update
@@ -189,8 +189,8 @@ tools:
         title: Retrieve a user interview response
         description: >
             Fetch a single completed user interview response by id, including the full AI-generated `transcript` and
-            `summary`. Use after `user-interviews-list` has narrowed down to a specific interview — for example, to
-            read what a particular interviewee said about a research topic.
+            `summary`. Use after `user-interviews-list` has narrowed down to a specific interview — for example, to read
+            what a particular interviewee said about a research topic.
         feature_flag: user-interviews
     user-interviews-update:
         operation: user_interviews_update

--- a/products/user_interviews/mcp/tools.yaml
+++ b/products/user_interviews/mcp/tools.yaml
@@ -156,13 +156,42 @@ tools:
         enabled: false
     user-interviews-list:
         operation: user_interviews_list
-        enabled: false
+        enabled: true
+        scopes:
+            - user_interview:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List user interview responses
+        description: >
+            List completed user interview responses in the current project, newest first. Each row includes the
+            interviewee email(s) and identifier, the linked `topic` UUID (set when the interview came in via a topic's
+            shared link), and the AI-generated `transcript` and `summary` fields. Pass `topic` with a topic UUID to
+            scope to a single research topic — use this to answer questions like "do I have any responses on my X
+            topic yet?". Use `limit`/`offset` for pagination. `transcript` and `summary` can be long; when listing,
+            prefer skimming the response shapes and then call `user-interviews-retrieve` for the full text of a
+            specific interview.
+        feature_flag: user-interviews
     user-interviews-partial-update:
         operation: user_interviews_partial_update
         enabled: false
     user-interviews-retrieve:
         operation: user_interviews_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - user_interview:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Retrieve a user interview response
+        description: >
+            Fetch a single completed user interview response by id, including the full AI-generated `transcript` and
+            `summary`. Use after `user-interviews-list` has narrowed down to a specific interview — for example, to
+            read what a particular interviewee said about a research topic.
+        feature_flag: user-interviews
     user-interviews-update:
         operation: user_interviews_update
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4838,6 +4838,38 @@
         },
         "feature_flag": "user-interviews"
     },
+    "user-interviews-list": {
+        "description": "List completed user interview responses in the current project, newest first. Each row includes the interviewee email(s) and identifier, the linked `topic` UUID (set when the interview came in via a topic's shared link), and the AI-generated `transcript` and `summary` fields. Pass `topic` with a topic UUID to scope to a single research topic — use this to answer questions like \"do I have any responses on my X topic yet?\". Use `limit`/`offset` for pagination. `transcript` and `summary` can be long; when listing, prefer skimming the response shapes and then call `user-interviews-retrieve` for the full text of a specific interview.",
+        "category": "User interview topics",
+        "feature": "user_interviews",
+        "summary": "List user interview responses",
+        "title": "List user interview responses",
+        "required_scopes": ["user_interview:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "user-interviews"
+    },
+    "user-interviews-retrieve": {
+        "description": "Fetch a single completed user interview response by id, including the full AI-generated `transcript` and `summary`. Use after `user-interviews-list` has narrowed down to a specific interview — for example, to read what a particular interviewee said about a research topic.",
+        "category": "User interview topics",
+        "feature": "user_interviews",
+        "summary": "Retrieve a user interview response",
+        "title": "Retrieve a user interview response",
+        "required_scopes": ["user_interview:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "user-interviews"
+    },
     "user-settings-update": {
         "description": "Update the authenticated user's profile and settings using PATCH semantics — only the fields included in the request body are changed. Pass `@me` as the UUID; non-staff callers may only update their own account. Use `user-get` first to inspect current settings. `notification_settings` merges key-by-key; changing `email` triggers a verification flow; changing `password` also requires `current_password`. Always confirm changes with the user before applying.",
         "category": "Core",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5319,6 +5319,38 @@
         },
         "feature_flag": "user-interviews"
     },
+    "user-interviews-list": {
+        "description": "List completed user interview responses in the current project, newest first. Each row includes the interviewee email(s) and identifier, the linked `topic` UUID (set when the interview came in via a topic's shared link), and the AI-generated `transcript` and `summary` fields. Pass `topic` with a topic UUID to scope to a single research topic — use this to answer questions like \"do I have any responses on my X topic yet?\". Use `limit`/`offset` for pagination. `transcript` and `summary` can be long; when listing, prefer skimming the response shapes and then call `user-interviews-retrieve` for the full text of a specific interview.",
+        "category": "User interview topics",
+        "feature": "user_interviews",
+        "summary": "List user interview responses",
+        "title": "List user interview responses",
+        "required_scopes": ["user_interview:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "user-interviews"
+    },
+    "user-interviews-retrieve": {
+        "description": "Fetch a single completed user interview response by id, including the full AI-generated `transcript` and `summary`. Use after `user-interviews-list` has narrowed down to a specific interview — for example, to read what a particular interviewee said about a research topic.",
+        "category": "User interview topics",
+        "feature": "user_interviews",
+        "summary": "Retrieve a user interview response",
+        "title": "Retrieve a user interview response",
+        "required_scopes": ["user_interview:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "user-interviews"
+    },
     "user-settings-update": {
         "description": "Update the authenticated user's profile and settings using PATCH semantics — only the fields included in the request body are changed. Pass `@me` as the UUID; non-staff callers may only update their own account. Use `user-get` first to inspect current settings. `notification_settings` merges key-by-key; changing `email` triggers a verification flow; changing `password` also requires `current_password`. Always confirm changes with the user before applying.",
         "category": "Core",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39909,6 +39909,7 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    topic?: string;
     };
 
     export type VisionLensesListParams = {

--- a/services/mcp/src/generated/user_interviews/api.ts
+++ b/services/mcp/src/generated/user_interviews/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 6 enabled ops
+ * PostHog API - MCP 8 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -159,5 +159,28 @@ export const UserInterviewTopicsIntervieweesCreateBody = /* @__PURE__ */ zod.obj
         .max(userInterviewTopicsIntervieweesCreateBodyAgentContextMax)
         .describe(
             "Extra context the voice agent should know about this specific interviewee — e.g. 'uses the replay product but has never used summarization'."
+        ),
+})
+
+export const UserInterviewsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const UserInterviewsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    topic: zod.string().optional(),
+})
+
+export const UserInterviewsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this user interview.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
 })

--- a/services/mcp/src/tools/generated/user_interviews.ts
+++ b/services/mcp/src/tools/generated/user_interviews.ts
@@ -12,6 +12,8 @@ import {
     UserInterviewTopicsListQueryParams,
     UserInterviewTopicsSendInvitesCreateBody,
     UserInterviewTopicsSendInvitesCreateParams,
+    UserInterviewsListQueryParams,
+    UserInterviewsRetrieveParams,
 } from '@/generated/user_interviews/api'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
@@ -175,6 +177,44 @@ const userInterviewTopicsSendInvites = (): ToolBase<
     },
 })
 
+const UserInterviewsListSchema = UserInterviewsListQueryParams
+
+const userInterviewsList = (): ToolBase<
+    typeof UserInterviewsListSchema,
+    WithPostHogUrl<Schemas.PaginatedUserInterviewList>
+> => ({
+    name: 'user-interviews-list',
+    schema: UserInterviewsListSchema,
+    handler: async (context: Context, params: z.infer<typeof UserInterviewsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedUserInterviewList>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/user_interviews/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+                topic: params.topic,
+            },
+        })
+        return await withPostHogUrl(context, result, '/user_interviews')
+    },
+})
+
+const UserInterviewsRetrieveSchema = UserInterviewsRetrieveParams.omit({ project_id: true })
+
+const userInterviewsRetrieve = (): ToolBase<typeof UserInterviewsRetrieveSchema, Schemas.UserInterview> => ({
+    name: 'user-interviews-retrieve',
+    schema: UserInterviewsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof UserInterviewsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.UserInterview>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/user_interviews/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'user-interview-topics-create': userInterviewTopicsCreate,
     'user-interview-topics-generate-links': userInterviewTopicsGenerateLinks,
@@ -182,4 +222,6 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'user-interview-topics-interviewees-list': userInterviewTopicsIntervieweesList,
     'user-interview-topics-list': userInterviewTopicsList,
     'user-interview-topics-send-invites': userInterviewTopicsSendInvites,
+    'user-interviews-list': userInterviewsList,
+    'user-interviews-retrieve': userInterviewsRetrieve,
 }


### PR DESCRIPTION
## Problem

We want to answer questions like "do I have any responses on my Session Summary Power User Interviews topic?" from inside an MCP client (Claude Desktop, Cursor, the PostHog AI chat). Today the MCP exposes the topic-planning side of `user_interviews` (create topic, generate links, send invites) but the response side — the rows with the AI-generated transcript and summary — is invisible. There's nothing to read from once the voice agent finishes a call.

## Changes

- Add `DjangoFilterBackend` + `filterset_fields = ["topic"]` to `UserInterviewViewSet` so the list endpoint accepts `?topic=<uuid>`. This is the missing piece that lets clients scope responses to a single research topic — the FK to `UserInterviewTopic` was added in #58435 but never exposed as a filter.
- Enable two MCP tools in `products/user_interviews/mcp/tools.yaml`, both requiring the `user_interview:read` scope and gated behind the `user-interviews` feature flag:
  - `user-interviews-list` — paginated list; `topic` filter; returns `id`, `interviewee_emails`, `interviewee_identifier`, `topic`, `transcript`, `summary`, `created_at`.
  - `user-interviews-retrieve` — single row by id (use after the list call to read full transcript/summary).
- Regenerate `services/mcp/...`, `products/user_interviews/frontend/generated/api.schemas.ts` via `hogli build:openapi`.

## How did you test this code?

I'm an agent (PostHog Code). I only ran automated tests:
- New `products/user_interviews/backend/test_user_interviews_list.py` — 4 tests covering: list returns all interviews with no filter, `?topic=<id>` narrows to that topic only, an empty topic returns `[]`, retrieve exposes the full `transcript`/`summary`/`topic` shape. All pass locally.
- `hogli build:openapi` succeeded and the regenerated `services/mcp/src/tools/generated/user_interviews.ts` shows `topic` plumbed through the `query` block of the list call — confirming the filter reached the wire.

No manual MCP-client testing.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored end-to-end by PostHog Code (Opus 4.7) in a single session prompted by the user noticing the MCP could plan interviews but not read responses.

Decisions worth flagging for the reviewer:
- **Filter scope.** Considered also exposing `interviewee_identifier` as a filter ("what did this person say across topics?") but parked it — current ask is per-topic, and adding more filters now would be speculative. Easy follow-up if needed.
- **`UserInterview` model already had the wiring.** The earlier "host AI interview calls via shared links" PR (#58435) added `UserInterview.topic` FK (nullable, `SET_NULL`), `interviewee_identifier`, `recording_url`, and the Vapi webhook that populates transcript + summary. So this PR is plumbing-only — no model changes, no migration.
- **No new HogQL system table.** The implementing-mcp-tools skill recommends one for list/get endpoints so v2 (SQL-first) agents can query the data directly. Skipped here because the data isn't shaped for ad-hoc SQL (transcript blobs are large) and the existing tool surface is enough to answer the targeted question. Worth a follow-up if we see agents wanting to aggregate across responses.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*