### PR TITLE
feat(user-interviews): templated first message via PostHog prompt management

### DIFF
--- a/frontend/src/lib/utils/router-utils.ts
+++ b/frontend/src/lib/utils/router-utils.ts
@@ -15,6 +15,7 @@ const pathsWithoutProjectId = [
     'oauth',
     'shared',
     'embedded',
+    'interview',
     'cli',
     'render_query',
 ]

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -20,7 +20,13 @@ from posthog.models.sharing_configuration import SharingConfiguration
 
 from products.user_interviews.backend.api import UserInterviewTopicSerializer
 from products.user_interviews.backend.models import IntervieweeContext, UserInterview, UserInterviewTopic
-from products.user_interviews.backend.webhooks import EMBEDDING_CONTENT_MAX_BYTES, _build_first_message
+from products.user_interviews.backend.webhooks import (
+    DEFAULT_FIRST_MESSAGE_TEMPLATE,
+    EMBEDDING_CONTENT_MAX_BYTES,
+    FIRST_MESSAGE_PROMPT_NAME,
+    _build_first_message,
+    _resolve_first_message_template,
+)
 
 
 class _FeatureFlagEnabledMixin(APIBaseTest):
@@ -328,43 +334,105 @@ class TestInterviewPublicViewer(APIBaseTest):
 class TestBuildFirstMessage(unittest.TestCase):
     @parameterized.expand(
         [
-            ("simple_name_and_topic", "Paul", "taxonomic filter search", ["Hi Paul!", "taxonomic filter search"]),
-            ("dotted_local_part", "Cory S", "session replay adoption", ["Hi Cory S!", "session replay adoption"]),
+            ("simple_name_and_topic", "Paul", "taxonomic filter search", ["Hey Paul!", "taxonomic filter search"]),
+            ("dotted_local_part", "Cory S", "session replay adoption", ["Hey Cory S!", "session replay adoption"]),
             (
                 "name_with_trailing_topic_whitespace",
                 "Kim",
                 "  feature flag rollout  ",
-                ["Hi Kim!", "feature flag rollout"],
+                ["Hey Kim!", "feature flag rollout"],
             ),
         ]
     )
     def test_includes_name_and_topic(self, _label: str, user_name: str, topic_text: str, expected_fragments: list[str]):
-        message = _build_first_message(user_name=user_name, topic_text=topic_text)
+        message = _build_first_message(DEFAULT_FIRST_MESSAGE_TEMPLATE, user_name=user_name, topic_text=topic_text)
         for fragment in expected_fragments:
             assert fragment in message
 
     @parameterized.expand([("empty", ""), ("whitespace_only", "   ")])
-    def test_drops_topic_sentence_when_topic_empty(self, _label: str, topic_text: str):
-        message = _build_first_message(user_name="Sam", topic_text=topic_text)
-        assert "Hi Sam!" in message
-        assert "Today we're talking about" not in message
+    def test_falls_back_to_generic_topic_when_topic_empty(self, _label: str, topic_text: str):
+        message = _build_first_message(DEFAULT_FIRST_MESSAGE_TEMPLATE, user_name="Sam", topic_text=topic_text)
+        assert "Hey Sam!" in message
+        assert "your experience" in message
 
     @parameterized.expand([("empty", ""), ("whitespace_only", "   ")])
     def test_falls_back_to_generic_greeting_when_user_name_empty(self, _label: str, user_name: str):
-        message = _build_first_message(user_name=user_name, topic_text="checkout funnel")
-        assert "Hi there!" in message
-        assert "Hi !" not in message
+        message = _build_first_message(
+            DEFAULT_FIRST_MESSAGE_TEMPLATE, user_name=user_name, topic_text="checkout funnel"
+        )
+        assert "Hey there!" in message
+        assert "Hey !" not in message
 
     def test_collapses_internal_whitespace_in_topic(self):
-        message = _build_first_message(user_name="Sam", topic_text="multi\nline\n\ttopic")
+        message = _build_first_message(
+            DEFAULT_FIRST_MESSAGE_TEMPLATE, user_name="Sam", topic_text="multi\nline\n\ttopic"
+        )
         assert "multi line topic" in message
         assert "\n" not in message
 
     def test_truncates_very_long_topic(self):
         long_topic = "x" * 500
-        message = _build_first_message(user_name="Sam", topic_text=long_topic)
+        message = _build_first_message(DEFAULT_FIRST_MESSAGE_TEMPLATE, user_name="Sam", topic_text=long_topic)
         assert "x" * 200 in message
         assert "x" * 201 not in message
+
+    def test_uses_custom_template_when_provided(self):
+        custom = "Hi {user_name}, today's topic: {topic_text}."
+        message = _build_first_message(custom, user_name="Paul", topic_text="onboarding")
+        assert message == "Hi Paul, today's topic: onboarding."
+
+    def test_falls_back_to_default_when_custom_template_missing_placeholder(self):
+        broken = "Hi {nonsense}, today is {missing_field}."
+        message = _build_first_message(broken, user_name="Paul", topic_text="onboarding")
+        assert "Hey Paul!" in message
+        assert "onboarding" in message
+
+    def test_falls_back_to_default_when_template_attribute_missing(self):
+        broken = "Hi {user_name.really_missing_attr}!"
+        message = _build_first_message(broken, user_name="Paul", topic_text="onboarding")
+        assert "Hey Paul!" in message
+        assert "onboarding" in message
+
+    def test_falls_back_to_default_when_rendered_message_exceeds_cap(self):
+        huge = "Hi {user_name:>2000}!"
+        message = _build_first_message(huge, user_name="Paul", topic_text="onboarding")
+        assert "Hey Paul!" in message
+        assert "onboarding" in message
+        assert len(message) <= 1000
+
+
+class TestResolveFirstMessageTemplate(APIBaseTest):
+    def test_returns_default_when_no_prompt_configured(self):
+        template = _resolve_first_message_template(self.team)
+        assert template == DEFAULT_FIRST_MESSAGE_TEMPLATE
+
+    def test_returns_team_override_when_prompt_published(self):
+        from posthog.models.llm_prompt import LLMPrompt
+
+        LLMPrompt.objects.create(
+            team=self.team,
+            name=FIRST_MESSAGE_PROMPT_NAME,
+            prompt="Hey {user_name}! Quick chat about {topic_text}?",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        template = _resolve_first_message_template(self.team)
+        assert template == "Hey {user_name}! Quick chat about {topic_text}?"
+
+    def test_returns_default_when_published_prompt_is_empty(self):
+        from posthog.models.llm_prompt import LLMPrompt
+
+        LLMPrompt.objects.create(
+            team=self.team,
+            name=FIRST_MESSAGE_PROMPT_NAME,
+            prompt="   ",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        template = _resolve_first_message_template(self.team)
+        assert template == DEFAULT_FIRST_MESSAGE_TEMPLATE
 
 
 class TestInterviewStartCall(APIBaseTest):
@@ -409,7 +477,7 @@ class TestInterviewStartCall(APIBaseTest):
         response = self.client.post(f"/api/user_interviews/share/{share.access_token}/start_call/")
         assert response.status_code == status.HTTP_200_OK, response.content
         first_message = response.json()["assistant_overrides"]["firstMessage"]
-        assert "Hi Alex!" in first_message
+        assert "Hey Alex!" in first_message
         assert "Replay adoption" in first_message
 
     @override_settings(VAPI_PUBLIC_KEY="pk_test", VAPI_ASSISTANT_ID="asst_test")

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -400,6 +400,10 @@ class TestBuildFirstMessage(unittest.TestCase):
         assert "onboarding" in message
         assert len(message) <= 1000
 
+    def test_return_value_is_always_bounded_even_with_long_user_name(self):
+        message = _build_first_message(DEFAULT_FIRST_MESSAGE_TEMPLATE, user_name="x" * 5000, topic_text="onboarding")
+        assert len(message) <= 1000
+
 
 class TestResolveFirstMessageTemplate(APIBaseTest):
     def test_returns_default_when_no_prompt_configured(self):

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -377,24 +377,26 @@ class TestBuildFirstMessage(unittest.TestCase):
         assert "x" * 201 not in message
 
     def test_uses_custom_template_when_provided(self):
-        custom = "Hi {user_name}, today's topic: {topic_text}."
+        custom = "Hi $user_name, today's topic: $topic_text."
         message = _build_first_message(custom, user_name="Paul", topic_text="onboarding")
         assert message == "Hi Paul, today's topic: onboarding."
 
     def test_falls_back_to_default_when_custom_template_missing_placeholder(self):
-        broken = "Hi {nonsense}, today is {missing_field}."
+        broken = "Hi $nonsense, today is $missing_field."
         message = _build_first_message(broken, user_name="Paul", topic_text="onboarding")
         assert "Hey Paul!" in message
         assert "onboarding" in message
 
-    def test_falls_back_to_default_when_template_attribute_missing(self):
-        broken = "Hi {user_name.really_missing_attr}!"
-        message = _build_first_message(broken, user_name="Paul", topic_text="onboarding")
-        assert "Hey Paul!" in message
-        assert "onboarding" in message
+    def test_format_spec_in_template_is_treated_as_literal_text(self):
+        # string.Template has no format-spec syntax, so an attacker cannot use
+        # `{user_name:>10000000000}` to allocate gigabytes — `:` is just a character.
+        attempted = "Hi $user_name, padded: {user_name:>10000000000}"
+        message = _build_first_message(attempted, user_name="Paul", topic_text="onboarding")
+        assert "Hi Paul" in message
+        assert len(message) <= 1000
 
     def test_falls_back_to_default_when_rendered_message_exceeds_cap(self):
-        huge = "Hi {user_name:>2000}!"
+        huge = "Hi $user_name! " + ("x" * 2000)
         message = _build_first_message(huge, user_name="Paul", topic_text="onboarding")
         assert "Hey Paul!" in message
         assert "onboarding" in message
@@ -416,13 +418,13 @@ class TestResolveFirstMessageTemplate(APIBaseTest):
         LLMPrompt.objects.create(
             team=self.team,
             name=FIRST_MESSAGE_PROMPT_NAME,
-            prompt="Hey {user_name}! Quick chat about {topic_text}?",
+            prompt="Hey $user_name! Quick chat about $topic_text?",
             version=1,
             is_latest=True,
             created_by=self.user,
         )
         template = _resolve_first_message_template(self.team)
-        assert template == "Hey {user_name}! Quick chat about {topic_text}?"
+        assert template == "Hey $user_name! Quick chat about $topic_text?"
 
     def test_returns_default_when_published_prompt_is_empty(self):
         from posthog.models.llm_prompt import LLMPrompt

--- a/products/user_interviews/backend/webhooks.py
+++ b/products/user_interviews/backend/webhooks.py
@@ -11,6 +11,7 @@ Two surfaces live here, both keyed on a SharingConfiguration access token:
 
 import hmac
 import json
+import string
 import hashlib
 from typing import Any
 
@@ -136,8 +137,8 @@ _TOPIC_MAX_CHARS = 200
 FIRST_MESSAGE_PROMPT_NAME = "user_interviews_vapi_first_message"
 
 DEFAULT_FIRST_MESSAGE_TEMPLATE = (
-    "Hey {user_name}! Thanks for making time — I know you're busy. "
-    "I'm here to learn how you actually use {topic_text} in the wild. "
+    "Hey $user_name! Thanks for making time — I know you're busy. "
+    "I'm here to learn how you actually use $topic_text in the wild. "
     "Mind if I ask a few questions? Should take about 5-10 minutes."
 )
 
@@ -175,14 +176,16 @@ def _build_first_message(
     name_part = user_name.strip() or "there"
     topic_part = _normalise_topic(topic_text) or "your experience"
     try:
-        rendered = template.format(user_name=name_part, topic_text=topic_part)
-    except (KeyError, IndexError, ValueError, AttributeError):
+        rendered = string.Template(template).substitute(user_name=name_part, topic_text=topic_part)
+    except (KeyError, ValueError):
         logger.warning(
             "user_interviews_first_message_template_invalid",
             team_id=team_id,
             template_prefix=template[:60],
         )
-        rendered = DEFAULT_FIRST_MESSAGE_TEMPLATE.format(user_name=name_part, topic_text=topic_part)
+        rendered = string.Template(DEFAULT_FIRST_MESSAGE_TEMPLATE).substitute(
+            user_name=name_part, topic_text=topic_part
+        )
     if len(rendered) > _FIRST_MESSAGE_MAX_CHARS:
         logger.warning(
             "user_interviews_first_message_too_long",
@@ -190,7 +193,9 @@ def _build_first_message(
             rendered_chars=len(rendered),
             limit=_FIRST_MESSAGE_MAX_CHARS,
         )
-        rendered = DEFAULT_FIRST_MESSAGE_TEMPLATE.format(user_name=name_part, topic_text=topic_part)
+        rendered = string.Template(DEFAULT_FIRST_MESSAGE_TEMPLATE).substitute(
+            user_name=name_part, topic_text=topic_part
+        )
     return rendered[:_FIRST_MESSAGE_MAX_CHARS]
 
 

--- a/products/user_interviews/backend/webhooks.py
+++ b/products/user_interviews/backend/webhooks.py
@@ -31,6 +31,8 @@ from posthog.schema import EmbeddingModelName
 from posthog.api.embedding_worker import emit_embedding_request
 from posthog.constants import AvailableFeature
 from posthog.models.sharing_configuration import SharingConfiguration
+from posthog.models.team import Team
+from posthog.storage.llm_prompt_cache import get_prompt_by_name_from_cache
 
 from .models import UserInterview, UserInterviewTopic
 
@@ -131,20 +133,65 @@ def _public_sharing_disabled_for_org(sharing_config: SharingConfiguration) -> bo
 
 _TOPIC_MAX_CHARS = 200
 
+FIRST_MESSAGE_PROMPT_NAME = "user_interviews_vapi_first_message"
+
+DEFAULT_FIRST_MESSAGE_TEMPLATE = (
+    "Hey {user_name}! Thanks for making time — I know you're busy. "
+    "I'm here to learn how you actually use {topic_text} in the wild. "
+    "Mind if I ask a few questions? Should take about 5-10 minutes."
+)
+
+_FIRST_MESSAGE_MAX_CHARS = 1000
+
 
 def _normalise_topic(topic_text: str) -> str:
     return " ".join(topic_text.split())[:_TOPIC_MAX_CHARS]
 
 
-def _build_first_message(*, user_name: str, topic_text: str) -> str:
-    name_part = f"Hi {user_name.strip()}!" if user_name.strip() else "Hi there!"
-    greeting = f"{name_part} Thanks for joining."
-    topic_normalised = _normalise_topic(topic_text)
-    if topic_normalised:
-        return (
-            f"{greeting} Today we're talking about {topic_normalised}. I'd love your perspective. Ready when you are."
+def _resolve_first_message_template(team: Team) -> str:
+    try:
+        cached = get_prompt_by_name_from_cache(team, FIRST_MESSAGE_PROMPT_NAME)
+    except Exception as err:
+        logger.warning(
+            "user_interviews_first_message_prompt_lookup_failed",
+            team_id=team.id,
+            error=str(err),
         )
-    return f"{greeting} I'd love your perspective. Ready when you are."
+        return DEFAULT_FIRST_MESSAGE_TEMPLATE
+    if cached is not None:
+        template = cached.get("prompt")
+        if isinstance(template, str) and template.strip():
+            return template
+    return DEFAULT_FIRST_MESSAGE_TEMPLATE
+
+
+def _build_first_message(
+    template: str,
+    *,
+    user_name: str,
+    topic_text: str,
+    team_id: int | None = None,
+) -> str:
+    name_part = user_name.strip() or "there"
+    topic_part = _normalise_topic(topic_text) or "your experience"
+    try:
+        rendered = template.format(user_name=name_part, topic_text=topic_part)
+    except (KeyError, IndexError, ValueError, AttributeError):
+        logger.warning(
+            "user_interviews_first_message_template_invalid",
+            team_id=team_id,
+            template_prefix=template[:60],
+        )
+        rendered = DEFAULT_FIRST_MESSAGE_TEMPLATE.format(user_name=name_part, topic_text=topic_part)
+    if len(rendered) > _FIRST_MESSAGE_MAX_CHARS:
+        logger.warning(
+            "user_interviews_first_message_too_long",
+            team_id=team_id,
+            rendered_chars=len(rendered),
+            limit=_FIRST_MESSAGE_MAX_CHARS,
+        )
+        return DEFAULT_FIRST_MESSAGE_TEMPLATE.format(user_name=name_part, topic_text=topic_part)
+    return rendered
 
 
 @api_view(["POST"])
@@ -182,7 +229,13 @@ def start_call(request: Request, access_token: str) -> Response:
     topic = ic.topic
     user_name, _ = _parse_identifier(ic.interviewee_identifier)
     agent_context = _merge_agent_context(topic.agent_context or "", ic.agent_context or "")
-    first_message = _build_first_message(user_name=user_name, topic_text=topic.topic or "")
+    first_message_template = _resolve_first_message_template(sharing_config.team)
+    first_message = _build_first_message(
+        first_message_template,
+        user_name=user_name,
+        topic_text=topic.topic or "",
+        team_id=sharing_config.team_id,
+    )
 
     return Response(
         {

--- a/products/user_interviews/backend/webhooks.py
+++ b/products/user_interviews/backend/webhooks.py
@@ -190,8 +190,8 @@ def _build_first_message(
             rendered_chars=len(rendered),
             limit=_FIRST_MESSAGE_MAX_CHARS,
         )
-        return DEFAULT_FIRST_MESSAGE_TEMPLATE.format(user_name=name_part, topic_text=topic_part)
-    return rendered
+        rendered = DEFAULT_FIRST_MESSAGE_TEMPLATE.format(user_name=name_part, topic_text=topic_part)
+    return rendered[:_FIRST_MESSAGE_MAX_CHARS]
 
 
 @api_view(["POST"])


### PR DESCRIPTION
(also fixes front end routing bug)

## Problem

The Vapi-dashboard-configured intro and the code-generated `firstMessage` were drifting. Dashboard reads:

> Hey Cory! Thanks for making time — I know you're busy. I'm here to learn how you actually use Session Replay's Session Summaries in the wild. Mind if I ask a few questions? Should take about 5-10 minutes.

Our code generated a more clinical "Hi {name}! Today we're talking about {topic}." version. And every prompt tweak meant a code deploy.

## Changes

1. **Style match.** `DEFAULT_FIRST_MESSAGE_TEMPLATE` now matches the dashboard's tone, parameterised on `{user_name}` and `{topic_text}`. A single template covers all branches — empty `user_name` falls back to `"there"`, empty topic falls back to `"your experience"`.

2. **Per-team override via PostHog prompt management.** `_resolve_first_message_template(team_id)` reads from `get_prompt_by_name_from_cache(team, "user_interviews_vapi_first_message")`. If a team has published a prompt by that name (via the LLM prompt management API), it wins; otherwise the code default applies. Future copy tweaks don't need a deploy.

3. **Pure builder.** `_build_first_message(template, *, user_name, topic_text)` is now a pure function — easier to unit-test, easier to swap templates. Falls back to the default if a published template's placeholders don't substitute.

Same `_normalise_topic` (collapse internal whitespace + 200-char cap) still applies.

## How did you test this code?

I'm an agent (PostHog Code). `pnpm --filter=@posthog/frontend typescript:check` doesn't apply (Python only).

Tests:
- All five existing `_build_first_message` parameterised cases updated for the new template wording (`"Hey Paul!"` instead of `"Hi Paul!"`, `"your experience"` fallback for empty topic).
- Two new cases: custom template substitution, broken-template fallback.
- Two new `TestResolveFirstMessageTemplate` DB cases: no prompt → default, published prompt → override.
- HTTP `test_returns_personalised_first_message` updated to assert `"Hey Alex!"`.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- New constant exports from `webhooks.py`: `DEFAULT_FIRST_MESSAGE_TEMPLATE`, `FIRST_MESSAGE_PROMPT_NAME`, `_resolve_first_message_template`. Tests import them; nothing else does.
- Uses `posthog.storage.llm_prompt_cache.get_prompt_by_name_from_cache` which is the cached read path (Hypercache + DB fallback) used by the rest of PostHog's prompt management.
- This file currently lives outside isolation (no `backend:contract-check`); the imports from `posthog.*` go through standard model/cache paths, no facade needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*