### PR TITLE
feat(replay): add feature flag filter to kiosk mode

### DIFF
--- a/frontend/src/scenes/session-recordings/kiosk/KioskSetup.tsx
+++ b/frontend/src/scenes/session-recordings/kiosk/KioskSetup.tsx
@@ -26,7 +26,12 @@ export function KioskSetup(): JSX.Element {
     const [featureFlagKey, setFeatureFlagKey] = useState(filters.featureFlagKey || '')
     const [featureFlagValue, setFeatureFlagValue] = useState(filters.featureFlagValue || '')
 
+    const featureFlagKeyMissingValue = !!featureFlagKey.trim() && !featureFlagValue.trim()
+
     const handleStart = (): void => {
+        if (featureFlagKeyMissingValue) {
+            return
+        }
         setFilters({
             visitedPage: visitedPage.trim() || null,
             dateFrom,
@@ -107,7 +112,14 @@ export function KioskSetup(): JSX.Element {
                     />
                 </div>
 
-                <LemonButton type="primary" fullWidth size="large" icon={<IconPlay />} onClick={handleStart}>
+                <LemonButton
+                    type="primary"
+                    fullWidth
+                    size="large"
+                    icon={<IconPlay />}
+                    onClick={handleStart}
+                    disabledReason={featureFlagKeyMissingValue ? 'Enter a feature flag value' : undefined}
+                >
                     Start kiosk
                 </LemonButton>
             </div>

--- a/frontend/src/scenes/session-recordings/kiosk/KioskSetup.tsx
+++ b/frontend/src/scenes/session-recordings/kiosk/KioskSetup.tsx
@@ -23,9 +23,17 @@ export function KioskSetup(): JSX.Element {
     const [visitedPage, setVisitedPage] = useState(filters.visitedPage || '')
     const [dateFrom, setDateFrom] = useState(filters.dateFrom || '-30d')
     const [minDurationSeconds, setMinDurationSeconds] = useState(filters.minDurationSeconds)
+    const [featureFlagKey, setFeatureFlagKey] = useState(filters.featureFlagKey || '')
+    const [featureFlagValue, setFeatureFlagValue] = useState(filters.featureFlagValue || '')
 
     const handleStart = (): void => {
-        setFilters({ visitedPage: visitedPage.trim() || null, dateFrom, minDurationSeconds })
+        setFilters({
+            visitedPage: visitedPage.trim() || null,
+            dateFrom,
+            minDurationSeconds,
+            featureFlagKey: featureFlagKey.trim() || null,
+            featureFlagValue: featureFlagValue.trim() || null,
+        })
         startPlayback()
     }
 
@@ -71,6 +79,31 @@ export function KioskSetup(): JSX.Element {
                         onChange={(val) => setMinDurationSeconds(Number(val) || 0)}
                         fullWidth
                         onPressEnter={handleStart}
+                    />
+                </div>
+
+                <div className="KioskSetup__field">
+                    <label htmlFor="kiosk-feature-flag-key">Feature flag (optional)</label>
+                    <LemonInput
+                        id="kiosk-feature-flag-key"
+                        value={featureFlagKey}
+                        onChange={setFeatureFlagKey}
+                        placeholder="flag key, e.g. new-checkout"
+                        fullWidth
+                        onPressEnter={handleStart}
+                    />
+                </div>
+
+                <div className="KioskSetup__field">
+                    <label htmlFor="kiosk-feature-flag-value">Feature flag value</label>
+                    <LemonInput
+                        id="kiosk-feature-flag-value"
+                        value={featureFlagValue}
+                        onChange={setFeatureFlagValue}
+                        placeholder="e.g. true, control, variant-a"
+                        fullWidth
+                        onPressEnter={handleStart}
+                        disabled={!featureFlagKey.trim()}
                     />
                 </div>
 

--- a/frontend/src/scenes/session-recordings/kiosk/KioskSetup.tsx
+++ b/frontend/src/scenes/session-recordings/kiosk/KioskSetup.tsx
@@ -32,12 +32,13 @@ export function KioskSetup(): JSX.Element {
         if (featureFlagKeyMissingValue) {
             return
         }
+        const trimmedFlagKey = featureFlagKey.trim() || null
         setFilters({
             visitedPage: visitedPage.trim() || null,
             dateFrom,
             minDurationSeconds,
-            featureFlagKey: featureFlagKey.trim() || null,
-            featureFlagValue: featureFlagValue.trim() || null,
+            featureFlagKey: trimmedFlagKey,
+            featureFlagValue: trimmedFlagKey ? featureFlagValue.trim() || null : null,
         })
         startPlayback()
     }

--- a/frontend/src/scenes/session-recordings/kiosk/sessionRecordingsKioskLogic.ts
+++ b/frontend/src/scenes/session-recordings/kiosk/sessionRecordingsKioskLogic.ts
@@ -258,8 +258,8 @@ export const sessionRecordingsKioskLogic = kea<sessionRecordingsKioskLogicType>(
     })),
 
     actionToUrl(({ values }) => {
-        const filterParams = (): Record<string, string> => {
-            const params: Record<string, string> = {}
+        const filterParams = (extra: Record<string, string | number> = {}): Record<string, string | number> => {
+            const params: Record<string, string | number> = { ...extra }
             if (values.filters.visitedPage) {
                 params.visited_page = values.filters.visitedPage
             }
@@ -279,7 +279,7 @@ export const sessionRecordingsKioskLogic = kea<sessionRecordingsKioskLogicType>(
         }
         return {
             resetPlayback: () => [urls.replayKiosk(), filterParams(), undefined, { replace: true }],
-            startPlayback: () => [urls.replayKiosk(), { ...filterParams(), play: 1 }, undefined, { replace: true }],
+            startPlayback: () => [urls.replayKiosk(), filterParams({ play: 1 }), undefined, { replace: true }],
         }
     }),
 

--- a/frontend/src/scenes/session-recordings/kiosk/sessionRecordingsKioskLogic.ts
+++ b/frontend/src/scenes/session-recordings/kiosk/sessionRecordingsKioskLogic.ts
@@ -47,12 +47,16 @@ export interface KioskFilters {
     visitedPage: string | null
     dateFrom: string
     minDurationSeconds: number
+    featureFlagKey: string | null
+    featureFlagValue: string | null
 }
 
 const DEFAULT_FILTERS: KioskFilters = {
     visitedPage: null,
     dateFrom: '-30d',
     minDurationSeconds: 5,
+    featureFlagKey: null,
+    featureFlagValue: null,
 }
 
 export const sessionRecordingsKioskLogic = kea<sessionRecordingsKioskLogicType>([
@@ -118,7 +122,26 @@ export const sessionRecordingsKioskLogic = kea<sessionRecordingsKioskLogicType>(
             [] as SessionRecordingType[],
             {
                 loadRecordings: async () => {
-                    const { visitedPage, dateFrom, minDurationSeconds } = values.filters
+                    const { visitedPage, dateFrom, minDurationSeconds, featureFlagKey, featureFlagValue } =
+                        values.filters
+
+                    const properties: RecordingsQuery['properties'] = []
+                    if (visitedPage) {
+                        properties.push({
+                            type: PropertyFilterType.Recording,
+                            key: 'visited_page',
+                            operator: PropertyOperator.IContains,
+                            value: [visitedPage],
+                        })
+                    }
+                    if (featureFlagKey && featureFlagValue) {
+                        properties.push({
+                            type: PropertyFilterType.Feature,
+                            key: featureFlagKey,
+                            operator: PropertyOperator.Exact,
+                            value: [featureFlagValue],
+                        })
+                    }
 
                     const query: RecordingsQuery = {
                         kind: NodeKind.RecordingsQuery,
@@ -128,16 +151,7 @@ export const sessionRecordingsKioskLogic = kea<sessionRecordingsKioskLogicType>(
                         date_to: null,
                         limit: 100,
                         filter_test_accounts: true,
-                        properties: visitedPage
-                            ? [
-                                  {
-                                      type: PropertyFilterType.Recording,
-                                      key: 'visited_page',
-                                      operator: PropertyOperator.IContains,
-                                      value: [visitedPage],
-                                  },
-                              ]
-                            : [],
+                        properties,
                         having_predicates:
                             minDurationSeconds > 0
                                 ? [
@@ -243,8 +257,8 @@ export const sessionRecordingsKioskLogic = kea<sessionRecordingsKioskLogicType>(
         },
     })),
 
-    actionToUrl(({ values }) => ({
-        resetPlayback: () => {
+    actionToUrl(({ values }) => {
+        const filterParams = (): Record<string, string> => {
             const params: Record<string, string> = {}
             if (values.filters.visitedPage) {
                 params.visited_page = values.filters.visitedPage
@@ -255,22 +269,19 @@ export const sessionRecordingsKioskLogic = kea<sessionRecordingsKioskLogicType>(
             if (values.filters.minDurationSeconds !== DEFAULT_FILTERS.minDurationSeconds) {
                 params.min_duration = String(values.filters.minDurationSeconds)
             }
-            return [urls.replayKiosk(), params, undefined, { replace: true }]
-        },
-        startPlayback: () => {
-            const params: Record<string, string | number> = { play: 1 }
-            if (values.filters.visitedPage) {
-                params.visited_page = values.filters.visitedPage
+            if (values.filters.featureFlagKey) {
+                params.feature_flag = values.filters.featureFlagKey
             }
-            if (values.filters.dateFrom && values.filters.dateFrom !== '-30d') {
-                params.date_from = values.filters.dateFrom
+            if (values.filters.featureFlagValue) {
+                params.feature_flag_value = values.filters.featureFlagValue
             }
-            if (values.filters.minDurationSeconds !== DEFAULT_FILTERS.minDurationSeconds) {
-                params.min_duration = String(values.filters.minDurationSeconds)
-            }
-            return [urls.replayKiosk(), params, undefined, { replace: true }]
-        },
-    })),
+            return params
+        }
+        return {
+            resetPlayback: () => [urls.replayKiosk(), filterParams(), undefined, { replace: true }],
+            startPlayback: () => [urls.replayKiosk(), { ...filterParams(), play: 1 }, undefined, { replace: true }],
+        }
+    }),
 
     urlToAction(({ actions, values }) => ({
         [urls.replayKiosk()]: (_, searchParams) => {
@@ -279,13 +290,17 @@ export const sessionRecordingsKioskLogic = kea<sessionRecordingsKioskLogicType>(
             const minDurationSeconds = searchParams.min_duration
                 ? Number(searchParams.min_duration)
                 : DEFAULT_FILTERS.minDurationSeconds
+            const featureFlagKey = searchParams.feature_flag || null
+            const featureFlagValue = searchParams.feature_flag_value || null
 
             if (
                 visitedPage !== values.filters.visitedPage ||
                 dateFrom !== values.filters.dateFrom ||
-                minDurationSeconds !== values.filters.minDurationSeconds
+                minDurationSeconds !== values.filters.minDurationSeconds ||
+                featureFlagKey !== values.filters.featureFlagKey ||
+                featureFlagValue !== values.filters.featureFlagValue
             ) {
-                actions.setFilters({ visitedPage, dateFrom, minDurationSeconds })
+                actions.setFilters({ visitedPage, dateFrom, minDurationSeconds, featureFlagKey, featureFlagValue })
             }
 
             if (searchParams.play === 1 && !values.started) {

--- a/frontend/src/scenes/session-recordings/kiosk/sessionRecordingsKioskLogic.ts
+++ b/frontend/src/scenes/session-recordings/kiosk/sessionRecordingsKioskLogic.ts
@@ -269,10 +269,8 @@ export const sessionRecordingsKioskLogic = kea<sessionRecordingsKioskLogicType>(
             if (values.filters.minDurationSeconds !== DEFAULT_FILTERS.minDurationSeconds) {
                 params.min_duration = String(values.filters.minDurationSeconds)
             }
-            if (values.filters.featureFlagKey) {
+            if (values.filters.featureFlagKey && values.filters.featureFlagValue) {
                 params.feature_flag = values.filters.featureFlagKey
-            }
-            if (values.filters.featureFlagValue) {
                 params.feature_flag_value = values.filters.featureFlagValue
             }
             return params


### PR DESCRIPTION
## Problem

Kiosk mode can only filter by date / page / duration today. Customer ask: also restrict the loop to sessions where a specific feature flag has a specific value.

## Changes

Two optional inputs on the kiosk setup screen (flag key + value). When both are set, the recordings query gets an extra `PropertyFilterType.Feature` filter with `Exact` operator. State is mirrored to the URL so the filtered kiosk URL stays shareable.

## How did you test this code?

Agent-authored. Ran `oxlint` and `tsc` (clean for the touched files). No manual browser testing — worth a local smoke before merging.

## Publish to changelog?

no

## 🤖 Agent context

Claude Code (Opus 4.7). Considered reusing the playlist's full `PropertyFilters` component but rejected as too heavy for kiosk's intentionally minimal setup screen; two plain `LemonInput`s match the existing style.