### PR TITLE
fix(dev): make kea disposables skill frontmatter valid yaml

### DIFF
--- a/.agents/skills/using-kea-disposables/SKILL.md
+++ b/.agents/skills/using-kea-disposables/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: using-kea-disposables
-description: Use when adding timers (`setInterval`, `setTimeout`), event listeners (`window.addEventListener`, `document.addEventListener`, `MediaQueryList.addEventListener`), or any other resource that needs cleanup inside a kea logic. Every logic has `cache.disposables.add(setup, key?, options?)` and `cache.disposables.dispose(key)` available via the globally registered `disposablesPlugin` (`frontend/src/kea-disposables.ts`). Replaces the bare `cache.foo = setInterval(...)` + `beforeUnmount: clearInterval(cache.foo)` pattern and auto-pauses background work when the tab is hidden.
+description: >
+  Use when adding timers (`setInterval`, `setTimeout`), event listeners
+  (`window.addEventListener`, `document.addEventListener`,
+  `MediaQueryList.addEventListener`), or any other resource that needs cleanup
+  inside a kea logic. Every logic has `cache.disposables.add(setup, key?,
+  options?)` and `cache.disposables.dispose(key)` available via the globally
+  registered `disposablesPlugin` (`frontend/src/kea-disposables.ts`). Replaces
+  the bare `cache.foo = setInterval(...)` + `beforeUnmount:
+  clearInterval(cache.foo)` pattern and auto-pauses background work when the tab
+  is hidden.
 ---
 
 # Using kea disposables


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Codex skips loading the `using-kea-disposables` skill because its `SKILL.md` frontmatter is invalid YAML.
The description contains `beforeUnmount: clearInterval(...)`, and the `: ` sequence is parsed as YAML syntax unless the value is quoted or written as a block scalar.
This was introduced when the skill was added in #58371.


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Convert the skill description to a YAML block scalar so the frontmatter parses correctly.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Verified the `SKILL.md` frontmatter parses with `python3` and `yaml.safe_load`.

Opened Codex in the repo and confirmed the skipped-skill warning no longer appears.


<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No.

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

Not needed.

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Codex helped identify that the `using-kea-disposables` skill frontmatter failed YAML parsing because the description contained `beforeUnmount: clearInterval(...)` on an unquoted line.

It changed the description to a YAML block scalar, which preserves the description as text while making it valid YAML for stricter parsers.


<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
