### PR TITLE
fix(customer-analytics): add back navigation to journey time view

### DIFF
--- a/products/customer_analytics/frontend/components/CustomerJourneys/CustomerJourneys.tsx
+++ b/products/customer_analytics/frontend/components/CustomerJourneys/CustomerJourneys.tsx
@@ -1,6 +1,7 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 
-import { Spinner } from '@posthog/lemon-ui'
+import { IconArrowLeft } from '@posthog/icons'
+import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 
@@ -13,9 +14,9 @@ import { customerJourneysLogic } from './customerJourneysLogic'
 export function CustomerJourneys(): JSX.Element {
     const mountedSceneLogic = useMountedLogic(customerAnalyticsSceneLogic)
     const mountedCustomerJourneysLogic = customerJourneysLogic()
-    const { journeyOptions, journeysLoading, activeInsightLoading, activeJourneyFullQuery } =
+    const { journeyOptions, journeysLoading, activeInsightLoading, activeJourneyFullQuery, hasQueryOverride } =
         useValues(mountedCustomerJourneysLogic)
-    const { setQueryOverride } = useActions(mountedCustomerJourneysLogic)
+    const { setQueryOverride, clearQueryOverride } = useActions(mountedCustomerJourneysLogic)
     useAttachedLogic(mountedCustomerJourneysLogic, mountedSceneLogic)
 
     if (journeysLoading) {
@@ -41,7 +42,20 @@ export function CustomerJourneys(): JSX.Element {
                     <Spinner />
                 </div>
             ) : activeJourneyFullQuery ? (
-                <Query query={activeJourneyFullQuery} setQuery={setQueryOverride} readOnly />
+                <>
+                    {hasQueryOverride && (
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            icon={<IconArrowLeft />}
+                            onClick={clearQueryOverride}
+                            data-attr="customer-journey-back-to-journey"
+                        >
+                            Back to journey
+                        </LemonButton>
+                    )}
+                    <Query query={activeJourneyFullQuery} setQuery={setQueryOverride} readOnly />
+                </>
             ) : (
                 <div className="text-muted text-center p-8">Insight not found</div>
             )}

--- a/products/customer_analytics/frontend/components/CustomerJourneys/customerJourneysLogic.test.ts
+++ b/products/customer_analytics/frontend/components/CustomerJourneys/customerJourneysLogic.test.ts
@@ -1,0 +1,50 @@
+import { expectLogic } from 'kea-test-utils'
+
+import type { FunnelsQuery, InsightVizNode } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { FunnelVizType } from '~/types'
+
+import { customerJourneysLogic } from './customerJourneysLogic'
+
+const timeToConvertQuery = {
+    kind: 'InsightVizNode',
+    source: {
+        kind: 'FunnelsQuery',
+        series: [],
+        funnelsFilter: {
+            funnelVizType: FunnelVizType.TimeToConvert,
+        },
+    },
+} as InsightVizNode<FunnelsQuery>
+
+describe('customerJourneysLogic', () => {
+    let logic: ReturnType<typeof customerJourneysLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = customerJourneysLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    describe('queryOverride', () => {
+        it('can clear an overridden journey query', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setQueryOverride(timeToConvertQuery)
+            }).toMatchValues({
+                activeJourneyFullQuery: timeToConvertQuery,
+                hasQueryOverride: true,
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.clearQueryOverride()
+            }).toMatchValues({
+                activeJourneyFullQuery: null,
+                hasQueryOverride: false,
+            })
+        })
+    })
+})

--- a/products/customer_analytics/frontend/components/CustomerJourneys/customerJourneysLogic.ts
+++ b/products/customer_analytics/frontend/components/CustomerJourneys/customerJourneysLogic.ts
@@ -35,6 +35,7 @@ export const customerJourneysLogic = kea<customerJourneysLogicType>([
         setActiveJourneyId: (journeyId: string | null) => ({ journeyId }),
         selectFirstJourneyIfNeeded: (journeys: CustomerJourneyApi[]) => ({ journeys }),
         setQueryOverride: (query: InsightVizNode<FunnelsQuery>) => ({ query }),
+        clearQueryOverride: true,
     }),
     lazyLoaders(({ values }) => ({
         journeys: {
@@ -96,6 +97,7 @@ export const customerJourneysLogic = kea<customerJourneysLogicType>([
             null as InsightVizNode<FunnelsQuery> | null,
             {
                 setQueryOverride: (_, { query }) => query,
+                clearQueryOverride: () => null,
                 setActiveJourneyId: () => null,
                 loadActiveInsightSuccess: () => null,
             },
@@ -195,6 +197,7 @@ export const customerJourneysLogic = kea<customerJourneysLogicType>([
                 } as InsightVizNode<FunnelsQuery>
             },
         ],
+        hasQueryOverride: [(s) => [s.queryOverride], (queryOverride): boolean => !!queryOverride],
         isProfileMode: [
             () => [(_, p) => p.personId, (_, p) => p.groupKey],
             (personId: string | undefined, groupKey: string | undefined): boolean => !!personId || !!groupKey,


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
Customer journeys lets users click the average time to convert value to inspect the funnel time-to-convert view.
After switching into that view, there is no clear way to return to the original journey flow without reloading the page or entering edit mode.

Closes #57540


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add a `Back to journey` button when the Customer journeys query is showing an overridden insight view.
The button clears the query override and returns the user to the saved journey flow.
Also adds a focused logic test for clearing the overridden query state.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Ran the targeted Customer journeys logic test inside Flox:

```bash
flox activate -- bash -c "pnpm --filter=@posthog/frontend jest products/customer_analytics/frontend/components/CustomerJourneys/customerJourneysLogic.test.ts --runInBand"
```
Result:

PASS customerJourneysLogic.test.ts
Tests: 1 passed, 1 total

Also ran:
git diff --check


<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
Not needed

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Codex helped trace the Customer journeys query override path and identify that clicking average time to convert sets a local queryOverride without exposing a way to clear it.
It chose a narrow fix: keep the existing query override behavior, add an explicit clear action in customerJourneysLogic, and show a small Back to journey button only while an override is active.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
