### PR TITLE
feat(notebooks): warn before leaving with unsaved changes

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.test.ts
@@ -2,9 +2,7 @@ import { shouldWarnBeforeLeavingNotebook } from './notebookBeforeUnload'
 
 describe('shouldWarnBeforeLeavingNotebook', () => {
     const baseInput = {
-        mode: 'notebook' as const,
         isLocalOnly: false,
-        isShared: false,
         isEditable: true,
         syncStatus: 'unsaved' as const,
         currentPathname: '/project/1/notebooks/abc',
@@ -19,19 +17,11 @@ describe('shouldWarnBeforeLeavingNotebook', () => {
         expect(shouldWarnBeforeLeavingNotebook({ ...baseInput, syncStatus })).toBe(expected)
     })
 
-    it('does not warn for canvas mode', () => {
-        expect(shouldWarnBeforeLeavingNotebook({ ...baseInput, mode: 'canvas' })).toBe(false)
-    })
-
-    it('does not warn for local-only notebooks (scratchpad / template)', () => {
+    it('does not warn for local-only notebooks (scratchpad / canvas / template)', () => {
         expect(shouldWarnBeforeLeavingNotebook({ ...baseInput, isLocalOnly: true })).toBe(false)
     })
 
-    it('does not warn for shared / read-only views', () => {
-        expect(shouldWarnBeforeLeavingNotebook({ ...baseInput, isShared: true })).toBe(false)
-    })
-
-    it('does not warn when the notebook is not editable for the current user', () => {
+    it('does not warn when the notebook is not editable (viewer access, history preview, shared/exported view)', () => {
         expect(shouldWarnBeforeLeavingNotebook({ ...baseInput, isEditable: false })).toBe(false)
     })
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.test.ts
@@ -1,0 +1,59 @@
+import { shouldWarnBeforeLeavingNotebook } from './notebookBeforeUnload'
+
+describe('shouldWarnBeforeLeavingNotebook', () => {
+    const baseInput = {
+        mode: 'notebook' as const,
+        isLocalOnly: false,
+        isShared: false,
+        isEditable: true,
+        syncStatus: 'unsaved' as const,
+        currentPathname: '/project/1/notebooks/abc',
+    }
+
+    it.each([
+        ['unsaved', 'unsaved' as const, true],
+        ['saving (in flight, including 409 retry loop)', 'saving' as const, true],
+        ['synced', 'synced' as const, false],
+        ['local', 'local' as const, false],
+    ])('warns when syncStatus is %s -> %s', (_label, syncStatus, expected) => {
+        expect(shouldWarnBeforeLeavingNotebook({ ...baseInput, syncStatus })).toBe(expected)
+    })
+
+    it('does not warn for canvas mode', () => {
+        expect(shouldWarnBeforeLeavingNotebook({ ...baseInput, mode: 'canvas' })).toBe(false)
+    })
+
+    it('does not warn for local-only notebooks (scratchpad / template)', () => {
+        expect(shouldWarnBeforeLeavingNotebook({ ...baseInput, isLocalOnly: true })).toBe(false)
+    })
+
+    it('does not warn for shared / read-only views', () => {
+        expect(shouldWarnBeforeLeavingNotebook({ ...baseInput, isShared: true })).toBe(false)
+    })
+
+    it('does not warn when the notebook is not editable for the current user', () => {
+        expect(shouldWarnBeforeLeavingNotebook({ ...baseInput, isEditable: false })).toBe(false)
+    })
+
+    it('does not warn for in-page URL updates (same pathname)', () => {
+        expect(
+            shouldWarnBeforeLeavingNotebook({
+                ...baseInput,
+                newPathname: '/project/1/notebooks/abc',
+            })
+        ).toBe(false)
+    })
+
+    it('warns when navigating to a different pathname', () => {
+        expect(
+            shouldWarnBeforeLeavingNotebook({
+                ...baseInput,
+                newPathname: '/project/1/dashboard',
+            })
+        ).toBe(true)
+    })
+
+    it('warns when no newPathname is provided (browser tab close)', () => {
+        expect(shouldWarnBeforeLeavingNotebook(baseInput)).toBe(true)
+    })
+})

--- a/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.ts
@@ -26,7 +26,7 @@ export function shouldWarnBeforeLeavingNotebook(input: ShouldWarnBeforeLeavingNo
         return false
     }
     // Ignore in-page URL updates (side panel, hash params, comment selection, ...).
-    if (input.newPathname !== undefined && input.newPathname === input.currentPathname) {
+    if (input.newPathname === input.currentPathname) {
         return false
     }
     return true

--- a/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.ts
@@ -1,10 +1,7 @@
 import type { NotebookSyncStatus } from '../types'
-import type { NotebookLogicMode } from './notebookLogic'
 
 export type ShouldWarnBeforeLeavingNotebookInput = {
-    mode: NotebookLogicMode
     isLocalOnly: boolean
-    isShared: boolean
     isEditable: boolean
     syncStatus: NotebookSyncStatus
     currentPathname: string
@@ -15,16 +12,17 @@ export type ShouldWarnBeforeLeavingNotebookInput = {
  * Pure decision helper for the unsaved-changes prompt. Returns `true` if the user should be
  * warned before navigating away. Extracted from the `beforeUnload` builder so it can be unit
  * tested without mounting the full `notebookLogic` (which connects a dozen other logics).
+ *
+ * `isLocalOnly` covers scratchpad / canvas / templates (no server save ever happens).
+ * `isEditable` covers viewer-level access, history-preview mode, and shared/exported read-only
+ * views (`<Notebook editable={false}>` flips `shouldBeEditable` off, which kills `isEditable`).
+ * `syncStatus` is `unsaved` while there is local content not yet on the server, and `saving`
+ * while a save is in flight (including the 409 retry loop in collab mode).
  */
 export function shouldWarnBeforeLeavingNotebook(input: ShouldWarnBeforeLeavingNotebookInput): boolean {
-    // Only guard real, server-backed notebooks that the current user can edit.
-    // Scratchpad/canvas/templates are local-only, shared views are read-only.
-    if (input.mode !== 'notebook' || input.isLocalOnly || input.isShared || !input.isEditable) {
+    if (input.isLocalOnly || !input.isEditable) {
         return false
     }
-    // syncStatus is `unsaved` while there is local content not yet on the server, and `saving`
-    // while a save is in flight (including the 409 retry loop in collab mode). Either way,
-    // leaving now risks dropping changes.
     if (input.syncStatus !== 'unsaved' && input.syncStatus !== 'saving') {
         return false
     }

--- a/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.ts
@@ -1,0 +1,36 @@
+import type { NotebookSyncStatus } from '../types'
+import type { NotebookLogicMode } from './notebookLogic'
+
+export type ShouldWarnBeforeLeavingNotebookInput = {
+    mode: NotebookLogicMode
+    isLocalOnly: boolean
+    isShared: boolean
+    isEditable: boolean
+    syncStatus: NotebookSyncStatus
+    currentPathname: string
+    newPathname?: string
+}
+
+/**
+ * Pure decision helper for the unsaved-changes prompt. Returns `true` if the user should be
+ * warned before navigating away. Extracted from the `beforeUnload` builder so it can be unit
+ * tested without mounting the full `notebookLogic` (which connects a dozen other logics).
+ */
+export function shouldWarnBeforeLeavingNotebook(input: ShouldWarnBeforeLeavingNotebookInput): boolean {
+    // Only guard real, server-backed notebooks that the current user can edit.
+    // Scratchpad/canvas/templates are local-only, shared views are read-only.
+    if (input.mode !== 'notebook' || input.isLocalOnly || input.isShared || !input.isEditable) {
+        return false
+    }
+    // syncStatus is `unsaved` while there is local content not yet on the server, and `saving`
+    // while a save is in flight (including the 409 retry loop in collab mode). Either way,
+    // leaving now risks dropping changes.
+    if (input.syncStatus !== 'unsaved' && input.syncStatus !== 'saving') {
+        return false
+    }
+    // Ignore in-page URL updates (side panel, hash params, comment selection, ...).
+    if (input.newPathname !== undefined && input.newPathname === input.currentPathname) {
+        return false
+    }
+    return true
+}

--- a/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookBeforeUnload.ts
@@ -9,9 +9,8 @@ export type ShouldWarnBeforeLeavingNotebookInput = {
 }
 
 /**
- * Pure decision helper for the unsaved-changes prompt. Returns `true` if the user should be
- * warned before navigating away. Extracted from the `beforeUnload` builder so it can be unit
- * tested without mounting the full `notebookLogic` (which connects a dozen other logics).
+ * Helper for the unsaved-changes prompt. Returns `true` if the user should be warned before
+ * navigating away.
  *
  * `isLocalOnly` covers scratchpad / canvas / templates (no server save ever happens).
  * `isEditable` covers viewer-level access, history-preview mode, and shared/exported read-only

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -71,6 +71,7 @@ import {
 } from '../types'
 import { updateContentHeading } from '../utils'
 import { NOTEBOOKS_VERSION, migrate } from './migrations/migrate'
+import { shouldWarnBeforeLeavingNotebook } from './notebookBeforeUnload'
 import { notebookCollabLogic } from './notebookCollabLogic'
 import { notebookKernelInfoLogic } from './notebookKernelInfoLogic'
 import type { notebookLogicType } from './notebookLogicType'
@@ -1195,29 +1196,16 @@ export const notebookLogic = kea<notebookLogicType>([
     })),
 
     beforeUnload((logic) => ({
-        enabled: (newLocation?: CombinedLocation) => {
-            // Only guard real, server-backed notebooks that the current user can edit.
-            // Scratchpad/canvas/templates are local-only, shared views are read-only.
-            if (
-                logic.values.mode !== 'notebook' ||
-                logic.values.isLocalOnly ||
-                logic.values.isShared ||
-                !logic.values.isEditable
-            ) {
-                return false
-            }
-            // syncStatus is `unsaved` while there is local content not yet on the server,
-            // and `saving` while a save is in flight (including the 409 retry loop in
-            // collab mode). Either way, leaving now risks dropping changes.
-            if (logic.values.syncStatus !== 'unsaved' && logic.values.syncStatus !== 'saving') {
-                return false
-            }
-            // Ignore in-page URL updates (side panel, hash params, comment selection, ...).
-            if (newLocation && newLocation.pathname === router.values.location.pathname) {
-                return false
-            }
-            return true
-        },
+        enabled: (newLocation?: CombinedLocation) =>
+            shouldWarnBeforeLeavingNotebook({
+                mode: logic.values.mode,
+                isLocalOnly: logic.values.isLocalOnly,
+                isShared: logic.values.isShared,
+                isEditable: logic.values.isEditable,
+                syncStatus: logic.values.syncStatus,
+                currentPathname: router.values.location.pathname,
+                newPathname: newLocation?.pathname,
+            }),
         message: 'Leave notebook?\nChanges you made may not be saved.',
     })),
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -1198,9 +1198,7 @@ export const notebookLogic = kea<notebookLogicType>([
     beforeUnload((logic) => ({
         enabled: (newLocation?: CombinedLocation) =>
             shouldWarnBeforeLeavingNotebook({
-                mode: logic.values.mode,
                 isLocalOnly: logic.values.isLocalOnly,
-                isShared: logic.values.isShared,
                 isEditable: logic.values.isEditable,
                 syncStatus: logic.values.syncStatus,
                 currentPathname: router.values.location.pathname,

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -14,7 +14,8 @@ import {
     selectors,
 } from 'kea'
 import { loaders } from 'kea-loaders'
-import { router, urlToAction } from 'kea-router'
+import { beforeUnload, router, urlToAction } from 'kea-router'
+import { CombinedLocation } from 'kea-router/lib/utils'
 import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
 
@@ -1191,6 +1192,33 @@ export const notebookLogic = kea<notebookLogicType>([
                 actions.setLocalContent(JSON.parse(base64Decode(hashParams['🦔'])))
             }
         },
+    })),
+
+    beforeUnload((logic) => ({
+        enabled: (newLocation?: CombinedLocation) => {
+            // Only guard real, server-backed notebooks that the current user can edit.
+            // Scratchpad/canvas/templates are local-only, shared views are read-only.
+            if (
+                logic.values.mode !== 'notebook' ||
+                logic.values.isLocalOnly ||
+                logic.values.isShared ||
+                !logic.values.isEditable
+            ) {
+                return false
+            }
+            // syncStatus is `unsaved` while there is local content not yet on the server,
+            // and `saving` while a save is in flight (including the 409 retry loop in
+            // collab mode). Either way, leaving now risks dropping changes.
+            if (logic.values.syncStatus !== 'unsaved' && logic.values.syncStatus !== 'saving') {
+                return false
+            }
+            // Ignore in-page URL updates (side panel, hash params, comment selection, ...).
+            if (newLocation && newLocation.pathname === router.values.location.pathname) {
+                return false
+            }
+            return true
+        },
+        message: 'Leave notebook?\nChanges you made may not be saved.',
     })),
 
     afterMount(({ props }) => {


### PR DESCRIPTION
## Problem

Closing the tab or navigating away while a notebook still has unsaved local content silently drops the changes. Two cases:
- Collab path retries `409 Conflict` in a loop — user has no idea save is still in flight.
- Throttled save (`SYNC_DELAY = 1000ms`) hasn't fired yet when the user clicks away.

## Changes

- Wires up `kea-router`'s `beforeUnload` on `notebookLogic`. Native browser dialog on tab close / back button, `confirm()` on in-app navigation. Triggers when `syncStatus` is `unsaved` or `saving`
- Skips local-only notebooks (scratchpad, canvas, templates), read-only views, and same-pathname URL changes (side panel etc.)

<img width="1183" height="332" alt="Screenshot 2026-05-18 at 22 20 40" src="https://github.com/user-attachments/assets/d9412fb3-5c12-4b94-8070-e6c59446a403" />

## How did you test this code?
Unit tests

## Publish to changelog?

no