### PR TITLE
fix(phrocs): treat stopped procs as ready and cache builds

### DIFF
--- a/tools/phrocs/Makefile
+++ b/tools/phrocs/Makefile
@@ -14,8 +14,20 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS  = -ldflags '-s -w -X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildDate=$(DATE)'
 
-build: deps
-	$(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME) .
+# Track every .go file plus the module manifests so `make build` becomes a
+# no-op when nothing has changed. The Flox on-activate hook calls `make
+# build` on every shell activation; without proper dependency tracking the
+# .PHONY target would re-run `go build` from scratch each time (~3-5s per
+# shell), and downstream AMI bakes wouldn't get to reuse the cached binary.
+SOURCES := $(shell find . -type f -name '*.go' -not -path './$(DIST_DIR)/*') go.mod go.sum
+
+build: $(DIST_DIR)/$(BINARY_NAME)
+
+$(DIST_DIR)/$(BINARY_NAME): $(SOURCES) | $(DIST_DIR)
+	$(GOBUILD) $(LDFLAGS) -o $@ .
+
+$(DIST_DIR):
+	mkdir -p $@
 
 build-linux-amd64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-linux-amd64 .

--- a/tools/phrocs/subcommands.go
+++ b/tools/phrocs/subcommands.go
@@ -102,7 +102,9 @@ func runWait(timeoutSec int, asJSON bool) int {
 //
 // "done" counts as ready: a one-shot setup proc (migrations, seed scripts) that
 // exits 0 should not block `phrocs wait` forever just because it lacks a
-// `ready_pattern`. Only `crashed` is a terminal failure.
+// `ready_pattern`. "stopped" likewise counts as ready: it's the steady state
+// for procs configured `autostart: false`, which the manager intentionally
+// never launched. Only `crashed` is a terminal failure.
 func classify(procs map[string]any) (verdict string, crashed []string, notReady []string) {
 	if len(procs) == 0 {
 		return "pending", nil, nil
@@ -116,7 +118,7 @@ func classify(procs map[string]any) (verdict string, crashed []string, notReady 
 			crashed = append(crashed, name)
 			continue
 		}
-		if status == "done" {
+		if status == "done" || status == "stopped" {
 			continue
 		}
 		if !ready {

--- a/tools/phrocs/subcommands_test.go
+++ b/tools/phrocs/subcommands_test.go
@@ -256,6 +256,30 @@ func TestClassify_doneCountsAsReady(t *testing.T) {
 	}
 }
 
+// Regression: a proc configured `autostart: false` sits in status="stopped"
+// indefinitely because the manager intentionally never launches it. Treating
+// "stopped" as not-ready would cause `phrocs wait` to time out on configs
+// that mix autostart and on-demand procs (storybook, generate-demo-data,
+// migrate-flags-read-store, etc.).
+func TestClassify_stoppedCountsAsReady(t *testing.T) {
+	procs := map[string]any{
+		"storybook": map[string]any{"status": "stopped", "ready": false},
+		"web":       map[string]any{"status": "running", "ready": true},
+	}
+
+	verdict, crashed, notReady := classify(procs)
+
+	if verdict != "ready" {
+		t.Fatalf("verdict: got %q, want %q", verdict, "ready")
+	}
+	if len(crashed) != 0 {
+		t.Fatalf("crashed: got %v, want empty", crashed)
+	}
+	if len(notReady) != 0 {
+		t.Fatalf("notReady: got %v, want empty", notReady)
+	}
+}
+
 // runWait must surface an empty-config response as a distinct "no_procs"
 // verdict (exit 0) rather than spinning until the deadline and printing
 // "still not ready: " with an empty list.


### PR DESCRIPTION
## Problem

Two small phrocs annoyances surfaced while iterating on the dev environment:

1. `phrocs wait` times out on configs that mix `autostart: true` and `autostart: false` procs. The classifier treats `status="stopped"` as not-ready, but stopped is the intentional steady state for procs the manager was told never to launch (storybook, generate-demo-data, etc.). Every shell activation that ran `phrocs wait` would hang until the deadline.
2. `make build` re-links the binary from scratch on every Flox shell activation (~3-5s), because the `build` target was `.PHONY` with no prerequisite tracking.

## Changes

- `classify()` now treats `status="stopped"` as ready alongside `done`. Only `crashed` remains a terminal failure.
- `Makefile` tracks `*.go` + `go.mod`/`go.sum` as prerequisites of `$(DIST_DIR)/$(BINARY_NAME)`, so subsequent invocations are a no-op when nothing changed.

## How did you test this code?

I'm an agent. Automated coverage:

- Added `TestClassify_stoppedCountsAsReady` covering the new branch.
- Existing `TestClassify_doneCountsAsReady` and the empty-config / no_procs cases still pass.

I did not manually re-run `./bin/start` or the Flox activation hook.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) in a session iterating on phrocs reliability. The user identified both issues and the agent implemented + tested them locally. Two separate commits keep the fix and the build-speed change reviewable independently.