### PR TITLE
fix(hogql): unquote name-position identifiers, accept bare throw

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -124,7 +124,7 @@ class ReturnStatement(Statement):
 
 @dataclass(kw_only=True, slots=True)
 class ThrowStatement(Statement):
-    expr: Expr
+    expr: Optional[Expr]
 
 
 @dataclass(kw_only=True, slots=True)

--- a/posthog/hogql/compiler/bytecode.py
+++ b/posthog/hogql/compiler/bytecode.py
@@ -578,6 +578,8 @@ class BytecodeCompiler(Visitor):
         return response
 
     def visit_throw_statement(self, node: ast.ThrowStatement):
+        if node.expr is None:
+            raise QueryError("THROW requires an expression")
         return [*self.visit(node.expr), Operation.THROW]
 
     def visit_try_catch_statement(self, node: ast.TryCatchStatement):

--- a/posthog/hogql/compiler/javascript.py
+++ b/posthog/hogql/compiler/javascript.py
@@ -406,6 +406,8 @@ class JavaScriptCompiler(Visitor):
             return "return null;"
 
     def visit_throw_statement(self, node: ast.ThrowStatement):
+        if node.expr is None:
+            raise QueryError("THROW requires an expression")
         return f"throw {self.visit(node.expr)};"
 
     def visit_try_catch_statement(self, node: ast.TryCatchStatement):

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -466,7 +466,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
 
     def visitVarDecl(self, ctx: HogQLParser.VarDeclContext):
         return ast.VariableDeclaration(
-            name=ctx.identifier().getText(),
+            name=self.visit(ctx.identifier()),
             expr=self.visit(ctx.expression()) if ctx.expression() else None,
         )
 
@@ -487,9 +487,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
 
     def visitThrowStmt(self, ctx: HogQLParser.ThrowStmtContext):
         expression = ctx.expression()
-        if expression is None:
-            raise SyntaxError("THROW requires an expression")
-        return ast.ThrowStatement(expr=self.visit(expression))
+        return ast.ThrowStatement(expr=self.visit(expression) if expression else None)
 
     def visitCatchBlock(self, ctx: HogQLParser.CatchBlockContext):
         return (
@@ -519,8 +517,8 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return ast.WhileStatement(expr=self.visit(ctx.expression()), body=self.visit(statement))
 
     def visitForInStmt(self, ctx: HogQLParser.ForInStmtContext):
-        first_identifier = ctx.identifier(0).getText()
-        second_identifier = ctx.identifier(1).getText() if ctx.identifier(1) else None
+        first_identifier = self.visit(ctx.identifier(0))
+        second_identifier = self.visit(ctx.identifier(1)) if ctx.identifier(1) else None
         return ast.ForInStatement(
             valueVar=second_identifier if second_identifier is not None else first_identifier,
             keyVar=first_identifier if second_identifier is not None else None,
@@ -541,7 +539,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
 
     def visitFuncStmt(self, ctx: HogQLParser.FuncStmtContext):
         return ast.Function(
-            name=ctx.identifier().getText(),
+            name=self.visit(ctx.identifier()),
             params=self.visit(ctx.identifierList()) if ctx.identifierList() else [],
             body=self.visit(ctx.block()),
         )
@@ -554,7 +552,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return (self.visit(k), self.visit(v))
 
     def visitIdentifierList(self, ctx: HogQLParser.IdentifierListContext):
-        return [ident.getText() for ident in ctx.nestedIdentifier()]
+        return [".".join(self.visit(nested)) for nested in ctx.nestedIdentifier()]
 
     def visitEmptyStmt(self, ctx: HogQLParser.EmptyStmtContext):
         return ast.ExprStatement(expr=None)

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -1455,6 +1455,16 @@ def parser_test_factory(backend: HogQLParserBackend):
                 ),
             )
 
+        def test_select_columns_quoted_exclude(self):
+            # Quoted identifiers inside an exclude list must be unquoted, matching the cpp parser.
+            self.assertEqual(
+                self._select('select * exclude ("first name") from customers'),
+                ast.SelectQuery(
+                    select=[ast.ColumnsExpr(all_columns=True, exclude=["first name"])],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=["customers"])),
+                ),
+            )
+
         def test_ignore_nulls_expr(self):
             self.assertEqual(
                 self._expr("event IGNORE NULLS"),
@@ -3655,6 +3665,50 @@ def parser_test_factory(backend: HogQLParserBackend):
                 ],
             )
             self.assertEqual(program, expected)
+
+        def test_program_quoted_identifiers(self):
+            # Quoted identifiers in name positions must be unquoted, matching the cpp parser.
+            self.assertEqual(
+                self._program('fn "my fn"("a b", "c d") { return 1; }'),
+                Program(
+                    declarations=[
+                        Function(
+                            name="my fn",
+                            params=["a b", "c d"],
+                            body=Block(declarations=[ast.ReturnStatement(expr=Constant(value=1))]),
+                        )
+                    ],
+                ),
+            )
+            self.assertEqual(
+                self._program('let "my var" := 1;'),
+                Program(declarations=[VariableDeclaration(name="my var", expr=Constant(value=1))]),
+            )
+            self.assertEqual(
+                self._program('for (let "key", "val" in [1]) {}'),
+                Program(
+                    declarations=[
+                        ast.ForInStatement(
+                            keyVar="key",
+                            valueVar="val",
+                            expr=ast.Array(exprs=[Constant(value=1)]),
+                            body=Block(declarations=[]),
+                        )
+                    ],
+                ),
+            )
+
+        def test_program_throw_without_expression(self):
+            # The grammar marks the throw expression optional, so a bare throw parses,
+            # matching the cpp parser.
+            self.assertEqual(
+                self._program("throw"),
+                Program(declarations=[ast.ThrowStatement(expr=None)]),
+            )
+            self.assertEqual(
+                self._program("throw;"),
+                Program(declarations=[ast.ThrowStatement(expr=None)]),
+            )
 
         def test_program_array(self):
             code = "let a := [1, 2, 3];"


### PR DESCRIPTION
## Problem

Property-based testing of the Hog parser (comparing the Python parser against the C++ parser as an oracle) surfaced two divergences:

- **Quoted identifiers in name positions** kept their quotes in the Python parser.
For example `fn "nqik"() {}` produced a function named `"nqik"` in Python but `nqik` in C++.
The same divergence appeared for quoted entries in `* exclude(...)` lists.
- **A bare `throw`** (no expression) was rejected by the Python parser with `"THROW requires an expression"`, even though the grammar marks the expression optional (`throwStmt : THROW expression? SEMICOLON?`) and the C++ parser accepts it.

The C++ parser is the correct reference: it routes identifiers through `unquoteIdentifierText` and emits `ThrowStatement` with `expr: null` for a bare throw.

## Changes

- `posthog/hogql/parser.py`: name-position identifiers (`visitFuncStmt`, `visitVarDecl`, `visitForInStmt`, `visitIdentifierList`) now go through `self.visit(...)` instead of raw `getText()`, so quoted identifiers are unquoted to match the C++ parser. `visitThrowStmt` no longer rejects a bare throw and produces `ThrowStatement(expr=None)`.
- `posthog/hogql/ast.py`: `ThrowStatement.expr` is now `Optional[Expr]`.
- `posthog/hogql/compiler/bytecode.py`, `posthog/hogql/compiler/javascript.py`: raise a clear `QueryError` if asked to compile a bare throw, so the parser change does not introduce a crash path downstream.
- `posthog/hogql/test/_test_parser.py`: new tests covering quoted identifiers in function names / params / var declarations / for-in loops / exclude lists, and a bare throw. These run against both the Python and C++ parser backends.

Based on the parser fixes in #58665.

## How did you test this code?

I'm an agent; I did not do manual testing. Automated tests run:

- The three new tests were confirmed to fail against the unfixed Python parser (red), then pass after the fix (green), on both the Python and C++ backends.
- Full Python parser suite: 237 passed.
- Bytecode and JavaScript compiler suites: 48 passed.
- The C++ parser suite has 32 pre-existing `signed_radix` failures inherited from the base branch (the compiled extension is stale relative to the base PR's lexer changes and is rebuilt in CI); they are unrelated to this change.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7).
The bugs were identified by a property-based test run that the agent did not have direct access to; the agent reproduced each divergence, added red-green tests against the shared parser test suite (which exercises both backends), then applied the fixes.

Decision notes:

- The PBT report only named function names and exclude lists, but the same `getText()`-instead-of-visit bug existed for var declarations and for-in loop variables. All four were fixed together for consistency with the C++ parser, since the others would surface in future PBT runs.
- Making the parser accept a bare throw would otherwise leave the bytecode compiler crashing on `[*None, ...]`. Rather than invent throw-null semantics, the compilers raise a clear error, mirroring the existing "try alone parses but fails at bytecode" pattern.
