### PR TITLE
fix(user-interviews): authenticate Vapi webhook via X-Vapi-Secret

### DIFF
--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -609,26 +609,25 @@ class TestVapiWebhook(APIBaseTest):
         response = self._signed_post("topsecret", self._end_of_call_payload("does-not-exist"))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    @parameterized.expand(
+        [
+            ("wrong_secret", "wrong"),
+            ("empty_secret", ""),
+            ("missing_header", None),
+        ]
+    )
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    def test_webhook_requires_valid_secret(self):
+    def test_webhook_rejects_bad_or_missing_secret(self, _label: str, header_value: str | None):
         share = self._create_share()
         self.client.logout()
+        extra: dict[str, str] = {}
+        if header_value is not None:
+            extra["HTTP_X_VAPI_SECRET"] = header_value
         response = self.client.post(
             "/api/user_interviews/vapi_webhook/",
             data=json.dumps(self._end_of_call_payload(share.access_token)),
             content_type="application/json",
-            HTTP_X_VAPI_SECRET="wrong",
-        )
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-    @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    def test_webhook_requires_secret_header(self):
-        share = self._create_share()
-        self.client.logout()
-        response = self.client.post(
-            "/api/user_interviews/vapi_webhook/",
-            data=json.dumps(self._end_of_call_payload(share.access_token)),
-            content_type="application/json",
+            **extra,
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -1,6 +1,4 @@
-import hmac
 import json
-import hashlib
 import datetime
 from typing import Any
 
@@ -573,13 +571,11 @@ class TestVapiWebhook(APIBaseTest):
         }
 
     def _signed_post(self, secret: str, payload: dict) -> Any:
-        body = json.dumps(payload)
-        signature = hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
         return self.client.post(
             "/api/user_interviews/vapi_webhook/",
-            data=body,
+            data=json.dumps(payload),
             content_type="application/json",
-            HTTP_X_VAPI_SIGNATURE=signature,
+            HTTP_X_VAPI_SECRET=secret,
         )
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
@@ -614,14 +610,25 @@ class TestVapiWebhook(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    def test_webhook_requires_valid_signature(self):
+    def test_webhook_requires_valid_secret(self):
         share = self._create_share()
         self.client.logout()
         response = self.client.post(
             "/api/user_interviews/vapi_webhook/",
-            data=self._end_of_call_payload(share.access_token),
+            data=json.dumps(self._end_of_call_payload(share.access_token)),
             content_type="application/json",
-            HTTP_X_VAPI_SIGNATURE="wrong",
+            HTTP_X_VAPI_SECRET="wrong",
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
+    def test_webhook_requires_secret_header(self):
+        share = self._create_share()
+        self.client.logout()
+        response = self.client.post(
+            "/api/user_interviews/vapi_webhook/",
+            data=json.dumps(self._end_of_call_payload(share.access_token)),
+            content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -620,15 +620,14 @@ class TestVapiWebhook(APIBaseTest):
     def test_webhook_rejects_bad_or_missing_secret(self, _label: str, header_value: str | None):
         share = self._create_share()
         self.client.logout()
-        extra: dict[str, str] = {}
-        if header_value is not None:
-            extra["HTTP_X_VAPI_SECRET"] = header_value
-        response = self.client.post(
-            "/api/user_interviews/vapi_webhook/",
-            data=json.dumps(self._end_of_call_payload(share.access_token)),
-            content_type="application/json",
-            **extra,
-        )
+        body = json.dumps(self._end_of_call_payload(share.access_token))
+        url = "/api/user_interviews/vapi_webhook/"
+        if header_value is None:
+            response = self.client.post(url, data=body, content_type="application/json")
+        else:
+            response = self.client.post(
+                url, data=body, content_type="application/json", HTTP_X_VAPI_SECRET=header_value
+            )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")

--- a/products/user_interviews/backend/webhooks.py
+++ b/products/user_interviews/backend/webhooks.py
@@ -12,7 +12,6 @@ Two surfaces live here, both keyed on a SharingConfiguration access token:
 import hmac
 import json
 import string
-import hashlib
 from typing import Any
 
 from django.conf import settings
@@ -92,11 +91,12 @@ def _emit_interview_embeddings(interview: UserInterview, topic: UserInterviewTop
             )
 
 
-def _verify_signature(secret: str, raw_body: bytes, provided_signature: str | None) -> bool:
-    if not secret or not provided_signature:
+def _verify_secret(expected_secret: str, provided_secret: str | None) -> bool:
+    """Vapi sends the configured webhook secret verbatim in ``X-Vapi-Secret`` —
+    constant-time compare it against ``VAPI_WEBHOOK_SECRET`` to authenticate."""
+    if not expected_secret or not provided_secret:
         return False
-    expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(provided_signature, expected)
+    return hmac.compare_digest(provided_secret, expected_secret)
 
 
 def _resolve_share(access_token: str) -> SharingConfiguration | None:
@@ -286,7 +286,9 @@ def vapi_webhook(request: Request) -> Response:
 
     Fail-closed: if ``VAPI_WEBHOOK_SECRET`` is not configured we refuse to accept any
     request — treating an unconfigured deployment as inert rather than insecure.
-    With the secret set, the request body is HMAC-SHA256 verified.
+    With the secret set, the ``X-Vapi-Secret`` header is constant-time compared
+    against it (Vapi's documented webhook auth — the configured token is sent
+    verbatim in that header).
 
     Idempotent: Vapi retries on 5xx and transient errors, so we de-duplicate by
     ``call.id`` (stored in ``call_metadata.id``). A repeat delivery returns the
@@ -298,19 +300,19 @@ def vapi_webhook(request: Request) -> Response:
             {"error": "Vapi webhook secret is not configured on this PostHog instance."},
             status=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
-    provided = request.headers.get("x-vapi-signature") or request.headers.get("X-Vapi-Signature")
+    provided = request.headers.get("X-Vapi-Secret")
     logger.info(
         "user_interviews_vapi_webhook_received",
         header_keys=sorted(request.headers.keys()),
-        has_provided_signature=bool(provided),
+        has_provided_secret=bool(provided),
         body_bytes=len(request.body),
     )
-    if not _verify_signature(settings.VAPI_WEBHOOK_SECRET, request.body, provided):
+    if not _verify_secret(settings.VAPI_WEBHOOK_SECRET, provided):
         logger.warning(
-            "user_interviews_vapi_webhook_signature_failed",
-            has_provided_signature=bool(provided),
+            "user_interviews_vapi_webhook_auth_failed",
+            has_provided_secret=bool(provided),
         )
-        return Response({"error": "invalid signature"}, status=status.HTTP_401_UNAUTHORIZED)
+        return Response({"error": "invalid secret"}, status=status.HTTP_401_UNAUTHORIZED)
 
     payload = request.data if isinstance(request.data, dict) else {}
     message: dict[str, Any] = payload.get("message", {})


### PR DESCRIPTION
## Problem

Vapi webhook auth was rejecting 100% of real deliveries — 29 received, 29 signature_failed, 0 stored in a 6-hour window. The previous implementation HMAC-SHA256'd the request body and compared against an `X-Vapi-Signature` header, but [Vapi's documented webhook auth](https://docs.vapi.ai/server-url/server-authentication) sends the configured secret verbatim in `X-Vapi-Secret`. Transcripts and summaries from completed interviews were never being persisted.

## Changes

Switched `vapi_webhook` authentication from "HMAC-SHA256 over body, compared against `X-Vapi-Signature`" to "constant-time compare of `X-Vapi-Secret` against `VAPI_WEBHOOK_SECRET`", matching Vapi's actual scheme.

Fail-closed semantics preserved: if `VAPI_WEBHOOK_SECRET` isn't configured we still return 503. The constant-time compare uses `hmac.compare_digest` to keep timing-side-channel resistance. A `user_interviews_vapi_webhook_auth_failed` warning is emitted on 401 so the next misconfiguration is observable before it's every delivery again.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — no manual verification of live Vapi traffic.

- New parameterized test `test_webhook_rejects_bad_or_missing_secret` covering wrong / empty / missing `X-Vapi-Secret` headers (3 cases).
- Existing `test_webhook_creates_user_interview`, `test_webhook_rejects_unknown_token`, `test_webhook_ignores_non_end_of_call_events`, `test_webhook_is_idempotent_on_call_id` updated to the new auth scheme; all 17 `TestVapiWebhook` cases pass locally.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

PostHog Code session diagnosed the 100% rejection rate via the PostHog MCP `query-logs` / `logs-count` tools: 29 `user_interviews_vapi_webhook_received` events, 29 `user_interviews_vapi_webhook_signature_failed` events, 0 stored interviews in the last 6 hours. Header inspection on a received delivery showed `X-Vapi-Secret` and `X-Vapi-Signature` both present; Vapi docs confirmed `X-Vapi-Secret` is the supported scheme (HMAC is a legacy credential type with no documented body-signing algorithm).

Considered alternatives: (a) implementing HMAC for `X-Vapi-Signature` — rejected, scheme isn't documented and the secret-in-header path is what Vapi actually uses; (b) accepting either header — rejected, accepting an unauthenticated scheme alongside the authenticated one adds attack surface for no gain.

QA-swarm flagged a redundant case-variant header lookup, a stale `"invalid signature"` error string, and the two new auth-failure tests being parameterizable; all applied in `6dc2f78526d`. One deployment-hygiene item deferred: with the secret now in a header rather than HMAC over the body, anything that captures inbound headers (Sentry, ingress access logs, error trackers) becomes a leakage vector for `VAPI_WEBHOOK_SECRET`. Worth confirming redaction before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*