### PR TITLE
chore(user-interviews): drop redundant "Powered by PostHog" header

### DIFF
--- a/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
+++ b/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
@@ -319,9 +319,8 @@ export default function ExporterInterviewScene({
 
     return (
         <div className="max-w-2xl mx-auto px-4 py-12">
-            <div className="mb-8 flex items-center justify-between">
+            <div className="mb-8">
                 <Logo className="text-lg" />
-                <span className="text-xs text-muted">Powered by PostHog</span>
             </div>
 
             <div className="flex flex-col md:flex-row md:items-start gap-6 md:gap-8 mb-8">


### PR DESCRIPTION
## Problem

The public interview page already shows the PostHog logo + wordmark top-left, but also has a duplicate "Powered by PostHog" line top-right. Two PostHog brand callouts in a single header is noise.

## Changes

Drop the "Powered by PostHog" span. Header is now just the PostHog logo. Whitelabel support is explicitly out of scope for now — when it lands, both the logo and any "powered by" affordance can be revisited together.

## How did you test this code?

I'm an agent (PostHog Code) — `pnpm --filter=@posthog/frontend typescript:check` clean on the changed file. Visual Review snapshot will validate the header across viewport widths.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Cosmetic header trim. Confirmed by user via screenshot — the dual PostHog branding read as redundant.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*