### PR TITLE
fix(llma): populate playground from gemini otel traces

### DIFF
--- a/nodejs/src/ingestion/ai/metrics.ts
+++ b/nodejs/src/ingestion/ai/metrics.ts
@@ -47,3 +47,9 @@ export const aiOtelOlderSpecEventsCounter = new Counter({
     help: 'Outcome of decoding the older OTel GenAI span-events `events` attribute',
     labelNames: ['outcome'],
 })
+
+export const aiOtelSystemInstructionsCounter = new Counter({
+    name: 'llma_ai_otel_system_instructions_total',
+    help: 'Outcome of promoting `gen_ai.system_instructions` into a leading $ai_input system message',
+    labelNames: ['outcome'],
+})

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
@@ -484,15 +484,50 @@ describe('mapOtelAttributes', () => {
     })
 
     describe('gen_ai.system_instructions (Gemini OTel)', () => {
-        it('creates $ai_input with a leading system message when input is missing', () => {
-            const event = createEvent('$ai_generation', {
-                'gen_ai.system_instructions': JSON.stringify([
-                    { type: 'text', content: 'You are a helpful assistant.' },
-                ]),
-            })
+        // Each row tests the same invariant — "given `gen_ai.system_instructions`
+        // of shape X with no existing `$ai_input`, produce `$ai_input` as a
+        // single leading system message with content Y, and strip the raw
+        // attribute." Cases with existing `$ai_input` state, no-op outcomes, or
+        // unrelated assertions live as their own `it()` blocks below.
+        it.each([
+            {
+                name: 'JSON-encoded parts array (Gemini default)',
+                value: JSON.stringify([{ type: 'text', content: 'You are a helpful assistant.' }]),
+                expectedContent: 'You are a helpful assistant.',
+            },
+            {
+                name: 'plain string',
+                value: 'Speak like a pirate.',
+                expectedContent: 'Speak like a pirate.',
+            },
+            {
+                name: 'already-parsed multi-part array (joined with \\n\\n)',
+                value: [
+                    { type: 'text', content: 'Part one.' },
+                    { type: 'text', content: 'Part two.' },
+                ],
+                expectedContent: 'Part one.\n\nPart two.',
+            },
+            {
+                name: 'invalid JSON kept as raw string',
+                value: 'not [valid json',
+                expectedContent: 'not [valid json',
+            },
+            {
+                name: 'unexpected object shape stringified',
+                value: { text: 'Speak softly.' },
+                expectedContent: '{"text":"Speak softly."}',
+            },
+            {
+                name: 'parts array with null/undefined entries filtered out',
+                value: [null, { type: 'text', content: 'Only this survives.' }, undefined],
+                expectedContent: 'Only this survives.',
+            },
+        ])('extracts system content from $name', ({ value, expectedContent }) => {
+            const event = createEvent('$ai_generation', { 'gen_ai.system_instructions': value })
             mapOtelAttributes(event)
 
-            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: 'You are a helpful assistant.' }])
+            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: expectedContent }])
             expect(event.properties!['gen_ai.system_instructions']).toBeUndefined()
         })
 
@@ -507,27 +542,6 @@ describe('mapOtelAttributes', () => {
                 { role: 'system', content: 'Be concise.' },
                 { role: 'user', content: 'Hi' },
             ])
-        })
-
-        it('accepts a plain-string gen_ai.system_instructions', () => {
-            const event = createEvent('$ai_generation', {
-                'gen_ai.system_instructions': 'Speak like a pirate.',
-            })
-            mapOtelAttributes(event)
-
-            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: 'Speak like a pirate.' }])
-        })
-
-        it('accepts an already-parsed parts array', () => {
-            const event = createEvent('$ai_generation', {
-                'gen_ai.system_instructions': [
-                    { type: 'text', content: 'Part one.' },
-                    { type: 'text', content: 'Part two.' },
-                ],
-            })
-            mapOtelAttributes(event)
-
-            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: 'Part one.\n\nPart two.' }])
         })
 
         it('does not double-prepend when $ai_input already starts with a system message', () => {
@@ -564,33 +578,6 @@ describe('mapOtelAttributes', () => {
 
             expect(event.properties!.$ai_input).toBeUndefined()
             expect(event.properties!['gen_ai.system_instructions']).toBeUndefined()
-        })
-
-        it('keeps the original string when JSON parsing fails', () => {
-            const event = createEvent('$ai_generation', {
-                'gen_ai.system_instructions': 'not [valid json',
-            })
-            mapOtelAttributes(event)
-
-            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: 'not [valid json' }])
-        })
-
-        it('stringifies an unexpected object shape into the system content', () => {
-            const event = createEvent('$ai_generation', {
-                'gen_ai.system_instructions': { text: 'Speak softly.' },
-            })
-            mapOtelAttributes(event)
-
-            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: '{"text":"Speak softly."}' }])
-        })
-
-        it('tolerates null entries inside the parts array', () => {
-            const event = createEvent('$ai_generation', {
-                'gen_ai.system_instructions': [null, { type: 'text', content: 'Only this survives.' }, undefined],
-            })
-            mapOtelAttributes(event)
-
-            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: 'Only this survives.' }])
         })
 
         it('skips parsing when the string exceeds the size guard and still strips the attribute', () => {

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
@@ -483,6 +483,127 @@ describe('mapOtelAttributes', () => {
         })
     })
 
+    describe('gen_ai.system_instructions (Gemini OTel)', () => {
+        it('creates $ai_input with a leading system message when input is missing', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': JSON.stringify([
+                    { type: 'text', content: 'You are a helpful assistant.' },
+                ]),
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: 'You are a helpful assistant.' }])
+            expect(event.properties!['gen_ai.system_instructions']).toBeUndefined()
+        })
+
+        it('prepends a system message in front of existing user-only $ai_input', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': JSON.stringify([{ type: 'text', content: 'Be concise.' }]),
+                'gen_ai.input.messages': JSON.stringify([{ role: 'user', content: 'Hi' }]),
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([
+                { role: 'system', content: 'Be concise.' },
+                { role: 'user', content: 'Hi' },
+            ])
+        })
+
+        it('accepts a plain-string gen_ai.system_instructions', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': 'Speak like a pirate.',
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: 'Speak like a pirate.' }])
+        })
+
+        it('accepts an already-parsed parts array', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': [
+                    { type: 'text', content: 'Part one.' },
+                    { type: 'text', content: 'Part two.' },
+                ],
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: 'Part one.\n\nPart two.' }])
+        })
+
+        it('does not double-prepend when $ai_input already starts with a system message', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': 'Ignored — already present.',
+                'gen_ai.input.messages': JSON.stringify([
+                    { role: 'system', content: 'Original system prompt.' },
+                    { role: 'user', content: 'Hi' },
+                ]),
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([
+                { role: 'system', content: 'Original system prompt.' },
+                { role: 'user', content: 'Hi' },
+            ])
+            expect(event.properties!['gen_ai.system_instructions']).toBeUndefined()
+        })
+
+        it('no-ops when the attribute is absent', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.input.messages': JSON.stringify([{ role: 'user', content: 'Hi' }]),
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'Hi' }])
+        })
+
+        it('strips the raw attribute even when the text is empty', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': JSON.stringify([{ type: 'text', content: '' }]),
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toBeUndefined()
+            expect(event.properties!['gen_ai.system_instructions']).toBeUndefined()
+        })
+
+        it('keeps the original string when JSON parsing fails', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': 'not [valid json',
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: 'not [valid json' }])
+        })
+
+        it('stringifies an unexpected object shape into the system content', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': { text: 'Speak softly.' },
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: '{"text":"Speak softly."}' }])
+        })
+
+        it('tolerates null entries inside the parts array', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': [null, { type: 'text', content: 'Only this survives.' }, undefined],
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'system', content: 'Only this survives.' }])
+        })
+
+        it('skips parsing when the string exceeds the size guard and still strips the attribute', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': 'x'.repeat(500_001),
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toBeUndefined()
+            expect(event.properties!['gen_ai.system_instructions']).toBeUndefined()
+        })
+    })
+
     describe('older-spec span events composed with pydantic-ai middleware', () => {
         it('reconstructs $ai_input/$ai_output_choices alongside pydantic-ai framework attributes', () => {
             // Realistic runtime path: pydantic-ai middleware runs, calls

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
@@ -602,6 +602,32 @@ describe('mapOtelAttributes', () => {
             expect(event.properties!.$ai_input).toBeUndefined()
             expect(event.properties!['gen_ai.system_instructions']).toBeUndefined()
         })
+
+        it('strips a null-valued attribute without touching existing $ai_input', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': null,
+                'gen_ai.input.messages': JSON.stringify([{ role: 'user', content: 'Hi' }]),
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'Hi' }])
+            expect(event.properties!['gen_ai.system_instructions']).toBeUndefined()
+        })
+
+        it('does not overwrite an existing non-array $ai_input', () => {
+            // Upstream bug shape: `$ai_input` already set to a non-array value
+            // (e.g. a raw string from a malformed `gen_ai.input.messages` that
+            // failed JSON parsing). Don't clobber it — the `conflict` outcome
+            // surfaces this in prod via the counter.
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system_instructions': 'You are a helpful assistant.',
+                'gen_ai.input.messages': 'not valid json',
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toBe('not valid json')
+            expect(event.properties!['gen_ai.system_instructions']).toBeUndefined()
+        })
     })
 
     describe('older-spec span events composed with pydantic-ai middleware', () => {

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '~/plugin-scaffold'
 
 import { parseJSON } from '../../../utils/json-parse'
-import { aiOtelOlderSpecEventsCounter } from '../metrics'
+import { aiOtelOlderSpecEventsCounter, aiOtelSystemInstructionsCounter } from '../metrics'
 
 const ATTRIBUTE_MAP: Record<string, string> = {
     'gen_ai.input.messages': '$ai_input',
@@ -204,74 +204,111 @@ function reconstructOutputChoice(entry: Record<string, unknown>): Record<string,
     return null
 }
 
+type SystemInstructionsOutcome =
+    | 'absent'
+    | 'too_large'
+    | 'empty'
+    | 'prepended'
+    | 'created'
+    | 'already_system'
+    | 'conflict'
+    | 'unexpected_error'
+
 // Gemini's OTel auto-instrumentor emits the system prompt as a top-level
 // `gen_ai.system_instructions` attribute (a string or a parts array like
 // `[{type:'text', content:'...'}]`) rather than as a `role:'system'` entry
 // inside `gen_ai.input.messages`. Promote it into `$ai_input` as a leading
 // system message so the conversation tab and the playground both see it.
+//
+// Mirrors the structure of `convertOlderSpecEvents`: skip entirely when the
+// attribute key is missing (no counter emitted), otherwise route every
+// branch through a single counter in `finally` so prod can observe how
+// often each outcome fires — including the `absent` case (key present but
+// value null/undefined), the silent-drop `empty`, and the unexpected
+// `conflict` case where `$ai_input` is set to a non-array value upstream.
 function convertSystemInstructions(event: PluginEvent): void {
     const props = event.properties!
-    const raw = props['gen_ai.system_instructions']
-    if (raw === undefined || raw === null) {
-        delete props['gen_ai.system_instructions']
+    if (!('gen_ai.system_instructions' in props)) {
         return
     }
 
-    let value: unknown = raw
-    if (typeof value === 'string') {
-        // Same size ceiling as `convertOlderSpecEvents` — defensive against
-        // pathological payloads that would pressure the ingestion worker.
-        if (value.length > MAX_OLDER_SPEC_EVENTS_LENGTH) {
-            delete props['gen_ai.system_instructions']
+    let outcome: SystemInstructionsOutcome = 'unexpected_error'
+    try {
+        const raw = props['gen_ai.system_instructions']
+        if (raw === undefined || raw === null) {
+            outcome = 'absent'
             return
         }
-        try {
-            value = parseJSON(value)
-        } catch {
-            // Keep the original string — it's already the system text.
+
+        let value: unknown = raw
+        if (typeof value === 'string') {
+            // Same size ceiling as `convertOlderSpecEvents` — defensive against
+            // pathological payloads that would pressure the ingestion worker.
+            if (value.length > MAX_OLDER_SPEC_EVENTS_LENGTH) {
+                outcome = 'too_large'
+                return
+            }
+            try {
+                value = parseJSON(value)
+            } catch {
+                // Keep the original string — it's already the system text.
+            }
         }
-    }
 
-    let text: string
-    if (typeof value === 'string') {
-        text = value
-    } else if (Array.isArray(value)) {
-        text = value
-            .filter(
-                (part): part is { type: string; content: unknown } =>
-                    typeof part === 'object' &&
-                    part !== null &&
-                    'type' in part &&
-                    (part as { type: unknown }).type === 'text'
-            )
-            .map((part) => (typeof part.content === 'string' ? part.content : ''))
-            .filter((s) => s.length > 0)
-            .join('\n\n')
-    } else {
-        try {
-            text = JSON.stringify(value)
-        } catch {
-            text = String(value)
+        let text: string
+        if (typeof value === 'string') {
+            text = value
+        } else if (Array.isArray(value)) {
+            text = value
+                .filter(
+                    (part): part is { type: string; content: unknown } =>
+                        typeof part === 'object' &&
+                        part !== null &&
+                        'type' in part &&
+                        (part as { type: unknown }).type === 'text'
+                )
+                .map((part) => (typeof part.content === 'string' ? part.content : ''))
+                .filter((s) => s.length > 0)
+                .join('\n\n')
+        } else {
+            try {
+                text = JSON.stringify(value)
+            } catch {
+                text = String(value)
+            }
         }
-    }
 
-    delete props['gen_ai.system_instructions']
-
-    if (!text) {
-        return
-    }
-
-    const systemMessage = { role: 'system', content: text }
-    const existing = props.$ai_input
-    if (Array.isArray(existing)) {
-        const first = existing[0]
-        const firstIsSystem =
-            typeof first === 'object' && first !== null && (first as { role?: unknown }).role === 'system'
-        if (!firstIsSystem) {
-            props.$ai_input = [systemMessage, ...existing]
+        if (!text) {
+            outcome = 'empty'
+            return
         }
-    } else if (existing === undefined) {
-        props.$ai_input = [systemMessage]
+
+        const systemMessage = { role: 'system', content: text }
+        const existing = props.$ai_input
+        if (Array.isArray(existing)) {
+            const first = existing[0]
+            const firstIsSystem =
+                typeof first === 'object' && first !== null && (first as { role?: unknown }).role === 'system'
+            if (firstIsSystem) {
+                outcome = 'already_system'
+            } else {
+                props.$ai_input = [systemMessage, ...existing]
+                outcome = 'prepended'
+            }
+        } else if (existing === undefined) {
+            props.$ai_input = [systemMessage]
+            outcome = 'created'
+        } else {
+            // `$ai_input` was set to a non-array value (a string, a single
+            // object, etc.) — don't replace it, but flag the unexpected shape
+            // so prod can surface upstream bugs we'd otherwise silently absorb.
+            outcome = 'conflict'
+        }
+    } catch {
+        outcome = 'unexpected_error'
+    } finally {
+        delete props['gen_ai.system_instructions']
+        aiOtelSystemInstructionsCounter.labels({ outcome }).inc()
     }
 }
 

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
@@ -98,6 +98,7 @@ export function mapOtelAttributes(event: PluginEvent): void {
     }
 
     convertOlderSpecEvents(event)
+    convertSystemInstructions(event)
 
     computeLatency(event)
     promoteRootSpanToTrace(event)
@@ -201,6 +202,77 @@ function reconstructOutputChoice(entry: Record<string, unknown>): Record<string,
         return message
     }
     return null
+}
+
+// Gemini's OTel auto-instrumentor emits the system prompt as a top-level
+// `gen_ai.system_instructions` attribute (a string or a parts array like
+// `[{type:'text', content:'...'}]`) rather than as a `role:'system'` entry
+// inside `gen_ai.input.messages`. Promote it into `$ai_input` as a leading
+// system message so the conversation tab and the playground both see it.
+function convertSystemInstructions(event: PluginEvent): void {
+    const props = event.properties!
+    const raw = props['gen_ai.system_instructions']
+    if (raw === undefined || raw === null) {
+        delete props['gen_ai.system_instructions']
+        return
+    }
+
+    let value: unknown = raw
+    if (typeof value === 'string') {
+        // Same size ceiling as `convertOlderSpecEvents` — defensive against
+        // pathological payloads that would pressure the ingestion worker.
+        if (value.length > MAX_OLDER_SPEC_EVENTS_LENGTH) {
+            delete props['gen_ai.system_instructions']
+            return
+        }
+        try {
+            value = parseJSON(value)
+        } catch {
+            // Keep the original string — it's already the system text.
+        }
+    }
+
+    let text: string
+    if (typeof value === 'string') {
+        text = value
+    } else if (Array.isArray(value)) {
+        text = value
+            .filter(
+                (part): part is { type: string; content: unknown } =>
+                    typeof part === 'object' &&
+                    part !== null &&
+                    'type' in part &&
+                    (part as { type: unknown }).type === 'text'
+            )
+            .map((part) => (typeof part.content === 'string' ? part.content : ''))
+            .filter((s) => s.length > 0)
+            .join('\n\n')
+    } else {
+        try {
+            text = JSON.stringify(value)
+        } catch {
+            text = String(value)
+        }
+    }
+
+    delete props['gen_ai.system_instructions']
+
+    if (!text) {
+        return
+    }
+
+    const systemMessage = { role: 'system', content: text }
+    const existing = props.$ai_input
+    if (Array.isArray(existing)) {
+        const first = existing[0]
+        const firstIsSystem =
+            typeof first === 'object' && first !== null && (first as { role?: unknown }).role === 'system'
+        if (!firstIsSystem) {
+            props.$ai_input = [systemMessage, ...existing]
+        }
+    } else if (existing === undefined) {
+        props.$ai_input = [systemMessage]
+    }
 }
 
 function convertOlderSpecEvents(event: PluginEvent): void {

--- a/products/llm_analytics/frontend/playground/llmPlaygroundLogic.test.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundLogic.test.ts
@@ -1324,6 +1324,59 @@ describe('llmPlaygroundLogic', () => {
 
             expect(llmPlaygroundPromptsLogic.values.model).toBe('claude-3-opus')
         })
+
+        it('should populate playground from Gemini OTel parts-shaped input', () => {
+            // Matches what opentelemetry-instrumentation-google-generativeai emits in gen_ai.input.messages.
+            const input = [
+                { role: 'user', parts: [{ type: 'text', content: 'What is the capital of France?' }] },
+                { role: 'model', parts: [{ type: 'text', content: 'The capital of France is Paris.' }] },
+                { role: 'user', parts: [{ type: 'text', content: 'And of Spain?' }] },
+            ]
+
+            llmPlaygroundPromptsLogic.actions.setupPlaygroundFromEvent({ input })
+
+            expect(llmPlaygroundPromptsLogic.values.messages).toEqual([
+                { role: 'user', content: 'What is the capital of France?' },
+                { role: 'assistant', content: 'The capital of France is Paris.' },
+                { role: 'user', content: 'And of Spain?' },
+            ])
+        })
+
+        it('should populate system prompt + conversation from a Gemini OTel trace shape', () => {
+            // After Fix A (ingestion) prepends the system message synthesized from gen_ai.system_instructions,
+            // the playground sees a mix of standard `{role, content}` and OTel parts-shaped items.
+            const input = [
+                { role: 'system', content: 'You are a concise assistant.' },
+                { role: 'user', parts: [{ type: 'text', content: 'Tell me about Paris.' }] },
+                { role: 'model', parts: [{ type: 'text', content: 'Paris is the capital of France.' }] },
+            ]
+
+            llmPlaygroundPromptsLogic.actions.setupPlaygroundFromEvent({ input })
+
+            expect(llmPlaygroundPromptsLogic.values.systemPrompt).toBe('You are a concise assistant.')
+            expect(llmPlaygroundPromptsLogic.values.messages).toEqual([
+                { role: 'user', content: 'Tell me about Paris.' },
+                { role: 'assistant', content: 'Paris is the capital of France.' },
+            ])
+        })
+
+        it('should join multi-part text content for OTel parts messages', () => {
+            const input = [
+                {
+                    role: 'user',
+                    parts: [
+                        { type: 'text', content: 'First chunk.' },
+                        { type: 'text', content: 'Second chunk.' },
+                    ],
+                },
+            ]
+
+            llmPlaygroundPromptsLogic.actions.setupPlaygroundFromEvent({ input })
+
+            const message = llmPlaygroundPromptsLogic.values.messages[0]
+            expect(message.role).toBe('user')
+            expect(message.content).toBe('First chunk.\n\nSecond chunk.')
+        })
     })
 
     describe('Multi-prompt state management', () => {

--- a/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -14,7 +14,7 @@ import { llmEvaluationLogic } from '../evaluations/llmEvaluationLogic'
 import type { EvaluationConfig } from '../evaluations/types'
 import { getApiErrorDetail, llmPromptLogic } from '../prompts/llmPromptLogic'
 import { normalizeLLMProvider } from '../settings/llmProviderKeysLogic'
-import { normalizeRole, safeStringify } from '../utils'
+import { isOTelPartsMessage, normalizeMessage, normalizeRole, safeStringify } from '../utils'
 import type { llmPlaygroundPromptsLogicType } from './llmPlaygroundPromptsLogicType'
 import { isTraceLikeSelection } from './playgroundModelMatching'
 
@@ -974,9 +974,22 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
 
                 if (input) {
                     try {
+                        // OTel `parts` messages (Gemini auto-instrumentor and any other gen_ai.* OTel
+                        // provider that follows the OpenTelemetry AI semantic conventions) carry their
+                        // text in `parts: [{type, content}]` instead of `content`. Expand only those
+                        // entries via the shared normalizer the Conversation tab uses, so non-parts
+                        // shapes keep their existing handling and we don't change behavior for
+                        // OpenAI / Anthropic / Vercel / Traceloop / Pydantic traces.
+                        const expandedInput = Array.isArray(input)
+                            ? input.flatMap((msg) =>
+                                  isOTelPartsMessage(msg)
+                                      ? normalizeMessage(msg, normalizeRole(msg.role, 'user'))
+                                      : [msg]
+                              )
+                            : input
                         if (
-                            Array.isArray(input) &&
-                            input.every(
+                            Array.isArray(expandedInput) &&
+                            expandedInput.every(
                                 (msg) =>
                                     // Standard chat message: must have role + content/tool_calls
                                     (msg.role && (msg.content != null || msg.tool_calls)) ||
@@ -985,7 +998,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                                     msg.type === 'function_call_output'
                             )
                         ) {
-                            const systemContents = input
+                            const systemContents = expandedInput
                                 .filter((msg) => msg.role === 'system')
                                 .map((msg) => msg.content)
                                 .filter(
@@ -997,7 +1010,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                                 systemPromptContent = systemContents.join('\n\n')
                             }
 
-                            for (const msg of input as RawMessage[]) {
+                            for (const msg of expandedInput as RawMessage[]) {
                                 if (msg.role === 'system') {
                                     continue
                                 }


### PR DESCRIPTION
## Problem

Reported in [this ticket](https://posthoghelp.zendesk.com/agent/tickets/58120): Traces captured via the officially recommended Google Gemini OTel integration
(`google-genai` + `opentelemetry-instrumentation-google-generativeai` +
`PostHogSpanProcessor` from `posthog.ai.otel`) open an empty playground when the
user clicks "Open in Playground" — no system prompt, no user message, no
assistant output. The Conversation tab on the same trace renders correctly, so
the data is intact but two layers are dropping it on the floor:

1. `gen_ai.system_instructions` (the OTel GenAI attribute carrying the system
   prompt, used by Gemini and any other gen_ai.* provider that follows the
   OpenTelemetry AI semantic conventions for system prompts) was not in
   `ATTRIBUTE_MAP` in `nodejs/src/ingestion/ai/otel/attribute-mapping.ts`. The
   system prompt landed as a raw stray property and never reached `$ai_input`.
2. The playground's `setupPlaygroundFromEvent` listener had an inline message
   validator that required `msg.content` or a known OpenAI-Responses
   `msg.type`. Gemini OTel messages are shaped `{role, parts: [{type, content}]}`,
   so every item failed the predicate and control fell into a JSON-stringify
   fallback. The Conversation tab handles this shape via `normalizeMessage` in
   `products/llm_analytics/frontend/utils.ts` — the playground just was not
   calling it.

## Changes

- Map `gen_ai.system_instructions` on ingestion and prepend a `role: 'system'`
  message to `$ai_input` (idempotent if a system turn is already there).
  Handles both parts-shaped (Gemini default) and plain-string instructions,
  with a 500-KB size guard mirroring `convertOlderSpecEvents`.
- Selectively route only OTel parts-shaped entries through the exported
  `normalizeMessage` (which dispatches into the OTel parts branch) before the
  playground's inline gate. Non-parts shapes pass through untouched so
  OpenAI / Anthropic / Vercel AI SDK / Pydantic / Traceloop / LiteLLM /
  LangChain inputs keep their existing handling.

## How did you test this code?

Automated, run by the agent:

- New unit tests in `nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts`
  cover: creating `\$ai_input` from empty, prepending in front of existing
  user-only input, plain-string instructions, already-parsed parts array,
  idempotent no-op when a system message is already first, attribute-absent
  no-op, raw attribute stripped on empty text, JSON-parse failure fallback,
  unexpected-object stringification, null entries inside the parts array, and
  the 500-KB size-guard short-circuit. Full suite: 73 of 73 pass.
- New cases in
  `products/llm_analytics/frontend/playground/llmPlaygroundLogic.test.ts` for
  Gemini OTel parts-shaped input, the combined ingestion + playground flow
  with a leading system message, and multi-part text concatenation. Full
  suite: 98 of 98 pass.
- `tsc --noEmit` reports zero errors in the four files changed by this PR.
  (There is pre-existing kea-typegen drift in unrelated areas — `user_interviews`,
  `workflows`, `surveys`, `health`, `feature-flags` — none of which is touched
  by this branch.)

This PR is agent-authored, so live trace verification (capturing a fresh
Gemini OTel trace end-to-end and clicking "Open in Playground" in the UI) is
left for the reviewer.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

- Tools: PostHog Code with Claude Opus 4.7. Used the
  `file-bug-or-feature-report` shared team skill for pre-flight verification
  (no existing fix on master, no open PR matching the symptoms, no open issue),
  then switched to a PR since both fixes are small and isolated.
- Considered alternatives:
  - For the playground gate, considered extending the inline validator with
    \`|| (msg.role && Array.isArray(msg.parts))\` and inlining a parts-to-content
    conversion. Rejected: leaves the format-detection logic split across the
    playground and \`normalizeMessage\`, guaranteeing drift the next time a
    provider lands.
  - Also considered routing the playground's whole input through
    \`normalizeMessages\` from \`utils.ts\`. Rejected after reading the existing
    \`flattenOutputMessages\` comment (\`llmPlaygroundPromptsLogic.ts\` L308-311):
    \`normalizeMessages\` fans out tool_use / tool_result blocks into separate
    display bubbles, which would regress OpenAI / Anthropic / Vercel tool-call
    rendering. The chosen selective-expansion approach avoids that.
  - For the ingestion side, considered a Gemini-specific OTel middleware
    alongside the existing \`vercel-ai\`, \`traceloop\`, \`pydantic-ai\` middlewares.
    Rejected: \`gen_ai.system_instructions\` is part of the standard \`gen_ai.*\`
    namespace, not Gemini-proprietary, so a one-attribute fix in the shared
    \`mapOtelAttributes\` path is the right scope.
- The pre-flight surfaced three closely-named merged PRs (#53534, #53690,
  #55684); confirmed none cover this case before drafting. #53534 / #53690
  fixed an unrelated kea state-transfer issue; #55684 added support for
  roleless OpenAI-Responses items (the inverse of this case — Gemini items
  have \`role\` but use \`parts\` instead of \`content\`).
- Code review pass: handed the diff to the \`code-reviewer\` agent before
  committing. Applied its three non-blocking suggestions (size guard around
  \`parseJSON\`, additional test for unexpected-object-shape fallback,
  tightened multi-part text assertion from \`.toContain\` to \`.toBe\`).
- Human author: @slshults.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*