### PR TITLE
fix(insights): coerce sortableSemver argument to string

### DIFF
--- a/posthog/hogql/functions/posthog.py
+++ b/posthog/hogql/functions/posthog.py
@@ -9,7 +9,7 @@ HOGQL_POSTHOG_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "explainCSPReport": HogQLFunctionMeta("explainCSPReport", 1, 1),
     # Allow case-insensitive matching since people might not know "SemVer" is the right capitalization
     "sortablesemver": HogQLFunctionMeta(
-        "arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(assumeNotNull({}), '(\\d+(\\.\\d+)+)')))",
+        "arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(toString(assumeNotNull({})), '(\\d+(\\.\\d+)+)')))",
         1,
         1,
         case_sensitive=False,

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -2988,10 +2988,10 @@ class TestPrinter(BaseTest):
         )
         self.assertEqual(
             (
-                f"SELECT arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(assumeNotNull(%(hogql_val_0)s), '(\\d+(\\.\\d+)+)'))) AS semver1, "
-                f"arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(assumeNotNull(%(hogql_val_1)s), '(\\d+(\\.\\d+)+)'))) AS semver2, "
-                f"arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(assumeNotNull(%(hogql_val_2)s), '(\\d+(\\.\\d+)+)'))) AS semver3, "
-                f"arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(assumeNotNull(%(hogql_val_3)s), '(\\d+(\\.\\d+)+)'))) AS semver4 "
+                f"SELECT arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(toString(assumeNotNull(%(hogql_val_0)s)), '(\\d+(\\.\\d+)+)'))) AS semver1, "
+                f"arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(toString(assumeNotNull(%(hogql_val_1)s)), '(\\d+(\\.\\d+)+)'))) AS semver2, "
+                f"arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(toString(assumeNotNull(%(hogql_val_2)s)), '(\\d+(\\.\\d+)+)'))) AS semver3, "
+                f"arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(toString(assumeNotNull(%(hogql_val_3)s)), '(\\d+(\\.\\d+)+)'))) AS semver4 "
                 "LIMIT 50000 SETTINGS readonly=2, max_execution_time=10, allow_experimental_object_type=1, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0"
             ),
             printed,

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 from django.test import override_settings
 from django.utils import timezone
 
+from parameterized import parameterized
+
 from posthog.schema import (
     DateRange,
     EventPropertyFilter,
@@ -1904,28 +1906,49 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         # Ignore everything after string, return as array of ints
         self.assertEqual(response.results, [([1, 2, 3, 4, 15],)])
 
-    def test_sortable_semver_on_numeric_property(self):
+    @parameterized.expand(
+        [
+            # (property_scope, stored_value, lower_semver, higher_semver)
+            ("event", "1.7", "1.6", "1.8"),
+            ("event", "170.5", "170.4", "170.6"),
+            ("person", "1.7", "1.6", "1.8"),
+        ]
+    )
+    def test_sortable_semver_on_numeric_property(self, scope, stored_value, lower, higher):
         # A property defined as Numeric is coerced to Float64 by the property-types
-        # transform; sortableSemver must still operate on it as a string.
+        # transform; sortableSemver must still operate on it as a string and parse
+        # the dotted version correctly.
+        prop_type = PropertyDefinition.Type.EVENT if scope == "event" else PropertyDefinition.Type.PERSON
         PropertyDefinition.objects.create(
             team=self.team,
             name="app_build",
-            type=PropertyDefinition.Type.EVENT,
+            type=prop_type,
             property_type=PropertyType.Numeric,
         )
+        prop_chain = "properties.app_build" if scope == "event" else "person.properties.app_build"
         with freeze_time("2020-01-10"):
-            _create_event(
-                distinct_id="bla",
-                event="random event",
-                team=self.team,
-                properties={"app_build": "170"},
-            )
+            if scope == "event":
+                _create_event(
+                    distinct_id="bla", event="random event", team=self.team, properties={"app_build": stored_value}
+                )
+            else:
+                _create_person(distinct_ids=["bla"], team_id=self.team.pk, properties={"app_build": stored_value})
+                _create_event(distinct_id="bla", event="random event", team=self.team)
             flush_persons_and_events()
-            response = execute_hogql_query(
-                "SELECT count() FROM events WHERE sortableSemVer(properties.app_build) >= sortableSemVer('170')",
-                self.team,
+            self.assertEqual(
+                execute_hogql_query(
+                    f"SELECT count() FROM events WHERE sortableSemVer({prop_chain}) >= sortableSemVer('{lower}')",
+                    self.team,
+                ).results,
+                [(1,)],
             )
-            self.assertEqual(response.results, [(1,)])
+            self.assertEqual(
+                execute_hogql_query(
+                    f"SELECT count() FROM events WHERE sortableSemVer({prop_chain}) >= sortableSemVer('{higher}')",
+                    self.team,
+                ).results,
+                [(0,)],
+            )
 
     def test_exchange_rate_table(self):
         query = "SELECT DISTINCT currency FROM exchange_rate LIMIT 500"

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -32,7 +32,7 @@ from posthog.hogql.test.utils import (
 )
 
 from posthog.errors import InternalCHQueryError
-from posthog.models import Cohort
+from posthog.models import Cohort, PropertyDefinition
 from posthog.models.cohort.util import recalculate_cohortpeople
 from posthog.models.exchange_rate.currencies import SUPPORTED_CURRENCY_CODES
 from posthog.models.insight_variable import InsightVariable
@@ -42,6 +42,7 @@ from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 
 from products.data_warehouse.backend.models import ExternalDataSource
 from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.event_definitions.backend.models.property_definition import PropertyType
 
 
 class TestQuery(ClickhouseTestMixin, APIBaseTest):
@@ -1902,6 +1903,29 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
         # Ignore everything after string, return as array of ints
         self.assertEqual(response.results, [([1, 2, 3, 4, 15],)])
+
+    def test_sortable_semver_on_numeric_property(self):
+        # A property defined as Numeric is coerced to Float64 by the property-types
+        # transform; sortableSemver must still operate on it as a string.
+        PropertyDefinition.objects.create(
+            team=self.team,
+            name="app_build",
+            type=PropertyDefinition.Type.EVENT,
+            property_type=PropertyType.Numeric,
+        )
+        with freeze_time("2020-01-10"):
+            _create_event(
+                distinct_id="bla",
+                event="random event",
+                team=self.team,
+                properties={"app_build": "170"},
+            )
+            flush_persons_and_events()
+            response = execute_hogql_query(
+                "SELECT count() FROM events WHERE sortableSemVer(properties.app_build) >= sortableSemVer('170')",
+                self.team,
+            )
+            self.assertEqual(response.results, [(1,)])
 
     def test_exchange_rate_table(self):
         query = "SELECT DISTINCT currency FROM exchange_rate LIMIT 500"


### PR DESCRIPTION
## Problem

ClickHouse queries using a semver comparison operator against an event/person property that has a Numeric `PropertyDefinition` fail deterministically with `Illegal type Float64 of argument of function extract` (code 43).

`sortableSemver` inlines to `extract(assumeNotNull({}), ...)` — a string operation. When the comparison targets a Numeric-typed property, the property-types transform first coerces the field to `Float64`, so `extract()` receives a `Float64` and ClickHouse rejects it.

Part of an effort to reduce deterministic product-analytics query-builder failures — tracking dashboard: https://metabase.prod-us.posthog.dev/dashboard/207-product-analytics-insight-query-failures

## Changes

Wrap the `sortableSemver` argument in `toString()` so the function always operates on a string, regardless of how the property was typed upstream.

## How did you test this code?

I'm an agent. Added an executing HogQL test (`test_sortable_semver_on_numeric_property`) that creates a Numeric `PropertyDefinition` and runs a `sortableSemVer` comparison against it through ClickHouse. Verified the test fails on `origin/master` with the exact `code 43` error and passes with the fix. Ran the existing `sortable_semver` test suite — all pass. No snapshot files reference `sortableSemver`.

## Publish to changelog?

no

## 🤖 Agent context

Agent-authored (Claude Code, Opus 4.7). Requires human review.

Root cause traced from a production failing query: the offending expression was `extract(assumeNotNull(accurateCastOrNull(..., 'Float64')), '(\d+(\.\d+)+)')`. The Float64 cast comes from the property-types transform, not from `sortableSemver` itself. Fix chosen at the function definition (`posthog/hogql/functions/posthog.py`) so it is robust to any upstream coercion rather than special-casing the property-types transform.