### PR TITLE
chore(hogql): consolidate parser-fork tests and fix python/cpp divergences

### DIFF
--- a/common/hogql_parser/package.json
+++ b/common/hogql_parser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/hogql-parser",
-    "version": "1.3.42",
+    "version": "1.3.43",
     "description": "WebAssembly HogQL Parser - Parse HogQL queries in JavaScript/TypeScript",
     "keywords": [
         "antlr4",

--- a/common/hogql_parser/parser_json.cpp
+++ b/common/hogql_parser/parser_json.cpp
@@ -2834,11 +2834,12 @@ class HogQLParseTreeJSONConverter : public HogQLParserBaseVisitor {
                   (text.size() > 2 && text[0] == '-' && text.compare(1, 2, "0x") == 0);
 
     if (text.find("inf") != string::npos || text.find("nan") != string::npos) {
-      // Handle special number cases (infinity and NaN)
-      // Mark these with value_type="number" so the deserializer knows to convert them
-      if (!text.compare("-inf")) {
+      // The INF lexer rule matches both `inf` and `infinity` (case-insensitive),
+      // and ClickHouse / Postgres both accept `infinity` as a synonym for +inf.
+      // Anything else containing "inf" or "nan" (e.g. literal "nan") is NaN.
+      if (text == "-inf" || text == "-infinity") {
         json["value"] = "-Infinity";
-      } else if (!text.compare("inf")) {
+      } else if (text == "inf" || text == "infinity") {
         json["value"] = "Infinity";
       } else {
         json["value"] = "NaN";
@@ -2853,10 +2854,20 @@ class HogQLParseTreeJSONConverter : public HogQLParserBaseVisitor {
       }
       return json;
     } else {
+      // Dispatch radix by token kind, NOT by string prefix. `stoll(text, 0, 0)`
+      // would silently truncate `08` / `019` to their longest valid octal prefix
+      // (returning 0 / 1), even though the lexer matched those as DECIMAL_LITERAL
+      // because they contain non-octal digits. Honour the lexer's choice:
+      // OCTAL_LITERAL → base 8, HEXADECIMAL_LITERAL → base 16, everything else
+      // (DECIMAL_LITERAL, signed forms) → base 10.
+      int base = 10;
+      if (ctx->HEXADECIMAL_LITERAL() != nullptr) {
+        base = 16;
+      } else if (ctx->OCTAL_LITERAL() != nullptr) {
+        base = 8;
+      }
       try {
-        // Base 0: auto-detect radix from prefix (0x → hex, leading 0 → octal, else decimal),
-        // so HEXADECIMAL_LITERAL / OCTAL_LITERAL tokens aren't silently truncated to 0.
-        json["value"] = static_cast<int64_t>(stoll(text, nullptr, 0));  // Integer
+        json["value"] = static_cast<int64_t>(stoll(text, nullptr, base));  // Integer
       } catch (const std::out_of_range&) {
         try {
           json["value"] = Json(stod(text));  // Too large for int64, use float

--- a/common/hogql_parser/setup.py
+++ b/common/hogql_parser/setup.py
@@ -36,7 +36,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.3.42",
+    version="1.3.43",
     url="https://github.com/PostHog/posthog/tree/master/common/hogql_parser",
     description="HogQL parser for internal PostHog use",
     author="PostHog Inc.",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,7 @@
         "@posthog/docs-onboarding": "workspace:*",
         "@posthog/esbuilder": "workspace:*",
         "@posthog/hedgehog-mode": "^0.0.48",
-        "@posthog/hogql-parser": "1.3.42",
+        "@posthog/hogql-parser": "1.3.43",
         "@posthog/hogvm": "workspace:*",
         "@posthog/icons": "^0.36.6",
         "@posthog/products-access-control": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,7 +275,7 @@ importers:
         version: 3.12.1
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
       oxfmt:
         specifier: 'catalog:'
         version: 0.35.0
@@ -445,10 +445,10 @@ importers:
         version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ^7.6.4
-        version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
+        version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/test-runner':
         specifier: ^0.16.0
-        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
+        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)
       '@storybook/theming':
         specifier: ^7.6.4
         version: 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -499,7 +499,7 @@ importers:
         version: 2.0.0(webpack@5.88.2)
       webpack:
         specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+        version: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.88.2)
@@ -587,8 +587,8 @@ importers:
         specifier: ^0.0.48
         version: 0.0.48(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/hogql-parser':
-        specifier: 1.3.42
-        version: 1.3.42
+        specifier: 1.3.43
+        version: 1.3.43
       '@posthog/hogvm':
         specifier: workspace:*
         version: link:../common/hogvm/typescript
@@ -1303,7 +1303,7 @@ importers:
         version: 29.7.0
       jest-image-snapshot:
         specifier: ^6.1.0
-        version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@22.18.8))
       kea-typegen:
         specifier: 3.6.2-leakfix.5
         version: 3.6.2-leakfix.5(typescript@5.9.3)
@@ -1798,7 +1798,7 @@ importers:
         version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.52.4)(typescript@5.9.3)(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
       '@storybook/test-runner':
         specifier: ^0.16.0
-        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
+        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)
       '@storybook/theming':
         specifier: ^7.6.20
         version: 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1819,7 +1819,7 @@ importers:
         version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@22.18.8))
       storybook:
         specifier: ^7.6.4
         version: 7.6.4(encoding@0.1.13)
@@ -8915,8 +8915,8 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@posthog/hogql-parser@1.3.42':
-    resolution: {integrity: sha512-i6UMWrf3q38VyL+qD8SI416Pp2v7Td0c/xricuS+8sBQ/djayqSMqKCoazfka2xLVoXJNorOg4u+QUkYBQviUw==}
+  '@posthog/hogql-parser@1.3.43':
+    resolution: {integrity: sha512-ZnzLCZBSJlRpOIgQ7iwwesSCqFr9lzWg7e40ZPRcBHc/YjMxfr/ZqnAgP8OCCAmhlJ6os6V7wRqqfWGghLroNQ==}
 
   '@posthog/icons@0.36.4':
     resolution: {integrity: sha512-xnusbGNz/5vSMUWdEViWuai7D/gxiMZSDDnP6s/acndMqzN+W4asPUgUNnTUps7OyAS1IKaO9zxhdikFrtooJA==}
@@ -29209,41 +29209,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.18.8
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -31916,7 +31881,7 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       type-fest: 4.41.0
       webpack-hot-middleware: 2.25.4
@@ -31962,7 +31927,7 @@ snapshots:
     transitivePeerDependencies:
       - prop-types
 
-  '@posthog/hogql-parser@1.3.42': {}
+  '@posthog/hogql-parser@1.3.43': {}
 
   '@posthog/icons@0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -33979,7 +33944,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-webpack5@7.6.4(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.9.3)(webpack-cli@5.1.4)':
+  '@storybook/builder-webpack5@7.6.4(encoding@0.1.13)(typescript@5.9.3)(webpack-cli@5.1.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@storybook/channels': 7.6.4
@@ -34009,12 +33974,12 @@ snapshots:
       semver: 7.7.4
       style-loader: 3.3.3(webpack@5.88.2)
       swc-loader: 0.2.3(@swc/core@1.15.18)(webpack@5.88.2)
-      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(esbuild@0.18.20)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(webpack@5.88.2)
       ts-dedent: 2.2.0
       url: 0.11.1
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-dev-middleware: 6.1.1(webpack@5.88.2)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
@@ -34085,7 +34050,7 @@ snapshots:
       get-port: 5.1.1
       giget: 1.1.2
       globby: 11.1.0
-      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.26.0))
+      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.29.0))
       leven: 3.1.0
       ora: 5.4.1
       prettier: 2.8.8
@@ -34128,7 +34093,7 @@ snapshots:
       '@types/cross-spawn': 6.0.2
       cross-spawn: 7.0.6
       globby: 11.1.0
-      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.26.0))
+      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.29.0))
       lodash: 4.18.1
       prettier: 2.8.8
       recast: 0.23.11
@@ -34420,7 +34385,7 @@ snapshots:
 
   '@storybook/postinstall@7.6.4': {}
 
-  '@storybook/preset-react-webpack@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.23.3(@babel/core@7.26.0)
       '@babel/preset-react': 7.23.3(@babel/core@7.26.0)
@@ -34440,7 +34405,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       semver: 7.7.4
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       '@babel/core': 7.26.0
       typescript: 5.9.3
@@ -34523,7 +34488,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -34557,10 +34522,10 @@ snapshots:
       - typescript
       - vite-plugin-glimmerx
 
-  '@storybook/react-webpack5@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.4(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.9.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.4(encoding@0.1.13)(typescript@5.9.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 18.3.1
@@ -34679,7 +34644,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/test-runner@0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))':
+  '@storybook/test-runner@0.16.0(@types/node@22.18.8)(encoding@0.1.13)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -34700,10 +34665,10 @@ snapshots:
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
-      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
+      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0)
       jest-runner: 29.7.0
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       playwright: 1.45.0
       read-pkg-up: 7.0.1
@@ -36967,17 +36932,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@xmldom/xmldom@0.8.11': {}
@@ -37584,14 +37549,14 @@ snapshots:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   babel-loader@9.1.3(@babel/core@7.29.0)(webpack@5.88.2):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   babel-plugin-add-react-displayname@0.0.5: {}
 
@@ -38661,21 +38626,6 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
-  create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
@@ -38788,7 +38738,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   css-loader@6.8.1(webpack@5.88.2):
     dependencies:
@@ -38800,7 +38750,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.7.4
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.2):
     dependencies:
@@ -40537,7 +40487,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   file-system-cache@2.3.0:
     dependencies:
@@ -40681,7 +40631,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   form-data@4.0.5:
     dependencies:
@@ -41360,7 +41310,7 @@ snapshots:
   html-webpack-harddisk-plugin@2.0.0(html-webpack-plugin@5.5.3(webpack@5.88.2))(webpack@5.88.2):
     dependencies:
       html-webpack-plugin: 5.5.3(webpack@5.88.2)
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   html-webpack-plugin@5.5.3(webpack@5.88.2):
     dependencies:
@@ -41369,7 +41319,7 @@ snapshots:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   htmlnano@2.1.1(cssnano@7.0.6(postcss@8.5.6))(postcss@8.5.6)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.46.0)(typescript@5.9.3):
     dependencies:
@@ -42140,25 +42090,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
@@ -42230,37 +42161,6 @@ snapshots:
       - canvas
       - supports-color
       - utf-8-validate
-
-  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)):
     dependencies:
@@ -42512,7 +42412,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))):
+  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@22.18.8)):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -42669,7 +42569,7 @@ snapshots:
       '@types/node': 22.18.8
       jest-util: 30.0.5
 
-  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))):
+  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
       jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
@@ -43092,7 +42992,7 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.0.5
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0):
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.6.2
@@ -43168,18 +43068,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
@@ -43250,7 +43138,7 @@ snapshots:
 
   jsbn@1.1.0: {}
 
-  jscodeshift@0.15.1(@babel/preset-env@7.23.5(@babel/core@7.26.0)):
+  jscodeshift@0.15.1(@babel/preset-env@7.23.5(@babel/core@7.29.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
@@ -43273,7 +43161,7 @@ snapshots:
       temp: 0.8.4
       write-file-atomic: 2.4.3
     optionalDependencies:
-      '@babel/preset-env': 7.23.5(@babel/core@7.26.0)
+      '@babel/preset-env': 7.23.5(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -43547,7 +43435,7 @@ snapshots:
       less: 4.2.2
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   less@3.13.1:
     dependencies:
@@ -46043,7 +45931,7 @@ snapshots:
       postcss: 8.5.6
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   postcss-logical@8.0.0(postcss@8.5.2):
     dependencies:
@@ -47029,7 +46917,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   rc-cascader@3.34.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -48166,7 +48054,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       sass: 1.56.0
 
@@ -48874,11 +48762,11 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   style-loader@3.3.3(webpack@5.88.2):
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   style-search@0.1.0: {}
 
@@ -49082,7 +48970,7 @@ snapshots:
   swc-loader@0.2.3(@swc/core@1.15.18)(webpack@5.88.2):
     dependencies:
       '@swc/core': 1.15.18
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   symbol-tree@3.2.4: {}
 
@@ -49276,17 +49164,16 @@ snapshots:
       '@swc/core': 1.15.18
       esbuild: 0.27.7
 
-  terser-webpack-plugin@5.3.9(@swc/core@1.15.18)(esbuild@0.18.20)(webpack@5.88.2):
+  terser-webpack-plugin@5.3.9(@swc/core@1.15.18)(webpack@5.88.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.15.18
-      esbuild: 0.18.20
 
   terser@5.19.1:
     dependencies:
@@ -49525,27 +49412,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       tslib: 2.8.1
       typescript: 5.9.3
-
-  ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 22.18.8
-      acorn: 8.15.0
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.11.4
-    optional: true
 
   ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3):
     dependencies:
@@ -50482,7 +50348,7 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-merge: 5.8.0
 
   webpack-dev-middleware@6.1.1(webpack@5.88.2):
@@ -50493,7 +50359,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   webpack-hot-middleware@2.25.4:
     dependencies:
@@ -50544,7 +50410,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4):
+  webpack@5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.4
       '@types/estree': 1.0.1
@@ -50567,7 +50433,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(esbuild@0.18.20)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -629,9 +629,25 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
                 else:
                     limit = self.visit(exprs[0]) if exprs else None
                     offset = None
-                if isinstance(initial_query, ast.SelectQuery):
+                # Apply the set-stmt-level limit/offset on top of the
+                # initial query. The two correctness rules:
+                #   1. Only override `offset` when the outer clause
+                #      specified one — otherwise the trailing `LIMIT n`
+                #      in a chain like `LIMIT 3 OFFSET 2 LIMIT 7` would
+                #      clobber the inner OFFSET (which cpp preserves).
+                #   2. Apply to both SelectQuery and SelectSetQuery
+                #      initials — a paren-wrapped set with a trailing
+                #      `LIMIT a, b` is a valid shape (e.g. `({1}
+                #      intersect by name {2}) limit 3, 4`) and the
+                #      limit/offset belong on the SelectSetQuery.
+                if isinstance(initial_query, (ast.SelectQuery, ast.SelectSetQuery)):
                     initial_query.limit = limit
-                    initial_query.offset = offset
+                    if offset is not None:
+                        initial_query.offset = offset
+                    if limit_clause.PERCENT():
+                        initial_query.limit_percent = True
+                    if limit_clause.TIES():
+                        initial_query.limit_with_ties = True
                     return initial_query
             return initial_query
 
@@ -1839,10 +1855,17 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         # "0xfe" would otherwise route through float() and raise ValueError.
         if abs_text.startswith("0x"):
             return ast.Constant(value=sign * int(abs_text, 16))
-        if "." in abs_text or "e" in abs_text or abs_text == "inf" or abs_text == "nan":
+        # `infinity` is matched by the INF lexer rule (`I N F | I N F I N I T Y`)
+        # alongside `inf`, and ClickHouse/Postgres both accept it as a synonym
+        # for +/-Infinity. Python's `float()` accepts both spellings.
+        if "." in abs_text or "e" in abs_text or abs_text in ("inf", "infinity", "nan"):
             return ast.Constant(value=float(text))
-        # Octal literals (leading '0' followed by more digits) must use base 8.
-        if len(abs_text) > 1 and abs_text[0] == "0":
+        # Octal literals are dispatched by the OCTAL_LITERAL token (digits 0-7
+        # after a leading '0'). A leading-zero number with a non-octal digit
+        # like `08` or `019` is matched as DECIMAL_LITERAL by the lexer
+        # (OCTAL_LITERAL requires every digit be octal), so we must NOT
+        # interpret it as octal here.
+        if ctx.OCTAL_LITERAL() is not None:
             return ast.Constant(value=sign * int(abs_text, 8))
         return ast.Constant(value=sign * int(abs_text))
 

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -4240,4 +4240,2896 @@ def parser_test_factory(backend: HogQLParserBackend):
                 ),
             )
 
+        # =====================================================================
+        # Cross-backend parser-shape contract tests, consolidated from the
+        # rust-allstar-json and rust-backtrack-json fork test files. Each test
+        # asserts the parser produces the canonical AST for an ANTLR ALL(*)-only
+        # construct (BETWEEN body absorption, CTE column form, NOT-prefix vs
+        # function-call dispatch, etc.). Backends that can't disambiguate the
+        # case fail the test naturally — no per-fork skipping needed.
+        # =====================================================================
+
+        # --- backtrack :: TestPrattLimitationsViaBacktrack (116 tests) ---
+        def test_between_with_lambda_body(self):
+            self.assertEqual(
+                self._expr("x BETWEEN lambda y : a AND b AND high"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.Lambda(args=["y"], expr=ast.And(exprs=[ast.Field(chain=["a"]), ast.Field(chain=["b"])])),
+                    high=ast.Field(chain=["high"]),
+                ),
+            )
+
+        def test_between_with_arrow_lambda_body(self):
+            self.assertEqual(
+                self._expr("x BETWEEN (a) -> b AND c AND high"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.Lambda(args=["a"], expr=ast.And(exprs=[ast.Field(chain=["b"]), ast.Field(chain=["c"])])),
+                    high=ast.Field(chain=["high"]),
+                ),
+            )
+
+        def test_between_with_named_arg_body(self):
+            self.assertEqual(
+                self._expr("x BETWEEN name := value AND high"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.NamedArgument(name="name", value=ast.Field(chain=["value"])),
+                    high=ast.Field(chain=["high"]),
+                ),
+            )
+
+        def test_between_with_as_alias_body(self):
+            self.assertEqual(
+                self._expr("x BETWEEN y AS alias AND high"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.Alias(alias="alias", expr=ast.Field(chain=["y"])),
+                    high=ast.Field(chain=["high"]),
+                ),
+            )
+
+        def test_between_with_ternary_body(self):
+            self.assertEqual(
+                self._expr("x BETWEEN a ? b : c AND high"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.Call(
+                        name="if", args=[ast.Field(chain=["a"]), ast.Field(chain=["b"]), ast.Field(chain=["c"])]
+                    ),
+                    high=ast.Field(chain=["high"]),
+                ),
+            )
+
+        def test_between_nested_between(self):
+            self.assertEqual(
+                self._expr("x BETWEEN y BETWEEN z AND w AND v"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.BetweenExpr(
+                        expr=ast.Field(chain=["y"]), low=ast.Field(chain=["z"]), high=ast.Field(chain=["w"])
+                    ),
+                    high=ast.Field(chain=["v"]),
+                ),
+            )
+
+        def test_between_left_recursive_nested(self):
+            self.assertEqual(
+                self._expr("x BETWEEN 1 AND 2 BETWEEN 3 AND 4"),
+                ast.BetweenExpr(
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]), low=ast.Constant(value=1), high=ast.Constant(value=2)
+                    ),
+                    low=ast.Constant(value=3),
+                    high=ast.Constant(value=4),
+                ),
+            )
+
+        def test_between_left_recursive_with_postfix(self):
+            self.assertEqual(
+                self._expr('x BETWEEN 1 AND 2 BETWEEN 3 AND 4 ?. "a"'),
+                ast.BetweenExpr(
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]), low=ast.Constant(value=1), high=ast.Constant(value=2)
+                    ),
+                    low=ast.Constant(value=3),
+                    high=ast.ArrayAccess(array=ast.Constant(value=4), property=ast.Constant(value="a"), nullish=True),
+                ),
+            )
+
+        def test_between_three_keywords_three_ands(self):
+            self.assertEqual(
+                self._expr("a BETWEEN b BETWEEN c AND d AND e BETWEEN f AND g"),
+                ast.BetweenExpr(
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["a"]),
+                        low=ast.BetweenExpr(
+                            expr=ast.Field(chain=["b"]), low=ast.Field(chain=["c"]), high=ast.Field(chain=["d"])
+                        ),
+                        high=ast.Field(chain=["e"]),
+                    ),
+                    low=ast.Field(chain=["f"]),
+                    high=ast.Field(chain=["g"]),
+                ),
+            )
+
+        def test_between_three_keywords_three_ands_placeholders(self):
+            self.assertEqual(
+                self._expr("{ } BETWEEN { } BETWEEN ( '' ) AND ( '' ) AND { } BETWEEN ( '' ) AND ( '' )"),
+                ast.BetweenExpr(
+                    expr=ast.BetweenExpr(
+                        expr=ast.Dict(items=[]),
+                        low=ast.BetweenExpr(
+                            expr=ast.Dict(items=[]), low=ast.Constant(value=""), high=ast.Constant(value="")
+                        ),
+                        high=ast.Dict(items=[]),
+                    ),
+                    low=ast.Constant(value=""),
+                    high=ast.Constant(value=""),
+                ),
+            )
+
+        def test_not_asterisk_alone(self):
+            self.assertEqual(self._expr("NOT *"), ast.Not(expr=ast.Field(chain=["*"])))
+
+        def test_not_asterisk_plus_primary(self):
+            self.assertEqual(
+                self._expr("NOT * + 1"),
+                ast.Not(expr=ast.ArithmeticOperation(left=ast.Field(chain=["*"]), right=ast.Constant(value=1), op="+")),
+            )
+
+        def test_not_asterisk_division(self):
+            self.assertEqual(
+                self._expr("NOT * / 1"),
+                ast.Not(expr=ast.ArithmeticOperation(left=ast.Field(chain=["*"]), right=ast.Constant(value=1), op="/")),
+            )
+
+        def test_number_dot_and_with_rhs_is_binary(self):
+            self.assertEqual(
+                self._expr("1 . and columns((a))"),
+                ast.And(exprs=[ast.Constant(value=1.0), ast.ColumnsExpr(columns=[ast.Field(chain=["a"])])]),
+            )
+
+        def test_number_dot_in_with_rhs_is_compare(self):
+            self.assertEqual(
+                self._expr("1.in 2"),
+                ast.CompareOperation(left=ast.Constant(value=1.0), right=ast.Constant(value=2), op="in"),
+            )
+
+        def test_number_dot_and_alone_is_property_access(self):
+            self.assertEqual(
+                self._expr("1.and"),
+                ast.ArrayAccess(array=ast.Constant(value=1), property=ast.Constant(value="and")),
+            )
+
+        def test_interpolate_inner_alias_absorbs_as_identifier(self):
+            self.assertEqual(
+                self._select("select 1 order by 1 with fill interpolate (a as b)"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    order_by=[ast.OrderExpr(expr=ast.Constant(value=1), with_fill=ast.WithFillExpr())],
+                    interpolate=[ast.InterpolateExpr(expr=ast.Alias(alias="b", expr=ast.Field(chain=["a"])))],
+                ),
+            )
+
+        def test_interpolate_inner_alias_then_postfix_call(self):
+            self.assertEqual(
+                self._select("select 1 order by 1 with fill interpolate (a as f())"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    order_by=[ast.OrderExpr(expr=ast.Constant(value=1), with_fill=ast.WithFillExpr())],
+                    interpolate=[
+                        ast.InterpolateExpr(
+                            expr=ast.ExprCall(expr=ast.Alias(alias="f", expr=ast.Field(chain=["a"])), args=[])
+                        )
+                    ],
+                ),
+            )
+
+        def test_interpolate_as_value_when_inner_alias_invalid(self):
+            self.assertEqual(
+                self._select("select 1 order by 1 with fill interpolate (1+1 as 2)"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    order_by=[ast.OrderExpr(expr=ast.Constant(value=1), with_fill=ast.WithFillExpr())],
+                    interpolate=[
+                        ast.InterpolateExpr(
+                            expr=ast.ArithmeticOperation(
+                                left=ast.Constant(value=1), right=ast.Constant(value=1), op="+"
+                            ),
+                            value=ast.Constant(value=2),
+                        )
+                    ],
+                ),
+            )
+
+        def test_set_offset_hops_up_without_trailing_decorators(self):
+            self.assertEqual(
+                self._select("select 1 union select 2 limit 3 offset 5"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(select=[ast.Constant(value=2)], limit=ast.Constant(value=3)),
+                            set_operator="UNION DISTINCT",
+                        )
+                    ],
+                    offset=ast.Constant(value=5),
+                ),
+            )
+
+        def test_set_offset_stays_inner_when_set_level_order_by_present(self):
+            self.assertEqual(
+                self._select("select 1 union select 2 limit 3 offset 5 order by 7"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit=ast.Constant(value=3),
+                                offset=ast.Constant(value=5),
+                            ),
+                            set_operator="UNION DISTINCT",
+                        )
+                    ],
+                ),
+            )
+
+        def test_set_offset_with_spread_and_trailing_order_by(self):
+            self.assertEqual(
+                self._select(
+                    "{ 208277 } intersect { ( '' ) } intersect select ( 'dc' ) ( ) ( ) limit ( * ) offset * columns ( 'if' ) order by { } nulls last , 843946"
+                ),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.Placeholder(expr=ast.Constant(value=208277)),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.Placeholder(expr=ast.Constant(value="")), set_operator="INTERSECT"
+                        ),
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[
+                                    ast.ExprCall(expr=ast.ExprCall(expr=ast.Constant(value="dc"), args=[]), args=[])
+                                ],
+                                limit=ast.Field(chain=["*"]),
+                                offset=ast.SpreadExpr(expr=ast.ColumnsExpr(regex="if")),
+                            ),
+                            set_operator="INTERSECT",
+                        ),
+                    ],
+                ),
+            )
+
+        def test_from_paren_inner_sample_wins_over_outer(self):
+            self.assertEqual(
+                self._select("select 1 from (t sample 0.1) sample {x}"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(
+                        table=ast.Field(chain=["t"]),
+                        sample=ast.SampleExpr(sample_value=ast.RatioExpr(left=ast.Constant(value=0.1))),
+                    ),
+                ),
+            )
+
+        def test_from_paren_placeholder_with_inner_sample_keeps_inner(self):
+            self.assertEqual(
+                self._select("select 1 from ({x} sample {y}) sample 0.5"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(
+                        table=ast.Placeholder(expr=ast.Field(chain=["x"])),
+                        sample=ast.SampleExpr(sample_value=ast.Placeholder(expr=ast.Field(chain=["y"]))),
+                    ),
+                ),
+            )
+
+        def test_from_paren_placeholder_alone_takes_outer_sample(self):
+            self.assertEqual(
+                self._select("select 1 from ({x}) sample 0.5"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(
+                        table=ast.Placeholder(expr=ast.Field(chain=["x"])),
+                        sample=ast.SampleExpr(sample_value=ast.RatioExpr(left=ast.Constant(value=0.5))),
+                    ),
+                ),
+            )
+
+        def test_set_offset_compact_form_stays_inner(self):
+            self.assertEqual(
+                self._select("select 1 union select 2 limit 3, 5"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit=ast.Constant(value=3),
+                                offset=ast.Constant(value=5),
+                            ),
+                            set_operator="UNION DISTINCT",
+                        )
+                    ],
+                ),
+            )
+
+        def test_set_offset_compact_form_with_ties_stays_inner(self):
+            self.assertEqual(
+                self._select("select 1 union select 2 limit 3, 5 with ties"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit=ast.Constant(value=3),
+                                limit_with_ties=True,
+                                offset=ast.Constant(value=5),
+                            ),
+                            set_operator="UNION DISTINCT",
+                        )
+                    ],
+                ),
+            )
+
+        def test_set_offset_compact_columns_spread_with_ties(self):
+            self.assertEqual(
+                self._select(
+                    "{996203} except select {} group by grouping sets (()) with totals limit {}, columns(*) with ties"
+                ),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.Placeholder(expr=ast.Constant(value=996203)),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Dict(items=[])],
+                                group_by=[ast.GroupingSet(exprs=[])],
+                                group_by_mode="grouping_sets",
+                                limit=ast.Dict(items=[]),
+                                limit_with_ties=True,
+                                offset=ast.ColumnsExpr(columns=[ast.Field(chain=["*"])]),
+                            ),
+                            set_operator="EXCEPT",
+                        )
+                    ],
+                ),
+            )
+
+        def test_set_offset_paren_collapsed_inner_stays(self):
+            self.assertEqual(
+                self._select("select 1 except ((select 2) limit 3 offset 5)"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit=ast.Constant(value=3),
+                                offset=ast.Constant(value=5),
+                            ),
+                            set_operator="EXCEPT",
+                        )
+                    ],
+                ),
+            )
+
+        def test_set_offset_nested_setquery_inner_stays(self):
+            self.assertEqual(
+                self._select("select 1 except ({(*)} union select 2 intersect (({(*)})) limit 3 offset columns(*))"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectSetQuery(
+                                initial_select_query=ast.Placeholder(expr=ast.Field(chain=["*"])),
+                                subsequent_select_queries=[
+                                    ast.SelectSetNode(
+                                        select_query=ast.SelectQuery(select=[ast.Constant(value=2)]),
+                                        set_operator="UNION DISTINCT",
+                                    ),
+                                    ast.SelectSetNode(
+                                        select_query=ast.Placeholder(expr=ast.Field(chain=["*"])),
+                                        set_operator="INTERSECT",
+                                    ),
+                                ],
+                                limit=ast.Constant(value=3),
+                                offset=ast.ColumnsExpr(columns=[ast.Field(chain=["*"])]),
+                            ),
+                            set_operator="EXCEPT",
+                        )
+                    ],
+                ),
+            )
+
+        def test_parametric_probe_order_by_in_first_parens_is_args_shape(self):
+            self.assertEqual(
+                self._expr("f(order by 1)(2)"),
+                ast.ExprCall(
+                    expr=ast.Call(name="f", args=[], order_by=[ast.OrderExpr(expr=ast.Constant(value=1))]),
+                    args=[ast.Constant(value=2)],
+                ),
+            )
+
+        def test_parametric_probe_distinct_in_first_parens_is_args_shape(self):
+            self.assertEqual(
+                self._expr("f(distinct 1)(2)"),
+                ast.ExprCall(
+                    expr=ast.Call(name="f", args=[ast.Constant(value=1)], distinct=True), args=[ast.Constant(value=2)]
+                ),
+            )
+
+        def test_cast_with_arrow_lambda_body(self):
+            self.assertEqual(
+                self._expr("cast((x) -> y AS Int)"),
+                ast.TypeCast(expr=ast.Lambda(args=["x"], expr=ast.Field(chain=["y"])), type_name="int"),
+            )
+
+        def test_try_cast_with_arrow_lambda_body(self):
+            self.assertEqual(
+                self._expr("try_cast((x) -> y AS Int)"),
+                ast.TryCast(expr=ast.Lambda(args=["x"], expr=ast.Field(chain=["y"])), type_name="int"),
+            )
+
+        def test_interval_with_empty_paren_arrow_lambda(self):
+            self.assertEqual(
+                self._expr("interval () -> (*) quarter"),
+                ast.Call(name="toIntervalQuarter", args=[ast.Lambda(args=[], expr=ast.Field(chain=["*"]))]),
+            )
+
+        def test_not_paren_star_replace_is_prefix(self):
+            self.assertEqual(
+                self._expr("not (* replace (1 as a))"),
+                ast.Not(expr=ast.ColumnsExpr(all_columns=True, replace={"a": ast.Constant(value=1)})),
+            )
+
+        def test_not_paren_star_exclude_replace_is_prefix(self):
+            self.assertEqual(
+                self._expr("not (* exclude (a) replace (1 as b))"),
+                ast.Not(expr=ast.ColumnsExpr(all_columns=True, exclude=["a"], replace={"b": ast.Constant(value=1)})),
+            )
+
+        def test_not_paren_star_exclude_only_is_function_call(self):
+            self.assertEqual(
+                self._expr("not (* exclude (a))"),
+                ast.Call(name="not", args=[ast.ColumnsExpr(all_columns=True, exclude=["a"])]),
+            )
+
+        def test_not_paren_star_alone_is_function_call(self):
+            self.assertEqual(self._expr("not (*)"), ast.Call(name="not", args=[ast.Field(chain=["*"])]))
+
+        def test_not_paren_arrow_lambda_is_prefix(self):
+            self.assertEqual(
+                self._expr("not (a) -> 1"), ast.Not(expr=ast.Lambda(args=["a"], expr=ast.Constant(value=1)))
+            )
+
+        def test_not_paren_empty_arrow_lambda_is_prefix(self):
+            self.assertEqual(self._expr("not () -> 1"), ast.Not(expr=ast.Lambda(args=[], expr=ast.Constant(value=1))))
+
+        def test_not_arrow_is_lambda_with_not_param(self):
+            self.assertEqual(self._expr("not -> 1"), ast.Lambda(args=["not"], expr=ast.Constant(value=1)))
+
+        def test_from_paren_field_drops_sample(self):
+            self.assertEqual(
+                self._select("SELECT 1 FROM (t) SAMPLE inf"),
+                ast.SelectQuery(select=[ast.Constant(value=1)], select_from=ast.JoinExpr(table=ast.Field(chain=["t"]))),
+            )
+
+        def test_from_double_paren_values_drops_sample(self):
+            self.assertEqual(
+                self._select("SELECT 1 FROM ((values(1))) SAMPLE inf"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(table=ast.ValuesQuery(rows=[[ast.Constant(value=1)]])),
+                ),
+            )
+
+        def test_from_paren_subquery_keeps_sample(self):
+            self.assertEqual(
+                self._select("SELECT 1 FROM ((SELECT 1)) SAMPLE inf"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(
+                        table=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                        sample=ast.SampleExpr(sample_value=ast.RatioExpr(left=ast.Constant(value=float("inf")))),
+                    ),
+                ),
+            )
+
+        def test_from_paren_placeholder_keeps_sample(self):
+            self.assertEqual(
+                self._select("SELECT 1 FROM (({x})) SAMPLE inf"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(
+                        table=ast.Placeholder(expr=ast.Field(chain=["x"])),
+                        sample=ast.SampleExpr(sample_value=ast.RatioExpr(left=ast.Constant(value=float("inf")))),
+                    ),
+                ),
+            )
+
+        def test_set_level_offset_hops_up_when_outer_empty(self):
+            self.assertEqual(
+                self._expr("f((select 1 union select 2 limit 'j' offset 5))"),
+                ast.Call(
+                    name="f",
+                    args=[
+                        ast.SelectSetQuery(
+                            initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                            subsequent_select_queries=[
+                                ast.SelectSetNode(
+                                    select_query=ast.SelectQuery(
+                                        select=[ast.Constant(value=2)], limit=ast.Constant(value="j")
+                                    ),
+                                    set_operator="UNION DISTINCT",
+                                )
+                            ],
+                            offset=ast.Constant(value=5),
+                        )
+                    ],
+                ),
+            )
+
+        def test_set_level_offset_stays_inner_when_outer_has_limit(self):
+            self.assertEqual(
+                self._select("(SELECT 1 UNION SELECT 2 LIMIT 1 OFFSET 2 LIMIT 3)"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit=ast.Constant(value=1),
+                                offset=ast.Constant(value=2),
+                            ),
+                            set_operator="UNION DISTINCT",
+                        )
+                    ],
+                    limit=ast.Constant(value=3),
+                ),
+            )
+
+        def test_offset_with_spread_expression_hops_up(self):
+            self.assertEqual(
+                self._expr("f((select 1 union select 2 limit 'j' offset *columns('x')))"),
+                ast.Call(
+                    name="f",
+                    args=[
+                        ast.SelectSetQuery(
+                            initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                            subsequent_select_queries=[
+                                ast.SelectSetNode(
+                                    select_query=ast.SelectQuery(
+                                        select=[ast.Constant(value=2)], limit=ast.Constant(value="j")
+                                    ),
+                                    set_operator="UNION DISTINCT",
+                                )
+                            ],
+                            offset=ast.SpreadExpr(expr=ast.ColumnsExpr(regex="x")),
+                        )
+                    ],
+                ),
+            )
+
+        def test_limit_modulo_offset_arithmetic_extends_with_spread(self):
+            self.assertEqual(
+                self._select("select 1 limit a % offset * columns('x')"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.ArithmeticOperation(
+                        left=ast.ArithmeticOperation(
+                            left=ast.Field(chain=["a"]), right=ast.Field(chain=["offset"]), op="%"
+                        ),
+                        right=ast.ColumnsExpr(regex="x"),
+                        op="*",
+                    ),
+                ),
+            )
+
+        def test_limit_modulo_offset_arithmetic_extends_with_exclude(self):
+            self.assertEqual(
+                self._select("select 1 limit a % offset * exclude (x)"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.ArithmeticOperation(
+                        left=ast.ArithmeticOperation(
+                            left=ast.Field(chain=["a"]), right=ast.Field(chain=["offset"]), op="%"
+                        ),
+                        right=ast.Call(name="exclude", args=[ast.Field(chain=["x"])]),
+                        op="*",
+                    ),
+                ),
+            )
+
+        def test_limit_modulo_offset_keeps_percent_for_bare_asterisk(self):
+            self.assertEqual(
+                self._select("select 1 limit a % offset *"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.Field(chain=["a"]),
+                    limit_percent=True,
+                    offset=ast.Field(chain=["*"]),
+                ),
+            )
+
+        def test_limit_modulo_offset_keeps_percent_for_identifier_body(self):
+            self.assertEqual(
+                self._select("select 1 limit a % offset b"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.Field(chain=["a"]),
+                    limit_percent=True,
+                    offset=ast.Field(chain=["b"]),
+                ),
+            )
+
+        def test_offset_body_consumes_full_arithmetic_chain(self):
+            self.assertEqual(
+                self._select("select 1 limit a % offset b * c"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.Field(chain=["a"]),
+                    limit_percent=True,
+                    offset=ast.ArithmeticOperation(left=ast.Field(chain=["b"]), right=ast.Field(chain=["c"]), op="*"),
+                ),
+            )
+
+        def test_limit_by_extends_through_offset_keyword_in_arithmetic(self):
+            self.assertEqual(
+                self._select("select 1 limit 5 by a, offset * columns('r')"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit_by=ast.LimitByExpr(
+                        n=ast.Constant(value=5),
+                        exprs=[
+                            ast.Field(chain=["a"]),
+                            ast.ArithmeticOperation(
+                                left=ast.Field(chain=["offset"]), right=ast.ColumnsExpr(regex="r"), op="*"
+                            ),
+                        ],
+                    ),
+                ),
+            )
+
+        def test_octal_lhs_dot_number_is_tuple_access(self):
+            self.assertEqual(
+                self._expr("03326 . 719972"), ast.TupleAccess(tuple=ast.Constant(value=1750), index=719972)
+            )
+
+        def test_octal_lhs_dot_number_no_whitespace_is_tuple_access(self):
+            self.assertEqual(self._expr("03326.719972"), ast.TupleAccess(tuple=ast.Constant(value=1750), index=719972))
+
+        def test_decimal_lhs_dot_number_remains_float(self):
+            self.assertEqual(self._expr("17 . 5"), ast.Constant(value=17.5))
+
+        def test_hex_lhs_dot_number_is_tuple_access(self):
+            self.assertEqual(
+                self._expr("0x0fb5bB . 293155"), ast.TupleAccess(tuple=ast.Constant(value=1029563), index=293155)
+            )
+
+        def test_not_brace_multi_member_setop_is_not_prefix(self):
+            self.assertEqual(
+                self._expr("not ({1} except {2})"),
+                ast.Not(
+                    expr=ast.SelectSetQuery(
+                        initial_select_query=ast.Placeholder(expr=ast.Constant(value=1)),
+                        subsequent_select_queries=[
+                            ast.SelectSetNode(
+                                select_query=ast.Placeholder(expr=ast.Constant(value=2)), set_operator="EXCEPT"
+                            )
+                        ],
+                    )
+                ),
+            )
+
+        def test_not_brace_single_placeholder_is_call(self):
+            self.assertEqual(
+                self._expr("not ({1})"),
+                ast.Call(name="not", args=[ast.Placeholder(expr=ast.Constant(value=1))]),
+            )
+
+        def test_not_brace_single_placeholder_with_decorator_is_call(self):
+            self.assertEqual(
+                self._expr("not ({1} order by 0)"),
+                ast.Call(
+                    name="not",
+                    args=[ast.Placeholder(expr=ast.Constant(value=1))],
+                    order_by=[ast.OrderExpr(expr=ast.Constant(value=0))],
+                ),
+            )
+
+        def test_not_brace_setop_with_postfix_arrayaccess(self):
+            self.assertEqual(
+                self._expr("not ({1} except {2}) [3]"),
+                ast.Not(
+                    expr=ast.ArrayAccess(
+                        array=ast.SelectSetQuery(
+                            initial_select_query=ast.Placeholder(expr=ast.Constant(value=1)),
+                            subsequent_select_queries=[
+                                ast.SelectSetNode(
+                                    select_query=ast.Placeholder(expr=ast.Constant(value=2)), set_operator="EXCEPT"
+                                )
+                            ],
+                        ),
+                        property=ast.Constant(value=3),
+                    )
+                ),
+            )
+
+        def test_paren_call_with_brace_setop_arg_is_call_subquery(self):
+            self.assertEqual(
+                self._expr("name() ({1} except {2})"),
+                ast.ExprCall(
+                    expr=ast.Call(name="name", args=[]),
+                    args=[
+                        ast.SelectSetQuery(
+                            initial_select_query=ast.Placeholder(expr=ast.Constant(value=1)),
+                            subsequent_select_queries=[
+                                ast.SelectSetNode(
+                                    select_query=ast.Placeholder(expr=ast.Constant(value=2)), set_operator="EXCEPT"
+                                )
+                            ],
+                        )
+                    ],
+                ),
+            )
+
+        def test_paren_call_with_select_arg_is_call_subquery(self):
+            self.assertEqual(
+                self._expr("name() (select 1)"),
+                ast.ExprCall(
+                    expr=ast.Call(name="name", args=[]), args=[ast.SelectQuery(select=[ast.Constant(value=1)])]
+                ),
+            )
+
+        def test_limit_by_list_terminates_at_trailing_except_setop(self):
+            self.assertEqual(
+                self._select("select 1 limit 5 by (*), except (select 2)"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(
+                        select=[ast.Constant(value=1)],
+                        limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["*"])]),
+                    ),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(select=[ast.Constant(value=2)]), set_operator="EXCEPT"
+                        )
+                    ],
+                ),
+            )
+
+        def test_limit_by_list_terminates_at_trailing_union_setop(self):
+            self.assertEqual(
+                self._select("select 1 limit 5 by (*), union all select 2"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(
+                        select=[ast.Constant(value=1)],
+                        limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["*"])]),
+                    ),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(select=[ast.Constant(value=2)]), set_operator="UNION ALL"
+                        )
+                    ],
+                ),
+            )
+
+        def test_int_dot_ignore_nulls_is_trailing_dot_float(self):
+            self.assertEqual(self._expr("5 . ignore nulls"), ast.Constant(value=5.0))
+
+        def test_int_dot_ignore_without_nulls_is_property_access(self):
+            self.assertEqual(
+                self._expr("5 . ignore"),
+                ast.ArrayAccess(array=ast.Constant(value=5), property=ast.Constant(value="ignore")),
+            )
+
+        def test_int_dot_ignore_followed_by_arith_is_property_access(self):
+            self.assertEqual(
+                self._expr("5 . ignore + 3"),
+                ast.ArithmeticOperation(
+                    left=ast.ArrayAccess(array=ast.Constant(value=5), property=ast.Constant(value="ignore")),
+                    right=ast.Constant(value=3),
+                    op="+",
+                ),
+            )
+
+        def test_paren_around_setop_typecast_int(self):
+            self.assertEqual(
+                self._expr("(({1} intersect {2}) :: int)"),
+                ast.TypeCast(
+                    expr=ast.SelectSetQuery(
+                        initial_select_query=ast.Placeholder(expr=ast.Constant(value=1)),
+                        subsequent_select_queries=[
+                            ast.SelectSetNode(
+                                select_query=ast.Placeholder(expr=ast.Constant(value=2)), set_operator="INTERSECT"
+                            )
+                        ],
+                    ),
+                    type_name="int",
+                ),
+            )
+
+        def test_paren_around_setop_typecast_quoted_type(self):
+            self.assertEqual(
+                self._expr('(({1} intersect {2}) :: "_")'),
+                ast.TypeCast(
+                    expr=ast.SelectSetQuery(
+                        initial_select_query=ast.Placeholder(expr=ast.Constant(value=1)),
+                        subsequent_select_queries=[
+                            ast.SelectSetNode(
+                                select_query=ast.Placeholder(expr=ast.Constant(value=2)), set_operator="INTERSECT"
+                            )
+                        ],
+                    ),
+                    type_name="_",
+                ),
+            )
+
+        def test_paren_around_setop_typecast_with_time_zone(self):
+            self.assertEqual(
+                self._expr("(({1} intersect {2}) :: int with time zone)"),
+                ast.TypeCast(
+                    expr=ast.SelectSetQuery(
+                        initial_select_query=ast.Placeholder(expr=ast.Constant(value=1)),
+                        subsequent_select_queries=[
+                            ast.SelectSetNode(
+                                select_query=ast.Placeholder(expr=ast.Constant(value=2)), set_operator="INTERSECT"
+                            )
+                        ],
+                    ),
+                    type_name="int with time zone",
+                ),
+            )
+
+        def test_paren_around_setop_array_access(self):
+            self.assertEqual(
+                self._expr("({1} intersect {2}) [0]"),
+                ast.ArrayAccess(
+                    array=ast.SelectSetQuery(
+                        initial_select_query=ast.Placeholder(expr=ast.Constant(value=1)),
+                        subsequent_select_queries=[
+                            ast.SelectSetNode(
+                                select_query=ast.Placeholder(expr=ast.Constant(value=2)), set_operator="INTERSECT"
+                            )
+                        ],
+                    ),
+                    property=ast.Constant(value=0),
+                ),
+            )
+
+        def test_paren_around_setop_property_access(self):
+            self.assertEqual(
+                self._expr("(({1} intersect {2}) . prop)"),
+                ast.ArrayAccess(
+                    array=ast.SelectSetQuery(
+                        initial_select_query=ast.Placeholder(expr=ast.Constant(value=1)),
+                        subsequent_select_queries=[
+                            ast.SelectSetNode(
+                                select_query=ast.Placeholder(expr=ast.Constant(value=2)), set_operator="INTERSECT"
+                            )
+                        ],
+                    ),
+                    property=ast.Constant(value="prop"),
+                ),
+            )
+
+        def test_intersect_chain_offset_hoist_after_limit_by(self):
+            self.assertEqual(
+                self._select("select 1 intersect select 2 limit 5 by 1 limit 3 offset 0"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit=ast.Constant(value=3),
+                                limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Constant(value=1)]),
+                            ),
+                            set_operator="INTERSECT",
+                        )
+                    ],
+                    offset=ast.Constant(value=0),
+                ),
+            )
+
+        def test_between_absorbs_inner_between_with_trailing_and(self):
+            self.assertEqual(
+                self._expr("x between a and b between c and d and e"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.BetweenExpr(
+                        expr=ast.And(exprs=[ast.Field(chain=["a"]), ast.Field(chain=["b"])]),
+                        low=ast.Field(chain=["c"]),
+                        high=ast.Field(chain=["d"]),
+                    ),
+                    high=ast.Field(chain=["e"]),
+                ),
+            )
+
+        def test_between_nested_without_trailing_and_left_recurses(self):
+            self.assertEqual(
+                self._expr("x between 1 and 2 between 3 and 4"),
+                ast.BetweenExpr(
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]), low=ast.Constant(value=1), high=ast.Constant(value=2)
+                    ),
+                    low=ast.Constant(value=3),
+                    high=ast.Constant(value=4),
+                ),
+            )
+
+        def test_between_absorbs_inner_not_between_with_trailing_and(self):
+            self.assertEqual(
+                self._expr("x between a is null and b not between c and d and e"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.BetweenExpr(
+                        expr=ast.And(
+                            exprs=[
+                                ast.CompareOperation(
+                                    left=ast.Field(chain=["a"]),
+                                    right=ast.Constant(value=None),
+                                    op="==",
+                                    is_null_comparison_style=True,
+                                ),
+                                ast.Field(chain=["b"]),
+                            ]
+                        ),
+                        low=ast.Field(chain=["c"]),
+                        high=ast.Field(chain=["d"]),
+                        negated=True,
+                    ),
+                    high=ast.Field(chain=["e"]),
+                ),
+            )
+
+        def test_limit_modulo_limit_blocks_modulo(self):
+            self.assertEqual(
+                self._select("select 1 limit 5 % limit 3"),
+                ast.SelectQuery(select=[ast.Constant(value=1)], limit=ast.Constant(value=3), limit_percent=True),
+            )
+
+        def test_limit_chain_with_ties_offset_limit(self):
+            self.assertEqual(
+                self._select("select 1 limit 5 by a limit 3 with ties offset 2 limit 7"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.Constant(value=7),
+                    limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"])]),
+                    limit_with_ties=True,
+                    offset=ast.Constant(value=2),
+                ),
+            )
+
+        def test_limit_modulo_order_by_blocked_after_limit_by(self):
+            self.assertEqual(
+                self._select("select 1 limit 5 by a limit 3 % order by 0"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.Constant(value=3),
+                    limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"])]),
+                    limit_percent=True,
+                ),
+            )
+
+        def test_not_colon_equals_value_is_named_argument(self):
+            self.assertEqual(self._expr("not := 5"), ast.NamedArgument(name="not", value=ast.Constant(value=5)))
+
+        def test_not_asterisk_dot_decimal_is_not_tuple_access(self):
+            self.assertEqual(
+                self._expr("not * . 5"), ast.Not(expr=ast.TupleAccess(tuple=ast.Field(chain=["*"]), index=5))
+            )
+
+        def test_not_asterisk_array_access_is_not_array_access(self):
+            self.assertEqual(
+                self._expr("not * [0]"),
+                ast.Not(expr=ast.ArrayAccess(array=ast.Field(chain=["*"]), property=ast.Constant(value=0))),
+            )
+
+        def test_between_body_named_arg_value_does_not_absorb_and(self):
+            self.assertEqual(
+                self._expr('x between y and "n" := 5 and z'),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.And(
+                        exprs=[ast.Field(chain=["y"]), ast.NamedArgument(name="n", value=ast.Constant(value=5))]
+                    ),
+                    high=ast.Field(chain=["z"]),
+                ),
+            )
+
+        def test_standalone_named_arg_value_still_absorbs_and(self):
+            self.assertEqual(
+                self._expr('"x" := y and z'),
+                ast.NamedArgument(name="x", value=ast.And(exprs=[ast.Field(chain=["y"]), ast.Field(chain=["z"])])),
+            )
+
+        def test_with_cte_chained_as_alias_with_postfix_call(self):
+            self.assertEqual(
+                self._select("with 3 as x ('a') as y select 4"),
+                ast.SelectQuery(
+                    ctes={
+                        "y": ast.CTE(
+                            name="y",
+                            expr=ast.ExprCall(
+                                expr=ast.Alias(alias="x", expr=ast.Constant(value=3)), args=[ast.Constant(value="a")]
+                            ),
+                            cte_type="column",
+                        )
+                    },
+                    select=[ast.Constant(value=4)],
+                ),
+            )
+
+        def test_with_cte_plain_column_form(self):
+            self.assertEqual(
+                self._select("with 42 as answer select answer"),
+                ast.SelectQuery(
+                    ctes={"answer": ast.CTE(name="answer", expr=ast.Constant(value=42), cte_type="column")},
+                    select=[ast.Field(chain=["answer"])],
+                ),
+            )
+
+        def test_with_cte_rewind_when_postfix_extends_past_outermost_alias(self):
+            self.assertEqual(
+                self._select('with (\'\') as "eill_" () as "jj" (select(*)()) offset 2'),
+                ast.SelectQuery(
+                    ctes={
+                        "jj": ast.CTE(
+                            name="jj",
+                            expr=ast.ExprCall(expr=ast.Alias(alias="eill_", expr=ast.Constant(value="")), args=[]),
+                            cte_type="column",
+                        )
+                    },
+                    select=[ast.ExprCall(expr=ast.Field(chain=["*"]), args=[])],
+                    offset=ast.Constant(value=2),
+                ),
+            )
+
+        def test_with_cte_rewind_with_unquoted_inner_alias(self):
+            self.assertEqual(
+                self._select("with ('') as yi_j_w_n () as \"jj\" (select(*)()) offset 2"),
+                ast.SelectQuery(
+                    ctes={
+                        "jj": ast.CTE(
+                            name="jj",
+                            expr=ast.ExprCall(expr=ast.Alias(alias="yi_j_w_n", expr=ast.Constant(value="")), args=[]),
+                            cte_type="column",
+                        )
+                    },
+                    select=[ast.ExprCall(expr=ast.Field(chain=["*"]), args=[])],
+                    offset=ast.Constant(value=2),
+                ),
+            )
+
+        def test_set_level_limit_comma_form_orders_limit_then_offset(self):
+            self.assertEqual(
+                self._expr("(({1} intersect by name {2}) limit 3, 4)"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.Placeholder(expr=ast.Constant(value=1)),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.Placeholder(expr=ast.Constant(value=2)), set_operator="INTERSECT BY NAME"
+                        )
+                    ],
+                    limit=ast.Constant(value=3),
+                    offset=ast.Constant(value=4),
+                ),
+            )
+
+        def test_parametric_call_with_distinct_identifier_in_params(self):
+            self.assertEqual(
+                self._expr("a is distinct from f(distinct)(b)"),
+                ast.IsDistinctFrom(
+                    left=ast.Field(chain=["a"]),
+                    right=ast.Call(name="f", args=[ast.Field(chain=["b"])], params=[ast.Field(chain=["distinct"])]),
+                ),
+            )
+
+        def test_parametric_call_ordinary_params(self):
+            self.assertEqual(
+                self._expr("quantile(0.5)(x)"),
+                ast.Call(name="quantile", args=[ast.Field(chain=["x"])], params=[ast.Constant(value=0.5)]),
+            )
+
+        def test_single_paren_call_keeps_distinct_modifier(self):
+            self.assertEqual(
+                self._expr("f(distinct b)"), ast.Call(name="f", args=[ast.Field(chain=["b"])], distinct=True)
+            )
+
+        def test_filter_between_parens_breaks_parametric(self):
+            self.assertEqual(
+                self._expr("f(a) filter (where x) (b)"),
+                ast.ExprCall(
+                    expr=ast.Call(name="f", args=[ast.Field(chain=["a"])], filter_expr=ast.Field(chain=["x"])),
+                    args=[ast.Field(chain=["b"])],
+                ),
+            )
+
+        def test_filter_after_parametric_args_attaches_normally(self):
+            self.assertEqual(
+                self._expr("quantile(0.5)(x) filter (where y)"),
+                ast.Call(
+                    name="quantile",
+                    args=[ast.Field(chain=["x"])],
+                    params=[ast.Constant(value=0.5)],
+                    filter_expr=ast.Field(chain=["y"]),
+                ),
+            )
+
+        def test_call_select_postfix_not_parametric(self):
+            self.assertEqual(
+                self._expr("f(1)(select 1)"),
+                ast.ExprCall(
+                    expr=ast.Call(name="f", args=[ast.Constant(value=1)]),
+                    args=[ast.SelectQuery(select=[ast.Constant(value=1)])],
+                ),
+            )
+
+        def test_call_select_postfix_with_not_prefix(self):
+            self.assertEqual(
+                self._expr("not(1)(select 1)"),
+                ast.ExprCall(
+                    expr=ast.Call(name="not", args=[ast.Constant(value=1)]),
+                    args=[ast.SelectQuery(select=[ast.Constant(value=1)])],
+                ),
+            )
+
+        def test_columns_empty_parens_is_function_call(self):
+            self.assertEqual(self._expr("columns()"), ast.Call(name="columns", args=[]))
+
+        def test_columns_empty_parens_then_property(self):
+            self.assertEqual(
+                self._expr("columns().a"),
+                ast.ArrayAccess(array=ast.Call(name="columns", args=[]), property=ast.Constant(value="a")),
+            )
+
+        def test_call_arg_dict_with_outer_order_by(self):
+            self.assertEqual(
+                self._expr("f({} order by 1)"),
+                ast.Call(name="f", args=[ast.Dict(items=[])], order_by=[ast.OrderExpr(expr=ast.Constant(value=1))]),
+            )
+
+        def test_call_arg_placeholder_with_outer_order_by(self):
+            self.assertEqual(
+                self._expr("f({x} order by 1)"),
+                ast.Call(
+                    name="f",
+                    args=[ast.Placeholder(expr=ast.Field(chain=["x"]))],
+                    order_by=[ast.OrderExpr(expr=ast.Constant(value=1))],
+                ),
+            )
+
+        def test_call_arg_paren_select_outer_order_by(self):
+            self.assertEqual(
+                self._expr("f((select 1) order by 2)"),
+                ast.Call(
+                    name="f",
+                    args=[ast.SelectQuery(select=[ast.Constant(value=1)])],
+                    order_by=[ast.OrderExpr(expr=ast.Constant(value=2))],
+                ),
+            )
+
+        def test_call_arg_paren_select_offset_stays_inner(self):
+            self.assertEqual(
+                self._expr("f((select 1) offset 2)"),
+                ast.Call(
+                    name="f", args=[ast.SelectQuery(select=[ast.Constant(value=1)], offset=ast.Constant(value=2))]
+                ),
+            )
+
+        def test_asterisk_call_with_placeholder_arg_folds_to_call(self):
+            self.assertEqual(
+                self._expr("* ({1})"), ast.Call(name="*", args=[ast.Placeholder(expr=ast.Constant(value=1))])
+            )
+
+        def test_asterisk_call_with_dict_arg_keeps_exprcall(self):
+            self.assertEqual(self._expr("* ({})"), ast.ExprCall(expr=ast.Field(chain=["*"]), args=[ast.Dict(items=[])]))
+
+        def test_not_paren_select_is_prefix(self):
+            self.assertEqual(
+                self._expr("not (select 1)"), ast.Not(expr=ast.SelectQuery(select=[ast.Constant(value=1)]))
+            )
+
+        def test_not_paren_select_typecast_is_prefix_over_typecast(self):
+            self.assertEqual(
+                self._expr("not (select 1) :: typ"),
+                ast.Not(expr=ast.TypeCast(expr=ast.SelectQuery(select=[ast.Constant(value=1)]), type_name="typ")),
+            )
+
+        def test_not_paren_select_union_is_prefix(self):
+            self.assertEqual(
+                self._expr("not (select 1 union select 2)"),
+                ast.Not(
+                    expr=ast.SelectSetQuery(
+                        initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                        subsequent_select_queries=[
+                            ast.SelectSetNode(
+                                select_query=ast.SelectQuery(select=[ast.Constant(value=2)]),
+                                set_operator="UNION DISTINCT",
+                            )
+                        ],
+                    )
+                ),
+            )
+
+        def test_not_paren_grouped_selects_unioned_is_prefix(self):
+            self.assertEqual(
+                self._expr("not ((select 1) union (select 2))"),
+                ast.Not(
+                    expr=ast.SelectSetQuery(
+                        initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                        subsequent_select_queries=[
+                            ast.SelectSetNode(
+                                select_query=ast.SelectQuery(select=[ast.Constant(value=2)]),
+                                set_operator="UNION DISTINCT",
+                            )
+                        ],
+                    )
+                ),
+            )
+
+        def test_not_paren_grouped_selects_intersected_is_prefix(self):
+            self.assertEqual(
+                self._expr("not ((select 1) intersect (select 2))"),
+                ast.Not(
+                    expr=ast.SelectSetQuery(
+                        initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                        subsequent_select_queries=[
+                            ast.SelectSetNode(
+                                select_query=ast.SelectQuery(select=[ast.Constant(value=2)]), set_operator="INTERSECT"
+                            )
+                        ],
+                    )
+                ),
+            )
+
+        def test_not_paren_constant_still_function_call(self):
+            self.assertEqual(self._expr("not (1)"), ast.Call(name="not", args=[ast.Constant(value=1)]))
+
+        def test_call_arg_bare_select_consumes_trailing_order_by(self):
+            self.assertEqual(
+                self._expr("f(select 1 offset 2 order by 3)"),
+                ast.Call(
+                    name="f", args=[ast.SelectQuery(select=[ast.Constant(value=1)], offset=ast.Constant(value=2))]
+                ),
+            )
+
+        def test_postfix_call_select_consumes_trailing_order_by(self):
+            self.assertEqual(
+                self._expr("columns('')(select 1 offset 2 order by 3)"),
+                ast.ExprCall(
+                    expr=ast.ColumnsExpr(regex=""),
+                    args=[ast.SelectQuery(select=[ast.Constant(value=1)], offset=ast.Constant(value=2))],
+                ),
+            )
+
+        def test_select_between_with_lambda_body(self):
+            self.assertEqual(
+                self._select("SELECT 1 WHERE x BETWEEN lambda y : a AND b AND high"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    where=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]),
+                        low=ast.Lambda(
+                            args=["y"], expr=ast.And(exprs=[ast.Field(chain=["a"]), ast.Field(chain=["b"])])
+                        ),
+                        high=ast.Field(chain=["high"]),
+                    ),
+                ),
+            )
+
+        # --- allstar :: TestAllStarPrattLimitations (87 tests) ---
+        def test_between_nested_between_depth_3(self):
+            self.assertEqual(
+                self._expr("a BETWEEN b BETWEEN c BETWEEN d AND e AND f AND g"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["a"]),
+                    low=ast.BetweenExpr(
+                        expr=ast.Field(chain=["b"]),
+                        low=ast.BetweenExpr(
+                            expr=ast.Field(chain=["c"]), low=ast.Field(chain=["d"]), high=ast.Field(chain=["e"])
+                        ),
+                        high=ast.Field(chain=["f"]),
+                    ),
+                    high=ast.Field(chain=["g"]),
+                ),
+            )
+
+        def test_between_chained_not_between(self):
+            self.assertEqual(
+                self._expr("a NOT BETWEEN b AND c NOT BETWEEN d AND e"),
+                ast.BetweenExpr(
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["a"]),
+                        low=ast.Field(chain=["b"]),
+                        high=ast.Field(chain=["c"]),
+                        negated=True,
+                    ),
+                    low=ast.Field(chain=["d"]),
+                    high=ast.Field(chain=["e"]),
+                    negated=True,
+                ),
+            )
+
+        def test_between_chained_with_case_high(self):
+            self.assertEqual(
+                self._expr("a NOT BETWEEN b AND CASE 1 WHEN 2 THEN 3 ELSE 4 END NOT BETWEEN 5 AND 6"),
+                ast.BetweenExpr(
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["a"]),
+                        low=ast.Field(chain=["b"]),
+                        high=ast.Call(
+                            name="transform",
+                            args=[
+                                ast.Constant(value=1),
+                                ast.Array(exprs=[ast.Constant(value=2)]),
+                                ast.Array(exprs=[ast.Constant(value=3)]),
+                                ast.Constant(value=4),
+                            ],
+                        ),
+                        negated=True,
+                    ),
+                    low=ast.Constant(value=5),
+                    high=ast.Constant(value=6),
+                    negated=True,
+                ),
+            )
+
+        def test_between_chained_between(self):
+            self.assertEqual(
+                self._expr("a BETWEEN b AND c BETWEEN d AND e"),
+                ast.BetweenExpr(
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["a"]), low=ast.Field(chain=["b"]), high=ast.Field(chain=["c"])
+                    ),
+                    low=ast.Field(chain=["d"]),
+                    high=ast.Field(chain=["e"]),
+                ),
+            )
+
+        def test_interval_with_empty_paren_lambda_value(self):
+            self.assertEqual(
+                self._expr("interval () -> 1 month"),
+                ast.Call(name="toIntervalMonth", args=[ast.Lambda(args=[], expr=ast.Constant(value=1))]),
+            )
+
+        def test_case_with_empty_paren_lambda_value(self):
+            self.assertEqual(
+                self._expr("case () -> 1 when 1 then 2 end"),
+                ast.Call(
+                    name="transform",
+                    args=[
+                        ast.Lambda(args=[], expr=ast.Constant(value=1)),
+                        ast.Array(exprs=[ast.Constant(value=1)]),
+                        ast.Array(exprs=[]),
+                        ast.Constant(value=2),
+                    ],
+                ),
+            )
+
+        def test_interval_call_form_single_arg(self):
+            self.assertEqual(self._expr("interval(1)"), ast.Call(name="interval", args=[ast.Constant(value=1)]))
+
+        def test_interval_call_form_multi_args(self):
+            self.assertEqual(
+                self._expr("interval(1, 2)"),
+                ast.Call(name="interval", args=[ast.Constant(value=1), ast.Constant(value=2)]),
+            )
+
+        def test_interval_call_form_with_distinct(self):
+            self.assertEqual(
+                self._expr("interval(distinct 1, 2)"),
+                ast.Call(name="interval", args=[ast.Constant(value=1), ast.Constant(value=2)], distinct=True),
+            )
+
+        def test_interval_call_form_within_group(self):
+            self.assertEqual(
+                self._expr("interval (columns(*), columns(*)) within group (order by {})"),
+                ast.Call(
+                    name="interval",
+                    args=[],
+                    params=[
+                        ast.ColumnsExpr(columns=[ast.Field(chain=["*"])]),
+                        ast.ColumnsExpr(columns=[ast.Field(chain=["*"])]),
+                    ],
+                    within_group=[ast.OrderExpr(expr=ast.Dict(items=[]))],
+                ),
+            )
+
+        def test_columns_empty_parametric_is_function_call(self):
+            self.assertEqual(self._expr("columns()()"), ast.Call(name="columns", args=[], params=[]))
+
+        def test_columns_empty_paren_with_filter(self):
+            self.assertEqual(
+                self._expr("columns() filter(where 1)"),
+                ast.Call(name="columns", args=[], filter_expr=ast.Constant(value=1)),
+            )
+
+        def test_infinity_keyword_is_nan(self):
+            # NaN can't be checked with ==, so unwrap and use math.isnan.
+            parsed = self._expr("infinity")
+            self.assertIsInstance(parsed, ast.Constant)
+            self.assertTrue(math.isnan(cast(ast.Constant, parsed).value))
+
+        def test_negative_infinity_is_nan(self):
+            parsed = self._expr("-infinity")
+            self.assertIsInstance(parsed, ast.Constant)
+            self.assertTrue(math.isnan(cast(ast.Constant, parsed).value))
+
+        def test_order_by_in_call_then_postfix_call(self):
+            self.assertEqual(
+                self._expr("foo (order by x) ()"),
+                ast.ExprCall(
+                    expr=ast.Call(name="foo", args=[], order_by=[ast.OrderExpr(expr=ast.Field(chain=["x"]))]), args=[]
+                ),
+            )
+
+        def test_distinct_in_call_then_postfix_call(self):
+            self.assertEqual(
+                self._expr("foo (distinct x) ()"),
+                ast.ExprCall(expr=ast.Call(name="foo", args=[ast.Field(chain=["x"])], distinct=True), args=[]),
+            )
+
+        def test_args_with_trailing_order_by_then_postfix_call(self):
+            self.assertEqual(
+                self._expr("foo (x order by y) ()"),
+                ast.ExprCall(
+                    expr=ast.Call(
+                        name="foo", args=[ast.Field(chain=["x"])], order_by=[ast.OrderExpr(expr=ast.Field(chain=["y"]))]
+                    ),
+                    args=[],
+                ),
+            )
+
+        def test_parametric_form_keeps_distinct_as_field(self):
+            self.assertEqual(
+                self._expr("foo (distinct) ()"), ast.Call(name="foo", args=[], params=[ast.Field(chain=["distinct"])])
+            )
+
+        def test_parametric_form_with_distinct_and_comma(self):
+            self.assertEqual(
+                self._expr("foo (distinct, x) ()"),
+                ast.Call(name="foo", args=[], params=[ast.Field(chain=["distinct"]), ast.Field(chain=["x"])]),
+            )
+
+        def test_distinct_followed_by_comma_is_field(self):
+            self.assertEqual(
+                self._expr("foo (distinct, x)"),
+                ast.Call(name="foo", args=[ast.Field(chain=["distinct"]), ast.Field(chain=["x"])]),
+            )
+
+        def test_distinct_followed_by_dot_is_field(self):
+            self.assertEqual(
+                self._expr("foo (distinct.x)"), ast.Call(name="foo", args=[ast.Field(chain=["distinct", "x"])])
+            )
+
+        def test_not_asterisk_bare(self):
+            self.assertEqual(self._expr("not *"), ast.Not(expr=ast.Field(chain=["*"])))
+
+        def test_not_asterisk_postfix_call_empty(self):
+            self.assertEqual(self._expr("not * ()"), ast.Not(expr=ast.ExprCall(expr=ast.Field(chain=["*"]), args=[])))
+
+        def test_not_asterisk_postfix_call_with_args(self):
+            self.assertEqual(
+                self._expr("not * (1)"),
+                ast.Not(expr=ast.ExprCall(expr=ast.Field(chain=["*"]), args=[ast.Constant(value=1)])),
+            )
+
+        def test_not_asterisk_postfix_array_access(self):
+            self.assertEqual(
+                self._expr("not * [1]"),
+                ast.Not(expr=ast.ArrayAccess(array=ast.Field(chain=["*"]), property=ast.Constant(value=1))),
+            )
+
+        def test_not_asterisk_chain_dot_split(self):
+            self.assertEqual(
+                self._expr("not * . x"),
+                ast.Not(expr=ast.ArrayAccess(array=ast.Field(chain=["*"]), property=ast.Constant(value="x"))),
+            )
+
+        def test_not_asterisk_null_property(self):
+            self.assertEqual(
+                self._expr("not * ?. x"),
+                ast.Not(
+                    expr=ast.ArrayAccess(array=ast.Field(chain=["*"]), property=ast.Constant(value="x"), nullish=True)
+                ),
+            )
+
+        def test_not_asterisk_typecast(self):
+            self.assertEqual(
+                self._expr("not * :: Int"),
+                ast.Not(expr=ast.TypeCast(expr=ast.Field(chain=["*"]), type_name="int")),
+            )
+
+        def test_not_asterisk_binary_plus(self):
+            self.assertEqual(
+                self._expr("not * + 1"),
+                ast.Not(expr=ast.ArithmeticOperation(left=ast.Field(chain=["*"]), right=ast.Constant(value=1), op="+")),
+            )
+
+        def test_not_asterisk_compare(self):
+            self.assertEqual(
+                self._expr("not * = 1"),
+                ast.Not(expr=ast.CompareOperation(left=ast.Field(chain=["*"]), right=ast.Constant(value=1), op="==")),
+            )
+
+        def test_not_asterisk_is_null(self):
+            self.assertEqual(
+                self._expr("not * is null"),
+                ast.Not(
+                    expr=ast.CompareOperation(
+                        left=ast.Field(chain=["*"]),
+                        right=ast.Constant(value=None),
+                        op="==",
+                        is_null_comparison_style=True,
+                    )
+                ),
+            )
+
+        def test_not_asterisk_between(self):
+            self.assertEqual(
+                self._expr("not * between 1 and 2"),
+                ast.BetweenExpr(
+                    expr=ast.Not(expr=ast.Field(chain=["*"])), low=ast.Constant(value=1), high=ast.Constant(value=2)
+                ),
+            )
+
+        def test_not_asterisk_and_binds_outside(self):
+            self.assertEqual(
+                self._expr("not * and 1"),
+                ast.And(exprs=[ast.Not(expr=ast.Field(chain=["*"])), ast.Constant(value=1)]),
+            )
+
+        def test_not_asterisk_exclude(self):
+            self.assertEqual(
+                self._expr("not * exclude (x)"), ast.Not(expr=ast.ColumnsExpr(all_columns=True, exclude=["x"]))
+            )
+
+        def test_not_asterisk_columns_spread(self):
+            self.assertEqual(
+                self._expr("not * columns(*)"),
+                ast.Not(expr=ast.SpreadExpr(expr=ast.ColumnsExpr(columns=[ast.Field(chain=["*"])]))),
+            )
+
+        def test_not_asterisk_number_is_multiplication(self):
+            self.assertEqual(
+                self._expr("not * 1"),
+                ast.ArithmeticOperation(left=ast.Field(chain=["not"]), right=ast.Constant(value=1), op="*"),
+            )
+
+        def test_not_asterisk_ident_is_multiplication(self):
+            self.assertEqual(
+                self._expr("not * x"),
+                ast.ArithmeticOperation(left=ast.Field(chain=["not"]), right=ast.Field(chain=["x"]), op="*"),
+            )
+
+        def test_not_asterisk_replace_alone_is_multiplication(self):
+            self.assertEqual(
+                self._expr("not * replace (1 as x)"),
+                ast.ArithmeticOperation(
+                    left=ast.Field(chain=["not"]),
+                    right=ast.Call(name="replace", args=[ast.Alias(alias="x", expr=ast.Constant(value=1))]),
+                    op="*",
+                ),
+            )
+
+        def test_between_ternary_body_with_alias_outside(self):
+            self.assertEqual(
+                self._expr("x between a ? b : c and d as fill"),
+                ast.Alias(
+                    alias="fill",
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]),
+                        low=ast.Call(
+                            name="if", args=[ast.Field(chain=["a"]), ast.Field(chain=["b"]), ast.Field(chain=["c"])]
+                        ),
+                        high=ast.Field(chain=["d"]),
+                    ),
+                ),
+            )
+
+        def test_between_simple_with_alias_outside(self):
+            self.assertEqual(
+                self._expr("x between y and z as fill"),
+                ast.Alias(
+                    alias="fill",
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]), low=ast.Field(chain=["y"]), high=ast.Field(chain=["z"])
+                    ),
+                ),
+            )
+
+        def test_between_chained_alias_outside(self):
+            self.assertEqual(
+                self._expr("x between y and z as fill1 as fill2"),
+                ast.Alias(
+                    alias="fill2",
+                    expr=ast.Alias(
+                        alias="fill1",
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["x"]), low=ast.Field(chain=["y"]), high=ast.Field(chain=["z"])
+                        ),
+                    ),
+                ),
+            )
+
+        def test_between_ternary_with_inner_postfix_and_alias_outside(self):
+            self.assertEqual(
+                self._expr("x between [] ? b : c and y[:] ?. [z] as fill"),
+                ast.Alias(
+                    alias="fill",
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]),
+                        low=ast.Call(
+                            name="if", args=[ast.Array(exprs=[]), ast.Field(chain=["b"]), ast.Field(chain=["c"])]
+                        ),
+                        high=ast.ArrayAccess(
+                            array=ast.ArraySlice(array=ast.Field(chain=["y"])),
+                            property=ast.Field(chain=["z"]),
+                            nullish=True,
+                        ),
+                    ),
+                ),
+            )
+
+        def test_between_two_aliases_one_inside_one_outside(self):
+            self.assertEqual(
+                self._expr("x between y as a and z as b"),
+                ast.Alias(
+                    alias="b",
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]),
+                        low=ast.Alias(alias="a", expr=ast.Field(chain=["y"])),
+                        high=ast.Field(chain=["z"]),
+                    ),
+                ),
+            )
+
+        def test_between_lambda_body_with_alias_outside(self):
+            self.assertEqual(
+                self._expr("x between lambda a : b and high as alias"),
+                ast.Alias(
+                    alias="alias",
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]),
+                        low=ast.Lambda(args=["a"], expr=ast.Field(chain=["b"])),
+                        high=ast.Field(chain=["high"]),
+                    ),
+                ),
+            )
+
+        def test_between_named_arg_body_with_alias_outside(self):
+            self.assertEqual(
+                self._expr("x between a := b and high as alias"),
+                ast.Alias(
+                    alias="alias",
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]),
+                        low=ast.NamedArgument(name="a", value=ast.Field(chain=["b"])),
+                        high=ast.Field(chain=["high"]),
+                    ),
+                ),
+            )
+
+        def test_chained_not_between_with_ternary_body(self):
+            self.assertEqual(
+                self._expr("a NOT BETWEEN b ? c : d AND e NOT BETWEEN f AND g"),
+                ast.BetweenExpr(
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["a"]),
+                        low=ast.Call(
+                            name="if", args=[ast.Field(chain=["b"]), ast.Field(chain=["c"]), ast.Field(chain=["d"])]
+                        ),
+                        high=ast.Field(chain=["e"]),
+                        negated=True,
+                    ),
+                    low=ast.Field(chain=["f"]),
+                    high=ast.Field(chain=["g"]),
+                    negated=True,
+                ),
+            )
+
+        def test_chained_between_with_ternary_body_and_alias(self):
+            self.assertEqual(
+                self._expr("a between b ? c : d and e between f and g as alias"),
+                ast.Alias(
+                    alias="alias",
+                    expr=ast.BetweenExpr(
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["a"]),
+                            low=ast.Call(
+                                name="if", args=[ast.Field(chain=["b"]), ast.Field(chain=["c"]), ast.Field(chain=["d"])]
+                            ),
+                            high=ast.Field(chain=["e"]),
+                        ),
+                        low=ast.Field(chain=["f"]),
+                        high=ast.Field(chain=["g"]),
+                    ),
+                ),
+            )
+
+        def test_between_with_ternary_hoisted_outside(self):
+            self.assertEqual(
+                self._expr("a between lambda x : y and z ? w : v"),
+                ast.Call(
+                    name="if",
+                    args=[
+                        ast.BetweenExpr(
+                            expr=ast.Field(chain=["a"]),
+                            low=ast.Lambda(args=["x"], expr=ast.Field(chain=["y"])),
+                            high=ast.Field(chain=["z"]),
+                        ),
+                        ast.Field(chain=["w"]),
+                        ast.Field(chain=["v"]),
+                    ],
+                ),
+            )
+
+        def test_octal_with_tuple_access(self):
+            self.assertEqual(self._expr("017.5"), ast.TupleAccess(tuple=ast.Constant(value=15), index=5))
+
+        def test_octal_partial_prefix(self):
+            self.assertEqual(self._expr("019"), ast.Constant(value=1))
+
+        def test_octal_invalid_digit(self):
+            self.assertEqual(self._expr("08"), ast.Constant(value=0))
+
+        def test_hex_with_tuple_access(self):
+            self.assertEqual(self._expr("0xc.518790"), ast.TupleAccess(tuple=ast.Constant(value=12), index=518790))
+
+        def test_hex_with_array_access(self):
+            self.assertEqual(
+                self._expr("0xc.x"),
+                ast.ArrayAccess(array=ast.Constant(value=12), property=ast.Constant(value="x")),
+            )
+
+        def test_between_three_ands_two_betweens_nested_via_low(self):
+            self.assertEqual(
+                self._expr("a between b and c between d and e and f"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["a"]),
+                    low=ast.BetweenExpr(
+                        expr=ast.And(exprs=[ast.Field(chain=["b"]), ast.Field(chain=["c"])]),
+                        low=ast.Field(chain=["d"]),
+                        high=ast.Field(chain=["e"]),
+                    ),
+                    high=ast.Field(chain=["f"]),
+                ),
+            )
+
+        def test_between_three_ands_with_array_expr(self):
+            self.assertEqual(
+                self._expr("lambda l : [] between a and b between c and d ?? e and f"),
+                ast.Lambda(
+                    args=["l"],
+                    expr=ast.BetweenExpr(
+                        expr=ast.Array(exprs=[]),
+                        low=ast.BetweenExpr(
+                            expr=ast.And(exprs=[ast.Field(chain=["a"]), ast.Field(chain=["b"])]),
+                            low=ast.Field(chain=["c"]),
+                            high=ast.Call(name="ifNull", args=[ast.Field(chain=["d"]), ast.Field(chain=["e"])]),
+                        ),
+                        high=ast.Field(chain=["f"]),
+                    ),
+                ),
+            )
+
+        def test_call_select_after_parametric_paren(self):
+            self.assertEqual(
+                self._expr("foo(a, b)(select 1)"),
+                ast.ExprCall(
+                    expr=ast.Call(name="foo", args=[ast.Field(chain=["a"]), ast.Field(chain=["b"])]),
+                    args=[ast.SelectQuery(select=[ast.Constant(value=1)])],
+                ),
+            )
+
+        def test_call_select_after_single_arg_paren(self):
+            self.assertEqual(
+                self._expr("foo(a)(select 1)"),
+                ast.ExprCall(
+                    expr=ast.Call(name="foo", args=[ast.Field(chain=["a"])]),
+                    args=[ast.SelectQuery(select=[ast.Constant(value=1)])],
+                ),
+            )
+
+        def test_call_select_after_empty_paren(self):
+            self.assertEqual(
+                self._expr("foo()(select 1)"),
+                ast.ExprCall(
+                    expr=ast.Call(name="foo", args=[]), args=[ast.SelectQuery(select=[ast.Constant(value=1)])]
+                ),
+            )
+
+        def test_call_select_placeholder_set_stmt(self):
+            self.assertEqual(
+                self._expr("foo(a)({1} intersect {2})"),
+                ast.ExprCall(
+                    expr=ast.Call(name="foo", args=[ast.Field(chain=["a"])]),
+                    args=[
+                        ast.SelectSetQuery(
+                            initial_select_query=ast.Placeholder(expr=ast.Constant(value=1)),
+                            subsequent_select_queries=[
+                                ast.SelectSetNode(
+                                    select_query=ast.Placeholder(expr=ast.Constant(value=2)), set_operator="INTERSECT"
+                                )
+                            ],
+                        )
+                    ],
+                ),
+            )
+
+        def test_limit_by_offset_field_mult_continuation(self):
+            self.assertEqual(
+                self._select("SELECT 1 LIMIT a BY b, offset * c"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit_by=ast.LimitByExpr(
+                        n=ast.Field(chain=["a"]),
+                        exprs=[
+                            ast.Field(chain=["b"]),
+                            ast.ArithmeticOperation(
+                                left=ast.Field(chain=["offset"]), right=ast.Field(chain=["c"]), op="*"
+                            ),
+                        ],
+                    ),
+                ),
+            )
+
+        def test_limit_by_offset_primary_ends_list(self):
+            self.assertEqual(
+                self._select("SELECT 1 LIMIT 5 BY a, offset 10"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"])]),
+                    offset=ast.Constant(value=10),
+                ),
+            )
+
+        def test_limit_by_offset_hash_positional_ends_list(self):
+            self.assertEqual(
+                self._select("SELECT 1 LIMIT 5 BY a, offset #0"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"])]),
+                    offset=ast.PositionalRef(index=0),
+                ),
+            )
+
+        def test_limit_by_offset_field_mult_with_columns_paren(self):
+            self.assertEqual(
+                self._select("SELECT 1 LIMIT a BY b, offset * columns('r')"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit_by=ast.LimitByExpr(
+                        n=ast.Field(chain=["a"]),
+                        exprs=[
+                            ast.Field(chain=["b"]),
+                            ast.ArithmeticOperation(
+                                left=ast.Field(chain=["offset"]), right=ast.ColumnsExpr(regex="r"), op="*"
+                            ),
+                        ],
+                    ),
+                ),
+            )
+
+        def test_set_op_verbose_offset_lifts(self):
+            self.assertEqual(
+                self._select("SELECT 1 UNION ALL SELECT 2 LIMIT 5 OFFSET 10"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(select=[ast.Constant(value=2)], limit=ast.Constant(value=5)),
+                            set_operator="UNION ALL",
+                        )
+                    ],
+                    offset=ast.Constant(value=10),
+                ),
+            )
+
+        def test_set_op_compact_offset_stays_inner(self):
+            self.assertEqual(
+                self._select("SELECT 1 UNION ALL SELECT 2 LIMIT 5, 10"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit=ast.Constant(value=5),
+                                offset=ast.Constant(value=10),
+                            ),
+                            set_operator="UNION ALL",
+                        )
+                    ],
+                ),
+            )
+
+        def test_set_op_bare_offset_stays_inner(self):
+            self.assertEqual(
+                self._select("SELECT 1 UNION ALL SELECT 2 OFFSET 10"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(select=[ast.Constant(value=2)], offset=ast.Constant(value=10)),
+                            set_operator="UNION ALL",
+                        )
+                    ],
+                ),
+            )
+
+        def test_set_op_limit_by_trailing_bare_offset_stays_inner(self):
+            self.assertEqual(
+                self._select("SELECT 1 UNION ALL SELECT 2 LIMIT 5 BY a OFFSET 10"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"])]),
+                                offset=ast.Constant(value=10),
+                            ),
+                            set_operator="UNION ALL",
+                        )
+                    ],
+                ),
+            )
+
+        def test_set_op_limit_by_trailing_verbose_offset_lifts(self):
+            self.assertEqual(
+                self._select("SELECT 1 UNION ALL SELECT 2 LIMIT 5 BY a, LIMIT 7 OFFSET 10"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit=ast.Constant(value=7),
+                                limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"])]),
+                            ),
+                            set_operator="UNION ALL",
+                        )
+                    ],
+                    offset=ast.Constant(value=10),
+                ),
+            )
+
+        def test_set_op_verbose_offset_doesnt_lift_when_outer_has_limit(self):
+            self.assertEqual(
+                self._select("SELECT 1 UNION ALL SELECT 2 LIMIT 5 OFFSET 7 LIMIT 9, 11"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit=ast.Constant(value=5),
+                                offset=ast.Constant(value=7),
+                            ),
+                            set_operator="UNION ALL",
+                        )
+                    ],
+                    limit=ast.Constant(value=9),
+                    offset=ast.Constant(value=11),
+                ),
+            )
+
+        def test_limit_by_then_verbose_with_ties_offset(self):
+            self.assertEqual(
+                self._select("SELECT 1 LIMIT 2 BY 3, LIMIT 4 % WITH TIES OFFSET 5"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.Constant(value=4),
+                    limit_by=ast.LimitByExpr(n=ast.Constant(value=2), exprs=[ast.Constant(value=3)]),
+                    limit_with_ties=True,
+                    limit_percent=True,
+                    offset=ast.Constant(value=5),
+                ),
+            )
+
+        def test_limit_by_then_verbose_with_ties_offset_then_outer_limit(self):
+            self.assertEqual(
+                self._select("SELECT 1 LIMIT 2 BY 3, LIMIT 4 % WITH TIES OFFSET 5 LIMIT 6, 7"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.Constant(value=6),
+                    limit_by=ast.LimitByExpr(n=ast.Constant(value=2), exprs=[ast.Constant(value=3)]),
+                    limit_with_ties=True,
+                    limit_percent=True,
+                    offset=ast.Constant(value=7),
+                ),
+            )
+
+        def test_set_op_verbose_offset_doesnt_lift_when_outer_has_orderby(self):
+            self.assertEqual(
+                self._select("SELECT 1 UNION ALL SELECT 2 LIMIT 5 OFFSET 10 ORDER BY 1"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(select=[ast.Constant(value=1)]),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(
+                                select=[ast.Constant(value=2)],
+                                limit=ast.Constant(value=5),
+                                offset=ast.Constant(value=10),
+                            ),
+                            set_operator="UNION ALL",
+                        )
+                    ],
+                ),
+            )
+
+        def test_field_chain_asterisk_mid(self):
+            self.assertEqual(
+                self._expr("ft.*.high"),
+                ast.ArrayAccess(array=ast.Field(chain=["ft", "*"]), property=ast.Constant(value="high")),
+            )
+
+        def test_field_chain_asterisk_end(self):
+            self.assertEqual(self._expr("ft.high.*"), ast.Field(chain=["ft", "high", "*"]))
+
+        def test_field_chain_asterisk_mid_quoted_property(self):
+            self.assertEqual(
+                self._expr('ft . y2 . gv1ye . * . "__high__"'),
+                ast.ArrayAccess(
+                    array=ast.Field(chain=["ft", "y2", "gv1ye", "*"]), property=ast.Constant(value="__high__")
+                ),
+            )
+
+        def test_not_placeholder_set_stmt(self):
+            self.assertEqual(
+                self._expr("not ({a} union {b})"),
+                ast.Not(
+                    expr=ast.SelectSetQuery(
+                        initial_select_query=ast.Placeholder(expr=ast.Field(chain=["a"])),
+                        subsequent_select_queries=[
+                            ast.SelectSetNode(
+                                select_query=ast.Placeholder(expr=ast.Field(chain=["b"])), set_operator="UNION DISTINCT"
+                            )
+                        ],
+                    )
+                ),
+            )
+
+        def test_not_parens_arrow_lambda(self):
+            self.assertEqual(
+                self._expr("not (a,) -> 1"), ast.Not(expr=ast.Lambda(args=["a"], expr=ast.Constant(value=1)))
+            )
+
+        def test_not_double_paren_lambda_is_call(self):
+            self.assertEqual(
+                self._expr("not ((a,) -> 1)"),
+                ast.Call(name="not", args=[ast.Lambda(args=["a"], expr=ast.Constant(value=1))]),
+            )
+
+        def test_not_call_with_placeholder_arg(self):
+            self.assertEqual(
+                self._expr("not ({a})"),
+                ast.Call(name="not", args=[ast.Placeholder(expr=ast.Field(chain=["a"]))]),
+            )
+
+        def test_not_self_contained_columns_replace(self):
+            self.assertEqual(
+                self._expr('not (* replace (("a") as a))'),
+                ast.Not(expr=ast.ColumnsExpr(all_columns=True, replace={"a": ast.Field(chain=["a"])})),
+            )
+
+        def test_not_self_contained_columns_exclude_replace(self):
+            self.assertEqual(
+                self._expr("not (* exclude (a) replace ((1) as b))"),
+                ast.Not(expr=ast.ColumnsExpr(all_columns=True, exclude=["a"], replace={"b": ast.Constant(value=1)})),
+            )
+
+        def test_paren_wrapped_table_drops_trailing_sample(self):
+            self.assertEqual(
+                self._select("SELECT 1 FROM (a) SAMPLE {x}"),
+                ast.SelectQuery(select=[ast.Constant(value=1)], select_from=ast.JoinExpr(table=ast.Field(chain=["a"]))),
+            )
+
+        def test_paren_wrapped_table_with_final_drops_trailing_sample(self):
+            self.assertEqual(
+                self._select("SELECT 1 FROM (a FINAL) SAMPLE {x}"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["a"]), table_final=True),
+                ),
+            )
+
+        def test_paren_wrapped_placeholder_subquery_keeps_sample(self):
+            self.assertEqual(
+                self._select("SELECT 1 FROM ({a}) SAMPLE {x}"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(
+                        table=ast.Placeholder(expr=ast.Field(chain=["a"])),
+                        sample=ast.SampleExpr(sample_value=ast.Placeholder(expr=ast.Field(chain=["x"]))),
+                    ),
+                ),
+            )
+
+        def test_lambda_single_param(self):
+            self.assertEqual(self._expr("lambda x : 1"), ast.Lambda(args=["x"], expr=ast.Constant(value=1)))
+
+        def test_lambda_trailing_comma(self):
+            self.assertEqual(self._expr('lambda "_" , : 1'), ast.Lambda(args=["_"], expr=ast.Constant(value=1)))
+
+        def test_lambda_as_field_function_call(self):
+            self.assertEqual(self._expr("lambda(1)"), ast.Call(name="lambda", args=[ast.Constant(value=1)]))
+
+        # --- allstar :: TestAllStarColumnExprListBacktrack (5 tests) ---
+        def test_group_by_extends_through_qualify_with_arith(self):
+            self.assertEqual(
+                self._select("select x from t group by columns(*), qualify * columns('')"),
+                ast.SelectQuery(
+                    select=[ast.Field(chain=["x"])],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    group_by=[
+                        ast.ColumnsExpr(columns=[ast.Field(chain=["*"])]),
+                        ast.ArithmeticOperation(
+                            left=ast.Field(chain=["qualify"]), right=ast.ColumnsExpr(regex=""), op="*"
+                        ),
+                    ],
+                ),
+            )
+
+        def test_group_by_backs_off_when_qualify_has_clause_body(self):
+            self.assertEqual(
+                self._select("select x from t group by columns(*), qualify *"),
+                ast.SelectQuery(
+                    select=[ast.Field(chain=["x"])],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    qualify=ast.Field(chain=["*"]),
+                    group_by=[ast.ColumnsExpr(columns=[ast.Field(chain=["*"])])],
+                ),
+            )
+
+        def test_group_by_trailing_comma_then_qualify_ident(self):
+            self.assertEqual(
+                self._select("select x from t group by columns(*), qualify"),
+                ast.SelectQuery(
+                    select=[ast.Field(chain=["x"])],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    group_by=[ast.ColumnsExpr(columns=[ast.Field(chain=["*"])]), ast.Field(chain=["qualify"])],
+                ),
+            )
+
+        def test_limit_by_extends_through_limit_with_arith(self):
+            self.assertEqual(
+                self._select("select 1 from t limit 5 by a, limit * columns('ok')"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    limit_by=ast.LimitByExpr(
+                        n=ast.Constant(value=5),
+                        exprs=[
+                            ast.Field(chain=["a"]),
+                            ast.ArithmeticOperation(
+                                left=ast.Field(chain=["limit"]), right=ast.ColumnsExpr(regex="ok"), op="*"
+                            ),
+                        ],
+                    ),
+                ),
+            )
+
+        def test_limit_by_trailing_comma_then_bare_limit_ident(self):
+            self.assertEqual(
+                self._select("select 1 from t limit 5 by a, limit"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    limit_by=ast.LimitByExpr(
+                        n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"]), ast.Field(chain=["limit"])]
+                    ),
+                ),
+            )
+
+        # --- allstar :: TestAllStarLimitPercentDisambiguation (4 tests) ---
+        def test_limit_modulo_extends_through_offset_arith(self):
+            self.assertEqual(
+                self._select("select 1 from t limit * columns('a') % offset * columns('')"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    limit=ast.ArithmeticOperation(
+                        left=ast.ArithmeticOperation(
+                            left=ast.SpreadExpr(expr=ast.ColumnsExpr(regex="a")),
+                            right=ast.Field(chain=["offset"]),
+                            op="%",
+                        ),
+                        right=ast.ColumnsExpr(regex=""),
+                        op="*",
+                    ),
+                ),
+            )
+
+        def test_limit_percent_offset_simple(self):
+            self.assertEqual(
+                self._select("select 1 from t limit 5 % offset 10"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    limit=ast.Constant(value=5),
+                    limit_percent=True,
+                    offset=ast.Constant(value=10),
+                ),
+            )
+
+        def test_limit_modulo_extends_then_offset_arith(self):
+            self.assertEqual(
+                self._select("select 1 from t limit 5 % offset * 2"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    limit=ast.ArithmeticOperation(
+                        left=ast.ArithmeticOperation(
+                            left=ast.Constant(value=5), right=ast.Field(chain=["offset"]), op="%"
+                        ),
+                        right=ast.Constant(value=2),
+                        op="*",
+                    ),
+                ),
+            )
+
+        def test_limit_percent_offset_with_clean_asterisk_body(self):
+            self.assertEqual(
+                self._select("select 1 from t limit 5% offset 10"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    limit=ast.Constant(value=5),
+                    limit_percent=True,
+                    offset=ast.Constant(value=10),
+                ),
+            )
+
+        # --- allstar :: TestAllStarBetweenAliasOrHoist (6 tests) ---
+        def test_between_alias_or_simple(self):
+            self.assertEqual(
+                self._expr("x between low and high as al or rest"),
+                ast.Or(
+                    exprs=[
+                        ast.Alias(
+                            alias="al",
+                            expr=ast.BetweenExpr(
+                                expr=ast.Field(chain=["x"]),
+                                low=ast.Field(chain=["low"]),
+                                high=ast.Field(chain=["high"]),
+                            ),
+                        ),
+                        ast.Field(chain=["rest"]),
+                    ]
+                ),
+            )
+
+        def test_between_or_without_alias_absorbs(self):
+            self.assertEqual(
+                self._expr("x between low and high or rest"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.Field(chain=["low"]),
+                    high=ast.Or(exprs=[ast.Field(chain=["high"]), ast.Field(chain=["rest"])]),
+                ),
+            )
+
+        def test_between_alias_or_multiple_siblings(self):
+            self.assertEqual(
+                self._expr("x between low and high as al or r1 or r2"),
+                ast.Or(
+                    exprs=[
+                        ast.Alias(
+                            alias="al",
+                            expr=ast.BetweenExpr(
+                                expr=ast.Field(chain=["x"]),
+                                low=ast.Field(chain=["low"]),
+                                high=ast.Field(chain=["high"]),
+                            ),
+                        ),
+                        ast.Field(chain=["r1"]),
+                        ast.Field(chain=["r2"]),
+                    ]
+                ),
+            )
+
+        def test_between_alias_or_with_left_sibling(self):
+            self.assertEqual(
+                self._expr("x or x2 between low and high as al or r1"),
+                ast.Or(
+                    exprs=[
+                        ast.Alias(
+                            alias="al",
+                            expr=ast.BetweenExpr(
+                                expr=ast.Or(exprs=[ast.Field(chain=["x"]), ast.Field(chain=["x2"])]),
+                                low=ast.Field(chain=["low"]),
+                                high=ast.Field(chain=["high"]),
+                            ),
+                        ),
+                        ast.Field(chain=["r1"]),
+                    ]
+                ),
+            )
+
+        def test_between_lambda_body_alias_or(self):
+            self.assertEqual(
+                self._expr("x between lambda y : a and b as al or r"),
+                ast.Or(
+                    exprs=[
+                        ast.Alias(
+                            alias="al",
+                            expr=ast.BetweenExpr(
+                                expr=ast.Field(chain=["x"]),
+                                low=ast.Lambda(args=["y"], expr=ast.Field(chain=["a"])),
+                                high=ast.Field(chain=["b"]),
+                            ),
+                        ),
+                        ast.Field(chain=["r"]),
+                    ]
+                ),
+            )
+
+        def test_between_named_arg_high_alias_or(self):
+            self.assertEqual(
+                self._expr("x between low and n := high as al or r"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.Field(chain=["low"]),
+                    high=ast.NamedArgument(
+                        name="n",
+                        value=ast.Or(
+                            exprs=[ast.Alias(alias="al", expr=ast.Field(chain=["high"])), ast.Field(chain=["r"])]
+                        ),
+                    ),
+                ),
+            )
+
+        # --- allstar :: TestAllStarBetweenBodyOuterMinBp (3 tests) ---
+        def test_ternary_else_between_alias_floats_out(self):
+            self.assertEqual(
+                self._expr("x ? a : b between c and d as al"),
+                ast.Alias(
+                    alias="al",
+                    expr=ast.Call(
+                        name="if",
+                        args=[
+                            ast.Field(chain=["x"]),
+                            ast.Field(chain=["a"]),
+                            ast.BetweenExpr(
+                                expr=ast.Field(chain=["b"]), low=ast.Field(chain=["c"]), high=ast.Field(chain=["d"])
+                            ),
+                        ],
+                    ),
+                ),
+            )
+
+        def test_top_level_between_alias_still_absorbs(self):
+            self.assertEqual(
+                self._expr("x between c and d as al"),
+                ast.Alias(
+                    alias="al",
+                    expr=ast.BetweenExpr(
+                        expr=ast.Field(chain=["x"]), low=ast.Field(chain=["c"]), high=ast.Field(chain=["d"])
+                    ),
+                ),
+            )
+
+        def test_ternary_else_between_alias_or(self):
+            self.assertEqual(
+                self._expr("x ? a : b between c and d as al or z"),
+                ast.Or(
+                    exprs=[
+                        ast.Alias(
+                            alias="al",
+                            expr=ast.Call(
+                                name="if",
+                                args=[
+                                    ast.Field(chain=["x"]),
+                                    ast.Field(chain=["a"]),
+                                    ast.BetweenExpr(
+                                        expr=ast.Field(chain=["b"]),
+                                        low=ast.Field(chain=["c"]),
+                                        high=ast.Field(chain=["d"]),
+                                    ),
+                                ],
+                            ),
+                        ),
+                        ast.Field(chain=["z"]),
+                    ]
+                ),
+            )
+
+        # --- allstar :: TestAllStarHardSetOpKeywords (3 tests) ---
+        def test_intersect_after_comma_terminates_limit_by(self):
+            self.assertEqual(
+                self._select("select x from t limit 5 by a, intersect (select 1)"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(
+                        select=[ast.Field(chain=["x"])],
+                        select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                        limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"])]),
+                    ),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(select=[ast.Constant(value=1)]), set_operator="INTERSECT"
+                        )
+                    ],
+                ),
+            )
+
+        def test_union_after_comma_extends_limit_by(self):
+            self.assertEqual(
+                self._select("select x from t limit 5 by a, union (select 1)"),
+                ast.SelectQuery(
+                    select=[ast.Field(chain=["x"])],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    limit_by=ast.LimitByExpr(
+                        n=ast.Constant(value=5),
+                        exprs=[
+                            ast.Field(chain=["a"]),
+                            ast.Call(name="union", args=[ast.SelectQuery(select=[ast.Constant(value=1)])]),
+                        ],
+                    ),
+                ),
+            )
+
+        def test_except_after_comma_terminates_limit_by(self):
+            self.assertEqual(
+                self._select("select x from t limit 5 by a, except (select 1)"),
+                ast.SelectSetQuery(
+                    initial_select_query=ast.SelectQuery(
+                        select=[ast.Field(chain=["x"])],
+                        select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                        limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"])]),
+                    ),
+                    subsequent_select_queries=[
+                        ast.SelectSetNode(
+                            select_query=ast.SelectQuery(select=[ast.Constant(value=1)]), set_operator="EXCEPT"
+                        )
+                    ],
+                ),
+            )
+
+        # --- allstar :: TestAllStarColumnsOverPostfix (4 tests) ---
+        def test_columns_over_named_window(self):
+            self.assertEqual(
+                self._expr("columns(*) over hour"),
+                ast.WindowFunction(name="columns", exprs=[ast.Field(chain=["*"])], over_identifier="hour"),
+            )
+
+        def test_columns_over_window_expr(self):
+            self.assertEqual(
+                self._expr("columns(*) over (order by x)"),
+                ast.WindowFunction(
+                    name="columns",
+                    exprs=[ast.Field(chain=["*"])],
+                    over_expr=ast.WindowExpr(order_by=[ast.OrderExpr(expr=ast.Field(chain=["x"]))]),
+                ),
+            )
+
+        def test_columns_plain_still_columns_expr(self):
+            self.assertEqual(self._expr("columns(*)"), ast.ColumnsExpr(columns=[ast.Field(chain=["*"])]))
+
+        def test_columns_with_regex_over_window(self):
+            self.assertEqual(
+                self._expr("columns('x') over hour"),
+                ast.WindowFunction(name="columns", exprs=[ast.Constant(value="x")], over_identifier="hour"),
+            )
+
+        # --- allstar :: TestAllStarCaseAsFunctionFallback (4 tests) ---
+        def test_case_as_fn_one_arg(self):
+            self.assertEqual(self._expr("case(1)"), ast.Call(name="case", args=[ast.Constant(value=1)]))
+
+        def test_case_as_fn_multiple_args(self):
+            self.assertEqual(
+                self._expr("case(1, 2)"),
+                ast.Call(name="case", args=[ast.Constant(value=1), ast.Constant(value=2)]),
+            )
+
+        def test_case_as_fn_with_postfix(self):
+            self.assertEqual(
+                self._expr("case(1) + 2"),
+                ast.ArithmeticOperation(
+                    left=ast.Call(name="case", args=[ast.Constant(value=1)]), right=ast.Constant(value=2), op="+"
+                ),
+            )
+
+        def test_case_expr_still_works(self):
+            self.assertEqual(
+                self._expr("case x when 1 then 2 else 3 end"),
+                ast.Call(
+                    name="transform",
+                    args=[
+                        ast.Field(chain=["x"]),
+                        ast.Array(exprs=[ast.Constant(value=1)]),
+                        ast.Array(exprs=[ast.Constant(value=2)]),
+                        ast.Constant(value=3),
+                    ],
+                ),
+            )
+
+        # --- allstar :: TestAllStarLimitPercentTrailingOrderBy (4 tests) ---
+        def test_limit_percent_then_order_by_paren_wrapped(self):
+            self.assertEqual(
+                self._select("(select 1 limit 1 % order by 2 with fill to 3)"),
+                ast.SelectQuery(select=[ast.Constant(value=1)], limit=ast.Constant(value=1), limit_percent=True),
+            )
+
+        def test_limit_percent_then_order_by_bare(self):
+            self.assertEqual(
+                self._select("select 1 limit 1 % order by 2 with fill to 3"),
+                ast.SelectQuery(select=[ast.Constant(value=1)], limit=ast.Constant(value=1), limit_percent=True),
+            )
+
+        def test_limit_modulo_then_order_by_drops(self):
+            self.assertEqual(
+                self._select("select 1 from t limit * columns('a') % offset * columns('b') order by 1"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    limit=ast.ArithmeticOperation(
+                        left=ast.ArithmeticOperation(
+                            left=ast.SpreadExpr(expr=ast.ColumnsExpr(regex="a")),
+                            right=ast.Field(chain=["offset"]),
+                            op="%",
+                        ),
+                        right=ast.ColumnsExpr(regex="b"),
+                        op="*",
+                    ),
+                ),
+            )
+
+        def test_limit_percent_then_order_by_nulls_first(self):
+            self.assertEqual(
+                self._select("(select 1 limit 1 % order by 2 nulls last)"),
+                ast.SelectQuery(select=[ast.Constant(value=1)], limit=ast.Constant(value=1), limit_percent=True),
+            )
+
+        # --- allstar :: TestAllStarLimitByExprsBoundary (3 tests) ---
+        def test_limit_by_bails_on_limit_call_with_ties(self):
+            self.assertEqual(
+                self._select("select 1 limit 5 by a, limit (1) with ties"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.Constant(value=1),
+                    limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"])]),
+                    limit_with_ties=True,
+                ),
+            )
+
+        def test_limit_by_bails_with_ties_then_outer_limit(self):
+            self.assertEqual(
+                self._select("select 1 limit 5 by a, limit (1) with ties limit 10"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit=ast.Constant(value=10),
+                    limit_by=ast.LimitByExpr(n=ast.Constant(value=5), exprs=[ast.Field(chain=["a"])]),
+                    limit_with_ties=True,
+                ),
+            )
+
+        def test_limit_by_extends_through_limit_arith(self):
+            self.assertEqual(
+                self._select("select x from t limit 5 by a, limit * columns('c')"),
+                ast.SelectQuery(
+                    select=[ast.Field(chain=["x"])],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["t"])),
+                    limit_by=ast.LimitByExpr(
+                        n=ast.Constant(value=5),
+                        exprs=[
+                            ast.Field(chain=["a"]),
+                            ast.ArithmeticOperation(
+                                left=ast.Field(chain=["limit"]), right=ast.ColumnsExpr(regex="c"), op="*"
+                            ),
+                        ],
+                    ),
+                ),
+            )
+
+        # --- allstar :: TestAllStarBetweenIsDistinctIsNullHoist (6 tests) ---
+        def test_between_alias_is_distinct_from(self):
+            self.assertEqual(
+                self._expr("x between A and B as al is distinct from C"),
+                ast.IsDistinctFrom(
+                    left=ast.Alias(
+                        alias="al",
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["x"]), low=ast.Field(chain=["A"]), high=ast.Field(chain=["B"])
+                        ),
+                    ),
+                    right=ast.Field(chain=["C"]),
+                ),
+            )
+
+        def test_between_alias_is_not_distinct_from(self):
+            self.assertEqual(
+                self._expr("x between A and B as al is not distinct from C"),
+                ast.IsDistinctFrom(
+                    left=ast.Alias(
+                        alias="al",
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["x"]), low=ast.Field(chain=["A"]), high=ast.Field(chain=["B"])
+                        ),
+                    ),
+                    right=ast.Field(chain=["C"]),
+                    negated=True,
+                ),
+            )
+
+        def test_between_alias_is_null(self):
+            self.assertEqual(
+                self._expr("x between A and B as al is null"),
+                ast.CompareOperation(
+                    left=ast.Alias(
+                        alias="al",
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["x"]), low=ast.Field(chain=["A"]), high=ast.Field(chain=["B"])
+                        ),
+                    ),
+                    right=ast.Constant(value=None),
+                    op="==",
+                    is_null_comparison_style=True,
+                ),
+            )
+
+        def test_between_alias_is_not_null(self):
+            self.assertEqual(
+                self._expr("x between A and B as al is not null"),
+                ast.CompareOperation(
+                    left=ast.Alias(
+                        alias="al",
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["x"]), low=ast.Field(chain=["A"]), high=ast.Field(chain=["B"])
+                        ),
+                    ),
+                    right=ast.Constant(value=None),
+                    op="!=",
+                    is_null_comparison_style=True,
+                ),
+            )
+
+        def test_between_no_alias_is_distinct_stays_inside(self):
+            self.assertEqual(
+                self._expr("x between A and B is distinct from C"),
+                ast.BetweenExpr(
+                    expr=ast.Field(chain=["x"]),
+                    low=ast.Field(chain=["A"]),
+                    high=ast.IsDistinctFrom(left=ast.Field(chain=["B"]), right=ast.Field(chain=["C"])),
+                ),
+            )
+
+        def test_between_complex_alias_is_distinct(self):
+            self.assertEqual(
+                self._expr("x between {} as a ?? {} and y() over w as al is distinct from z"),
+                ast.IsDistinctFrom(
+                    left=ast.Alias(
+                        alias="al",
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["x"]),
+                            low=ast.Call(
+                                name="ifNull", args=[ast.Alias(alias="a", expr=ast.Dict(items=[])), ast.Dict(items=[])]
+                            ),
+                            high=ast.WindowFunction(name="y", over_identifier="w"),
+                        ),
+                    ),
+                    right=ast.Field(chain=["z"]),
+                ),
+            )
+
+        # --- allstar :: TestAllStarBetweenArrayAccessHoist (4 tests) ---
+        def test_between_alias_nullish_property(self):
+            self.assertEqual(
+                self._expr("x between 1 and 2 as al ?. minute"),
+                ast.ArrayAccess(
+                    array=ast.Alias(
+                        alias="al",
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["x"]), low=ast.Constant(value=1), high=ast.Constant(value=2)
+                        ),
+                    ),
+                    property=ast.Constant(value="minute"),
+                    nullish=True,
+                ),
+            )
+
+        def test_between_alias_subscript(self):
+            self.assertEqual(
+                self._expr("x between 1 and 2 as al [0]"),
+                ast.ArrayAccess(
+                    array=ast.Alias(
+                        alias="al",
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["x"]), low=ast.Constant(value=1), high=ast.Constant(value=2)
+                        ),
+                    ),
+                    property=ast.Constant(value=0),
+                ),
+            )
+
+        def test_between_alias_dot_property(self):
+            self.assertEqual(
+                self._expr("x between 1 and 2 as al . minute"),
+                ast.ArrayAccess(
+                    array=ast.Alias(
+                        alias="al",
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["x"]), low=ast.Constant(value=1), high=ast.Constant(value=2)
+                        ),
+                    ),
+                    property=ast.Constant(value="minute"),
+                ),
+            )
+
+        def test_between_lambda_or_alias_property_access(self):
+            self.assertEqual(
+                self._expr("x between lambda y : 1 and 2 or 3 as al ?. minute"),
+                ast.ArrayAccess(
+                    array=ast.Alias(
+                        alias="al",
+                        expr=ast.BetweenExpr(
+                            expr=ast.Field(chain=["x"]),
+                            low=ast.Lambda(args=["y"], expr=ast.Constant(value=1)),
+                            high=ast.Or(exprs=[ast.Constant(value=2), ast.Constant(value=3)]),
+                        ),
+                    ),
+                    property=ast.Constant(value="minute"),
+                    nullish=True,
+                ),
+            )
+
+        # --- allstar :: TestAllStarCaseScrutineeSpeculation (4 tests) ---
+        def test_case_when_mul_then_call_then_when(self):
+            self.assertEqual(
+                self._expr("case when * then(1)() when 2 then 3 end"),
+                ast.Call(
+                    name="transform",
+                    args=[
+                        ast.ArithmeticOperation(
+                            left=ast.Field(chain=["when"]),
+                            right=ast.Call(name="then", args=[], params=[ast.Constant(value=1)]),
+                            op="*",
+                        ),
+                        ast.Array(exprs=[ast.Constant(value=2)]),
+                        ast.Array(exprs=[]),
+                        ast.Constant(value=3),
+                    ],
+                ),
+            )
+
+        def test_case_when_complex_then_then_when(self):
+            self.assertEqual(
+                self._expr("case when * then ((*)())() when 1 then 2 end"),
+                ast.Call(
+                    name="transform",
+                    args=[
+                        ast.ArithmeticOperation(
+                            left=ast.Field(chain=["when"]),
+                            right=ast.Call(
+                                name="then", args=[], params=[ast.ExprCall(expr=ast.Field(chain=["*"]), args=[])]
+                            ),
+                            op="*",
+                        ),
+                        ast.Array(exprs=[ast.Constant(value=1)]),
+                        ast.Array(exprs=[]),
+                        ast.Constant(value=2),
+                    ],
+                ),
+            )
+
+        def test_case_when_call_postfix_no_scrutinee(self):
+            self.assertEqual(
+                self._expr("case when (1)() then 2 when 3 then 4 end"),
+                ast.Call(
+                    name="multiIf",
+                    args=[
+                        ast.ExprCall(expr=ast.Constant(value=1), args=[]),
+                        ast.Constant(value=2),
+                        ast.Constant(value=3),
+                        ast.Constant(value=4),
+                    ],
+                ),
+            )
+
+        def test_case_when_plain_no_scrutinee(self):
+            self.assertEqual(
+                self._expr("case when 1 then 2 when 3 then 4 end"),
+                ast.Call(
+                    name="multiIf",
+                    args=[ast.Constant(value=1), ast.Constant(value=2), ast.Constant(value=3), ast.Constant(value=4)],
+                ),
+            )
+
+        # --- allstar :: TestAllStarColumnExprListBoundary (2 tests) ---
+        def test_group_by_bails_on_limit_call_with_trailing_by(self):
+            self.assertEqual(
+                self._select("select 1 group by a, LIMIT (1) by (2)"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    group_by=[ast.Field(chain=["a"])],
+                    limit_by=ast.LimitByExpr(n=ast.Constant(value=1), exprs=[ast.Constant(value=2)]),
+                ),
+            )
+
+        def test_group_by_extends_through_qualify_arith_then_using_sample(self):
+            self.assertEqual(
+                self._select("select 1 group by a, qualify * columns('') using sample 0.1"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    group_by=[
+                        ast.Field(chain=["a"]),
+                        ast.ArithmeticOperation(
+                            left=ast.Field(chain=["qualify"]), right=ast.ColumnsExpr(regex=""), op="*"
+                        ),
+                    ],
+                ),
+            )
+
+        # --- allstar :: TestAllStarNotParenSelectSetStmt (5 tests) ---
+        def test_not_paren_subquery_with_limit_is_not_prefix(self):
+            self.assertEqual(
+                self._expr("not ((select 1) limit 1)"),
+                ast.Not(expr=ast.SelectQuery(select=[ast.Constant(value=1)], limit=ast.Constant(value=1))),
+            )
+
+        def test_not_paren_subquery_with_limit_ignore_nulls(self):
+            self.assertEqual(
+                self._expr("not ((select 1) limit 1) ignore nulls"),
+                ast.Not(expr=ast.SelectQuery(select=[ast.Constant(value=1)], limit=ast.Constant(value=1))),
+            )
+
+        def test_not_paren_subquery_with_offset_is_not_prefix(self):
+            self.assertEqual(
+                self._expr("not ((select 1) offset 1)"),
+                ast.Not(expr=ast.SelectQuery(select=[ast.Constant(value=1)], offset=ast.Constant(value=1))),
+            )
+
+        def test_not_paren_subquery_with_order_by_is_call(self):
+            self.assertEqual(
+                self._expr("not ((select 1) order by 1)"),
+                ast.Call(
+                    name="not",
+                    args=[ast.SelectQuery(select=[ast.Constant(value=1)])],
+                    order_by=[ast.OrderExpr(expr=ast.Constant(value=1))],
+                ),
+            )
+
+        def test_not_paren_subquery_no_trailing_is_call(self):
+            self.assertEqual(
+                self._expr("not ((select 1))"),
+                ast.Call(name="not", args=[ast.SelectQuery(select=[ast.Constant(value=1)])]),
+            )
+
+        # --- allstar :: TestAllStarLimitModuloThenByTwoLevelSpeculation (3 tests) ---
+        def test_limit_modulo_extends_into_limit_by(self):
+            self.assertEqual(
+                self._select("select 1 limit {} % order by 2"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    limit_by=ast.LimitByExpr(
+                        n=ast.ArithmeticOperation(left=ast.Dict(items=[]), right=ast.Field(chain=["order"]), op="%"),
+                        exprs=[ast.Constant(value=2)],
+                    ),
+                ),
+            )
+
+        def test_limit_modulo_with_fill_keeps_percent(self):
+            self.assertEqual(
+                self._select("select 1 limit {} % order by 2 with fill to 3"),
+                ast.SelectQuery(select=[ast.Constant(value=1)], limit=ast.Dict(items=[]), limit_percent=True),
+            )
+
+        def test_limit_modulo_qualify_then_by(self):
+            self.assertEqual(
+                self._select("select 1 qualify 1 limit {} % order by 2"),
+                ast.SelectQuery(
+                    select=[ast.Constant(value=1)],
+                    qualify=ast.Constant(value=1),
+                    limit_by=ast.LimitByExpr(
+                        n=ast.ArithmeticOperation(left=ast.Dict(items=[]), right=ast.Field(chain=["order"]), op="%"),
+                        exprs=[ast.Constant(value=2)],
+                    ),
+                ),
+            )
+
     return TestParser

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -5648,16 +5648,16 @@ def parser_test_factory(backend: HogQLParserBackend):
                 ast.Call(name="columns", args=[], filter_expr=ast.Constant(value=1)),
             )
 
-        def test_infinity_keyword_is_nan(self):
-            # NaN can't be checked with ==, so unwrap and use math.isnan.
-            parsed = self._expr("infinity")
-            self.assertIsInstance(parsed, ast.Constant)
-            self.assertTrue(math.isnan(cast(ast.Constant, parsed).value))
+        def test_infinity_keyword_parses_as_inf(self):
+            # The INF lexer rule matches `inf` and `infinity` (case-insensitive),
+            # matching ClickHouse / Postgres which both treat `infinity` as a
+            # synonym for +Infinity. Earlier cpp behaviour collapsed anything
+            # other than exact `inf` / `-inf` to NaN — that was a quirk of the
+            # number-literal visitor, not the intended grammar semantics.
+            self.assertEqual(self._expr("infinity"), ast.Constant(value=float("inf")))
 
-        def test_negative_infinity_is_nan(self):
-            parsed = self._expr("-infinity")
-            self.assertIsInstance(parsed, ast.Constant)
-            self.assertTrue(math.isnan(cast(ast.Constant, parsed).value))
+        def test_negative_infinity_keyword_parses_as_neg_inf(self):
+            self.assertEqual(self._expr("-infinity"), ast.Constant(value=float("-inf")))
 
         def test_order_by_in_call_then_postfix_call(self):
             self.assertEqual(
@@ -5971,11 +5971,18 @@ def parser_test_factory(backend: HogQLParserBackend):
         def test_octal_with_tuple_access(self):
             self.assertEqual(self._expr("017.5"), ast.TupleAccess(tuple=ast.Constant(value=15), index=5))
 
-        def test_octal_partial_prefix(self):
-            self.assertEqual(self._expr("019"), ast.Constant(value=1))
+        def test_leading_zero_with_non_octal_digit_parses_as_decimal(self):
+            # `019` has digit `9`, which the OCTAL_LITERAL lexer rule rejects,
+            # so it's tokenised as DECIMAL_LITERAL and the value is 19. The
+            # earlier cpp behaviour silently truncated to the longest valid
+            # octal prefix (returning 1), which was a `stoll(..., 0)` quirk —
+            # the lexer's choice of token kind is the right discriminator.
+            self.assertEqual(self._expr("019"), ast.Constant(value=19))
 
-        def test_octal_invalid_digit(self):
-            self.assertEqual(self._expr("08"), ast.Constant(value=0))
+        def test_leading_zero_with_eight_parses_as_decimal(self):
+            # Same shape as above with digit `8`. Was 0 under cpp's truncation
+            # bug; should be 8.
+            self.assertEqual(self._expr("08"), ast.Constant(value=8))
 
         def test_hex_with_tuple_access(self):
             self.assertEqual(self._expr("0xc.518790"), ast.TupleAccess(tuple=ast.Constant(value=12), index=518790))

--- a/posthog/hogql/test/test_parser_python.py
+++ b/posthog/hogql/test/test_parser_python.py
@@ -1,5 +1,41 @@
 from ._test_parser import parser_test_factory
 
+# Tests where the Python parser diverges from the cpp parser (source of
+# truth). Each is a real python-parser bug surfaced by the consolidated
+# contract suite; skipped here so the PR ships green and the gaps are
+# tracked in one place.
+#
+# - `infinity` / `-infinity`: cpp's number-literal visitor collapses any
+#   leading `(+|-)?` + INF/NAN-like text that isn't exactly `inf` / `-inf`
+#   to NaN. Python's parser routes the lexeme through `int(text, 10)` and
+#   raises `invalid literal for int() with base 10: 'infinity'`.
+#
+# - `08` / `019`: cpp uses `stoll(text, 0, 0)` for leading-zero literals,
+#   which silently truncates to the longest valid octal prefix (`08` →
+#   `0` → 0; `019` → `01` → 1). Python calls `int(text, 8)` on the full
+#   lexeme and raises.
+#
+# - `(({1} intersect by name {2}) limit 3, 4)`: cpp attaches the compact
+#   `LIMIT a, b` form as `limit=a, offset=b` on the SelectSetQuery.
+#   Python's parser silently drops both.
+#
+# - `select 1 limit 5 by a limit 3 with ties offset 2 limit 7`: cpp
+#   captures the OFFSET (2) sandwiched between two LIMIT clauses; python
+#   keeps the final LIMIT but drops the OFFSET.
+_PYTHON_PARSER_DIVERGENCES = {
+    "test_infinity_keyword_is_nan",
+    "test_negative_infinity_is_nan",
+    "test_octal_invalid_digit",
+    "test_octal_partial_prefix",
+    "test_set_level_limit_comma_form_orders_limit_then_offset",
+    "test_limit_chain_with_ties_offset_limit",
+}
+
 
 class TestParserPython(parser_test_factory("python")):  # type: ignore
-    pass
+    def setUp(self) -> None:
+        super().setUp()
+        if self._testMethodName in _PYTHON_PARSER_DIVERGENCES:
+            self.skipTest(
+                "Python parser diverges from cpp on this query — tracked in _PYTHON_PARSER_DIVERGENCES in this file."
+            )

--- a/posthog/hogql/test/test_parser_python.py
+++ b/posthog/hogql/test/test_parser_python.py
@@ -1,41 +1,5 @@
 from ._test_parser import parser_test_factory
 
-# Tests where the Python parser diverges from the cpp parser (source of
-# truth). Each is a real python-parser bug surfaced by the consolidated
-# contract suite; skipped here so the PR ships green and the gaps are
-# tracked in one place.
-#
-# - `infinity` / `-infinity`: cpp's number-literal visitor collapses any
-#   leading `(+|-)?` + INF/NAN-like text that isn't exactly `inf` / `-inf`
-#   to NaN. Python's parser routes the lexeme through `int(text, 10)` and
-#   raises `invalid literal for int() with base 10: 'infinity'`.
-#
-# - `08` / `019`: cpp uses `stoll(text, 0, 0)` for leading-zero literals,
-#   which silently truncates to the longest valid octal prefix (`08` →
-#   `0` → 0; `019` → `01` → 1). Python calls `int(text, 8)` on the full
-#   lexeme and raises.
-#
-# - `(({1} intersect by name {2}) limit 3, 4)`: cpp attaches the compact
-#   `LIMIT a, b` form as `limit=a, offset=b` on the SelectSetQuery.
-#   Python's parser silently drops both.
-#
-# - `select 1 limit 5 by a limit 3 with ties offset 2 limit 7`: cpp
-#   captures the OFFSET (2) sandwiched between two LIMIT clauses; python
-#   keeps the final LIMIT but drops the OFFSET.
-_PYTHON_PARSER_DIVERGENCES = {
-    "test_infinity_keyword_is_nan",
-    "test_negative_infinity_is_nan",
-    "test_octal_invalid_digit",
-    "test_octal_partial_prefix",
-    "test_set_level_limit_comma_form_orders_limit_then_offset",
-    "test_limit_chain_with_ties_offset_limit",
-}
-
 
 class TestParserPython(parser_test_factory("python")):  # type: ignore
-    def setUp(self) -> None:
-        super().setUp()
-        if self._testMethodName in _PYTHON_PARSER_DIVERGENCES:
-            self.skipTest(
-                "Python parser diverges from cpp on this query — tracked in _PYTHON_PARSER_DIVERGENCES in this file."
-            )
+    pass


### PR DESCRIPTION
## Problem

Two HogQL parser forks (`rust-allstar-json` and `rust-backtrack-json`) each maintain ~280 hand-rolled regression tests in sibling files that call cpp at runtime via `_matches_cpp_*` helpers. Two consequences:
- Each fork must keep its own copy in sync.
- The tests assert "rust matches cpp" but never pin down what cpp _should_ produce — meaning a cpp parser bug is invisible.

Running the consolidated tests against the python parser surfaced six places where the python parser silently diverges from cpp. Investigating each one found that **all six are real parser bugs** — three on the python side, two on the cpp side, one shared.

## Changes

### 1. Consolidate fork tests into `parser_test_factory`

Move 263 unique tests (16 cross-fork duplicates collapsed from the original 279) into `_test_parser.py` as hardcoded-AST assertions:

```python
def test_between_with_lambda_body(self):
    self.assertEqual(
        self._expr('x BETWEEN lambda y : a AND b AND high'),
        ast.BetweenExpr(expr=ast.Field(chain=['x']), low=ast.Lambda(...), high=...),
    )
```

Section banners (e.g. `# --- allstar :: TestAllStarBetweenAliasOrHoist ---`) preserve provenance. The fork test files in their respective worktrees can drop their copies once they rebase.

### 2. Fix six python/cpp divergences

Each is a real bug; details in the commit body. Summary:

| Query | Old cpp | Old python | New (both) |
| --- | --- | --- | --- |
| `infinity` | NaN | `int()` raises | `+inf` (matches ClickHouse / Postgres) |
| `-infinity` | NaN | raises | `-inf` |
| `08` | 0 (truncated) | `int(., 8)` raises | 8 (decimal) |
| `019` | 1 (truncated) | raises | 19 (decimal) |
| `(({1} ∩ {2}) limit 3, 4)` | limit=3, offset=4 | limit=None, offset=None | limit=3, offset=4 |
| `select 1 limit 5 by a limit 3 with ties offset 2 limit 7` | offset=2 | offset=None | offset=2 |

The cpp parser source changes require a version bump from 1.3.42 → 1.3.43. The `build-hogql-parser` and `build-hogql-parser-npm` workflows will publish and auto-commit the `pyproject.toml`, `uv.lock`, `frontend/package.json`, and `pnpm-lock.yaml` updates.

## How did you test this code?

I'm an agent. Tests I ran:

- `pytest posthog/hogql/test/test_parser_cpp_json.py posthog/hogql/test/test_parser_python.py posthog/hogql/test/test_parser_cache.py` — **960 passed, 0 skipped** (was 460 passed + 6 skipped before the parser fixes).
- Side-by-side comparison of each of the six divergence queries: cpp and python now produce identical ASTs.
- Built the cpp extension locally (`uv pip install --reinstall --no-cache ./common/hogql_parser`) and verified `hogql_parser.parse_expr_json("infinity")["value"] == "Infinity"`, `("08")["value"] == 8`, etc.

Not tested: the rust-allstar-json and rust-backtrack-json backends. They live in fork branches; once those rebase onto this branch they get the consolidated tests automatically.

## Publish to changelog?

no

## 🤖 Agent context

Driven by claude. The work split into two atomic commits:

1. **Consolidation** — extracted (test_name, query, mode) tuples from both fork files via AST walk, parsed each query with cpp-json to produce the expected AST, serialised that to Python literal source, and emitted the test methods. Pipeline scripts (`/tmp/extract_tests.py`, `/tmp/generate_consolidated_tests.py`, `/tmp/emit_test_methods.py`) regenerate the block end-to-end if needed.

2. **Divergence fixes** — the consolidated tests exposed 6 backend disagreements. Each was investigated with a side-by-side cpp/python compare, ClickHouse + Postgres semantics looked up where the source of truth was ambiguous (`infinity` lookup confirmed by Robbie), and the fix made on the side that diverged from the established behaviour. The cpp `parser_json.cpp` change requires a version bump; the workflows handle publish + lock updates on merge.