### PR TITLE
feat(insights): label query metric with has_user_authored_hogql

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -121,7 +121,7 @@ logger = structlog.get_logger(__name__)
 QUERY_EXECUTION_TOTAL = Counter(
     "posthog_query_execution_total",
     "Query executions by category",
-    labelnames=["query_type", "category", "error_type"],
+    labelnames=["query_type", "category", "error_type", "has_user_authored_hogql"],
 )
 
 QUERY_EXECUTION_DURATION = Histogram(
@@ -143,6 +143,34 @@ SURVEY_QUERY_EXECUTION_DURATION = Histogram(
     labelnames=["query_type", "query_name"],
     buckets=[0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 7.5, 10.0, 15.0, 20.0, 30.0, 60.0, 120.0],
 )
+
+
+def query_uses_user_authored_hogql(query: Any) -> bool:
+    """Whether the query contains a user-authored HogQL expression — a HogQL property
+    filter, breakdown, funnel aggregation, or series math. A failure on a query built
+    purely from structured input (no user HogQL) is almost always a query-builder bug,
+    so this label lets observability separate those from user-written-HogQL failures."""
+
+    def _walk(obj: Any) -> bool:
+        if isinstance(obj, dict):
+            if obj.get("type") == "hogql" or obj.get("kind") == "HogQLQuery":
+                return True
+            if obj.get("breakdown_type") == "hogql":
+                return True
+            if obj.get("math") == "hogql" or obj.get("math_hogql"):
+                return True
+            if obj.get("funnelAggregateByHogQL") not in (None, "", "person_id"):
+                return True
+            return any(_walk(value) for value in obj.values())
+        if isinstance(obj, list):
+            return any(_walk(item) for item in obj)
+        return False
+
+    try:
+        return _walk(query.model_dump())
+    except Exception:
+        return False
+
 
 EXTENDED_CACHE_AGE = timedelta(days=1)
 
@@ -1565,11 +1593,17 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             self.modifiers.useMaterializedViews = True
 
         query_type = getattr(self.query, "kind", "Other")
+        has_user_authored_hogql = str(query_uses_user_authored_hogql(self.query)).lower()
         survey_query_metric_labels = get_survey_query_metric_labels(self.query)
         query_start = perf_counter()
         try:
             query_result, query_duration_ms = self._call_with_rate_limits(dashboard_id=dashboard_id)
-            QUERY_EXECUTION_TOTAL.labels(query_type=query_type, category="success", error_type="none").inc()
+            QUERY_EXECUTION_TOTAL.labels(
+                query_type=query_type,
+                category="success",
+                error_type="none",
+                has_user_authored_hogql=has_user_authored_hogql,
+            ).inc()
             if survey_query_metric_labels:
                 SURVEY_QUERY_EXECUTION_TOTAL.labels(
                     **survey_query_metric_labels, category="success", error_type="none"
@@ -1579,6 +1613,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 query_type=query_type,
                 category=classify_query_error(e),
                 error_type=clickhouse_error_type(e),
+                has_user_authored_hogql=has_user_authored_hogql,
             ).inc()
             if survey_query_metric_labels:
                 SURVEY_QUERY_EXECUTION_TOTAL.labels(

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
@@ -145,6 +146,9 @@ SURVEY_QUERY_EXECUTION_DURATION = Histogram(
 )
 
 
+_GROUP_AGGREGATION_RE = re.compile(r"^\$group_\d+$")
+
+
 def query_uses_user_authored_hogql(query: Any) -> bool:
     """Whether the query contains a user-authored HogQL expression — a HogQL property
     filter, breakdown, funnel aggregation, or series math. A failure on a query built
@@ -157,9 +161,14 @@ def query_uses_user_authored_hogql(query: Any) -> bool:
                 return True
             if obj.get("breakdown_type") == "hogql":
                 return True
-            if obj.get("math") == "hogql" or obj.get("math_hogql"):
+            # math_hogql is only meaningful alongside math == "hogql"; checking
+            # it standalone would false-positive on stale data where math changed.
+            if obj.get("math") == "hogql":
                 return True
-            if obj.get("funnelAggregateByHogQL") not in (None, "", "person_id"):
+            # funnelAggregateByHogQL holds a user-authored HogQL expression, except
+            # for the structured "person_id" / "$group_N" values picked from a dropdown.
+            funnel_agg = obj.get("funnelAggregateByHogQL")
+            if funnel_agg and funnel_agg != "person_id" and not _GROUP_AGGREGATION_RE.match(funnel_agg):
                 return True
             return any(_walk(value) for value in obj.values())
         if isinstance(obj, list):
@@ -169,6 +178,9 @@ def query_uses_user_authored_hogql(query: Any) -> bool:
     try:
         return _walk(query.model_dump())
     except Exception:
+        # query is always a pydantic BaseModel here, so model_dump() should not
+        # raise — log rather than silently mislabel a real bug in _walk as false.
+        logger.warning("query_uses_user_authored_hogql failed", exc_info=True)
         return False
 
 

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -15,11 +15,15 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
     BounceRatePageViewMode,
+    BreakdownFilter,
     CacheMissResponse,
     CurrencyCode,
     DataTableNode,
     DataVisualizationNode,
     EventsNode,
+    FunnelsFilter,
+    FunnelsQuery,
+    HogQLPropertyFilter,
     HogQLQuery,
     HogQLQueryModifiers,
     InCohortVia,
@@ -45,6 +49,7 @@ from posthog.hogql_queries.query_runner import (
     ExecutionMode,
     QueryRunner,
     get_query_runner,
+    query_uses_user_authored_hogql,
     shared_insights_execution_mode,
 )
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -501,10 +506,10 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
 
         before_success = QUERY_EXECUTION_TOTAL.labels(
-            query_type="TestQuery", category="success", error_type="none"
+            query_type="TestQuery", category="success", error_type="none", has_user_authored_hogql="false"
         )._value.get()
         before_failure = QUERY_EXECUTION_TOTAL.labels(
-            query_type="TestQuery", category="error", error_type="ValueError"
+            query_type="TestQuery", category="error", error_type="ValueError", has_user_authored_hogql="false"
         )._value.get()
         before_duration_sum = QUERY_EXECUTION_DURATION.labels(query_type="TestQuery")._sum.get()
 
@@ -515,12 +520,16 @@ class TestQueryRunner(BaseTest):
             runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
 
         assert (
-            QUERY_EXECUTION_TOTAL.labels(query_type="TestQuery", category="success", error_type="none")._value.get()
+            QUERY_EXECUTION_TOTAL.labels(
+                query_type="TestQuery", category="success", error_type="none", has_user_authored_hogql="false"
+            )._value.get()
             - before_success
             == success_delta
         )
         assert (
-            QUERY_EXECUTION_TOTAL.labels(query_type="TestQuery", category="error", error_type="ValueError")._value.get()
+            QUERY_EXECUTION_TOTAL.labels(
+                query_type="TestQuery", category="error", error_type="ValueError", has_user_authored_hogql="false"
+            )._value.get()
             - before_failure
             == failure_delta
         )
@@ -569,10 +578,10 @@ class TestQueryRunner(BaseTest):
             runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
 
         before_success = QUERY_EXECUTION_TOTAL.labels(
-            query_type="TestQuery", category="success", error_type="none"
+            query_type="TestQuery", category="success", error_type="none", has_user_authored_hogql="false"
         )._value.get()
         before_failure = QUERY_EXECUTION_TOTAL.labels(
-            query_type="TestQuery", category="error", error_type="ValueError"
+            query_type="TestQuery", category="error", error_type="ValueError", has_user_authored_hogql="false"
         )._value.get()
         before_duration_sum = QUERY_EXECUTION_DURATION.labels(query_type="TestQuery")._sum.get()
 
@@ -581,11 +590,15 @@ class TestQueryRunner(BaseTest):
             runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
 
         assert (
-            QUERY_EXECUTION_TOTAL.labels(query_type="TestQuery", category="success", error_type="none")._value.get()
+            QUERY_EXECUTION_TOTAL.labels(
+                query_type="TestQuery", category="success", error_type="none", has_user_authored_hogql="false"
+            )._value.get()
             == before_success
         )
         assert (
-            QUERY_EXECUTION_TOTAL.labels(query_type="TestQuery", category="error", error_type="ValueError")._value.get()
+            QUERY_EXECUTION_TOTAL.labels(
+                query_type="TestQuery", category="error", error_type="ValueError", has_user_authored_hogql="false"
+            )._value.get()
             == before_failure
         )
         assert QUERY_EXECUTION_DURATION.labels(query_type="TestQuery")._sum.get() == before_duration_sum
@@ -1138,3 +1151,37 @@ class TestSharedInsightsExecutionMode(BaseTest):
         last_refresh = None if last_refresh_offset is None else datetime.now(UTC) - last_refresh_offset
         result = shared_insights_execution_mode(execution_mode, last_refresh=last_refresh)
         self.assertEqual(result, expected_mode)
+
+
+class TestQueryUsesUserAuthoredHogQL(BaseTest):
+    @parameterized.expand(
+        [
+            ("plain_trends", TrendsQuery(series=[EventsNode(event="$pageview")]), False),
+            (
+                "hogql_property_filter",
+                TrendsQuery(
+                    series=[EventsNode(event="$pageview", properties=[HogQLPropertyFilter(type="hogql", key="1 = 1")])]
+                ),
+                True,
+            ),
+            (
+                "hogql_breakdown",
+                TrendsQuery(
+                    series=[EventsNode(event="$pageview")],
+                    breakdownFilter=BreakdownFilter(breakdown_type="hogql", breakdown="properties.x"),
+                ),
+                True,
+            ),
+            ("hogql_query", HogQLQuery(query="select 1"), True),
+            (
+                "funnel_hogql_aggregation",
+                FunnelsQuery(
+                    series=[EventsNode(event="a"), EventsNode(event="b")],
+                    funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="properties.x"),
+                ),
+                True,
+            ),
+        ]
+    )
+    def test_detects_user_authored_hogql(self, _name: str, query: Any, expected: bool) -> None:
+        assert query_uses_user_authored_hogql(query) is expected

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -1174,12 +1174,33 @@ class TestQueryUsesUserAuthoredHogQL(BaseTest):
             ),
             ("hogql_query", HogQLQuery(query="select 1"), True),
             (
+                "hogql_series_math",
+                TrendsQuery(series=[EventsNode(event="$pageview", math="hogql", math_hogql="properties.revenue")]),
+                True,
+            ),
+            (
                 "funnel_hogql_aggregation",
                 FunnelsQuery(
                     series=[EventsNode(event="a"), EventsNode(event="b")],
                     funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="properties.x"),
                 ),
                 True,
+            ),
+            (
+                "funnel_group_aggregation_is_structured",
+                FunnelsQuery(
+                    series=[EventsNode(event="a"), EventsNode(event="b")],
+                    funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="$group_0"),
+                ),
+                False,
+            ),
+            (
+                "funnel_person_id_aggregation_is_structured",
+                FunnelsQuery(
+                    series=[EventsNode(event="a"), EventsNode(event="b")],
+                    funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="person_id"),
+                ),
+                False,
             ),
         ]
     )


### PR DESCRIPTION
## Problem

A failed insight query carries a ClickHouse error code (43, 386, …) that cannot say *who* malformed the query — the user (a bad regex / HogQL expression they wrote) or our query builder (the user picked normal dropdowns and we generated invalid SQL). The `category="user_error"` metric label lumps both together, so there's no signal that specifically tracks query-builder bugs.

A query built purely from **structured input** — no user-authored HogQL — that fails is almost always a builder bug. That's the distinction worth alerting on. Part of the effort behind the [insight query failures dashboard](https://metabase.prod-us.posthog.dev/dashboard/207-product-analytics-insight-query-failures).

## Changes

- Add a `has_user_authored_hogql` label to the `posthog_query_execution_total` counter.
- `query_uses_user_authored_hogql()` walks the query and returns true when it contains a HogQL property filter (`type="hogql"`), a HogQL breakdown (`breakdown_type="hogql"`), a `funnelAggregateByHogQL`, HogQL series math, or is itself a `HogQLQuery`.
- Both metric emission sites (success / failure) carry the new label.

This lets observability target builder bugs precisely — `category="user_error", has_user_authored_hogql="false"` is a high-confidence builder-bug signal — separately from failures rooted in user-written HogQL.

## How did you test this code?

I'm an agent. Automated tests run locally:
- New `TestQueryUsesUserAuthoredHogQL` — 5 cases covering plain / HogQL-property / HogQL-breakdown / HogQLQuery / funnel-HogQL-aggregation.
- Full `test_query_runner.py` suite — 65 passed (the existing `QUERY_EXECUTION_TOTAL` metric tests were updated for the new label).

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). The detector walks `query.model_dump()` recursively rather than enumerating schema paths, so new HogQL-bearing fields are caught without maintenance; it fails closed (returns `false`) if `model_dump()` ever raises, so a metric-label computation can never break query execution. A companion `PostHog/charts` alert rule consuming this label is being opened separately.

Agent-authored; requires human review.