### PR TITLE
perf(frontend): lazy-load WebVitals query nodes, fix taxonomy duplicate import

### DIFF
--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -1,7 +1,8 @@
 import { BuiltLogic, LogicWrapper } from 'kea'
-import { useEffect, useState } from 'react'
+import { Suspense, lazy, useEffect, useState } from 'react'
 
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { HogDebug } from 'scenes/debug/HogDebug'
 import { MarketingAnalyticsOverview } from 'scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsOverview/MarketingAnalyticsOverview'
 
@@ -10,7 +11,6 @@ import { DataNode } from '~/queries/nodes/DataNode/DataNode'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { InsightViz, insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { WebOverview } from '~/queries/nodes/WebOverview/WebOverview'
-import { WebVitals } from '~/queries/nodes/WebVitals/WebVitals'
 import { QueryEditor } from '~/queries/QueryEditor/QueryEditor'
 import {
     AnyResponseType,
@@ -34,7 +34,6 @@ import {
 
 import { DataTableVisualization } from '../nodes/DataVisualization/DataVisualization'
 import { SavedInsight } from '../nodes/SavedInsight/SavedInsight'
-import { WebVitalsPathBreakdown } from '../nodes/WebVitals/WebVitalsPathBreakdown'
 import {
     isDataTableNode,
     isDataVisualizationNode,
@@ -53,6 +52,11 @@ import {
     isWebVitalsPathBreakdownQuery,
     isWebVitalsQuery,
 } from '../utils'
+
+const WebVitals = lazy(() => import('~/queries/nodes/WebVitals/WebVitals').then((m) => ({ default: m.WebVitals })))
+const WebVitalsPathBreakdown = lazy(() =>
+    import('../nodes/WebVitals/WebVitalsPathBreakdown').then((m) => ({ default: m.WebVitalsPathBreakdown }))
+)
 
 export interface QueryProps<Q extends Node> {
     /** An optional key to identify the query */
@@ -268,21 +272,25 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
         )
     } else if (isWebVitalsQuery(query)) {
         component = (
-            <WebVitals
-                attachTo={props.attachTo}
-                query={query}
-                cachedResults={props.cachedResults}
-                context={queryContext}
-            />
+            <Suspense fallback={<Spinner />}>
+                <WebVitals
+                    attachTo={props.attachTo}
+                    query={query}
+                    cachedResults={props.cachedResults}
+                    context={queryContext}
+                />
+            </Suspense>
         )
     } else if (isWebVitalsPathBreakdownQuery(query)) {
         component = (
-            <WebVitalsPathBreakdown
-                attachTo={props.attachTo}
-                query={query}
-                cachedResults={props.cachedResults}
-                context={queryContext}
-            />
+            <Suspense fallback={<Spinner />}>
+                <WebVitalsPathBreakdown
+                    attachTo={props.attachTo}
+                    query={query}
+                    cachedResults={props.cachedResults}
+                    context={queryContext}
+                />
+            </Suspense>
         )
     } else if (isHogQuery(query)) {
         component = (

--- a/frontend/src/taxonomy/taxonomy.tsx
+++ b/frontend/src/taxonomy/taxonomy.tsx
@@ -6,7 +6,7 @@ import {
 
 import { CoreFilterDefinition } from '~/types'
 
-import * as coreFilterDefinitionsByGroup from './core-filter-definitions-by-group.json'
+import coreFilterDefinitionsByGroup from './core-filter-definitions-by-group.json'
 import { transformFilterDefinitions } from './transformations'
 
 export type CoreFilterDefinitionsGroup = Exclude<keyof typeof coreFilterDefinitionsByGroup, '//'>


### PR DESCRIPTION
> 🧵 Part of the memory-leak investigation tracked in [#32479](https://github.com/PostHog/posthog/issues/32479).

Related to #32479 (browser memory leak investigation).
## Problem

A 100-reload memory test on `/dashboard` showed renderer RSS at 1.3-1.7 GB across reloads while V8 JS heap stayed flat at 116 MB. The cost is overwhelmingly off-heap.

A V8 heap snapshot taken on `/dashboard` revealed two specific wins worth a small, surgical PR:

1. The single largest object in the V8 heap was a **4.5 MB base64-encoded sourcemap data URI for `validators.js`** (AJV-generated query-schema validators). It was being loaded eagerly by every render of `Query.tsx` via this chain:

   ```
   Query.tsx (top-level import)
     → WebVitals.tsx
       → webAnalyticsLogic.tsx
         → schema-guards.ts
           → validators.js (711 KB compiled, 4.5 MB sourcemap)
   ```

   Any scene that renders any `<Query>` was paying the full web-analytics validator cost, even if no web-vitals query was on the page.

2. `core-filter-definitions-by-group.json` (304 KB) was imported with `import * as ...`. With Vite's JSON plugin this produces a module namespace where the JSON content shows up twice in V8 internalized strings (once as the default export, once as the namespace value), and the `Object.entries(...)` reduce below was also implicitly creating an unused `CORE_FILTER_DEFINITIONS_BY_GROUP.default` entry from the namespace's `default` key.

## Changes

- `frontend/src/queries/Query/Query.tsx` — `WebVitals` and `WebVitalsPathBreakdown` are now `React.lazy()`-loaded with a `Spinner` Suspense fallback. The eager imports + their transitive `webAnalyticsLogic` + `validators.js` chain are no longer in the initial Query bundle.
- `frontend/src/taxonomy/taxonomy.tsx` — switched `import * as coreFilterDefinitionsByGroup` to default import. Removes the duplicate V8 string copy of the JSON, removes the unused `.default` entry that the reduce was producing, and tightens the `CoreFilterDefinitionsGroup` keyof type (no longer admits `'default'`).

## How did you test this code?

I'm an agent. I ran:

- TypeScript: `pnpm --filter=@posthog/frontend exec tsc --noEmit` against the two changed files — clean.
- A 100-iteration headless reload loop on `/dashboard` (Playwright + ps RSS sampling). With both fixes applied, cold first-load renderer RSS dropped from **2170 MB → 1595 MB** (~575 MB drop). Subsequent reloads landed in the same 1.3-1.7 GB range as the baseline, which is expected — once Vite's dev server has served a lazy chunk it stays in the module cache for the rest of the run, so reload-loop steady state does not reflect real user cold-load benefit.
- No manual UI testing — please verify that opening a Web Analytics dashboard / scene that renders a `WebVitalsQuery` / `WebVitalsPathBreakdownQuery` still works and shows the spinner fallback briefly during the lazy import.

## Publish to changelog?

no

## 🤖 Agent context

Investigation was driven by a heap snapshot taken from a real browser tab observed growing in memory while idle on `/home`. That snapshot was opened with the memlab MCP and revealed:

- 2,643 inline-sourcemap `data:application/json;base64,...` strings totalling 44.7 MB in the V8 heap (88% of all V8 heap strings) — confirmed dev-mode artifact, not addressed here.
- `validators.js` at 4.5 MB (#1 largest single object) — addressed by this PR.
- The taxonomy JSON duplicated twice in V8 internalized strings — addressed by this PR.
- Several other findings that were investigated and deferred (DOMPurify duplicates ruled out, SSE substring-pinning ruled out for `/dashboard` since `/dashboard` doesn't exercise the SSE path).

Both fixes are narrow and behavior-preserving. The `import * as` → default change does have a subtle semantic difference — it removes the accidental `CORE_FILTER_DEFINITIONS_BY_GROUP.default` entry that was being created by the reduce-over-Object.entries — but a grep confirmed no caller reads `.default` from this map, so the behavior change is safely net-positive.

The Suspense fallback inherits the existing `<ErrorBoundary>` wrapper around Query's rendered component, so chunk-load failures will surface there.

I considered just doing the lazy-load and skipping the taxonomy change because the runtime impact of one duplicated 355 KB string is small, but the taxonomy fix is a 1-character diff with no risk and tightens the type, so it's bundled in.

Agent tool: PostHog Code (Claude Opus 4.7).

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
