### PR TITLE
feat(error-tracking): include customer revenue in autocapture disable survey

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/exception_autocapture/disableSurveyLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/exception_autocapture/disableSurveyLogic.ts
@@ -1,6 +1,9 @@
-import { actions, kea, listeners, path, reducers } from 'kea'
+import { actions, connect, kea, listeners, path, reducers } from 'kea'
 import posthog from 'posthog-js'
 
+import { billingLogic } from 'scenes/billing/billingLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
 import { SurveyQuestion } from '~/types'
 
 import type { disableSurveyLogicType } from './disableSurveyLogicType'
@@ -9,6 +12,10 @@ const SURVEY_ID = '019c89a0-1469-0000-a31c-35883eb31be4'
 
 export const disableSurveyLogic = kea<disableSurveyLogicType>([
     path(['scenes', 'error-tracking', 'configuration', 'disableSurveyLogic']),
+
+    connect(() => ({
+        values: [billingLogic, ['billing']],
+    })),
 
     actions({
         showSurvey: true,
@@ -82,6 +89,20 @@ export const disableSurveyLogic = kea<disableSurveyLogicType>([
             }
             if (values.openResponse.trim()) {
                 payload.$survey_response_1 = values.openResponse
+            }
+            const billing = values.billing
+            const errorTrackingProduct = billing?.products?.find((p) => p.type === ProductKey.ERROR_TRACKING)
+            if (errorTrackingProduct?.current_amount_usd) {
+                payload.error_tracking_current_amount_usd = errorTrackingProduct.current_amount_usd
+            }
+            if (errorTrackingProduct?.projected_amount_usd) {
+                payload.error_tracking_projected_amount_usd = errorTrackingProduct.projected_amount_usd
+            }
+            if (billing?.current_total_amount_usd) {
+                payload.current_total_amount_usd = billing.current_total_amount_usd
+            }
+            if (billing?.projected_total_amount_usd) {
+                payload.projected_total_amount_usd = billing.projected_total_amount_usd
             }
             posthog.capture('survey sent', payload)
             cache.hideTimeout = setTimeout(() => {


### PR DESCRIPTION
## Problem

When customers disable exception autocapture, the in-product survey
captures their reason and free-text feedback but no signal about how much
revenue is on the line. That makes it hard to tell which reasons skew
toward higher-value customers and where to focus follow-up.

## Changes

In `disableSurveyLogic`, on `submitResponse` we now pull from
`billingLogic` and add the following properties to the `survey sent`
event payload (only when present):

- `error_tracking_current_amount_usd` and `error_tracking_projected_amount_usd`
  from the Error tracking product line.
- `current_total_amount_usd` and `projected_total_amount_usd` for the
  customer's overall account spend.

`billingLogic` is wired in via `connect` so the values mount alongside
the survey logic.

## How did you test this code?

I'm an agent (PostHog Code). Verified locally:

- `pnpm --filter=@posthog/frontend typescript:check` — no new errors.
- Formatted the changed file with `oxfmt`.
- No manual UI testing performed.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by the PostHog Code agent. The user asked to enrich responses
  from the existing "error tracking autocapture turn off" survey with
  the customer's error-tracking-line revenue and their overall account
  revenue.
- Located the survey in
  `products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/exception_autocapture/disableSurveyLogic.ts`
  (survey ID `019c89a0-1469-0000-a31c-35883eb31be4`).
- Reused the existing `billingLogic` selector — same shape as
  `supportLogic.ts` uses for plan tagging — to avoid introducing a new
  data source.
- Chose to forward the raw `*_amount_usd` strings (as exposed by the
  billing API) so downstream survey analysis can decide on bucketing
  rather than baking it into the client.
- Properties are added conditionally so a customer on a free plan with
  no billing data doesn't get noisy empty fields.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*