### PR TITLE
fix(insights): fix funnel correlation join for HogQL aggregation

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -824,11 +824,21 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
                 ON funnel_actors.actor_id = event.$group_{self.funnels_query.aggregation_group_type_index}
             """
 
-        return (
-            aggregation_group_join
-            if self.funnels_query.aggregation_group_type_index is not None
-            else aggregation_person_join
-        )
+        if self.funnels_query.aggregation_group_type_index is not None:
+            return aggregation_group_join
+
+        # When the funnel aggregates by a custom HogQL expression, funnel_actors.actor_id
+        # holds that value — joining on event.person_id would mismatch types (UUID vs the
+        # expression's type). Join on the same expression instead.
+        funnels_filter = self.funnels_query.funnelsFilter
+        aggregate_by_hogql = funnels_filter.funnelAggregateByHogQL if funnels_filter else None
+        if aggregate_by_hogql and aggregate_by_hogql != "person_id":
+            return f"""
+            JOIN funnel_actors
+                ON funnel_actors.actor_id = {aggregate_by_hogql}
+            """
+
+        return aggregation_person_join
 
     def _get_aggregation_join_query(self):
         if self.funnels_query.aggregation_group_type_index is None:

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -23,7 +23,7 @@ from posthog.schema import (
 
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
-from posthog.hogql.parser import parse_select
+from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
@@ -416,6 +416,7 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
                 "date_from": date_from,
                 "date_to": date_to,
                 "target_event": ast.Constant(value=target_event),
+                **self._aggregation_join_placeholders(),
             },
         )
         assert isinstance(query, ast.SelectQuery)
@@ -547,6 +548,7 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
                 "date_to": date_to,
                 "exclude_event_names": exclude_event_names_ast,
                 "total_identifier": ast.Constant(value=self.TOTAL_IDENTIFIER),
+                **self._aggregation_join_placeholders(),
             },
         )
 
@@ -654,6 +656,7 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
                     if exclude_property_names
                     else {}
                 ),
+                **self._aggregation_join_placeholders(),
             },
         )
 
@@ -833,12 +836,29 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
         funnels_filter = self.funnels_query.funnelsFilter
         aggregate_by_hogql = funnels_filter.funnelAggregateByHogQL if funnels_filter else None
         if aggregate_by_hogql and aggregate_by_hogql != "person_id":
-            return f"""
+            # funnelAggregateByHogQL is user-controlled. Emit a placeholder rather than
+            # interpolating the raw string — _aggregation_join_placeholders parses it
+            # into a bounded AST expression so it can't inject query structure.
+            return """
             JOIN funnel_actors
-                ON funnel_actors.actor_id = {aggregate_by_hogql}
+                ON funnel_actors.actor_id = {aggregation_join_target}
             """
 
         return aggregation_person_join
+
+    def _aggregation_join_placeholders(self) -> dict[str, ast.Expr]:
+        """Placeholder for the HogQL-aggregation join target. Parsing the user-controlled
+        funnelAggregateByHogQL into an AST (rather than string-interpolating it) keeps it a
+        single bounded expression — it cannot add joins or clauses to the query."""
+        funnels_filter = self.funnels_query.funnelsFilter
+        aggregate_by_hogql = funnels_filter.funnelAggregateByHogQL if funnels_filter else None
+        if (
+            self.funnels_query.aggregation_group_type_index is None
+            and aggregate_by_hogql
+            and aggregate_by_hogql != "person_id"
+        ):
+            return {"aggregation_join_target": parse_expr(aggregate_by_hogql)}
+        return {}
 
     def _get_aggregation_join_query(self):
         if self.funnels_query.aggregation_group_type_index is None:

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -832,13 +832,10 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
 
         # When the funnel aggregates by a custom HogQL expression, funnel_actors.actor_id
         # holds that value — joining on event.person_id would mismatch types (UUID vs the
-        # expression's type). Join on the same expression instead.
-        funnels_filter = self.funnels_query.funnelsFilter
-        aggregate_by_hogql = funnels_filter.funnelAggregateByHogQL if funnels_filter else None
-        if aggregate_by_hogql and aggregate_by_hogql != "person_id":
-            # funnelAggregateByHogQL is user-controlled. Emit a placeholder rather than
-            # interpolating the raw string — _aggregation_join_placeholders parses it
-            # into a bounded AST expression so it can't inject query structure.
+        # expression's type). Join on the same expression instead, emitted as a placeholder
+        # parsed by _aggregation_join_placeholders so the user-controlled string can't
+        # inject query structure.
+        if self._hogql_aggregation_expr() is not None:
             return """
             JOIN funnel_actors
                 ON funnel_actors.actor_id = {aggregation_join_target}
@@ -846,19 +843,21 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
 
         return aggregation_person_join
 
-    def _aggregation_join_placeholders(self) -> dict[str, ast.Expr]:
-        """Placeholder for the HogQL-aggregation join target. Parsing the user-controlled
-        funnelAggregateByHogQL into an AST (rather than string-interpolating it) keeps it a
+    def _hogql_aggregation_expr(self) -> ast.Expr | None:
+        """Parsed AST for funnelAggregateByHogQL when set and non-trivial, else None for
+        person/group aggregation. Parsing the user-controlled string into an AST keeps it a
         single bounded expression — it cannot add joins or clauses to the query."""
+        if self.funnels_query.aggregation_group_type_index is not None:
+            return None
         funnels_filter = self.funnels_query.funnelsFilter
         aggregate_by_hogql = funnels_filter.funnelAggregateByHogQL if funnels_filter else None
-        if (
-            self.funnels_query.aggregation_group_type_index is None
-            and aggregate_by_hogql
-            and aggregate_by_hogql != "person_id"
-        ):
-            return {"aggregation_join_target": parse_expr(aggregate_by_hogql)}
-        return {}
+        if aggregate_by_hogql and aggregate_by_hogql != "person_id":
+            return parse_expr(aggregate_by_hogql)
+        return None
+
+    def _aggregation_join_placeholders(self) -> dict[str, ast.Expr]:
+        expr = self._hogql_aggregation_expr()
+        return {"aggregation_join_target": expr} if expr is not None else {}
 
     def _get_aggregation_join_query(self):
         if self.funnels_query.aggregation_group_type_index is None:

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -115,6 +115,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="properties.session_id"),
         )
 
+        # Converting sessions (reach "paid") that also fire "positively_related".
         for i in range(5):
             _create_person(distinct_ids=[f"user_{i}"], team_id=self.team.pk)
             _create_event(
@@ -139,8 +140,25 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                 properties={"session_id": f"session_{i}"},
             )
 
+        # Non-converting sessions (never reach "paid"), needed so odds ratios are
+        # computable rather than the totals being skewed to 100% conversion.
+        for i in range(5, 10):
+            _create_person(distinct_ids=[f"user_{i}"], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="user signed up",
+                distinct_id=f"user_{i}",
+                timestamp="2020-01-02T14:00:00Z",
+                properties={"session_id": f"session_{i}"},
+            )
+
+        # Before the fix this raised TYPE_MISMATCH (joining event.person_id, a UUID,
+        # against the string actor id). The join must now run and actually match rows.
         result, _ = self._get_events_for_query(query)
-        assert result is not None
+        events = {item["event"]: item for item in result}
+        self.assertIn("positively_related", events)
+        self.assertEqual(events["positively_related"]["success_count"], 5)
+        self.assertEqual(events["positively_related"]["correlation_type"], "success")
 
     def test_funnel_correlation_hogql_aggregation_rejects_injection(self):
         # funnelAggregateByHogQL is user-controlled — a value that isn't a single

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -142,6 +142,18 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         result, _ = self._get_events_for_query(query)
         assert result is not None
 
+    def test_funnel_correlation_hogql_aggregation_rejects_injection(self):
+        # funnelAggregateByHogQL is user-controlled — a value that isn't a single
+        # bounded expression (e.g. an attempt to inject an extra JOIN) must be
+        # rejected by the parser, not interpolated into the query.
+        query = FunnelsQuery(
+            series=[EventsNode(event="user signed up"), EventsNode(event="paid")],
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+            funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="properties.session_id JOIN persons ON 1=1"),
+        )
+        with self.assertRaises(Exception):
+            self._get_events_for_query(query)
+
     def test_basic_funnel_correlation_with_events(self):
         query = FunnelsQuery(
             series=[EventsNode(event="user signed up"), EventsNode(event="paid")],

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -105,6 +105,43 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )
         return [str(row[0]) for row in serialized_actors]
 
+    def test_funnel_correlation_with_events_and_hogql_aggregation(self):
+        # When the funnel aggregates by a custom HogQL expression, the correlation
+        # event join must use that expression — joining on event.person_id would
+        # mismatch types (UUID vs the string actor id) and fail the query.
+        query = FunnelsQuery(
+            series=[EventsNode(event="user signed up"), EventsNode(event="paid")],
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+            funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="properties.session_id"),
+        )
+
+        for i in range(5):
+            _create_person(distinct_ids=[f"user_{i}"], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="user signed up",
+                distinct_id=f"user_{i}",
+                timestamp="2020-01-02T14:00:00Z",
+                properties={"session_id": f"session_{i}"},
+            )
+            _create_event(
+                team=self.team,
+                event="positively_related",
+                distinct_id=f"user_{i}",
+                timestamp="2020-01-03T14:00:00Z",
+                properties={"session_id": f"session_{i}"},
+            )
+            _create_event(
+                team=self.team,
+                event="paid",
+                distinct_id=f"user_{i}",
+                timestamp="2020-01-04T14:00:00Z",
+                properties={"session_id": f"session_{i}"},
+            )
+
+        result, _ = self._get_events_for_query(query)
+        assert result is not None
+
     def test_basic_funnel_correlation_with_events(self):
         query = FunnelsQuery(
             series=[EventsNode(event="user signed up"), EventsNode(event="paid")],


### PR DESCRIPTION
## Problem

A funnel correlation query crashed with ClickHouse `TYPE_MISMATCH` (`no supertype for types UUID, String`) when the funnel aggregated by a custom HogQL expression. Surfaced from `system.query_log` (`exception_code = 53`) as part of the effort to reduce deterministic query-builder bugs ([dashboard](https://metabase.prod-us.posthog.dev/dashboard/207-product-analytics-insight-query-failures)).

`_get_aggregation_target_join_query` only handled two cases — person aggregation (`event.person_id`) and group aggregation (`event.$group_N`). With a custom HogQL aggregation (`funnelAggregateByHogQL`), it fell back to the person join, comparing `event.person_id` (UUID) against `funnel_actors.actor_id` (the HogQL expression's value, e.g. a string).

## Changes

- `_get_aggregation_target_join_query` now joins on the funnel's `funnelAggregateByHogQL` expression when one is set, matching how the funnel actors CTE computes `actor_id`.

## How did you test this code?

I'm an agent. Automated tests run locally:
- New test `test_funnel_correlation_with_events_and_hogql_aggregation` — a correlation query over a funnel aggregating by `properties.session_id`. Verified it fails (`TYPE_MISMATCH`) without the fix and passes with it.
- Full `test_funnel_correlation.py` suite — 19 passed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Found via `system.query_log` analysis (`exception_code = 53`, `Can't infer common type for joined columns`).

Scope note: the sibling `_get_aggregation_join_query` (person/group *properties* correlation) has the same person/group-only assumption, but property correlation against a non-person aggregation target is a different code path and wasn't in the observed failures — left for a separate change if it surfaces.

Agent-authored; requires human review.