### PR TITLE
chore(user-interviews): drop interviewee_cohort, snapshot audience at create time

### DIFF
--- a/products/user_interviews/backend/api.py
+++ b/products/user_interviews/backend/api.py
@@ -243,20 +243,15 @@ class UserInterviewViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
 class UserInterviewTopicSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
-    interviewee_cohort = serializers.IntegerField(
-        required=False,
-        allow_null=True,
-        help_text="Optional cohort ID identifying who to target. Not enforced as a foreign key.",
-    )
     interviewee_emails = serializers.ListField(
         child=serializers.CharField(max_length=254, validators=[EmailWithDisplayNameValidator()]),
         required=False,
-        help_text="Email addresses of people to interview. May be combined with interviewee_cohort and interviewee_distinct_ids.",
+        help_text="Email addresses of people to interview. May be combined with interviewee_distinct_ids.",
     )
     interviewee_distinct_ids = serializers.ListField(
         child=serializers.CharField(max_length=400),
         required=False,
-        help_text="PostHog distinct IDs of people to interview. May be combined with interviewee_cohort and interviewee_emails.",
+        help_text="PostHog distinct IDs of people to interview. May be combined with interviewee_emails.",
     )
     topic = serializers.CharField(
         help_text="The product, feature, or idea you want to ask interviewees about.",
@@ -278,7 +273,6 @@ class UserInterviewTopicSerializer(serializers.ModelSerializer):
             "id",
             "created_by",
             "created_at",
-            "interviewee_cohort",
             "interviewee_emails",
             "interviewee_distinct_ids",
             "topic",
@@ -288,11 +282,6 @@ class UserInterviewTopicSerializer(serializers.ModelSerializer):
         read_only_fields = ("id", "created_by", "created_at")
 
     def validate(self, attrs: dict) -> dict:
-        cohort = (
-            attrs.get("interviewee_cohort")
-            if "interviewee_cohort" in attrs
-            else getattr(self.instance, "interviewee_cohort", None)
-        )
         emails = (
             attrs.get("interviewee_emails")
             if "interviewee_emails" in attrs
@@ -303,9 +292,9 @@ class UserInterviewTopicSerializer(serializers.ModelSerializer):
             if "interviewee_distinct_ids" in attrs
             else getattr(self.instance, "interviewee_distinct_ids", [])
         )
-        if cohort is None and not emails and not distinct_ids:
+        if not emails and not distinct_ids:
             raise serializers.ValidationError(
-                "At least one of interviewee_cohort, interviewee_emails, or interviewee_distinct_ids must be provided."
+                "At least one of interviewee_emails or interviewee_distinct_ids must be provided."
             )
         return attrs
 
@@ -455,7 +444,7 @@ class SendInvitesRequestSerializer(serializers.Serializer):
 
 @extend_schema(tags=[ProductKey.USER_INTERVIEWS])
 class UserInterviewTopicViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
-    """Planned user interview topics: who we want to target (cohort) and what we want to ask about."""
+    """Planned user interview topics: who we want to target and what we want to ask about."""
 
     scope_object = "user_interview"
     # Treat the custom @action endpoints as writes so personal API keys with
@@ -498,8 +487,8 @@ class UserInterviewTopicViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             return response.Response(
                 {
                     "error": (
-                        "Topic targets a cohort but has no resolved emails or distinct IDs. "
-                        "Add interviewee_emails or interviewee_distinct_ids before generating links."
+                        "Topic has no interviewee_emails or interviewee_distinct_ids set. "
+                        "Add them before generating links."
                     )
                 },
                 status=status.HTTP_400_BAD_REQUEST,
@@ -544,8 +533,8 @@ class UserInterviewTopicViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             return response.Response(
                 {
                     "error": (
-                        "Topic targets a cohort but has no resolved emails or distinct IDs. "
-                        "Add interviewee_emails or interviewee_distinct_ids before sending invites."
+                        "Topic has no interviewee_emails or interviewee_distinct_ids set. "
+                        "Add them before sending invites."
                     )
                 },
                 status=status.HTTP_400_BAD_REQUEST,

--- a/products/user_interviews/backend/api.py
+++ b/products/user_interviews/backend/api.py
@@ -281,22 +281,19 @@ class UserInterviewTopicSerializer(serializers.ModelSerializer):
         )
         read_only_fields = ("id", "created_by", "created_at")
 
+    MISSING_TARGETING_ERROR = "At least one of interviewee_emails or interviewee_distinct_ids must be provided."
+
     def validate(self, attrs: dict) -> dict:
-        emails = (
-            attrs.get("interviewee_emails")
-            if "interviewee_emails" in attrs
-            else getattr(self.instance, "interviewee_emails", [])
-        )
-        distinct_ids = (
-            attrs.get("interviewee_distinct_ids")
-            if "interviewee_distinct_ids" in attrs
-            else getattr(self.instance, "interviewee_distinct_ids", [])
-        )
-        if not emails and not distinct_ids:
-            raise serializers.ValidationError(
-                "At least one of interviewee_emails or interviewee_distinct_ids must be provided."
-            )
+        if not self._current(attrs, "interviewee_emails", []) and not self._current(
+            attrs, "interviewee_distinct_ids", []
+        ):
+            raise serializers.ValidationError(self.MISSING_TARGETING_ERROR)
         return attrs
+
+    def _current(self, attrs: dict, field: str, default: Any) -> Any:
+        if field in attrs:
+            return attrs[field]
+        return getattr(self.instance, field, default)
 
     def create(self, validated_data: dict) -> UserInterviewTopic:
         request = self.context["request"]

--- a/products/user_interviews/backend/migrations/0005_remove_userinterviewtopic_interviewee_cohort_state.py
+++ b/products/user_interviews/backend/migrations/0005_remove_userinterviewtopic_interviewee_cohort_state.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("user_interviews", "0004_userinterview_vapi_fields"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name="userinterviewtopic",
+                    name="interviewee_cohort",
+                ),
+            ],
+            database_operations=[],
+        ),
+    ]

--- a/products/user_interviews/backend/migrations/0005_remove_userinterviewtopic_interviewee_cohort_state.py
+++ b/products/user_interviews/backend/migrations/0005_remove_userinterviewtopic_interviewee_cohort_state.py
@@ -1,3 +1,13 @@
+"""Phase 1 of 2: remove `UserInterviewTopic.interviewee_cohort` from Django state.
+
+The actual `DROP COLUMN` happens in a follow-up migration once this deploy bakes —
+keeping the column in the DB during one deploy cycle lets old workers and rollbacks
+keep reading from it without error (the field was nullable, so any reader gets None).
+
+See PostHog's safe-django-migrations playbook (docs/published/handbook/engineering/
+safe-django-migrations.md#dropping-columns) for the two-phase pattern.
+"""
+
 from django.db import migrations
 
 

--- a/products/user_interviews/backend/migrations/max_migration.txt
+++ b/products/user_interviews/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0004_userinterview_vapi_fields
+0005_remove_userinterviewtopic_interviewee_cohort_state

--- a/products/user_interviews/backend/models.py
+++ b/products/user_interviews/backend/models.py
@@ -44,7 +44,6 @@ class UserInterview(UUIDTModel, CreatedMetaFields):
 
 class UserInterviewTopic(UUIDTModel, CreatedMetaFields):
     team = models.ForeignKey(Team, on_delete=models.CASCADE)
-    interviewee_cohort = models.BigIntegerField(null=True, blank=True)
     interviewee_emails = ArrayField(
         models.CharField(max_length=254, validators=[EmailWithDisplayNameValidator()]),
         default=list,

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -94,14 +94,44 @@ class TestGenerateInterviewLinks(_FeatureFlagEnabledMixin):
         self.assertIn("heavy user, churned last quarter", link["agent_context"])
         self.assertIn("Researching adoption of session replay", link["agent_context"])
 
-    def test_generate_links_rejects_topic_with_only_cohort(self):
-        topic = self._create_topic(
-            interviewee_emails=[],
-            interviewee_distinct_ids=[],
-            interviewee_cohort=123,
-        )
+    def test_generate_links_rejects_topic_with_no_identifiers(self):
+        topic = self._create_topic(interviewee_emails=[], interviewee_distinct_ids=[])
         response = self.client.post(self._generate_links_url(str(topic.id)))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class TestUserInterviewTopicCreate(_FeatureFlagEnabledMixin):
+    def _url(self) -> str:
+        return f"/api/environments/{self.team.id}/user_interview_topics/"
+
+    @parameterized.expand(
+        [
+            ("no_targeting", {}),
+            ("empty_lists", {"interviewee_emails": [], "interviewee_distinct_ids": []}),
+        ]
+    )
+    def test_rejects_topic_without_identifiers(self, _name: str, targeting: dict[str, Any]):
+        payload = {"topic": "Why people churn", **targeting}
+        response = self.client.post(self._url(), data=payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        body = response.json()
+        errors = body.get("non_field_errors") or [body.get("detail", "")]
+        assert any("interviewee_emails" in str(e) and "interviewee_distinct_ids" in str(e) for e in errors), body
+
+    @parameterized.expand(
+        [
+            ("emails_only", {"interviewee_emails": ["alex@example.com"]}),
+            ("distinct_ids_only", {"interviewee_distinct_ids": ["distinct-abc"]}),
+            (
+                "both",
+                {"interviewee_emails": ["alex@example.com"], "interviewee_distinct_ids": ["distinct-abc"]},
+            ),
+        ]
+    )
+    def test_accepts_topic_with_identifiers(self, _name: str, targeting: dict[str, Any]):
+        payload = {"topic": "Why people churn", **targeting}
+        response = self.client.post(self._url(), data=payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
 
 
 class TestInterviewPublicViewer(APIBaseTest):
@@ -544,8 +574,8 @@ class TestSendInterviewInvites(_FeatureFlagEnabledMixin):
             response = self.client.post(self._url(str(topic.id)), data={}, format="json")
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
 
-    def test_send_invites_400_when_topic_only_has_cohort(self):
-        topic = self._create_topic(interviewee_emails=[], interviewee_distinct_ids=[], interviewee_cohort=123)
+    def test_send_invites_400_when_topic_has_no_identifiers(self):
+        topic = self._create_topic(interviewee_emails=[], interviewee_distinct_ids=[])
         with patch("products.user_interviews.backend.api.is_email_available", return_value=True):
             response = self.client.post(self._url(str(topic.id)), data={}, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -17,6 +17,7 @@ from rest_framework import status
 from posthog.api.test.test_sharing import mock_exporter_template
 from posthog.models.sharing_configuration import SharingConfiguration
 
+from products.user_interviews.backend.api import UserInterviewTopicSerializer
 from products.user_interviews.backend.models import IntervieweeContext, UserInterview, UserInterviewTopic
 from products.user_interviews.backend.webhooks import EMBEDDING_CONTENT_MAX_BYTES
 
@@ -115,8 +116,8 @@ class TestUserInterviewTopicCreate(_FeatureFlagEnabledMixin):
         response = self.client.post(self._url(), data=payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
         body = response.json()
-        errors = body.get("non_field_errors") or [body.get("detail", "")]
-        assert any("interviewee_emails" in str(e) and "interviewee_distinct_ids" in str(e) for e in errors), body
+        candidates = body.get("non_field_errors") or [body.get("detail", "")]
+        assert UserInterviewTopicSerializer.MISSING_TARGETING_ERROR in candidates, body
 
     @parameterized.expand(
         [

--- a/products/user_interviews/frontend/UserInterview.tsx
+++ b/products/user_interviews/frontend/UserInterview.tsx
@@ -23,11 +23,7 @@ export const scene: SceneExport<UserInterviewLogicProps> = {
 function targetingLabel(topic: UserInterviewTopicApi): string {
     const emailCount = topic.interviewee_emails?.length || 0
     const distinctIdCount = topic.interviewee_distinct_ids?.length || 0
-    const hasCohort = topic.interviewee_cohort != null
     const parts: string[] = []
-    if (hasCohort) {
-        parts.push(`Cohort #${topic.interviewee_cohort}`)
-    }
     if (emailCount > 0) {
         parts.push(`${emailCount} email${emailCount !== 1 ? 's' : ''}`)
     }

--- a/products/user_interviews/frontend/UserInterviewResponse.tsx
+++ b/products/user_interviews/frontend/UserInterviewResponse.tsx
@@ -185,9 +185,6 @@ export function UserInterviewResponse({ topicId, responseId }: UserInterviewResp
                         <div className="p-4 space-y-2">
                             <DetailRow label="Topic" value={topic.topic} />
                             <DetailRow label="Created" value={topic.created_at.split('T')[0]} />
-                            {topic.interviewee_cohort != null && (
-                                <DetailRow label="Cohort" value={`#${topic.interviewee_cohort}`} />
-                            )}
                         </div>
                     </LemonWidget>
                 </div>

--- a/products/user_interviews/frontend/UserInterviews.tsx
+++ b/products/user_interviews/frontend/UserInterviews.tsx
@@ -37,7 +37,7 @@ function targetingLabel(topic: UserInterviewTopicApi): string {
 const NEW_TOPIC_PROMPT = `!I want to set up a new user research topic. Help me through the process:
 
 1. First, let's figure out what I want to learn — what feature, behavior, or question I want to research.
-2. Then, help me identify the right users to interview — find or create a cohort, or I can provide emails.
+2. Then, help me identify the right users to interview — pick a cohort, find users by behavior, or provide emails directly.
 3. Draft interview questions based on the topic.
 4. Set up the outreach workflow to email each user with their unique interview link.
 5. Once I confirm, trigger the emails — I'll track responses in User research.
@@ -52,7 +52,7 @@ export function UserInterviews(): JSX.Element {
         <SceneContent>
             <SceneTitleSection
                 name={sceneConfigurations[Scene.UserInterviews].name}
-                description="Run AI-powered voice research campaigns. Target a cohort, set a topic, and let the AI handle the interviews."
+                description="Run AI-powered voice research campaigns. Target an audience, set a topic, and let the AI handle the interviews."
                 resourceType={{
                     type: sceneConfigurations[Scene.UserInterviews].iconType || 'default_icon_type',
                 }}

--- a/products/user_interviews/frontend/UserInterviews.tsx
+++ b/products/user_interviews/frontend/UserInterviews.tsx
@@ -24,11 +24,7 @@ export const scene: SceneExport = {
 function targetingLabel(topic: UserInterviewTopicApi): string {
     const emailCount = topic.interviewee_emails?.length || 0
     const distinctIdCount = topic.interviewee_distinct_ids?.length || 0
-    const hasCohort = topic.interviewee_cohort != null
     const parts: string[] = []
-    if (hasCohort) {
-        parts.push(`Cohort #${topic.interviewee_cohort}`)
-    }
     if (emailCount > 0) {
         parts.push(`${emailCount} email${emailCount !== 1 ? 's' : ''}`)
     }

--- a/products/user_interviews/frontend/generated/api.schemas.ts
+++ b/products/user_interviews/frontend/generated/api.schemas.ts
@@ -66,14 +66,9 @@ export interface UserInterviewTopicApi {
     readonly id: string
     readonly created_by: UserBasicApi
     readonly created_at: string
-    /**
-     * Optional cohort ID identifying who to target. Not enforced as a foreign key.
-     * @nullable
-     */
-    interviewee_cohort?: number | null
-    /** Email addresses of people to interview. May be combined with interviewee_cohort and interviewee_distinct_ids. */
+    /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
     interviewee_emails?: string[]
-    /** PostHog distinct IDs of people to interview. May be combined with interviewee_cohort and interviewee_emails. */
+    /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
     interviewee_distinct_ids?: string[]
     /** The product, feature, or idea you want to ask interviewees about. */
     topic: string
@@ -96,14 +91,9 @@ export interface PatchedUserInterviewTopicApi {
     readonly id?: string
     readonly created_by?: UserBasicApi
     readonly created_at?: string
-    /**
-     * Optional cohort ID identifying who to target. Not enforced as a foreign key.
-     * @nullable
-     */
-    interviewee_cohort?: number | null
-    /** Email addresses of people to interview. May be combined with interviewee_cohort and interviewee_distinct_ids. */
+    /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
     interviewee_emails?: string[]
-    /** PostHog distinct IDs of people to interview. May be combined with interviewee_cohort and interviewee_emails. */
+    /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
     interviewee_distinct_ids?: string[]
     /** The product, feature, or idea you want to ask interviewees about. */
     topic?: string

--- a/products/user_interviews/frontend/generated/api.ts
+++ b/products/user_interviews/frontend/generated/api.ts
@@ -60,7 +60,7 @@ export const getUserInterviewTopicsListUrl = (projectId: string, params?: UserIn
 }
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const userInterviewTopicsList = async (
     projectId: string,
@@ -78,7 +78,7 @@ export const getUserInterviewTopicsCreateUrl = (projectId: string) => {
 }
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const userInterviewTopicsCreate = async (
     projectId: string,
@@ -98,7 +98,7 @@ export const getUserInterviewTopicsRetrieveUrl = (projectId: string, id: string)
 }
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const userInterviewTopicsRetrieve = async (
     projectId: string,
@@ -116,7 +116,7 @@ export const getUserInterviewTopicsUpdateUrl = (projectId: string, id: string) =
 }
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const userInterviewTopicsUpdate = async (
     projectId: string,
@@ -137,7 +137,7 @@ export const getUserInterviewTopicsPartialUpdateUrl = (projectId: string, id: st
 }
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const userInterviewTopicsPartialUpdate = async (
     projectId: string,
@@ -158,7 +158,7 @@ export const getUserInterviewTopicsDestroyUrl = (projectId: string, id: string) 
 }
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const userInterviewTopicsDestroy = async (
     projectId: string,

--- a/products/user_interviews/frontend/generated/api.zod.ts
+++ b/products/user_interviews/frontend/generated/api.zod.ts
@@ -10,29 +10,21 @@
 import * as zod from 'zod'
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const userInterviewTopicsCreateBodyIntervieweeEmailsItemMax = 254
 
 export const userInterviewTopicsCreateBodyIntervieweeDistinctIdsItemMax = 400
 
 export const UserInterviewTopicsCreateBody = /* @__PURE__ */ zod.object({
-    interviewee_cohort: zod
-        .number()
-        .nullish()
-        .describe('Optional cohort ID identifying who to target. Not enforced as a foreign key.'),
     interviewee_emails: zod
         .array(zod.string().max(userInterviewTopicsCreateBodyIntervieweeEmailsItemMax))
         .optional()
-        .describe(
-            'Email addresses of people to interview. May be combined with interviewee_cohort and interviewee_distinct_ids.'
-        ),
+        .describe('Email addresses of people to interview. May be combined with interviewee_distinct_ids.'),
     interviewee_distinct_ids: zod
         .array(zod.string().max(userInterviewTopicsCreateBodyIntervieweeDistinctIdsItemMax))
         .optional()
-        .describe(
-            'PostHog distinct IDs of people to interview. May be combined with interviewee_cohort and interviewee_emails.'
-        ),
+        .describe('PostHog distinct IDs of people to interview. May be combined with interviewee_emails.'),
     topic: zod.string().describe('The product, feature, or idea you want to ask interviewees about.'),
     agent_context: zod
         .string()
@@ -45,29 +37,21 @@ export const UserInterviewTopicsCreateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const userInterviewTopicsUpdateBodyIntervieweeEmailsItemMax = 254
 
 export const userInterviewTopicsUpdateBodyIntervieweeDistinctIdsItemMax = 400
 
 export const UserInterviewTopicsUpdateBody = /* @__PURE__ */ zod.object({
-    interviewee_cohort: zod
-        .number()
-        .nullish()
-        .describe('Optional cohort ID identifying who to target. Not enforced as a foreign key.'),
     interviewee_emails: zod
         .array(zod.string().max(userInterviewTopicsUpdateBodyIntervieweeEmailsItemMax))
         .optional()
-        .describe(
-            'Email addresses of people to interview. May be combined with interviewee_cohort and interviewee_distinct_ids.'
-        ),
+        .describe('Email addresses of people to interview. May be combined with interviewee_distinct_ids.'),
     interviewee_distinct_ids: zod
         .array(zod.string().max(userInterviewTopicsUpdateBodyIntervieweeDistinctIdsItemMax))
         .optional()
-        .describe(
-            'PostHog distinct IDs of people to interview. May be combined with interviewee_cohort and interviewee_emails.'
-        ),
+        .describe('PostHog distinct IDs of people to interview. May be combined with interviewee_emails.'),
     topic: zod.string().describe('The product, feature, or idea you want to ask interviewees about.'),
     agent_context: zod
         .string()
@@ -80,29 +64,21 @@ export const UserInterviewTopicsUpdateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const userInterviewTopicsPartialUpdateBodyIntervieweeEmailsItemMax = 254
 
 export const userInterviewTopicsPartialUpdateBodyIntervieweeDistinctIdsItemMax = 400
 
 export const UserInterviewTopicsPartialUpdateBody = /* @__PURE__ */ zod.object({
-    interviewee_cohort: zod
-        .number()
-        .nullish()
-        .describe('Optional cohort ID identifying who to target. Not enforced as a foreign key.'),
     interviewee_emails: zod
         .array(zod.string().max(userInterviewTopicsPartialUpdateBodyIntervieweeEmailsItemMax))
         .optional()
-        .describe(
-            'Email addresses of people to interview. May be combined with interviewee_cohort and interviewee_distinct_ids.'
-        ),
+        .describe('Email addresses of people to interview. May be combined with interviewee_distinct_ids.'),
     interviewee_distinct_ids: zod
         .array(zod.string().max(userInterviewTopicsPartialUpdateBodyIntervieweeDistinctIdsItemMax))
         .optional()
-        .describe(
-            'PostHog distinct IDs of people to interview. May be combined with interviewee_cohort and interviewee_emails.'
-        ),
+        .describe('PostHog distinct IDs of people to interview. May be combined with interviewee_emails.'),
     topic: zod.string().optional().describe('The product, feature, or idea you want to ask interviewees about.'),
     agent_context: zod
         .string()

--- a/products/user_interviews/mcp/tools.yaml
+++ b/products/user_interviews/mcp/tools.yaml
@@ -23,11 +23,11 @@ tools:
             Plan a user interview by recording who you want to target and what product or idea you want to ask them
             about. `topic` is the free-text description of the question or product area. Targets are specified as a
             combination of `interviewee_emails` (list of email addresses) and `interviewee_distinct_ids` (list of
-            PostHog distinct IDs) — at least one of the two must be provided. To target a cohort, resolve cohort
-            members to emails/distinct_ids in the calling agent first (see the planning-user-interviews skill) and
-            pass them explicitly here — topics snapshot their audience at creation time. Pass `agent_context` (free
-            text) to give the voice agent extra background or instructions, and `questions` (list of strings) for the
-            ordered set of questions the agent should work through.
+            PostHog distinct IDs) — at least one of the two must be provided. To target a cohort, resolve cohort members
+            to emails/distinct_ids in the calling agent first (see the planning-user-interviews skill) and pass them
+            explicitly here — topics snapshot their audience at creation time. Pass `agent_context` (free text) to give
+            the voice agent extra background or instructions, and `questions` (list of strings) for the ordered set of
+            questions the agent should work through.
         include_params:
             - interviewee_emails
             - interviewee_distinct_ids

--- a/products/user_interviews/mcp/tools.yaml
+++ b/products/user_interviews/mcp/tools.yaml
@@ -21,13 +21,14 @@ tools:
         title: Create user interview topic
         description: >
             Plan a user interview by recording who you want to target and what product or idea you want to ask them
-            about. `topic` is the free-text description of the question or product area. Targets can be specified as any
-            combination of `interviewee_cohort` (optional cohort identifier), `interviewee_emails` (list of email
-            addresses), and `interviewee_distinct_ids` (list of PostHog distinct IDs) — at least one target must be
-            provided. Pass `agent_context` (free text) to give the voice agent extra background or instructions, and
-            `questions` (list of strings) for the ordered set of questions the agent should work through.
+            about. `topic` is the free-text description of the question or product area. Targets are specified as a
+            combination of `interviewee_emails` (list of email addresses) and `interviewee_distinct_ids` (list of
+            PostHog distinct IDs) — at least one of the two must be provided. To target a cohort, resolve cohort
+            members to emails/distinct_ids in the calling agent first (see the planning-user-interviews skill) and
+            pass them explicitly here — topics snapshot their audience at creation time. Pass `agent_context` (free
+            text) to give the voice agent extra background or instructions, and `questions` (list of strings) for the
+            ordered set of questions the agent should work through.
         include_params:
-            - interviewee_cohort
             - interviewee_emails
             - interviewee_distinct_ids
             - topic
@@ -114,9 +115,8 @@ tools:
         title: List user interview topics
         description: >
             List planned user interview topics in the current project, newest first. Each result includes the topic,
-            targeting (interviewee_cohort, interviewee_emails, interviewee_distinct_ids), and the voice agent setup
-            (agent_context, questions). Supports `search` for substring match against the topic, and `limit`/`offset`
-            for pagination.
+            targeting (interviewee_emails, interviewee_distinct_ids), and the voice agent setup (agent_context,
+            questions). Supports `search` for substring match against the topic, and `limit`/`offset` for pagination.
         feature_flag: user-interviews
     user-interview-topics-partial-update:
         operation: user_interview_topics_partial_update

--- a/products/user_interviews/skills/planning-user-interviews/SKILL.md
+++ b/products/user_interviews/skills/planning-user-interviews/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planning-user-interviews
-description: 'Plan a user interview topic in PostHog — pick who to target (cohort, emails, or PostHog distinct IDs), draft what to ask about, and prepare the voice-agent context plus a question list. Use when the user asks to "talk to users", "check how users feel about X", "interview some customers", "set up a user interview", "run a user-research call", "find users to ask about Y", or otherwise wants qualitative feedback through a conversation. Walks the user through targeting (cohorts-list, persons-list, or accepting emails / distinct IDs directly), captures the topic, and prompts for agent context and questions before calling user-interview-topics-create. Do NOT trigger when the user is uploading a recorded interview audio file (that''s the separate UserInterview/transcript flow) or only browsing existing topics with user-interview-topics-list.'
+description: 'Plan a user interview topic in PostHog — pick who to target (cohort, emails, or PostHog distinct IDs), draft what to ask about, and prepare the voice-agent context plus a question list. Use when the user asks to "talk to users", "check how users feel about X", "interview some customers", "set up a user interview", "run a user-research call", "find users to ask about Y", or otherwise wants qualitative feedback through a conversation. Walks the user through targeting (cohorts-list, persons-list, or accepting emails / distinct IDs directly), captures the topic, and prompts for agent context and questions before calling user-interview-topics-create. Cohort targeting is resolved to explicit emails/distinct_ids at create time — topics snapshot their audience and do not re-evaluate cohort membership later. Do NOT trigger when the user is uploading a recorded interview audio file (that''s the separate UserInterview/transcript flow) or only browsing existing topics with user-interview-topics-list.'
 ---
 
 # Planning user interviews
@@ -12,14 +12,15 @@ Use this skill when someone asks to set up a user interview — to talk to custo
 Before calling `user-interview-topics-create`, gather these:
 
 1. **Who to interview** — at least one of:
-   - `interviewee_cohort` — an existing cohort ID
    - `interviewee_emails` — list of email addresses
    - `interviewee_distinct_ids` — list of PostHog distinct IDs
 2. **What to ask about** — `topic` (required free text)
 3. **How the agent should frame the conversation** — optional `agent_context` (extra system prompt)
 4. **The questions to work through** — optional ordered `questions` list
 
-The API rejects topics with no targeting, so at least one of the three audience fields must be set. They can be combined — a cohort plus a handful of extra emails is fine.
+Topics snapshot their audience at create time — there is no live cohort link. If the user names a cohort, you (the agent) resolve cohort members to emails/distinct_ids before calling `user-interview-topics-create`. See Step 2 for the resolution flow and the 500-member cap UX.
+
+The API rejects topics with no targeting, so `interviewee_emails` and/or `interviewee_distinct_ids` must end up non-empty.
 
 ## Step 1: Clarify intent
 
@@ -35,8 +36,8 @@ Skip these questions only when the user has already answered them.
 
 Map what the user said to one of these paths:
 
-- **They named a cohort** ("our power users", "trial signups last week") — use `cohorts-list` filtered by name to find the cohort, confirm the match, and pass the cohort ID as `interviewee_cohort`.
-- **They described the kind of person but no cohort exists** — offer to either create the cohort first (`cohorts-create`) or fall back to finding people by behavior (see below).
+- **They named a cohort** ("our power users", "trial signups last week") — use `cohorts-list` (or a `system.cohorts` SQL search) to find the cohort, confirm the match, then resolve cohort members to emails/distinct_ids (see "Resolving a cohort" below).
+- **They described the kind of person but no cohort exists** — offer to either create the cohort first (`cohorts-create`), then resolve it, or fall back to finding people by behavior (see below).
 - **They gave email addresses or distinct IDs** — accept them directly. Skip the cohort lookup.
 - **They described a behavior, not a cohort** ("users who tried checkout but didn't finish", "people who used to use dark mode and stopped") — find them by querying their events (see below).
 - **They were vague** ("a few customers", "some power users") — ask which they prefer:
@@ -46,6 +47,39 @@ Map what the user said to one of these paths:
   - Paste a list of email addresses
 
 Each email passes through DRF email validation (display-name format `Paul D'Ambra <paul@x.com>` is accepted alongside plain `paul@x.com`).
+
+### Resolving a cohort
+
+Topics snapshot their audience at create time. When the user picks a cohort, you must materialize the member list into `interviewee_emails` (and `interviewee_distinct_ids` for members without emails) before creating the topic.
+
+1. **Count the cohort first.** Cheap query, decides the next step:
+
+   ```sql
+   SELECT count() FROM persons WHERE id IN COHORT <cohort_id>
+   ```
+
+2. **If the cohort has 500 or fewer members**, fetch them and use the results:
+
+   ```sql
+   SELECT properties.email AS email, id AS distinct_id
+   FROM persons
+   WHERE id IN COHORT <cohort_id>
+   LIMIT 500
+   ```
+
+   Put rows with a non-null email into `interviewee_emails`; for rows where email is null, fall back to `distinct_id` in `interviewee_distinct_ids`. Dedupe.
+
+3. **If the cohort has more than 500 members**, stop and ask the user. Do not silently truncate, sample, or fall back to a different cohort — the user needs to choose. Surface:
+   - The cohort name and count (e.g. "PostHog Team has 28,563 members — over the 500 cap.")
+   - Why the cap exists ("we snapshot the audience at create time, and 500 is a sensible upper bound for one interview campaign")
+   - Their options:
+     - **Narrow the cohort** — describe the subset they actually want (e.g. "engineers only", "active in the last 30 days"). You can offer to write a more specific HogQL filter or create a new, smaller cohort via `cohorts-create`.
+     - **Sample randomly** — confirm a count (e.g. 200) and use `ORDER BY rand() LIMIT <n>` on the cohort query. Make the randomness explicit so they know they're not getting the "top" members.
+     - **Paste a curated list** — they take over and provide emails directly.
+
+   Pick the path with them, then re-run the resolution. Never proceed without an explicit decision.
+
+4. **Tell the user what you resolved.** After resolution, confirm before creating: "Cohort 'X' has N members, resolved to E emails and D distinct IDs (snapshot — won't update if the cohort changes later)." This makes the snapshot semantics visible.
 
 ### Finding users by behavior
 
@@ -124,8 +158,8 @@ Once you have the pieces:
 ```json
 {
   "topic": "Why trial users churned in week 2",
-  "interviewee_cohort": 42,
-  "interviewee_emails": ["paul@acme.com"],
+  "interviewee_emails": ["paul@acme.com", "alex@beta.com"],
+  "interviewee_distinct_ids": ["distinct-id-with-no-email"],
   "agent_context": "Be warm. The interviewee just churned — don't pitch.",
   "questions": [
     "What were you hoping PostHog would help with?",

--- a/products/user_interviews/skills/planning-user-interviews/SKILL.md
+++ b/products/user_interviews/skills/planning-user-interviews/SKILL.md
@@ -58,20 +58,22 @@ Topics snapshot their audience at create time. When the user picks a cohort, you
    SELECT count() FROM persons WHERE id IN COHORT <cohort_id>
    ```
 
-2. **If the cohort has 500 or fewer members**, fetch them and use the results:
+2. **If the cohort has 500 or fewer members**, fetch their emails:
 
    ```sql
-   SELECT properties.email AS email, id AS distinct_id
+   SELECT properties.email AS email
    FROM persons
-   WHERE id IN COHORT <cohort_id>
+   WHERE id IN COHORT <cohort_id> AND properties.email IS NOT NULL
    LIMIT 500
    ```
 
-   Put rows with a non-null email into `interviewee_emails`; for rows where email is null, fall back to `distinct_id` in `interviewee_distinct_ids`. Dedupe.
+   Put each row into `interviewee_emails`. Dedupe.
+
+   Cohort members without an email property aren't included by default — the `persons.id` column is the person UUID, not the SDK distinct_id, so it can't be used as an `interviewee_distinct_id` without a `pdi.distinct_id` join. If you specifically need to reach members who only exist as distinct IDs, ask the user first, then do the join explicitly.
 
 3. **If the cohort has more than 500 members**, stop and ask the user. Do not silently truncate, sample, or fall back to a different cohort — the user needs to choose. Surface:
    - The cohort name and count (e.g. "PostHog Team has 28,563 members — over the 500 cap.")
-   - Why the cap exists ("we snapshot the audience at create time, and 500 is a sensible upper bound for one interview campaign")
+   - Why the cap exists ("we snapshot the audience at create time, and 500 is an agent-side guardrail to keep one interview campaign manageable — the backend itself does not cap the array length")
    - Their options:
      - **Narrow the cohort** — describe the subset they actually want (e.g. "engineers only", "active in the last 30 days"). You can offer to write a more specific HogQL filter or create a new, smaller cohort via `cohorts-create`.
      - **Sample randomly** — confirm a count (e.g. 200) and use `ORDER BY rand() LIMIT <n>` on the cohort query. Make the randomness explicit so they know they're not getting the "top" members.

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4743,7 +4743,7 @@
         }
     },
     "user-interview-topics-create": {
-        "description": "Plan a user interview by recording who you want to target and what product or idea you want to ask them about. `topic` is the free-text description of the question or product area. Targets can be specified as any combination of `interviewee_cohort` (optional cohort identifier), `interviewee_emails` (list of email addresses), and `interviewee_distinct_ids` (list of PostHog distinct IDs) — at least one target must be provided. Pass `agent_context` (free text) to give the voice agent extra background or instructions, and `questions` (list of strings) for the ordered set of questions the agent should work through.",
+        "description": "Plan a user interview by recording who you want to target and what product or idea you want to ask them about. `topic` is the free-text description of the question or product area. Targets are specified as a combination of `interviewee_emails` (list of email addresses) and `interviewee_distinct_ids` (list of PostHog distinct IDs) — at least one of the two must be provided. To target a cohort, resolve cohort members to emails/distinct_ids in the calling agent first (see the planning-user-interviews skill) and pass them explicitly here — topics snapshot their audience at creation time. Pass `agent_context` (free text) to give the voice agent extra background or instructions, and `questions` (list of strings) for the ordered set of questions the agent should work through.",
         "category": "User interview topics",
         "feature": "user_interviews",
         "summary": "Create user interview topic",
@@ -4807,7 +4807,7 @@
         "feature_flag": "user-interviews"
     },
     "user-interview-topics-list": {
-        "description": "List planned user interview topics in the current project, newest first. Each result includes the topic, targeting (interviewee_cohort, interviewee_emails, interviewee_distinct_ids), and the voice agent setup (agent_context, questions). Supports `search` for substring match against the topic, and `limit`/`offset` for pagination.",
+        "description": "List planned user interview topics in the current project, newest first. Each result includes the topic, targeting (interviewee_emails, interviewee_distinct_ids), and the voice agent setup (agent_context, questions). Supports `search` for substring match against the topic, and `limit`/`offset` for pagination.",
         "category": "User interview topics",
         "feature": "user_interviews",
         "summary": "List user interview topics",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5224,7 +5224,7 @@
         }
     },
     "user-interview-topics-create": {
-        "description": "Plan a user interview by recording who you want to target and what product or idea you want to ask them about. `topic` is the free-text description of the question or product area. Targets can be specified as any combination of `interviewee_cohort` (optional cohort identifier), `interviewee_emails` (list of email addresses), and `interviewee_distinct_ids` (list of PostHog distinct IDs) — at least one target must be provided. Pass `agent_context` (free text) to give the voice agent extra background or instructions, and `questions` (list of strings) for the ordered set of questions the agent should work through.",
+        "description": "Plan a user interview by recording who you want to target and what product or idea you want to ask them about. `topic` is the free-text description of the question or product area. Targets are specified as a combination of `interviewee_emails` (list of email addresses) and `interviewee_distinct_ids` (list of PostHog distinct IDs) — at least one of the two must be provided. To target a cohort, resolve cohort members to emails/distinct_ids in the calling agent first (see the planning-user-interviews skill) and pass them explicitly here — topics snapshot their audience at creation time. Pass `agent_context` (free text) to give the voice agent extra background or instructions, and `questions` (list of strings) for the ordered set of questions the agent should work through.",
         "category": "User interview topics",
         "feature": "user_interviews",
         "summary": "Create user interview topic",
@@ -5288,7 +5288,7 @@
         "feature_flag": "user-interviews"
     },
     "user-interview-topics-list": {
-        "description": "List planned user interview topics in the current project, newest first. Each result includes the topic, targeting (interviewee_cohort, interviewee_emails, interviewee_distinct_ids), and the voice agent setup (agent_context, questions). Supports `search` for substring match against the topic, and `limit`/`offset` for pagination.",
+        "description": "List planned user interview topics in the current project, newest first. Each result includes the topic, targeting (interviewee_emails, interviewee_distinct_ids), and the voice agent setup (agent_context, questions). Supports `search` for substring match against the topic, and `limit`/`offset` for pagination.",
         "category": "User interview topics",
         "feature": "user_interviews",
         "summary": "List user interview topics",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -24776,14 +24776,9 @@ export namespace Schemas {
       readonly id: string;
       readonly created_by: UserBasic;
       readonly created_at: string;
-      /**
-         * Optional cohort ID identifying who to target. Not enforced as a foreign key.
-         * @nullable
-         */
-      interviewee_cohort?: number | null;
-      /** Email addresses of people to interview. May be combined with interviewee_cohort and interviewee_distinct_ids. */
+      /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
       interviewee_emails?: string[];
-      /** PostHog distinct IDs of people to interview. May be combined with interviewee_cohort and interviewee_emails. */
+      /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
       interviewee_distinct_ids?: string[];
       /** The product, feature, or idea you want to ask interviewees about. */
       topic: string;
@@ -30540,14 +30535,9 @@ export namespace Schemas {
       readonly id?: string;
       readonly created_by?: UserBasic;
       readonly created_at?: string;
-      /**
-         * Optional cohort ID identifying who to target. Not enforced as a foreign key.
-         * @nullable
-         */
-      interviewee_cohort?: number | null;
-      /** Email addresses of people to interview. May be combined with interviewee_cohort and interviewee_distinct_ids. */
+      /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
       interviewee_emails?: string[];
-      /** PostHog distinct IDs of people to interview. May be combined with interviewee_cohort and interviewee_emails. */
+      /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
       interviewee_distinct_ids?: string[];
       /** The product, feature, or idea you want to ask interviewees about. */
       topic?: string;

--- a/services/mcp/src/generated/user_interviews/api.ts
+++ b/services/mcp/src/generated/user_interviews/api.ts
@@ -9,7 +9,7 @@
 import * as zod from 'zod'
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const UserInterviewTopicsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -26,7 +26,7 @@ export const UserInterviewTopicsListQueryParams = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Planned user interview topics: who we want to target (cohort) and what we want to ask about.
+ * Planned user interview topics: who we want to target and what we want to ask about.
  */
 export const UserInterviewTopicsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -41,22 +41,14 @@ export const userInterviewTopicsCreateBodyIntervieweeEmailsItemMax = 254
 export const userInterviewTopicsCreateBodyIntervieweeDistinctIdsItemMax = 400
 
 export const UserInterviewTopicsCreateBody = /* @__PURE__ */ zod.object({
-    interviewee_cohort: zod
-        .number()
-        .nullish()
-        .describe('Optional cohort ID identifying who to target. Not enforced as a foreign key.'),
     interviewee_emails: zod
         .array(zod.string().max(userInterviewTopicsCreateBodyIntervieweeEmailsItemMax))
         .optional()
-        .describe(
-            'Email addresses of people to interview. May be combined with interviewee_cohort and interviewee_distinct_ids.'
-        ),
+        .describe('Email addresses of people to interview. May be combined with interviewee_distinct_ids.'),
     interviewee_distinct_ids: zod
         .array(zod.string().max(userInterviewTopicsCreateBodyIntervieweeDistinctIdsItemMax))
         .optional()
-        .describe(
-            'PostHog distinct IDs of people to interview. May be combined with interviewee_cohort and interviewee_emails.'
-        ),
+        .describe('PostHog distinct IDs of people to interview. May be combined with interviewee_emails.'),
     topic: zod.string().describe('The product, feature, or idea you want to ask interviewees about.'),
     agent_context: zod
         .string()

--- a/services/mcp/src/tools/generated/user_interviews.ts
+++ b/services/mcp/src/tools/generated/user_interviews.ts
@@ -24,9 +24,6 @@ const userInterviewTopicsCreate = (): ToolBase<typeof UserInterviewTopicsCreateS
     handler: async (context: Context, params: z.infer<typeof UserInterviewTopicsCreateSchema>) => {
         const projectId = await context.stateManager.getProjectId()
         const body: Record<string, unknown> = {}
-        if (params.interviewee_cohort !== undefined) {
-            body['interviewee_cohort'] = params.interviewee_cohort
-        }
         if (params.interviewee_emails !== undefined) {
             body['interviewee_emails'] = params.interviewee_emails
         }


### PR DESCRIPTION
## Problem

A `UserInterviewTopic` could be "targeted" by setting `interviewee_cohort` to a cohort ID, but nothing in the backend ever resolved that cohort to a list of interviewees. The result was a partial feature that looked like it worked: the topic page showed `Cohort #98`, but `generate_links` and `send_invites` both returned 400 ("Topic targets a cohort but has no resolved emails or distinct IDs") and the UI couldn't list who would actually receive an invite.

The live-link semantics (re-evaluate cohort membership on every send) also conflict with what we want from a research campaign — the audience should be deterministic and visible up front, so people aren't silently added or removed between when the topic is planned and when invites go out.

## Changes

- Drop `interviewee_cohort` from `UserInterviewTopic`. The model now only carries `interviewee_emails` and `interviewee_distinct_ids`; the serializer requires at least one of the two and the viewset error messages stop referencing cohorts.
- Migration `0005_remove_userinterviewtopic_interviewee_cohort_state.py` is a state-only `RemoveField` via `SeparateDatabaseAndState`. The column stays in the DB until a follow-up PR drops it post-deploy, per the project's safe-migration playbook.
- `planning-user-interviews` skill now does the cohort -> emails / distinct IDs resolution at create time. It counts the cohort first; <=500 members get materialised into the topic's audience, >500 the agent stops and asks the user to narrow, sample, or paste a curated list. The skill makes the snapshot semantics explicit so the user knows the audience will not update if the cohort changes later.
- Frontend (`UserInterview.tsx`, `UserInterviewResponse.tsx`, `UserInterviews.tsx`) no longer renders the `Cohort #N` chip, since that data is gone.
- MCP `tools.yaml` description rewritten to say targeting is emails + distinct IDs only, and that cohorts must be resolved upstream. Regenerated `api.schemas.ts`, `api.zod.ts`, and the MCP tool definitions reflect the smaller shape.
- Tests: replaced two cohort-only fixtures with no-identifier equivalents, and added a parametrised `TestUserInterviewTopicCreate` covering both accept and reject paths through the serializer's `validate()`.

## How did you test this code?

I'm an agent (PostHog Code, Opus 4.7). I ran:

- `hogli test products/user_interviews/backend/test_interview_sharing.py` — 39 passed.
- `DEBUG=1 ./manage.py sqlmigrate user_interviews 0005` — confirms the state migration is a SQL no-op.
- `ruff check products/user_interviews/ --fix` and `ruff format products/user_interviews/`.
- `hogli build:openapi` to regenerate the OpenAPI / TypeScript / MCP artifacts.
- `pnpm --filter=@posthog/frontend typescript:check` — remaining errors in `products/user_interviews/frontend/` are pre-existing on master (kea-typegen missing `*LogicType` modules + an implicit-any in the questions map), unrelated to this PR.

I did not run the UI manually. Reviewers should sanity-check the topic page after a fresh `hogli build:openapi`.

## Publish to changelog?

no

## Docs update

Not needed — no public docs reference `interviewee_cohort`.

## 🤖 Agent context

Authored end-to-end by PostHog Code (Opus 4.7).

The original design considered resolving cohorts lazily inside `_materialize_links_for_topic`, but that runs into a fan-out problem for any large cohort: each call would create one `IntervieweeContext` + `SharingConfiguration` per member on every invocation. Pushing the resolution to the agent at create time keeps the backend deterministic and forces the user to make an explicit choice about who the audience is, which also surfaces overly broad cohorts before we email anyone. The 500 cap is enforced in the skill rather than the API; the API just trusts the caller now.

The migration is intentionally state-only this PR — the follow-up `RemoveField` should ship after this deploys.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*