### PR TITLE
chore(user-interviews): add storybook scenes for shared interview page

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1452,6 +1452,22 @@ snapshots:
         hash: v1.k794b7964.5d0d328d83dd60bee58184c0c33ec821333a741e828d9912c45804c2f608a7d4.fE4t8YqdB3Ohnsxul2QTfJ_too7TAUNk0rZgr7Ll1Es
     exporter-funnels--funnel-top-to-bottom-insight-no-results--light:
         hash: v1.k794b7964.9225d8fd25066264d4b17b2f2e1eaf912252f71215ef01f66375d816baa65b5b.rnlYKUzVzsDLlpiLMAhUCDJTh_3kbaraSu98rjmdmEc
+    exporter-interview--default--medium--dark:
+        hash: v1.k794b7964.7c4eb178ea47aecef441a210979fd749a5393e612c3116c5aea81fcfa5fd01fc.QmSK8ISG9yruiBWiU6f7Ef706DTEvpTqDx8hJWJ53kM
+    exporter-interview--default--medium--light:
+        hash: v1.k794b7964.d4ce02ae0b66a073a445985d229f3a24b71c5c8a42f6f39c32d0d6186d0dc568.Kg9QjtCPGiRvNuXeoz6FMKRgD8zs9zu3ldBS7i87T6Y
+    exporter-interview--default--narrow--dark:
+        hash: v1.k794b7964.4534dd934dd7b596d5e0f7eae452809f6bab2c212703d5d81fd2265ef0a56201.GD7KsJkH1LDNFyjIkcP8iKkBnJ610NYUk34quRnzHP0
+    exporter-interview--default--narrow--light:
+        hash: v1.k794b7964.0b5b45f4dded145fc0caee559eae27bc48e351ace5755c66ceb3539a2148b81a.TrV6E4VwY1GTujrD620T6jE5gF2WTqHCDIXi6P4925w
+    exporter-interview--default--superwide--dark:
+        hash: v1.k794b7964.e2b7be92c8dda676881b79c1ebee852fdf0da4ae9308538300626d76aa4808ec.XsZFx-0VpczPh1ok3v9MJ4vMq4NOenahTfn2DmpGaLQ
+    exporter-interview--default--superwide--light:
+        hash: v1.k794b7964.a3938a530517fe018b35ea523063fea3dfb21eb8751b5c7fe580b98a3f1e45ca.A05A4GLE7zM2g_QYoLZFK3YZJVv9jRkSXosLC8poJfo
+    exporter-interview--default--wide--dark:
+        hash: v1.k794b7964.7822c8871f1bb27bde31297394f0e8dc9cc6d80066d44d2b9d21f393816becb4.WbD1ja7-iBct5bq_yiSjKd1LVvCuhpDcsKcbK9acD80
+    exporter-interview--default--wide--light:
+        hash: v1.k794b7964.fe86239bbd8dc4e4556a9c0b7d69f46c5c43b700f0a7476d868fb0a47e61188a.PQPuSD0pjKnAog9H8u-XRvGiao8qVi3fNEIFSAkcr-E
     exporter-other--event-table-insight--dark:
         hash: v1.k794b7964.cdefc1d85f5f375fb9b15ecb4b6a371e98175c5ae136d57dd3b6d204096457c2.IRs92pwVTJ7WYExLWPu1he-krTNZ8WtsG9Rwgm6qYrs
     exporter-other--event-table-insight--light:

--- a/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
+++ b/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { Logo } from 'lib/brand/Logo'
+import { RobotHog } from 'lib/components/hedgehogs'
 
 import { InterviewExportPayload } from '../types'
 
@@ -94,6 +95,10 @@ export default function ExporterInterviewScene({
             <div className="mb-8 flex items-center justify-between">
                 <Logo className="text-lg" />
                 <span className="text-xs text-muted">Powered by PostHog</span>
+            </div>
+
+            <div className="flex justify-center mb-6">
+                <RobotHog className="w-40 h-40" alt="" />
             </div>
 
             <h1 className="text-3xl font-bold mb-4">Hi {interview.user_name}!</h1>

--- a/frontend/src/exporter/stories/ExporterInterview.stories.tsx
+++ b/frontend/src/exporter/stories/ExporterInterview.stories.tsx
@@ -5,7 +5,7 @@ import { ExportType, ExportedData, InterviewExportPayload } from '~/exporter/typ
 
 import { Exporter } from '../Exporter'
 
-const baseInterview: InterviewExportPayload = {
+const interview: InterviewExportPayload = {
     topic_id: 'topic-123',
     interviewee_identifier: 'interviewee-abc',
     user_name: 'Sam',
@@ -23,11 +23,12 @@ const meta: Meta<ExportedData> = {
         legend: false,
         detailed: false,
         accessToken: 'storybook-access-token',
-        interview: baseInterview,
+        interview,
     },
     parameters: {
         testOptions: {
             snapshotBrowsers: ['chromium'],
+            viewportWidths: ['narrow', 'medium', 'wide', 'superwide'],
         },
         mockDate: '2023-02-01',
         viewMode: 'story',
@@ -49,23 +50,3 @@ const meta: Meta<ExportedData> = {
 export default meta
 
 export const Default: Story = {}
-
-export const LongTopic: Story = {
-    args: {
-        interview: {
-            ...baseInterview,
-            user_name: 'Alexandra',
-            topic: 'the new onboarding flow we shipped last month and how it felt to set up your first dashboard',
-        },
-    },
-}
-
-export const ShortName: Story = {
-    args: {
-        interview: {
-            ...baseInterview,
-            user_name: 'Jo',
-            topic: 'session replay',
-        },
-    },
-}

--- a/frontend/src/exporter/stories/ExporterInterview.stories.tsx
+++ b/frontend/src/exporter/stories/ExporterInterview.stories.tsx
@@ -26,6 +26,7 @@ const meta: Meta<ExportedData> = {
         interview,
     },
     parameters: {
+        layout: 'fullscreen',
         testOptions: {
             snapshotBrowsers: ['chromium'],
             viewportWidths: ['narrow', 'medium', 'wide', 'superwide'],

--- a/frontend/src/exporter/stories/ExporterInterview.stories.tsx
+++ b/frontend/src/exporter/stories/ExporterInterview.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useEffect } from 'react'
+
+import { ExportType, ExportedData, InterviewExportPayload } from '~/exporter/types'
+
+import { Exporter } from '../Exporter'
+
+const baseInterview: InterviewExportPayload = {
+    topic_id: 'topic-123',
+    interviewee_identifier: 'interviewee-abc',
+    user_name: 'Sam',
+    topic: 'how you use dashboards',
+}
+
+type Story = StoryObj<ExportedData>
+const meta: Meta<ExportedData> = {
+    title: 'Exporter/Interview',
+    component: Exporter,
+    args: {
+        type: ExportType.Interview,
+        whitelabel: false,
+        noHeader: false,
+        legend: false,
+        detailed: false,
+        accessToken: 'storybook-access-token',
+        interview: baseInterview,
+    },
+    parameters: {
+        testOptions: {
+            snapshotBrowsers: ['chromium'],
+        },
+        mockDate: '2023-02-01',
+        viewMode: 'story',
+    },
+    tags: [],
+    render: (props) => {
+        useEffect(() => {
+            document.body.className = ''
+            document.documentElement.className = `export-type-${props.type}`
+        }, [props.type])
+        return (
+            <div className={`storybook-export-type-${props.type} p-4`}>
+                <Exporter {...props} />
+            </div>
+        )
+    },
+}
+
+export default meta
+
+export const Default: Story = {}
+
+export const LongTopic: Story = {
+    args: {
+        interview: {
+            ...baseInterview,
+            user_name: 'Alexandra',
+            topic: 'the new onboarding flow we shipped last month and how it felt to set up your first dashboard',
+        },
+    },
+}
+
+export const ShortName: Story = {
+    args: {
+        interview: {
+            ...baseInterview,
+            user_name: 'Jo',
+            topic: 'session replay',
+        },
+    },
+}


### PR DESCRIPTION
## Problem

We have a new shared-interview page (`ExporterInterviewScene`) generated by the exporter for the AI user researcher feature, but it had no Storybook coverage and no mascot/visual anchor on the landing screen.

## Changes

- Add a `RobotHog` mascot to the shared interview landing page, centered above the greeting headline.
- Add `frontend/src/exporter/stories/ExporterInterview.stories.tsx` with a single `Default` story, rendered via the existing `Exporter` wrapper at `type: ExportType.Interview`, snapshotted at four widths (`narrow`, `medium`, `wide`, `superwide`) via `parameters.testOptions.viewportWidths` and `layout: 'fullscreen'`.

## How did you test this code?

I'm an agent. I made the changes and verified:

- `pnpm --filter=@posthog/frontend typescript:check` — no new errors introduced by these files (pre-existing errors in `products/workflows/` are unrelated).
- Manual visual / Storybook review was not performed by me — the snapshot suite captures the rendered idle state at the four configured widths.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

- Authored by PostHog Code (Opus 4.7) at the user's request.
- Explored the exporter to find `ExporterInterviewScene`, the lazy-load wiring in `Exporter.tsx`, and the existing `ExporterOther` story pattern before writing.
- Picked `RobotHog` from `lib/components/hedgehogs` as the most thematically obvious choice for an AI interviewer landing page; other candidates considered (`MicrophoneHog`, `ProfessorHog`).
- Used `Exporter` (not the scene directly) in stories to exercise the full exporter routing path, matching existing convention.
- Iteration 2: collapsed initial three name/topic variants to a single story snapshotted at multiple widths per user direction — that exercises responsive layout, which the original variants did not.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*