### PR TITLE
ci: extract pnpm + node setup composite

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,34 @@
+name: Setup pnpm + Node.js
+description: |
+    Installs pnpm, applies the gyp_main.py executable bit fix, and sets up Node.js with pnpm caching enabled.
+    Action version pins live here so dependabot/renovate updates touch one file instead of every workflow.
+
+inputs:
+    cache-dependency-path:
+        description: Extra files to mix into the pnpm cache key (typically the calling workflow file). pnpm-lock.yaml is always included.
+        required: false
+        default: ''
+    registry-url:
+        description: Optional registry URL for setup-node (used when publishing to npm).
+        required: false
+        default: ''
+
+runs:
+    using: composite
+    steps:
+        - name: Install pnpm
+          uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+        - name: Fix node-gyp permissions
+          shell: bash
+          run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
+
+        - name: Set up Node.js
+          uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+          with:
+              node-version-file: .nvmrc
+              cache: pnpm
+              registry-url: ${{ inputs.registry-url }}
+              cache-dependency-path: |
+                  pnpm-lock.yaml
+                  ${{ inputs.cache-dependency-path }}

--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -32,17 +32,8 @@ jobs:
                   git config --global user.email "action@github.com"
                   git config --global user.name "Browserslist Update Action"
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Reset stale browserslist branch
               env:

--- a/.github/workflows/build-hogql-parser-npm.yml
+++ b/.github/workflows/build-hogql-parser-npm.yml
@@ -132,14 +132,8 @@ jobs:
                   ref: ${{ github.event.pull_request.head.ref }}
                   token: ${{ steps.app-token.outputs.token }}
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Install uv
               id: setup-uv

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -290,17 +290,10 @@ jobs:
                       echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
                   fi
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Setup Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-backend.yml
+                  cache-dependency-path: .github/workflows/ci-backend.yml
 
             - name: Install pnpm dependencies
               run: pnpm install --frozen-lockfile --filter=@posthog/root
@@ -362,17 +355,10 @@ jobs:
                     db redis7 clickhouse zookeeper kafka objectstorage feature-flags \
                     temporal elasticsearch objectstorage-azure
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Setup Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-backend.yml
+                  cache-dependency-path: .github/workflows/ci-backend.yml
 
             - name: Install pnpm dependencies
               run: pnpm install --frozen-lockfile --filter=@posthog/root
@@ -1042,20 +1028,10 @@ jobs:
                       echo "::endgroup::"
                   done
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-backend.yml
+                  cache-dependency-path: .github/workflows/ci-backend.yml
 
             - name: Install package.json dependencies with pnpm
               env:

--- a/.github/workflows/ci-docs-check.yml
+++ b/.github/workflows/ci-docs-check.yml
@@ -48,19 +48,11 @@ jobs:
               if: steps.source-check.outputs.changed == 'true'
               uses: actions/checkout@v6
 
-            - name: Setup pnpm
+            - name: Setup pnpm + Node.js
               if: steps.source-check.outputs.changed == 'true'
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Setup Node.js
-              if: steps.source-check.outputs.changed == 'true'
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-docs-check.yml
+                  cache-dependency-path: .github/workflows/ci-docs-check.yml
 
             - name: Install dependencies
               if: steps.source-check.outputs.changed == 'true'

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -339,20 +339,10 @@ jobs:
               run: |
                   sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-e2e-playwright.yml
+                  cache-dependency-path: .github/workflows/ci-e2e-playwright.yml
 
             # tests would intermittently fail in GH actions
             # with exit code 134 _after passing_ all tests

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -107,20 +107,10 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-frontend.yml
+                  cache-dependency-path: .github/workflows/ci-frontend.yml
 
             - name: Install package.json dependencies with pnpm
               run: |
@@ -155,20 +145,10 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   filter: blob:none
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-frontend.yml
+                  cache-dependency-path: .github/workflows/ci-frontend.yml
 
             - name: Install package.json dependencies with pnpm
               run: |
@@ -246,20 +226,10 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-frontend.yml
+                  cache-dependency-path: .github/workflows/ci-frontend.yml
 
             - name: Install package.json dependencies with pnpm
               run: |
@@ -329,20 +299,10 @@ jobs:
               if: matrix.segment == 'FOSS'
               run: rm -rf ee
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-frontend.yml
+                  cache-dependency-path: .github/workflows/ci-frontend.yml
 
             - name: Install package.json dependencies with pnpm
               run: pnpm --filter=@posthog/frontend... install --frozen-lockfile

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -97,17 +97,8 @@ jobs:
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Check if ANTLR definitions are up to date
               run: |
@@ -200,15 +191,9 @@ jobs:
             - name: Install Python dependencies
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
                   registry-url: https://registry.npmjs.org
             - name: Install package.json dependencies
               run: pnpm --filter=@posthog/hogvm install --frozen-lockfile

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -65,17 +65,8 @@ jobs:
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Setup Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Install dependencies
               run: pnpm --filter=@posthog/mcp... --filter='./products/*' install --frozen-lockfile

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -106,17 +106,8 @@ jobs:
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Setup Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Install dependencies
               run: pnpm --filter=@posthog/mcp... --filter='./products/*' install --frozen-lockfile
@@ -161,17 +152,8 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Setup Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Install dependencies
               run: pnpm --filter=@posthog/mcp... --filter='./products/*' install --frozen-lockfile
@@ -323,17 +305,8 @@ jobs:
               run: |
                   sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Setup Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Install Python dependencies
               shell: bash

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -73,20 +73,10 @@ jobs:
               with:
                   clean: false
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-nodejs.yml
+                  cache-dependency-path: .github/workflows/ci-nodejs.yml
 
             - name: Install package.json dependencies with pnpm
               env:
@@ -114,20 +104,10 @@ jobs:
               with:
                   clean: false
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-nodejs.yml
+                  cache-dependency-path: .github/workflows/ci-nodejs.yml
 
             - name: Install package.json dependencies with pnpm
               env:
@@ -237,20 +217,10 @@ jobs:
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-nodejs.yml
+                  cache-dependency-path: .github/workflows/ci-nodejs.yml
 
             - name: Download MaxMind Database
               run: |

--- a/.github/workflows/ci-oauth-proxy.yml
+++ b/.github/workflows/ci-oauth-proxy.yml
@@ -49,17 +49,8 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Setup Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Install dependencies
               run: pnpm --filter=@posthog/auth-proxy... install --frozen-lockfile

--- a/.github/workflows/ci-openapi-codegen.yml
+++ b/.github/workflows/ci-openapi-codegen.yml
@@ -24,14 +24,8 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Setup Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Install dependencies
               run: pnpm --filter=@posthog/openapi-codegen install --frozen-lockfile

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -110,20 +110,10 @@ jobs:
                   ref: ${{ github.event.pull_request.head.sha || github.sha }}
                   repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-storybook.yml
+                  cache-dependency-path: .github/workflows/ci-storybook.yml
 
             - name: Install dependencies
               run: pnpm --filter=@posthog/storybook... install --frozen-lockfile
@@ -246,20 +236,10 @@ jobs:
                   ref: ${{ github.event.pull_request.head.sha || github.sha }}
                   repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-storybook.yml
+                  cache-dependency-path: .github/workflows/ci-storybook.yml
 
             - name: Install package.json dependencies with pnpm
               run: pnpm --filter=@posthog/storybook... install --frozen-lockfile
@@ -374,20 +354,10 @@ jobs:
                   ref: ${{ github.event.pull_request.head.sha }}
                   repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      .github/workflows/ci-storybook.yml
+                  cache-dependency-path: .github/workflows/ci-storybook.yml
 
             - name: Install dependencies
               run: pnpm --filter=@posthog/storybook... install --frozen-lockfile

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -62,14 +62,8 @@ jobs:
                   enable-cache: true
                   cache-dependency-glob: uv.lock
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Run Python and Node setup in parallel
               env:

--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -31,15 +31,10 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
               with:
-                  node-version-file: .nvmrc
                   registry-url: https://registry.npmjs.org
-                  cache: 'pnpm'
 
             - name: Ensure modern npm (OIDC trusted publishing support)
               run: npm install -g npm@11.6.4

--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -28,17 +28,8 @@ jobs:
               with:
                   token: ${{ steps.app-token.outputs.token }}
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-            - name: Fix node-gyp permissions
-              run: chmod +x ~/setup-pnpm/node_modules/.pnpm/pnpm@*/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py
-
-            - name: Set up Node.js
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  cache: 'pnpm'
+            - name: Setup pnpm + Node.js
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Install dependencies
               env:


### PR DESCRIPTION
## Problem

Twenty-eight CI jobs hand-rolled the same `pnpm/action-setup` → `chmod gyp_main.py` → `actions/setup-node` block. Twenty-one had the chmod workaround for the gyp_main.py executable-bit bug; seven didn't, so adding any node-gyp-rebuilt dep to those workflows would have broken silently. Pin updates also had to touch all 28 callsites.

## Changes

New composite at `.github/actions/setup-node-pnpm/`. All 28 callsites migrated; the seven missing the chmod inherit it for free. Optional `cache-dependency-path` and `registry-url` inputs cover all existing variation. SHAs unchanged. Mirrors the `setup-sqlx-cli` precedent. Net: −314 / +105 across 17 files.

## How did you test this code?

Agent-authored, no manual CI verification. Locally: `yaml.safe_load` parses every changed file, `oxfmt --check` passes, grep confirms zero remaining `pnpm/action-setup` callsites and 28 composite callsites.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Empty-string defaults for both inputs — `setup-node` treats empty `registry-url` as unset and filters blank lines from `cache-dependency-path`. Per-step `if:` on `ci-docs-check.yml` and `registry-url` on `publish-quill-npm.yml` / `ci-hog.yml` (release-hogvm) preserved.