### PR TITLE
fix(user-interviews): show Listening (not Thinking) while mic is open

### DIFF
--- a/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
+++ b/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
@@ -10,12 +10,12 @@ import { InterviewExportPayload } from '../types'
 
 type CallState = 'idle' | 'loading' | 'connecting' | 'in-call' | 'ended' | 'error'
 
-type ConversationPhase = 'agent-talking' | 'user-speaking' | 'waiting'
+type ConversationPhase = 'agent-talking' | 'listening' | 'thinking'
 
 const PHASE_LABELS: Record<ConversationPhase, string> = {
     'agent-talking': '🎤 Talking',
-    'user-speaking': '👂 Listening',
-    waiting: '🧠 Thinking',
+    listening: '👂 Listening',
+    thinking: '🧠 Thinking',
 }
 
 interface VapiTranscriptMessage {
@@ -212,11 +212,11 @@ export default function ExporterInterviewScene({
     accessToken?: string
 }): JSX.Element {
     const [state, setState] = useState<CallState>('idle')
-    const [conversationPhase, setConversationPhase] = useState<ConversationPhase>('waiting')
+    const [conversationPhase, setConversationPhase] = useState<ConversationPhase>('listening')
     const [errorMessage, setErrorMessage] = useState<string | null>(null)
     const vapiRef = useRef<Vapi | null>(null)
     const agentTalkingRef = useRef<boolean>(false)
-    const lastPhaseRef = useRef<ConversationPhase>('waiting')
+    const lastPhaseRef = useRef<ConversationPhase>('listening')
     const isMountedRef = useRef<boolean>(true)
 
     useEffect(() => {
@@ -240,8 +240,8 @@ export default function ExporterInterviewScene({
         vapiRef.current?.stop()
         vapiRef.current = null
         agentTalkingRef.current = false
-        lastPhaseRef.current = 'waiting'
-        setConversationPhase('waiting')
+        lastPhaseRef.current = 'listening'
+        setConversationPhase('listening')
         setState('loading')
         void (async () => {
             try {
@@ -270,12 +270,12 @@ export default function ExporterInterviewScene({
                 })
                 vapi.on('speech-end', () => {
                     agentTalkingRef.current = false
-                    setPhase('waiting')
+                    setPhase('listening')
                 })
                 vapi.on('message', (message: VapiTranscriptMessage) => {
                     if (message.type === 'user-interrupted') {
                         agentTalkingRef.current = false
-                        setPhase('user-speaking')
+                        setPhase('listening')
                         return
                     }
                     if (message.type !== 'transcript' || message.role !== 'user') {
@@ -285,9 +285,9 @@ export default function ExporterInterviewScene({
                         return
                     }
                     if (message.transcriptType === 'partial') {
-                        setPhase('user-speaking')
+                        setPhase('listening')
                     } else if (message.transcriptType === 'final') {
-                        setPhase('waiting')
+                        setPhase('thinking')
                     }
                 })
                 setState('connecting')


### PR DESCRIPTION
## Problem

The phase indicator on the interview page dropped to "🧠 Thinking" the moment the agent finished speaking, but Vapi keeps the mic open the whole time and is actually *listening* for the user to talk. Interviewees saw "Thinking" during the entire silent gap before they started speaking — sometimes 10+ seconds — which felt like the agent had hung.

## Changes

Reshape the conversation-phase state machine so the labels match what's happening:

- **🎤 Talking** — agent speech is playing (unchanged).
- **👂 Listening** — default state and after `speech-end`. Previously this was `"waiting"` → "Thinking".
- **🧠 Thinking** — set *only* after a user transcript's `final` chunk, i.e. the narrow window where the agent is actually processing a turn before replying.

Net effect: the long silent-mic-open moments after the agent stops speaking now read as Listening (correct) instead of Thinking (misleading). User-during-partial-transcript, agent-talking, and user-interrupted paths are unchanged.

## How did you test this code?

I'm an agent (PostHog Code). Manual testing not performed end-to-end — the change is to label/state-transition logic only, no business logic.

- Reviewed each Vapi event handler path and confirmed every transition now lands on the conceptually correct label.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

User flagged that the interview page "still shows as thinking when i think it's listening". Traced the issue to the state machine in `ExporterInterviewScene` defaulting `waiting` → "Thinking" after `speech-end`. Considered adding a separate "starting" phase for the pre-first-speech window but that gap is sub-second and `CallStatusPanel` doesn't render labels until `state === 'in-call'` anyway — not worth the extra state.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*