### PR TITLE
fix(email): add SMTP timeout and warn on port 465 + EMAIL_USE_TLS misconfiguration

### DIFF
--- a/posthog/email.py
+++ b/posthog/email.py
@@ -5,8 +5,11 @@ import html
 import uuid
 import datetime
 import dataclasses
+import logging
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Optional
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from posthog.models import User
@@ -237,13 +240,28 @@ def _send_via_smtp(
         connection = None
         try:
             klass = import_string(settings.EMAIL_BACKEND) if settings.EMAIL_BACKEND else EmailBackend
+            port = get_instance_setting("EMAIL_PORT")
+            use_tls = get_instance_setting("EMAIL_USE_TLS")
+            use_ssl = get_instance_setting("EMAIL_USE_SSL")
+
+            # Port 465 uses implicit SSL (SMTPS). EMAIL_USE_TLS enables STARTTLS which is
+            # incompatible with port 465 and causes the connection to hang indefinitely.
+            # The correct setting for port 465 is EMAIL_USE_SSL=true, EMAIL_USE_TLS=false.
+            if port == 465 and use_tls and not use_ssl:
+                logger.warning(
+                    "SMTP misconfiguration: EMAIL_PORT=465 requires EMAIL_USE_SSL=true, not EMAIL_USE_TLS=true. "
+                    "Port 465 uses implicit SSL (SMTPS); STARTTLS (EMAIL_USE_TLS) is for port 587. "
+                    "Connections on port 465 with EMAIL_USE_TLS=true will hang indefinitely."
+                )
+
             connection = klass(
                 host=get_instance_setting("EMAIL_HOST"),
-                port=get_instance_setting("EMAIL_PORT"),
+                port=port,
                 username=get_instance_setting("EMAIL_HOST_USER"),
                 password=get_instance_setting("EMAIL_HOST_PASSWORD"),
-                use_tls=get_instance_setting("EMAIL_USE_TLS"),
-                use_ssl=get_instance_setting("EMAIL_USE_SSL"),
+                use_tls=use_tls,
+                use_ssl=use_ssl,
+                timeout=get_instance_setting("EMAIL_TIMEOUT"),
             )
             connection.open()
             connection.send_messages(messages)

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -110,6 +110,11 @@ CONSTANCE_CONFIG = {
         "Whether to use SSL protocol when connecting to the email host.",
         bool,
     ),
+    "EMAIL_TIMEOUT": (
+        get_from_env("EMAIL_TIMEOUT", 10, type_cast=int),
+        "Timeout in seconds for SMTP connections. Prevents indefinite hangs on misconfigured hosts.",
+        int,
+    ),
     "EMAIL_DEFAULT_FROM": (
         get_from_env("EMAIL_DEFAULT_FROM", get_from_env("DEFAULT_FROM_EMAIL", "root@localhost")),
         "Email address that will appear as the sender in emails (From header).",
@@ -302,6 +307,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "EMAIL_HOST_PASSWORD",
     "EMAIL_USE_TLS",
     "EMAIL_USE_SSL",
+    "EMAIL_TIMEOUT",
     "EMAIL_DEFAULT_FROM",
     "EMAIL_REPLY_TO",
     "ASYNC_MIGRATIONS_OPT_OUT_EMAILS",


### PR DESCRIPTION
## Problem

When `EMAIL_PORT=465` and `EMAIL_USE_TLS=true`, PostHog's login request hangs indefinitely. Port 465 uses implicit SSL (SMTPS) and requires `EMAIL_USE_SSL=true`. `EMAIL_USE_TLS` enables STARTTLS, which is the protocol for port 587 — not port 465. Django's SMTP backend attempts to negotiate STARTTLS on a port the server is already expecting to be SSL-wrapped, causing the connection to wait forever for a response that never comes. Any login that triggers an email send (magic link, verification, etc.) blocks on that hung SMTP connection.

Closes #57936

## Changes

**`posthog/email.py`**
- Pass `EMAIL_TIMEOUT` (default 10 s) to the `EmailBackend` constructor so misconfigured connections fail fast instead of hanging
- Log a `WARNING` when `EMAIL_PORT=465` + `EMAIL_USE_TLS=true` is detected, explaining the correct setting (`EMAIL_USE_SSL=true, EMAIL_USE_TLS=false`)

**`posthog/settings/dynamic_settings.py`**
- Add `EMAIL_TIMEOUT` (default `10`) to `DYNAMIC_SETTINGS` so it can be tuned without a redeploy

## How did you test this code?

Traced the Django `EmailBackend.__init__` source — it accepts a `timeout` kwarg that maps directly to the `smtplib` socket timeout. The warning path is hit only when port=465, use_tls=True, use_ssl=False, which is the exact misconfiguration described in the issue. No changes to the happy path.

## 🤖 Agent context

Authored with Claude Code. Root cause: port 465 expects SMTPS (SSL from connection open), but `EMAIL_USE_TLS=true` triggers STARTTLS negotiation after connecting — these are incompatible. The fix adds a timeout so the hang becomes a fast failure, plus a log warning pointing users to the correct setting.