### PR TITLE
feat(llma): dynamic LLM-defined tag categories for taggers

### DIFF
--- a/posthog/temporal/llm_analytics/run_tagger.py
+++ b/posthog/temporal/llm_analytics/run_tagger.py
@@ -102,6 +102,42 @@ def build_tag_result_schema(
     return DynamicTagResult
 
 
+GENERIC_EVENT_CONTEXT_MAX_LEN = 8000
+
+
+def build_tagger_event_context(
+    event_type: str,
+    properties: dict[str, Any],
+    target_property_keys: list[str],
+) -> str:
+    """Build the user-message context for a tagger when running on an arbitrary event.
+
+    When `target_property_keys` is set, only those keys are surfaced (in the order the user listed
+    them). Otherwise the full property bag is serialised, truncated to ``GENERIC_EVENT_CONTEXT_MAX_LEN``
+    characters so an autocapture-shaped event with thousands of properties can't blow the LLM context
+    window. The user message is intentionally structured as JSON so the LLM can read keys
+    deterministically.
+    """
+    if target_property_keys:
+        selected: dict[str, Any] = {}
+        for key in target_property_keys:
+            if key in properties:
+                selected[key] = properties[key]
+    else:
+        selected = properties
+
+    try:
+        serialised = json.dumps(selected, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        # Last-resort fallback — never let a single weird property type kill a tagger run.
+        serialised = str(selected)
+
+    if len(serialised) > GENERIC_EVENT_CONTEXT_MAX_LEN:
+        serialised = serialised[:GENERIC_EVENT_CONTEXT_MAX_LEN] + '... [truncated]"}'
+
+    return f"Event: {event_type}\nProperties: {serialised}"
+
+
 def build_tagger_system_prompt(
     prompt: str,
     tags: list[dict[str, str]],
@@ -257,6 +293,8 @@ async def execute_tagger_activity(inputs: ExecuteTaggerInputs) -> dict[str, Any]
 
     min_tags = tagger_config.get("min_tags", 0)
     max_tags = tagger_config.get("max_tags")
+    target_event_types = tagger_config.get("target_event_types")
+    target_property_keys = tagger_config.get("target_property_keys", [])
 
     # Resolve model configuration and API key
     team_id = tagger["team_id"]
@@ -323,17 +361,26 @@ async def execute_tagger_activity(inputs: ExecuteTaggerInputs) -> dict[str, Any]
     if isinstance(properties, str):
         properties = json.loads(properties)
 
-    input_raw, output_raw = extract_event_io(event_type, properties)
-    input_data = extract_text_from_messages(input_raw)
-    output_data = extract_text_from_messages(output_raw)
+    # When the tagger is configured for the legacy $ai_generation path (no explicit
+    # target_event_types, no explicit property-key projection), preserve the original
+    # input/output prompt shape so existing taggers keep working byte-for-byte.
+    use_legacy_ai_generation_shape = (
+        target_event_types is None or target_event_types == ["$ai_generation"]
+    ) and not target_property_keys
+
+    if use_legacy_ai_generation_shape:
+        input_raw, output_raw = extract_event_io(event_type, properties)
+        input_data = extract_text_from_messages(input_raw)
+        output_data = extract_text_from_messages(output_raw)
+        user_prompt = f"""Input: {input_data}
+
+Output: {output_data}"""
+    else:
+        user_prompt = build_tagger_event_context(event_type, properties, target_property_keys)
 
     system_prompt = build_tagger_system_prompt(prompt, tags, min_tags, max_tags, dynamic_tags, tags_url)
     tag_names = [tag["name"] for tag in tags]
     response_format = build_tag_result_schema(tag_names, min_tags, max_tags, dynamic_tags)
-
-    user_prompt = f"""Input: {input_data}
-
-Output: {output_data}"""
 
     config = get_eval_config(provider) if provider_key is None else None
 

--- a/posthog/temporal/llm_analytics/run_tagger.py
+++ b/posthog/temporal/llm_analytics/run_tagger.py
@@ -55,23 +55,43 @@ class TagResult(BaseModel):
     reasoning: str
 
 
-def build_tag_result_schema(tag_names: list[str], min_tags: int = 0, max_tags: int | None = None) -> type[TagResult]:
+def build_tag_result_schema(
+    tag_names: list[str],
+    min_tags: int = 0,
+    max_tags: int | None = None,
+    dynamic_tags: bool = False,
+) -> type[TagResult]:
     """Build a TagResult schema with valid tag names and constraints in the field description.
 
     This ensures the JSON schema sent to the LLM provider includes the allowed
     tag values and min/max constraints, improving structured output reliability.
+
+    When `dynamic_tags` is true, no static allowlist is encoded — the LLM defines
+    its own category names based on the prompt and optional reference URL.
     """
-    tag_list = ", ".join(f'"{name}"' for name in tag_names)
-
-    constraint_parts = [f"Valid values: [{tag_list}]"]
-    if min_tags > 0:
-        constraint_parts.append(f"Minimum {min_tags} tag(s)")
-    if max_tags is not None:
-        constraint_parts.append(f"Maximum {max_tags} tag(s)")
-    if min_tags == 0:
-        constraint_parts.append("Can be empty if no tags apply")
-
-    description = "Tags to apply. " + ". ".join(constraint_parts) + "."
+    if dynamic_tags:
+        constraint_parts = ["Use concise, lowercase, kebab-case identifiers"]
+        if min_tags > 0:
+            constraint_parts.append(f"Minimum {min_tags} tag(s)")
+        if max_tags is not None:
+            constraint_parts.append(f"Maximum {max_tags} tag(s)")
+        if min_tags == 0:
+            constraint_parts.append("Can be empty if no tags apply")
+        description = (
+            "Tags to apply. The categories are defined by you based on the prompt and any referenced context. "
+            + ". ".join(constraint_parts)
+            + "."
+        )
+    else:
+        tag_list = ", ".join(f'"{name}"' for name in tag_names)
+        constraint_parts = [f"Valid values: [{tag_list}]"]
+        if min_tags > 0:
+            constraint_parts.append(f"Minimum {min_tags} tag(s)")
+        if max_tags is not None:
+            constraint_parts.append(f"Maximum {max_tags} tag(s)")
+        if min_tags == 0:
+            constraint_parts.append("Can be empty if no tags apply")
+        description = "Tags to apply. " + ". ".join(constraint_parts) + "."
 
     class DynamicTagResult(TagResult):
         tags: list[str] = Field(description=description)
@@ -82,8 +102,41 @@ def build_tag_result_schema(tag_names: list[str], min_tags: int = 0, max_tags: i
     return DynamicTagResult
 
 
-def build_tagger_system_prompt(prompt: str, tags: list[dict[str, str]], min_tags: int, max_tags: int | None) -> str:
+def build_tagger_system_prompt(
+    prompt: str,
+    tags: list[dict[str, str]],
+    min_tags: int,
+    max_tags: int | None,
+    dynamic_tags: bool = False,
+    tags_url: str | None = None,
+) -> str:
     """Build the system prompt for the LLM tagger."""
+    constraint_parts = []
+    if min_tags > 0:
+        constraint_parts.append(f"at least {min_tags}")
+    if max_tags is not None:
+        constraint_parts.append(f"at most {max_tags}")
+
+    if dynamic_tags:
+        if constraint_parts:
+            constraint = f"Select {' and '.join(constraint_parts)} tags."
+        else:
+            constraint = "Select as many tags as apply."
+
+        url_section = (
+            f"\nReference URL (treat its contents as the source of truth for category names): {tags_url}\n"
+            if tags_url
+            else ""
+        )
+
+        return f"""You are a tagger. Given the following AI generation, define and apply the tags that best categorize it according to the instructions below.
+
+{prompt}
+{url_section}
+You must determine the appropriate tag categories yourself based on the instructions and (if provided) the reference URL. Use short, lowercase, kebab-case identifiers (e.g. "billing-question", "account-settings"). Reuse the same identifier across generations when the same category applies — do not invent a synonym for a category you have already named.
+
+{constraint} If no tags apply, return an empty list."""
+
     tag_lines = []
     for tag in tags:
         name = tag["name"]
@@ -94,12 +147,6 @@ def build_tagger_system_prompt(prompt: str, tags: list[dict[str, str]], min_tags
             tag_lines.append(f"- {name}")
 
     tag_list = "\n".join(tag_lines)
-
-    constraint_parts = []
-    if min_tags > 0:
-        constraint_parts.append(f"at least {min_tags}")
-    if max_tags is not None:
-        constraint_parts.append(f"at most {max_tags}")
 
     if constraint_parts:
         constraint = f"Select {' and '.join(constraint_parts)} tags."
@@ -203,7 +250,9 @@ async def execute_tagger_activity(inputs: ExecuteTaggerInputs) -> dict[str, Any]
         raise ApplicationError("Missing prompt in tagger_config", non_retryable=True)
 
     tags = tagger_config.get("tags", [])
-    if not tags:
+    dynamic_tags = tagger_config.get("dynamic_tags", False)
+    tags_url = tagger_config.get("tags_url")
+    if not dynamic_tags and not tags:
         raise ApplicationError("No tags defined in tagger_config", non_retryable=True)
 
     min_tags = tagger_config.get("min_tags", 0)
@@ -278,9 +327,9 @@ async def execute_tagger_activity(inputs: ExecuteTaggerInputs) -> dict[str, Any]
     input_data = extract_text_from_messages(input_raw)
     output_data = extract_text_from_messages(output_raw)
 
-    system_prompt = build_tagger_system_prompt(prompt, tags, min_tags, max_tags)
+    system_prompt = build_tagger_system_prompt(prompt, tags, min_tags, max_tags, dynamic_tags, tags_url)
     tag_names = [tag["name"] for tag in tags]
-    response_format = build_tag_result_schema(tag_names, min_tags, max_tags)
+    response_format = build_tag_result_schema(tag_names, min_tags, max_tags, dynamic_tags)
 
     user_prompt = f"""Input: {input_data}
 
@@ -356,9 +405,14 @@ Output: {output_data}"""
     if not isinstance(result, TagResult):
         raise TypeError(f"Expected TagResult, got {type(result).__name__} for tagger {tagger['id']}")
 
-    # Validate tags — strip any not in the configured set
-    valid_tag_names = {tag["name"] for tag in tags}
-    validated_tags = [t for t in result.tags if t in valid_tag_names]
+    if dynamic_tags:
+        # In dynamic mode the LLM defines its own category names — keep whatever non-empty
+        # strings it returned. Normalize whitespace so downstream aggregations are stable.
+        validated_tags = [t.strip() for t in result.tags if isinstance(t, str) and t.strip()]
+    else:
+        # Validate tags — strip any not in the configured set
+        valid_tag_names = {tag["name"] for tag in tags}
+        validated_tags = [t for t in result.tags if t in valid_tag_names]
 
     # Enforce min/max constraints
     if max_tags is not None:

--- a/posthog/temporal/llm_analytics/test_run_tagger.py
+++ b/posthog/temporal/llm_analytics/test_run_tagger.py
@@ -725,6 +725,40 @@ class TestBuildTagResultSchema:
         for needle in forbidden_substrings:
             assert needle not in description
 
+    def test_dynamic_tags_schema_omits_static_allowlist(self):
+        schema = build_tag_result_schema([], min_tags=0, max_tags=None, dynamic_tags=True)
+        description = schema.model_fields["tags"].description or ""
+        assert "Valid values:" not in description
+        assert "defined by you" in description
+
+
+class TestBuildTaggerSystemPromptDynamic:
+    def test_dynamic_prompt_omits_available_tags_section(self):
+        prompt = build_tagger_system_prompt(
+            "Route this to the right team.",
+            [],
+            0,
+            None,
+            dynamic_tags=True,
+            tags_url=None,
+        )
+        assert "Available tags:" not in prompt
+        assert "determine the appropriate tag categories yourself" in prompt
+        assert "Route this to the right team." in prompt
+
+    def test_dynamic_prompt_includes_reference_url(self):
+        prompt = build_tagger_system_prompt(
+            "Tag by owner.",
+            [],
+            1,
+            3,
+            dynamic_tags=True,
+            tags_url="https://posthog.com/handbook/engineering/feature-ownership",
+        )
+        assert "https://posthog.com/handbook/engineering/feature-ownership" in prompt
+        assert "at least 1" in prompt
+        assert "at most 3" in prompt
+
 
 class TestFetchTaggerActivityDisabled:
     @pytest.mark.asyncio

--- a/posthog/temporal/llm_analytics/test_run_tagger.py
+++ b/posthog/temporal/llm_analytics/test_run_tagger.py
@@ -13,12 +13,14 @@ from posthog.models import Organization, Team
 from products.llm_analytics.backend.models.taggers import Tagger
 
 from .run_tagger import (
+    GENERIC_EVENT_CONTEXT_MAX_LEN,
     EmitTaggerEventInputs,
     ExecuteTaggerInputs,
     RunTaggerInputs,
     RunTaggerWorkflow,
     TagResult,
     build_tag_result_schema,
+    build_tagger_event_context,
     build_tagger_system_prompt,
     disable_tagger_activity,
     emit_tagger_event_activity,
@@ -758,6 +760,45 @@ class TestBuildTaggerSystemPromptDynamic:
         assert "https://posthog.com/handbook/engineering/feature-ownership" in prompt
         assert "at least 1" in prompt
         assert "at most 3" in prompt
+
+
+class TestBuildTaggerEventContext:
+    def test_includes_event_name_and_properties_when_no_keys_selected(self):
+        ctx = build_tagger_event_context(
+            "support_message_received",
+            {"subject": "Billing issue", "body": "I was charged twice", "$current_url": "/billing"},
+            target_property_keys=[],
+        )
+        assert "Event: support_message_received" in ctx
+        assert "Billing issue" in ctx
+        assert "I was charged twice" in ctx
+        assert "/billing" in ctx
+
+    def test_property_keys_filter_to_listed_only(self):
+        ctx = build_tagger_event_context(
+            "support_message_received",
+            {"subject": "Billing issue", "body": "redacted", "internal_id": "abc-123"},
+            target_property_keys=["subject", "body"],
+        )
+        assert "Billing issue" in ctx
+        assert "redacted" in ctx
+        assert "abc-123" not in ctx
+
+    def test_missing_keys_are_silently_skipped(self):
+        ctx = build_tagger_event_context(
+            "support_message_received",
+            {"subject": "ok"},
+            target_property_keys=["subject", "missing_key"],
+        )
+        # The missing key shouldn't show up at all rather than producing "missing_key": null.
+        assert '"missing_key"' not in ctx
+        assert '"subject": "ok"' in ctx
+
+    def test_truncates_oversized_payload(self):
+        huge = "x" * (GENERIC_EVENT_CONTEXT_MAX_LEN * 2)
+        ctx = build_tagger_event_context("e", {"body": huge}, target_property_keys=[])
+        assert len(ctx) <= GENERIC_EVENT_CONTEXT_MAX_LEN + 200
+        assert "truncated" in ctx
 
 
 class TestFetchTaggerActivityDisabled:

--- a/products/llm_analytics/backend/api/taggers.py
+++ b/products/llm_analytics/backend/api/taggers.py
@@ -65,27 +65,50 @@ class TaggerConditionSerializer(serializers.Serializer):
 
 class LLMTaggerConfigSerializer(serializers.Serializer):
     prompt = serializers.CharField(min_length=1, help_text="Prompt instructing the LLM how to tag generations")
-    tags = TagDefinitionSerializer(many=True, help_text="Available tags the LLM can assign")
+    tags = TagDefinitionSerializer(
+        many=True,
+        required=False,
+        default=list,
+        help_text="Available tags the LLM can assign. Ignored when dynamic_tags is true.",
+    )
     min_tags = serializers.IntegerField(default=0, min_value=0, help_text="Minimum number of tags to apply")
     max_tags = serializers.IntegerField(
         required=False, allow_null=True, min_value=1, help_text="Maximum number of tags to apply (null = no limit)"
     )
+    dynamic_tags = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text=(
+            "When true, the LLM defines the output tag categories itself based on the prompt and optional reference URL. "
+            "The static `tags` list is ignored in this mode."
+        ),
+    )
+    tags_url = serializers.URLField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        max_length=2000,
+        help_text="Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true.",
+    )
 
     def validate_tags(self, value: list[dict]) -> list[dict]:
-        if not value:
-            raise serializers.ValidationError("At least one tag is required")
         names = [tag["name"] for tag in value]
         if len(names) != len(set(names)):
             raise serializers.ValidationError("Tag names must be unique")
         return value
 
     def validate(self, data: dict) -> dict:
+        dynamic_tags = data.get("dynamic_tags", False)
+        tags = data.get("tags", [])
+        if not dynamic_tags and not tags:
+            raise serializers.ValidationError({"tags": "At least one tag is required when dynamic_tags is false"})
         min_tags = data.get("min_tags", 0)
         max_tags = data.get("max_tags")
         if max_tags is not None and min_tags > max_tags:
             raise serializers.ValidationError({"min_tags": "min_tags cannot be greater than max_tags"})
-        tags = data.get("tags", [])
-        if max_tags is not None and max_tags > len(tags):
+        # When dynamic_tags is on, the LLM may invent any number of categories so we can't bound
+        # max_tags by the static list length.
+        if not dynamic_tags and max_tags is not None and max_tags > len(tags):
             raise serializers.ValidationError({"max_tags": "max_tags cannot exceed the number of defined tags"})
         return data
 

--- a/products/llm_analytics/backend/api/taggers.py
+++ b/products/llm_analytics/backend/api/taggers.py
@@ -90,6 +90,26 @@ class LLMTaggerConfigSerializer(serializers.Serializer):
         max_length=2000,
         help_text="Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true.",
     )
+    target_event_types = serializers.ListField(
+        child=serializers.CharField(max_length=200),
+        required=False,
+        allow_null=True,
+        max_length=20,
+        help_text=(
+            "Event names this tagger should run on. Defaults to ['$ai_generation'] when null. "
+            "Dispatch-side support for non-$ai_generation events is a separate change — see PR notes."
+        ),
+    )
+    target_property_keys = serializers.ListField(
+        child=serializers.CharField(max_length=200),
+        required=False,
+        default=list,
+        max_length=50,
+        help_text=(
+            "Event property keys to surface to the LLM. Empty list = include all top-level properties "
+            "(truncated to a size budget). Only used when target_event_types includes events other than $ai_generation."
+        ),
+    )
 
     def validate_tags(self, value: list[dict]) -> list[dict]:
         names = [tag["name"] for tag in value]

--- a/products/llm_analytics/backend/api/test/test_taggers.py
+++ b/products/llm_analytics/backend/api/test/test_taggers.py
@@ -337,6 +337,59 @@ class TestTaggersApi(APIBaseTest):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_can_create_tagger_with_dynamic_tags(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/taggers/",
+            {
+                "name": "Support ticket router",
+                "enabled": True,
+                "tagger_config": {
+                    "prompt": "Tag the conversation with the responsible team.",
+                    "tags": [],
+                    "dynamic_tags": True,
+                    "tags_url": "https://posthog.com/handbook/engineering/feature-ownership",
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        tagger = Tagger.objects.first()
+        assert tagger is not None
+        assert tagger.tagger_config["dynamic_tags"] is True
+        assert tagger.tagger_config["tags_url"] == "https://posthog.com/handbook/engineering/feature-ownership"
+        assert tagger.tagger_config["tags"] == []
+
+    def test_dynamic_tags_allows_unbounded_max_tags(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/taggers/",
+            {
+                "name": "Dynamic tagger",
+                "tagger_config": {
+                    "prompt": "Tag this.",
+                    "tags": [],
+                    "dynamic_tags": True,
+                    "max_tags": 25,
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    def test_non_dynamic_tagger_still_requires_tags(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/taggers/",
+            {
+                "name": "Static tagger",
+                "tagger_config": {
+                    "prompt": "Tag this.",
+                    "tags": [],
+                    "dynamic_tags": False,
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
     def test_patch_tagger_type_without_fresh_config_is_rejected(self):
         tagger = Tagger.objects.create(
             name="LLM tagger",

--- a/products/llm_analytics/backend/api/test/test_taggers.py
+++ b/products/llm_analytics/backend/api/test/test_taggers.py
@@ -375,6 +375,26 @@ class TestTaggersApi(APIBaseTest):
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
 
+    def test_tagger_persists_target_event_types_and_property_keys(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/taggers/",
+            {
+                "name": "Support router",
+                "tagger_config": {
+                    "prompt": "Tag the message.",
+                    "tags": [{"name": "billing"}, {"name": "auth"}],
+                    "target_event_types": ["support_message_received", "$ai_generation"],
+                    "target_property_keys": ["subject", "body"],
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        tagger = Tagger.objects.first()
+        assert tagger is not None
+        assert tagger.tagger_config["target_event_types"] == ["support_message_received", "$ai_generation"]
+        assert tagger.tagger_config["target_property_keys"] == ["subject", "body"]
+
     def test_non_dynamic_tagger_still_requires_tags(self):
         response = self.client.post(
             f"/api/environments/{self.team.id}/taggers/",

--- a/products/llm_analytics/backend/models/taggers.py
+++ b/products/llm_analytics/backend/models/taggers.py
@@ -36,9 +36,18 @@ class LLMTaggerConfig(BaseModel):
     """Configuration for LLM-based taggers."""
 
     prompt: str = Field(..., min_length=1, description="Prompt instructing the LLM how to tag generations")
-    tags: list[TagDefinition] = Field(..., min_length=1, description="Available tags")
+    tags: list[TagDefinition] = Field(default_factory=list, description="Available tags")
     min_tags: int = Field(default=0, ge=0, description="Minimum tags to apply")
     max_tags: int | None = Field(default=None, ge=1, description="Maximum tags to apply (null = no limit)")
+    dynamic_tags: bool = Field(
+        default=False,
+        description="When true, the LLM defines the output tag categories itself based on the prompt and optional reference URL — `tags` is ignored",
+    )
+    tags_url: str | None = Field(
+        default=None,
+        max_length=2000,
+        description="Optional reference URL that is surfaced to the LLM alongside the prompt when dynamic_tags is true",
+    )
 
     @field_validator("prompt")
     @classmethod
@@ -46,6 +55,18 @@ class LLMTaggerConfig(BaseModel):
         if not v or not v.strip():
             raise ValueError("Prompt cannot be empty")
         return v.strip()
+
+    @field_validator("tags_url")
+    @classmethod
+    def validate_tags_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip()
+        if not v:
+            return None
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError("tags_url must start with http:// or https://")
+        return v
 
     @field_validator("tags")
     @classmethod
@@ -57,10 +78,15 @@ class LLMTaggerConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_tag_count_bounds(self) -> "LLMTaggerConfig":
+        if not self.dynamic_tags and len(self.tags) == 0:
+            # When not in dynamic mode, the LLM picks from a fixed list, so we still require at least one tag.
+            raise ValueError("At least one tag is required when dynamic_tags is false")
         if self.max_tags is not None:
             if self.min_tags > self.max_tags:
                 raise ValueError("min_tags cannot be greater than max_tags")
-            if self.max_tags > len(self.tags):
+            # max_tags can't exceed the static tag list when not in dynamic mode; in dynamic mode the
+            # LLM is free to invent any number of categories so the upper-bound check doesn't apply.
+            if not self.dynamic_tags and self.max_tags > len(self.tags):
                 raise ValueError("max_tags cannot exceed the number of defined tags")
         return self
 

--- a/products/llm_analytics/backend/models/taggers.py
+++ b/products/llm_analytics/backend/models/taggers.py
@@ -48,6 +48,24 @@ class LLMTaggerConfig(BaseModel):
         max_length=2000,
         description="Optional reference URL that is surfaced to the LLM alongside the prompt when dynamic_tags is true",
     )
+    target_event_types: list[str] | None = Field(
+        default=None,
+        description=(
+            "Event names this tagger should run on (e.g. ['$ai_generation', 'support_message']). "
+            "When null, only $ai_generation is targeted (legacy default) and the LLM context is built from "
+            "$ai_input / $ai_output_choices. Dispatch-side filtering broadens beyond $ai_generation is a "
+            "separate change — until then, only $ai_generation actually reaches the tagger."
+        ),
+    )
+    target_property_keys: list[str] = Field(
+        default_factory=list,
+        max_length=50,
+        description=(
+            "Top-level event property keys to surface to the LLM. When empty and target_event_types includes "
+            "anything other than $ai_generation, all top-level properties are included up to a size budget. "
+            "Ignored for the legacy $ai_generation-only path."
+        ),
+    )
 
     @field_validator("prompt")
     @classmethod
@@ -75,6 +93,28 @@ class LLMTaggerConfig(BaseModel):
         if len(names) != len(set(names)):
             raise ValueError("Tag names must be unique")
         return v
+
+    @field_validator("target_event_types")
+    @classmethod
+    def validate_target_event_types(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        cleaned = [s.strip() for s in v if s and s.strip()]
+        if not cleaned:
+            # An empty list after stripping is ambiguous — collapse to the legacy default
+            # so downstream code only has one "no targeting configured" state.
+            return None
+        if len(cleaned) != len(set(cleaned)):
+            raise ValueError("target_event_types must be unique")
+        return cleaned
+
+    @field_validator("target_property_keys")
+    @classmethod
+    def validate_target_property_keys(cls, v: list[str]) -> list[str]:
+        cleaned = [s.strip() for s in v if s and s.strip()]
+        if len(cleaned) != len(set(cleaned)):
+            raise ValueError("target_property_keys must be unique")
+        return cleaned
 
     @model_validator(mode="after")
     def validate_tag_count_bounds(self) -> "LLMTaggerConfig":

--- a/products/llm_analytics/backend/models/test/test_taggers.py
+++ b/products/llm_analytics/backend/models/test/test_taggers.py
@@ -79,6 +79,44 @@ class TestLLMTaggerConfig(BaseTest):
         )
         assert config.max_tags is None
 
+    def test_dynamic_tags_allows_empty_tag_list(self):
+        config = LLMTaggerConfig(
+            prompt="Tag support tickets by feature owner.",
+            tags=[],
+            dynamic_tags=True,
+            tags_url="https://posthog.com/handbook/engineering/feature-ownership",
+        )
+        assert config.dynamic_tags is True
+        assert config.tags == []
+        assert config.tags_url == "https://posthog.com/handbook/engineering/feature-ownership"
+
+    def test_dynamic_tags_skips_max_tags_upper_bound_check(self):
+        config = LLMTaggerConfig(
+            prompt="Test",
+            tags=[],
+            dynamic_tags=True,
+            max_tags=10,
+        )
+        assert config.max_tags == 10
+
+    def test_tags_url_requires_scheme(self):
+        with self.assertRaises(Exception):
+            LLMTaggerConfig(
+                prompt="Test",
+                tags=[],
+                dynamic_tags=True,
+                tags_url="example.com/no-scheme",
+            )
+
+    def test_tags_url_blank_string_normalised_to_none(self):
+        config = LLMTaggerConfig(
+            prompt="Test",
+            tags=[],
+            dynamic_tags=True,
+            tags_url="   ",
+        )
+        assert config.tags_url is None
+
 
 class TestTaggerModel(BaseTest):
     def _make_tagger_config(self, **overrides):

--- a/products/llm_analytics/backend/models/test/test_taggers.py
+++ b/products/llm_analytics/backend/models/test/test_taggers.py
@@ -117,6 +117,39 @@ class TestLLMTaggerConfig(BaseTest):
         )
         assert config.tags_url is None
 
+    def test_target_event_types_strips_and_dedupes(self):
+        config = LLMTaggerConfig(
+            prompt="Test",
+            tags=[TagDefinition(name="a")],
+            target_event_types=[" $ai_generation ", "support_message", ""],
+        )
+        assert config.target_event_types == ["$ai_generation", "support_message"]
+
+    def test_target_event_types_empty_list_becomes_none(self):
+        config = LLMTaggerConfig(
+            prompt="Test",
+            tags=[TagDefinition(name="a")],
+            target_event_types=["", "   "],
+        )
+        # Empty after stripping collapses to None so we only have one "no targeting" sentinel.
+        assert config.target_event_types is None
+
+    def test_target_event_types_rejects_duplicates(self):
+        with self.assertRaises(Exception):
+            LLMTaggerConfig(
+                prompt="Test",
+                tags=[TagDefinition(name="a")],
+                target_event_types=["foo", "foo"],
+            )
+
+    def test_target_property_keys_strips_and_dedupes(self):
+        config = LLMTaggerConfig(
+            prompt="Test",
+            tags=[TagDefinition(name="a")],
+            target_property_keys=["  message ", "subject", ""],
+        )
+        assert config.target_property_keys == ["message", "subject"]
+
 
 class TestTaggerModel(BaseTest):
     def _make_tagger_config(self, **overrides):

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -2047,8 +2047,8 @@ export interface LLMTaggerConfigApi {
      * @minLength 1
      */
     prompt: string
-    /** Available tags the LLM can assign */
-    tags: TagDefinitionApi[]
+    /** Available tags the LLM can assign. Ignored when dynamic_tags is true. */
+    tags?: TagDefinitionApi[]
     /**
      * Minimum number of tags to apply
      * @minimum 0
@@ -2060,6 +2060,14 @@ export interface LLMTaggerConfigApi {
      * @nullable
      */
     max_tags?: number | null
+    /** When true, the LLM defines the output tag categories itself based on the prompt and optional reference URL. The static `tags` list is ignored in this mode. */
+    dynamic_tags?: boolean
+    /**
+     * Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true.
+     * @maxLength 2000
+     * @nullable
+     */
+    tags_url?: string | null
 }
 
 export interface HogTaggerConfigApi {

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -2068,6 +2068,17 @@ export interface LLMTaggerConfigApi {
      * @nullable
      */
     tags_url?: string | null
+    /**
+     * Event names this tagger should run on. Defaults to ['$ai_generation'] when null. Dispatch-side support for non-$ai_generation events is a separate change — see PR notes.
+     * @maxItems 20
+     * @nullable
+     */
+    target_event_types?: string[] | null
+    /**
+     * Event property keys to surface to the LLM. Empty list = include all top-level properties (truncated to a size budget). Only used when target_event_types includes events other than $ai_generation.
+     * @maxItems 50
+     */
+    target_property_keys?: string[]
 }
 
 export interface HogTaggerConfigApi {

--- a/products/llm_analytics/frontend/generated/api.zod.ts
+++ b/products/llm_analytics/frontend/generated/api.zod.ts
@@ -1727,6 +1727,14 @@ export const taggersCreateBodyTaggerConfigOneOneMinTagsMin = 0
 export const taggersCreateBodyTaggerConfigOneOneDynamicTagsDefault = false
 export const taggersCreateBodyTaggerConfigOneOneTagsUrlMax = 2000
 
+export const taggersCreateBodyTaggerConfigOneOneTargetEventTypesItemMax = 200
+
+export const taggersCreateBodyTaggerConfigOneOneTargetEventTypesMax = 20
+
+export const taggersCreateBodyTaggerConfigOneOneTargetPropertyKeysItemMax = 200
+
+export const taggersCreateBodyTaggerConfigOneOneTargetPropertyKeysMax = 50
+
 export const taggersCreateBodyTaggerConfigOneTwoTagsItemNameMax = 100
 
 export const taggersCreateBodyTaggerConfigOneTwoTagsItemDescriptionDefault = ``
@@ -1786,6 +1794,20 @@ export const TaggersCreateBody = /* @__PURE__ */ zod.object({
                     .nullish()
                     .describe(
                         'Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true.'
+                    ),
+                target_event_types: zod
+                    .array(zod.string().max(taggersCreateBodyTaggerConfigOneOneTargetEventTypesItemMax))
+                    .max(taggersCreateBodyTaggerConfigOneOneTargetEventTypesMax)
+                    .nullish()
+                    .describe(
+                        "Event names this tagger should run on. Defaults to ['$ai_generation'] when null. Dispatch-side support for non-$ai_generation events is a separate change — see PR notes."
+                    ),
+                target_property_keys: zod
+                    .array(zod.string().max(taggersCreateBodyTaggerConfigOneOneTargetPropertyKeysItemMax))
+                    .max(taggersCreateBodyTaggerConfigOneOneTargetPropertyKeysMax)
+                    .optional()
+                    .describe(
+                        'Event property keys to surface to the LLM. Empty list = include all top-level properties (truncated to a size budget). Only used when target_event_types includes events other than $ai_generation.'
                     ),
             }),
             zod.object({

--- a/products/llm_analytics/frontend/generated/api.zod.ts
+++ b/products/llm_analytics/frontend/generated/api.zod.ts
@@ -1724,6 +1724,9 @@ export const taggersCreateBodyTaggerConfigOneOneTagsItemDescriptionMax = 500
 export const taggersCreateBodyTaggerConfigOneOneMinTagsDefault = 0
 export const taggersCreateBodyTaggerConfigOneOneMinTagsMin = 0
 
+export const taggersCreateBodyTaggerConfigOneOneDynamicTagsDefault = false
+export const taggersCreateBodyTaggerConfigOneOneTagsUrlMax = 2000
+
 export const taggersCreateBodyTaggerConfigOneTwoTagsItemNameMax = 100
 
 export const taggersCreateBodyTaggerConfigOneTwoTagsItemDescriptionDefault = ``
@@ -1763,13 +1766,27 @@ export const TaggersCreateBody = /* @__PURE__ */ zod.object({
                                 .describe('Description to help the LLM classify'),
                         })
                     )
-                    .describe('Available tags the LLM can assign'),
+                    .optional()
+                    .describe('Available tags the LLM can assign. Ignored when dynamic_tags is true.'),
                 min_tags: zod
                     .number()
                     .min(taggersCreateBodyTaggerConfigOneOneMinTagsMin)
                     .default(taggersCreateBodyTaggerConfigOneOneMinTagsDefault)
                     .describe('Minimum number of tags to apply'),
                 max_tags: zod.number().min(1).nullish().describe('Maximum number of tags to apply (null = no limit)'),
+                dynamic_tags: zod
+                    .boolean()
+                    .default(taggersCreateBodyTaggerConfigOneOneDynamicTagsDefault)
+                    .describe(
+                        'When true, the LLM defines the output tag categories itself based on the prompt and optional reference URL. The static `tags` list is ignored in this mode.'
+                    ),
+                tags_url: zod
+                    .url()
+                    .max(taggersCreateBodyTaggerConfigOneOneTagsUrlMax)
+                    .nullish()
+                    .describe(
+                        'Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true.'
+                    ),
             }),
             zod.object({
                 source: zod.string().min(1).describe('Hog source code to classify a generation into tags.'),

--- a/products/llm_analytics/frontend/tags/LLMAnalyticsTag.tsx
+++ b/products/llm_analytics/frontend/tags/LLMAnalyticsTag.tsx
@@ -620,6 +620,74 @@ function LLMAnalyticsTaggerForm({ id }: { id: string }): JSX.Element {
                                         />
                                     </div>
                                 </div>
+
+                                <div className="bg-bg-light border rounded p-3 space-y-2">
+                                    <label className="font-semibold text-sm">
+                                        Target events <span className="text-muted font-normal">(advanced)</span>
+                                    </label>
+                                    <p className="text-muted text-xs m-0">
+                                        Comma-separated event names this tagger should classify. Leave empty for the
+                                        default ($ai_generation only). Other event types are accepted by the API for
+                                        forward compatibility, but the dispatcher currently only forwards $ai_generation
+                                        — broader dispatch is a follow-up.
+                                    </p>
+                                    <LemonInput
+                                        placeholder="$ai_generation, support_message_received"
+                                        value={
+                                            ('target_event_types' in taggerForm.tagger_config &&
+                                                taggerForm.tagger_config.target_event_types?.join(', ')) ||
+                                            ''
+                                        }
+                                        onChange={(value) => {
+                                            const trimmed = value.trim()
+                                            const list = trimmed
+                                                ? trimmed
+                                                      .split(',')
+                                                      .map((s) => s.trim())
+                                                      .filter(Boolean)
+                                                : null
+                                            setTaggerFormValues({
+                                                tagger_config: {
+                                                    ...taggerForm.tagger_config,
+                                                    target_event_types: list,
+                                                },
+                                            })
+                                        }}
+                                        size="small"
+                                    />
+
+                                    <label className="font-semibold text-sm pt-2 block">Property keys to include</label>
+                                    <p className="text-muted text-xs m-0">
+                                        Comma-separated property keys to show the LLM (e.g. <code>message</code>,{' '}
+                                        <code>subject</code>, <code>$current_url</code>). Leave empty to include all
+                                        top-level properties (truncated to ~8KB). Only applies when target events go
+                                        beyond $ai_generation.
+                                    </p>
+                                    <LemonInput
+                                        placeholder="message, subject, $current_url"
+                                        value={
+                                            ('target_property_keys' in taggerForm.tagger_config &&
+                                                taggerForm.tagger_config.target_property_keys?.join(', ')) ||
+                                            ''
+                                        }
+                                        onChange={(value) => {
+                                            const trimmed = value.trim()
+                                            const list = trimmed
+                                                ? trimmed
+                                                      .split(',')
+                                                      .map((s) => s.trim())
+                                                      .filter(Boolean)
+                                                : []
+                                            setTaggerFormValues({
+                                                tagger_config: {
+                                                    ...taggerForm.tagger_config,
+                                                    target_property_keys: list,
+                                                },
+                                            })
+                                        }}
+                                        size="small"
+                                    />
+                                </div>
                             </div>
                         )}
                     </div>

--- a/products/llm_analytics/frontend/tags/LLMAnalyticsTag.tsx
+++ b/products/llm_analytics/frontend/tags/LLMAnalyticsTag.tsx
@@ -513,54 +513,112 @@ function LLMAnalyticsTaggerForm({ id }: { id: string }): JSX.Element {
                             </div>
                         )}
 
-                        {taggerForm.tagger_type !== 'hog' && <TagDefinitionsEditor id={id} />}
-
                         {taggerForm.tagger_type !== 'hog' && (
-                            <div className="flex gap-4">
-                                <div>
-                                    <label className="font-semibold">Min tags</label>
-                                    <LemonInput
-                                        type="number"
-                                        min={0}
-                                        value={
-                                            'min_tags' in taggerForm.tagger_config
-                                                ? taggerForm.tagger_config.min_tags
-                                                : 0
+                            <div className="space-y-3">
+                                <div className="bg-bg-light border rounded p-3 space-y-2">
+                                    <LemonSwitch
+                                        checked={
+                                            'dynamic_tags' in taggerForm.tagger_config
+                                                ? !!taggerForm.tagger_config.dynamic_tags
+                                                : false
                                         }
-                                        onChange={(value) =>
+                                        onChange={(checked) =>
                                             setTaggerFormValues({
                                                 tagger_config: {
                                                     ...taggerForm.tagger_config,
-                                                    min_tags: value ?? 0,
+                                                    dynamic_tags: checked,
                                                 },
                                             })
                                         }
-                                        size="small"
-                                        className="w-24"
+                                        label="Let the LLM define tag categories"
                                     />
+                                    <p className="text-muted text-sm m-0">
+                                        Skip defining tags upfront — the LLM picks category names based on the prompt
+                                        and an optional reference URL. Useful when the set of categories is large or
+                                        evolves over time (e.g. routing support tickets to feature owners).
+                                    </p>
+                                    {'dynamic_tags' in taggerForm.tagger_config &&
+                                        taggerForm.tagger_config.dynamic_tags && (
+                                            <div className="pt-2 space-y-1">
+                                                <label className="font-semibold text-sm">
+                                                    Reference URL (optional)
+                                                </label>
+                                                <LemonInput
+                                                    placeholder="https://posthog.com/handbook/engineering/feature-ownership"
+                                                    value={
+                                                        ('tags_url' in taggerForm.tagger_config &&
+                                                            taggerForm.tagger_config.tags_url) ||
+                                                        ''
+                                                    }
+                                                    onChange={(value) =>
+                                                        setTaggerFormValues({
+                                                            tagger_config: {
+                                                                ...taggerForm.tagger_config,
+                                                                tags_url: value || null,
+                                                            },
+                                                        })
+                                                    }
+                                                    size="small"
+                                                />
+                                                <p className="text-muted text-xs m-0">
+                                                    Surfaced to the LLM alongside the prompt. Reference it from the
+                                                    prompt to anchor categories (e.g. "use the team names from this
+                                                    URL").
+                                                </p>
+                                            </div>
+                                        )}
                                 </div>
-                                <div>
-                                    <label className="font-semibold">Max tags</label>
-                                    <LemonInput
-                                        type="number"
-                                        min={1}
-                                        value={
-                                            'max_tags' in taggerForm.tagger_config
-                                                ? (taggerForm.tagger_config.max_tags ?? undefined)
-                                                : undefined
-                                        }
-                                        onChange={(value) =>
-                                            setTaggerFormValues({
-                                                tagger_config: {
-                                                    ...taggerForm.tagger_config,
-                                                    max_tags: value ?? null,
-                                                },
-                                            })
-                                        }
-                                        size="small"
-                                        className="w-24"
-                                        placeholder="No limit"
-                                    />
+
+                                {!(
+                                    'dynamic_tags' in taggerForm.tagger_config && taggerForm.tagger_config.dynamic_tags
+                                ) && <TagDefinitionsEditor id={id} />}
+
+                                <div className="flex gap-4">
+                                    <div>
+                                        <label className="font-semibold">Min tags</label>
+                                        <LemonInput
+                                            type="number"
+                                            min={0}
+                                            value={
+                                                'min_tags' in taggerForm.tagger_config
+                                                    ? taggerForm.tagger_config.min_tags
+                                                    : 0
+                                            }
+                                            onChange={(value) =>
+                                                setTaggerFormValues({
+                                                    tagger_config: {
+                                                        ...taggerForm.tagger_config,
+                                                        min_tags: value ?? 0,
+                                                    },
+                                                })
+                                            }
+                                            size="small"
+                                            className="w-24"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="font-semibold">Max tags</label>
+                                        <LemonInput
+                                            type="number"
+                                            min={1}
+                                            value={
+                                                'max_tags' in taggerForm.tagger_config
+                                                    ? (taggerForm.tagger_config.max_tags ?? undefined)
+                                                    : undefined
+                                            }
+                                            onChange={(value) =>
+                                                setTaggerFormValues({
+                                                    tagger_config: {
+                                                        ...taggerForm.tagger_config,
+                                                        max_tags: value ?? null,
+                                                    },
+                                                })
+                                            }
+                                            size="small"
+                                            className="w-24"
+                                            placeholder="No limit"
+                                        />
+                                    </div>
                                 </div>
                             </div>
                         )}

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
@@ -56,6 +56,8 @@ const DEFAULT_TAGGER_CONFIG: TaggerConfig = {
     max_tags: null,
     dynamic_tags: false,
     tags_url: null,
+    target_event_types: null,
+    target_property_keys: [],
 }
 
 const DEFAULT_CONDITION: TaggerConditionSet = {

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
@@ -54,6 +54,8 @@ const DEFAULT_TAGGER_CONFIG: TaggerConfig = {
     tags: [{ name: '', description: '' }],
     min_tags: 0,
     max_tags: null,
+    dynamic_tags: false,
+    tags_url: null,
 }
 
 const DEFAULT_CONDITION: TaggerConditionSet = {
@@ -250,14 +252,18 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
                               // tags with no error. Synthesize a single-entry error for the
                               // empty-tags case so the form stays invalid (the UI guardrail
                               // blocks reaching this state, but a programmatic removeTag could).
+                              // Skip tag-list validation entirely when dynamic_tags is on — the LLM
+                              // defines the categories itself, so the user shouldn't need to author any.
                               tags:
-                                  values.tagger_config.tags.length === 0
-                                      ? [{ name: 'At least one tag is required' }]
-                                      : values.tagger_config.tags.some((t) => !t.name.trim())
-                                        ? values.tagger_config.tags.map((t) =>
-                                              !t.name.trim() ? { name: 'All tags must have a name' } : {}
-                                          )
-                                        : undefined,
+                                  'dynamic_tags' in values.tagger_config && values.tagger_config.dynamic_tags
+                                      ? undefined
+                                      : values.tagger_config.tags.length === 0
+                                        ? [{ name: 'At least one tag is required' }]
+                                        : values.tagger_config.tags.some((t) => !t.name.trim())
+                                          ? values.tagger_config.tags.map((t) =>
+                                                !t.name.trim() ? { name: 'All tags must have a name' } : {}
+                                            )
+                                          : undefined,
                           },
             }),
             submit: async (values: TaggerForm) => {

--- a/products/llm_analytics/frontend/tags/types.ts
+++ b/products/llm_analytics/frontend/tags/types.ts
@@ -40,6 +40,13 @@ export interface LLMTaggerConfig {
     tags: TagDefinition[]
     min_tags: number
     max_tags: number | null
+    /**
+     * When true, the LLM defines the output tag categories itself based on the prompt and
+     * optional reference URL. The static `tags` list is ignored in this mode.
+     */
+    dynamic_tags?: boolean
+    /** Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true. */
+    tags_url?: string | null
 }
 
 export interface HogTaggerConfig {

--- a/products/llm_analytics/frontend/tags/types.ts
+++ b/products/llm_analytics/frontend/tags/types.ts
@@ -47,6 +47,16 @@ export interface LLMTaggerConfig {
     dynamic_tags?: boolean
     /** Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true. */
     tags_url?: string | null
+    /**
+     * Event names this tagger should run on. Defaults to `["$ai_generation"]` when null/undefined.
+     * Note: until the evaluation-scheduler is broadened, only `$ai_generation` is actually dispatched.
+     */
+    target_event_types?: string[] | null
+    /**
+     * Event property keys to surface to the LLM. Empty = include all top-level properties (truncated
+     * to a size budget). Only used when target_event_types is something other than `$ai_generation`.
+     */
+    target_property_keys?: string[]
 }
 
 export interface HogTaggerConfig {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19629,8 +19629,8 @@ export namespace Schemas {
          * @minLength 1
          */
       prompt: string;
-      /** Available tags the LLM can assign */
-      tags: TagDefinition[];
+      /** Available tags the LLM can assign. Ignored when dynamic_tags is true. */
+      tags?: TagDefinition[];
       /**
          * Minimum number of tags to apply
          * @minimum 0
@@ -19642,6 +19642,14 @@ export namespace Schemas {
          * @nullable
          */
       max_tags?: number | null;
+      /** When true, the LLM defines the output tag categories itself based on the prompt and optional reference URL. The static `tags` list is ignored in this mode. */
+      dynamic_tags?: boolean;
+      /**
+         * Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true.
+         * @maxLength 2000
+         * @nullable
+         */
+      tags_url?: string | null;
     }
 
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19650,6 +19650,17 @@ export namespace Schemas {
          * @nullable
          */
       tags_url?: string | null;
+      /**
+         * Event names this tagger should run on. Defaults to ['$ai_generation'] when null. Dispatch-side support for non-$ai_generation events is a separate change — see PR notes.
+         * @maxItems 20
+         * @nullable
+         */
+      target_event_types?: string[] | null;
+      /**
+         * Event property keys to surface to the LLM. Empty list = include all top-level properties (truncated to a size budget). Only used when target_event_types includes events other than $ai_generation.
+         * @maxItems 50
+         */
+      target_property_keys?: string[];
     }
 
     /**

--- a/services/mcp/src/generated/llm_analytics/api.ts
+++ b/services/mcp/src/generated/llm_analytics/api.ts
@@ -1819,6 +1819,9 @@ export const taggersCreateBodyTaggerConfigOneOneTagsItemDescriptionMax = 500
 export const taggersCreateBodyTaggerConfigOneOneMinTagsDefault = 0
 export const taggersCreateBodyTaggerConfigOneOneMinTagsMin = 0
 
+export const taggersCreateBodyTaggerConfigOneOneDynamicTagsDefault = false
+export const taggersCreateBodyTaggerConfigOneOneTagsUrlMax = 2000
+
 export const taggersCreateBodyTaggerConfigOneTwoTagsItemNameMax = 100
 
 export const taggersCreateBodyTaggerConfigOneTwoTagsItemDescriptionDefault = ``
@@ -1858,13 +1861,27 @@ export const TaggersCreateBody = /* @__PURE__ */ zod.object({
                                 .describe('Description to help the LLM classify'),
                         })
                     )
-                    .describe('Available tags the LLM can assign'),
+                    .optional()
+                    .describe('Available tags the LLM can assign. Ignored when dynamic_tags is true.'),
                 min_tags: zod
                     .number()
                     .min(taggersCreateBodyTaggerConfigOneOneMinTagsMin)
                     .default(taggersCreateBodyTaggerConfigOneOneMinTagsDefault)
                     .describe('Minimum number of tags to apply'),
                 max_tags: zod.number().min(1).nullish().describe('Maximum number of tags to apply (null = no limit)'),
+                dynamic_tags: zod
+                    .boolean()
+                    .default(taggersCreateBodyTaggerConfigOneOneDynamicTagsDefault)
+                    .describe(
+                        'When true, the LLM defines the output tag categories itself based on the prompt and optional reference URL. The static `tags` list is ignored in this mode.'
+                    ),
+                tags_url: zod
+                    .url()
+                    .max(taggersCreateBodyTaggerConfigOneOneTagsUrlMax)
+                    .nullish()
+                    .describe(
+                        'Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true.'
+                    ),
             }),
             zod.object({
                 source: zod.string().min(1).describe('Hog source code to classify a generation into tags.'),

--- a/services/mcp/src/generated/llm_analytics/api.ts
+++ b/services/mcp/src/generated/llm_analytics/api.ts
@@ -1822,6 +1822,14 @@ export const taggersCreateBodyTaggerConfigOneOneMinTagsMin = 0
 export const taggersCreateBodyTaggerConfigOneOneDynamicTagsDefault = false
 export const taggersCreateBodyTaggerConfigOneOneTagsUrlMax = 2000
 
+export const taggersCreateBodyTaggerConfigOneOneTargetEventTypesItemMax = 200
+
+export const taggersCreateBodyTaggerConfigOneOneTargetEventTypesMax = 20
+
+export const taggersCreateBodyTaggerConfigOneOneTargetPropertyKeysItemMax = 200
+
+export const taggersCreateBodyTaggerConfigOneOneTargetPropertyKeysMax = 50
+
 export const taggersCreateBodyTaggerConfigOneTwoTagsItemNameMax = 100
 
 export const taggersCreateBodyTaggerConfigOneTwoTagsItemDescriptionDefault = ``
@@ -1881,6 +1889,20 @@ export const TaggersCreateBody = /* @__PURE__ */ zod.object({
                     .nullish()
                     .describe(
                         'Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true.'
+                    ),
+                target_event_types: zod
+                    .array(zod.string().max(taggersCreateBodyTaggerConfigOneOneTargetEventTypesItemMax))
+                    .max(taggersCreateBodyTaggerConfigOneOneTargetEventTypesMax)
+                    .nullish()
+                    .describe(
+                        "Event names this tagger should run on. Defaults to ['$ai_generation'] when null. Dispatch-side support for non-$ai_generation events is a separate change — see PR notes."
+                    ),
+                target_property_keys: zod
+                    .array(zod.string().max(taggersCreateBodyTaggerConfigOneOneTargetPropertyKeysItemMax))
+                    .max(taggersCreateBodyTaggerConfigOneOneTargetPropertyKeysMax)
+                    .optional()
+                    .describe(
+                        'Event property keys to surface to the LLM. Empty list = include all top-level properties (truncated to a size budget). Only used when target_event_types includes events other than $ai_generation.'
                     ),
             }),
             zod.object({

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/llma-tagger-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/llma-tagger-create.json
@@ -153,6 +153,31 @@
                                 }
                             ],
                             "description": "Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true."
+                        },
+                        "target_event_types": {
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "maxLength": 200,
+                                        "type": "string"
+                                    },
+                                    "maxItems": 20,
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Event names this tagger should run on. Defaults to ['$ai_generation'] when null. Dispatch-side support for non-$ai_generation events is a separate change — see PR notes."
+                        },
+                        "target_property_keys": {
+                            "description": "Event property keys to surface to the LLM. Empty list = include all top-level properties (truncated to a size budget). Only used when target_event_types includes events other than $ai_generation.",
+                            "items": {
+                                "maxLength": 200,
+                                "type": "string"
+                            },
+                            "maxItems": 50,
+                            "type": "array"
                         }
                     },
                     "required": ["prompt"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/llma-tagger-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/llma-tagger-create.json
@@ -92,6 +92,11 @@
             "anyOf": [
                 {
                     "properties": {
+                        "dynamic_tags": {
+                            "default": false,
+                            "description": "When true, the LLM defines the output tag categories itself based on the prompt and optional reference URL. The static `tags` list is ignored in this mode.",
+                            "type": "boolean"
+                        },
                         "max_tags": {
                             "anyOf": [
                                 {
@@ -116,7 +121,7 @@
                             "type": "string"
                         },
                         "tags": {
-                            "description": "Available tags the LLM can assign",
+                            "description": "Available tags the LLM can assign. Ignored when dynamic_tags is true.",
                             "items": {
                                 "properties": {
                                     "description": {
@@ -135,9 +140,22 @@
                                 "type": "object"
                             },
                             "type": "array"
+                        },
+                        "tags_url": {
+                            "anyOf": [
+                                {
+                                    "format": "uri",
+                                    "maxLength": 2000,
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Optional reference URL surfaced to the LLM alongside the prompt when dynamic_tags is true."
                         }
                     },
-                    "required": ["prompt", "tags"],
+                    "required": ["prompt"],
                     "type": "object"
                 },
                 {


### PR DESCRIPTION
## Problem

Today an LLM tagger requires the user to enumerate every output tag upfront. That works when the categories are small and stable, but breaks down when:

- the user wants to route something to a team/owner and the canonical list lives elsewhere (e.g. the feature-ownership handbook page)
- the category space is large or evolves over time
- the user doesn't yet know the right cut of categories and wants the LLM to discover them

This adds an optional toggle that hands tag-category definition over to the LLM itself, while keeping the existing structured-output guarantees on number of tags etc.

## Changes

**Backend**
- `LLMTaggerConfig` gains `dynamic_tags: bool = False` and `tags_url: str | None = None`. When `dynamic_tags=True`, `tags` may be empty and `max_tags` is no longer bounded by the static list length.
- `build_tagger_system_prompt` branches on `dynamic_tags`: omits the static "Available tags" section and instead tells the LLM to derive categories itself, surfacing `tags_url` if provided.
- `build_tag_result_schema` drops the static allowlist from the field description in dynamic mode.
- `execute_tagger_activity` skips post-hoc allowlist filtering when dynamic mode is on — LLM-returned tags are kept (whitespace-normalized).
- Serializer (`LLMTaggerConfigSerializer`) makes `tags` optional and gates the "at least one tag" / "max_tags <= len(tags)" checks behind `dynamic_tags=False`.

**Frontend**
- `LLMTaggerConfig` type extended with `dynamic_tags?: boolean` and `tags_url?: string | null`.
- New form section with a `LemonSwitch` for the toggle and a conditional URL input. When the toggle is on, the static tag editor is hidden and the form-level "at least one tag" validation is bypassed.

**Tests**
- Pydantic-level tests for dynamic mode (empty tags allowed, max_tags upper-bound check skipped, URL scheme enforcement).
- API tests for create-with-dynamic-tags, unbounded `max_tags`, and that non-dynamic taggers still require tags.
- `run_tagger` tests for the dynamic system-prompt + schema description shape.

## How did you test this code?

I'm an agent — no manual UI testing performed. Only the automated tests added in this PR were authored; they were not executed in CI from this run.

## Publish to changelog?

no

## Docs update

No docs changes.

## Agent context

Authored by PostHog Code (Opus). Approach:
- Considered making the dynamic toggle a separate `tagger_type` ("llm_dynamic") but rejected — it would fork the LLM code path and the model_configuration handling for no real isolation benefit. A flag inside `LLMTaggerConfig` keeps the path single and the migration trivial (JSON field).
- Considered enforcing categories as a JSON-schema `enum` in dynamic mode (which would require an extra LLM round-trip to discover them) but rejected — the prompt-driven approach matches what the user asked for and matches how the existing static mode already encodes the allowlist (in the field description, not as JSON-schema enum).
- The reference URL is *not* fetched by the backend — it's surfaced to the LLM as part of the system prompt. Modern frontier models will follow the URL on their own when given an explicit instruction to use it as a source. This avoids adding an outbound fetch path (with the credential/SSRF surface that would imply) and keeps the change local to the tagger config.

Open question separate from this diff: today taggers are hard-coded to run only on `\$ai_generation` events (Kafka consumer filter in `nodejs/src/evaluation-scheduler/evaluation-scheduler.ts`). The dispatcher would need to be loosened — or this capability would need to move to HogFlows — for taggers to run on arbitrary events. Out of scope for this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*