### PR TITLE
refactor(surveys): rename wizard tabs to Targeting and Triggers

### DIFF
--- a/frontend/src/scenes/surveys/wizard/WizardStepper.tsx
+++ b/frontend/src/scenes/surveys/wizard/WizardStepper.tsx
@@ -13,8 +13,8 @@ interface Step {
 
 const STEPS: Step[] = [
     { key: 'questions', label: 'Questions' },
-    { key: 'where', label: 'Where' },
-    { key: 'when', label: 'When' },
+    { key: 'where', label: 'Targeting' },
+    { key: 'when', label: 'Triggers' },
     { key: 'appearance', label: 'Customize', optional: true },
 ]
 


### PR DESCRIPTION
## Problem

The survey guided editor labels its middle tabs "Where" and "When". They're short but force users to guess what each tab actually configures — and the answer isn't always obvious (e.g. user-property audience filters live under "Where", and event triggers live under "When").

## Changes

Rename two tab labels in `WizardStepper.tsx`:

- "Where" → "Targeting"
- "When" → "Triggers"

The tab contents already split cleanly between page + audience + device + flag targeting (Where) and event triggers + frequency + scheduling (When). The labels just didn't say so. No content moved between tabs; internal step keys (`'where'`, `'when'`) are unchanged.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual UI testing. The change is a two-line rename to a label literal — no logic, no types, no tests touched.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7), single session, no shared skills loaded for this change.
- Considered reorganizing fields between the two tabs (e.g. promoting "Audience" to its own tab) but found the existing split already matches Targeting vs Triggers — `SurveyAudienceFilters` is already rendered inside `WhereStep`, and `WhenStep` is event/frequency/schedule focused. Concluded a label-only change was sufficient and lower risk than a refactor.
- Kept the internal `WizardStep` keys (`'where'`, `'when'`) untouched to avoid breaking persisted wizard state or any analytics that key off them.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*