### PR TITLE
fix(retention): mark custom bracket cells as in-progress when window hasn't elapsed

### DIFF
--- a/frontend/src/scenes/retention/retentionLogic.ts
+++ b/frontend/src/scenes/retention/retentionLogic.ts
@@ -190,11 +190,28 @@ export const retentionLogic = kea<retentionLogicType>([
                         const cellDate = dayjs(result.date).tz(timezone).add(index, periodUnit)
                         const now = dayjs().tz(timezone)
 
+                        // For custom brackets, a cell is in-progress when the bracket's
+                        // END period hasn't elapsed yet (not just its start). Individual
+                        // periods use the standard same-period check.
+                        const customBrackets = retentionFilter?.retentionCustomBrackets
+                        let isCurrentPeriod: boolean
+                        if (customBrackets && customBrackets.length > 0 && index > 0) {
+                            // Sum bracket sizes up to this index to get the end period offset.
+                            // e.g. brackets [1,3,4,8] at index 4 → offset 16 → ends at cohort+16 periods
+                            const bracketEndOffset = customBrackets
+                                .slice(0, index)
+                                .reduce((acc: number, size: number) => acc + size, 0)
+                            const bracketEndDate = dayjs(result.date).tz(timezone).add(bracketEndOffset, periodUnit)
+                            isCurrentPeriod = bracketEndDate.isAfter(now)
+                        } else {
+                            isCurrentPeriod = cellDate.isSame(now, periodUnit)
+                        }
+
                         return {
                             ...value,
                             percentage,
                             cellDate,
-                            isCurrentPeriod: cellDate.isSame(now, periodUnit),
+                            isCurrentPeriod,
                             isFuture: cellDate.isAfter(now),
                         }
                     }),


### PR DESCRIPTION
## Problem

Custom retention bracket columns show 0% instead of graying out with "Period in progress" for cohorts whose bracket window hasn't fully closed yet. For example, with brackets `[1, 3, 4, 8]` weeks and a cohort starting Feb 1 2026, the "weeks 9–16" column shows 0% on May 17 even though the window doesn't close until May 24.

Individual period columns correctly detect in-progress state by comparing the cell date against today. The same logic was never applied to custom bracket columns.

Fixes #58679

## Changes

In `retentionLogic.ts`, the `isCurrentPeriod` calculation is updated to handle custom brackets:

- **Individual periods (unchanged):** `cellDate.isSame(now, periodUnit)` — marks the current period column
- **Custom brackets (new):** A bracket cell is in-progress when its END period offset (cumulative sum of all bracket sizes up to that index) is still after today — i.e. `cohort_date + bracketEndOffset > now`

Example with brackets `[1, 3, 4, 8]` weeks, cohort Feb 1 2026, today May 17 2026:
- Index 4 → `bracketEndOffset = 1+3+4+8 = 16` → end date = Feb 1 + 16 weeks = May 24 → `isAfter(now)` → **in-progress** ✓

## How did you test this code?

Automated: TypeScript compilation passes. The logic change is isolated to the `isCurrentPeriod` computation inside `retentionLogic.ts`. Manual testing requires a retention insight with custom brackets and a cohort whose latest bracket window straddles today.

## Publish to changelog?

No

## 🤖 Agent context

Authored with Claude Code. Root cause traced to `retentionLogic.ts` — the per-value `isCurrentPeriod` check used `cellDate.isSame(now, periodUnit)` uniformly, but for custom brackets `cellDate` is the bracket's start, not end. The fix accumulates bracket sizes to find the bracket's true end date and compares that against now.