### PR TITLE
feat(experiments): default end-experiment flow to leaving flag untouched

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -37,6 +37,7 @@ import { PropertyFilterButton } from 'lib/components/PropertyFilters/components/
 import { superpowersLogic } from 'lib/components/Superpowers/superpowersLogic'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
+import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
@@ -619,6 +620,8 @@ export function ResumeExperimentModal(): JSX.Element {
     )
 }
 
+type FinishExperimentRolloutChoice = 'keep' | 'rollout'
+
 export function FinishExperimentModal(): JSX.Element {
     const { experiment, isSingleVariantShipped, shippedVariantKey } = useValues(experimentLogic)
     const { finishExperiment, endExperimentWithoutShipping, restoreUnmodifiedExperiment } = useActions(experimentLogic)
@@ -626,122 +629,144 @@ export function FinishExperimentModal(): JSX.Element {
     const { isFinishExperimentModalOpen } = useValues(modalsLogic)
     const { aggregationLabel } = useValues(groupsModel)
 
-    const [selectedVariantKey, setSelectedVariantKey] = useState<string | null>()
+    // Default to the safe option: don't touch the feature flag. Users must explicitly
+    // opt in to rolling out a variant — otherwise ending an experiment can silently
+    // change which users see which variant, which has caused production incidents.
+    const [rolloutChoice, setRolloutChoice] = useState<FinishExperimentRolloutChoice>('keep')
+    const [selectedVariantKey, setSelectedVariantKey] = useState<string | null>(null)
 
     useEffect(() => {
-        if (experiment.parameters?.feature_flag_variants?.length > 1) {
-            // First test variant selected by default
-            setSelectedVariantKey(experiment.parameters.feature_flag_variants[1].key)
+        if (isFinishExperimentModalOpen) {
+            setRolloutChoice('keep')
+            setSelectedVariantKey(null)
         }
-    }, [
-        experiment.id,
-        experiment.parameters?.feature_flag_variants?.length,
-        experiment.parameters?.feature_flag_variants,
-    ])
+    }, [isFinishExperimentModalOpen, experiment.id])
 
     const aggregationTargetName =
         experiment.filters.aggregation_group_type_index != null
             ? aggregationLabel(experiment.filters.aggregation_group_type_index).plural
             : 'users'
 
+    const willModifyFlag = !isSingleVariantShipped && rolloutChoice === 'rollout'
+
     const handleEndExperiment = (): void => {
-        if (isSingleVariantShipped || !selectedVariantKey) {
-            endExperimentWithoutShipping()
-        } else {
+        if (willModifyFlag && selectedVariantKey) {
             finishExperiment({ selectedVariantKey })
+        } else {
+            endExperimentWithoutShipping()
         }
     }
 
+    const handleClose = (): void => {
+        restoreUnmodifiedExperiment()
+        closeFinishExperimentModal()
+    }
+
+    const disabledReason = !experiment.conclusion
+        ? 'Select a conclusion'
+        : willModifyFlag && !selectedVariantKey
+          ? 'Select a variant to roll out'
+          : undefined
+
     return (
-        <>
-            <LemonModal
-                isOpen={isFinishExperimentModalOpen}
-                onClose={() => {
-                    restoreUnmodifiedExperiment()
-                    closeFinishExperimentModal()
-                }}
-                width={600}
-                title="End experiment"
-                footer={
-                    <div className="flex items-center gap-2">
-                        <LemonButton
-                            type="secondary"
-                            onClick={() => {
-                                restoreUnmodifiedExperiment()
-                                closeFinishExperimentModal()
-                            }}
-                        >
-                            Cancel
-                        </LemonButton>
-                        <LemonButton
-                            onClick={handleEndExperiment}
-                            type="primary"
-                            disabledReason={!experiment.conclusion && 'Select a conclusion'}
-                        >
-                            End experiment
-                        </LemonButton>
-                    </div>
-                }
-            >
-                <div className="space-y-4">
-                    {isSingleVariantShipped ? (
-                        <div>
-                            <LemonBanner type="info" className="mb-4">
-                                <b>
-                                    <VariantTag variantKey={shippedVariantKey || ''} />
-                                </b>{' '}
-                                is already rolled out to 100% of {aggregationTargetName}. Ending this experiment will
-                                mark it as complete without changing the feature flag.
-                            </LemonBanner>
-                        </div>
-                    ) : (
-                        <div>
-                            <LemonLabel>Variant to keep</LemonLabel>
-                            <div className="text-sm text-secondary mb-2">
-                                The selected variant will be rolled out to <b>100% of {aggregationTargetName}</b>.
-                            </div>
-                            <div className="w-1/2">
-                                <LemonSelect
-                                    className="w-full"
-                                    data-attr="metrics-selector"
-                                    value={selectedVariantKey}
-                                    placeholder="Select a variant"
-                                    onChange={(variantKey) => {
-                                        setSelectedVariantKey(variantKey)
-                                    }}
-                                    allowClear={true}
-                                    options={
-                                        experiment.feature_flag?.filters.multivariate?.variants?.map(({ key }) => ({
-                                            value: key,
-                                            label: (
-                                                <div className="deprecated-space-x-2 inline-flex">
-                                                    <VariantTag variantKey={key} />
-                                                </div>
-                                            ),
-                                        })) || []
-                                    }
-                                />
-                            </div>
-                        </div>
-                    )}
-                    <ConclusionForm />
-                    {!isSingleVariantShipped && (
-                        <LemonBanner type="info" className="mb-4">
-                            For more precise control over your release, adjust the rollout percentage and release
-                            conditions in the{' '}
-                            <Link
-                                target="_blank"
-                                className="font-semibold"
-                                to={experiment.feature_flag ? urls.featureFlag(experiment.feature_flag.id) : undefined}
-                            >
-                                {experiment.feature_flag?.key}
-                            </Link>{' '}
-                            feature flag.
-                        </LemonBanner>
-                    )}
+        <LemonModal
+            isOpen={isFinishExperimentModalOpen}
+            onClose={handleClose}
+            width={600}
+            title="End experiment"
+            footer={
+                <div className="flex items-center gap-2">
+                    <LemonButton type="secondary" onClick={handleClose}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        onClick={handleEndExperiment}
+                        type="primary"
+                        disabledReason={disabledReason}
+                        data-attr="end-experiment-confirm"
+                    >
+                        End experiment
+                    </LemonButton>
                 </div>
-            </LemonModal>
-        </>
+            }
+        >
+            <div className="space-y-4">
+                {isSingleVariantShipped ? (
+                    <LemonBanner type="info">
+                        <b>
+                            <VariantTag variantKey={shippedVariantKey || ''} />
+                        </b>{' '}
+                        is already rolled out to 100% of {aggregationTargetName}. Ending this experiment will mark it as
+                        complete without changing the feature flag.
+                    </LemonBanner>
+                ) : (
+                    <div>
+                        <LemonLabel>What should happen to the feature flag?</LemonLabel>
+                        <LemonRadio
+                            className="mt-2"
+                            radioPosition="top"
+                            value={rolloutChoice}
+                            onChange={(value) => setRolloutChoice(value)}
+                            options={[
+                                {
+                                    value: 'keep',
+                                    label: 'Keep feature flag as-is',
+                                    description: `${aggregationTargetName.charAt(0).toUpperCase()}${aggregationTargetName.slice(
+                                        1
+                                    )} continue to see their currently assigned variant. The feature flag will not be modified.`,
+                                    'data-attr': 'end-experiment-keep-flag',
+                                },
+                                {
+                                    value: 'rollout',
+                                    label: 'Roll out a variant to 100%',
+                                    description: `The selected variant will be served to all ${aggregationTargetName}. This will modify the feature flag.`,
+                                    'data-attr': 'end-experiment-rollout-variant',
+                                },
+                            ]}
+                        />
+                        {rolloutChoice === 'rollout' && (
+                            <div className="mt-3 ml-6">
+                                <LemonLabel>Variant to roll out</LemonLabel>
+                                <div className="w-1/2 mt-1">
+                                    <LemonSelect
+                                        className="w-full"
+                                        data-attr="end-experiment-variant-select"
+                                        value={selectedVariantKey}
+                                        placeholder="Select a variant"
+                                        onChange={(variantKey) => setSelectedVariantKey(variantKey)}
+                                        options={
+                                            experiment.feature_flag?.filters.multivariate?.variants?.map(({ key }) => ({
+                                                value: key,
+                                                label: (
+                                                    <div className="deprecated-space-x-2 inline-flex">
+                                                        <VariantTag variantKey={key} />
+                                                    </div>
+                                                ),
+                                            })) || []
+                                        }
+                                    />
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                )}
+                <ConclusionForm />
+                {willModifyFlag && (
+                    <LemonBanner type="info">
+                        For more precise control over your release, adjust the rollout percentage and release conditions
+                        in the{' '}
+                        <Link
+                            target="_blank"
+                            className="font-semibold"
+                            to={experiment.feature_flag ? urls.featureFlag(experiment.feature_flag.id) : undefined}
+                        >
+                            {experiment.feature_flag?.key}
+                        </Link>{' '}
+                        feature flag after ending the experiment.
+                    </LemonBanner>
+                )}
+            </div>
+        </LemonModal>
     )
 }
 


### PR DESCRIPTION
## Problem

Ending an experiment can silently update its linked feature flag. The current "End experiment" modal pre-selects the first non-control variant in a "Variant to keep" dropdown; if the user clicks "End experiment" without clearing that selection, the flag is rewritten to roll that variant out to 100% of users. For non-engineers who think they're just marking the experiment as finished, this is easy to do by accident, and feature flag mutations are high-blast-radius.

## Changes

Replaces the implicit, pre-filled variant picker with an explicit two-way choice at the top of the modal:

- **Keep feature flag as-is** (default, recommended) — calls `endExperimentWithoutShipping`, which marks the experiment ended without touching the flag.
- **Roll out a variant to 100%** — reveals the variant selector and calls the existing `finishExperiment` / `ship_variant` path.

Other details:

- The variant selector and the "for more precise control..." banner now only appear when the user has actively chosen the rollout path.
- The footer's primary button is disabled with a clear reason until the user has picked a conclusion (existing behavior) and, when rolling out, a variant.
- The `isSingleVariantShipped` branch (a variant is already at 100%) is unchanged — it still just confirms ending without modifying the flag.
- Both the current and legacy experiment headers use this same component, so the safer default applies to both flows.

No backend, API, kea action, or test fixture changes — `finishExperiment({ selectedVariantKey })` and `endExperimentWithoutShipping()` retain identical signatures and behavior.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual browser testing — the dev server isn't running in this environment. Automated checks I did run:

- `pnpm --filter=@posthog/frontend format` — completed with 0 errors (1165 pre-existing repo-wide warnings unchanged).
- `pnpm --filter=@posthog/frontend exec tsc --noEmit` on the touched file — the only TS error reported is `TS7031` on the `({ key })` destructuring in the variants `.map()`, which is pre-existing on master (line 714 before, line 739 after) and not introduced by this change.

No existing tests reference the modal at the React level — `experimentLogic.test.ts` covers the underlying `finishExperiment` action, whose signature is unchanged.

The commit was made with `--no-verify` because the temp workspace lacks the Python venv `bin/hogli format:js` needs; the equivalent formatter (`oxlint --fix` + `oxfmt`) was run manually beforehand via the frontend `format` script.

## Publish to changelog?

no

## Docs update

No docs changes required — the experiment lifecycle docs describe ending an experiment in terms of "ship a variant or end without shipping," which still matches this UI.

## 🤖 Agent context

Authored by PostHog Code in response to a sev-1 report where a non-engineer ended an experiment and unintentionally rolled a variant out to 100% of users.

Approach considered and rejected: removing the `ConclusionForm` from the modal. The user's brief asked for the rollout decision specifically to be simple, but removing the conclusion form would drop a separate piece of experiment metadata (won/lost/inconclusive/stopped early) that isn't tied to the flag mutation problem. Kept the conclusion form unchanged.

Approach considered and rejected: a `LemonDialog` confirm. Discarded because the variant picker only makes sense alongside the rollout option, and `LemonDialog` is awkward for that kind of conditional sub-input.

Files touched:

- `frontend/src/scenes/experiments/ExperimentView/components.tsx` — `FinishExperimentModal` rewritten to use a `LemonRadio` with `keep` as the default; helper `willModifyFlag` computed once and reused for the action dispatch, the disabled-reason, and the "more precise control" banner.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*