### PR TITLE
feat(user-interviews): copy interview link button per interviewee

### DIFF
--- a/products/user_interviews/frontend/UserInterview.tsx
+++ b/products/user_interviews/frontend/UserInterview.tsx
@@ -1,11 +1,12 @@
 import { useValues } from 'kea'
 
-import { IconArrowLeft, IconCheck, IconChevronRight, IconClock } from '@posthog/icons'
+import { IconArrowLeft, IconCheck, IconChevronRight, IconClock, IconCopy } from '@posthog/icons'
 import { LemonButton, LemonSkeleton, LemonTag, LemonWidget } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { Link } from 'lib/lemon-ui/Link'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -39,6 +40,7 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
         topicLoading,
         interviewees,
         intervieweesLoading,
+        linkByIdentifier,
         respondedIdentifiers,
         respondedCount,
         totalTargeted,
@@ -133,6 +135,7 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
                                         identifier={identifier}
                                         topicId={id}
                                         hasResponded={respondedIdentifiers.has(identifier)}
+                                        interviewUrl={linkByIdentifier[identifier]}
                                     />
                                 ))
                             )}
@@ -221,11 +224,22 @@ function PersonRow({
     identifier,
     topicId,
     hasResponded,
+    interviewUrl,
 }: {
     identifier: string
     topicId: string
     hasResponded: boolean
+    interviewUrl?: string
 }): JSX.Element {
+    const handleCopy = (e: React.MouseEvent): void => {
+        e.preventDefault()
+        e.stopPropagation()
+        if (!interviewUrl) {
+            return
+        }
+        void copyToClipboard(interviewUrl, 'interview link')
+    }
+
     return (
         <Link
             to={urls.userInterviewResponse(topicId, encodeURIComponent(identifier))}
@@ -237,6 +251,14 @@ function PersonRow({
                         <div className="font-medium text-sm">{identifier}</div>
                     </div>
                     <div className="flex items-center gap-2">
+                        <LemonButton
+                            type="tertiary"
+                            size="xsmall"
+                            icon={<IconCopy />}
+                            onClick={handleCopy}
+                            disabledReason={interviewUrl ? undefined : 'Generating link…'}
+                            tooltip="Copy interview link"
+                        />
                         {hasResponded ? (
                             <LemonTag type="success" icon={<IconCheck />}>
                                 Responded

--- a/products/user_interviews/frontend/UserInterview.tsx
+++ b/products/user_interviews/frontend/UserInterview.tsx
@@ -40,8 +40,6 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
         topicLoading,
         interviewees,
         intervieweesLoading,
-        linkByIdentifier,
-        linksLoading,
         respondedIdentifiers,
         respondedCount,
         totalTargeted,
@@ -136,8 +134,6 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
                                         identifier={identifier}
                                         topicId={id}
                                         hasResponded={respondedIdentifiers.has(identifier)}
-                                        interviewUrl={linkByIdentifier[identifier]}
-                                        linksLoading={linksLoading}
                                     />
                                 ))
                             )}
@@ -222,19 +218,10 @@ function DetailRow({ label, value }: { label: string; value: string }): JSX.Elem
     )
 }
 
-function PersonRow({
-    identifier,
-    topicId,
-    hasResponded,
-    interviewUrl,
-    linksLoading,
-}: {
-    identifier: string
-    topicId: string
-    hasResponded: boolean
-    interviewUrl?: string
-    linksLoading: boolean
-}): JSX.Element {
+function InterviewLinkCopyButton({ identifier, topicId }: { identifier: string; topicId: string }): JSX.Element {
+    const { linkForIdentifier, linksLoading } = useValues(userInterviewLogic({ id: topicId }))
+    const interviewUrl = linkForIdentifier(identifier)
+
     const handleCopy = (e: React.MouseEvent): void => {
         e.preventDefault()
         e.stopPropagation()
@@ -247,6 +234,27 @@ function PersonRow({
     const disabledReason = interviewUrl ? undefined : linksLoading ? 'Generating link…' : 'No link available'
 
     return (
+        <LemonButton
+            type="tertiary"
+            size="xsmall"
+            icon={<IconCopy />}
+            onClick={handleCopy}
+            disabledReason={disabledReason}
+            tooltip="Copy interview link"
+        />
+    )
+}
+
+function PersonRow({
+    identifier,
+    topicId,
+    hasResponded,
+}: {
+    identifier: string
+    topicId: string
+    hasResponded: boolean
+}): JSX.Element {
+    return (
         <Link
             to={urls.userInterviewResponse(topicId, encodeURIComponent(identifier))}
             className="block no-underline text-current"
@@ -257,14 +265,7 @@ function PersonRow({
                         <div className="font-medium text-sm">{identifier}</div>
                     </div>
                     <div className="flex items-center gap-2">
-                        <LemonButton
-                            type="tertiary"
-                            size="xsmall"
-                            icon={<IconCopy />}
-                            onClick={handleCopy}
-                            disabledReason={disabledReason}
-                            tooltip="Copy interview link"
-                        />
+                        <InterviewLinkCopyButton identifier={identifier} topicId={topicId} />
                         {hasResponded ? (
                             <LemonTag type="success" icon={<IconCheck />}>
                                 Responded

--- a/products/user_interviews/frontend/UserInterview.tsx
+++ b/products/user_interviews/frontend/UserInterview.tsx
@@ -41,6 +41,7 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
         interviewees,
         intervieweesLoading,
         linkByIdentifier,
+        linksLoading,
         respondedIdentifiers,
         respondedCount,
         totalTargeted,
@@ -136,6 +137,7 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
                                         topicId={id}
                                         hasResponded={respondedIdentifiers.has(identifier)}
                                         interviewUrl={linkByIdentifier[identifier]}
+                                        linksLoading={linksLoading}
                                     />
                                 ))
                             )}
@@ -225,11 +227,13 @@ function PersonRow({
     topicId,
     hasResponded,
     interviewUrl,
+    linksLoading,
 }: {
     identifier: string
     topicId: string
     hasResponded: boolean
     interviewUrl?: string
+    linksLoading: boolean
 }): JSX.Element {
     const handleCopy = (e: React.MouseEvent): void => {
         e.preventDefault()
@@ -239,6 +243,8 @@ function PersonRow({
         }
         void copyToClipboard(interviewUrl, 'interview link')
     }
+
+    const disabledReason = interviewUrl ? undefined : linksLoading ? 'Generating link…' : 'No link available'
 
     return (
         <Link
@@ -256,7 +262,7 @@ function PersonRow({
                             size="xsmall"
                             icon={<IconCopy />}
                             onClick={handleCopy}
-                            disabledReason={interviewUrl ? undefined : 'Generating link…'}
+                            disabledReason={disabledReason}
                             tooltip="Copy interview link"
                         />
                         {hasResponded ? (

--- a/products/user_interviews/frontend/userInterviewLogic.ts
+++ b/products/user_interviews/frontend/userInterviewLogic.ts
@@ -6,8 +6,18 @@ import { urls } from 'scenes/urls'
 
 import { Breadcrumb } from '~/types'
 
-import { userInterviewTopicsRetrieve, userInterviewTopicsIntervieweesList, userInterviewsList } from './generated/api'
-import type { UserInterviewTopicApi, IntervieweeContextApi, UserInterviewApi } from './generated/api.schemas'
+import {
+    userInterviewTopicsGenerateLinksCreate,
+    userInterviewTopicsIntervieweesList,
+    userInterviewTopicsRetrieve,
+    userInterviewsList,
+} from './generated/api'
+import type {
+    IntervieweeContextApi,
+    InterviewLinkApi,
+    UserInterviewApi,
+    UserInterviewTopicApi,
+} from './generated/api.schemas'
 import type { userInterviewLogicType } from './userInterviewLogicType'
 
 export interface UserInterviewLogicProps {
@@ -54,11 +64,28 @@ export const userInterviewLogic = kea<userInterviewLogicType>([
                 }
             },
         },
+        links: {
+            __default: [] as InterviewLinkApi[],
+            loadLinks: async () => {
+                const projectId = String(teamLogic.values.currentTeamId)
+                try {
+                    const response = await userInterviewTopicsGenerateLinksCreate(projectId, props.id)
+                    return response.results
+                } catch {
+                    return []
+                }
+            },
+        },
     })),
     selectors(({ props }) => ({
         topicInterviews: [
             (s) => [s.interviews],
             (interviews): UserInterviewApi[] => interviews.filter((i) => i.topic === props.id),
+        ],
+        linkByIdentifier: [
+            (s) => [s.links],
+            (links): Record<string, string> =>
+                Object.fromEntries(links.map((link) => [link.interviewee_identifier, link.interview_url])),
         ],
         respondedIdentifiers: [
             (s) => [s.topicInterviews],
@@ -113,5 +140,6 @@ export const userInterviewLogic = kea<userInterviewLogicType>([
         actions.loadTopic()
         actions.loadInterviewees()
         actions.loadInterviews()
+        actions.loadLinks()
     }),
 ])

--- a/products/user_interviews/frontend/userInterviewLogic.ts
+++ b/products/user_interviews/frontend/userInterviewLogic.ts
@@ -88,6 +88,12 @@ export const userInterviewLogic = kea<userInterviewLogicType>([
             (links): Record<string, string> =>
                 Object.fromEntries(links.map((link) => [link.interviewee_identifier, link.interview_url])),
         ],
+        linkForIdentifier: [
+            (s) => [s.linkByIdentifier],
+            (linkByIdentifier): ((identifier: string) => string | undefined) =>
+                (identifier: string) =>
+                    linkByIdentifier[identifier],
+        ],
         respondedIdentifiers: [
             (s) => [s.topicInterviews],
             (interviews): Set<string> => {

--- a/products/user_interviews/frontend/userInterviewLogic.ts
+++ b/products/user_interviews/frontend/userInterviewLogic.ts
@@ -66,14 +66,15 @@ export const userInterviewLogic = kea<userInterviewLogicType>([
         },
         links: {
             __default: [] as InterviewLinkApi[],
-            loadLinks: async () => {
+            loadLinks: async (): Promise<InterviewLinkApi[]> => {
                 const projectId = String(teamLogic.values.currentTeamId)
-                try {
-                    const response = await userInterviewTopicsGenerateLinksCreate(projectId, props.id)
-                    return response.results
-                } catch {
-                    return []
+                const response = (await userInterviewTopicsGenerateLinksCreate(projectId, props.id)) as unknown as
+                    | InterviewLinkApi[]
+                    | { results?: InterviewLinkApi[] }
+                if (Array.isArray(response)) {
+                    return response
                 }
+                return response.results ?? []
             },
         },
     })),


### PR DESCRIPTION
## Problem

On the user-research topic scene (e.g. `/user_research/<topic_id>`), researchers can see who they're targeting but have no quick way to grab a specific interviewee's link to paste into Slack / email / a doc. The "send invites" flow exists for bulk delivery, but for one-off shares the link was inaccessible without leaving the page.

## Changes

- `userInterviewLogic` now eagerly calls the `generate_links` endpoint on mount and exposes a `linkByIdentifier` selector mapping each targeted identifier → public interview URL.
- Each row in the people list shows a small copy button next to the responded/awaiting tag. Click copies that interviewee's personalised link to the clipboard (uses the existing `copyToClipboard` toast helper).
- The button is disabled with a "Generating link…" tooltip until the loader resolves so the click can't no-op silently.
- The row stays a `<Link>` to the response page — the copy button stops propagation so it doesn't navigate.

`generate_links` is already idempotent server-side (`get_or_create` on `IntervieweeContext` + `SharingConfiguration`), so visiting the topic page repeatedly is safe.

## How did you test this code?

I'm an agent (PostHog Code, Opus 4.7) — I haven't clicked through the UI. I ran `pnpm --filter=@posthog/frontend typescript:check` and saw no errors on the changed files. Visual review snapshot CI will validate the row layout.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Tools: PostHog Code (Opus 4.7), Graphite MCP for branching + submitting.
- Considered lazy-fetching links on first copy click — rejected because the API call cost is the same and eager fetch gives instant copy + lets us show the button as disabled-while-loading instead of disabled-forever-on-error. Idempotency on the backend means there's no harm in pre-warming.
- `linkByIdentifier` lives on the topic logic rather than spawning per-row state, so the API is called once per scene visit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*