### PR TITLE
fix(notebooks): make history revert work with collab

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -172,9 +172,12 @@ describe('Notebook history revert flow', () => {
             logic.actions.setPreviewContent(HISTORICAL_DOC)
             editorSetContent.mockClear()
 
-            // user clicks Revert
+            // user clicks Revert — mirror the full action sequence in NotebookHistoryWarning.onRevert.
+            // setShowHistory(false)'s listener fires a second clearPreviewContent, so leaving it out
+            // would skip part of the sequence that runs in production.
             logic.actions.clearPreviewContent()
             logic.actions.setLocalContent(HISTORICAL_DOC, true)
+            logic.actions.setShowHistory(false)
             // wait past debounce
             await expectLogic(logic)
                 .delay(SYNC_DELAY + 100)

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -8,9 +8,9 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
-import { AccessControlLevel, NotebookType } from '~/types'
+import { AccessControlLevel } from '~/types'
 
-import { NotebookEditor } from '../types'
+import { NotebookEditor, NotebookType } from '../types'
 import { notebookCollabLogic } from './notebookCollabLogic'
 import { SYNC_DELAY, notebookLogic } from './notebookLogic'
 
@@ -116,7 +116,10 @@ describe('Notebook history revert flow', () => {
         expect(logic.values.previewContent).toEqual(HISTORICAL_DOC)
         expect(logic.values.localContent).toBeNull()
         // previewing is non-mutating
-        expect(apiCreateSpy).not.toHaveBeenCalled()
+        expect(apiCreateSpy).not.toHaveBeenCalledWith(
+            expect.stringContaining(`/notebooks/${SHORT_ID}/collab/save/`),
+            expect.anything()
+        )
         expect(apiUpdateSpy).not.toHaveBeenCalled()
     })
 
@@ -142,12 +145,15 @@ describe('Notebook history revert flow', () => {
 
         expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
         expect(logic.values.previewContent).toBeNull()
-        expect(logic.values.localContent).toEqual(HISTORICAL_DOC)
+        // saveNotebook clears localContent after a successful save; we assert on the wire payload instead
         expect(apiUpdateSpy).toHaveBeenCalledWith(
             SHORT_ID,
             expect.objectContaining({ content: HISTORICAL_DOC, version: 1 })
         )
-        expect(apiCreateSpy).not.toHaveBeenCalled()
+        expect(apiCreateSpy).not.toHaveBeenCalledWith(
+            expect.stringContaining(`/notebooks/${SHORT_ID}/collab/save/`),
+            expect.anything()
+        )
     })
 
     it('revert in collab mode: clears preview, updates editor, dispatches collab/save POST with historical content', async () => {
@@ -186,7 +192,7 @@ describe('Notebook history revert flow', () => {
 
         expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
         expect(logic.values.previewContent).toBeNull()
-        expect(logic.values.localContent).toEqual(HISTORICAL_DOC)
+        // saveNotebook clears localContent after a successful save; we assert on the wire payload instead
         expect(apiCreateSpy).toHaveBeenCalledWith(
             `api/projects/@current/notebooks/${SHORT_ID}/collab/save/`,
             expect.objectContaining({ content: HISTORICAL_DOC, client_id: 'test-client' })

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -145,7 +145,8 @@ describe('Notebook history revert flow', () => {
 
         expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
         expect(logic.values.previewContent).toBeNull()
-        // saveNotebook clears localContent after a successful save; we assert on the wire payload instead
+        // localContent is cleared by saveNotebook once the save resolves
+        expect(logic.values.localContent).toBeNull()
         expect(apiUpdateSpy).toHaveBeenCalledWith(
             SHORT_ID,
             expect.objectContaining({ content: HISTORICAL_DOC, version: 1 })
@@ -192,7 +193,8 @@ describe('Notebook history revert flow', () => {
 
         expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
         expect(logic.values.previewContent).toBeNull()
-        // saveNotebook clears localContent after a successful save; we assert on the wire payload instead
+        // localContent is cleared by saveNotebook once the save resolves
+        expect(logic.values.localContent).toBeNull()
         expect(apiCreateSpy).toHaveBeenCalledWith(
             `api/projects/@current/notebooks/${SHORT_ID}/collab/save/`,
             expect.objectContaining({ content: HISTORICAL_DOC, client_id: 'test-client' })

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -1,86 +1,32 @@
 import { JSONContent } from '@tiptap/core'
 import { expectLogic } from 'kea-test-utils'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-
-import { useMocks } from '~/mocks/jest'
-import { initKeaTests } from '~/test/init'
-
-import { NotebookEditor, NotebookType } from '../types'
+import { NotebookEditor } from '../types'
 import { notebookLogic } from './notebookLogic'
 
-// Integration test for the history revert flow at the notebookLogic boundary.
-// Mounts a real notebookLogic with a cached notebook (skipping the HTTP load),
-// binds a stubbed Tiptap editor surface, and exercises the action sequence that
-// `NotebookHistoryWarning.onRevert` dispatches. Asserts on the actual
-// behaviour — what reaches the editor and how the kea state advances —
-// rather than on which props the component passed.
+import { initKeaTests } from '~/test/init'
 
 const SHORT_ID = 'test-notebook-revert'
 
-const CURRENT_DOC: JSONContent = {
-    type: 'doc',
-    content: [{ type: 'paragraph', content: [{ type: 'text', text: 'current' }] }],
-}
 const HISTORICAL_DOC: JSONContent = {
     type: 'doc',
     content: [{ type: 'paragraph', content: [{ type: 'text', text: 'historical' }] }],
 }
-
-const cachedNotebook: NotebookType = {
-    id: 'notebook-id',
-    short_id: SHORT_ID,
-    title: 'Test',
-    content: CURRENT_DOC as any,
-    text_content: 'current',
-    version: 1,
-    deleted: false,
-    created_at: '2025-01-01T00:00:00Z',
-    created_by: null,
-    last_modified_at: '2025-01-01T00:00:00Z',
-    last_modified_by: null,
-    is_template: false,
-    user_access_level: 'editor' as any,
-} as unknown as NotebookType
 
 describe('Notebook history revert', () => {
     let logic: ReturnType<typeof notebookLogic.build>
     let editorSetContent: jest.Mock
 
     beforeEach(() => {
-        useMocks({
-            get: {
-                '/api/projects/@current/notebooks/': () => [200, { results: [cachedNotebook] }],
-                [`/api/projects/@current/notebooks/${SHORT_ID}/`]: () => [200, cachedNotebook],
-                '/api/projects/@current/comments/': () => [200, { results: [] }],
-                '/api/projects/@current/comments/related_objects/': () => [200, { results: [] }],
-            },
-        })
         initKeaTests()
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.NOTEBOOKS_COLLABORATION], {
-            [FEATURE_FLAGS.NOTEBOOKS_COLLABORATION]: true,
-        })
 
-        logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook', cachedNotebook })
+        logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook' })
         logic.mount()
 
-        // Stub the NotebookEditor surface — only the methods that get exercised
-        // along the revert path. setContent is the integration point we assert on.
+        // Stub the NotebookEditor surface — only the methods exercised along the revert path.
+        // setContent is the integration point we assert on.
         editorSetContent = jest.fn()
-        const editor: Partial<NotebookEditor> = {
-            setContent: editorSetContent,
-            getJSON: () => CURRENT_DOC,
-            getText: () => 'current',
-            getCurrentPosition: () => 0,
-            setTextSelection: jest.fn(),
-            nextNode: () => null,
-            insertContentAfterNode: jest.fn(),
-            findCommentPosition: () => null,
-            getAllCommentTexts: () => ({}),
-            removeComment: jest.fn(),
-        }
-        logic.actions.setEditor(editor as NotebookEditor)
+        logic.actions.setEditor({ setContent: editorSetContent } as unknown as NotebookEditor)
     })
 
     afterEach(() => {
@@ -88,13 +34,13 @@ describe('Notebook history revert', () => {
     })
 
     it('on Revert: clears preview and pushes the historical content into the editor', async () => {
-        // User clicks a history entry — preview is set, editor visually transitions to historical
+        // User clicks a history entry — preview is set, editor visually transitions to historical.
         logic.actions.setPreviewContent(HISTORICAL_DOC)
         await expectLogic(logic).toFinishAllListeners()
         expect(editorSetContent).toHaveBeenLastCalledWith(HISTORICAL_DOC)
         expect(logic.values.previewContent).toEqual(HISTORICAL_DOC)
 
-        // User clicks "Revert to this version" — same action sequence as NotebookHistoryWarning.onRevert
+        // User clicks "Revert to this version" — same action sequence as NotebookHistoryWarning.onRevert.
         editorSetContent.mockClear()
         logic.actions.clearPreviewContent()
         logic.actions.setLocalContent(HISTORICAL_DOC, true)

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -12,7 +12,7 @@ import { AccessControlLevel, NotebookType } from '~/types'
 
 import { NotebookEditor } from '../types'
 import { notebookCollabLogic } from './notebookCollabLogic'
-import { notebookLogic } from './notebookLogic'
+import { SYNC_DELAY, notebookLogic } from './notebookLogic'
 
 // Skip the API-driven query upgrade step inside migrate so the loader doesn't try
 // to upgrade insight nodes. Our fixture content has no insight nodes anyway, but
@@ -61,10 +61,6 @@ const cachedNotebook: NotebookType = {
     last_modified_by: null,
 } as unknown as NotebookType
 
-// notebookLogic.ts: const SYNC_DELAY = 1000. We can't import it (module-private)
-// but we wait past it so the debounced save dispatch resolves.
-const SYNC_DELAY_MS = 1000
-
 describe('Notebook history revert flow', () => {
     let logic: ReturnType<typeof notebookLogic.build>
     let editorSetContent: jest.Mock
@@ -111,7 +107,7 @@ describe('Notebook history revert flow', () => {
 
         logic.actions.setPreviewContent(HISTORICAL_DOC)
         await expectLogic(logic)
-            .delay(SYNC_DELAY_MS + 100)
+            .delay(SYNC_DELAY + 100)
             .toFinishAllListeners()
 
         expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
@@ -135,7 +131,7 @@ describe('Notebook history revert flow', () => {
         logic.actions.clearPreviewContent()
         logic.actions.setLocalContent(HISTORICAL_DOC, true)
         await expectLogic(logic)
-            .delay(SYNC_DELAY_MS + 100)
+            .delay(SYNC_DELAY + 100)
             .toFinishAllListeners()
 
         expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
@@ -173,7 +169,7 @@ describe('Notebook history revert flow', () => {
         logic.actions.clearPreviewContent()
         logic.actions.setLocalContent(HISTORICAL_DOC, true)
         await expectLogic(logic)
-            .delay(SYNC_DELAY_MS + 100)
+            .delay(SYNC_DELAY + 100)
             .toFinishAllListeners()
 
         expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -131,82 +131,76 @@ describe('Notebook history revert flow', () => {
         expect(apiUpdateSpy).not.toHaveBeenCalled()
     })
 
-    it('revert in non-collab mode: clears preview, updates editor, dispatches PATCH save with historical content', async () => {
-        // load the notebook
-        logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook', cachedNotebook })
-        logic.mount()
-        logic.actions.setEditor(stubEditor())
-        logic.actions.loadNotebook()
-        await expectLogic(logic).toDispatchActions(['loadNotebookSuccess']).toFinishAllListeners()
+    describe.each([
+        {
+            name: 'non-collab mode dispatches PATCH save with historical content',
+            collab: false,
+            expectedSave: 'patch' as const,
+        },
+        {
+            name: 'collab mode dispatches collab/save POST with historical content',
+            collab: true,
+            expectedSave: 'collab' as const,
+        },
+    ])('reverting to a historical version in $name', ({ collab, expectedSave }) => {
+        it('clears preview, updates editor, and dispatches the right save', async () => {
+            if (collab) {
+                featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.NOTEBOOKS_COLLABORATION], {
+                    [FEATURE_FLAGS.NOTEBOOKS_COLLABORATION]: true,
+                })
+                // pretend the editor has a pending step ready to send
+                ;(PMCollab.sendableSteps as jest.Mock).mockReturnValue({
+                    version: 1,
+                    steps: [{ toJSON: () => ({ stepType: 'replace', from: 0, to: 0, slice: { content: [] } }) }],
+                    clientID: 'test-client',
+                })
+            }
 
-        // user clicks a history entry
-        logic.actions.setPreviewContent(HISTORICAL_DOC)
-        editorSetContent.mockClear()
+            // load the notebook
+            logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook', cachedNotebook })
+            logic.mount()
+            logic.actions.setEditor(stubEditor())
+            if (collab) {
+                notebookCollabLogic({ shortId: SHORT_ID }).actions.bindEditor({
+                    state: { selection: { head: 0 } },
+                } as any)
+            }
+            logic.actions.loadNotebook()
+            await expectLogic(logic).toDispatchActions(['loadNotebookSuccess']).toFinishAllListeners()
 
-        // user clicks Revert
-        logic.actions.clearPreviewContent()
-        logic.actions.setLocalContent(HISTORICAL_DOC, true)
-        // wait past debounce
-        await expectLogic(logic)
-            .delay(SYNC_DELAY + 100)
-            .toFinishAllListeners()
+            // user clicks a history entry
+            logic.actions.setPreviewContent(HISTORICAL_DOC)
+            editorSetContent.mockClear()
 
-        expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
-        expect(logic.values.previewContent).toBeNull()
-        // localContent is cleared by saveNotebook once the save resolves
-        expect(logic.values.localContent).toBeNull()
-        expect(apiUpdateSpy).toHaveBeenCalledWith(
-            SHORT_ID,
-            expect.objectContaining({ content: HISTORICAL_DOC, version: 1 })
-        )
-        expect(apiCreateSpy).not.toHaveBeenCalledWith(
-            expect.stringContaining(`/notebooks/${SHORT_ID}/collab/save/`),
-            expect.anything()
-        )
-    })
+            // user clicks Revert
+            logic.actions.clearPreviewContent()
+            logic.actions.setLocalContent(HISTORICAL_DOC, true)
+            // wait past debounce
+            await expectLogic(logic)
+                .delay(SYNC_DELAY + 100)
+                .toFinishAllListeners()
 
-    it('revert in collab mode: clears preview, updates editor, dispatches collab/save POST with historical content', async () => {
-        // enable collab mode
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.NOTEBOOKS_COLLABORATION], {
-            [FEATURE_FLAGS.NOTEBOOKS_COLLABORATION]: true,
+            expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
+            expect(logic.values.previewContent).toBeNull()
+            // localContent is cleared by saveNotebook once the save resolves
+            expect(logic.values.localContent).toBeNull()
+
+            if (expectedSave === 'collab') {
+                expect(apiCreateSpy).toHaveBeenCalledWith(
+                    `api/projects/@current/notebooks/${SHORT_ID}/collab/save/`,
+                    expect.objectContaining({ content: HISTORICAL_DOC, client_id: 'test-client' })
+                )
+                expect(apiUpdateSpy).not.toHaveBeenCalled()
+            } else {
+                expect(apiUpdateSpy).toHaveBeenCalledWith(
+                    SHORT_ID,
+                    expect.objectContaining({ content: HISTORICAL_DOC, version: 1 })
+                )
+                expect(apiCreateSpy).not.toHaveBeenCalledWith(
+                    expect.stringContaining(`/notebooks/${SHORT_ID}/collab/save/`),
+                    expect.anything()
+                )
+            }
         })
-        // pretend the editor has a pending step ready to send
-        ;(PMCollab.sendableSteps as jest.Mock).mockReturnValue({
-            version: 1,
-            steps: [{ toJSON: () => ({ stepType: 'replace', from: 0, to: 0, slice: { content: [] } }) }],
-            clientID: 'test-client',
-        })
-
-        // load the notebook with a bound ttEditor
-        logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook', cachedNotebook })
-        logic.mount()
-        logic.actions.setEditor(stubEditor())
-        notebookCollabLogic({ shortId: SHORT_ID }).actions.bindEditor({
-            state: { selection: { head: 0 } },
-        } as any)
-        logic.actions.loadNotebook()
-        await expectLogic(logic).toDispatchActions(['loadNotebookSuccess']).toFinishAllListeners()
-
-        // user clicks a history entry
-        logic.actions.setPreviewContent(HISTORICAL_DOC)
-        editorSetContent.mockClear()
-
-        // user clicks Revert
-        logic.actions.clearPreviewContent()
-        logic.actions.setLocalContent(HISTORICAL_DOC, true)
-        // wait past debounce
-        await expectLogic(logic)
-            .delay(SYNC_DELAY + 100)
-            .toFinishAllListeners()
-
-        expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
-        expect(logic.values.previewContent).toBeNull()
-        // localContent is cleared by saveNotebook once the save resolves
-        expect(logic.values.localContent).toBeNull()
-        expect(apiCreateSpy).toHaveBeenCalledWith(
-            `api/projects/@current/notebooks/${SHORT_ID}/collab/save/`,
-            expect.objectContaining({ content: HISTORICAL_DOC, client_id: 'test-client' })
-        )
-        expect(apiUpdateSpy).not.toHaveBeenCalled()
     })
 })

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -105,7 +105,9 @@ describe('Notebook history revert flow', () => {
         logic.mount()
         logic.actions.setEditor(stubEditor())
 
+        // user clicks a history entry
         logic.actions.setPreviewContent(HISTORICAL_DOC)
+        // wait past debounce so any save would have fired
         await expectLogic(logic)
             .delay(SYNC_DELAY + 100)
             .toFinishAllListeners()
@@ -113,23 +115,27 @@ describe('Notebook history revert flow', () => {
         expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
         expect(logic.values.previewContent).toEqual(HISTORICAL_DOC)
         expect(logic.values.localContent).toBeNull()
-        // Critical: previewing is non-mutating. No save fires for either save path.
+        // previewing is non-mutating
         expect(apiCreateSpy).not.toHaveBeenCalled()
         expect(apiUpdateSpy).not.toHaveBeenCalled()
     })
 
     it('revert in non-collab mode: clears preview, updates editor, dispatches PATCH save with historical content', async () => {
+        // load the notebook
         logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook', cachedNotebook })
         logic.mount()
         logic.actions.setEditor(stubEditor())
         logic.actions.loadNotebook()
         await expectLogic(logic).toDispatchActions(['loadNotebookSuccess']).toFinishAllListeners()
 
+        // user clicks a history entry
         logic.actions.setPreviewContent(HISTORICAL_DOC)
         editorSetContent.mockClear()
 
+        // user clicks Revert
         logic.actions.clearPreviewContent()
         logic.actions.setLocalContent(HISTORICAL_DOC, true)
+        // wait past debounce
         await expectLogic(logic)
             .delay(SYNC_DELAY + 100)
             .toFinishAllListeners()
@@ -145,15 +151,18 @@ describe('Notebook history revert flow', () => {
     })
 
     it('revert in collab mode: clears preview, updates editor, dispatches collab/save POST with historical content', async () => {
+        // enable collab mode
         featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.NOTEBOOKS_COLLABORATION], {
             [FEATURE_FLAGS.NOTEBOOKS_COLLABORATION]: true,
         })
+        // pretend the editor has a pending step ready to send
         ;(PMCollab.sendableSteps as jest.Mock).mockReturnValue({
             version: 1,
             steps: [{ toJSON: () => ({ stepType: 'replace', from: 0, to: 0, slice: { content: [] } }) }],
             clientID: 'test-client',
         })
 
+        // load the notebook with a bound ttEditor
         logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook', cachedNotebook })
         logic.mount()
         logic.actions.setEditor(stubEditor())
@@ -163,11 +172,14 @@ describe('Notebook history revert flow', () => {
         logic.actions.loadNotebook()
         await expectLogic(logic).toDispatchActions(['loadNotebookSuccess']).toFinishAllListeners()
 
+        // user clicks a history entry
         logic.actions.setPreviewContent(HISTORICAL_DOC)
         editorSetContent.mockClear()
 
+        // user clicks Revert
         logic.actions.clearPreviewContent()
         logic.actions.setLocalContent(HISTORICAL_DOC, true)
+        // wait past debounce
         await expectLogic(logic)
             .delay(SYNC_DELAY + 100)
             .toFinishAllListeners()

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { JSONContent } from '@tiptap/core'
+
+import { NotebookHistoryWarning } from './NotebookHistory'
+
+// We mock kea's `useValues` / `useActions` so we can drive `NotebookHistoryWarning`
+// without bootstrapping the full notebookLogic (which depends on a Tiptap editor,
+// notebookCollabLogic, kea-loaders, etc.). The fix under test is purely about the
+// arguments the component passes to `setLocalContent` — kea wiring is incidental.
+const setLocalContent = jest.fn()
+const clearPreviewContent = jest.fn()
+const duplicateNotebook = jest.fn()
+const setShowHistory = jest.fn()
+let mockPreviewContent: JSONContent | null = null
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useValues: () => ({ previewContent: mockPreviewContent }),
+    useActions: () => ({ setLocalContent, clearPreviewContent, duplicateNotebook, setShowHistory }),
+}))
+
+jest.mock('./notebookLogic', () => ({
+    notebookLogic: {},
+}))
+
+describe('NotebookHistoryWarning', () => {
+    afterEach(() => {
+        cleanup()
+        setLocalContent.mockReset()
+        clearPreviewContent.mockReset()
+        duplicateNotebook.mockReset()
+        setShowHistory.mockReset()
+        mockPreviewContent = null
+    })
+
+    it('on Revert: clears preview and pushes the historical content into the editor', () => {
+        // Regression test for the silent-no-op revert in collab mode.
+        //
+        // Before the fix, onRevert called `setLocalContent(previewContent)` with the
+        // default `updateEditor=false`, leaving the live Tiptap editor at the
+        // pre-revert state. The collab save reads `sendableSteps` from the editor and
+        // `editor.getJSON()` for the wire payload, so the save sent no meaningful
+        // steps and the server content was unchanged.
+        //
+        // The fix passes `updateEditor=true`, which makes the listener call
+        // `editor.setContent(historical)` so PM-collab produces real steps for the
+        // delta. We assert on the literal `true` because that single boolean is the
+        // entire fix.
+        const historical: JSONContent = {
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'historical' }] }],
+        }
+        mockPreviewContent = historical
+
+        render(<NotebookHistoryWarning />)
+        fireEvent.click(screen.getByText('Revert to this version'))
+
+        expect(clearPreviewContent).toHaveBeenCalledTimes(1)
+        expect(setLocalContent).toHaveBeenCalledTimes(1)
+        expect(setLocalContent).toHaveBeenCalledWith(historical, true)
+        expect(setShowHistory).toHaveBeenCalledWith(false)
+    })
+})

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -1,65 +1,109 @@
-import '@testing-library/jest-dom'
-
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { JSONContent } from '@tiptap/core'
+import { expectLogic } from 'kea-test-utils'
 
-import { NotebookHistoryWarning } from './NotebookHistory'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
-// We mock kea's `useValues` / `useActions` so we can drive `NotebookHistoryWarning`
-// without bootstrapping the full notebookLogic (which depends on a Tiptap editor,
-// notebookCollabLogic, kea-loaders, etc.). The fix under test is purely about the
-// arguments the component passes to `setLocalContent` — kea wiring is incidental.
-const setLocalContent = jest.fn()
-const clearPreviewContent = jest.fn()
-const duplicateNotebook = jest.fn()
-const setShowHistory = jest.fn()
-let mockPreviewContent: JSONContent | null = null
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
 
-jest.mock('kea', () => ({
-    ...jest.requireActual('kea'),
-    useValues: () => ({ previewContent: mockPreviewContent }),
-    useActions: () => ({ setLocalContent, clearPreviewContent, duplicateNotebook, setShowHistory }),
-}))
+import { NotebookEditor, NotebookType } from '../types'
+import { notebookLogic } from './notebookLogic'
 
-jest.mock('./notebookLogic', () => ({
-    notebookLogic: {},
-}))
+// Integration test for the history revert flow at the notebookLogic boundary.
+// Mounts a real notebookLogic with a cached notebook (skipping the HTTP load),
+// binds a stubbed Tiptap editor surface, and exercises the action sequence that
+// `NotebookHistoryWarning.onRevert` dispatches. Asserts on the actual
+// behaviour — what reaches the editor and how the kea state advances —
+// rather than on which props the component passed.
 
-describe('NotebookHistoryWarning', () => {
-    afterEach(() => {
-        cleanup()
-        setLocalContent.mockReset()
-        clearPreviewContent.mockReset()
-        duplicateNotebook.mockReset()
-        setShowHistory.mockReset()
-        mockPreviewContent = null
+const SHORT_ID = 'test-notebook-revert'
+
+const CURRENT_DOC: JSONContent = {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: 'current' }] }],
+}
+const HISTORICAL_DOC: JSONContent = {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: 'historical' }] }],
+}
+
+const cachedNotebook: NotebookType = {
+    id: 'notebook-id',
+    short_id: SHORT_ID,
+    title: 'Test',
+    content: CURRENT_DOC as any,
+    text_content: 'current',
+    version: 1,
+    deleted: false,
+    created_at: '2025-01-01T00:00:00Z',
+    created_by: null,
+    last_modified_at: '2025-01-01T00:00:00Z',
+    last_modified_by: null,
+    is_template: false,
+    user_access_level: 'editor' as any,
+} as unknown as NotebookType
+
+describe('Notebook history revert', () => {
+    let logic: ReturnType<typeof notebookLogic.build>
+    let editorSetContent: jest.Mock
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/@current/notebooks/': () => [200, { results: [cachedNotebook] }],
+                [`/api/projects/@current/notebooks/${SHORT_ID}/`]: () => [200, cachedNotebook],
+                '/api/projects/@current/comments/': () => [200, { results: [] }],
+                '/api/projects/@current/comments/related_objects/': () => [200, { results: [] }],
+            },
+        })
+        initKeaTests()
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.NOTEBOOKS_COLLABORATION], {
+            [FEATURE_FLAGS.NOTEBOOKS_COLLABORATION]: true,
+        })
+
+        logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook', cachedNotebook })
+        logic.mount()
+
+        // Stub the NotebookEditor surface — only the methods that get exercised
+        // along the revert path. setContent is the integration point we assert on.
+        editorSetContent = jest.fn()
+        const editor: Partial<NotebookEditor> = {
+            setContent: editorSetContent,
+            getJSON: () => CURRENT_DOC,
+            getText: () => 'current',
+            getCurrentPosition: () => 0,
+            setTextSelection: jest.fn(),
+            nextNode: () => null,
+            insertContentAfterNode: jest.fn(),
+            findCommentPosition: () => null,
+            getAllCommentTexts: () => ({}),
+            removeComment: jest.fn(),
+        }
+        logic.actions.setEditor(editor as NotebookEditor)
     })
 
-    it('on Revert: clears preview and pushes the historical content into the editor', () => {
-        // Regression test for the silent-no-op revert in collab mode.
-        //
-        // Before the fix, onRevert called `setLocalContent(previewContent)` with the
-        // default `updateEditor=false`, leaving the live Tiptap editor at the
-        // pre-revert state. The collab save reads `sendableSteps` from the editor and
-        // `editor.getJSON()` for the wire payload, so the save sent no meaningful
-        // steps and the server content was unchanged.
-        //
-        // The fix passes `updateEditor=true`, which makes the listener call
-        // `editor.setContent(historical)` so PM-collab produces real steps for the
-        // delta. We assert on the literal `true` because that single boolean is the
-        // entire fix.
-        const historical: JSONContent = {
-            type: 'doc',
-            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'historical' }] }],
-        }
-        mockPreviewContent = historical
+    afterEach(() => {
+        logic.unmount()
+    })
 
-        render(<NotebookHistoryWarning />)
-        fireEvent.click(screen.getByText('Revert to this version'))
+    it('on Revert: clears preview and pushes the historical content into the editor', async () => {
+        // User clicks a history entry — preview is set, editor visually transitions to historical
+        logic.actions.setPreviewContent(HISTORICAL_DOC)
+        await expectLogic(logic).toFinishAllListeners()
+        expect(editorSetContent).toHaveBeenLastCalledWith(HISTORICAL_DOC)
+        expect(logic.values.previewContent).toEqual(HISTORICAL_DOC)
 
-        expect(clearPreviewContent).toHaveBeenCalledTimes(1)
-        expect(setLocalContent).toHaveBeenCalledTimes(1)
-        expect(setLocalContent).toHaveBeenCalledWith(historical, true)
-        expect(setShowHistory).toHaveBeenCalledWith(false)
+        // User clicks "Revert to this version" — same action sequence as NotebookHistoryWarning.onRevert
+        editorSetContent.mockClear()
+        logic.actions.clearPreviewContent()
+        logic.actions.setLocalContent(HISTORICAL_DOC, true)
+        await expectLogic(logic).toFinishAllListeners()
+
+        // The fix: setLocalContent's updateEditor=true branch pushes the historical doc into the editor,
+        // so prosemirror-collab generates real steps for the delta and the collab save isn't a no-op.
+        expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
+        expect(logic.values.previewContent).toBeNull()
+        expect(logic.values.localContent).toEqual(HISTORICAL_DOC)
     })
 })

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -64,19 +64,27 @@ const cachedNotebook: NotebookType = {
 describe('Notebook history revert flow', () => {
     let logic: ReturnType<typeof notebookLogic.build>
     let editorSetContent: jest.Mock
+    let editorContent: JSONContent | null
     let apiCreateSpy: jest.SpyInstance
     let apiUpdateSpy: jest.SpyInstance
 
+    // The stub tracks its own content so getJSON() reflects the result of setContent
+    // calls. Otherwise the collab path's wire payload (which is editor.getJSON()) would
+    // appear correct even when the editor never actually transitioned to the historical doc.
     const stubEditor = (): NotebookEditor =>
         ({
-            setContent: editorSetContent,
-            getJSON: () => HISTORICAL_DOC,
+            setContent: (content: JSONContent) => {
+                editorContent = content
+                editorSetContent(content)
+            },
+            getJSON: () => editorContent,
             getText: () => 'historical',
             getCurrentPosition: () => 0,
             setTextSelection: jest.fn(),
         }) as unknown as NotebookEditor
 
     beforeEach(() => {
+        editorContent = null
         useMocks({
             get: {
                 [`/api/projects/@current/notebooks/${SHORT_ID}/`]: () => [200, cachedNotebook],

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx
@@ -1,55 +1,188 @@
 import { JSONContent } from '@tiptap/core'
+import * as PMCollab from '@tiptap/pm/collab'
 import { expectLogic } from 'kea-test-utils'
 
+import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { AccessControlLevel, NotebookType } from '~/types'
+
 import { NotebookEditor } from '../types'
+import { notebookCollabLogic } from './notebookCollabLogic'
 import { notebookLogic } from './notebookLogic'
 
-import { initKeaTests } from '~/test/init'
+// Skip the API-driven query upgrade step inside migrate so the loader doesn't try
+// to upgrade insight nodes. Our fixture content has no insight nodes anyway, but
+// migrate's per-node walk + transitive imports are out of scope for this test.
+jest.mock('./migrations/migrate', () => {
+    const actual = jest.requireActual('./migrations/migrate')
+    return {
+        ...actual,
+        migrate: jest.fn(async (notebook) => notebook),
+    }
+})
 
-const SHORT_ID = 'test-notebook-revert'
+// In tests we don't run a real Tiptap editor with a collab plugin, so sendableSteps
+// can't compute pending steps from a real EditorState. The collab branch of
+// saveNotebook gates on a non-null sendable — return a real-looking step so the
+// branch fires and we can assert on the resulting api.create call shape.
+jest.mock('@tiptap/pm/collab', () => ({
+    ...jest.requireActual('@tiptap/pm/collab'),
+    sendableSteps: jest.fn(),
+}))
 
+const SHORT_ID = 'test-revert'
+
+const SAMPLE_DOC: JSONContent = {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: 'current' }] }],
+}
 const HISTORICAL_DOC: JSONContent = {
     type: 'doc',
     content: [{ type: 'paragraph', content: [{ type: 'text', text: 'historical' }] }],
 }
 
-describe('Notebook history revert', () => {
+const cachedNotebook: NotebookType = {
+    id: 'notebook-id',
+    short_id: SHORT_ID,
+    title: 'Test',
+    content: SAMPLE_DOC,
+    text_content: 'current',
+    version: 1,
+    deleted: false,
+    is_template: false,
+    user_access_level: AccessControlLevel.Editor,
+    created_at: '2025-01-01T00:00:00Z',
+    created_by: null,
+    last_modified_at: '2025-01-01T00:00:00Z',
+    last_modified_by: null,
+} as unknown as NotebookType
+
+// notebookLogic.ts: const SYNC_DELAY = 1000. We can't import it (module-private)
+// but we wait past it so the debounced save dispatch resolves.
+const SYNC_DELAY_MS = 1000
+
+describe('Notebook history revert flow', () => {
     let logic: ReturnType<typeof notebookLogic.build>
     let editorSetContent: jest.Mock
+    let apiCreateSpy: jest.SpyInstance
+    let apiUpdateSpy: jest.SpyInstance
+
+    const stubEditor = (): NotebookEditor =>
+        ({
+            setContent: editorSetContent,
+            getJSON: () => HISTORICAL_DOC,
+            getText: () => 'historical',
+            getCurrentPosition: () => 0,
+            setTextSelection: jest.fn(),
+        }) as unknown as NotebookEditor
 
     beforeEach(() => {
+        useMocks({
+            get: {
+                [`/api/projects/@current/notebooks/${SHORT_ID}/`]: () => [200, cachedNotebook],
+            },
+        })
         initKeaTests()
 
-        logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook' })
-        logic.mount()
-
-        // Stub the NotebookEditor surface — only the methods exercised along the revert path.
-        // setContent is the integration point we assert on.
         editorSetContent = jest.fn()
-        logic.actions.setEditor({ setContent: editorSetContent } as unknown as NotebookEditor)
+        apiCreateSpy = jest.spyOn(api, 'create').mockResolvedValue({ ...cachedNotebook, version: 2 })
+        apiUpdateSpy = jest
+            .spyOn(api.notebooks, 'update')
+            .mockResolvedValue({ ...cachedNotebook, version: 2, content: HISTORICAL_DOC })
+        // collabStream opens an SSE connection that never resolves in production —
+        // resolve immediately in tests so the listener doesn't dangle.
+        jest.spyOn(api.notebooks, 'collabStream').mockResolvedValue(undefined as any)
     })
 
     afterEach(() => {
-        logic.unmount()
+        logic?.unmount()
+        jest.restoreAllMocks()
+        ;(PMCollab.sendableSteps as jest.Mock).mockReset()
     })
 
-    it('on Revert: clears preview and pushes the historical content into the editor', async () => {
-        // User clicks a history entry — preview is set, editor visually transitions to historical.
-        logic.actions.setPreviewContent(HISTORICAL_DOC)
-        await expectLogic(logic).toFinishAllListeners()
-        expect(editorSetContent).toHaveBeenLastCalledWith(HISTORICAL_DOC)
-        expect(logic.values.previewContent).toEqual(HISTORICAL_DOC)
+    it('opening preview: setPreviewContent updates editor + reducer, no save dispatched', async () => {
+        logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook' })
+        logic.mount()
+        logic.actions.setEditor(stubEditor())
 
-        // User clicks "Revert to this version" — same action sequence as NotebookHistoryWarning.onRevert.
+        logic.actions.setPreviewContent(HISTORICAL_DOC)
+        await expectLogic(logic)
+            .delay(SYNC_DELAY_MS + 100)
+            .toFinishAllListeners()
+
+        expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
+        expect(logic.values.previewContent).toEqual(HISTORICAL_DOC)
+        expect(logic.values.localContent).toBeNull()
+        // Critical: previewing is non-mutating. No save fires for either save path.
+        expect(apiCreateSpy).not.toHaveBeenCalled()
+        expect(apiUpdateSpy).not.toHaveBeenCalled()
+    })
+
+    it('revert in non-collab mode: clears preview, updates editor, dispatches PATCH save with historical content', async () => {
+        logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook', cachedNotebook })
+        logic.mount()
+        logic.actions.setEditor(stubEditor())
+        logic.actions.loadNotebook()
+        await expectLogic(logic).toDispatchActions(['loadNotebookSuccess']).toFinishAllListeners()
+
+        logic.actions.setPreviewContent(HISTORICAL_DOC)
         editorSetContent.mockClear()
+
         logic.actions.clearPreviewContent()
         logic.actions.setLocalContent(HISTORICAL_DOC, true)
-        await expectLogic(logic).toFinishAllListeners()
+        await expectLogic(logic)
+            .delay(SYNC_DELAY_MS + 100)
+            .toFinishAllListeners()
 
-        // The fix: setLocalContent's updateEditor=true branch pushes the historical doc into the editor,
-        // so prosemirror-collab generates real steps for the delta and the collab save isn't a no-op.
         expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
         expect(logic.values.previewContent).toBeNull()
         expect(logic.values.localContent).toEqual(HISTORICAL_DOC)
+        expect(apiUpdateSpy).toHaveBeenCalledWith(
+            SHORT_ID,
+            expect.objectContaining({ content: HISTORICAL_DOC, version: 1 })
+        )
+        expect(apiCreateSpy).not.toHaveBeenCalled()
+    })
+
+    it('revert in collab mode: clears preview, updates editor, dispatches collab/save POST with historical content', async () => {
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.NOTEBOOKS_COLLABORATION], {
+            [FEATURE_FLAGS.NOTEBOOKS_COLLABORATION]: true,
+        })
+        ;(PMCollab.sendableSteps as jest.Mock).mockReturnValue({
+            version: 1,
+            steps: [{ toJSON: () => ({ stepType: 'replace', from: 0, to: 0, slice: { content: [] } }) }],
+            clientID: 'test-client',
+        })
+
+        logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook', cachedNotebook })
+        logic.mount()
+        logic.actions.setEditor(stubEditor())
+        notebookCollabLogic({ shortId: SHORT_ID }).actions.bindEditor({
+            state: { selection: { head: 0 } },
+        } as any)
+        logic.actions.loadNotebook()
+        await expectLogic(logic).toDispatchActions(['loadNotebookSuccess']).toFinishAllListeners()
+
+        logic.actions.setPreviewContent(HISTORICAL_DOC)
+        editorSetContent.mockClear()
+
+        logic.actions.clearPreviewContent()
+        logic.actions.setLocalContent(HISTORICAL_DOC, true)
+        await expectLogic(logic)
+            .delay(SYNC_DELAY_MS + 100)
+            .toFinishAllListeners()
+
+        expect(editorSetContent).toHaveBeenCalledWith(HISTORICAL_DOC)
+        expect(logic.values.previewContent).toBeNull()
+        expect(logic.values.localContent).toEqual(HISTORICAL_DOC)
+        expect(apiCreateSpy).toHaveBeenCalledWith(
+            `api/projects/@current/notebooks/${SHORT_ID}/collab/save/`,
+            expect.objectContaining({ content: HISTORICAL_DOC, client_id: 'test-client' })
+        )
+        expect(apiUpdateSpy).not.toHaveBeenCalled()
     })
 })

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
@@ -158,8 +158,14 @@ export function NotebookHistoryWarning(): JSX.Element | null {
         duplicateNotebook()
     }
     const onRevert = (): void => {
+        // Capture before clearing — clearPreviewContent's listener snaps the editor back to current,
+        // then setLocalContent(..., updateEditor=true) puts the historical doc into the editor so
+        // PM-collab produces real steps for the delta and saveNotebook sends them.
+        // Without updateEditor=true the collab path's sendableSteps would be a no-op (the editor never
+        // actually transitions to the historical doc) and the revert would silently do nothing.
+        const content = previewContent
         clearPreviewContent()
-        setLocalContent(previewContent)
+        setLocalContent(content, true)
         setShowHistory(false)
     }
 

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
@@ -158,11 +158,9 @@ export function NotebookHistoryWarning(): JSX.Element | null {
         duplicateNotebook()
     }
     const onRevert = (): void => {
-        // Capture before clearing — clearPreviewContent's listener snaps the editor back to current,
-        // then setLocalContent(..., updateEditor=true) puts the historical doc into the editor so
-        // PM-collab produces real steps for the delta and saveNotebook sends them.
-        // Without updateEditor=true the collab path's sendableSteps would be a no-op (the editor never
-        // actually transitions to the historical doc) and the revert would silently do nothing.
+        // updateEditor=true puts the historical doc into the editor so prosemirror-collab
+        // produces real steps for the delta. Without it, sendableSteps stays empty and the
+        // collab save is a no-op — revert would silently do nothing.
         const content = previewContent
         clearPreviewContent()
         setLocalContent(content, true)

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -75,7 +75,7 @@ import { notebookKernelInfoLogic } from './notebookKernelInfoLogic'
 import type { notebookLogicType } from './notebookLogicType'
 import { notebookSettingsLogic } from './notebookSettingsLogic'
 
-const SYNC_DELAY = 1000
+export const SYNC_DELAY = 1000
 const NOTEBOOK_REFRESH_MS = window.location.origin === 'http://localhost:8000' ? 5000 : 30000
 
 export type NotebookLogicMode = 'notebook' | 'canvas'


### PR DESCRIPTION
## Problem

~~In collab mode, clicking **Revert to this version** in the notebook history panel doesn't trigger collab/save~~

Master works around this by dispatching `clearPreviewContent` first, then relying on `setShowHistory(false)` listener to fire a second `clearPreviewContent` that picks up `localContent` and snaps the editor.
**This could be fragile:** the chain breaks silently if anyone touches the dispatch order or `setShowHistory` listener.

## Changes

Pass `updateEditor=true` when committing the historical content with `setLocalContent`.
With `true`, the editor transitions to the historical doc, `prosemirror-collab` produces steps for the delta, and the collab save sends them.

No effect on non-collab mode: the legacy save path PATCHes `notebook.content` from kea state (not from the editor) and its response handler already does `editor.setContent(response.content)` after a successful save. 

---

**Caveat:** 
Reverting to the historical version works like "force save this version". 

If Client A reverts to a historical version and that revert is saved before Client B saves their local edits based on the pre-revert version, Client B's pending edits can be dropped when the revert steps are streamed/applied. This is expected for now: reverting behaves like overwriting the notebook with the selected historical version.

We could make this smarter in the future, but preserving parts of Client B's edits after a restore may also be surprising. Client A would click "Revert to this version" and then see a document that is not exactly the historical version they selected.

## How did you test this code?

Added `frontend/src/scenes/notebooks/Notebook/NotebookHistory.test.tsx` covering the revert flow to make sure `collab/save` or PATCH save is triggered after reverting, and that opening a history preview does not trigger a save.

## Publish to changelog?

no
