### PR TITLE
fix(insights): coerce nullable string args of array-returning functions

### DIFF
--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -71,6 +71,22 @@ def team_id_guard_for_table(table_type: ast.TableOrSelectType, context: HogQLCon
     )
 
 
+# String functions that return an Array — a Nullable string arg would produce an
+# illegal Nullable(Array(...)) type, so their nullable string args are coerced.
+_ARRAY_RETURNING_STRING_FUNCTIONS = frozenset(
+    {
+        "splitByChar",
+        "splitByString",
+        "splitByRegexp",
+        "splitByWhitespace",
+        "splitByNonAlpha",
+        "alphaTokens",
+        "extractAllGroups",
+        "ngrams",
+        "tokens",
+    }
+)
+
 # In non-nullable materialized columns, these values are treated as NULL
 MAT_COL_NULL_SENTINELS = ["", "null"]
 
@@ -155,6 +171,18 @@ class ClickHousePrinter(BasePrinter):
                         args.append(f"ifNull({self.visit(arg)}, '')")
                 else:
                     args.append(f"ifNull(toString({self.visit(arg)}), '')")
+        elif node.name in _ARRAY_RETURNING_STRING_FUNCTIONS:
+            # These return Array(...). A Nullable string argument would make the
+            # result Nullable(Array(...)), which ClickHouse rejects, so coerce
+            # nullable string args to a non-nullable empty string.
+            args = []
+            for arg in node_args:
+                visited = self.visit(arg)
+                arg_type = arg.type.resolve_constant_type(self.context) if arg.type is not None else None
+                if isinstance(arg_type, ast.StringType) and arg_type.nullable:
+                    args.append(f"ifNull({visited}, '')")
+                else:
+                    args.append(visited)
         else:
             args = [self.visit(arg) for arg in node_args]
 

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -81,7 +81,11 @@ _ARRAY_RETURNING_STRING_FUNCTIONS = frozenset(
         "splitByWhitespace",
         "splitByNonAlpha",
         "alphaTokens",
+        "extractAll",
         "extractAllGroups",
+        "extractAllGroupsHorizontal",
+        "extractAllGroupsVertical",
+        "extractGroups",
         "ngrams",
         "tokens",
     }
@@ -172,14 +176,21 @@ class ClickHousePrinter(BasePrinter):
                 else:
                     args.append(f"ifNull(toString({self.visit(arg)}), '')")
         elif node.name in _ARRAY_RETURNING_STRING_FUNCTIONS:
-            # These return Array(...). A Nullable string argument would make the
-            # result Nullable(Array(...)), which ClickHouse rejects, so coerce
-            # nullable string args to a non-nullable empty string.
+            # A Nullable string arg would make the result Nullable(Array(...)),
+            # which ClickHouse rejects, so coerce nullable string args to a
+            # non-nullable empty string. Coercion is position-agnostic on
+            # purpose — a nullable separator would be just as illegal.
             args = []
             for arg in node_args:
                 visited = self.visit(arg)
                 arg_type = arg.type.resolve_constant_type(self.context) if arg.type is not None else None
-                if isinstance(arg_type, ast.StringType) and arg_type.nullable:
+                # StringArrayType is a StringType subclass but resolves to an
+                # Array — coercing it to a bare '' would be invalid, so exclude it.
+                if (
+                    isinstance(arg_type, ast.StringType)
+                    and not isinstance(arg_type, ast.StringArrayType)
+                    and arg_type.nullable
+                ):
                     args.append(f"ifNull({visited}, '')")
                 else:
                     args.append(visited)

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -4813,11 +4813,37 @@ class TestPrinted(APIBaseTest):
         )
         assert query_response.results == [(6,)]
 
-    def test_split_function_on_nullable_property(self):
-        # splitByChar on a nullable property would produce an illegal Nullable(Array)
-        query = parse_select("SELECT splitByChar('@', properties.email) FROM events")
+    @parameterized.expand(
+        [
+            ("splitByChar", "splitByChar('@', properties.email)"),
+            ("splitByString", "splitByString('@@', properties.email)"),
+            ("splitByRegexp", "splitByRegexp('[^a-z]+', properties.email)"),
+            ("splitByWhitespace", "splitByWhitespace(properties.email)"),
+            ("splitByNonAlpha", "splitByNonAlpha(properties.email)"),
+            ("alphaTokens", "alphaTokens(properties.email)"),
+            ("ngrams", "ngrams(properties.email, 3)"),
+            ("tokens", "tokens(properties.email)"),
+            ("extractAll", "extractAll(properties.email, '[a-z]+')"),
+            ("extractAllGroups", "extractAllGroups(properties.email, '([a-z]+)')"),
+            ("extractAllGroupsHorizontal", "extractAllGroupsHorizontal(properties.email, '([a-z]+)')"),
+            ("extractAllGroupsVertical", "extractAllGroupsVertical(properties.email, '([a-z]+)')"),
+            ("extractGroups", "extractGroups(properties.email, '([a-z]+)')"),
+        ]
+    )
+    def test_array_returning_string_function_on_nullable_property(self, _name, func_call):
+        # A nullable string arg to an array-returning function would produce an
+        # illegal Nullable(Array(...)) — ClickHouse rejects it (exception_code=43).
+        query = parse_select(f"SELECT {func_call} FROM events")
         query_response = execute_hogql_query(team=self.team, query=query)
-        assert query_response.results is not None
+        assert query_response.clickhouse is not None
+        assert "ifNull(" in query_response.clickhouse
+
+    def test_array_returning_string_function_no_spurious_ifnull_on_constant(self):
+        # A non-nullable (constant) string arg must not be wrapped in ifNull.
+        query = parse_select("SELECT splitByChar('@', 'a@b') FROM events")
+        query_response = execute_hogql_query(team=self.team, query=query)
+        assert query_response.clickhouse is not None
+        assert "ifNull(" not in query_response.clickhouse
 
 
 class TestPostgresPrinter(BaseTest):

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -4813,6 +4813,12 @@ class TestPrinted(APIBaseTest):
         )
         assert query_response.results == [(6,)]
 
+    def test_split_function_on_nullable_property(self):
+        # splitByChar on a nullable property would produce an illegal Nullable(Array)
+        query = parse_select("SELECT splitByChar('@', properties.email) FROM events")
+        query_response = execute_hogql_query(team=self.team, query=query)
+        assert query_response.results is not None
+
 
 class TestPostgresPrinter(BaseTest):
     maxDiff = None


### PR DESCRIPTION
## Problem

An insight using `splitByChar` (or another string-splitting function) on a nullable value crashed the whole query with ClickHouse `Nested type Array(String) cannot be inside Nullable type`. Surfaced from `system.query_log` (`exception_code = 43`) as part of the effort to reduce deterministic query-builder bugs ([dashboard](https://metabase.prod-us.posthog.dev/dashboard/207-product-analytics-insight-query-failures)).

`splitByChar` and friends return `Array(...)`. A JSON property resolves to a `Nullable(String)`, so e.g. a breakdown on `splitByChar('@', properties.$distinct_id)` produces `Nullable(Array(String))` — a type ClickHouse forbids.

## Changes

- The ClickHouse printer wraps a nullable string argument of array-returning string functions (`splitByChar`, `splitByString`, `splitByRegexp`, `splitByWhitespace`, `splitByNonAlpha`, `alphaTokens`, `extractAllGroups`, `ngrams`, `tokens`) in `ifNull(arg, '')`, keeping the result a plain `Array`.

## How did you test this code?

I'm an agent. Automated tests run locally:
- New test `test_split_function_on_nullable_property` executing `splitByChar('@', properties.email)`.
- Full `posthog/hogql/printer/test/test_printer.py` suite — 608 passed, 175 snapshots unchanged.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Found via `system.query_log` analysis (`exception_code = 43`, `Nested type Array(...) cannot be inside Nullable`).

Only nullable string args are wrapped (checked via the resolved arg type), so non-nullable args and non-string args like the split-count are untouched — no snapshot churn for existing split-function usage.

Agent-authored; requires human review.