### PR TITLE
fix(hogql): bump hogql-parser to 1.3.42

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.40",
+    "hogql-parser==1.3.42",
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-04T09:17:41.700000357Z"
+exclude-newer = "2026-05-08T13:58:42.986529031Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -2990,14 +2990,14 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "hogql-parser"
-version = "1.3.40"
+version = "1.3.42"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/f9/11a8d6e8c63c90a76f9e7acc481ba0909f5bca28c3b4498827e126a3b528/hogql_parser-1.3.40.tar.gz", hash = "sha256:e6d3237f24c5ed126d1da075b81a430b2fd82862f27f9a2fd241f7750bff9edd", size = 90110, upload-time = "2026-04-17T14:44:34.952Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/6c/6e18630a7c9f6f3bfff766a4f8937f8a26c3ac5a13e54f5988f71af41ce8/hogql_parser-1.3.42.tar.gz", hash = "sha256:2c6fe93c7c031280543d0a335fadaee0d7a0eba644f41730d2d01a8fd92c449c", size = 90112, upload-time = "2026-05-14T20:22:15.513Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/a7/9c9f70b5d68dc788e9a65df8902d6d036316325f483c6339796b7cd5b132/hogql_parser-1.3.40-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1d95e6b3281ca3268d9a00c1d33e2717da7b842b47838f4f6057d6aaa1f67cb5", size = 660095, upload-time = "2026-04-17T14:44:16.44Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d6/7b89850ed5cafbe961ea378dd9e1391c0e8ab9d4bdd3bffde837ff935b58/hogql_parser-1.3.40-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:a213237f36828e1855e8da3617ad8bc00a7ac175a1cb26ecfbd4d4ac31ad3487", size = 662763, upload-time = "2026-04-17T14:44:18.328Z" },
-    { url = "https://files.pythonhosted.org/packages/11/e6/b31f66411dc0fbc22f5bad5e1b521aa90d863d6a5602fe294987a3b3d92e/hogql_parser-1.3.40-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:44efd85f1551500ec09871388edf70b4b1160ccaaa846f1373b46478bc29b3bf", size = 5019414, upload-time = "2026-04-17T14:44:20.739Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/f0/c7cc320b4d164f0eaf432b177f5c6c24944a800285b60eb9fc5646ec1bb4/hogql_parser-1.3.40-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b91786ce9d3943b51dc647209d32995bcd1951738578ed8c0a9c73f579b5a201", size = 5123934, upload-time = "2026-04-17T14:44:23.593Z" },
+    { url = "https://files.pythonhosted.org/packages/49/24/f5b5e7427e8648be1aa8a8bd81c09ca4a6cf91cad0a816e7fca13a08941c/hogql_parser-1.3.42-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:745807b424fadc90ef9702420b024967d320e461739eec136b6f30640b481928", size = 660628, upload-time = "2026-05-14T20:22:02.33Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4c/db29f5758988cac5dd05499f9a736e753a03f2fa505bf7706ce171aec74e/hogql_parser-1.3.42-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:790d6c74589309ab22136425829dc7a8a69f1e62fdf6de1921865647757478ae", size = 663028, upload-time = "2026-05-14T20:22:03.862Z" },
+    { url = "https://files.pythonhosted.org/packages/67/04/555407716578257493e1d73e9170d1cf6e0de153ad331e25ebbab9e3eec9/hogql_parser-1.3.42-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:de15156746ba9e606ec40f1bf4c6a7d4e884c0fec712b9f18b4aa5fc950ed181", size = 5020749, upload-time = "2026-05-14T20:22:05.743Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bc/b49755af022235318fed3e3a0a71a4b112e104f59d4a0338dac6e14df61f/hogql_parser-1.3.42-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:baed6947807f511187dd5348601de9a1a41546e23d3f96d0d4442bb9a2b90205", size = 5128323, upload-time = "2026-05-14T20:22:07.887Z" },
 ]
 
 [[package]]
@@ -5521,7 +5521,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", specifier = "==1.3.40" },
+    { name = "hogql-parser", specifier = "==1.3.42" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },


### PR DESCRIPTION
## Problem

Master CI is failing on 9 `test_signed_radix_number_literals_*` tests in `posthog/hogql/test/test_parser_cpp_json.py`. The C++ parser source under `common/hogql_parser/` (and `setup.py` / `package.json`) was bumped to 1.3.42 with support for signed radix literals (hex `0x1F`, octal `0o17`, `inf`), and the wheel was published to PyPI, but `pyproject.toml` + `uv.lock` were never re-pinned and remained on `1.3.40`. CI installs the pinned wheel from PyPI instead of building from source, so it runs against the old parser and the new tests fail (hex returns `0`, `0o17` returns decimal `17`, `inf` returns `NaN`).

The auto-bump step in `.github/workflows/build-hogql-parser.yml` should have done this on the original PR, but didn't land.

## Changes

- `pyproject.toml`: `hogql-parser==1.3.40` → `1.3.42`
- `uv.lock`: regenerated with `uv add hogql-parser==1.3.42` so it points at the 1.3.42 sdist + wheels already published on PyPI

Other places already at 1.3.42 (no change needed): `common/hogql_parser/setup.py`, `common/hogql_parser/package.json`, `frontend/package.json`, `pnpm-lock.yaml`.

## How did you test this code?

I'm an agent — I did not run the test suite locally. Verified by:

- `curl https://pypi.org/pypi/hogql-parser/json` confirming `1.3.42` is published
- `uv add hogql-parser==1.3.42` resolved cleanly and produced matching lock entries with sdist + wheel hashes
- Grep across the repo for any remaining `1.3.40` / `1.3.41` references — none found

The signed-radix-literal tests on master should turn green once CI installs the 1.3.42 wheel.

## Publish to changelog?

no

## Docs update

No docs change.

## 🤖 Agent context

Authored by PostHog Code in response to a Mendral incident report (signed radix number literal tests failing on master) and Robbie's request to bump the parser version everywhere it was missed. The agent confirmed via PyPI that 1.3.42 was already published, then used `uv add` to update `pyproject.toml` and `uv.lock` in lockstep — this is the same path the `build-hogql-parser` workflow takes when it auto-commits the pin.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*