### PR TITLE
fix(lemon-ui): fix permanent scrollbar in ScrollableShadows on non-auto-hiding platforms

### DIFF
--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
@@ -78,10 +78,14 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
                         ? { overflow: 'hidden' }
                         : direction
                           ? {
-                                overflowX: direction === 'horizontal' ? undefined : 'hidden',
-                                overflowY: direction === 'vertical' ? undefined : 'hidden',
+                                // Base UI's ScrollArea.Viewport sets `overflow: scroll` as an inline
+                                // style. Using `undefined` here lets that value win, which renders a
+                                // permanent scrollbar even when content fits. `'auto'` overrides it so
+                                // the scrollbar only appears when content actually overflows.
+                                overflowX: direction === 'horizontal' ? 'auto' : 'hidden',
+                                overflowY: direction === 'vertical' ? 'auto' : 'hidden',
                             }
-                          : undefined
+                          : { overflowX: 'auto', overflowY: 'auto' }
                 }
             >
                 <ScrollArea.Content className={clsx('min-w-0', contentClassName)}>{children}</ScrollArea.Content>


### PR DESCRIPTION
## Problem

On browsers and platforms where native scrollbars don't auto-hide (e.g. Windows Chrome, Linux), `LemonTable` and every other `ScrollableShadows` consumer render a permanent horizontal scrollbar even when the content fits within the viewport. The scrollbar reserves space and makes tables look like they're overflowing when nothing is actually scrollable.

Root cause: Base UI's `ScrollArea.Viewport` sets `overflow: scroll` as a hardcoded inline style. PostHog's per-axis override in `ScrollableShadows.tsx` was passing `undefined` for the scrollable axis, which let Base UI's `overflow: scroll` win. Since PostHog restores the native scrollbar (rather than using Base UI's custom scrollbar), the combination of `overflow: scroll` + a visible native scrollbar means the scrollbar always appears.

Fixes #55041

## Changes

In `ScrollableShadows.tsx`, change the per-axis overflow values from `undefined` to `'auto'` so the inline style actually overrides Base UI's value:

**Before:**
```tsx
overflowX: direction === 'horizontal' ? undefined : 'hidden',
overflowY: direction === 'vertical' ? undefined : 'hidden',
```

**After:**
```tsx
overflowX: direction === 'horizontal' ? 'auto' : 'hidden',
overflowY: direction === 'vertical' ? 'auto' : 'hidden',
```

Also applies `{ overflowX: 'auto', overflowY: 'auto' }` for the undirected case (was `undefined`, which also let Base UI's value win).

## How did you test this code?

Not tested in a live browser — this is a pure CSS property fix on a platform I can't reproduce locally (requires a browser/OS where scrollbars don't auto-hide). The fix directly addresses the root cause described in the issue. The change is 1–2 values; the blast radius is all `ScrollableShadows` consumers but the only expected visual change is scrollbars disappearing when content fits.

## Publish to changelog?

No

## 🤖 Agent context

Authored with Claude Code. Root cause and exact fix were already identified in the issue by the PostHog team. Implementation is a direct translation of the suggested diff.