### PR TITLE
fix(frontend): wrap lazy-loaded scene components with ChunkLoadErrorBoundary

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -18,6 +18,7 @@ import { Collapsible } from 'lib/ui/Collapsible/Collapsible'
 import { Label } from 'lib/ui/Label/Label'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { cn } from 'lib/utils/css-classes'
+import { ChunkLoadErrorBoundary } from 'scenes/ChunkLoadErrorBoundary'
 import { sceneLogic } from 'scenes/sceneLogic'
 
 import { NavExperimentTab, PanelLayoutNavIdentifier, panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
@@ -261,19 +262,21 @@ export function Nav(): JSX.Element {
                                 keepMounted
                                 tabIndex={-1}
                             >
-                                <Suspense
-                                    fallback={
-                                        <div className="flex flex-col gap-px px-1 pt-2">
-                                            {Array.from({ length: 15 }).map((_, index) => (
-                                                <WrappingLoadingSkeleton fullWidth key={index}>
-                                                    <ButtonPrimitive aria-hidden inert menuItem />
-                                                </WrappingLoadingSkeleton>
-                                            ))}
-                                        </div>
-                                    }
-                                >
-                                    <NavTabChat />
-                                </Suspense>
+                                <ChunkLoadErrorBoundary>
+                                    <Suspense
+                                        fallback={
+                                            <div className="flex flex-col gap-px px-1 pt-2">
+                                                {Array.from({ length: 15 }).map((_, index) => (
+                                                    <WrappingLoadingSkeleton fullWidth key={index}>
+                                                        <ButtonPrimitive aria-hidden inert menuItem />
+                                                    </WrappingLoadingSkeleton>
+                                                ))}
+                                            </div>
+                                        }
+                                    >
+                                        <NavTabChat />
+                                    </Suspense>
+                                </ChunkLoadErrorBoundary>
                             </Tabs.Panel>
                         )}
                     </div>
@@ -322,25 +325,27 @@ export function Nav(): JSX.Element {
             {activePanelIdentifier === 'Notifications' && <NotificationsPanel />}
             {activePanelIdentifier === 'Chat' && (
                 <div className="flex flex-col h-full min-h-screen max-h-screen bg-surface-tertiary border-r overflow-hidden w-[var(--project-panel-width)]">
-                    <Suspense
-                        fallback={
-                            <div className="flex flex-col gap-px px-1 pt-2">
-                                {Array.from({ length: 15 }).map((_, index) => (
-                                    <WrappingLoadingSkeleton fullWidth key={index}>
-                                        <ButtonPrimitive aria-hidden inert menuItem />
-                                    </WrappingLoadingSkeleton>
-                                ))}
-                            </div>
-                        }
-                    >
-                        <NavTabChat
-                            inPanel
-                            onItemClick={() => {
-                                clearActivePanelIdentifier()
-                                showLayoutPanel(false)
-                            }}
-                        />
-                    </Suspense>
+                    <ChunkLoadErrorBoundary>
+                        <Suspense
+                            fallback={
+                                <div className="flex flex-col gap-px px-1 pt-2">
+                                    {Array.from({ length: 15 }).map((_, index) => (
+                                        <WrappingLoadingSkeleton fullWidth key={index}>
+                                            <ButtonPrimitive aria-hidden inert menuItem />
+                                        </WrappingLoadingSkeleton>
+                                    ))}
+                                </div>
+                            }
+                        >
+                            <NavTabChat
+                                inPanel
+                                onItemClick={() => {
+                                    clearActivePanelIdentifier()
+                                    showLayoutPanel(false)
+                                }}
+                            />
+                        </Suspense>
+                    </ChunkLoadErrorBoundary>
                 </div>
             )}
         </div>

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -6,6 +6,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
+import { ChunkLoadErrorBoundary } from 'scenes/ChunkLoadErrorBoundary'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { BoldNumber } from 'scenes/insights/views/BoldNumber'
 import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable'
@@ -125,15 +126,17 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
         <>
             {series && (
                 <div className={embedded ? 'InsightCard__viz' : `TrendsInsight TrendsInsight--${display}`}>
-                    <Suspense
-                        fallback={
-                            <WrappingLoadingSkeleton fullWidth>
-                                <span className="block w-full h-72" />
-                            </WrappingLoadingSkeleton>
-                        }
-                    >
-                        {renderViz()}
-                    </Suspense>
+                    <ChunkLoadErrorBoundary>
+                        <Suspense
+                            fallback={
+                                <WrappingLoadingSkeleton fullWidth>
+                                    <span className="block w-full h-72" />
+                                </WrappingLoadingSkeleton>
+                            }
+                        >
+                            {renderViz()}
+                        </Suspense>
+                    </ChunkLoadErrorBoundary>
                 </div>
             )}
             {!embedded &&


### PR DESCRIPTION
## Problem

After a frontend deploy, users on stale bundles occasionally see an error card instead of a working chart or nav panel. The root cause: lazy-loaded components inside scenes (`WorldMap`, `RegionMap`, `TrendsCalendarHeatMap`, `BoxPlotChart`, `TrendsLineChart`, `TrendsBarChart` in `Trends.tsx` and `NavTabChat` in `Nav.tsx`) were wrapped in `<Suspense>` but not `<ChunkLoadErrorBoundary>`. When a chunk hash mismatch causes the dynamic import to fail, the error escapes the Suspense boundary and surfaces as an error card rather than triggering the reload-once recovery already in place at the app level.

Closes #55535

## Changes

- Wrap the `<Suspense>` block in `Trends.tsx` (which renders all lazy viz types — WorldMap, RegionMap, CalendarHeatMap, BoxPlot, TrendsLineChart, TrendsBarChart) with `<ChunkLoadErrorBoundary>`
- Wrap both `<Suspense>` blocks in `Nav.tsx` that render `NavTabChat` (inline nav tab + panel variant) with `<ChunkLoadErrorBoundary>`

No behavioural change under normal conditions — the boundary is transparent. On a chunk-load failure it reloads once within a 20s guard window before surfacing the error, consistent with how `AuthenticatedShell` is handled in `App.tsx`.

## How did you test this code?

Automated: TypeScript compilation passes with no new errors.

Manual: Not tested in a live browser; the boundary logic is unchanged from the existing `ChunkLoadErrorBoundary` — only the placement is new. The fix mirrors the pattern already in `App.tsx`.

## Publish to changelog?

No

## 🤖 Agent context

Authored with Claude Code. Investigation identified that `ChunkLoadErrorBoundary` (added in a prior PR) only wrapped the top-level `AuthenticatedShell` import in `App.tsx`, leaving intra-scene lazy imports unprotected. Fixed by adding the boundary as an outer wrapper around existing `<Suspense>` elements in the two affected files — no new boundary logic, purely placement.