### PR TITLE
fix(web-analytics): pin events prefilter off in timezone snapshot test

### DIFF
--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -692,15 +692,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Africa/Cairo')), max(toTimeZone(raw_sessions.max_timestamp, 'Africa/Cairo'))), 10)))) AS `$is_bounce`,
@@ -716,7 +708,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Africa/Cairo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Africa/Cairo'))), lessOrEquals(toTimeZone(events.timestamp, 'Africa/Cairo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Africa/Cairo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Africa/Cairo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Africa/Cairo'))), lessOrEquals(toTimeZone(events.timestamp, 'Africa/Cairo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Africa/Cairo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`

--- a/posthog/models/web_preaggregated/test_web_pre_aggregated_timezones.py
+++ b/posthog/models/web_preaggregated/test_web_pre_aggregated_timezones.py
@@ -1,4 +1,5 @@
 from posthog.test.base import _create_event, _create_person, flush_persons_and_events, snapshot_clickhouse_queries
+from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -15,6 +16,19 @@ from posthog.models.web_preaggregated.sql import WEB_BOUNCES_INSERT_SQL, WEB_STA
 
 @snapshot_clickhouse_queries
 class TestTimezonePreAggregatedIntegration(WebAnalyticsPreAggregatedTestBase, FloatAwareTestCase):
+    def setUp(self):
+        super().setUp()
+        # The events prefilter fires on a fixed allowlist of team IDs. Test team pks are
+        # small sequential integers, so a team can land on an allowlisted id and wrap
+        # FROM events in a prefiltered subquery, making the captured SQL snapshot flaky.
+        # Pin it off so the snapshot is deterministic, matching TestWebStatsTableQueryRunner.
+        patcher = patch(
+            "posthog.hogql_queries.web_analytics.stats_table.is_web_analytics_events_prefilter_team",
+            return_value=False,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def _setup_test_data(self):
         """Required by WebAnalyticsPreAggregatedTestBase. Each test handles its own data setup."""
         pass

--- a/posthog/models/web_preaggregated/test_web_pre_aggregated_timezones.py
+++ b/posthog/models/web_preaggregated/test_web_pre_aggregated_timezones.py
@@ -18,10 +18,6 @@ from posthog.models.web_preaggregated.sql import WEB_BOUNCES_INSERT_SQL, WEB_STA
 class TestTimezonePreAggregatedIntegration(WebAnalyticsPreAggregatedTestBase, FloatAwareTestCase):
     def setUp(self):
         super().setUp()
-        # The events prefilter fires on a fixed allowlist of team IDs. Test team pks are
-        # small sequential integers, so a team can land on an allowlisted id and wrap
-        # FROM events in a prefiltered subquery, making the captured SQL snapshot flaky.
-        # Pin it off so the snapshot is deterministic, matching TestWebStatsTableQueryRunner.
         patcher = patch(
             "posthog.hogql_queries.web_analytics.stats_table.is_web_analytics_events_prefilter_team",
             return_value=False,


### PR DESCRIPTION
## Problem

`TestTimezonePreAggregatedIntegration` (`test_web_pre_aggregated_timezones.py`) captures ClickHouse query snapshots, and one of them was flaky: the `test_timezone_hourly_bucketing_05_Cairo_UTC_02_00_.1` query alternated between a plain `FROM events` scan and a `FROM (SELECT … FROM events WHERE …) AS events` prefiltered subquery between runs.

The cause is the web-analytics events prefilter (added in #54506). `WebStatsTableQueryRunner` wraps `FROM events` in a prefiltered subquery when the team's pk is in `WEB_ANALYTICS_EVENTS_PREFILTER_TEAM_IDS` (default `[2, 140988]`). Test team pks are small sequential integers, so whichever team in the file happens to land on pk `2` gets the prefilter applied, while the rest do not. That one team's captured SQL therefore flips depending on test execution order, and a regenerate run produces a different `.ambr` than master.

`TestWebStatsTableQueryRunner` already guards against exactly this by patching `is_web_analytics_events_prefilter_team` to `False` in `setUp`; the timezone test class never got that patch.

## Changes

- `test_web_pre_aggregated_timezones.py`: add a `setUp` that patches `is_web_analytics_events_prefilter_team` to `False`, mirroring `TestWebStatsTableQueryRunner`. The captured SQL is now deterministic regardless of which pk the test teams receive.
- `test_web_pre_aggregated_timezones.ambr`: regenerate the affected snapshot block to its non-prefilter form so all 30 snapshots reflect the deterministic output.

This is test-only; no production behavior changes.

## How did you test this code?

I'm an agent (Claude Code). Automated tests I ran:

- `hogli test posthog/models/web_preaggregated/test_web_pre_aggregated_timezones.py` — all 13 tests pass, 30 snapshots pass.

## Publish to changelog?

no

## 🤖 Agent context

Tool: Claude Code. Started from a report that the SQL snapshot diff on #58665 (an unrelated HogQL parser PR) looked like a master flake. Traced it: that PR's snapshot-regenerate commit captured the non-prefilter variant, while master holds the prefilter variant — both are valid outputs of the same flaky test. Confirmed the mechanism by reading the prefilter wiring (`events_prefilter.py`, `stats_table.py`, `data_stores.py`, `dynamic_settings.py`) and noting that exactly one of the file's ~15 teams (the one on pk 2) carried the prefilter subquery in the committed `.ambr`.

Decision: rather than touch the production default `WEB_ANALYTICS_EVENTS_PREFILTER_TEAM_IDS`, mirror the existing `TestWebStatsTableQueryRunner` pattern and pin the prefilter off in the test — smallest, most consistent fix.