### PR TITLE
fix(data-pipelines): make Name column sortable on destinations list

### DIFF
--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -145,7 +145,7 @@ export function HogFunctionList({
             {
                 title: 'Name',
                 sticky: true,
-                sorter: true,
+                sorter: (a, b) => (a.name ?? '').localeCompare(b.name ?? ''),
                 key: 'name',
                 dataIndex: 'name',
                 render: (_, hogFunction) => {

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -145,7 +145,8 @@ export function HogFunctionList({
             {
                 title: 'Name',
                 sticky: true,
-                sorter: (a, b) => (a.name ?? '').localeCompare(b.name ?? ''),
+                sorter: (a, b) =>
+                    (a.name ?? '').localeCompare(b.name ?? '', undefined, { sensitivity: 'base', numeric: true }),
                 key: 'name',
                 dataIndex: 'name',
                 render: (_, hogFunction) => {


### PR DESCRIPTION
## Problem

The "Sort by Name" column header at `/data-management/destinations` showed a sort arrow and toggled the URL `?order=name` param when clicked, but the rows never reordered. @slshults caught this while working in the data management area.

Root cause was in a shared component, so the same bug existed on `/data-management/transformations` and any other consumer of `HogFunctionList` (messaging, linked hog functions, sources, error tracking alerting). It just *looked* like it worked on transformations because that list often arrived alphabetical from the API — destinations mixes hog function destinations, batch exports, and legacy plugin destinations into one `manualFunctions` list, so the no-op sort was visually obvious.

In `frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx`, the Name column declared `sorter: true`. That value is a sentinel reserved for server-side / manual pagination — `LemonTable` (`frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx`, around the `sortedDataSource` memo) only applies a client-side sort when `typeof sorter === 'function'`. The pre-sort in `hogFunctionsListLogic.tsx` orders by `enabled` status only, never by name, so nothing else was filling the gap.

## Changes

Replaced `sorter: true` with a `localeCompare`-based comparator on the Name column. The comparator uses `{ sensitivity: 'base', numeric: true }` so:

- Case differences don't split otherwise-equal names.
- Numeric suffixes sort intuitively (`Webhook 2` before `Webhook 10`, not `Webhook 10` before `Webhook 2`).

`a.name`/`b.name` are statically typed `string` on `HogFunctionType`, but the `manualFunctions` payload mixes in batch exports and legacy plugin destinations whose runtime shape is looser — the `?? ''` keeps the comparator defensive (mirrors the existing `f.name?.toLowerCase()` pattern in `hogFunctionsListLogic.tsx`).

## How did you test this code?

I'm an agent — manual browser testing was done by @slshults on his local against this branch (he confirmed Name sort now reorders rows on `/data-management/destinations`).

I did not run any automated tests for this change. A grep for the file/component name across `*.test.*` did not surface any tests asserting the previous `sorter: true` behavior, so no existing tests should regress on this one-line behavior change.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Opus 4.7) under @slshults's direction.

- **Tools used**: Explore subagent for codebase discovery, code-reviewer subagent for a second-pass review on the proposed fix.
- **Decisions**:
  - Considered fixing only the destinations-specific data flow, but the column definition lives in the shared `HogFunctionList` and the bug affects every consumer equally — fixing once at the shared component is the right blast radius.
  - Considered plain `localeCompare(b.name)` (no options) for v1; code reviewer flagged numeric/casing edge cases as a non-blocking polish suggestion and @slshults asked to include it before opening the PR, so the final commit layers `{ sensitivity: 'base', numeric: true }` on top.
  - Left the `enabled`-first pre-sort in `hogFunctionsListLogic.tsx` alone — it is intentional baseline ordering and the LemonTable column sort layers cleanly on top of it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*