### PR TITLE
fix(workflows): scope replay_blocked_run validation to incident window

### DIFF
--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -788,7 +788,8 @@ class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, vie
               AND log_source_id = %(log_source_id)s
               AND instance_id = %(instance_id)s
               AND positionCaseInsensitiveUTF8(message, 'duplicate execution detected') > 0
-              AND timestamp >= toDate(NOW() - INTERVAL 30 DAY)
+              AND timestamp >= toDateTime('2026-03-30 00:00:00')
+              AND timestamp <= toDateTime('2026-04-23 00:00:00')
             LIMIT 1
             """,
             {"team_id": self.team_id, "log_source_id": str(hog_flow.id), "instance_id": instance_id},


### PR DESCRIPTION
I pointed Claude at the blocked CI on master, it came up with this. It doesn't look super convincing to me. I'd want @PostHog/team-workflows to take a look

CC continues:

## Problem

Backend CI on master HEAD ([13cb4c7](https://github.com/PostHog/posthog/commit/13cb4c7b9b8)) is failing on two tests in `TestHogFlowBlockedRuns`:

- `test_replay_blocked_run_success` — got 404, expected 200
- `test_replay_blocked_run_mismatched_event_uuid` — got 404, expected 400

The root cause is a time-bomb in production code. The `replay_blocked_run` validation query in [`posthog/api/hog_flow.py`](posthog/api/hog_flow.py:791) filtered log rows with a rolling `timestamp >= toDate(NOW() - INTERVAL 30 DAY)`, while everything else in the blocked-runs feature (`BLOCKED_RUNS_SQL` at line 577-578) is bounded to the fixed 2026-03-30 → 2026-04-23 incident window. The seeded test data sits at `2026-04-15`, which is now older than 30 days, so the validation matched zero rows and the action returned 404 ("Blocked run … not found").

Two other tests in the class expect 404 for different reasons and were passing for the wrong reason; the one that expects 400 (`test_replay_blocked_run_missing_params`) survived because the missing-params check fires before the SQL.

## Changes

Replace the rolling window with the same fixed incident window already used by `BLOCKED_RUNS_SQL`. The whole feature exists specifically for the 2026-03-30 → 2026-04-23 dedup incident; users can only attempt to replay runs they see in the list (already window-bounded), so the tighter bound here doesn't restrict any legitimate replay path — it just keeps validation consistent with the list query and stops it drifting as time passes.

## How did you test this code?

I'm an agent. I reproduced the two failures locally on master HEAD, applied the fix, then ran `pytest posthog/api/test/test_hog_flow.py::TestHogFlowBlockedRuns` — all 29 tests pass. No manual testing.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code at Robbie's request to debug master CI failures.

- Pulled the failing Backend CI run via `gh run view --log-failed`, reproduced the two failing tests locally with `hogli test`.
- Added a one-shot debug print to dump the response body, which revealed the 404 was coming from line 797 of `hog_flow.py` ("Blocked run … not found"), not from URL routing — narrowing the cause to the validation SQL.
- Compared the validation query's 30-day rolling window against the rest of the feature's fixed incident window in `BLOCKED_RUNS_SQL`. Chose to align them rather than freeze time in tests or seed log rows with `NOW()`-relative timestamps, because the entire feature is incident-specific and the rolling window was the inconsistent one.
- Verified all 29 `TestHogFlowBlockedRuns` tests pass after the change.