### PR TITLE
fix(user-interviews): address qa-swarm findings on copy-link button

### DIFF
--- a/products/user_interviews/frontend/UserInterview.tsx
+++ b/products/user_interviews/frontend/UserInterview.tsx
@@ -219,7 +219,7 @@ function DetailRow({ label, value }: { label: string; value: string }): JSX.Elem
 }
 
 function InterviewLinkCopyButton({ identifier, topicId }: { identifier: string; topicId: string }): JSX.Element {
-    const { linkForIdentifier, linksLoading } = useValues(userInterviewLogic({ id: topicId }))
+    const { linkForIdentifier, linksLoading, linksLoadFailed } = useValues(userInterviewLogic({ id: topicId }))
     const interviewUrl = linkForIdentifier(identifier)
 
     const handleCopy = (e: React.MouseEvent): void => {
@@ -231,7 +231,13 @@ function InterviewLinkCopyButton({ identifier, topicId }: { identifier: string; 
         void copyToClipboard(interviewUrl, 'interview link')
     }
 
-    const disabledReason = interviewUrl ? undefined : linksLoading ? 'Generating link…' : 'No link available'
+    const disabledReason = interviewUrl
+        ? undefined
+        : linksLoadFailed
+          ? "Couldn't generate link — refresh to retry"
+          : linksLoading
+            ? 'Generating link…'
+            : 'No link available'
 
     return (
         <LemonButton

--- a/products/user_interviews/frontend/userInterviewLogic.ts
+++ b/products/user_interviews/frontend/userInterviewLogic.ts
@@ -1,4 +1,4 @@
-import { afterMount, kea, key, path, props, selectors } from 'kea'
+import { afterMount, kea, key, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { teamLogic } from 'scenes/teamLogic'
@@ -22,6 +22,13 @@ import type { userInterviewLogicType } from './userInterviewLogicType'
 
 export interface UserInterviewLogicProps {
     id: string
+}
+
+function unwrapPaginatedOrArray<T>(response: T[] | { results?: T[] }): T[] {
+    if (Array.isArray(response)) {
+        return response
+    }
+    return response.results ?? []
 }
 
 export const userInterviewLogic = kea<userInterviewLogicType>([
@@ -71,13 +78,19 @@ export const userInterviewLogic = kea<userInterviewLogicType>([
                 const response = (await userInterviewTopicsGenerateLinksCreate(projectId, props.id)) as unknown as
                     | InterviewLinkApi[]
                     | { results?: InterviewLinkApi[] }
-                if (Array.isArray(response)) {
-                    return response
-                }
-                return response.results ?? []
+                return unwrapPaginatedOrArray(response)
             },
         },
     })),
+    reducers({
+        linksLoadFailed: [
+            false,
+            {
+                loadLinks: () => false,
+                loadLinksFailure: () => true,
+            },
+        ],
+    }),
     selectors(({ props }) => ({
         topicInterviews: [
             (s) => [s.interviews],


### PR DESCRIPTION
## Problem

Follow-up to #58695 (merged before the qa-swarm review fixes could land). Three convergent MEDIUM findings from the swarm:

1. The `(...) as unknown as T[] | { results?: T[] }` cast on `loadLinks` admits the generated OpenAPI client lies about response shape, but the lie is inlined into a product loader with no comment or named helper.
2. `loadLinks` has no `try/catch` while sibling loaders swallow errors. The earlier "loading vs failed" fix only solved loading-vs-loaded; failure-vs-empty still collapses to `disabledReason="No link available"`.

## Changes

- Extract `unwrapPaginatedOrArray<T>` helper at the top of `userInterviewLogic.ts`. The schema-lie smell still exists but now lives in one place.
- Add a `linksLoadFailed` reducer driven by kea-loaders' `loadLinksFailure` action.
- The button's `disabledReason` now flips to "Couldn't generate link — refresh to retry" when the load failed, so the user can tell a backend error apart from a successful-but-empty result.

The loader still throws (no try/catch added) so kea fires the failure action automatically.

## How did you test this code?

I'm an agent (PostHog Code). `pnpm --filter=@posthog/frontend typescript:check` clean. No manual UI test.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Follow-up to #58695 which merged at HEAD `4e8ee0d` before this commit could land on the same PR.
- Other qa-swarm findings explicitly NOT addressed here: button-in-anchor a11y (deferred — bigger restructure), drop `linkForIdentifier` factory (disagree — was added per author request earlier), eager Create on mount (the backend endpoint is idempotent via `get_or_create`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*