### PR TITLE
fix(user-interviews): use static Vapi default import

### DIFF
--- a/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
+++ b/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
@@ -1,3 +1,4 @@
+import Vapi from '@vapi-ai/web'
 import { useEffect, useRef, useState } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
@@ -44,7 +45,7 @@ export default function ExporterInterviewScene({
 }): JSX.Element {
     const [state, setState] = useState<CallState>('idle')
     const [errorMessage, setErrorMessage] = useState<string | null>(null)
-    const vapiRef = useRef<{ stop: () => void } | null>(null)
+    const vapiRef = useRef<Vapi | null>(null)
 
     useEffect(() => {
         document.title = `Interview · ${interview.topic}`
@@ -64,10 +65,7 @@ export default function ExporterInterviewScene({
         }
         setState('loading')
         try {
-            const [{ default: Vapi }, startPayload] = await Promise.all([
-                import(/* webpackChunkName: "vapi-sdk" */ '@vapi-ai/web'),
-                fetchStartCallPayload(accessToken),
-            ])
+            const startPayload = await fetchStartCallPayload(accessToken)
             const vapi = new Vapi(startPayload.public_key)
             vapiRef.current = vapi
             vapi.on('call-end', () => setState('ended'))


### PR DESCRIPTION
## Problem

Clicking *Start interview* on a public interview link (the `ExporterInterviewScene`) surfaced "i is not a constructor" before the call could connect. The page was effectively dead-on-click for every recipient of a generated interview URL.

## Changes

Switched `@vapi-ai/web` to the static default import that Vapi's own README documents:

```ts
import Vapi from '@vapi-ai/web'
```

The previous code used a dynamic `import('@vapi-ai/web')` and destructured `{ default: Vapi }`. `@vapi-ai/web`'s CommonJS dist sets both `__esModule = true` and `exports.default = Vapi`, and Vite/Rollup's dynamic-import interop ends up exposing the whole exports object as the namespace's `default` — so the destructured `Vapi` was the exports namespace, not the constructor. Minified, the call site read `new i(...)`, hence the error.

Also dropped the `/* webpackChunkName: "vapi-sdk" */` magic comment — we're on Vite/Rollup, not webpack, so it was a no-op. `ExporterInterviewScene` is already in the separate `exporter` bundle, so the SDK lazy-load wasn't pulling its weight here.

## How did you test this code?

I'm an agent (PostHog Code, Opus 4.7) — I did not click through the live call. I ran `pnpm --filter=@posthog/frontend typescript:check` and confirmed no new errors on the changed file (only pre-existing failures in `products/workflows/`). The user who flagged the bug will retest the live interview link.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Tools: PostHog Code (Opus 4.7), graphite MCP for branch + submit, PostHog MCP for the user-interview-topic flow that surfaced the bug, repo Read/Grep/Edit.
- Considered: a defensive `default.default` unwrap at the call site (rejected — invents complexity for a problem the static import has no opinion on), and adding `@vapi-ai/web` to `optimizeDeps.include` (rejected — only affects dev pre-bundling, doesn't fix the Rollup prod build where the symptom originated).
- Chose the static import because Vapi's own README is unambiguous about the shape, and Vite resolves the CJS default correctly at build time when the import is static.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*