### PR TITLE
fix(hogql): run hogql-parser version probes from package dir

### DIFF
--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -47,7 +47,7 @@ jobs:
                   parser_release_needed='false'
                   if [[ "$PARSER_CHANGED" == 'true' ]]; then
                     published=$(curl -fSsl https://pypi.org/pypi/hogql-parser/json | jq -r '.info.version')
-                    local=$(python common/hogql_parser/setup.py --version)
+                    local=$(cd common/hogql_parser && python setup.py --version)
                     if [[ "$published" != "$local" ]]; then
                       parser_release_needed='true'
                     else
@@ -195,7 +195,7 @@ jobs:
                   # setuptools isn't installed by default after actions/setup-python, but
                   # `python setup.py --version` needs it. Mirrors the sdist step above.
                   pip install setuptools==80.9.0
-                  VERSION=$(python common/hogql_parser/setup.py --version)
+                  VERSION=$(cd common/hogql_parser && python setup.py --version)
                   # In case the version is not available yet, try up to $RETRIES times
                   for i in $(seq 1 "$RETRIES"); do
                       if uv add "hogql-parser==$VERSION"; then


### PR DESCRIPTION
## Problem

The `Release hogql-parser` workflow has a latent bug. Two steps probe the package version with `python common/hogql_parser/setup.py --version` from the repo root. Under the workflow's pinned `setuptools==80.9.0`, running `setup.py` from the repo root makes setuptools discover and apply the *root* `pyproject.toml`'s `[project]` table to the `hogql_parser` distribution. Since `common/hogql_parser/setup.py` passes `long_description=` directly, setuptools' `_handle_missing_dynamic` sets `project_table["readme"] = None` (no `readme` entry in `_RESET_PREVIOUSLY_DEFINED`), and `_long_description` then crashes with `AttributeError: 'NoneType' object has no attribute 'get'`.

This breaks the post-publish "Update hogql-parser in requirements" step every time hogql-parser is version-bumped. The PyPI publish itself succeeds, but the `pyproject.toml` / `uv.lock` auto-bump step dies.

## Changes

Both `python common/hogql_parser/setup.py --version` invocations now run from inside the package directory: `(cd common/hogql_parser && python setup.py --version)`. When run from there, setuptools reads `common/hogql_parser/pyproject.toml`, which has no `[project]` table, so `_apply_project_table` short-circuits and the crash is avoided. This makes the two version-probe steps consistent with the sdist and cibuildwheel steps in the same workflow, which already `cd common/hogql_parser` first.

## How did you test this code?

I'm an agent. I reproduced the failure locally with `setuptools 80.9.0` installed:

- `python3 common/hogql_parser/setup.py --version` from the repo root crashes with the exact `AttributeError` in `_long_description`.
- `cd common/hogql_parser && python3 setup.py --version` prints the version (`1.3.42`) cleanly.

No automated test was added; the change is a workflow shell tweak.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). The root cause was already diagnosed before the session; the agent applied the two-line fix, reproduced the crash and the clean run locally to confirm, and opened this PR. The `cd`-subshell form was chosen over alternatives (e.g. unsetting the root `pyproject.toml`) because it mirrors what the sdist/cibuildwheel steps already do, keeping the workflow internally consistent.