### PR TITLE
fix(dev-env): guard migrate-clickhouse on Postgres tables existing

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -440,7 +440,12 @@ procs:
             tech: Migrations
 
     migrate-clickhouse:
-        shell: 'bin/wait-for-docker && bin/migrate --scope=clickhouse'
+        # Wait on posthog_instancesetting because Django queries that table at
+        # import time -- it's created by migrate-postgres. Without the guard,
+        # migrate-clickhouse races migrate-postgres on a fresh DB and crashes
+        # with ProgrammingError. phrocs has no depends_on field, so the
+        # dependency lives here in the shell command.
+        shell: 'bin/wait-for-docker && bin/wait-for-postgres-tables posthog_instancesetting && bin/migrate --scope=clickhouse'
         capability: core_infra
         ready_pattern: 'All migrations completed successfully'
         groups:

--- a/bin/wait-for-postgres-tables
+++ b/bin/wait-for-postgres-tables
@@ -20,8 +20,15 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
-DEADLINE=$(($(date +%s) + TIMEOUT))
 for table in "$@"; do
+  # Basic name validation to prevent sql injection
+  if ! [[ "$table" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    echo "[wait-for-postgres-tables] invalid table name: '$table'" >&2
+    exit 2
+  fi
+  # Per-table deadline so the second arg doesn't inherit time spent waiting
+  # for the first.
+  DEADLINE=$(($(date +%s) + TIMEOUT))
   echo "[wait-for-postgres-tables] waiting for $table at $PGHOST:$PGPORT/$PGDATABASE..."
   while ! psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -tAc \
       "SELECT 1 FROM information_schema.tables WHERE table_name='$table' LIMIT 1" \

--- a/bin/wait-for-postgres-tables
+++ b/bin/wait-for-postgres-tables
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Block until specified tables exist in Postgres. Used by phrocs processes
+# that depend on Django migrations (Postgres) having run -- phrocs has no
+# depends_on field, so dependency ordering lives in the shell command.
+#
+# Usage: bin/wait-for-postgres-tables <table_name> [<table_name>...]
+
+TIMEOUT="${WAIT_FOR_POSTGRES_TIMEOUT:-300}"
+PGHOST="${PGHOST:-db}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-posthog}"
+PGPASSWORD="${PGPASSWORD:-posthog}"
+PGDATABASE="${PGDATABASE:-posthog}"
+export PGPASSWORD
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <table_name> [<table_name>...]" >&2
+  exit 2
+fi
+
+DEADLINE=$(($(date +%s) + TIMEOUT))
+for table in "$@"; do
+  echo "[wait-for-postgres-tables] waiting for $table at $PGHOST:$PGPORT/$PGDATABASE..."
+  while ! psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -tAc \
+      "SELECT 1 FROM information_schema.tables WHERE table_name='$table' LIMIT 1" \
+      2>/dev/null | grep -q '^1$'; do
+    if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+      echo "[wait-for-postgres-tables] timed out after ${TIMEOUT}s waiting for $table" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+  echo "[wait-for-postgres-tables] $table exists"
+done

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1004,3 +1004,7 @@ environment:
         bin_script: rust-jumphost
         description: 'Shell into the flags-cache-jumphost pod (uses $KUBE_NAMESPACE, defaults to posthog)'
         hidden: true
+    wait:for:postgres:tables:
+        bin_script: wait-for-postgres-tables
+        description: 'Block until the named Postgres tables exist'
+        hidden: true


### PR DESCRIPTION
migrate-postgres and migrate-clickhouse both wait on bin/wait-for-docker and have no other ordering. migrate-clickhouse imports Django, which queries posthog_instancesetting at import time -- a table created by migrate-postgres. On a fresh DB they race and migrate-clickhouse crashes with ProgrammingError ~always (Django takes ~10s to import while migrate-postgres takes ~30-60s). Interactive devs hit "restart" in mprocs; one-shot consumers (AMI bakes, fresh laptop after `docker compose down -v`) just fail.

Phrocs has no depends_on field, so the dependency lives in the shell command via a new bin/wait-for-postgres-tables script that polls psql until the named tables exist.

