### PR TITLE
perf(tasks): trim start_agent_server activity hot path

### DIFF
--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -695,7 +695,7 @@ class DockerSandbox(SandboxBase):
         if result.exit_code != 0:
             logger.warning(f"Agent-server process failed to launch in sandbox {self.id}: {result.stderr}")
             return False
-        return self._wait_for_health_check(max_attempts=20)
+        return self._wait_for_health_check(max_attempts=100)
 
     def start_agent_server(
         self,
@@ -854,7 +854,7 @@ class DockerSandbox(SandboxBase):
 
         logger.info("agentsh daemon started and session created in Docker sandbox %s", self.id)
 
-    def _wait_for_health_check(self, max_attempts: int = 60, poll_interval: float = 0.5) -> bool:
+    def _wait_for_health_check(self, max_attempts: int = 300, poll_interval: float = 0.1) -> bool:
         """Poll health endpoint until server is ready (single remote call)."""
 
         return wait_for_health_check(self.execute, self.id, AGENT_SERVER_PORT, max_attempts, poll_interval)

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -78,7 +78,9 @@ SANDBOX_BASE_IMAGE = "ghcr.io/posthog/posthog-sandbox-base"
 SANDBOX_NOTEBOOK_IMAGE = "ghcr.io/posthog/posthog-sandbox-notebook"
 SANDBOX_IMAGE = SANDBOX_BASE_IMAGE
 AGENT_SERVER_PORT = 8080  # Modal connect tokens require port 8080
-AGENT_SERVER_HEALTH_MAX_ATTEMPTS = 240
+# 120s ceiling (1200 x 100ms) — enough headroom for the EADDRINUSE retry path
+# to come up, while polling at 10 Hz so a ready server is detected quickly.
+AGENT_SERVER_HEALTH_MAX_ATTEMPTS = 1200
 
 # Modal region mapping based on cloud deployment
 MODAL_REGION_BY_DEPLOYMENT: dict[str | None, str] = {
@@ -737,15 +739,31 @@ class ModalSandbox(SandboxBase):
         config_yaml = generate_config_yaml(enable_ptrace=True, full_trace=True)
         policy_yaml = generate_policy_yaml(allowed_domains)
 
-        self.execute("pkill -f 'agentsh server' || true", timeout_seconds=5)
-        self.execute("mkdir -p /etc/agentsh/policies /var/log/agentsh /var/lib/agentsh/sessions", timeout_seconds=5)
+        # Three filesystem writes are kept as discrete RPCs because the Modal
+        # sandbox API exposes write_bytes — they cannot be folded into the
+        # batched shell call below without base64 encoding the YAML payloads.
         self.write_file("/etc/agentsh/config.yaml", config_yaml.encode())
         self.write_file("/etc/agentsh/policies/default.yaml", policy_yaml.encode())
         self.write_file(ENV_WRAPPER_SCRIPT, generate_env_wrapper().encode())
-        self.execute(f"chmod +x {ENV_WRAPPER_SCRIPT}", timeout_seconds=5)
 
+        # Collapse pkill / mkdir / chmod / setup_script / session_check into a
+        # single sandbox.execute round trip. Each separate execute() round-trips
+        # to Modal (~100-300ms each), so on cold start this used to add ~1-2s
+        # of pure latency on the agentsh path.
         setup_script = build_setup_script(workspace_path)
-        result = self.execute(setup_script, timeout_seconds=30)
+        combined = (
+            "set -e; "
+            "pkill -f 'agentsh server' || true; "
+            "mkdir -p /etc/agentsh/policies /var/log/agentsh /var/lib/agentsh/sessions; "
+            f"chmod +x {shlex.quote(ENV_WRAPPER_SCRIPT)}; "
+            f"{setup_script}; "
+            f"[ -s {shlex.quote(SESSION_ID_FILE)} ] || {{ "
+            "  echo 'agentsh session id file empty' >&2; "
+            "  cat /var/log/agentsh/agentsh.log >&2 2>/dev/null || true; "
+            "  exit 1; "
+            "}}"
+        )
+        result = self.execute(combined, timeout_seconds=30)
         if result.exit_code != 0:
             agentsh_log = self.execute("cat /var/log/agentsh/agentsh.log 2>/dev/null || true", timeout_seconds=5)
             raise SandboxExecutionError(
@@ -756,26 +774,13 @@ class ModalSandbox(SandboxBase):
                     "stdout": result.stdout,
                     "agentsh_log": agentsh_log.stdout,
                 },
-                cause=RuntimeError(result.stderr),
-            )
-
-        session_check = self.execute(f"cat {SESSION_ID_FILE}", timeout_seconds=5)
-        if session_check.exit_code != 0 or not session_check.stdout.strip():
-            agentsh_log = self.execute("cat /var/log/agentsh/agentsh.log 2>/dev/null || true", timeout_seconds=5)
-            raise SandboxExecutionError(
-                "Failed to create agentsh session",
-                {
-                    "sandbox_id": self.id,
-                    "stderr": session_check.stderr,
-                    "agentsh_log": agentsh_log.stdout,
-                },
-                cause=RuntimeError("agentsh session create failed"),
+                cause=RuntimeError(result.stderr or "agentsh setup failed"),
             )
 
         logger.info("agentsh daemon started and session created in sandbox %s", self.id)
 
     def _wait_for_health_check(
-        self, max_attempts: int = AGENT_SERVER_HEALTH_MAX_ATTEMPTS, poll_interval: float = 0.5
+        self, max_attempts: int = AGENT_SERVER_HEALTH_MAX_ATTEMPTS, poll_interval: float = 0.1
     ) -> bool:
         """Poll health endpoint until server is ready (single remote call)."""
         return wait_for_health_check(self.execute, self.id, AGENT_SERVER_PORT, max_attempts, poll_interval)

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -291,24 +291,27 @@ def wait_for_health_check(
     execute: _ExecuteFn,
     sandbox_id: str,
     port: int,
-    max_attempts: int = 60,
-    poll_interval: float = 0.5,
+    max_attempts: int = 300,
+    poll_interval: float = 0.1,
 ) -> bool:
     """Poll health endpoint until server is ready (single remote call).
 
     Runs a bash polling loop inside the sandbox so only one round-trip is
     needed regardless of how many attempts are required.
+
+    Defaults give a 30s ceiling at 100ms polling. Health response is a
+    fixed-shape JSON object (``{"status":"ok","hasSession":true}``) so we
+    use grep instead of spawning a python interpreter every iteration —
+    that adds up at 10 Hz polling.
     """
     health_script = (
         f"for i in $(seq 1 {max_attempts}); do "
         f"  body=$(curl -s http://localhost:{port}/health); "
         "  status=$?; "
-        '  if [ "$status" = "0" ]; then '
-        "    python3 -c '"
-        "import json, sys; "
-        "payload = json.loads(sys.argv[1]); "
-        'sys.exit(0 if payload.get("status") == "ok" and payload.get("hasSession") is True else 1)'
-        f'\' "$body" && echo "ok:$i" && exit 0; '
+        '  if [ "$status" = "0" ] && '
+        '     printf %s "$body" | grep -q \'"status":"ok"\' && '
+        '     printf %s "$body" | grep -q \'"hasSession":true\'; then '
+        f'    echo "ok:$i" && exit 0; '
         "  fi; "
         f"  sleep {poll_interval}; "
         f"done; "

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -1,4 +1,3 @@
-import shlex
 from dataclasses import dataclass
 
 from temporalio import activity
@@ -8,7 +7,6 @@ from posthog.temporal.common.utils import asyncify
 from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.models import Task, TaskRun
-from products.tasks.backend.services.agentsh import ENV_FILE, ENV_WRAPPER_SCRIPT, build_exec_prefix
 from products.tasks.backend.services.connection_token import create_sandbox_event_ingest_token
 from products.tasks.backend.services.sandbox import Sandbox, SandboxBase
 from products.tasks.backend.temporal.exceptions import OAuthTokenError, SandboxExecutionError
@@ -48,45 +46,6 @@ def _emit_agent_server_log_tail(ctx: TaskProcessingContext, sandbox: SandboxBase
     log_tail = result.stdout.strip()
     if log_tail:
         emit_agent_log(ctx.run_id, "debug", f"agent-server log tail:\n{log_tail}")
-
-
-def _run_connectivity_diagnostics(ctx: TaskProcessingContext, sandbox: SandboxBase) -> None:
-    """Emit diagnostic info about env vars and network connectivity.
-
-    When allowed_domains is set, runs the checks inside the agentsh exec
-    context to verify the env wrapper restores variables and the DNS proxy
-    resolves correctly.  Without domains, runs directly.
-    """
-    try:
-        checks = (
-            "echo ENV_CHECK:"
-            " LLM_GATEWAY_URL=${LLM_GATEWAY_URL:-UNSET}"
-            " POSTHOG_API_URL=${POSTHOG_API_URL:-UNSET}"
-            " ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-UNSET};"
-            ' node -e "'
-            "const dns=require('dns');"
-            "dns.resolve('gateway.us.posthog.com',(e,a)=>console.log('DNS_RESOLVE:',e?e.code:JSON.stringify(a)));"
-            "dns.lookup('gateway.us.posthog.com',(e,a)=>console.log('DNS_LOOKUP:',e?e.code:a))"
-            '" 2>&1;'
-            " curl -sS --max-time 5 -o /dev/null"
-            " -w 'CURL_GATEWAY: http_code=%{http_code}'"
-            " https://gateway.us.posthog.com/health 2>&1 || echo 'CURL_GATEWAY: failed'"
-        )
-
-        if ctx.allowed_domains is not None:
-            cmd = (
-                f"cd /scripts && env -0 > {ENV_FILE} && "
-                f"{build_exec_prefix()} {ENV_WRAPPER_SCRIPT} bash -c {shlex.quote(checks)}"
-            )
-        else:
-            cmd = f"bash -c {shlex.quote(checks)}"
-
-        result = sandbox.execute(cmd, timeout_seconds=15)
-        output = (result.stdout + "\n" + result.stderr).strip()
-        if output:
-            emit_agent_log(ctx.run_id, "debug", f"Connectivity diagnostics:\n{output}")
-    except Exception as e:
-        logger.warning("Connectivity diagnostics failed (non-fatal)", error=str(e), run_id=ctx.run_id)
 
 
 @dataclass
@@ -219,11 +178,11 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
             # 30m window skip the redundant refresh.
             if mcp_configs:
                 mark_mcp_token_issued(ctx.run_id)
-
-            # emit agentsh logs
-            if ctx.allowed_domains is not None:
-                _emit_agentsh_log_tail(ctx, sandbox)
         except Exception as e:
+            # Failure-only diagnostics: these are sandbox.execute round trips
+            # we don't want to pay on the hot path. Keeping them here means
+            # we still get rich debug output when the agent server fails to
+            # come up.
             if ctx.allowed_domains is not None:
                 _emit_agentsh_log_tail(ctx, sandbox)
             _emit_agent_server_log_tail(ctx, sandbox)
@@ -240,12 +199,6 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
 
         if ctx.allowed_domains is not None:
             emit_agent_log(ctx.run_id, "debug", "agentsh policy initialized successfully")
-            _emit_agentsh_log_tail(ctx, sandbox)
-        _emit_agent_server_log_tail(ctx, sandbox)
-
-        # Connectivity diagnostics — run inside the agentsh exec context when
-        # domains are restricted so we can verify the env wrapper + DNS proxy work.
-        _run_connectivity_diagnostics(ctx, sandbox)
 
         emit_agent_log(ctx.run_id, "debug", f"Agent server started at {sandbox_url}")
         activity.logger.info(f"Agent server started at {sandbox_url} for task {ctx.task_id}")


### PR DESCRIPTION
## Problem

The `start_agent_server` activity has been showing a 5–10s p95 with frequent spikes toward 60s, let's try to improve this.

## Changes

- cleaner debug paths
- batch agentsh setup since we already here
- `wait_for_health_check` went from 60×0.5s to 300×0.1s (same ~30s ceiling) and now uses `grep` on the fixed-shape health JSON instead of spawning a py interpreter