### PR TITLE
feat(alerts): add HogQL support to insight alerts

### DIFF
--- a/frontend/src/lib/components/Alerts/AlertsButton.tsx
+++ b/frontend/src/lib/components/Alerts/AlertsButton.tsx
@@ -4,9 +4,12 @@ import { router } from 'kea-router'
 import { IconBell } from '@posthog/icons'
 import { LemonButton, LemonButtonProps } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { IconWithCount } from 'lib/lemon-ui/icons'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
+import { isHogQLBackedQuery } from '~/queries/utils'
 import { InsightLogicProps, QueryBasedInsightModel } from '~/types'
 
 import { areAlertsSupportedForInsight, insightAlertsLogic } from './insightAlertsLogic'
@@ -21,16 +24,21 @@ export function AlertsButton({ insight, insightLogicProps, text, ...props }: Ale
     const { push } = useActions(router)
     const logic = insightAlertsLogic({ insightId: insight.id!, insightLogicProps })
     const { alerts } = useValues(logic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const hogqlAlertsEnabled = !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHT_ALERTS]
+
+    const supported = areAlertsSupportedForInsight(insight.query, { hogqlAlertsEnabled })
+    const disabledReason = supported
+        ? undefined
+        : isHogQLBackedQuery(insight.query)
+          ? 'SQL insight alerts are not enabled for your account.'
+          : 'Alerts are only available for trends and SQL insights. Change the insight representation to add alerts.'
 
     return (
         <LemonButton
             data-attr="manage-alerts-button"
             onClick={() => push(urls.insightAlerts(insight.short_id!))}
-            disabledReason={
-                !areAlertsSupportedForInsight(insight.query)
-                    ? 'Alerts are only available for trends. Change the insight representation to add alerts.'
-                    : undefined
-            }
+            disabledReason={disabledReason}
             {...props}
             icon={
                 <IconWithCount count={alerts?.length} showZero={false}>

--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -203,10 +203,11 @@ export const alertFormLogic = kea<alertFormLogicType>([
                     if (!detectorConfig || !props.insightId) {
                         return null
                     }
+                    const formConfig = values.alertForm.config
                     return await api.alerts.simulate({
                         insight: props.insightId,
                         detector_config: detectorConfig,
-                        series_index: values.alertForm.config?.series_index ?? 0,
+                        series_index: isTrendsAlertConfig(formConfig) ? formConfig.series_index : 0,
                         date_from:
                             values.simulationDateFrom ??
                             getDefaultSimulationRange(values.alertForm.calculation_interval),
@@ -449,7 +450,8 @@ export const alertFormLogic = kea<alertFormLogicType>([
                         }))
                     )
                 } else {
-                    const seriesIndex = values.alertForm.config?.series_index ?? 0
+                    const formConfig = values.alertForm.config
+                    const seriesIndex = isTrendsAlertConfig(formConfig) ? formConfig.series_index : 0
                     anomalyPoints = simulationResult.triggered_indices.map((idx) => ({
                         index: idx,
                         date: simulationResult.dates[idx] ?? '',

--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -21,7 +21,14 @@ import { alertLogic } from './alertLogic'
 import { alertNotificationLogic } from './alertNotificationLogic'
 import { insightAlertsLogic } from './insightAlertsLogic'
 import { quietHoursFormError } from './scheduleRestrictionValidation'
-import { AlertSimulationResult, AlertType, AlertTypeWrite, AnomalyPoint } from './types'
+import {
+    AlertConfig,
+    AlertSimulationResult,
+    AlertType,
+    AlertTypeWrite,
+    AnomalyPoint,
+    isTrendsAlertConfig,
+} from './types'
 
 export type AlertFormType = Pick<
     AlertType,
@@ -77,6 +84,19 @@ export interface AlertFormLogicProps {
     insightInterval?: IntervalType
     /** Must match the `alertLogic` instance keyed on the same alertId — read from `useFeatureFlag('ALERTS_HISTORY_CHART')` in the parent. */
     historyChartEnabled: boolean
+    /** When true, new alerts default to HogQLAlertConfig instead of TrendsAlertConfig. */
+    isHogQLBackedInsight?: boolean
+}
+
+const defaultConfigForInsight = (isHogQLBacked: boolean): AlertConfig => {
+    if (isHogQLBacked) {
+        return { type: 'HogQLAlertConfig' }
+    }
+    return {
+        type: 'TrendsAlertConfig',
+        series_index: 0,
+        check_ongoing_interval: false,
+    }
 }
 
 /**
@@ -207,11 +227,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                     created_by: null,
                     created_at: '',
                     enabled: true,
-                    config: {
-                        type: 'TrendsAlertConfig',
-                        series_index: 0,
-                        check_ongoing_interval: false,
-                    },
+                    config: defaultConfigForInsight(!!props.isHogQLBackedInsight),
                     threshold: {
                         configuration: {
                             type: InsightThresholdType.ABSOLUTE,
@@ -247,11 +263,14 @@ export const alertFormLogic = kea<alertFormLogicType>([
                         (alert.calculation_interval === AlertCalculationInterval.DAILY ||
                             alert.calculation_interval === AlertCalculationInterval.HOURLY) &&
                         alert.skip_weekend,
-                    // can only check ongoing interval for absolute value/increase alerts with upper threshold
-                    config: {
-                        ...alert.config,
-                        check_ongoing_interval: canCheckOngoingInterval(alert) && alert.config.check_ongoing_interval,
-                    },
+                    // only TrendsAlertConfig has check_ongoing_interval; HogQLAlertConfig passes through unchanged.
+                    config: isTrendsAlertConfig(alert.config)
+                        ? {
+                              ...alert.config,
+                              check_ongoing_interval:
+                                  canCheckOngoingInterval(alert) && alert.config.check_ongoing_interval,
+                          }
+                        : alert.config,
                     detector_config: alert.detector_config ?? null,
                     // Investigation agent only applies to anomaly (detector-based) alerts — force off otherwise.
                     investigation_agent_enabled: alert.detector_config

--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -263,7 +263,6 @@ export const alertFormLogic = kea<alertFormLogicType>([
                         (alert.calculation_interval === AlertCalculationInterval.DAILY ||
                             alert.calculation_interval === AlertCalculationInterval.HOURLY) &&
                         alert.skip_weekend,
-                    // only TrendsAlertConfig has check_ongoing_interval; HogQLAlertConfig passes through unchanged.
                     config: isTrendsAlertConfig(alert.config)
                         ? {
                               ...alert.config,

--- a/frontend/src/lib/components/Alerts/alertSchedulingStale.ts
+++ b/frontend/src/lib/components/Alerts/alertSchedulingStale.ts
@@ -18,7 +18,8 @@ export type SchedulingSnapshot = {
     calculation_interval: AlertCalculationInterval
     schedule_restriction?: ScheduleRestriction | null
     skip_weekend?: boolean | null
-    config?: { check_ongoing_interval?: boolean } | null
+    // Trends-style config provides check_ongoing_interval; HogQL config carries no scheduling-relevant field.
+    config?: { type?: string; check_ongoing_interval?: boolean } | null
 }
 
 export function isNextPlannedEvaluationStale(

--- a/frontend/src/lib/components/Alerts/insightAlertsLogic.ts
+++ b/frontend/src/lib/components/Alerts/insightAlertsLogic.ts
@@ -2,11 +2,13 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { AlertConditionType, BreakdownFilter, GoalLine, InsightThresholdType } from '~/queries/schema/schema-general'
-import { isInsightVizNode, isTrendsQuery, hasBreakdownFilter } from '~/queries/utils'
+import { hasBreakdownFilter, isHogQLBackedQuery, isInsightVizNode, isTrendsQuery } from '~/queries/utils'
 import { InsightLogicProps } from '~/types'
 
 import type { insightAlertsLogicType } from './insightAlertsLogicType'
@@ -23,8 +25,17 @@ export interface InsightAlertsLogicProps {
     deferInitialAlertsLoad?: boolean
 }
 
-export const areAlertsSupportedForInsight = (query?: Record<string, any> | null): boolean => {
-    return !!query && isInsightVizNode(query) && isTrendsQuery(query.source) && query.source.trendsFilter !== null
+export const areAlertsSupportedForInsight = (
+    query?: Record<string, any> | null,
+    options: { hogqlAlertsEnabled?: boolean } = {}
+): boolean => {
+    if (!query) {
+        return false
+    }
+    if (isInsightVizNode(query) && isTrendsQuery(query.source) && query.source.trendsFilter !== null) {
+        return true
+    }
+    return !!options.hogqlAlertsEnabled && isHogQLBackedQuery(query)
 }
 
 export const insightAlertsLogic = kea<insightAlertsLogicType>([
@@ -47,6 +58,8 @@ export const insightAlertsLogic = kea<insightAlertsLogicType>([
             ['showAlertThresholdLines', 'breakdownFilter'],
             insightLogic(props.insightLogicProps),
             ['insight'],
+            featureFlagLogic,
+            ['featureFlags'],
         ],
     })),
 
@@ -204,7 +217,8 @@ export const insightAlertsLogic = kea<insightAlertsLogicType>([
 
     listeners(({ actions, values }) => ({
         setQuery: ({ query }) => {
-            if (values.alerts.length === 0 || areAlertsSupportedForInsight(query)) {
+            const hogqlAlertsEnabled = !!values.featureFlags[FEATURE_FLAGS.HOGQL_INSIGHT_ALERTS]
+            if (values.alerts.length === 0 || areAlertsSupportedForInsight(query, { hogqlAlertsEnabled })) {
                 actions.setShouldShowAlertDeletionWarning(false)
             } else {
                 actions.setShouldShowAlertDeletionWarning(true)

--- a/frontend/src/lib/components/Alerts/insightAlertsLogic.ts
+++ b/frontend/src/lib/components/Alerts/insightAlertsLogic.ts
@@ -12,7 +12,7 @@ import { hasBreakdownFilter, isHogQLBackedQuery, isInsightVizNode, isTrendsQuery
 import { InsightLogicProps } from '~/types'
 
 import type { insightAlertsLogicType } from './insightAlertsLogicType'
-import { AlertType, AnomalyPoint } from './types'
+import { AlertType, AnomalyPoint, isTrendsAlertConfig } from './types'
 
 export interface InsightAlertsLogicProps {
     insightId: number
@@ -178,7 +178,7 @@ export const insightAlertsLogic = kea<insightAlertsLogicType>([
                     if (!alert.detector_config || !alert.checks?.length) {
                         return []
                     }
-                    const defaultSeriesIndex = alert.config?.series_index ?? 0
+                    const defaultSeriesIndex = isTrendsAlertConfig(alert.config) ? alert.config.series_index : 0
                     return alert.checks.flatMap((check) => {
                         if (!check.triggered_dates?.length) {
                             return []

--- a/frontend/src/lib/components/Alerts/types.ts
+++ b/frontend/src/lib/components/Alerts/types.ts
@@ -5,12 +5,19 @@ import {
     AlertScheduleRestrictionWindow,
     AlertState,
     DetectorConfig,
+    HogQLAlertConfig,
     InsightThreshold,
     TrendsAlertConfig,
 } from '~/queries/schema/schema-general'
 import { QueryBasedInsightModel, UserBasicType } from '~/types'
 
-export type AlertConfig = TrendsAlertConfig
+export type AlertConfig = TrendsAlertConfig | HogQLAlertConfig
+
+export const isTrendsAlertConfig = (config: AlertConfig): config is TrendsAlertConfig =>
+    config.type === 'TrendsAlertConfig'
+
+export const isHogQLAlertConfig = (config: AlertConfig): config is HogQLAlertConfig =>
+    config.type === 'HogQLAlertConfig'
 
 export type BlockedWindow = AlertScheduleRestrictionWindow
 

--- a/frontend/src/lib/components/Alerts/types.ts
+++ b/frontend/src/lib/components/Alerts/types.ts
@@ -13,11 +13,11 @@ import { QueryBasedInsightModel, UserBasicType } from '~/types'
 
 export type AlertConfig = TrendsAlertConfig | HogQLAlertConfig
 
-export const isTrendsAlertConfig = (config: AlertConfig): config is TrendsAlertConfig =>
-    config.type === 'TrendsAlertConfig'
+export const isTrendsAlertConfig = (config: AlertConfig | null | undefined): config is TrendsAlertConfig =>
+    config?.type === 'TrendsAlertConfig'
 
-export const isHogQLAlertConfig = (config: AlertConfig): config is HogQLAlertConfig =>
-    config.type === 'HogQLAlertConfig'
+export const isHogQLAlertConfig = (config: AlertConfig | null | undefined): config is HogQLAlertConfig =>
+    config?.type === 'HogQLAlertConfig'
 
 export type BlockedWindow = AlertScheduleRestrictionWindow
 

--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -121,11 +121,12 @@ export function EditAlertModal({
     const _alertLogic = alertLogic({ alertId, historyChartEnabled: alertsHistoryChartEnabled })
     const { alert, alertLoading } = useValues(_alertLogic)
 
-    // For new alerts, fall back to the bound insightLogic to read the query kind. doNotLoad keeps this from
-    // triggering a second fetch when our key differs from the caller's instance.
-    const boundInsight = useValues(
-        insightLogic(insightLogicProps ?? { dashboardItemId: insightShortId, doNotLoad: true })
-    ).insight
+    // For new alerts the insight isn't yet on the alert payload, so read it from the same insightLogic
+    // the caller is using. The kea key only depends on dashboardItemId/dashboardId — falling back to
+    // { dashboardItemId: insightShortId } reuses the existing instance when present rather than mounting a
+    // second one.
+    const boundInsightLogicProps = insightLogicProps ?? { dashboardItemId: insightShortId }
+    const boundInsight = useValues(insightLogic(boundInsightLogicProps)).insight
     const insightQuery = alert?.insight?.query ?? boundInsight?.query ?? null
     const isHogQLBackedInsight = isHogQLBackedQuery(insightQuery)
 

--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -24,6 +24,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { alphabet, formatDate } from 'lib/utils'
+import { insightLogic } from 'scenes/insights/insightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import { urls } from 'scenes/urls'
@@ -34,6 +35,7 @@ import {
     AlertState,
     InsightThresholdType,
 } from '~/queries/schema/schema-general'
+import { isHogQLBackedQuery } from '~/queries/utils'
 import { InsightLogicProps, InsightShortId, QueryBasedInsightModel } from '~/types'
 
 import { alertFormLogic, canCheckOngoingInterval, getDefaultSimulationRange } from '../alertFormLogic'
@@ -42,7 +44,7 @@ import { alertNotificationLogic } from '../alertNotificationLogic'
 import { isNextPlannedEvaluationStale } from '../alertSchedulingStale'
 import { insightAlertsLogic } from '../insightAlertsLogic'
 import { SnoozeButton } from '../SnoozeButton'
-import type { AlertType } from '../types'
+import { isHogQLAlertConfig, isTrendsAlertConfig, type AlertType } from '../types'
 import { AlertDestinationSelector } from './AlertDestinationSelector'
 import { AlertHistorySection, AlertHistorySectionSkeleton } from './AlertHistorySection'
 import { DetectorSelector, getDefaultWindow } from './DetectorSelector'
@@ -119,6 +121,14 @@ export function EditAlertModal({
     const _alertLogic = alertLogic({ alertId, historyChartEnabled: alertsHistoryChartEnabled })
     const { alert, alertLoading } = useValues(_alertLogic)
 
+    // For new alerts, fall back to the bound insightLogic to read the query kind. doNotLoad keeps this from
+    // triggering a second fetch when our key differs from the caller's instance.
+    const boundInsight = useValues(
+        insightLogic(insightLogicProps ?? { dashboardItemId: insightShortId, doNotLoad: true })
+    ).insight
+    const insightQuery = alert?.insight?.query ?? boundInsight?.query ?? null
+    const isHogQLBackedInsight = isHogQLBackedQuery(insightQuery)
+
     /** Parent callback only (e.g. close modal). `alertLogic` is hydrated from the save response inside `alertFormLogic`. */
     const _onEditSuccess = useCallback(
         (alertId: AlertType['id'] | undefined) => {
@@ -143,6 +153,7 @@ export function EditAlertModal({
         insightVizDataLogicProps: insightLogicProps,
         insightInterval: trendInterval ?? undefined,
         historyChartEnabled: alertsHistoryChartEnabled,
+        isHogQLBackedInsight,
     }
     const formLogic = alertFormLogic(formLogicProps)
     const {
@@ -182,8 +193,10 @@ export function EditAlertModal({
     }, [insightLogicProps, insightId])
 
     const creatingNewAlert = alertForm.id === undefined
+    const isHogQLAlert = isHogQLAlertConfig(alertForm.config)
+    const trendsConfig = isTrendsAlertConfig(alertForm.config) ? alertForm.config : null
     // can only check ongoing interval for absolute value/increase alerts with upper threshold
-    const can_check_ongoing_interval = canCheckOngoingInterval(alertForm)
+    const can_check_ongoing_interval = canCheckOngoingInterval(alertForm) && !!trendsConfig
     const alertMode = alertForm.detector_config ? 'detector' : 'threshold'
     const nextPlannedEvaluationStale = useMemo(
         () =>
@@ -205,7 +218,7 @@ export function EditAlertModal({
 
     const enabledAdvancedOptionsCount = useMemo(() => {
         let n = 0
-        if (can_check_ongoing_interval && alertForm.config.check_ongoing_interval) {
+        if (can_check_ongoing_interval && trendsConfig?.check_ongoing_interval) {
             n += 1
         }
         if (
@@ -221,7 +234,7 @@ export function EditAlertModal({
         return n
     }, [
         alertForm.calculation_interval,
-        alertForm.config.check_ongoing_interval,
+        trendsConfig?.check_ongoing_interval,
         alertForm.schedule_restriction?.blocked_windows?.length,
         alertForm.skip_weekend,
         can_check_ongoing_interval,
@@ -276,7 +289,14 @@ export function EditAlertModal({
                             <div className="deprecated-space-y-3">
                                 <h3 className="mb-0">Definition</h3>
                                 <div className="deprecated-space-y-3">
-                                    {isBreakdownValid && (
+                                    {isHogQLAlert && (
+                                        <LemonBanner type="info">
+                                            This alert evaluates the last row of the first column returned by your SQL
+                                            query. For relative conditions, the last row is compared against the
+                                            previous row — make sure your query returns rows ordered chronologically.
+                                        </LemonBanner>
+                                    )}
+                                    {!isHogQLAlert && isBreakdownValid && (
                                         <LemonBanner type="warning">
                                             {alertMode === 'detector'
                                                 ? 'For trends with breakdown, the detector will independently monitor each breakdown value (up to 25) and fire if any is anomalous.'
@@ -285,42 +305,53 @@ export function EditAlertModal({
                                     )}
                                     <div className="flex gap-3 items-center">
                                         <div>When</div>
-                                        <Group name={['config']}>
-                                            <LemonField name="series_index" className="flex-auto">
-                                                <LemonSelect
-                                                    fullWidth
-                                                    data-attr="alertForm-series-index"
-                                                    options={
-                                                        formulaNodes?.length > 0
-                                                            ? formulaNodes.map(({ formula, custom_name }, index) => ({
-                                                                  label: `${
-                                                                      custom_name ? custom_name : 'Formula'
-                                                                  } (${formula})`,
-                                                                  value: index,
-                                                              }))
-                                                            : (alertSeries?.map(
-                                                                  ({ custom_name, name, event }, index) => ({
-                                                                      label: isBreakdownValid
-                                                                          ? 'any breakdown value'
-                                                                          : `${alphabet[index]} - ${
-                                                                                custom_name ?? name ?? event
-                                                                            }`,
-                                                                      value: isBreakdownValid ? 0 : index,
-                                                                  })
-                                                              ) ?? [])
-                                                    }
-                                                    disabledReason={
-                                                        isBreakdownValid &&
-                                                        (alertMode === 'detector'
-                                                            ? 'For trends with breakdown, the detector will independently monitor each breakdown value (up to 25) and fire if any is anomalous.'
-                                                            : 'For trends with breakdown, the alert will fire if any of the breakdown values breaches the threshold.')
-                                                    }
-                                                />
-                                            </LemonField>
-                                        </Group>
+                                        {isHogQLAlert ? (
+                                            <div
+                                                className="flex-auto text-muted"
+                                                data-attr="alertForm-hogql-series-placeholder"
+                                            >
+                                                the SQL query result
+                                            </div>
+                                        ) : (
+                                            <Group name={['config']}>
+                                                <LemonField name="series_index" className="flex-auto">
+                                                    <LemonSelect
+                                                        fullWidth
+                                                        data-attr="alertForm-series-index"
+                                                        options={
+                                                            formulaNodes?.length > 0
+                                                                ? formulaNodes.map(
+                                                                      ({ formula, custom_name }, index) => ({
+                                                                          label: `${
+                                                                              custom_name ? custom_name : 'Formula'
+                                                                          } (${formula})`,
+                                                                          value: index,
+                                                                      })
+                                                                  )
+                                                                : (alertSeries?.map(
+                                                                      ({ custom_name, name, event }, index) => ({
+                                                                          label: isBreakdownValid
+                                                                              ? 'any breakdown value'
+                                                                              : `${alphabet[index]} - ${
+                                                                                    custom_name ?? name ?? event
+                                                                                }`,
+                                                                          value: isBreakdownValid ? 0 : index,
+                                                                      })
+                                                                  ) ?? [])
+                                                        }
+                                                        disabledReason={
+                                                            isBreakdownValid &&
+                                                            (alertMode === 'detector'
+                                                                ? 'For trends with breakdown, the detector will independently monitor each breakdown value (up to 25) and fire if any is anomalous.'
+                                                                : 'For trends with breakdown, the alert will fire if any of the breakdown values breaches the threshold.')
+                                                        }
+                                                    />
+                                                </LemonField>
+                                            </Group>
+                                        )}
                                     </div>
 
-                                    {anomalyDetectionEnabled && (
+                                    {anomalyDetectionEnabled && !isHogQLAlert && (
                                         <LemonSegmentedButton
                                             fullWidth
                                             value={alertMode}
@@ -370,15 +401,17 @@ export function EditAlertModal({
                                                                 label: 'increases by',
                                                                 value: AlertConditionType.RELATIVE_INCREASE,
                                                                 disabledReason:
-                                                                    isNonTimeSeriesDisplay &&
-                                                                    'This condition is only supported for time series trends',
+                                                                    !isHogQLAlert && isNonTimeSeriesDisplay
+                                                                        ? 'This condition is only supported for time series trends'
+                                                                        : undefined,
                                                             },
                                                             {
                                                                 label: 'decreases by',
                                                                 value: AlertConditionType.RELATIVE_DECREASE,
                                                                 disabledReason:
-                                                                    isNonTimeSeriesDisplay &&
-                                                                    'This condition is only supported for time series trends',
+                                                                    !isHogQLAlert && isNonTimeSeriesDisplay
+                                                                        ? 'This condition is only supported for time series trends'
+                                                                        : undefined,
                                                             },
                                                         ]}
                                                     />
@@ -623,27 +656,32 @@ export function EditAlertModal({
                                                 }))}
                                             />
                                         </LemonField>
-                                        <div>
-                                            and check {alertForm?.config.check_ongoing_interval ? 'current' : 'last'}
-                                        </div>
-                                        <LemonSelect
-                                            fullWidth
-                                            className="w-28"
-                                            data-attr="alertForm-trend-interval"
-                                            disabledReason={
-                                                <>
-                                                    To change the interval being checked, edit and <b>save</b> the
-                                                    interval which the insight is 'grouped by'
-                                                </>
-                                            }
-                                            value={trendInterval ?? 'day'}
-                                            options={[
-                                                {
-                                                    label: trendInterval ?? 'day',
-                                                    value: trendInterval ?? 'day',
-                                                },
-                                            ]}
-                                        />
+                                        {!isHogQLAlert && (
+                                            <>
+                                                <div>
+                                                    and check{' '}
+                                                    {trendsConfig?.check_ongoing_interval ? 'current' : 'last'}
+                                                </div>
+                                                <LemonSelect
+                                                    fullWidth
+                                                    className="w-28"
+                                                    data-attr="alertForm-trend-interval"
+                                                    disabledReason={
+                                                        <>
+                                                            To change the interval being checked, edit and <b>save</b>{' '}
+                                                            the interval which the insight is 'grouped by'
+                                                        </>
+                                                    }
+                                                    value={trendInterval ?? 'day'}
+                                                    options={[
+                                                        {
+                                                            label: trendInterval ?? 'day',
+                                                            value: trendInterval ?? 'day',
+                                                        },
+                                                    ]}
+                                                />
+                                            </>
+                                        )}
                                     </div>
                                     {!creatingNewAlert && alert ? (
                                         <div className="text-sm text-muted flex flex-wrap items-center gap-x-2 gap-y-0">
@@ -739,32 +777,34 @@ export function EditAlertModal({
                                             },
                                             content: (
                                                 <div className="space-y-2">
-                                                    <Group name={['config']}>
-                                                        <div className="flex gap-1">
-                                                            <LemonField name="check_ongoing_interval">
-                                                                <LemonCheckbox
-                                                                    checked={
-                                                                        can_check_ongoing_interval &&
-                                                                        alertForm?.config.check_ongoing_interval
-                                                                    }
-                                                                    data-attr="alertForm-check-ongoing-interval"
-                                                                    fullWidth
-                                                                    label="Check ongoing period"
-                                                                    disabledReason={
-                                                                        !can_check_ongoing_interval &&
-                                                                        'Can only alert for ongoing period when checking for absolute value/increase above a set upper threshold.'
-                                                                    }
-                                                                />
-                                                            </LemonField>
-                                                            <Tooltip
-                                                                title="Checks the insight value for the ongoing period (current week/month) that hasn't yet completed. Use this if you want to be alerted right away when the insight value rises/increases above threshold"
-                                                                placement="right"
-                                                                delayMs={0}
-                                                            >
-                                                                <IconInfo />
-                                                            </Tooltip>
-                                                        </div>
-                                                    </Group>
+                                                    {trendsConfig && (
+                                                        <Group name={['config']}>
+                                                            <div className="flex gap-1">
+                                                                <LemonField name="check_ongoing_interval">
+                                                                    <LemonCheckbox
+                                                                        checked={
+                                                                            can_check_ongoing_interval &&
+                                                                            trendsConfig.check_ongoing_interval
+                                                                        }
+                                                                        data-attr="alertForm-check-ongoing-interval"
+                                                                        fullWidth
+                                                                        label="Check ongoing period"
+                                                                        disabledReason={
+                                                                            !can_check_ongoing_interval &&
+                                                                            'Can only alert for ongoing period when checking for absolute value/increase above a set upper threshold.'
+                                                                        }
+                                                                    />
+                                                                </LemonField>
+                                                                <Tooltip
+                                                                    title="Checks the insight value for the ongoing period (current week/month) that hasn't yet completed. Use this if you want to be alerted right away when the insight value rises/increases above threshold"
+                                                                    placement="right"
+                                                                    delayMs={0}
+                                                                >
+                                                                    <IconInfo />
+                                                                </Tooltip>
+                                                            </div>
+                                                        </Group>
+                                                    )}
                                                     <LemonField name="skip_weekend">
                                                         <LemonCheckbox
                                                             checked={

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -195,7 +195,9 @@ export function InsightMeta({
             : true
 
     const showDashboardAlertsMenuItem = isUsedAsDashboardTile && !!dashboardId && !!insight.id && canViewInsight
-    const canCreateAlertForInsight = areAlertsSupportedForInsight(query)
+    const canCreateAlertForInsight = areAlertsSupportedForInsight(query, {
+        hogqlAlertsEnabled: !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHT_ALERTS],
+    })
 
     const canToggleDisplayLabels = isUsedAsDashboardTile && canEditInsight && canToggleDisplayLabelsForInsight
     const canToggleLegend = isUsedAsDashboardTile && canEditInsight && canToggleLegendForInsight

--- a/frontend/src/lib/components/TerraformExporter/alertHclExporter.ts
+++ b/frontend/src/lib/components/TerraformExporter/alertHclExporter.ts
@@ -59,8 +59,7 @@ const ALERT_FIELD_MAPPINGS: FieldMapping<Partial<AlertType>, AlertHclExportOptio
     {
         source: 'config',
         target: 'series_index',
-        shouldInclude: (_, alert) =>
-            isTrendsAlertConfig(alert.config) && alert.config.series_index !== undefined,
+        shouldInclude: (_, alert) => isTrendsAlertConfig(alert.config) && alert.config.series_index !== undefined,
         transform: (_, alert) =>
             formatHclValue(isTrendsAlertConfig(alert.config) ? alert.config.series_index : undefined),
     },

--- a/frontend/src/lib/components/TerraformExporter/alertHclExporter.ts
+++ b/frontend/src/lib/components/TerraformExporter/alertHclExporter.ts
@@ -1,6 +1,6 @@
 import { formatHclValue, sanitizeResourceName } from 'lib/components/TerraformExporter/hclExporterFormattingUtils'
 
-import { AlertType } from '~/lib/components/Alerts/types'
+import { AlertType, isTrendsAlertConfig } from '~/lib/components/Alerts/types'
 import { HogFunctionType } from '~/types'
 
 import { FieldMapping, HclExportOptions, HclExportResult, ResourceExporter, generateHCL } from './hclExporter'
@@ -59,14 +59,18 @@ const ALERT_FIELD_MAPPINGS: FieldMapping<Partial<AlertType>, AlertHclExportOptio
     {
         source: 'config',
         target: 'series_index',
-        shouldInclude: (_, alert) => alert.config?.series_index !== undefined,
-        transform: (_, alert) => formatHclValue(alert.config?.series_index),
+        shouldInclude: (_, alert) =>
+            isTrendsAlertConfig(alert.config) && alert.config.series_index !== undefined,
+        transform: (_, alert) =>
+            formatHclValue(isTrendsAlertConfig(alert.config) ? alert.config.series_index : undefined),
     },
     {
         source: 'config',
         target: 'check_ongoing_interval',
-        shouldInclude: (_, alert) => alert.config?.check_ongoing_interval !== undefined,
-        transform: (_, alert) => formatHclValue(alert.config?.check_ongoing_interval),
+        shouldInclude: (_, alert) =>
+            isTrendsAlertConfig(alert.config) && alert.config.check_ongoing_interval !== undefined,
+        transform: (_, alert) =>
+            formatHclValue(isTrendsAlertConfig(alert.config) ? alert.config.check_ongoing_interval : undefined),
     },
     {
         source: 'skip_weekend',

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -368,6 +368,7 @@ export const FEATURE_FLAGS = {
     MAX_AI_INSIGHT_SEARCH: 'max-ai-insight-search', // owner: #team-posthog-ai
     MAX_BILLING_CONTEXT: 'max-billing-context', // owner: @pawel-cebula #team-billing
     MAX_DEEP_RESEARCH: 'max-deep-research', // owner: @kappa90 #team-posthog-ai
+    HOGQL_INSIGHT_ALERTS: 'hogql-insight-alerts', // owner: @vdekrijger — gates SQL/HogQL insight alerts
     MCP_SERVERS: 'mcp-servers', // owner: #team-posthog-ai
     MESSAGING_SES: 'messaging-ses', // owner #team-workflows
     METRICS: 'metrics', // owner: #team-apm (@jonmcwest, @frankh)

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -20573,6 +20573,18 @@
             "enum": ["hog", "hogJson", "hogQL", "hogQLExpr", "hogTemplate", "liquid"],
             "type": "string"
         },
+        "HogQLAlertConfig": {
+            "additionalProperties": false,
+            "description": "Alert config for HogQL/SQL-backed insights. Empty by design — the query owns its own time window and the alert evaluates the last row of the single-column result.",
+            "properties": {
+                "type": {
+                    "const": "HogQLAlertConfig",
+                    "type": "string"
+                }
+            },
+            "required": ["type"],
+            "type": "object"
+        },
         "HogQLAutocomplete": {
             "additionalProperties": false,
             "properties": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -4316,6 +4316,12 @@ export interface TrendsAlertConfig {
     check_ongoing_interval?: boolean
 }
 
+/** Alert config for HogQL/SQL-backed insights. Empty by design — the query owns its own time window and the
+ * alert evaluates the last row of the single-column result. */
+export interface HogQLAlertConfig {
+    type: 'HogQLAlertConfig'
+}
+
 /** One blocked period for quiet hours: 24-hour HH:MM in the project timezone; interval is half-open [start, end). */
 export interface AlertScheduleRestrictionWindow {
     start: string

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -220,6 +220,17 @@ export function isHogQLQuery(node?: Record<string, any> | null): node is HogQLQu
     return node?.kind === NodeKind.HogQLQuery
 }
 
+/** Returns true when `node` is a HogQLQuery, or a DataTableNode/DataVisualizationNode wrapping one. */
+export function isHogQLBackedQuery(node?: Record<string, any> | null): boolean {
+    if (!node) {
+        return false
+    }
+    if (isHogQLQuery(node)) {
+        return true
+    }
+    return (isDataTableNode(node) || isDataVisualizationNode(node)) && isHogQLQuery(node.source)
+}
+
 export function isHogQLMetadata(node?: Record<string, any> | null): node is HogQLMetadata {
     return node?.kind === NodeKind.HogQLMetadata
 }

--- a/frontend/src/scenes/insights/InsightModals.tsx
+++ b/frontend/src/scenes/insights/InsightModals.tsx
@@ -8,6 +8,8 @@ import { ManageAlertsModal } from 'lib/components/Alerts/views/ManageAlertsModal
 import { SharingModal } from 'lib/components/Sharing/SharingModal'
 import { SubscriptionsModal } from 'lib/components/Subscriptions/SubscriptionsModal'
 import { TerraformExportModal } from 'lib/components/TerraformExporter/TerraformExportModal'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -88,9 +90,12 @@ function InsightAlertsModals({ insightLogicProps }: { insightLogicProps: Insight
     const { insightMode, alertId } = useValues(insightSceneLogic)
     const { insightProps, insight } = useValues(insightLogic(insightLogicProps))
     const { query } = useValues(insightDataLogic(insightProps))
+    const { featureFlags } = useValues(featureFlagLogic)
     const { push } = useActions(router)
 
-    const canCreateAlertForInsight = areAlertsSupportedForInsight(query)
+    const canCreateAlertForInsight = areAlertsSupportedForInsight(query, {
+        hogqlAlertsEnabled: !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHT_ALERTS],
+    })
 
     return (
         <>

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -4,7 +4,9 @@ import { useMemo } from 'react'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { areAlertsSupportedForInsight } from 'lib/components/Alerts/insightAlertsLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightSaveButton } from 'scenes/insights/InsightSaveButton'
@@ -54,7 +56,10 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const defaultInsightName =
         typeof lastBreadcrumb?.name === 'string' ? lastBreadcrumb.name : insight.name || insight.derived_name
 
-    const canCreateAlertForInsight = areAlertsSupportedForInsight(query)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const canCreateAlertForInsight = areAlertsSupportedForInsight(query, {
+        hogqlAlertsEnabled: !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHT_ALERTS],
+    })
 
     const insightDisplayName = insight?.name || insight?.derived_name
 

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -481,17 +481,21 @@ class AlertSerializer(serializers.ModelSerializer):
     def validate_insight(self, value):
         if not value:
             return value
-        if not value.are_alerts_supported:
-            raise ValidationError("Alerts are not supported for this insight.")
-        if value.is_hogql_backed and not self._hogql_alerts_enabled():
-            raise ValidationError("SQL insight alerts are not enabled for your account.")
-        return value
+        if value.are_alerts_supported:
+            return value
+        if value.is_hogql_backed:
+            if not self._hogql_alerts_enabled():
+                raise ValidationError("SQL insight alerts are not enabled for your account.")
+            return value
+        raise ValidationError("Alerts are not supported for this insight.")
 
     def _hogql_alerts_enabled(self) -> bool:
-        # `User` has `current_organization` (and the matching `current_organization_id`) plus an
-        # `organization` property — there's no plain `organization_id` field, so read via the property.
+        # Use the target alert's organization (from team scope), not the user's current_organization —
+        # otherwise a user belonging to multiple orgs could flip their current org to a flag-on org and
+        # create a HogQL alert in a different team where the flag is disabled.
         user = self.context["request"].user
-        org = user.organization
+        get_organization = self.context.get("get_organization")
+        org = get_organization() if get_organization else None
         return bool(
             posthoganalytics.feature_enabled(
                 "hogql-insight-alerts",

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -704,10 +704,11 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return queryset
 
     def perform_destroy(self, instance: AlertConfiguration) -> None:
-        instance.report_deleted(
-            self.request.user,
-            analytics_props=get_request_analytics_properties(self.request),
-        )
+        # The viewset enforces authentication, so self.request.user is always a real User here —
+        # narrow for mypy's sake.
+        user = self.request.user
+        assert isinstance(user, User)
+        instance.report_deleted(user, analytics_props=get_request_analytics_properties(self.request))
         super().perform_destroy(instance)
 
     CHECKS_DEFAULT_LIMIT = 5

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -6,6 +6,7 @@ from django.db.models import OuterRef, QuerySet, Subquery
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
+import posthoganalytics
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
@@ -478,9 +479,23 @@ class AlertSerializer(serializers.ModelSerializer):
         return value
 
     def validate_insight(self, value):
-        if value and not value.are_alerts_supported:
+        if not value:
+            return value
+        if not value.are_alerts_supported:
             raise ValidationError("Alerts are not supported for this insight.")
+        if value.is_hogql_backed and not self._hogql_alerts_enabled():
+            raise ValidationError("SQL insight alerts are not enabled for your account.")
         return value
+
+    def _hogql_alerts_enabled(self) -> bool:
+        user = self.context["request"].user
+        return bool(
+            posthoganalytics.feature_enabled(
+                "hogql-insight-alerts",
+                str(user.distinct_id),
+                groups={"organization": str(user.organization_id)} if user.organization_id else {},
+            )
+        )
 
     def validate_subscribed_users(self, value):
         for user in value:
@@ -680,6 +695,13 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         queryset = queryset.annotate(last_value=Subquery(latest_check.values("calculated_value")[:1]))
 
         return queryset
+
+    def perform_destroy(self, instance: AlertConfiguration) -> None:
+        instance.report_deleted(
+            self.request.user,
+            analytics_props=get_request_analytics_properties(self.request),
+        )
+        super().perform_destroy(instance)
 
     CHECKS_DEFAULT_LIMIT = 5
     CHECKS_MAX_LIMIT = 500

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -488,12 +488,15 @@ class AlertSerializer(serializers.ModelSerializer):
         return value
 
     def _hogql_alerts_enabled(self) -> bool:
+        # `User` has `current_organization` (and the matching `current_organization_id`) plus an
+        # `organization` property — there's no plain `organization_id` field, so read via the property.
         user = self.context["request"].user
+        org = user.organization
         return bool(
             posthoganalytics.feature_enabled(
                 "hogql-insight-alerts",
                 str(user.distinct_id),
-                groups={"organization": str(user.organization_id)} if user.organization_id else {},
+                groups={"organization": str(org.id)} if org else {},
             )
         )
 

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -271,13 +271,9 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
         }
 
     def _underlying_query_kind(self) -> str | None:
-        """Unwraps the insight's query through any DataTable/DataVisualization/InsightVizNode wrapper
-        and returns the innermost kind (TrendsQuery / HogQLQuery / …). None if the insight or query is absent."""
-        insight = self.insight if self.insight_id else None
-        query = getattr(insight, "query", None) if insight is not None else None
-        while isinstance(query, dict) and query.get("source"):
-            query = query["source"]
-        return query.get("kind") if isinstance(query, dict) else None
+        if not self.insight_id:
+            return None
+        return self.insight._unwrapped_query_kind()
 
     def report_created(self, user: User, analytics_props: AnalyticsProps | None = None) -> None:
         from posthog.event_usage import report_user_action

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -239,7 +239,9 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
         has_lower_bound = threshold_bounds.get("lower") is not None if has_threshold else False
         has_upper_bound = threshold_bounds.get("upper") is not None if has_threshold else False
 
-        trends_config = self.config if isinstance(self.config, dict) else {}
+        config_dict = self.config if isinstance(self.config, dict) else {}
+        alert_config_type = config_dict.get("type")
+        trends_config = config_dict if alert_config_type == "TrendsAlertConfig" else {}
 
         subscribed_users_count: int | None = None
         if self.pk is not None:
@@ -257,6 +259,8 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
             "threshold_type": threshold_type,
             "has_lower_bound": has_lower_bound,
             "has_upper_bound": has_upper_bound,
+            "alert_config_type": alert_config_type,
+            "alert_query_kind": self._underlying_query_kind(),
             "trends_series_index": trends_config.get("series_index"),
             "trends_check_ongoing_interval": trends_config.get("check_ongoing_interval"),
             "subscribed_users_count": subscribed_users_count,
@@ -265,6 +269,15 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
             "has_preprocessing": has_preprocessing,
             "schedule_restriction_blocked_window_count": blocked_window_count,
         }
+
+    def _underlying_query_kind(self) -> str | None:
+        """Unwraps the insight's query through any DataTable/DataVisualization/InsightVizNode wrapper
+        and returns the innermost kind (TrendsQuery / HogQLQuery / …). None if the insight or query is absent."""
+        insight = self.insight if self.insight_id else None
+        query = getattr(insight, "query", None) if insight is not None else None
+        while isinstance(query, dict) and query.get("source"):
+            query = query["source"]
+        return query.get("kind") if isinstance(query, dict) else None
 
     def report_created(self, user: User, analytics_props: AnalyticsProps | None = None) -> None:
         from posthog.event_usage import report_user_action
@@ -275,6 +288,11 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
         from posthog.event_usage import report_user_action
 
         report_user_action(user, "alert updated", self._get_event_properties(), analytics_props=analytics_props)
+
+    def report_deleted(self, user: User, analytics_props: AnalyticsProps | None = None) -> None:
+        from posthog.event_usage import report_user_action
+
+        report_user_action(user, "alert deleted", self._get_event_properties(), analytics_props=analytics_props)
 
     @classmethod
     def check_alert_limit(cls, team_id: int, organization: Organization) -> str | None:

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -312,33 +312,28 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
         except (AttributeError, TypeError, KeyError):
             return False
 
-    @property
-    def are_alerts_supported(self) -> bool:
+    def _unwrapped_query_kind(self) -> str | None:
+        """Returns the innermost query's `kind` after unwrapping DataTable/DataVisualization/InsightVizNode
+        wrappers, or None if the insight has no query."""
         from posthog.schema_migrations.upgrade_manager import upgrade_query
 
         with upgrade_query(self):
             query = self.query
             if query is None:
-                return False
+                return None
             while query.get("source"):
                 query = query["source"]
-            if query.get("kind") not in ("TrendsQuery", "HogQLQuery"):
-                return False
-        return True
+            return query.get("kind")
+
+    @property
+    def are_alerts_supported(self) -> bool:
+        return self._unwrapped_query_kind() in ("TrendsQuery", "HogQLQuery")
 
     @property
     def is_hogql_backed(self) -> bool:
         """True when the insight's underlying query (unwrapped from any DataTable/DataVisualization/InsightVizNode
         wrapper) is a HogQLQuery."""
-        from posthog.schema_migrations.upgrade_manager import upgrade_query
-
-        with upgrade_query(self):
-            query = self.query
-            if query is None:
-                return False
-            while query.get("source"):
-                query = query["source"]
-            return query.get("kind") == "HogQLQuery"
+        return self._unwrapped_query_kind() == "HogQLQuery"
 
     def generate_query_metadata(self):
         from posthog.hogql_queries.query_metadata import extract_query_metadata

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -327,7 +327,10 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
 
     @property
     def are_alerts_supported(self) -> bool:
-        return self._unwrapped_query_kind() in ("TrendsQuery", "HogQLQuery")
+        # Trends-only. HogQL-backed alerts are gated behind the `hogql-insight-alerts` flag and live
+        # entirely in `AlertSerializer.validate_insight` so legacy callers (Max upsert_alert, insight
+        # update preserving alerts on type change) don't silently accept HogQL without the flag check.
+        return self._unwrapped_query_kind() == "TrendsQuery"
 
     @property
     def is_hogql_backed(self) -> bool:

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -322,9 +322,23 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
                 return False
             while query.get("source"):
                 query = query["source"]
-            if query.get("kind") != "TrendsQuery":
+            if query.get("kind") not in ("TrendsQuery", "HogQLQuery"):
                 return False
         return True
+
+    @property
+    def is_hogql_backed(self) -> bool:
+        """True when the insight's underlying query (unwrapped from any DataTable/DataVisualization/InsightVizNode
+        wrapper) is a HogQLQuery."""
+        from posthog.schema_migrations.upgrade_manager import upgrade_query
+
+        with upgrade_query(self):
+            query = self.query
+            if query is None:
+                return False
+            while query.get("source"):
+                query = query["source"]
+            return query.get("kind") == "HogQLQuery"
 
     def generate_query_metadata(self):
         from posthog.hogql_queries.query_metadata import extract_query_metadata

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8907,6 +8907,13 @@ class TrendsAlertConfig(BaseModel):
     type: Literal["TrendsAlertConfig"] = "TrendsAlertConfig"
 
 
+class HogQLAlertConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Literal["HogQLAlertConfig"] = "HogQLAlertConfig"
+
+
 class TrendsFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2544,6 +2544,13 @@ class HogLanguage(StrEnum):
     LIQUID = "liquid"
 
 
+class HogQLAlertConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Literal["HogQLAlertConfig"] = "HogQLAlertConfig"
+
+
 class BounceRatePageViewMode(StrEnum):
     COUNT_PAGEVIEWS = "count_pageviews"
     UNIQ_URLS = "uniq_urls"
@@ -8905,13 +8912,6 @@ class TrendsAlertConfig(BaseModel):
         description="Zero-based index of the series in the insight's query to monitor.",
     )
     type: Literal["TrendsAlertConfig"] = "TrendsAlertConfig"
-
-
-class HogQLAlertConfig(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    type: Literal["HogQLAlertConfig"] = "HogQLAlertConfig"
 
 
 class TrendsFilter(BaseModel):

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -12,7 +12,7 @@ from celery.canvas import chain
 from dateutil.relativedelta import relativedelta
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
-from posthog.schema import AlertCalculationInterval, AlertState, HogQLQuery, TrendsQuery
+from posthog.schema import AlertCalculationInterval, AlertState, TrendsQuery
 
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import CH_TRANSIENT_ERRORS
@@ -434,8 +434,7 @@ def check_alert_for_insight(alert: AlertConfiguration) -> AlertEvaluationResult:
                     return check_trends_alert_with_detector(alert, insight, query, alert.detector_config)
                 return check_trends_alert(alert, insight, query)
             case "HogQLQuery":
-                query = HogQLQuery.model_validate(query)
-                return check_hogql_alert(alert, insight, query)
+                return check_hogql_alert(alert, insight)
             case _:
                 raise NotImplementedError(f"AlertCheckError: Alerts for {kind} are not supported yet")
 

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -12,7 +12,7 @@ from celery.canvas import chain
 from dateutil.relativedelta import relativedelta
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
-from posthog.schema import AlertCalculationInterval, AlertState, TrendsQuery
+from posthog.schema import AlertCalculationInterval, AlertState, HogQLQuery, TrendsQuery
 
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import CH_TRANSIENT_ERRORS
@@ -25,6 +25,7 @@ from posthog.scoping_audit import skip_team_scope_audit
 from posthog.slo.context import SloSpec, slo_operation
 from posthog.slo.types import SloArea, SloOperation
 from posthog.tasks.alerts.detector import check_trends_alert_with_detector
+from posthog.tasks.alerts.hogql import check_hogql_alert
 from posthog.tasks.alerts.schedule_restriction import is_utc_datetime_blocked, next_unblocked_utc
 from posthog.tasks.alerts.trends import check_trends_alert
 from posthog.tasks.alerts.utils import (
@@ -432,6 +433,9 @@ def check_alert_for_insight(alert: AlertConfiguration) -> AlertEvaluationResult:
                 if alert.detector_config:
                     return check_trends_alert_with_detector(alert, insight, query, alert.detector_config)
                 return check_trends_alert(alert, insight, query)
+            case "HogQLQuery":
+                query = HogQLQuery.model_validate(query)
+                return check_hogql_alert(alert, insight, query)
             case _:
                 raise NotImplementedError(f"AlertCheckError: Alerts for {kind} are not supported yet")
 

--- a/posthog/tasks/alerts/hogql.py
+++ b/posthog/tasks/alerts/hogql.py
@@ -1,0 +1,91 @@
+from typing import Any
+
+from posthog.schema import AlertCondition, AlertConditionType, HogQLQuery, InsightThreshold, InsightThresholdType
+
+from posthog.api.services.query import ExecutionMode
+from posthog.caching.calculate_results import calculate_for_query_based_insight
+from posthog.models import AlertConfiguration, Insight
+from posthog.tasks.alerts.utils import AlertEvaluationResult, compute_relative_change, format_threshold_breach
+
+_HOGQL_SUBJECT = "The SQL insight value"
+
+
+def check_hogql_alert(alert: AlertConfiguration, insight: Insight, query: HogQLQuery) -> AlertEvaluationResult:
+    condition = AlertCondition.model_validate(alert.condition)
+    threshold = InsightThreshold.model_validate(alert.threshold.configuration) if alert.threshold else None
+
+    if not threshold or not threshold.bounds:
+        return AlertEvaluationResult(value=0, breaches=[])
+
+    calculation_result = calculate_for_query_based_insight(
+        insight,
+        team=alert.team,
+        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+        user=None,
+    )
+
+    values = _extract_trailing_column_values(calculation_result.result)
+
+    match condition.type:
+        case AlertConditionType.ABSOLUTE_VALUE:
+            if threshold.type != InsightThresholdType.ABSOLUTE:
+                raise ValueError("Absolute threshold not configured for alert condition ABSOLUTE_VALUE")
+
+            current = values[-1]
+            breaches = format_threshold_breach(
+                threshold.bounds, current, threshold.type, condition.type, subject=_HOGQL_SUBJECT
+            )
+            return AlertEvaluationResult(value=current, breaches=breaches)
+
+        case AlertConditionType.RELATIVE_INCREASE | AlertConditionType.RELATIVE_DECREASE:
+            if len(values) < 2:
+                raise ValueError(
+                    "Relative alerts on HogQL insights need at least two rows (current and previous), "
+                    "ordered chronologically."
+                )
+
+            change = compute_relative_change(condition.type, threshold.type, values[-1], values[-2])
+            breaches = format_threshold_breach(
+                threshold.bounds, change, threshold.type, condition.type, subject=_HOGQL_SUBJECT
+            )
+            return AlertEvaluationResult(value=change, breaches=breaches)
+
+        case _:
+            raise NotImplementedError(f"Unsupported alert condition type: {condition.type}")
+
+
+def _extract_trailing_column_values(rows: Any) -> list[float]:
+    """Extracts the last two rows of a HogQL response as a list of floats.
+
+    Only the tail is inspected — alert evaluation never reads further back than the second-to-last
+    row, so validating earlier rows would waste work on data we won't use.
+    """
+    if rows is None or not isinstance(rows, list) or len(rows) == 0:
+        raise ValueError("HogQL alert query returned no rows.")
+
+    tail = rows[-2:]
+    # Position labels keep error messages meaningful regardless of how many rows the query returned.
+    positions = ["second-to-last row", "last row"] if len(tail) == 2 else ["last row"]
+    values: list[float] = []
+    for position, row in zip(positions, tail):
+        if not isinstance(row, list | tuple):
+            raise ValueError(
+                f"HogQL alert query must return rows as lists/tuples (got {type(row).__name__} for the {position})."
+            )
+        if len(row) != 1:
+            raise ValueError(
+                f"HogQL alert query must return exactly one column (got {len(row)} columns for the {position})."
+            )
+
+        raw = row[0]
+        if raw is None:
+            # None buckets are treated as 0 to match trends-alert handling of empty intervals.
+            values.append(0.0)
+            continue
+        if isinstance(raw, bool) or not isinstance(raw, int | float):
+            raise ValueError(
+                f"HogQL alert query must return a numeric column (got {type(raw).__name__} for the {position})."
+            )
+        values.append(float(raw))
+
+    return values

--- a/posthog/tasks/alerts/hogql.py
+++ b/posthog/tasks/alerts/hogql.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from posthog.schema import AlertCondition, AlertConditionType, HogQLQuery, InsightThreshold, InsightThresholdType
+from posthog.schema import AlertCondition, AlertConditionType, InsightThreshold, InsightThresholdType
 
 from posthog.api.services.query import ExecutionMode
 from posthog.caching.calculate_results import calculate_for_query_based_insight
@@ -10,7 +10,7 @@ from posthog.tasks.alerts.utils import AlertEvaluationResult, compute_relative_c
 _HOGQL_SUBJECT = "The SQL insight value"
 
 
-def check_hogql_alert(alert: AlertConfiguration, insight: Insight, query: HogQLQuery) -> AlertEvaluationResult:
+def check_hogql_alert(alert: AlertConfiguration, insight: Insight) -> AlertEvaluationResult:
     condition = AlertCondition.model_validate(alert.condition)
     threshold = InsightThreshold.model_validate(alert.threshold.configuration) if alert.threshold else None
 

--- a/posthog/tasks/alerts/test/test_hogql_alerts.py
+++ b/posthog/tasks/alerts/test/test_hogql_alerts.py
@@ -1,0 +1,325 @@
+from typing import Any, Optional
+
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseDestroyTablesMixin
+from unittest.mock import ANY, MagicMock, patch
+
+import dateutil
+from parameterized import parameterized
+
+from posthog.schema import AlertCalculationInterval, AlertConditionType, AlertState, HogQLQuery, InsightThresholdType
+
+from posthog.api.test.dashboards import DashboardAPI
+from posthog.models import AlertConfiguration
+from posthog.models.alert import AlertCheck
+from posthog.models.instance_setting import set_instance_setting
+from posthog.tasks.alerts.checks import check_alert
+
+FROZEN_TIME = dateutil.parser.parse("2024-06-02T08:55:00.000Z")
+
+
+@freeze_time(FROZEN_TIME)
+@patch("posthog.api.alert.posthoganalytics.feature_enabled", return_value=True)
+@patch("posthog.tasks.alerts.utils.send_notifications_for_errors", return_value=[])
+@patch("posthog.tasks.alerts.utils.send_notifications_for_breaches", return_value=[])
+class TestHogQLAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
+    def setUp(self) -> None:
+        super().setUp()
+
+        set_instance_setting("EMAIL_HOST", "fake_host")
+        set_instance_setting("EMAIL_ENABLED", True)
+
+        self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
+
+    def create_hogql_insight(self, sql: str) -> dict[str, Any]:
+        query_dict = HogQLQuery(query=sql).model_dump()
+        insight = self.dashboard_api.create_insight(
+            data={
+                "name": "hogql insight",
+                "query": query_dict,
+            }
+        )[1]
+        return insight
+
+    def create_alert(
+        self,
+        insight: dict,
+        *,
+        condition_type: AlertConditionType = AlertConditionType.ABSOLUTE_VALUE,
+        threshold_type: InsightThresholdType = InsightThresholdType.ABSOLUTE,
+        lower: Optional[float] = None,
+        upper: Optional[float] = None,
+        calculation_interval: AlertCalculationInterval = AlertCalculationInterval.DAILY,
+    ) -> dict:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/alerts",
+            data={
+                "name": "alert name",
+                "insight": insight["id"],
+                "subscribed_users": [self.user.id],
+                "config": {"type": "HogQLAlertConfig"},
+                "condition": {"type": condition_type.value},
+                "calculation_interval": calculation_interval,
+                "threshold": {
+                    "configuration": {
+                        "type": threshold_type.value,
+                        "bounds": {"lower": lower, "upper": upper},
+                    }
+                },
+            },
+        )
+        assert response.status_code == 201, response.content
+        return response.json()
+
+    # --- Absolute value ----------------------------------------------------
+
+    @parameterized.expand(
+        [
+            ("breach_lower", "SELECT 0", 1.0, None, AlertState.FIRING, 0.0, "less than lower threshold (1.0)"),
+            ("breach_upper", "SELECT 7", None, 5.0, AlertState.FIRING, 7.0, "more than upper threshold (5.0)"),
+            ("within_bounds", "SELECT 3", 1.0, 5.0, AlertState.NOT_FIRING, 3.0, None),
+            (
+                "uses_last_row_of_time_series",
+                "SELECT value FROM (SELECT 1 AS value UNION ALL SELECT 99 AS value) ORDER BY value ASC",
+                None,
+                10.0,
+                AlertState.FIRING,
+                99.0,
+                "more than upper threshold (10.0)",
+            ),
+        ]
+    )
+    def test_absolute_value(
+        self,
+        _name: str,
+        sql: str,
+        lower: Optional[float],
+        upper: Optional[float],
+        expected_state: AlertState,
+        expected_value: float,
+        expected_message_fragment: Optional[str],
+        mock_send_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+        mock_feature_enabled: MagicMock,
+    ) -> None:
+        insight = self.create_hogql_insight(sql)
+        alert = self.create_alert(insight, lower=lower, upper=upper)
+
+        check_alert(alert["id"])
+
+        updated_alert = AlertConfiguration.objects.get(pk=alert["id"])
+        assert updated_alert.state == expected_state
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+        assert alert_check.calculated_value == expected_value
+        assert alert_check.state == expected_state
+        assert alert_check.error is None
+
+        if expected_message_fragment is None:
+            mock_send_breaches.assert_not_called()
+        else:
+            mock_send_breaches.assert_called_once()
+            args = mock_send_breaches.call_args.args
+            breaches = args[1]
+            assert len(breaches) == 1
+            assert expected_message_fragment in breaches[0]
+
+    # --- Relative conditions ----------------------------------------------
+
+    @parameterized.expand(
+        [
+            (
+                "relative_increase_absolute_breach",
+                "SELECT value FROM (SELECT 10 AS value, 1 AS ord UNION ALL SELECT 25 AS value, 2 AS ord) ORDER BY ord",
+                AlertConditionType.RELATIVE_INCREASE,
+                InsightThresholdType.ABSOLUTE,
+                None,
+                10.0,
+                AlertState.FIRING,
+                15.0,
+                "more than upper threshold (10.0)",
+            ),
+            (
+                "relative_increase_percentage_breach",
+                "SELECT value FROM (SELECT 10 AS value, 1 AS ord UNION ALL SELECT 20 AS value, 2 AS ord) ORDER BY ord",
+                AlertConditionType.RELATIVE_INCREASE,
+                InsightThresholdType.PERCENTAGE,
+                None,
+                0.5,
+                AlertState.FIRING,
+                1.0,
+                "more than upper threshold",
+            ),
+            (
+                "relative_decrease_absolute_breach",
+                "SELECT value FROM (SELECT 20 AS value, 1 AS ord UNION ALL SELECT 5 AS value, 2 AS ord) ORDER BY ord",
+                AlertConditionType.RELATIVE_DECREASE,
+                InsightThresholdType.ABSOLUTE,
+                None,
+                10.0,
+                AlertState.FIRING,
+                15.0,
+                "more than upper threshold (10.0)",
+            ),
+            (
+                "relative_increase_no_breach",
+                "SELECT value FROM (SELECT 10 AS value, 1 AS ord UNION ALL SELECT 11 AS value, 2 AS ord) ORDER BY ord",
+                AlertConditionType.RELATIVE_INCREASE,
+                InsightThresholdType.ABSOLUTE,
+                None,
+                10.0,
+                AlertState.NOT_FIRING,
+                1.0,
+                None,
+            ),
+        ]
+    )
+    def test_relative(
+        self,
+        _name: str,
+        sql: str,
+        condition_type: AlertConditionType,
+        threshold_type: InsightThresholdType,
+        lower: Optional[float],
+        upper: Optional[float],
+        expected_state: AlertState,
+        expected_value: float,
+        expected_message_fragment: Optional[str],
+        mock_send_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+        mock_feature_enabled: MagicMock,
+    ) -> None:
+        insight = self.create_hogql_insight(sql)
+        alert = self.create_alert(
+            insight,
+            condition_type=condition_type,
+            threshold_type=threshold_type,
+            lower=lower,
+            upper=upper,
+        )
+
+        check_alert(alert["id"])
+
+        updated_alert = AlertConfiguration.objects.get(pk=alert["id"])
+        assert updated_alert.state == expected_state
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+        assert alert_check.calculated_value == expected_value
+        assert alert_check.state == expected_state
+
+        if expected_message_fragment is None:
+            mock_send_breaches.assert_not_called()
+        else:
+            mock_send_breaches.assert_called_once()
+            args = mock_send_breaches.call_args.args
+            breaches = args[1]
+            assert expected_message_fragment in breaches[0]
+
+    # --- Validation errors ------------------------------------------------
+
+    def test_relative_with_single_row_errors(
+        self,
+        mock_send_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+        mock_feature_enabled: MagicMock,
+    ) -> None:
+        insight = self.create_hogql_insight("SELECT 1")
+        alert = self.create_alert(insight, condition_type=AlertConditionType.RELATIVE_INCREASE, upper=1.0)
+
+        check_alert(alert["id"])
+
+        updated_alert = AlertConfiguration.objects.get(pk=alert["id"])
+        assert updated_alert.state == AlertState.ERRORED
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+        assert alert_check.error is not None
+        assert "at least two rows" in alert_check.error["message"]
+        mock_send_errors.assert_called_once_with(ANY, alert_check.error)
+
+    def test_multi_column_query_errors(
+        self,
+        mock_send_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+        mock_feature_enabled: MagicMock,
+    ) -> None:
+        insight = self.create_hogql_insight("SELECT 1, 2")
+        alert = self.create_alert(insight, upper=10)
+
+        check_alert(alert["id"])
+
+        updated_alert = AlertConfiguration.objects.get(pk=alert["id"])
+        assert updated_alert.state == AlertState.ERRORED
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+        assert alert_check.error is not None
+        assert "exactly one column" in alert_check.error["message"]
+
+    def test_non_numeric_column_errors(
+        self,
+        mock_send_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+        mock_feature_enabled: MagicMock,
+    ) -> None:
+        insight = self.create_hogql_insight("SELECT 'hello'")
+        alert = self.create_alert(insight, upper=10)
+
+        check_alert(alert["id"])
+
+        updated_alert = AlertConfiguration.objects.get(pk=alert["id"])
+        assert updated_alert.state == AlertState.ERRORED
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+        assert alert_check.error is not None
+        assert "numeric column" in alert_check.error["message"]
+
+
+@freeze_time(FROZEN_TIME)
+class TestAlertCreationGate(APIBaseTest, ClickhouseDestroyTablesMixin):
+    """Verifies the alert-creation API gate: accepts HogQL when flag is on, rejects when off,
+    still rejects truly unsupported kinds (Funnels)."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
+
+    def _create_hogql_insight(self, sql: str = "SELECT 1") -> dict[str, Any]:
+        return self.dashboard_api.create_insight(
+            data={"name": "hogql", "query": HogQLQuery(query=sql).model_dump()}
+        )[1]
+
+    def _post_alert(self, insight_id: int) -> Any:
+        return self.client.post(
+            f"/api/projects/{self.team.id}/alerts",
+            data={
+                "name": "alert name",
+                "insight": insight_id,
+                "subscribed_users": [self.user.id],
+                "config": {"type": "HogQLAlertConfig"},
+                "condition": {"type": "absolute_value"},
+                "calculation_interval": AlertCalculationInterval.DAILY,
+                "threshold": {"configuration": {"type": "absolute", "bounds": {"upper": 5}}},
+            },
+        )
+
+    @patch("posthog.api.alert.posthoganalytics.feature_enabled", return_value=True)
+    def test_creates_hogql_alert_when_flag_on(self, _mock_feature_enabled: MagicMock) -> None:
+        insight = self._create_hogql_insight()
+        response = self._post_alert(insight["id"])
+        assert response.status_code == 201, response.content
+
+    @patch("posthog.api.alert.posthoganalytics.feature_enabled", return_value=False)
+    def test_rejects_hogql_alert_when_flag_off(self, _mock_feature_enabled: MagicMock) -> None:
+        insight = self._create_hogql_insight()
+        response = self._post_alert(insight["id"])
+        assert response.status_code == 400
+        assert "SQL insight alerts are not enabled" in response.content.decode()
+
+    @patch("posthog.api.alert.posthoganalytics.feature_enabled", return_value=True)
+    def test_rejects_unsupported_query_kind(self, _mock_feature_enabled: MagicMock) -> None:
+        funnels_query = {
+            "kind": "FunnelsQuery",
+            "series": [{"kind": "EventsNode", "event": "$pageview"}],
+        }
+        insight = self.dashboard_api.create_insight(data={"name": "funnel", "query": funnels_query})[1]
+        response = self._post_alert(insight["id"])
+        assert response.status_code == 400

--- a/posthog/tasks/alerts/test/test_hogql_alerts.py
+++ b/posthog/tasks/alerts/test/test_hogql_alerts.py
@@ -217,14 +217,44 @@ class TestHogQLAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
 
     # --- Validation errors ------------------------------------------------
 
-    def test_relative_with_single_row_errors(
+    @parameterized.expand(
+        [
+            (
+                "single_row_relative",
+                "SELECT 1",
+                AlertConditionType.RELATIVE_INCREASE,
+                "at least two rows",
+                True,  # mock_send_errors should be called
+            ),
+            (
+                "multi_column",
+                "SELECT 1, 2",
+                AlertConditionType.ABSOLUTE_VALUE,
+                "exactly one column",
+                False,
+            ),
+            (
+                "non_numeric_column",
+                "SELECT 'hello'",
+                AlertConditionType.ABSOLUTE_VALUE,
+                "numeric column",
+                False,
+            ),
+        ]
+    )
+    def test_validation_errors(
         self,
-        mock_send_breaches: MagicMock,
+        _name: str,
+        sql: str,
+        condition_type: AlertConditionType,
+        expected_error_fragment: str,
+        expect_error_notification: bool,
+        _mock_send_breaches: MagicMock,
         mock_send_errors: MagicMock,
         _mock_feature_enabled: MagicMock,
     ) -> None:
-        insight = self.create_hogql_insight("SELECT 1")
-        alert = self.create_alert(insight, condition_type=AlertConditionType.RELATIVE_INCREASE, upper=1.0)
+        insight = self.create_hogql_insight(sql)
+        alert = self.create_alert(insight, condition_type=condition_type, upper=10.0)
 
         check_alert(alert["id"])
 
@@ -233,44 +263,10 @@ class TestHogQLAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
         assert alert_check.error is not None
-        assert "at least two rows" in alert_check.error["message"]
-        mock_send_errors.assert_called_once_with(ANY, alert_check.error)
+        assert expected_error_fragment in alert_check.error["message"]
 
-    def test_multi_column_query_errors(
-        self,
-        _mock_send_breaches: MagicMock,
-        _mock_send_errors: MagicMock,
-        _mock_feature_enabled: MagicMock,
-    ) -> None:
-        insight = self.create_hogql_insight("SELECT 1, 2")
-        alert = self.create_alert(insight, upper=10)
-
-        check_alert(alert["id"])
-
-        updated_alert = AlertConfiguration.objects.get(pk=alert["id"])
-        assert updated_alert.state == AlertState.ERRORED
-
-        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
-        assert alert_check.error is not None
-        assert "exactly one column" in alert_check.error["message"]
-
-    def test_non_numeric_column_errors(
-        self,
-        _mock_send_breaches: MagicMock,
-        _mock_send_errors: MagicMock,
-        _mock_feature_enabled: MagicMock,
-    ) -> None:
-        insight = self.create_hogql_insight("SELECT 'hello'")
-        alert = self.create_alert(insight, upper=10)
-
-        check_alert(alert["id"])
-
-        updated_alert = AlertConfiguration.objects.get(pk=alert["id"])
-        assert updated_alert.state == AlertState.ERRORED
-
-        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
-        assert alert_check.error is not None
-        assert "numeric column" in alert_check.error["message"]
+        if expect_error_notification:
+            mock_send_errors.assert_called_once_with(ANY, alert_check.error)
 
 
 @freeze_time(FROZEN_TIME)

--- a/posthog/tasks/alerts/test/test_hogql_alerts.py
+++ b/posthog/tasks/alerts/test/test_hogql_alerts.py
@@ -100,7 +100,7 @@ class TestHogQLAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
         expected_message_fragment: Optional[str],
         mock_send_breaches: MagicMock,
         mock_send_errors: MagicMock,
-        mock_feature_enabled: MagicMock,
+        _mock_feature_enabled: MagicMock,
     ) -> None:
         insight = self.create_hogql_insight(sql)
         alert = self.create_alert(insight, lower=lower, upper=upper)
@@ -187,7 +187,7 @@ class TestHogQLAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
         expected_message_fragment: Optional[str],
         mock_send_breaches: MagicMock,
         mock_send_errors: MagicMock,
-        mock_feature_enabled: MagicMock,
+        _mock_feature_enabled: MagicMock,
     ) -> None:
         insight = self.create_hogql_insight(sql)
         alert = self.create_alert(
@@ -221,7 +221,7 @@ class TestHogQLAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
         self,
         mock_send_breaches: MagicMock,
         mock_send_errors: MagicMock,
-        mock_feature_enabled: MagicMock,
+        _mock_feature_enabled: MagicMock,
     ) -> None:
         insight = self.create_hogql_insight("SELECT 1")
         alert = self.create_alert(insight, condition_type=AlertConditionType.RELATIVE_INCREASE, upper=1.0)
@@ -238,9 +238,9 @@ class TestHogQLAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
 
     def test_multi_column_query_errors(
         self,
-        mock_send_breaches: MagicMock,
-        mock_send_errors: MagicMock,
-        mock_feature_enabled: MagicMock,
+        _mock_send_breaches: MagicMock,
+        _mock_send_errors: MagicMock,
+        _mock_feature_enabled: MagicMock,
     ) -> None:
         insight = self.create_hogql_insight("SELECT 1, 2")
         alert = self.create_alert(insight, upper=10)
@@ -256,9 +256,9 @@ class TestHogQLAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
 
     def test_non_numeric_column_errors(
         self,
-        mock_send_breaches: MagicMock,
-        mock_send_errors: MagicMock,
-        mock_feature_enabled: MagicMock,
+        _mock_send_breaches: MagicMock,
+        _mock_send_errors: MagicMock,
+        _mock_feature_enabled: MagicMock,
     ) -> None:
         insight = self.create_hogql_insight("SELECT 'hello'")
         alert = self.create_alert(insight, upper=10)

--- a/posthog/tasks/alerts/test/test_hogql_alerts.py
+++ b/posthog/tasks/alerts/test/test_hogql_alerts.py
@@ -279,9 +279,7 @@ class TestAlertCreationGate(APIBaseTest, ClickhouseDestroyTablesMixin):
         self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
 
     def _create_hogql_insight(self, sql: str = "SELECT 1") -> dict[str, Any]:
-        return self.dashboard_api.create_insight(
-            data={"name": "hogql", "query": HogQLQuery(query=sql).model_dump()}
-        )[1]
+        return self.dashboard_api.create_insight(data={"name": "hogql", "query": HogQLQuery(query=sql).model_dump()})[1]
 
     def _post_alert(self, insight_id: int) -> Any:
         return self.client.post(

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -19,7 +19,7 @@ from posthog.caching.fetch_from_cache import InsightResult
 from posthog.event_usage import EventSource
 from posthog.hogql_queries.insights.utils.breakdowns import has_breakdown_filter
 from posthog.models import AlertConfiguration, Insight
-from posthog.tasks.alerts.utils import NON_TIME_SERIES_DISPLAY_TYPES, AlertEvaluationResult
+from posthog.tasks.alerts.utils import NON_TIME_SERIES_DISPLAY_TYPES, AlertEvaluationResult, compute_relative_change
 
 
 # TODO: move the TrendResult UI type to schema.ts and use that instead
@@ -249,20 +249,12 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 prev_prev_interval_value = _pick_interval_value_from_trend_result(query, result, -2)
 
                 if check_current_interval:
-                    if threshold.type == InsightThresholdType.ABSOLUTE:
-                        increase = current_interval_value - prev_interval_value
-                    elif threshold.type == InsightThresholdType.PERCENTAGE:
-                        if prev_interval_value == 0 and current_interval_value == 0:
-                            increase = 0
-                        elif prev_interval_value == 0:
-                            increase = float("inf")
-                        else:
-                            increase = (current_interval_value - prev_interval_value) / prev_interval_value
-                    else:
-                        raise ValueError(
-                            f"Neither relative nor absolute threshold configured for alert condition RELATIVE_INCREASE"
-                        )
-
+                    increase = compute_relative_change(
+                        AlertConditionType.RELATIVE_INCREASE,
+                        threshold.type,
+                        current_interval_value,
+                        prev_interval_value,
+                    )
                     breaches = _breach_messages(
                         threshold.bounds,
                         increase,
@@ -278,20 +270,12 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                         return AlertEvaluationResult(value=increase, breaches=breaches)
                 else:
                     # fallback to check previous intervals
-                    if threshold.type == InsightThresholdType.ABSOLUTE:
-                        increase = prev_interval_value - prev_prev_interval_value
-                    elif threshold.type == InsightThresholdType.PERCENTAGE:
-                        if prev_prev_interval_value == 0 and prev_interval_value == 0:
-                            increase = 0
-                        elif prev_prev_interval_value == 0:
-                            increase = float("inf")
-                        else:
-                            increase = (prev_interval_value - prev_prev_interval_value) / prev_prev_interval_value
-                    else:
-                        raise ValueError(
-                            f"Neither relative nor absolute threshold configured for alert condition RELATIVE_INCREASE"
-                        )
-
+                    increase = compute_relative_change(
+                        AlertConditionType.RELATIVE_INCREASE,
+                        threshold.type,
+                        prev_interval_value,
+                        prev_prev_interval_value,
+                    )
                     breaches = _breach_messages(
                         threshold.bounds,
                         increase,
@@ -349,19 +333,12 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 prev_interval_value = _pick_interval_value_from_trend_result(query, result, -1)
                 prev_prev_interval_value = _pick_interval_value_from_trend_result(query, result, -2)
 
-                if threshold.type == InsightThresholdType.ABSOLUTE:
-                    decrease = prev_prev_interval_value - prev_interval_value
-                elif threshold.type == InsightThresholdType.PERCENTAGE:
-                    if prev_prev_interval_value == 0 and prev_interval_value == 0:
-                        decrease = 0
-                    elif prev_prev_interval_value == 0:
-                        decrease = float("inf")
-                    else:
-                        decrease = (prev_prev_interval_value - prev_interval_value) / prev_prev_interval_value
-                else:
-                    raise ValueError(
-                        f"Neither relative nor absolute threshold configured for alert condition RELATIVE_INCREASE"
-                    )
+                decrease = compute_relative_change(
+                    AlertConditionType.RELATIVE_DECREASE,
+                    threshold.type,
+                    prev_interval_value,
+                    prev_prev_interval_value,
+                )
 
                 breaches = _breach_messages(
                     threshold.bounds,

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -81,7 +81,9 @@ def validate_alert_config(
     except Exception:
         raise ValueError(f"Alert has invalid condition: {condition}")
 
-    config_type = config.get("type") if isinstance(config, dict) else None
+    if not isinstance(config, dict):
+        raise ValueError(f"Unsupported alert config type: {config}")
+    config_type = config.get("type")
     if config_type == "HogQLAlertConfig":
         _validate_hogql_alert_config(query, parsed_condition, config, threshold_config)
         return

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -92,9 +92,10 @@ def validate_alert_config(
 
 
 def _unwrap_inner_query(query: dict) -> tuple[dict, str | None]:
-    """Strip DataTable/DataVisualization/InsightVizNode wrappers and return the inner query plus its kind."""
+    """Strip DataTable/DataVisualization/InsightVizNode wrappers and return the inner query plus its kind.
+    Iterates so multi-level wrappers stay consistent with `Insight._unwrapped_query_kind`."""
     kind = get_from_dict_or_attr(query, "kind")
-    if kind in WRAPPER_NODE_KINDS:
+    while kind in WRAPPER_NODE_KINDS:
         query = get_from_dict_or_attr(query, "source")
         kind = get_from_dict_or_attr(query, "kind")
     return query, kind

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -91,6 +91,37 @@ def validate_alert_config(
     raise ValueError(f"Unsupported alert config type: {config}")
 
 
+def _unwrap_inner_query(query: dict) -> tuple[dict, str | None]:
+    """Strip DataTable/DataVisualization/InsightVizNode wrappers and return the inner query plus its kind."""
+    kind = get_from_dict_or_attr(query, "kind")
+    if kind in WRAPPER_NODE_KINDS:
+        query = get_from_dict_or_attr(query, "source")
+        kind = get_from_dict_or_attr(query, "kind")
+    return query, kind
+
+
+def _validate_absolute_threshold_compatibility(
+    parsed_condition: AlertCondition,
+    threshold_config: dict | None,
+) -> InsightThreshold | None:
+    """Parse the threshold (if any) and enforce the absolute-value-needs-absolute-threshold rule. Shared
+    between trends and HogQL validators."""
+    if threshold_config is None:
+        return None
+    try:
+        threshold = InsightThreshold.model_validate(threshold_config)
+    except Exception:
+        raise ValueError(f"Alert has invalid threshold configuration: {threshold_config}")
+    if (
+        parsed_condition.type == AlertConditionType.ABSOLUTE_VALUE
+        and threshold.type != InsightThresholdType.ABSOLUTE
+    ):
+        raise ValueError(
+            "Absolute value alerts require an absolute threshold, but a percentage threshold was configured"
+        )
+    return threshold
+
+
 def _validate_trends_alert_config(
     query: dict,
     parsed_condition: AlertCondition,
@@ -102,16 +133,12 @@ def _validate_trends_alert_config(
     except Exception:
         raise ValueError(f"Alert has invalid TrendsAlertConfig: {config}")
 
-    kind = get_from_dict_or_attr(query, "kind")
-    if kind in WRAPPER_NODE_KINDS:
-        query = get_from_dict_or_attr(query, "source")
-        kind = get_from_dict_or_attr(query, "kind")
-
+    inner_query, kind = _unwrap_inner_query(query)
     if kind != NodeKind.TRENDS_QUERY:
         raise ValueError(f"Alert config is TrendsAlertConfig but insight query kind is '{kind}'")
 
     try:
-        trends_query = TrendsQuery.model_validate(query)
+        trends_query = TrendsQuery.model_validate(inner_query)
     except Exception as e:
         raise ValueError(f"Alert's insight has an invalid TrendsQuery: {e}")
 
@@ -128,28 +155,16 @@ def _validate_trends_alert_config(
     if parsed_config.series_index >= result_count:
         raise ValueError(f"series_index {parsed_config.series_index} is out of range (query has {result_count} series)")
 
-    if threshold_config is not None:
-        try:
-            threshold = InsightThreshold.model_validate(threshold_config)
-        except Exception:
-            raise ValueError(f"Alert has invalid threshold configuration: {threshold_config}")
+    threshold = _validate_absolute_threshold_compatibility(parsed_condition, threshold_config)
 
-        if (
-            parsed_condition.type == AlertConditionType.ABSOLUTE_VALUE
-            and threshold.type != InsightThresholdType.ABSOLUTE
-        ):
+    if threshold and parsed_config.check_ongoing_interval and parsed_condition.type in (
+        AlertConditionType.ABSOLUTE_VALUE,
+        AlertConditionType.RELATIVE_INCREASE,
+    ):
+        if not threshold.bounds or threshold.bounds.upper is None:
             raise ValueError(
-                "Absolute value alerts require an absolute threshold, but a percentage threshold was configured"
+                f"check_ongoing_interval is only supported for alert condition {parsed_condition.type} when upper threshold is specified"
             )
-
-        if parsed_config.check_ongoing_interval and parsed_condition.type in (
-            AlertConditionType.ABSOLUTE_VALUE,
-            AlertConditionType.RELATIVE_INCREASE,
-        ):
-            if not threshold.bounds or threshold.bounds.upper is None:
-                raise ValueError(
-                    f"check_ongoing_interval is only supported for alert condition {parsed_condition.type} when upper threshold is specified"
-                )
 
 
 def _validate_hogql_alert_config(
@@ -163,32 +178,16 @@ def _validate_hogql_alert_config(
     except Exception:
         raise ValueError(f"Alert has invalid HogQLAlertConfig: {config}")
 
-    kind = get_from_dict_or_attr(query, "kind")
-    if kind in WRAPPER_NODE_KINDS:
-        query = get_from_dict_or_attr(query, "source")
-        kind = get_from_dict_or_attr(query, "kind")
-
+    inner_query, kind = _unwrap_inner_query(query)
     if kind != NodeKind.HOG_QL_QUERY:
         raise ValueError(f"Alert config is HogQLAlertConfig but insight query kind is '{kind}'")
 
     try:
-        HogQLQuery.model_validate(query)
+        HogQLQuery.model_validate(inner_query)
     except Exception as e:
         raise ValueError(f"Alert's insight has an invalid HogQLQuery: {e}")
 
-    if threshold_config is not None:
-        try:
-            threshold = InsightThreshold.model_validate(threshold_config)
-        except Exception:
-            raise ValueError(f"Alert has invalid threshold configuration: {threshold_config}")
-
-        if (
-            parsed_condition.type == AlertConditionType.ABSOLUTE_VALUE
-            and threshold.type != InsightThresholdType.ABSOLUTE
-        ):
-            raise ValueError(
-                "Absolute value alerts require an absolute threshold, but a percentage threshold was configured"
-            )
+    _validate_absolute_threshold_compatibility(parsed_condition, threshold_config)
 
 
 def calculation_interval_to_order(interval: AlertCalculationInterval | None) -> int:

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -113,10 +113,7 @@ def _validate_absolute_threshold_compatibility(
         threshold = InsightThreshold.model_validate(threshold_config)
     except Exception:
         raise ValueError(f"Alert has invalid threshold configuration: {threshold_config}")
-    if (
-        parsed_condition.type == AlertConditionType.ABSOLUTE_VALUE
-        and threshold.type != InsightThresholdType.ABSOLUTE
-    ):
+    if parsed_condition.type == AlertConditionType.ABSOLUTE_VALUE and threshold.type != InsightThresholdType.ABSOLUTE:
         raise ValueError(
             "Absolute value alerts require an absolute threshold, but a percentage threshold was configured"
         )
@@ -158,9 +155,14 @@ def _validate_trends_alert_config(
 
     threshold = _validate_absolute_threshold_compatibility(parsed_condition, threshold_config)
 
-    if threshold and parsed_config.check_ongoing_interval and parsed_condition.type in (
-        AlertConditionType.ABSOLUTE_VALUE,
-        AlertConditionType.RELATIVE_INCREASE,
+    if (
+        threshold
+        and parsed_config.check_ongoing_interval
+        and parsed_condition.type
+        in (
+            AlertConditionType.ABSOLUTE_VALUE,
+            AlertConditionType.RELATIVE_INCREASE,
+        )
     ):
         if not threshold.bounds or threshold.bounds.upper is None:
             raise ValueError(

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -13,6 +13,9 @@ from posthog.schema import (
     AlertConditionType,
     AlertState,
     ChartDisplayType,
+    HogQLAlertConfig,
+    HogQLQuery,
+    InsightsThresholdBounds,
     InsightThreshold,
     InsightThresholdType,
     NodeKind,
@@ -78,8 +81,22 @@ def validate_alert_config(
     except Exception:
         raise ValueError(f"Alert has invalid condition: {condition}")
 
-    if not config or not isinstance(config, dict) or config.get("type") != "TrendsAlertConfig":
-        raise ValueError(f"Unsupported alert config type: {config}")
+    config_type = config.get("type") if isinstance(config, dict) else None
+    if config_type == "HogQLAlertConfig":
+        _validate_hogql_alert_config(query, parsed_condition, config, threshold_config)
+        return
+    if config_type == "TrendsAlertConfig":
+        _validate_trends_alert_config(query, parsed_condition, config, threshold_config)
+        return
+    raise ValueError(f"Unsupported alert config type: {config}")
+
+
+def _validate_trends_alert_config(
+    query: dict,
+    parsed_condition: AlertCondition,
+    config: dict,
+    threshold_config: dict | None,
+) -> None:
     try:
         parsed_config = TrendsAlertConfig.model_validate(config)
     except Exception:
@@ -91,7 +108,7 @@ def validate_alert_config(
         kind = get_from_dict_or_attr(query, "kind")
 
     if kind != NodeKind.TRENDS_QUERY:
-        raise ValueError(f"Alert's insight query kind '{kind}' is not supported (only TrendsQuery)")
+        raise ValueError(f"Alert config is TrendsAlertConfig but insight query kind is '{kind}'")
 
     try:
         trends_query = TrendsQuery.model_validate(query)
@@ -135,6 +152,45 @@ def validate_alert_config(
                 )
 
 
+def _validate_hogql_alert_config(
+    query: dict,
+    parsed_condition: AlertCondition,
+    config: dict,
+    threshold_config: dict | None,
+) -> None:
+    try:
+        HogQLAlertConfig.model_validate(config)
+    except Exception:
+        raise ValueError(f"Alert has invalid HogQLAlertConfig: {config}")
+
+    kind = get_from_dict_or_attr(query, "kind")
+    if kind in WRAPPER_NODE_KINDS:
+        query = get_from_dict_or_attr(query, "source")
+        kind = get_from_dict_or_attr(query, "kind")
+
+    if kind != NodeKind.HOG_QL_QUERY:
+        raise ValueError(f"Alert config is HogQLAlertConfig but insight query kind is '{kind}'")
+
+    try:
+        HogQLQuery.model_validate(query)
+    except Exception as e:
+        raise ValueError(f"Alert's insight has an invalid HogQLQuery: {e}")
+
+    if threshold_config is not None:
+        try:
+            threshold = InsightThreshold.model_validate(threshold_config)
+        except Exception:
+            raise ValueError(f"Alert has invalid threshold configuration: {threshold_config}")
+
+        if (
+            parsed_condition.type == AlertConditionType.ABSOLUTE_VALUE
+            and threshold.type != InsightThresholdType.ABSOLUTE
+        ):
+            raise ValueError(
+                "Absolute value alerts require an absolute threshold, but a percentage threshold was configured"
+            )
+
+
 def calculation_interval_to_order(interval: AlertCalculationInterval | None) -> int:
     match interval:
         case AlertCalculationInterval.HOURLY:
@@ -143,6 +199,60 @@ def calculation_interval_to_order(interval: AlertCalculationInterval | None) -> 
             return 1
         case _:
             return 2
+
+
+_BREACH_CONDITION_TEXT: dict[AlertConditionType, str] = {
+    AlertConditionType.ABSOLUTE_VALUE: "is",
+    AlertConditionType.RELATIVE_INCREASE: "increased",
+    AlertConditionType.RELATIVE_DECREASE: "decreased",
+}
+
+
+def compute_relative_change(
+    condition_type: AlertConditionType,
+    threshold_type: InsightThresholdType,
+    current: float,
+    previous: float,
+) -> float:
+    """Shared arithmetic for relative-increase/decrease alerts. RELATIVE_DECREASE returns a positive
+    number when the metric went down, matching how breach messages talk about 'decreased by N'."""
+    if condition_type == AlertConditionType.RELATIVE_INCREASE:
+        delta = current - previous
+    elif condition_type == AlertConditionType.RELATIVE_DECREASE:
+        delta = previous - current
+    else:
+        raise ValueError(f"compute_relative_change called with non-relative condition: {condition_type}")
+
+    if threshold_type == InsightThresholdType.ABSOLUTE:
+        return delta
+    if threshold_type == InsightThresholdType.PERCENTAGE:
+        if previous == 0 and current == 0:
+            return 0
+        if previous == 0:
+            return float("inf")
+        return delta / previous
+    raise ValueError(f"Unsupported threshold type for relative condition: {threshold_type}")
+
+
+def format_threshold_breach(
+    bounds: InsightsThresholdBounds,
+    calculated_value: float,
+    threshold_type: InsightThresholdType,
+    condition_type: AlertConditionType,
+    *,
+    subject: str,
+) -> list[str]:
+    """Returns 0 or 1 breach messages. `subject` is the caller-supplied prefix
+    (e.g. "The SQL insight value" or "The insight value (Series A) for previous day")."""
+    is_percentage = threshold_type == InsightThresholdType.PERCENTAGE
+    fmt = lambda v: f"{v:.2%}" if is_percentage else v  # noqa: E731
+    condition_text = _BREACH_CONDITION_TEXT[condition_type]
+
+    if bounds.lower is not None and calculated_value < bounds.lower:
+        return [f"{subject} ({fmt(calculated_value)}) {condition_text} less than lower threshold ({fmt(bounds.lower)})"]
+    if bounds.upper is not None and calculated_value > bounds.upper:
+        return [f"{subject} ({fmt(calculated_value)}) {condition_text} more than upper threshold ({fmt(bounds.upper)})"]
+    return []
 
 
 def alert_calculation_interval_to_relativedelta(alert_calculation_interval: AlertCalculationInterval) -> relativedelta:


### PR DESCRIPTION
## Summary
- Extends insight alerts to support `HogQLQuery`-backed insights in addition to `TrendsQuery`.
- The HogQL alert evaluator (`posthog/tasks/alerts/hogql.py`) treats the query result as a single-column time series: it alerts on the last row for absolute conditions and on the last vs second-to-last row for relative conditions (absolute or percentage threshold).
- Wrong query shapes (multi-column, non-numeric, too few rows) surface via the existing errored-alert notification path — same UX as a broken trends insight.
- Fixes an unraised `ValueError` in `trends.py` that the new HogQL config-type now makes reachable when users switch insight kinds.

## Result-shape contract
A HogQL alert assumes the insight returns:
- **Exactly one column** of a numeric type.
- **One or more rows** (≥2 for relative conditions).
- **Chronologically ordered** by the query itself (the evaluator trusts `ORDER BY`).

## Test plan
- [x] `pytest posthog/tasks/alerts/test/test_hogql_alerts.py` — covers absolute breach (lower/upper/within bounds), multi-row time-series picking the last row, relative_increase / relative_decrease in absolute & percentage modes, and the validation paths (multi-column, non-numeric, single-row + relative).
- [x] `pytest` gating coverage — alert-creation API accepts HogQL insights and still rejects unsupported kinds (e.g. Funnels).
- [x] `ruff check` clean on all changed Python.
- [x] `tsc --noEmit` clean on all Alerts frontend files.
- [ ] Manual: create a HogQL insight, open Alerts modal, save an alert, verify the HogQL-only banner appears and the trends-only controls (series picker, "check ongoing interval", trend interval) are hidden.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*