### PR TITLE
fix(insights): coerce numeric group-key filter values to strings

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -197,6 +197,22 @@ def _wildcard_bounds(value: str) -> tuple[str, str]:
 GROUP_KEY_PATTERN = re.compile(r"^\$group_[0-4]$")
 
 
+def _stringify_group_key_value(value: object) -> str | list[str]:
+    """Group keys ($group_0–$group_4) are always stored as strings. A numeric filter
+    value would produce equals(<string column>, <number>), which ClickHouse rejects
+    with NO_COMMON_TYPE — so coerce a group-key filter value to its string form."""
+
+    def _scalar(v: object) -> str:
+        # An integer-valued float ('13.0') stringifies to the plain integer ('13')
+        if isinstance(v, float) and v.is_integer():
+            return str(int(v))
+        return str(v)
+
+    if isinstance(value, list):
+        return [_scalar(v) for v in value]
+    return _scalar(value)
+
+
 def has_aggregation(expr: AST) -> bool:
     finder = AggregationFinder()
     finder.visit(expr)
@@ -745,6 +761,8 @@ def property_to_expr(
                 raise QueryError(f"The '{property.key}' property filter only supports one value in 'group' scope")
             value = property.value[0]
 
+        value = _stringify_group_key_value(value)
+
         # For groups table, $group_N filters should match both index and key
         # index should equal N, and key should match the value
         index_condition = ast.CompareOperation(
@@ -795,6 +813,9 @@ def property_to_expr(
             raise QueryError(f"The '{property.type}' property filter does not work in '{scope}' scope")
         operator = cast(Optional[PropertyOperator], property.operator) or PropertyOperator.EXACT
         value = property.value
+
+        if property.key and GROUP_KEY_PATTERN.match(str(property.key)):
+            value = _stringify_group_key_value(value)
 
         if property.type == "person" and property.key == "distinct_id":
             # distinct_id is not stored in person.properties.

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -1167,6 +1167,41 @@ class TestProperty(BaseTest):
             self._parse_expr("distinct_id in ('p3', 'p4')"),
         )
 
+    def test_property_to_expr_group_key_numeric_value(self):
+        # Group keys ($group_0–$group_4) are string columns. A numeric filter value
+        # would crash ClickHouse with NO_COMMON_TYPE, so it is coerced to a string.
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "event_metadata", "key": "$group_0", "value": 13, "operator": "exact"}, scope="event"
+            ),
+            self._parse_expr("$group_0 = '13'"),
+        )
+        # an integer-valued float coerces to the plain integer string (13.0 -> '13')
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "event_metadata", "key": "$group_2", "value": 13.0, "operator": "is_not"}, scope="event"
+            ),
+            self._parse_expr("$group_2 != '13'"),
+        )
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "event_metadata", "key": "$group_0", "value": [13, 14], "operator": "exact"}, scope="event"
+            ),
+            self._parse_expr("$group_0 in ('13', '14')"),
+        )
+        # a string value is unchanged
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "event_metadata", "key": "$group_0", "value": "13", "operator": "exact"}, scope="event"
+            ),
+            self._parse_expr("$group_0 = '13'"),
+        )
+        # a non-group-key property is left alone — the coercion is scoped to group keys
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "price", "value": 13, "operator": "exact"}),
+            self._parse_expr("properties.price = 13"),
+        )
+
     def test_property_to_expr_event_metadata_invalid_scope(self):
         with self.assertRaises(Exception) as e:
             self._property_to_expr(


### PR DESCRIPTION
## Problem

A property filter on a group key (`$group_0`–`$group_4`) with a numeric value crashed the whole insight query with ClickHouse `NO_COMMON_TYPE` (`String`, `Float64`). Group keys are string columns, but they often *look* numeric (e.g. `"13"`), so a numeric-typed filter value reaches the query builder and produces `equals(<string column>, <number>)`.

Surfaced from `system.query_log` — part of the effort to reduce deterministic query-builder bugs ([dashboard](https://metabase.prod-us.posthog.dev/dashboard/207-product-analytics-insight-query-failures)). A breakdown of the `NO_COMMON_TYPE` failures showed **~80% are group-key (`$group_N`) filters**; the rest are a small tail (a few custom group properties, the `event` column, materialized columns).

## Changes

- `property_to_expr` now coerces a `$group_N` filter value to its string form before building the comparison — an integer-valued float (`13.0`) becomes `"13"`.
- Scoped to group keys (`GROUP_KEY_PATTERN`), in both the event scope and the group scope. Only the failing case changes — every other comparison is untouched, so there is no test or snapshot churn.

This deliberately does **not** try to fix the long tail (custom group properties / `event` / materialized columns) — those are rarer and would need a broader change; group keys are a finite, well-defined set of identifier columns where the coercion is unambiguously correct.

## How did you test this code?

I'm an agent. Automated tests run locally:
- New `test_property_to_expr_group_key_numeric_value` — covers `exact`/`is_not`, integer-valued floats, multi-value `in`, string values (unchanged), and a non-group-key property (confirms it's left alone).
- Full `posthog/hogql/test/test_property.py` suite — 127 passed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). An earlier revision of this PR took a broader approach (wrapping every numeric-valued equality in `toString()` in `_expr_to_compare_op`). That was reworked: a `query_log` breakdown showed the failures are overwhelmingly group keys, so the fix was narrowed to a `$group_N`-scoped value coercion — same coverage of the real failures, near-zero blast radius, no churn of unrelated tests.

Agent-authored; requires human review.