### PR TITLE
feat(surveys): polish notifications page UX

### DIFF
--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -109,15 +109,7 @@ function Surveys(): JSX.Element {
                 sceneInset={true}
             />
             {tab === SurveysTabs.Settings && <SurveySettings />}
-            {tab === SurveysTabs.Notifications && (
-                <div className="flex flex-col gap-3">
-                    <p className="m-0 text-sm text-muted">
-                        Get notified whenever a survey result is submitted. Open a survey to add or edit its
-                        notifications.
-                    </p>
-                    <SurveyNotificationsList />
-                </div>
-            )}
+            {tab === SurveysTabs.Notifications && <SurveyNotificationsList />}
 
             {tab === SurveysTabs.History && <ActivityLog scope={ActivityScope.SURVEY} />}
 

--- a/frontend/src/scenes/surveys/components/SurveyNotifications.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotifications.tsx
@@ -3,6 +3,8 @@ import { useActions, useValues } from 'kea'
 import { IconCopy, IconPlus } from '@posthog/icons'
 import { LemonButton, LemonMenu, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
 
+import { MailHog } from 'lib/components/hedgehogs'
+import { LemonMenuItems } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { HogFunctionIcon } from 'scenes/hog-functions/configuration/HogFunctionIcon'
 import { NEW_SURVEY } from 'scenes/surveys/constants'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
@@ -55,114 +57,174 @@ export function SurveyNotifications({
     const { openDialog } = useActions(notificationModalLogic)
 
     const isUnsavedSurvey = survey.id === NEW_SURVEY.id
+    const addDisabledReason = isUnsavedSurvey ? 'Save the survey before adding notifications.' : undefined
     const copyDisabledReason = isUnsavedSurvey ? 'Save the survey before copying notifications.' : undefined
+
+    const copyMenuItems: LemonMenuItems = [
+        {
+            title: 'Copy from existing',
+            items: reusableSurveyNotifications.map((fn) => {
+                const notificationDescription = getNotificationDescription(fn)
+                return {
+                    key: fn.id,
+                    icon: <HogFunctionIcon src={fn.icon_url} size="small" />,
+                    label: (
+                        <div className="min-w-0">
+                            <div className="truncate">{fn.name}</div>
+                            {notificationDescription ? (
+                                <div className="text-xs text-muted truncate">{notificationDescription}</div>
+                            ) : null}
+                        </div>
+                    ),
+                    onClick: () => openDialog({ notification: fn, intent: 'copy' }),
+                }
+            }),
+        },
+    ]
+
+    const hasReusable = reusableSurveyNotifications.length > 0
+    const showCopyControl = reusableSurveyNotificationsLoading || hasReusable
+
+    const renderCopyControl = (buttonType: 'primary' | 'secondary'): JSX.Element | null => {
+        if (!showCopyControl) {
+            return null
+        }
+        if (reusableSurveyNotificationsLoading) {
+            return (
+                <LemonButton
+                    type={buttonType}
+                    size="small"
+                    icon={<IconCopy />}
+                    fullWidth={buttonFullWidth}
+                    loading
+                    disabledReason={copyDisabledReason}
+                    data-attr="survey-copy-notification"
+                >
+                    Copy from existing
+                </LemonButton>
+            )
+        }
+        return (
+            <LemonMenu items={copyMenuItems} placement="bottom-start" maxContentWidth>
+                <LemonButton
+                    type={buttonType}
+                    size="small"
+                    icon={<IconCopy />}
+                    fullWidth={buttonFullWidth}
+                    disabledReason={copyDisabledReason}
+                    data-attr="survey-copy-notification"
+                >
+                    Copy from existing
+                </LemonButton>
+            </LemonMenu>
+        )
+    }
+
+    if (surveyNotificationsLoading) {
+        return (
+            <div className="flex flex-col gap-1.5">
+                {Array.from({ length: 2 }).map((_, i) => (
+                    <div key={i} className="flex items-center gap-2 rounded border p-2 h-12">
+                        <LemonSkeleton className="h-[30px] w-[30px] rounded shrink-0" />
+                        <div className="flex-1 min-w-0 flex flex-col gap-1">
+                            <LemonSkeleton className="h-3 w-40 max-w-full" />
+                            <LemonSkeleton className="h-2 w-28 max-w-full" />
+                        </div>
+                        <LemonSkeleton className="h-5 w-9 rounded-full shrink-0" />
+                    </div>
+                ))}
+            </div>
+        )
+    }
+
+    if (surveyNotifications.length === 0) {
+        return (
+            <section className="flex flex-col items-center gap-5 px-6 py-12 text-center">
+                <MailHog className="h-32 w-auto" />
+                <div className="flex flex-col gap-1.5 max-w-md">
+                    <h3 className="m-0 text-base font-semibold">Get notified when responses land</h3>
+                    <p className="m-0 text-sm text-muted">
+                        Pipe survey responses straight into Slack, Discord, Microsoft Teams, or any webhook.
+                    </p>
+                </div>
+                <div className="flex flex-wrap items-center justify-center gap-2">
+                    <LemonButton
+                        type="primary"
+                        icon={<IconPlus />}
+                        onClick={() => openDialog()}
+                        data-attr="survey-new-notification"
+                        disabledReason={addDisabledReason}
+                    >
+                        Add notification
+                    </LemonButton>
+                    {renderCopyControl('secondary')}
+                </div>
+            </section>
+        )
+    }
+
+    const headerActions = (
+        <div className={buttonFullWidth ? 'flex flex-col gap-2' : 'flex flex-wrap gap-2'}>
+            <LemonButton
+                type="secondary"
+                size="small"
+                icon={<IconPlus />}
+                onClick={() => openDialog()}
+                fullWidth={buttonFullWidth}
+                data-attr="survey-new-notification"
+                disabledReason={addDisabledReason}
+            >
+                Add notification
+            </LemonButton>
+            {renderCopyControl('secondary')}
+        </div>
+    )
 
     return (
         <div className="flex flex-col gap-3">
-            {description ? <p className="m-0 text-sm text-muted">{description}</p> : null}
-            {surveyNotificationsLoading ? (
-                <div className="flex flex-col gap-2">
-                    <LemonSkeleton className="h-12" />
-                    <LemonSkeleton className="h-12" />
-                </div>
-            ) : surveyNotifications.length > 0 ? (
-                <div className="flex flex-col gap-1.5">
-                    {surveyNotifications.map((fn) => {
-                        const notificationDescription = getNotificationDescription(fn)
-                        return (
-                            <div key={fn.id} className="flex items-center gap-2 rounded border p-2">
-                                <HogFunctionIcon src={fn.icon_url} size="small" />
-                                <div className="flex-1 min-w-0">
-                                    <LemonButton
-                                        type="tertiary"
-                                        size="xsmall"
-                                        onClick={() => openDialog({ notification: fn, intent: 'edit' })}
-                                        className="font-medium p-0 h-auto min-h-0"
-                                        noPadding
-                                    >
-                                        <span className="truncate">{fn.name}</span>
-                                    </LemonButton>
-                                    {notificationDescription ? (
-                                        <div className="text-xs text-muted truncate">{notificationDescription}</div>
-                                    ) : null}
-                                </div>
-                                <LemonSwitch
-                                    checked={fn.enabled}
-                                    onChange={() => toggleSurveyNotificationEnabled(fn.id, !fn.enabled)}
-                                    size="small"
-                                />
-                            </div>
-                        )
-                    })}
-                </div>
+            {buttonFullWidth ? (
+                <>
+                    {description ? <p className="m-0 text-sm text-muted">{description}</p> : null}
+                    {headerActions}
+                </>
             ) : (
-                <p className="text-xs text-muted m-0">No notifications configured yet.</p>
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                    {description ? (
+                        <p className="m-0 text-sm text-muted flex-1 min-w-0">{description}</p>
+                    ) : (
+                        <div className="flex-1" />
+                    )}
+                    {headerActions}
+                </div>
             )}
-            <div className={buttonFullWidth ? 'flex flex-col gap-2' : 'flex flex-wrap gap-2'}>
-                <LemonButton
-                    type="secondary"
-                    size="small"
-                    icon={<IconPlus />}
-                    onClick={() => openDialog()}
-                    fullWidth={buttonFullWidth}
-                    data-attr="survey-new-notification"
-                    disabledReason={isUnsavedSurvey ? 'Save the survey before adding notifications.' : undefined}
-                >
-                    Add notification
-                </LemonButton>
-                {reusableSurveyNotificationsLoading ? (
-                    <LemonButton
-                        type="secondary"
-                        size="small"
-                        icon={<IconCopy />}
-                        fullWidth={buttonFullWidth}
-                        loading
-                        disabledReason={copyDisabledReason}
-                        data-attr="survey-copy-notification"
-                    >
-                        Copy from existing
-                    </LemonButton>
-                ) : reusableSurveyNotifications.length > 0 ? (
-                    <LemonMenu
-                        items={[
-                            {
-                                title: 'Copy from existing',
-                                items: reusableSurveyNotifications.map((fn) => {
-                                    const notificationDescription = getNotificationDescription(fn)
-
-                                    return {
-                                        key: fn.id,
-                                        icon: <HogFunctionIcon src={fn.icon_url} size="small" />,
-                                        label: (
-                                            <div className="min-w-0">
-                                                <div className="truncate">{fn.name}</div>
-                                                {notificationDescription ? (
-                                                    <div className="text-xs text-muted truncate">
-                                                        {notificationDescription}
-                                                    </div>
-                                                ) : null}
-                                            </div>
-                                        ),
-                                        onClick: () => openDialog({ notification: fn, intent: 'copy' }),
-                                    }
-                                }),
-                            },
-                        ]}
-                        placement="bottom-start"
-                        maxContentWidth
-                    >
-                        <LemonButton
-                            type="secondary"
-                            size="small"
-                            icon={<IconCopy />}
-                            fullWidth={buttonFullWidth}
-                            disabledReason={copyDisabledReason}
-                            data-attr="survey-copy-notification"
-                        >
-                            Copy from existing
-                        </LemonButton>
-                    </LemonMenu>
-                ) : null}
+            <div className="flex flex-col gap-1.5">
+                {surveyNotifications.map((fn) => {
+                    const notificationDescription = getNotificationDescription(fn)
+                    return (
+                        <div key={fn.id} className="flex items-center gap-2 rounded border p-2">
+                            <HogFunctionIcon src={fn.icon_url} size="small" />
+                            <div className="flex-1 min-w-0">
+                                <LemonButton
+                                    type="tertiary"
+                                    size="xsmall"
+                                    onClick={() => openDialog({ notification: fn, intent: 'edit' })}
+                                    className="font-medium p-0 h-auto min-h-0"
+                                    noPadding
+                                >
+                                    <span className="truncate">{fn.name}</span>
+                                </LemonButton>
+                                {notificationDescription ? (
+                                    <div className="text-xs text-muted truncate">{notificationDescription}</div>
+                                ) : null}
+                            </div>
+                            <LemonSwitch
+                                checked={fn.enabled}
+                                onChange={() => toggleSurveyNotificationEnabled(fn.id, !fn.enabled)}
+                                size="small"
+                            />
+                        </div>
+                    )
+                })}
             </div>
         </div>
     )

--- a/frontend/src/scenes/surveys/components/SurveyNotificationsList.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationsList.tsx
@@ -1,9 +1,10 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { LemonBanner, LemonButton, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
+import { IconPlus } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonDropdown, LemonInput, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
 
-import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
+import { MailHog } from 'lib/components/hedgehogs'
 import { HogFunctionIcon } from 'scenes/hog-functions/configuration/HogFunctionIcon'
 import {
     getSurveyIdsFromNotificationFilters,
@@ -11,7 +12,7 @@ import {
 } from 'scenes/surveys/surveyNotificationsListLogic'
 import { urls } from 'scenes/urls'
 
-import { HogFunctionType, Survey } from '~/types'
+import { HogFunctionType } from '~/types'
 
 function getNotificationDescription(fn: HogFunctionType): string | null {
     const inputs = fn.inputs
@@ -39,39 +40,82 @@ function surveyNotificationsUrl(surveyId: string, params: Record<string, string>
     return `${urls.survey(surveyId)}?${search}`
 }
 
-function NewNotificationPicker(): JSX.Element {
+function NewNotificationButton({
+    type = 'secondary',
+    size = 'small',
+}: {
+    type?: 'primary' | 'secondary'
+    size?: 'small' | 'medium'
+}): JSX.Element {
     const { push } = useActions(router)
-    const { selectableSurveys, knownSurveysLoading } = useValues(surveyNotificationsListLogic)
+    const {
+        selectableSurveys,
+        filteredSelectableSurveys,
+        knownSurveysLoading,
+        surveyPickerSearch,
+        surveyPickerVisible,
+    } = useValues(surveyNotificationsListLogic)
+    const { setSurveyPickerSearch, setSurveyPickerVisible } = useActions(surveyNotificationsListLogic)
 
-    const options = selectableSurveys.map((survey: Pick<Survey, 'id' | 'name'>) => ({
-        key: survey.id,
-        label: survey.name,
-    }))
+    const hasSurveys = selectableSurveys.length > 0
+    const disabledReason =
+        !knownSurveysLoading && !hasSurveys ? 'Create a survey first before adding notifications.' : undefined
 
-    const handleChange = (newValue: string[]): void => {
-        const surveyId = newValue[0]
-        if (surveyId) {
-            push(surveyNotificationsUrl(surveyId, { notification: 'add' }))
-        }
+    const handlePick = (surveyId: string): void => {
+        push(surveyNotificationsUrl(surveyId, { notification: 'add' }))
+        setSurveyPickerVisible(false)
     }
 
     return (
-        <div className="w-80 max-w-full">
-            <LemonInputSelect
-                mode="single"
-                placeholder="Add notification to a survey…"
-                title="Add notification to…"
-                options={options}
-                value={null}
-                onChange={handleChange}
+        <LemonDropdown
+            visible={surveyPickerVisible}
+            onVisibilityChange={setSurveyPickerVisible}
+            closeOnClickInside={false}
+            matchWidth={false}
+            placement="bottom-end"
+            overlay={
+                <div className="flex flex-col gap-2 w-80 max-w-full">
+                    <LemonInput
+                        type="search"
+                        placeholder="Search surveys…"
+                        value={surveyPickerSearch}
+                        onChange={setSurveyPickerSearch}
+                        autoFocus
+                        fullWidth
+                    />
+                    <div className="flex flex-col gap-px max-h-80 overflow-y-auto">
+                        {filteredSelectableSurveys.length === 0 ? (
+                            <p className="m-0 p-2 text-xs text-muted text-center">
+                                {surveyPickerSearch ? 'No surveys match your search.' : 'No surveys available.'}
+                            </p>
+                        ) : (
+                            filteredSelectableSurveys.map((survey) => (
+                                <LemonButton
+                                    key={survey.id}
+                                    fullWidth
+                                    size="small"
+                                    role="menuitem"
+                                    onClick={() => handlePick(survey.id)}
+                                >
+                                    <span className="truncate">{survey.name}</span>
+                                </LemonButton>
+                            ))
+                        )}
+                    </div>
+                </div>
+            }
+        >
+            <LemonButton
+                type={type}
+                size={size}
+                icon={<IconPlus />}
                 loading={knownSurveysLoading}
-                size="small"
-                emptyStateComponent={
-                    <div className="p-2 text-xs text-muted">No surveys to notify on. Create a survey first.</div>
-                }
-                data-attr="survey-list-new-notification-picker"
-            />
-        </div>
+                disabledReason={disabledReason}
+                data-attr="survey-list-new-notification-button"
+            >
+                Add notification
+            </LemonButton>
+        </LemonDropdown>
     )
 }
 
@@ -83,10 +127,17 @@ export function SurveyNotificationsList(): JSX.Element {
 
     if (notificationsLoading) {
         return (
-            <div className="flex flex-col gap-2">
-                <LemonSkeleton className="h-12" />
-                <LemonSkeleton className="h-12" />
-                <LemonSkeleton className="h-12" />
+            <div className="flex flex-col gap-1.5">
+                {Array.from({ length: 3 }).map((_, i) => (
+                    <div key={i} className="flex items-center gap-2 rounded border p-2 h-12">
+                        <LemonSkeleton className="h-[30px] w-[30px] rounded shrink-0" />
+                        <div className="flex-1 min-w-0 flex flex-col gap-1">
+                            <LemonSkeleton className="h-3 w-40 max-w-full" />
+                            <LemonSkeleton className="h-2 w-28 max-w-full" />
+                        </div>
+                        <LemonSkeleton className="h-5 w-9 rounded-full shrink-0" />
+                    </div>
+                ))}
             </div>
         )
     }
@@ -105,15 +156,16 @@ export function SurveyNotificationsList(): JSX.Element {
 
     if (notifications.length === 0) {
         return (
-            <div className="flex flex-col items-center gap-3 rounded border border-dashed p-6 text-center">
-                <div className="space-y-1">
-                    <p className="m-0 text-sm font-medium">No survey notifications yet</p>
-                    <p className="m-0 text-xs text-muted">
-                        Send every new survey response to Slack, Discord, Microsoft Teams, or a webhook.
+            <section className="flex flex-col items-center gap-5 px-6 py-12 text-center">
+                <MailHog className="h-32 w-auto" />
+                <div className="flex flex-col gap-1.5 max-w-md">
+                    <h3 className="m-0 text-base font-semibold">Get notified when responses land</h3>
+                    <p className="m-0 text-sm text-muted">
+                        Pipe survey responses straight into Slack, Discord, Microsoft Teams, or any webhook.
                     </p>
                 </div>
-                <NewNotificationPicker />
-            </div>
+                <NewNotificationButton type="primary" size="medium" />
+            </section>
         )
     }
 
@@ -128,6 +180,12 @@ export function SurveyNotificationsList(): JSX.Element {
                     We couldn't verify which surveys still exist, so notifications for deleted surveys may appear here.
                 </LemonBanner>
             ) : null}
+            <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="m-0 text-sm text-muted flex-1 min-w-0">
+                    Send survey responses to Slack, Discord, Microsoft Teams, or webhooks.
+                </p>
+                <NewNotificationButton />
+            </div>
             <div className="flex flex-col gap-1.5">
                 {notifications.map((fn) => {
                     const description = getNotificationDescription(fn)
@@ -166,7 +224,6 @@ export function SurveyNotificationsList(): JSX.Element {
                     )
                 })}
             </div>
-            <NewNotificationPicker />
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/components/SurveyNotificationsList.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationsList.tsx
@@ -52,14 +52,20 @@ function NewNotificationButton({
         selectableSurveys,
         filteredSelectableSurveys,
         knownSurveysLoading,
+        knownSurveysFailed,
         surveyPickerSearch,
         surveyPickerVisible,
     } = useValues(surveyNotificationsListLogic)
     const { setSurveyPickerSearch, setSurveyPickerVisible } = useActions(surveyNotificationsListLogic)
 
     const hasSurveys = selectableSurveys.length > 0
-    const disabledReason =
-        !knownSurveysLoading && !hasSurveys ? 'Create a survey first before adding notifications.' : undefined
+    const disabledReason = knownSurveysLoading
+        ? undefined
+        : knownSurveysFailed
+          ? "We couldn't load your surveys — retry from the warning above."
+          : !hasSurveys
+            ? 'Create a survey first before adding notifications.'
+            : undefined
 
     const handlePick = (surveyId: string): void => {
         push(surveyNotificationsUrl(surveyId, { notification: 'add' }))
@@ -156,16 +162,27 @@ export function SurveyNotificationsList(): JSX.Element {
 
     if (notifications.length === 0) {
         return (
-            <section className="flex flex-col items-center gap-5 px-6 py-12 text-center">
-                <MailHog className="h-32 w-auto" />
-                <div className="flex flex-col gap-1.5 max-w-md">
-                    <h3 className="m-0 text-base font-semibold">Get notified when responses land</h3>
-                    <p className="m-0 text-sm text-muted">
-                        Pipe survey responses straight into Slack, Discord, Microsoft Teams, or any webhook.
-                    </p>
-                </div>
-                <NewNotificationButton type="primary" size="medium" />
-            </section>
+            <div className="flex flex-col gap-3">
+                {knownSurveysFailed ? (
+                    <LemonBanner
+                        type="warning"
+                        action={{ children: 'Retry', onClick: () => loadKnownSurveys() }}
+                        data-attr="survey-notifications-known-surveys-error"
+                    >
+                        We couldn't load your surveys, so picking one to notify on isn't available right now.
+                    </LemonBanner>
+                ) : null}
+                <section className="flex flex-col items-center gap-5 px-6 py-12 text-center">
+                    <MailHog className="h-32 w-auto" />
+                    <div className="flex flex-col gap-1.5 max-w-md">
+                        <h3 className="m-0 text-base font-semibold">Get notified when responses land</h3>
+                        <p className="m-0 text-sm text-muted">
+                            Pipe survey responses straight into Slack, Discord, Microsoft Teams, or any webhook.
+                        </p>
+                    </div>
+                    <NewNotificationButton type="primary" size="medium" />
+                </section>
+            </div>
         )
     }
 

--- a/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
@@ -38,10 +38,14 @@ export function getSurveyIdsFromNotificationFilters(filters?: CyclotronJobFilter
     return Array.from(surveyIds)
 }
 
+type KnownSurvey = Pick<Survey, 'id' | 'name' | 'archived' | 'created_at'>
+
 export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType>([
     path(['scenes', 'surveys', 'surveyNotificationsListLogic']),
     actions({
         toggleNotificationEnabled: (notificationId: string, enabled: boolean) => ({ notificationId, enabled }),
+        setSurveyPickerSearch: (search: string) => ({ search }),
+        setSurveyPickerVisible: (visible: boolean) => ({ visible }),
     }),
     loaders(() => ({
         allNotifications: [
@@ -64,14 +68,15 @@ export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType
             },
         ],
         knownSurveys: [
-            [] as Pick<Survey, 'id' | 'name' | 'archived'>[],
+            [] as KnownSurvey[],
             {
-                loadKnownSurveys: async (): Promise<Pick<Survey, 'id' | 'name' | 'archived'>[]> => {
+                loadKnownSurveys: async (): Promise<KnownSurvey[]> => {
                     const response = await api.surveys.list({ limit: SURVEY_INDEX_LIMIT })
                     return response.results.map((survey) => ({
                         id: survey.id,
                         name: survey.name,
                         archived: survey.archived,
+                        created_at: survey.created_at,
                     }))
                 },
             },
@@ -94,38 +99,74 @@ export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType
                 loadKnownSurveysFailure: () => true,
             },
         ],
+        surveyPickerSearch: [
+            '',
+            {
+                setSurveyPickerSearch: (_, { search }) => search,
+                setSurveyPickerVisible: (state, { visible }) => (visible ? state : ''),
+            },
+        ],
+        surveyPickerVisible: [
+            false,
+            {
+                setSurveyPickerVisible: (_, { visible }) => visible,
+            },
+        ],
     }),
     selectors({
+        surveyCreatedAtById: [
+            (s) => [s.knownSurveys],
+            (knownSurveys: KnownSurvey[]) => new Map(knownSurveys.map((survey) => [survey.id, survey.created_at])),
+        ],
         knownSurveyIds: [
             (s) => [s.knownSurveys],
-            (knownSurveys: Pick<Survey, 'id' | 'name' | 'archived'>[]) =>
-                new Set(knownSurveys.map((survey) => survey.id)),
+            (knownSurveys: KnownSurvey[]) => new Set(knownSurveys.map((survey) => survey.id)),
         ],
         selectableSurveys: [
             (s) => [s.knownSurveys],
-            (knownSurveys: Pick<Survey, 'id' | 'name' | 'archived'>[]) =>
-                knownSurveys.filter((survey) => !survey.archived),
+            (knownSurveys: KnownSurvey[]) =>
+                knownSurveys
+                    .filter((survey) => !survey.archived)
+                    .slice()
+                    .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? '')),
+        ],
+        filteredSelectableSurveys: [
+            (s) => [s.selectableSurveys, s.surveyPickerSearch],
+            (selectableSurveys: KnownSurvey[], surveyPickerSearch: string) => {
+                const term = surveyPickerSearch.trim().toLowerCase()
+                if (!term) {
+                    return selectableSurveys
+                }
+                return selectableSurveys.filter((survey) => survey.name.toLowerCase().includes(term))
+            },
         ],
         notifications: [
-            (s) => [s.allNotifications, s.knownSurveyIds, s.knownSurveysFailed],
+            (s) => [s.allNotifications, s.knownSurveyIds, s.surveyCreatedAtById, s.knownSurveysFailed],
             (
                 allNotifications: HogFunctionType[],
                 knownSurveyIds: Set<string>,
+                surveyCreatedAtById: Map<string, string>,
                 knownSurveysFailed: boolean
             ): HogFunctionType[] => {
                 // If we couldn't load the survey index, skip the existence filter and show every
                 // notification we did load. The filter is just orphan cleanup — a transient
                 // surveys-API failure shouldn't hide live notifications from the user.
-                if (knownSurveysFailed) {
-                    return allNotifications
+                const filtered = knownSurveysFailed
+                    ? allNotifications
+                    : allNotifications.filter((notification) => {
+                          const linkedIds = getSurveyIdsFromNotificationFilters(notification.filters)
+                          if (linkedIds.length === 0) {
+                              return false
+                          }
+                          return linkedIds.some((surveyId) => knownSurveyIds.has(surveyId))
+                      })
+
+                const linkedSurveyCreatedAt = (notification: HogFunctionType): string => {
+                    const surveyId = getSurveyIdsFromNotificationFilters(notification.filters)[0]
+                    return (surveyId && surveyCreatedAtById.get(surveyId)) || ''
                 }
-                return allNotifications.filter((notification) => {
-                    const linkedIds = getSurveyIdsFromNotificationFilters(notification.filters)
-                    if (linkedIds.length === 0) {
-                        return false
-                    }
-                    return linkedIds.some((surveyId) => knownSurveyIds.has(surveyId))
-                })
+
+                return filtered.slice().sort((a, b) => linkedSurveyCreatedAt(b).localeCompare(linkedSurveyCreatedAt(a)))
             },
         ],
         notificationsLoading: [

--- a/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
@@ -127,7 +127,6 @@ export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType
             (knownSurveys: KnownSurvey[]) =>
                 knownSurveys
                     .filter((survey) => !survey.archived)
-                    .slice()
                     .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? '')),
         ],
         filteredSelectableSurveys: [

--- a/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationsListLogic.ts
@@ -38,7 +38,7 @@ export function getSurveyIdsFromNotificationFilters(filters?: CyclotronJobFilter
     return Array.from(surveyIds)
 }
 
-type KnownSurvey = Pick<Survey, 'id' | 'name' | 'archived' | 'created_at'>
+export type KnownSurvey = Pick<Survey, 'id' | 'name' | 'archived' | 'created_at'>
 
 export const surveyNotificationsListLogic = kea<surveyNotificationsListLogicType>([
     path(['scenes', 'surveys', 'surveyNotificationsListLogic']),


### PR DESCRIPTION
## Problem

The Surveys → Notifications screens had several rough edges:

- **"Add notification" CTA lived below the list**, so you had to scroll past every existing notification to reach it.
- **The new-notification picker on the list page was a combobox** that read like a filter input — confusing affordance, and lost when teams had many surveys (no search/scroll behaviour really fit).
- **Notifications were unsorted** — they came back in the hog-functions API's default order, with no relation to which survey they belonged to.
- **Skeleton loaders were plain bars** that didn't match the real card layout, causing a small layout shift on load.
- **Empty states were a generic dashed-border box** with no value proposition or visual personality.
- **Two redundant description lines** sat above the list, and one of them gave stale advice ("Open a survey to add or edit") that the new affordances make unnecessary.

## Changes

- Moved the action row to the **top** of the list, opposite a concise description.
- Per-survey notifications tab and the list page both get the same treatment.
- Replaced the list page's combobox-style picker with a **`LemonDropdown` containing a search input + scrollable, sorted list of surveys**. Clear "create" affordance via `IconPlus` + "Add notification" label, scales to hundreds of surveys.
- Surveys in the picker are sorted by `created_at` DESC so the newest surveys surface first.
- Notifications in the list are sorted by their **linked survey's `created_at`** DESC.
- Skeleton loaders now **mirror the real card structure** (30×30 icon placeholder, two text-line placeholders, switch placeholder) at fixed `h-12` — no layout shift when items load in.
- New empty states for **both** the list page and the per-survey tab:
  - When empty, the header description + action row is hidden — the empty state owns the surface and embeds the CTAs.
  - `MailHog` illustration at its natural aspect ratio (`h-32 w-auto` — fixed height, width derived from the 823×573 source PNG so it doesn't squash).
  - Value-prop headline ("Get notified when responses land") + concise description.
  - Primary "Add notification" button (and "Copy from existing" on the per-survey tab when reusable destinations exist) embedded inline.
- Removed the redundant outer description on the list-page tab; the inline copy now reads "Send survey responses to Slack, Discord, Microsoft Teams, or webhooks."

## How did you test this code?

I'm an agent — no manual browser testing was performed. Verified:

- `pnpm --filter=@posthog/frontend typescript:check` passes for all four touched files.
- Visual review of the empty state by the human author against the rendered screenshots provided during the session.

## Publish to changelog?

no

## Docs update

No docs changes needed — the affected surfaces are not documented externally beyond what already exists.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.7).

Decisions worth flagging for review:

- **Picker affordance.** The previous `LemonInputSelect` was searchable, but read as "filter the list below" rather than "create a new notification." I swapped to a button-with-dropdown so the affordance clearly says "create," then re-added search inside the dropdown (via `LemonInput` + filtered list) so teams with many surveys aren't stuck scrolling. Search and visibility state live in `surveyNotificationsListLogic` per the repo's "business logic in kea" convention.
- **Ordering choice.** Notifications are sorted by their **first linked survey's** `created_at` DESC, matching the existing "first linked survey" display logic in the row. Open to feedback if a different ordering (e.g. latest mutation across all linked surveys) is preferred.
- **Empty-state visual.** Started with a dashed-border block; moved to a tinted-background card after design-engineering review; landed on a chrome-less centered layout per maintainer feedback that the background didn't earn its keep.
- **Hedgehog sizing.** The source PNG is 823×573 (~1.44:1), not square. Using `size-XX` (forces 1:1) was squashing the hog. Switched to `h-32 w-auto` so the hog displays at its natural ratio while still pinning a fixed height for no-layout-shift.
- **Scope discipline.** A follow-up PR will add delete-from-row functionality (an overflow menu per notification row). That change touched additional files and felt cleaner as a separate review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*