### PR TITLE
feat(workflows): LLM classify, summarize, and extract action nodes

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -257,9 +257,12 @@ core:
         description: Full reset - wipe volumes, migrate, load demo data, sync flags
         prompt: true
     dev:api-key:
-        cmd: python manage.py setup_local_api_key
+        cmd: python manage.py setup_local_api_key --scopes "*" llm_gateway:read
         description: Creates a personal API key that's always the same, so you don't need
-            to manually create a new one every time you reset the stack.
+            to manually create a new one every time you reset the stack. Includes the
+            llm_gateway:read scope so LLM-backed dev paths (workflows LLM nodes, HogAI,
+            session summarization) work out of the box — the gateway requires this scope
+            explicitly and does not honor the wildcard for personal API keys.
         services:
             - postgresql
 health_checks:

--- a/nodejs/src/cdp/async-function-registry.ts
+++ b/nodejs/src/cdp/async-function-registry.ts
@@ -11,6 +11,8 @@ export type AsyncFunctionContext = {
     globals: HogFunctionInvocationGlobalsWithInputs
     teamManager: TeamManager
     siteUrl: string
+    llmGatewayUrl: string
+    llmGatewayApiKey: string
 }
 
 export type AsyncFunctionHandler = {

--- a/nodejs/src/cdp/async-functions/index.ts
+++ b/nodejs/src/cdp/async-functions/index.ts
@@ -1,4 +1,5 @@
 import './conversations'
 import './fetch-handler'
+import './llm-gateway'
 import './send-email'
 import './warehouse-webhooks'

--- a/nodejs/src/cdp/async-functions/llm-gateway.test.ts
+++ b/nodejs/src/cdp/async-functions/llm-gateway.test.ts
@@ -2,12 +2,12 @@ import { getAsyncFunctionHandler } from '../async-function-registry'
 import './llm-gateway'
 import { __TESTING_ALLOWED_LLM_TEMPLATE_IDS } from './llm-gateway'
 
-// Defense-in-depth: postHogLLMClassify / postHogLLMSummarize inject PostHog's internal service
-// LLM gateway key into outbound requests, so they MUST NOT be callable from arbitrary
-// user-authored destination Hog functions. The template_id gate is the load-bearing check —
-// these tests assert it actually rejects unauthorized callers and accepts the two built-in
-// LLM templates. Without this test the rest of the template-level tests pass even if the
-// gate is silently disabled, because they always run inside an allowed template.
+// Defense-in-depth: postHogLLMChatCompletion injects PostHog's internal service LLM gateway key
+// into outbound requests, so it MUST NOT be callable from arbitrary user-authored destination
+// Hog functions. The template_id gate is the load-bearing check — these tests assert it actually
+// rejects unauthorized callers and accepts the built-in LLM templates. Without this test the
+// rest of the template-level tests pass even if the gate is silently disabled, because they
+// always run inside an allowed template.
 describe('llm-gateway template_id gate', () => {
     const buildContext = (templateId: string | undefined): any => ({
         invocation: {
@@ -27,51 +27,39 @@ describe('llm-gateway template_id gate', () => {
         messages: [{ role: 'user', content: 'hi' }],
     })
 
-    it.each(['postHogLLMClassify', 'postHogLLMSummarize'] as const)(
-        '%s rejects a caller whose template_id is not on the allowlist',
-        (fnName) => {
-            const handler = getAsyncFunctionHandler(fnName)
-            expect(handler).toBeDefined()
-            expect(() =>
-                handler!.execute([buildOpts()], buildContext('template-some-user-destination'), buildResult())
-            ).toThrow(/restricted to PostHog-built LLM templates/)
-        }
-    )
-
-    it.each(['postHogLLMClassify', 'postHogLLMSummarize'] as const)(
-        '%s rejects a caller with an empty/undefined template_id',
-        (fnName) => {
-            const handler = getAsyncFunctionHandler(fnName)
-            expect(() => handler!.execute([buildOpts()], buildContext(undefined), buildResult())).toThrow(
-                /restricted to PostHog-built LLM templates/
-            )
-        }
-    )
-
-    it('postHogLLMClassify accepts the classify template', () => {
-        const handler = getAsyncFunctionHandler('postHogLLMClassify')
-        const result = buildResult()
+    it('rejects a caller whose template_id is not on the allowlist', () => {
+        const handler = getAsyncFunctionHandler('postHogLLMChatCompletion')
+        expect(handler).toBeDefined()
         expect(() =>
-            handler!.execute([buildOpts()], buildContext('template-posthog-llm-classify'), result)
-        ).not.toThrow()
+            handler!.execute([buildOpts()], buildContext('template-some-user-destination'), buildResult())
+        ).toThrow(/restricted to PostHog-built LLM templates/)
+    })
+
+    it('rejects a caller with an empty/undefined template_id', () => {
+        const handler = getAsyncFunctionHandler('postHogLLMChatCompletion')
+        expect(() => handler!.execute([buildOpts()], buildContext(undefined), buildResult())).toThrow(
+            /restricted to PostHog-built LLM templates/
+        )
+    })
+
+    it.each([
+        'template-posthog-llm-classify',
+        'template-posthog-llm-summarize',
+        'template-posthog-llm-extract',
+    ] as const)('accepts the %s template', (templateId) => {
+        const handler = getAsyncFunctionHandler('postHogLLMChatCompletion')
+        const result = buildResult()
+        expect(() => handler!.execute([buildOpts()], buildContext(templateId), result)).not.toThrow()
         // Sanity: the fetch was actually queued (not just silently no-op'd).
         expect(result.invocation.queueParameters).toBeDefined()
     })
 
-    it('postHogLLMSummarize accepts the summarize template', () => {
-        const handler = getAsyncFunctionHandler('postHogLLMSummarize')
-        const result = buildResult()
-        expect(() =>
-            handler!.execute([buildOpts()], buildContext('template-posthog-llm-summarize'), result)
-        ).not.toThrow()
-        expect(result.invocation.queueParameters).toBeDefined()
-    })
-
-    it('exposes the allowlist with the two expected templates', () => {
+    it('exposes the allowlist with the expected templates', () => {
         // Anyone changing this set needs to update the gate intentionally — keeping a snapshot
         // here makes a silent expansion show up in code review.
         expect([...__TESTING_ALLOWED_LLM_TEMPLATE_IDS].sort()).toEqual([
             'template-posthog-llm-classify',
+            'template-posthog-llm-extract',
             'template-posthog-llm-summarize',
         ])
     })

--- a/nodejs/src/cdp/async-functions/llm-gateway.test.ts
+++ b/nodejs/src/cdp/async-functions/llm-gateway.test.ts
@@ -1,0 +1,78 @@
+import { getAsyncFunctionHandler } from '../async-function-registry'
+import './llm-gateway'
+import { __TESTING_ALLOWED_LLM_TEMPLATE_IDS } from './llm-gateway'
+
+// Defense-in-depth: postHogLLMClassify / postHogLLMSummarize inject PostHog's internal service
+// LLM gateway key into outbound requests, so they MUST NOT be callable from arbitrary
+// user-authored destination Hog functions. The template_id gate is the load-bearing check —
+// these tests assert it actually rejects unauthorized callers and accepts the two built-in
+// LLM templates. Without this test the rest of the template-level tests pass even if the
+// gate is silently disabled, because they always run inside an allowed template.
+describe('llm-gateway template_id gate', () => {
+    const buildContext = (templateId: string | undefined): any => ({
+        invocation: {
+            hogFunction: { template_id: templateId },
+        },
+        globals: { event: { distinct_id: 'u1' } },
+        llmGatewayUrl: 'http://gw.test',
+        llmGatewayApiKey: 'svc',
+    })
+
+    const buildResult = (): any => ({
+        invocation: { queueParameters: undefined },
+    })
+
+    const buildOpts = () => ({
+        model: 'gpt-5.4-nano',
+        messages: [{ role: 'user', content: 'hi' }],
+    })
+
+    it.each(['postHogLLMClassify', 'postHogLLMSummarize'] as const)(
+        '%s rejects a caller whose template_id is not on the allowlist',
+        (fnName) => {
+            const handler = getAsyncFunctionHandler(fnName)
+            expect(handler).toBeDefined()
+            expect(() =>
+                handler!.execute([buildOpts()], buildContext('template-some-user-destination'), buildResult())
+            ).toThrow(/restricted to PostHog-built LLM templates/)
+        }
+    )
+
+    it.each(['postHogLLMClassify', 'postHogLLMSummarize'] as const)(
+        '%s rejects a caller with an empty/undefined template_id',
+        (fnName) => {
+            const handler = getAsyncFunctionHandler(fnName)
+            expect(() => handler!.execute([buildOpts()], buildContext(undefined), buildResult())).toThrow(
+                /restricted to PostHog-built LLM templates/
+            )
+        }
+    )
+
+    it('postHogLLMClassify accepts the classify template', () => {
+        const handler = getAsyncFunctionHandler('postHogLLMClassify')
+        const result = buildResult()
+        expect(() =>
+            handler!.execute([buildOpts()], buildContext('template-posthog-llm-classify'), result)
+        ).not.toThrow()
+        // Sanity: the fetch was actually queued (not just silently no-op'd).
+        expect(result.invocation.queueParameters).toBeDefined()
+    })
+
+    it('postHogLLMSummarize accepts the summarize template', () => {
+        const handler = getAsyncFunctionHandler('postHogLLMSummarize')
+        const result = buildResult()
+        expect(() =>
+            handler!.execute([buildOpts()], buildContext('template-posthog-llm-summarize'), result)
+        ).not.toThrow()
+        expect(result.invocation.queueParameters).toBeDefined()
+    })
+
+    it('exposes the allowlist with the two expected templates', () => {
+        // Anyone changing this set needs to update the gate intentionally — keeping a snapshot
+        // here makes a silent expansion show up in code review.
+        expect([...__TESTING_ALLOWED_LLM_TEMPLATE_IDS].sort()).toEqual([
+            'template-posthog-llm-classify',
+            'template-posthog-llm-summarize',
+        ])
+    })
+})

--- a/nodejs/src/cdp/async-functions/llm-gateway.ts
+++ b/nodejs/src/cdp/async-functions/llm-gateway.ts
@@ -4,7 +4,7 @@ import { CyclotronInvocationQueueParametersFetchSchema } from '~/schema/cyclotro
 
 import { registerAsyncFunction } from '../async-function-registry'
 
-type ClassifyArgs = {
+type ChatCompletionArgs = {
     model?: string
     messages?: Array<{ role: string; content: string }>
     response_format?: Record<string, unknown>
@@ -17,78 +17,110 @@ const buildGatewayUrl = (rawBase: string, product: string): string => {
     return `${base}/${sanitizeProduct(product)}/v1/chat/completions`
 }
 
+// Shared between postHogLLMClassify and postHogLLMSummarize. The async functions are intentionally
+// thin — they validate, resolve gateway URL/auth from server-side config, and dispatch a fetch
+// through cyclotron. The only thing that differs between callers is the Hog-side name (which
+// becomes part of the error message) and the mock content shape for tests.
+const queueChatCompletionFetch = (
+    fnName: string,
+    opts: ChatCompletionArgs | undefined,
+    context: any,
+    result: any
+): void => {
+    const model = opts?.model
+    const messages = opts?.messages
+    const responseFormat = opts?.response_format
+
+    if (!model || typeof model !== 'string') {
+        throw new Error(`[HogFunction] - ${fnName} call missing 'model' property`)
+    }
+    if (!Array.isArray(messages) || messages.length === 0) {
+        throw new Error(`[HogFunction] - ${fnName} call missing 'messages' property`)
+    }
+
+    if (!context.llmGatewayUrl) {
+        throw new Error('[HogFunction] - PostHog LLM gateway URL is not configured (LLM_GATEWAY_URL)')
+    }
+    if (!context.llmGatewayApiKey) {
+        throw new Error('[HogFunction] - PostHog LLM gateway API key is not configured (LLM_GATEWAY_API_KEY)')
+    }
+
+    const body: Record<string, unknown> = { model, messages }
+    if (responseFormat) {
+        body.response_format = responseFormat
+    }
+    // Implicit per-end-user accounting in the gateway — pull from the trigger event so users
+    // never have to bind {event.distinct_id} themselves on a built-in node.
+    const distinctId = context.globals?.event?.distinct_id
+    if (distinctId) {
+        body.user = distinctId
+    }
+
+    result.invocation.queueParameters = CyclotronInvocationQueueParametersFetchSchema.parse({
+        type: 'fetch',
+        url: buildGatewayUrl(context.llmGatewayUrl, 'workflows'),
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+            Authorization: `Bearer ${context.llmGatewayApiKey}`,
+            'Content-Type': 'application/json',
+        },
+        // LLM responses regularly exceed the 3s EXTERNAL_REQUEST_TIMEOUT_MS default
+        // (gpt-5-mini with reasoning routinely takes 4-8s). Without this override the
+        // fetch aborts mid-completion and the Hog VM sees status 500 / body undefined.
+        timeout_ms: 120_000,
+    })
+}
+
+const buildMockResponse = (fnName: string, opts: ChatCompletionArgs, mockContent: string, logs: any[]) => {
+    logs.push({
+        level: 'info',
+        timestamp: DateTime.now(),
+        message: `Async function '${fnName}' was mocked with arguments:`,
+    })
+    logs.push({
+        level: 'info',
+        timestamp: DateTime.now(),
+        message: `${fnName}(${JSON.stringify(opts, null, 2)})`,
+    })
+
+    return {
+        status: 200,
+        body: {
+            choices: [{ message: { content: mockContent } }],
+        },
+    }
+}
+
 registerAsyncFunction('postHogLLMClassify', {
     execute: (args, context, result) => {
-        const [opts] = args as [ClassifyArgs | undefined]
-
-        const model = opts?.model
-        const messages = opts?.messages
-        const responseFormat = opts?.response_format
-
-        if (!model || typeof model !== 'string') {
-            throw new Error("[HogFunction] - postHogLLMClassify call missing 'model' property")
-        }
-        if (!Array.isArray(messages) || messages.length === 0) {
-            throw new Error("[HogFunction] - postHogLLMClassify call missing 'messages' property")
-        }
-
-        if (!context.llmGatewayUrl) {
-            throw new Error('[HogFunction] - PostHog LLM gateway URL is not configured (LLM_GATEWAY_URL)')
-        }
-        if (!context.llmGatewayApiKey) {
-            throw new Error('[HogFunction] - PostHog LLM gateway API key is not configured (LLM_GATEWAY_API_KEY)')
-        }
-
-        const body: Record<string, unknown> = { model, messages }
-        if (responseFormat) {
-            body.response_format = responseFormat
-        }
-        // Implicit per-end-user accounting in the gateway — pull from the trigger event so users
-        // never have to bind {event.distinct_id} themselves on a built-in node.
-        const distinctId = context.globals?.event?.distinct_id
-        if (distinctId) {
-            body.user = distinctId
-        }
-
-        result.invocation.queueParameters = CyclotronInvocationQueueParametersFetchSchema.parse({
-            type: 'fetch',
-            url: buildGatewayUrl(context.llmGatewayUrl, 'workflows'),
-            method: 'POST',
-            body: JSON.stringify(body),
-            headers: {
-                Authorization: `Bearer ${context.llmGatewayApiKey}`,
-                'Content-Type': 'application/json',
-            },
-            // LLM responses regularly exceed the 3s EXTERNAL_REQUEST_TIMEOUT_MS default
-            // (gpt-5-mini with reasoning routinely takes 4-8s). Without this override the
-            // fetch aborts mid-completion and the Hog VM sees status 500 / body undefined.
-            timeout_ms: 120_000,
-        })
+        const [opts] = args as [ChatCompletionArgs | undefined]
+        queueChatCompletionFetch('postHogLLMClassify', opts, context, result)
     },
 
     mock: (args, logs) => {
-        const opts = (args[0] ?? {}) as ClassifyArgs
-        logs.push({
-            level: 'info',
-            timestamp: DateTime.now(),
-            message: `Async function 'postHogLLMClassify' was mocked with arguments:`,
-        })
-        logs.push({
-            level: 'info',
-            timestamp: DateTime.now(),
-            message: `postHogLLMClassify(${JSON.stringify(opts, null, 2)})`,
-        })
-
+        const opts = (args[0] ?? {}) as ChatCompletionArgs
         const isStructured = !!opts.response_format
         const mockContent = isStructured
             ? JSON.stringify({ category: 'mock-category', reasoning: 'mock reasoning' })
             : 'mock free-form classification'
+        return buildMockResponse('postHogLLMClassify', opts, mockContent, logs)
+    },
+})
 
-        return {
-            status: 200,
-            body: {
-                choices: [{ message: { content: mockContent } }],
-            },
-        }
+registerAsyncFunction('postHogLLMSummarize', {
+    execute: (args, context, result) => {
+        const [opts] = args as [ChatCompletionArgs | undefined]
+        queueChatCompletionFetch('postHogLLMSummarize', opts, context, result)
+    },
+
+    mock: (args, logs) => {
+        const opts = (args[0] ?? {}) as ChatCompletionArgs
+        // Summarize is always structured — the template enforces the { title, description } schema.
+        const mockContent = JSON.stringify({
+            title: 'mock title',
+            description: 'mock description',
+        })
+        return buildMockResponse('postHogLLMSummarize', opts, mockContent, logs)
     },
 })

--- a/nodejs/src/cdp/async-functions/llm-gateway.ts
+++ b/nodejs/src/cdp/async-functions/llm-gateway.ts
@@ -59,6 +59,10 @@ registerAsyncFunction('postHogLLMClassify', {
                 Authorization: `Bearer ${context.llmGatewayApiKey}`,
                 'Content-Type': 'application/json',
             },
+            // LLM responses regularly exceed the 3s EXTERNAL_REQUEST_TIMEOUT_MS default
+            // (gpt-5-mini with reasoning routinely takes 4-8s). Without this override the
+            // fetch aborts mid-completion and the Hog VM sees status 500 / body undefined.
+            timeout_ms: 120_000,
         })
     },
 

--- a/nodejs/src/cdp/async-functions/llm-gateway.ts
+++ b/nodejs/src/cdp/async-functions/llm-gateway.ts
@@ -2,7 +2,8 @@ import { DateTime } from 'luxon'
 
 import { CyclotronInvocationQueueParametersFetchSchema } from '~/schema/cyclotron'
 
-import { registerAsyncFunction } from '../async-function-registry'
+import { AsyncFunctionContext, registerAsyncFunction } from '../async-function-registry'
+import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult } from '../types'
 
 type ChatCompletionArgs = {
     model?: string
@@ -10,11 +11,19 @@ type ChatCompletionArgs = {
     response_format?: Record<string, unknown>
 }
 
-const sanitizeProduct = (raw: string): string => raw.replace(/[^a-z0-9_-]/gi, '').toLowerCase() || 'workflows'
+// Template-id allowlist: these async functions inject PostHog's internal service LLM gateway key
+// into outbound requests, so they MUST NOT be callable from arbitrary user-authored destination
+// Hog functions. Any caller whose hogFunction.template_id is not on this list is rejected, even
+// if Hog code references postHogLLMClassify / postHogLLMSummarize by name. template_id is set
+// server-side from the HogFunctionType record — users cannot spoof it from Hog code.
+const ALLOWED_LLM_TEMPLATE_IDS: ReadonlySet<string> = new Set([
+    'template-posthog-llm-classify',
+    'template-posthog-llm-summarize',
+])
 
-const buildGatewayUrl = (rawBase: string, product: string): string => {
+const buildGatewayUrl = (rawBase: string): string => {
     const base = rawBase.replace(/\/+$/, '')
-    return `${base}/${sanitizeProduct(product)}/v1/chat/completions`
+    return `${base}/workflows/v1/chat/completions`
 }
 
 // Shared between postHogLLMClassify and postHogLLMSummarize. The async functions are intentionally
@@ -24,9 +33,16 @@ const buildGatewayUrl = (rawBase: string, product: string): string => {
 const queueChatCompletionFetch = (
     fnName: string,
     opts: ChatCompletionArgs | undefined,
-    context: any,
-    result: any
+    context: AsyncFunctionContext,
+    result: CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction>
 ): void => {
+    const callerTemplateId = context.invocation.hogFunction.template_id ?? ''
+    if (!ALLOWED_LLM_TEMPLATE_IDS.has(callerTemplateId)) {
+        throw new Error(
+            `[HogFunction] - ${fnName} is restricted to PostHog-built LLM templates; caller template_id='${callerTemplateId}' is not allowed`
+        )
+    }
+
     const model = opts?.model
     const messages = opts?.messages
     const responseFormat = opts?.response_format
@@ -58,7 +74,7 @@ const queueChatCompletionFetch = (
 
     result.invocation.queueParameters = CyclotronInvocationQueueParametersFetchSchema.parse({
         type: 'fetch',
-        url: buildGatewayUrl(context.llmGatewayUrl, 'workflows'),
+        url: buildGatewayUrl(context.llmGatewayUrl),
         method: 'POST',
         body: JSON.stringify(body),
         headers: {
@@ -124,3 +140,6 @@ registerAsyncFunction('postHogLLMSummarize', {
         return buildMockResponse('postHogLLMSummarize', opts, mockContent, logs)
     },
 })
+
+// Exported for tests; the runtime gate uses this set directly.
+export const __TESTING_ALLOWED_LLM_TEMPLATE_IDS = ALLOWED_LLM_TEMPLATE_IDS

--- a/nodejs/src/cdp/async-functions/llm-gateway.ts
+++ b/nodejs/src/cdp/async-functions/llm-gateway.ts
@@ -11,27 +11,25 @@ type ChatCompletionArgs = {
     response_format?: Record<string, unknown>
 }
 
-// Template-id allowlist: these async functions inject PostHog's internal service LLM gateway key
-// into outbound requests, so they MUST NOT be callable from arbitrary user-authored destination
+// Template-id allowlist: this async function injects PostHog's internal LLM gateway service key
+// into outbound requests, so it MUST NOT be callable from arbitrary user-authored destination
 // Hog functions. Any caller whose hogFunction.template_id is not on this list is rejected, even
-// if Hog code references postHogLLMClassify / postHogLLMSummarize by name. template_id is set
-// server-side from the HogFunctionType record — users cannot spoof it from Hog code.
+// if Hog code references postHogLLMChatCompletion by name. template_id is set server-side from
+// the HogFunctionType record — users cannot spoof it from Hog code.
 const ALLOWED_LLM_TEMPLATE_IDS: ReadonlySet<string> = new Set([
     'template-posthog-llm-classify',
     'template-posthog-llm-summarize',
+    'template-posthog-llm-extract',
 ])
+
+const FN_NAME = 'postHogLLMChatCompletion'
 
 const buildGatewayUrl = (rawBase: string): string => {
     const base = rawBase.replace(/\/+$/, '')
     return `${base}/workflows/v1/chat/completions`
 }
 
-// Shared between postHogLLMClassify and postHogLLMSummarize. The async functions are intentionally
-// thin — they validate, resolve gateway URL/auth from server-side config, and dispatch a fetch
-// through cyclotron. The only thing that differs between callers is the Hog-side name (which
-// becomes part of the error message) and the mock content shape for tests.
 const queueChatCompletionFetch = (
-    fnName: string,
     opts: ChatCompletionArgs | undefined,
     context: AsyncFunctionContext,
     result: CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction>
@@ -39,7 +37,7 @@ const queueChatCompletionFetch = (
     const callerTemplateId = context.invocation.hogFunction.template_id ?? ''
     if (!ALLOWED_LLM_TEMPLATE_IDS.has(callerTemplateId)) {
         throw new Error(
-            `[HogFunction] - ${fnName} is restricted to PostHog-built LLM templates; caller template_id='${callerTemplateId}' is not allowed`
+            `[HogFunction] - ${FN_NAME} is restricted to PostHog-built LLM templates; caller template_id='${callerTemplateId}' is not allowed`
         )
     }
 
@@ -48,10 +46,10 @@ const queueChatCompletionFetch = (
     const responseFormat = opts?.response_format
 
     if (!model || typeof model !== 'string') {
-        throw new Error(`[HogFunction] - ${fnName} call missing 'model' property`)
+        throw new Error(`[HogFunction] - ${FN_NAME} call missing 'model' property`)
     }
     if (!Array.isArray(messages) || messages.length === 0) {
-        throw new Error(`[HogFunction] - ${fnName} call missing 'messages' property`)
+        throw new Error(`[HogFunction] - ${FN_NAME} call missing 'messages' property`)
     }
 
     if (!context.llmGatewayUrl) {
@@ -88,56 +86,59 @@ const queueChatCompletionFetch = (
     })
 }
 
-const buildMockResponse = (fnName: string, opts: ChatCompletionArgs, mockContent: string, logs: any[]) => {
-    logs.push({
-        level: 'info',
-        timestamp: DateTime.now(),
-        message: `Async function '${fnName}' was mocked with arguments:`,
-    })
-    logs.push({
-        level: 'info',
-        timestamp: DateTime.now(),
-        message: `${fnName}(${JSON.stringify(opts, null, 2)})`,
-    })
-
-    return {
-        status: 200,
-        body: {
-            choices: [{ message: { content: mockContent } }],
-        },
+// Derives a structurally valid mock response from the caller's response_format. Returning a
+// concrete object keyed off the requested schema means a single mock works for classify
+// ({category, reasoning}), summarize ({title, description}), extract ({...user-defined fields}),
+// and any future LLM-action template without a per-caller fixture.
+const deriveMockContent = (opts: ChatCompletionArgs): string => {
+    const schema = (opts.response_format as any)?.json_schema?.schema
+    const props = schema?.properties as Record<string, any> | undefined
+    if (!props) {
+        return 'mock free-form response'
     }
+    const mock: Record<string, unknown> = {}
+    for (const [key, propRaw] of Object.entries(props)) {
+        const prop = propRaw as any
+        if (Array.isArray(prop.enum) && prop.enum.length > 0) {
+            mock[key] = prop.enum[0]
+        } else if (prop.type === 'number' || prop.type === 'integer') {
+            mock[key] = 0
+        } else if (prop.type === 'boolean') {
+            mock[key] = false
+        } else if (prop.type === 'array') {
+            mock[key] = []
+        } else {
+            mock[key] = `mock ${key}`
+        }
+    }
+    return JSON.stringify(mock)
 }
 
-registerAsyncFunction('postHogLLMClassify', {
+registerAsyncFunction(FN_NAME, {
     execute: (args, context, result) => {
         const [opts] = args as [ChatCompletionArgs | undefined]
-        queueChatCompletionFetch('postHogLLMClassify', opts, context, result)
+        queueChatCompletionFetch(opts, context, result)
     },
 
     mock: (args, logs) => {
         const opts = (args[0] ?? {}) as ChatCompletionArgs
-        const isStructured = !!opts.response_format
-        const mockContent = isStructured
-            ? JSON.stringify({ category: 'mock-category', reasoning: 'mock reasoning' })
-            : 'mock free-form classification'
-        return buildMockResponse('postHogLLMClassify', opts, mockContent, logs)
-    },
-})
-
-registerAsyncFunction('postHogLLMSummarize', {
-    execute: (args, context, result) => {
-        const [opts] = args as [ChatCompletionArgs | undefined]
-        queueChatCompletionFetch('postHogLLMSummarize', opts, context, result)
-    },
-
-    mock: (args, logs) => {
-        const opts = (args[0] ?? {}) as ChatCompletionArgs
-        // Summarize is always structured — the template enforces the { title, description } schema.
-        const mockContent = JSON.stringify({
-            title: 'mock title',
-            description: 'mock description',
+        const mockContent = deriveMockContent(opts)
+        logs.push({
+            level: 'info',
+            timestamp: DateTime.now(),
+            message: `Async function '${FN_NAME}' was mocked with arguments:`,
         })
-        return buildMockResponse('postHogLLMSummarize', opts, mockContent, logs)
+        logs.push({
+            level: 'info',
+            timestamp: DateTime.now(),
+            message: `${FN_NAME}(${JSON.stringify(opts, null, 2)})`,
+        })
+        return {
+            status: 200,
+            body: {
+                choices: [{ message: { content: mockContent } }],
+            },
+        }
     },
 })
 

--- a/nodejs/src/cdp/async-functions/llm-gateway.ts
+++ b/nodejs/src/cdp/async-functions/llm-gateway.ts
@@ -1,0 +1,90 @@
+import { DateTime } from 'luxon'
+
+import { CyclotronInvocationQueueParametersFetchSchema } from '~/schema/cyclotron'
+
+import { registerAsyncFunction } from '../async-function-registry'
+
+type ClassifyArgs = {
+    model?: string
+    messages?: Array<{ role: string; content: string }>
+    response_format?: Record<string, unknown>
+}
+
+const sanitizeProduct = (raw: string): string => raw.replace(/[^a-z0-9_-]/gi, '').toLowerCase() || 'workflows'
+
+const buildGatewayUrl = (rawBase: string, product: string): string => {
+    const base = rawBase.replace(/\/+$/, '')
+    return `${base}/${sanitizeProduct(product)}/v1/chat/completions`
+}
+
+registerAsyncFunction('postHogLLMClassify', {
+    execute: (args, context, result) => {
+        const [opts] = args as [ClassifyArgs | undefined]
+
+        const model = opts?.model
+        const messages = opts?.messages
+        const responseFormat = opts?.response_format
+
+        if (!model || typeof model !== 'string') {
+            throw new Error("[HogFunction] - postHogLLMClassify call missing 'model' property")
+        }
+        if (!Array.isArray(messages) || messages.length === 0) {
+            throw new Error("[HogFunction] - postHogLLMClassify call missing 'messages' property")
+        }
+
+        if (!context.llmGatewayUrl) {
+            throw new Error('[HogFunction] - PostHog LLM gateway URL is not configured (LLM_GATEWAY_URL)')
+        }
+        if (!context.llmGatewayApiKey) {
+            throw new Error('[HogFunction] - PostHog LLM gateway API key is not configured (LLM_GATEWAY_API_KEY)')
+        }
+
+        const body: Record<string, unknown> = { model, messages }
+        if (responseFormat) {
+            body.response_format = responseFormat
+        }
+        // Implicit per-end-user accounting in the gateway — pull from the trigger event so users
+        // never have to bind {event.distinct_id} themselves on a built-in node.
+        const distinctId = context.globals?.event?.distinct_id
+        if (distinctId) {
+            body.user = distinctId
+        }
+
+        result.invocation.queueParameters = CyclotronInvocationQueueParametersFetchSchema.parse({
+            type: 'fetch',
+            url: buildGatewayUrl(context.llmGatewayUrl, 'workflows'),
+            method: 'POST',
+            body: JSON.stringify(body),
+            headers: {
+                Authorization: `Bearer ${context.llmGatewayApiKey}`,
+                'Content-Type': 'application/json',
+            },
+        })
+    },
+
+    mock: (args, logs) => {
+        const opts = (args[0] ?? {}) as ClassifyArgs
+        logs.push({
+            level: 'info',
+            timestamp: DateTime.now(),
+            message: `Async function 'postHogLLMClassify' was mocked with arguments:`,
+        })
+        logs.push({
+            level: 'info',
+            timestamp: DateTime.now(),
+            message: `postHogLLMClassify(${JSON.stringify(opts, null, 2)})`,
+        })
+
+        const isStructured = !!opts.response_format
+        const mockContent = isStructured
+            ? JSON.stringify({ category: 'mock-category', reasoning: 'mock reasoning' })
+            : 'mock free-form classification'
+
+        return {
+            status: 200,
+            body: {
+                choices: [{ message: { content: mockContent } }],
+            },
+        }
+    },
+})

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -95,7 +95,13 @@ export interface CdpCoreServices {
 
 export type CdpCoreServicesConfig = Pick<
     CommonConfig,
-    'REDIS_URL' | 'REDIS_POOL_MIN_SIZE' | 'REDIS_POOL_MAX_SIZE' | 'ENCRYPTION_SALT_KEYS' | 'SITE_URL'
+    | 'REDIS_URL'
+    | 'REDIS_POOL_MIN_SIZE'
+    | 'REDIS_POOL_MAX_SIZE'
+    | 'ENCRYPTION_SALT_KEYS'
+    | 'SITE_URL'
+    | 'LLM_GATEWAY_URL'
+    | 'LLM_GATEWAY_API_KEY'
 > &
     Pick<
         CdpConfig,
@@ -387,7 +393,12 @@ export function createCdpCoreServices(
             fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
         },
-        { teamManager: deps.teamManager, siteUrl: config.SITE_URL },
+        {
+            teamManager: deps.teamManager,
+            siteUrl: config.SITE_URL,
+            llmGatewayUrl: config.LLM_GATEWAY_URL,
+            llmGatewayApiKey: config.LLM_GATEWAY_API_KEY,
+        },
         hogInputsService,
         emailService,
         recipientTokensService

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -489,7 +489,12 @@ export function createHogTransformerService(
             fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
         },
-        { teamManager: deps.teamManager, siteUrl: config.SITE_URL },
+        {
+            teamManager: deps.teamManager,
+            siteUrl: config.SITE_URL,
+            llmGatewayUrl: config.LLM_GATEWAY_URL,
+            llmGatewayApiKey: config.LLM_GATEWAY_API_KEY,
+        },
         hogInputsService,
         emailService,
         recipientTokensService

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -71,7 +71,12 @@ describe('Hog Executor', () => {
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
             },
-            { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+            {
+                teamManager: hub.teamManager,
+                siteUrl: hub.SITE_URL,
+                llmGatewayUrl: hub.LLM_GATEWAY_URL,
+                llmGatewayApiKey: hub.LLM_GATEWAY_API_KEY,
+            },
             hogInputsService,
             emailService,
             recipientTokensService

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -51,6 +51,8 @@ export interface HogExecutorConfig {
 export interface HogExecutorAsyncContext {
     teamManager: TeamManager
     siteUrl: string
+    llmGatewayUrl: string
+    llmGatewayApiKey: string
 }
 
 const cdpHttpRequests = new Counter({

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -666,6 +666,10 @@ export class HogExecutorService {
             fetchParams.body = params.body
         }
 
+        if (params.timeout_ms) {
+            fetchParams.timeoutMs = params.timeout_ms
+        }
+
         const { fetchError, fetchResponse, fetchDuration } = await cdpTrackedFetch({
             url: params.url,
             fetchParams,

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -61,7 +61,12 @@ describe('HogFunctionHandler', () => {
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
             },
-            { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+            {
+                teamManager: hub.teamManager,
+                siteUrl: hub.SITE_URL,
+                llmGatewayUrl: hub.LLM_GATEWAY_URL,
+                llmGatewayApiKey: hub.LLM_GATEWAY_API_KEY,
+            },
             hogInputsService,
             emailService,
             recipientTokensService

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -81,7 +81,12 @@ describe('Hogflow Executor', () => {
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
             },
-            { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+            {
+                teamManager: hub.teamManager,
+                siteUrl: hub.SITE_URL,
+                llmGatewayUrl: hub.LLM_GATEWAY_URL,
+                llmGatewayApiKey: hub.LLM_GATEWAY_API_KEY,
+            },
             hogInputsService,
             emailService,
             recipientTokensService

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.test.ts
@@ -53,6 +53,8 @@ describe('posthog-llm-classify template', () => {
             Authorization: 'Bearer service-key',
             'Content-Type': 'application/json',
         })
+        // Generous timeout — LLM responses regularly exceed the 3s default.
+        expect(params.timeout_ms).toBe(120_000)
 
         const body = parseJSON(params.body)
         expect(body.model).toBe('gpt-5-mini')

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.test.ts
@@ -10,39 +10,52 @@ describe('posthog-llm-classify template', () => {
 
     beforeEach(async () => {
         await tester.beforeEach()
+        // Gateway URL + auth are resolved server-side; deterministic test values so we can assert
+        // they're not leaking to user-facing inputs and are routed via the workflows product path.
+        tester.setHubConfig({
+            LLM_GATEWAY_URL: 'http://gateway.test',
+            LLM_GATEWAY_API_KEY: 'service-key',
+        })
         const fixedTime = DateTime.fromISO('2025-01-01T00:00:00Z').toJSDate()
         jest.spyOn(Date, 'now').mockReturnValue(fixedTime.getTime())
     })
 
     const baseInputs = {
-        api_key: 'phx_test_key',
         model: 'gpt-5-mini',
-        system_prompt: 'You classify support tickets.',
-        user_content: 'My invoice is wrong',
-        user_distinct_id: 'distinct-id',
-        gateway_url: 'https://gateway.us.posthog.com/v1/chat/completions',
+        instructions: 'You classify support tickets.',
+        content: 'My invoice is wrong',
     }
 
-    it('builds a structured-output request when tags are provided', async () => {
+    it('does not expose gateway URL or API key as user-facing inputs', () => {
+        const keys = template.inputs_schema.map((field) => field.key)
+        expect(keys).not.toContain('api_key')
+        expect(keys).not.toContain('gateway_url')
+        expect(keys).not.toContain('user_distinct_id')
+        // The user-meaningful inputs the form should expose:
+        expect(keys).toEqual(expect.arrayContaining(['model', 'instructions', 'content', 'categories']))
+    })
+
+    it('builds a structured-output request when categories are provided', async () => {
         const response = await tester.invoke({
             ...baseInputs,
-            tags: 'billing, support, sales',
+            categories: 'billing, support, sales',
         })
 
         expect(response.error).toBeUndefined()
         expect(response.finished).toBe(false)
 
         const params = response.invocation.queueParameters as Record<string, any>
-        expect(params.url).toBe('https://gateway.us.posthog.com/v1/chat/completions')
+        // Routed through the workflows product path on the configured gateway, with service auth
+        // — never the user-provided URL/key.
+        expect(params.url).toBe('http://gateway.test/workflows/v1/chat/completions')
         expect(params.method).toBe('POST')
         expect(params.headers).toEqual({
-            Authorization: 'Bearer phx_test_key',
+            Authorization: 'Bearer service-key',
             'Content-Type': 'application/json',
         })
 
         const body = parseJSON(params.body)
         expect(body.model).toBe('gpt-5-mini')
-        expect(body.user).toBe('distinct-id')
         expect(body.messages).toEqual([
             { role: 'system', content: 'You classify support tickets.' },
             { role: 'user', content: 'My invoice is wrong' },
@@ -61,7 +74,7 @@ describe('posthog-llm-classify template', () => {
     it('parses the structured-output content on successful response', async () => {
         const initial = await tester.invoke({
             ...baseInputs,
-            tags: 'billing, support, sales',
+            categories: 'billing, support, sales',
         })
 
         const response = await tester.invokeFetchResponse(initial.invocation, {
@@ -88,8 +101,8 @@ describe('posthog-llm-classify template', () => {
         })
     })
 
-    it('omits response_format and returns free-form content when tags are empty', async () => {
-        const initial = await tester.invoke({ ...baseInputs, tags: '' })
+    it('omits response_format and returns free-form content when categories are empty', async () => {
+        const initial = await tester.invoke({ ...baseInputs, categories: '' })
 
         const body = parseJSON((initial.invocation.queueParameters as Record<string, any>).body)
         expect(body.response_format).toBeUndefined()
@@ -106,38 +119,46 @@ describe('posthog-llm-classify template', () => {
         expect(response.execResult).toEqual({ content: 'free-form classification' })
     })
 
-    it('drops empty entries from the tag list', async () => {
+    it('drops empty entries from the categories list', async () => {
         const response = await tester.invoke({
             ...baseInputs,
             // Trailing comma + extra whitespace would otherwise produce empty enum values, which
             // OpenAI's structured-output validator rejects with an opaque 400.
-            tags: 'billing, , support,  ',
+            categories: 'billing, , support,  ',
         })
 
         const body = parseJSON((response.invocation.queueParameters as Record<string, any>).body)
         expect(body.response_format.json_schema.schema.properties.category.enum).toEqual(['billing', 'support'])
     })
 
-    it('throws when api_key is missing', async () => {
-        const response = await tester.invoke({ ...baseInputs, api_key: '' })
+    it('throws when content is missing', async () => {
+        const response = await tester.invoke({ ...baseInputs, content: '' })
 
-        expect(response.error).toMatch(/PostHog personal API key/)
+        expect(response.error).toMatch(/Content to classify is required/)
     })
 
-    it('throws when user_content is missing', async () => {
-        const response = await tester.invoke({ ...baseInputs, user_content: '' })
+    it('throws when model is missing', async () => {
+        const response = await tester.invoke({ ...baseInputs, model: '' })
 
-        expect(response.error).toMatch(/User content is required/)
+        expect(response.error).toMatch(/Model is required/)
+    })
+
+    it('throws when the gateway is not configured', async () => {
+        tester.setHubConfig({ LLM_GATEWAY_URL: '', LLM_GATEWAY_API_KEY: '' })
+
+        const response = await tester.invoke({ ...baseInputs, categories: 'a, b' })
+
+        expect(response.error).toMatch(/PostHog LLM gateway URL is not configured/)
     })
 
     it('throws on a gateway error response', async () => {
-        const initial = await tester.invoke({ ...baseInputs, tags: 'a, b' })
+        const initial = await tester.invoke({ ...baseInputs, categories: 'a, b' })
 
         const response = await tester.invokeFetchResponse(initial.invocation, {
             status: 401,
             body: { error: 'invalid api key' },
         })
 
-        expect(response.error).toMatch(/LLM gateway returned status 401/)
+        expect(response.error).toMatch(/LLM classification failed with status 401/)
     })
 })

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.test.ts
@@ -163,4 +163,35 @@ describe('posthog-llm-classify template', () => {
 
         expect(response.error).toMatch(/LLM classification failed with status 401/)
     })
+
+    it('skips the LLM call and returns sampled_out when sample_rate is 0', async () => {
+        // sample_rate='0' deterministically samples out (random() >= 0 is always true).
+        // We assert no fetch was dispatched and the action returned the stable
+        // { sampled_out: true } shape that downstream conditional_branch can read.
+        const response = await tester.invoke({
+            ...baseInputs,
+            categories: 'billing, support, sales',
+            sample_rate: '0',
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.invocation.queueParameters).toBeUndefined()
+        expect(response.execResult).toEqual({ sampled_out: true })
+    })
+
+    it('runs normally when sample_rate is 1.0', async () => {
+        // Explicit default — confirms the guard is a no-op when sample_rate is at the top of the range.
+        const response = await tester.invoke({
+            ...baseInputs,
+            categories: 'billing, support, sales',
+            sample_rate: '1.0',
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(false)
+        expect((response.invocation.queueParameters as Record<string, any>).url).toBe(
+            'http://gateway.test/workflows/v1/chat/completions'
+        )
+    })
 })

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.test.ts
@@ -1,0 +1,143 @@
+import { DateTime } from 'luxon'
+
+import { parseJSON } from '~/utils/json-parse'
+
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './posthog-llm-classify.template'
+
+describe('posthog-llm-classify template', () => {
+    const tester = new TemplateTester(template)
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+        const fixedTime = DateTime.fromISO('2025-01-01T00:00:00Z').toJSDate()
+        jest.spyOn(Date, 'now').mockReturnValue(fixedTime.getTime())
+    })
+
+    const baseInputs = {
+        api_key: 'phx_test_key',
+        model: 'gpt-5-mini',
+        system_prompt: 'You classify support tickets.',
+        user_content: 'My invoice is wrong',
+        user_distinct_id: 'distinct-id',
+        gateway_url: 'https://gateway.us.posthog.com/v1/chat/completions',
+    }
+
+    it('builds a structured-output request when tags are provided', async () => {
+        const response = await tester.invoke({
+            ...baseInputs,
+            tags: 'billing, support, sales',
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(false)
+
+        const params = response.invocation.queueParameters as Record<string, any>
+        expect(params.url).toBe('https://gateway.us.posthog.com/v1/chat/completions')
+        expect(params.method).toBe('POST')
+        expect(params.headers).toEqual({
+            Authorization: 'Bearer phx_test_key',
+            'Content-Type': 'application/json',
+        })
+
+        const body = parseJSON(params.body)
+        expect(body.model).toBe('gpt-5-mini')
+        expect(body.user).toBe('distinct-id')
+        expect(body.messages).toEqual([
+            { role: 'system', content: 'You classify support tickets.' },
+            { role: 'user', content: 'My invoice is wrong' },
+        ])
+        expect(body.response_format.type).toBe('json_schema')
+        expect(body.response_format.json_schema.name).toBe('classification')
+        expect(body.response_format.json_schema.strict).toBe(true)
+        expect(body.response_format.json_schema.schema.properties.category.enum).toEqual([
+            'billing',
+            'support',
+            'sales',
+        ])
+        expect(body.response_format.json_schema.schema.required).toEqual(['category', 'reasoning'])
+    })
+
+    it('parses the structured-output content on successful response', async () => {
+        const initial = await tester.invoke({
+            ...baseInputs,
+            tags: 'billing, support, sales',
+        })
+
+        const response = await tester.invokeFetchResponse(initial.invocation, {
+            status: 200,
+            body: {
+                choices: [
+                    {
+                        message: {
+                            content: JSON.stringify({
+                                category: 'billing',
+                                reasoning: 'mentioned invoice',
+                            }),
+                        },
+                    },
+                ],
+            },
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.execResult).toEqual({
+            category: 'billing',
+            reasoning: 'mentioned invoice',
+        })
+    })
+
+    it('omits response_format and returns free-form content when tags are empty', async () => {
+        const initial = await tester.invoke({ ...baseInputs, tags: '' })
+
+        const body = parseJSON((initial.invocation.queueParameters as Record<string, any>).body)
+        expect(body.response_format).toBeUndefined()
+
+        const response = await tester.invokeFetchResponse(initial.invocation, {
+            status: 200,
+            body: {
+                choices: [{ message: { content: 'free-form classification' } }],
+            },
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.execResult).toEqual({ content: 'free-form classification' })
+    })
+
+    it('drops empty entries from the tag list', async () => {
+        const response = await tester.invoke({
+            ...baseInputs,
+            // Trailing comma + extra whitespace would otherwise produce empty enum values, which
+            // OpenAI's structured-output validator rejects with an opaque 400.
+            tags: 'billing, , support,  ',
+        })
+
+        const body = parseJSON((response.invocation.queueParameters as Record<string, any>).body)
+        expect(body.response_format.json_schema.schema.properties.category.enum).toEqual(['billing', 'support'])
+    })
+
+    it('throws when api_key is missing', async () => {
+        const response = await tester.invoke({ ...baseInputs, api_key: '' })
+
+        expect(response.error).toMatch(/PostHog personal API key/)
+    })
+
+    it('throws when user_content is missing', async () => {
+        const response = await tester.invoke({ ...baseInputs, user_content: '' })
+
+        expect(response.error).toMatch(/User content is required/)
+    })
+
+    it('throws on a gateway error response', async () => {
+        const initial = await tester.invoke({ ...baseInputs, tags: 'a, b' })
+
+        const response = await tester.invokeFetchResponse(initial.invocation, {
+            status: 401,
+            body: { error: 'invalid api key' },
+        })
+
+        expect(response.error).toMatch(/LLM gateway returned status 401/)
+    })
+})

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.ts
@@ -18,6 +18,19 @@ if (empty(inputs.content)) {
   throw Error('Content to classify is required')
 }
 
+// Probabilistic sampling — when sample_rate < 1, skip the LLM call on (1 - sample_rate)
+// of triggered events. Bucket is derived from sha256(event.uuid) so the decision is
+// deterministic per event (cyclotron retries on the same event get the same answer)
+// but pseudo-random across events. Returns a stable { sampled_out: true } shape so
+// downstream conditional_branch can read classification.sampled_out and route.
+let sample := toFloat(inputs.sample_rate)
+if (sample != null and sample < 1) {
+  let bucket := toInt(concat('0x', substring(sha256Hex(event.uuid), 1, 4)))
+  if (bucket >= sample * 65536) {
+    return {'sampled_out': true}
+  }
+}
+
 let messages := []
 if (not empty(inputs.instructions)) {
   messages := arrayPushBack(messages, {'role': 'system', 'content': inputs.instructions})
@@ -111,6 +124,16 @@ return {'content': content}
             required: false,
             description:
                 'Optional comma-separated list (e.g. `billing, support, sales`). When set, the model picks exactly one and the result is parsed as `{ category, reasoning }`. Leave empty for free-form classification — the result is parsed as `{ content }`.',
+        },
+        {
+            key: 'sample_rate',
+            type: 'string',
+            label: 'Sample rate',
+            secret: false,
+            required: false,
+            default: '1.0',
+            description:
+                'Probability that this action runs on a triggered event (0.0 to 1.0). Default 1.0 runs every time. Use 0.1 to sample 10% of triggered events — handy for keeping LLM costs bounded on high-volume triggers. When sampled out, the action returns `{ sampled_out: true }` so downstream `conditional_branch` steps can detect and route accordingly. The decision is deterministic per event (derived from `sha256(event.uuid)`), so retries on the same event always make the same choice.',
         },
     ],
 }

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.ts
@@ -6,43 +6,36 @@ export const template: HogFunctionTemplate = {
     type: 'destination',
     id: 'template-posthog-llm-classify',
     name: 'LLM classify',
-    description: 'Classify the triggering event with an LLM and write the result to a workflow variable',
+    description: 'Classify the triggering event with an LLM and store the result for downstream branches',
     icon_url: '/static/posthog-icon.svg',
     category: ['Custom', 'AI'],
     code_language: 'hog',
     code: `
-if (empty(inputs.api_key)) {
-  throw Error('PostHog personal API key with llm_gateway:read scope is required')
-}
 if (empty(inputs.model)) {
   throw Error('Model is required')
 }
-if (empty(inputs.user_content)) {
-  throw Error('User content is required')
+if (empty(inputs.content)) {
+  throw Error('Content to classify is required')
 }
 
 let messages := []
-if (not empty(inputs.system_prompt)) {
-  messages := arrayPushBack(messages, {'role': 'system', 'content': inputs.system_prompt})
+if (not empty(inputs.instructions)) {
+  messages := arrayPushBack(messages, {'role': 'system', 'content': inputs.instructions})
 }
-messages := arrayPushBack(messages, {'role': 'user', 'content': inputs.user_content})
+messages := arrayPushBack(messages, {'role': 'user', 'content': inputs.content})
 
-let body := {
+let request := {
   'model': inputs.model,
   'messages': messages
 }
 
-if (not empty(inputs.user_distinct_id)) {
-  body.user := inputs.user_distinct_id
-}
-
-// Tag-list shorthand: turn 'billing, support, sales' into a structured-output schema
+// Categories shorthand: turn 'billing, support, sales' into a structured-output schema
 // that forces the model to pick exactly one tag plus a short reasoning. The parsed
 // JSON ({ category, reasoning }) flows straight into the workflow variable so
 // downstream conditional_branch steps can route on classification.category.
-let tags := arrayFilter(x -> not empty(x), arrayMap(x -> trim(x), splitByString(',', inputs.tags ?? '')))
-if (length(tags) > 0) {
-  body.response_format := {
+let categories := arrayFilter(x -> not empty(x), arrayMap(x -> trim(x), splitByString(',', inputs.categories ?? '')))
+if (length(categories) > 0) {
+  request.response_format := {
     'type': 'json_schema',
     'json_schema': {
       'name': 'classification',
@@ -52,7 +45,7 @@ if (length(tags) > 0) {
         'additionalProperties': false,
         'required': ['category', 'reasoning'],
         'properties': {
-          'category': {'type': 'string', 'enum': tags},
+          'category': {'type': 'string', 'enum': categories},
           'reasoning': {'type': 'string'}
         }
       }
@@ -60,45 +53,29 @@ if (length(tags) > 0) {
   }
 }
 
-let res := fetch(inputs.gateway_url, {
-  'method': 'POST',
-  'headers': {
-    'Authorization': f'Bearer {inputs.api_key}',
-    'Content-Type': 'application/json'
-  },
-  'body': body
-})
+let res := postHogLLMClassify(request)
 
 if (res.status >= 400) {
-  throw Error(f'LLM gateway returned status {res.status}: {res.body}')
+  throw Error(f'LLM classification failed with status {res.status}: {res.body}')
 }
 
 let choices := res.body.choices
 if (empty(choices)) {
-  throw Error('LLM gateway returned no choices')
+  throw Error('LLM classification returned no choices')
 }
 
 let content := choices[1].message.content
 
-// Parse the structured output when a tag list was configured. Free-form
+// Parse the structured output when categories were configured. Free-form
 // responses pass through as { content: '...' } so the workflow variable
 // always has a stable shape.
-if (length(tags) > 0) {
+if (length(categories) > 0) {
   return jsonParse(content)
 }
 
 return {'content': content}
 `,
     inputs_schema: [
-        {
-            key: 'api_key',
-            type: 'string',
-            label: 'PostHog API key',
-            secret: true,
-            required: true,
-            description:
-                'PostHog personal API key with the `llm_gateway:read` scope. Create one at /settings/user-api-keys.',
-        },
         {
             key: 'model',
             type: 'string',
@@ -109,48 +86,31 @@ return {'content': content}
             description: 'Any model supported by the PostHog LLM gateway (OpenAI, Anthropic, OpenRouter, Fireworks).',
         },
         {
-            key: 'system_prompt',
+            key: 'instructions',
             type: 'string',
-            label: 'System prompt',
-            secret: false,
-            required: false,
-            description: 'Instructions for the model. Templated against the trigger event.',
-        },
-        {
-            key: 'user_content',
-            type: 'string',
-            label: 'User content',
-            secret: false,
-            required: true,
-            default: '{event.event}: {jsonStringify(event.properties)}',
-            description: 'The content the model should classify. Templated against the trigger event.',
-        },
-        {
-            key: 'tags',
-            type: 'string',
-            label: 'Tag list',
+            label: 'Instructions',
             secret: false,
             required: false,
             description:
-                'Optional comma-separated tag list (e.g. `billing, support, sales`). When set, the model picks one via structured outputs and the result is parsed as `{ category, reasoning }`. Leave empty for free-form completions.',
+                'What the model should do. Example: "Classify the support ticket below into one of the listed categories. Pick the best fit even if uncertain."',
         },
         {
-            key: 'user_distinct_id',
+            key: 'content',
             type: 'string',
-            label: 'End-user distinct ID',
-            secret: false,
-            required: false,
-            default: '{event.distinct_id}',
-            description: 'Passed to the gateway as `user` for per-end-user analytics and rate limiting.',
-        },
-        {
-            key: 'gateway_url',
-            type: 'string',
-            label: 'LLM gateway URL',
+            label: 'Content to classify',
             secret: false,
             required: true,
-            default: 'https://gateway.us.posthog.com/v1/chat/completions',
-            description: 'Override for EU (`https://gateway.eu.posthog.com/v1/chat/completions`) or self-hosted.',
+            default: '{event.event}: {jsonStringify(event.properties)}',
+            description: 'The data the model should look at. Templated against the trigger event.',
+        },
+        {
+            key: 'categories',
+            type: 'string',
+            label: 'Categories',
+            secret: false,
+            required: false,
+            description:
+                'Optional comma-separated list (e.g. `billing, support, sales`). When set, the model picks exactly one and the result is parsed as `{ category, reasoning }`. Leave empty for free-form classification — the result is parsed as `{ content }`.',
         },
     ],
 }

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.ts
@@ -1,0 +1,156 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'hidden',
+    type: 'destination',
+    id: 'template-posthog-llm-classify',
+    name: 'LLM classify',
+    description: 'Classify the triggering event with an LLM and write the result to a workflow variable',
+    icon_url: '/static/posthog-icon.svg',
+    category: ['Custom', 'AI'],
+    code_language: 'hog',
+    code: `
+if (empty(inputs.api_key)) {
+  throw Error('PostHog personal API key with llm_gateway:read scope is required')
+}
+if (empty(inputs.model)) {
+  throw Error('Model is required')
+}
+if (empty(inputs.user_content)) {
+  throw Error('User content is required')
+}
+
+let messages := []
+if (not empty(inputs.system_prompt)) {
+  messages := arrayPushBack(messages, {'role': 'system', 'content': inputs.system_prompt})
+}
+messages := arrayPushBack(messages, {'role': 'user', 'content': inputs.user_content})
+
+let body := {
+  'model': inputs.model,
+  'messages': messages
+}
+
+if (not empty(inputs.user_distinct_id)) {
+  body.user := inputs.user_distinct_id
+}
+
+// Tag-list shorthand: turn 'billing, support, sales' into a structured-output schema
+// that forces the model to pick exactly one tag plus a short reasoning. The parsed
+// JSON ({ category, reasoning }) flows straight into the workflow variable so
+// downstream conditional_branch steps can route on classification.category.
+let tags := arrayFilter(x -> not empty(x), arrayMap(x -> trim(x), splitByString(',', inputs.tags ?? '')))
+if (length(tags) > 0) {
+  body.response_format := {
+    'type': 'json_schema',
+    'json_schema': {
+      'name': 'classification',
+      'strict': true,
+      'schema': {
+        'type': 'object',
+        'additionalProperties': false,
+        'required': ['category', 'reasoning'],
+        'properties': {
+          'category': {'type': 'string', 'enum': tags},
+          'reasoning': {'type': 'string'}
+        }
+      }
+    }
+  }
+}
+
+let res := fetch(inputs.gateway_url, {
+  'method': 'POST',
+  'headers': {
+    'Authorization': f'Bearer {inputs.api_key}',
+    'Content-Type': 'application/json'
+  },
+  'body': body
+})
+
+if (res.status >= 400) {
+  throw Error(f'LLM gateway returned status {res.status}: {res.body}')
+}
+
+let choices := res.body.choices
+if (empty(choices)) {
+  throw Error('LLM gateway returned no choices')
+}
+
+let content := choices[1].message.content
+
+// Parse the structured output when a tag list was configured. Free-form
+// responses pass through as { content: '...' } so the workflow variable
+// always has a stable shape.
+if (length(tags) > 0) {
+  return jsonParse(content)
+}
+
+return {'content': content}
+`,
+    inputs_schema: [
+        {
+            key: 'api_key',
+            type: 'string',
+            label: 'PostHog API key',
+            secret: true,
+            required: true,
+            description:
+                'PostHog personal API key with the `llm_gateway:read` scope. Create one at /settings/user-api-keys.',
+        },
+        {
+            key: 'model',
+            type: 'string',
+            label: 'Model',
+            secret: false,
+            required: true,
+            default: 'gpt-5-mini',
+            description: 'Any model supported by the PostHog LLM gateway (OpenAI, Anthropic, OpenRouter, Fireworks).',
+        },
+        {
+            key: 'system_prompt',
+            type: 'string',
+            label: 'System prompt',
+            secret: false,
+            required: false,
+            description: 'Instructions for the model. Templated against the trigger event.',
+        },
+        {
+            key: 'user_content',
+            type: 'string',
+            label: 'User content',
+            secret: false,
+            required: true,
+            default: '{event.event}: {jsonStringify(event.properties)}',
+            description: 'The content the model should classify. Templated against the trigger event.',
+        },
+        {
+            key: 'tags',
+            type: 'string',
+            label: 'Tag list',
+            secret: false,
+            required: false,
+            description:
+                'Optional comma-separated tag list (e.g. `billing, support, sales`). When set, the model picks one via structured outputs and the result is parsed as `{ category, reasoning }`. Leave empty for free-form completions.',
+        },
+        {
+            key: 'user_distinct_id',
+            type: 'string',
+            label: 'End-user distinct ID',
+            secret: false,
+            required: false,
+            default: '{event.distinct_id}',
+            description: 'Passed to the gateway as `user` for per-end-user analytics and rate limiting.',
+        },
+        {
+            key: 'gateway_url',
+            type: 'string',
+            label: 'LLM gateway URL',
+            secret: false,
+            required: true,
+            default: 'https://gateway.us.posthog.com/v1/chat/completions',
+            description: 'Override for EU (`https://gateway.eu.posthog.com/v1/chat/completions`) or self-hosted.',
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.ts
@@ -82,7 +82,7 @@ return {'content': content}
             label: 'Model',
             secret: false,
             required: true,
-            default: 'gpt-5-mini',
+            default: 'gpt-5.4-nano',
             description: 'Any model supported by the PostHog LLM gateway (OpenAI, Anthropic, OpenRouter, Fireworks).',
         },
         {

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-classify.template.ts
@@ -66,7 +66,7 @@ if (length(categories) > 0) {
   }
 }
 
-let res := postHogLLMClassify(request)
+let res := postHogLLMChatCompletion(request)
 
 if (res.status >= 400) {
   throw Error(f'LLM classification failed with status {res.status}: {res.body}')

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-extract.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-extract.template.test.ts
@@ -1,0 +1,208 @@
+import { DateTime } from 'luxon'
+
+import { parseJSON } from '~/utils/json-parse'
+
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './posthog-llm-extract.template'
+
+describe('posthog-llm-extract template', () => {
+    const tester = new TemplateTester(template)
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+        // Gateway URL + auth are resolved server-side; deterministic test values so we can assert
+        // they're not leaking to user-facing inputs and are routed via the workflows product path.
+        tester.setHubConfig({
+            LLM_GATEWAY_URL: 'http://gateway.test',
+            LLM_GATEWAY_API_KEY: 'service-key',
+        })
+        const fixedTime = DateTime.fromISO('2025-01-01T00:00:00Z').toJSDate()
+        jest.spyOn(Date, 'now').mockReturnValue(fixedTime.getTime())
+    })
+
+    const baseInputs = {
+        model: 'gpt-5-mini',
+        instructions: 'Extract structured info from this support ticket.',
+        content: 'My invoice is wrong and I need help urgently!',
+        fields: {
+            sentiment: 'How the user feels.',
+            urgency: 'How urgent the issue is.',
+        },
+    }
+
+    it('does not expose gateway URL or API key as user-facing inputs', () => {
+        const keys = template.inputs_schema.map((field) => field.key)
+        expect(keys).not.toContain('api_key')
+        expect(keys).not.toContain('gateway_url')
+        expect(keys).not.toContain('user_distinct_id')
+        // The user-meaningful inputs the form should expose:
+        expect(keys).toEqual(expect.arrayContaining(['model', 'instructions', 'content', 'fields']))
+        // Categories belongs to classify, not extract — extract uses the generic `fields` dict.
+        expect(keys).not.toContain('categories')
+    })
+
+    it('builds a structured-output request from the fields dictionary', async () => {
+        const response = await tester.invoke(baseInputs)
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(false)
+
+        const params = response.invocation.queueParameters as Record<string, any>
+        // Routed through the workflows product path on the configured gateway with service auth.
+        expect(params.url).toBe('http://gateway.test/workflows/v1/chat/completions')
+        expect(params.method).toBe('POST')
+        expect(params.headers).toEqual({
+            Authorization: 'Bearer service-key',
+            'Content-Type': 'application/json',
+        })
+        expect(params.timeout_ms).toBe(120_000)
+
+        const body = parseJSON(params.body)
+        expect(body.model).toBe('gpt-5-mini')
+        expect(body.messages).toEqual([
+            { role: 'system', content: 'Extract structured info from this support ticket.' },
+            { role: 'user', content: 'My invoice is wrong and I need help urgently!' },
+        ])
+
+        const schema = body.response_format.json_schema
+        expect(body.response_format.type).toBe('json_schema')
+        expect(schema.name).toBe('extraction')
+        expect(schema.strict).toBe(true)
+        expect(schema.schema.additionalProperties).toBe(false)
+        // Both user-defined fields are required so the model addresses each one even
+        // when null. Strict mode requires every property to be listed in `required`.
+        expect(schema.schema.required.sort()).toEqual(['sentiment', 'urgency'])
+        // Each field is nullable so partial extraction is well-formed.
+        expect(schema.schema.properties.sentiment).toEqual({
+            type: ['string', 'null'],
+            description: 'How the user feels.',
+        })
+        expect(schema.schema.properties.urgency).toEqual({
+            type: ['string', 'null'],
+            description: 'How urgent the issue is.',
+        })
+    })
+
+    it('parses the extracted fields from a successful response', async () => {
+        const initial = await tester.invoke(baseInputs)
+
+        const response = await tester.invokeFetchResponse(initial.invocation, {
+            status: 200,
+            body: {
+                choices: [
+                    {
+                        message: {
+                            content: JSON.stringify({
+                                sentiment: 'frustrated',
+                                urgency: 'high',
+                            }),
+                        },
+                    },
+                ],
+            },
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.execResult).toEqual({
+            sentiment: 'frustrated',
+            urgency: 'high',
+        })
+    })
+
+    it('preserves nulls when the model cannot determine a field', async () => {
+        const initial = await tester.invoke(baseInputs)
+
+        const response = await tester.invokeFetchResponse(initial.invocation, {
+            status: 200,
+            body: {
+                choices: [
+                    {
+                        message: {
+                            content: JSON.stringify({
+                                sentiment: 'frustrated',
+                                urgency: null,
+                            }),
+                        },
+                    },
+                ],
+            },
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        // null passes through so downstream `extracted.urgency != null` checks work.
+        expect(response.execResult).toEqual({
+            sentiment: 'frustrated',
+            urgency: null,
+        })
+    })
+
+    it('omits the instructions message when instructions are blank', async () => {
+        const response = await tester.invoke({ ...baseInputs, instructions: '' })
+
+        const body = parseJSON((response.invocation.queueParameters as Record<string, any>).body)
+        expect(body.messages).toEqual([{ role: 'user', content: baseInputs.content }])
+        // Structured output is still enforced.
+        expect(body.response_format.json_schema.name).toBe('extraction')
+    })
+
+    it('throws when content is missing', async () => {
+        const response = await tester.invoke({ ...baseInputs, content: '' })
+
+        expect(response.error).toMatch(/Content to extract from is required/)
+    })
+
+    it('throws when model is missing', async () => {
+        const response = await tester.invoke({ ...baseInputs, model: '' })
+
+        expect(response.error).toMatch(/Model is required/)
+    })
+
+    it('throws when no fields are configured', async () => {
+        const response = await tester.invoke({ ...baseInputs, fields: {} })
+
+        expect(response.error).toMatch(/At least one field to extract is required/)
+    })
+
+    it('throws when the gateway is not configured', async () => {
+        tester.setHubConfig({ LLM_GATEWAY_URL: '', LLM_GATEWAY_API_KEY: '' })
+
+        const response = await tester.invoke(baseInputs)
+
+        expect(response.error).toMatch(/PostHog LLM gateway URL is not configured/)
+    })
+
+    it('throws on a gateway error response', async () => {
+        const initial = await tester.invoke(baseInputs)
+
+        const response = await tester.invokeFetchResponse(initial.invocation, {
+            status: 401,
+            body: { error: 'invalid api key' },
+        })
+
+        expect(response.error).toMatch(/LLM extraction failed with status 401/)
+    })
+
+    it('skips the LLM call and returns sampled_out when sample_rate is 0', async () => {
+        // sample_rate='0' deterministically samples out (bucket >= 0 is always true).
+        // Asserts no fetch was dispatched and the action returned the stable
+        // { sampled_out: true } shape downstream conditional_branch can read.
+        const response = await tester.invoke({ ...baseInputs, sample_rate: '0' })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.invocation.queueParameters).toBeUndefined()
+        expect(response.execResult).toEqual({ sampled_out: true })
+    })
+
+    it('runs normally when sample_rate is 1.0', async () => {
+        const response = await tester.invoke({ ...baseInputs, sample_rate: '1.0' })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(false)
+        expect((response.invocation.queueParameters as Record<string, any>).url).toBe(
+            'http://gateway.test/workflows/v1/chat/completions'
+        )
+    })
+})

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-extract.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-extract.template.ts
@@ -1,0 +1,150 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'hidden',
+    type: 'destination',
+    id: 'template-posthog-llm-extract',
+    name: 'LLM extract',
+    description:
+        'Extract one or more structured fields from the triggering event with an LLM and store them for downstream steps',
+    icon_url: '/static/posthog-icon.svg',
+    category: ['Custom', 'AI'],
+    code_language: 'hog',
+    code: `
+if (empty(inputs.model)) {
+  throw Error('Model is required')
+}
+if (empty(inputs.content)) {
+  throw Error('Content to extract from is required')
+}
+
+// Probabilistic sampling — when sample_rate < 1, skip the LLM call on (1 - sample_rate)
+// of triggered events. Bucket is derived from sha256(event.uuid) so the decision is
+// deterministic per event (cyclotron retries on the same event get the same answer)
+// but pseudo-random across events. Returns a stable { sampled_out: true } shape so
+// downstream conditional_branch can read extracted.sampled_out and route.
+let sample := toFloat(inputs.sample_rate)
+if (sample != null and sample < 1) {
+  let bucket := toInt(concat('0x', substring(sha256Hex(event.uuid), 1, 4)))
+  if (bucket >= sample * 65536) {
+    return {'sampled_out': true}
+  }
+}
+
+// Build the structured-output schema from inputs.fields. The dictionary key becomes
+// the JSON Schema property name (and the downstream workflow variable name); the
+// dictionary value is the description the model uses to know what to extract. Every
+// field is required and nullable so the model has to address each one — null when it
+// cannot determine a value — which keeps the downstream variable shape stable across
+// extraction quality, so conditional_branch steps never see a missing key.
+let properties := {}
+let required := []
+for (let name, description in inputs.fields ?? {}) {
+  if (empty(name)) {
+    continue
+  }
+  properties[name] := {
+    'type': ['string', 'null'],
+    'description': description
+  }
+  required := arrayPushBack(required, name)
+}
+
+if (length(required) == 0) {
+  throw Error('At least one field to extract is required')
+}
+
+let messages := []
+if (not empty(inputs.instructions)) {
+  messages := arrayPushBack(messages, {'role': 'system', 'content': inputs.instructions})
+}
+messages := arrayPushBack(messages, {'role': 'user', 'content': inputs.content})
+
+let request := {
+  'model': inputs.model,
+  'messages': messages,
+  'response_format': {
+    'type': 'json_schema',
+    'json_schema': {
+      'name': 'extraction',
+      'strict': true,
+      'schema': {
+        'type': 'object',
+        'additionalProperties': false,
+        'required': required,
+        'properties': properties
+      }
+    }
+  }
+}
+
+let res := postHogLLMChatCompletion(request)
+
+if (res.status >= 400) {
+  throw Error(f'LLM extraction failed with status {res.status}: {res.body}')
+}
+
+let choices := res.body.choices
+if (empty(choices)) {
+  throw Error('LLM extraction returned no choices')
+}
+
+return jsonParse(choices[1].message.content)
+`,
+    inputs_schema: [
+        {
+            key: 'model',
+            type: 'string',
+            label: 'Model',
+            secret: false,
+            required: true,
+            default: 'gpt-5.4-nano',
+            description: 'Any model supported by the PostHog LLM gateway (OpenAI, Anthropic, OpenRouter, Fireworks).',
+        },
+        {
+            key: 'instructions',
+            type: 'string',
+            label: 'Instructions',
+            secret: false,
+            required: false,
+            default:
+                'Extract the requested fields from the content below. Be concise — single values or short phrases. Return null for any field you cannot confidently determine from the content rather than guessing.',
+            description:
+                'What the model should do. Example: "Extract structured info from this support ticket. Be conservative: return null when uncertain."',
+        },
+        {
+            key: 'content',
+            type: 'string',
+            label: 'Content to extract from',
+            secret: false,
+            required: true,
+            default: '{event.event}: {jsonStringify(event.properties)}',
+            description: 'The data the model should look at. Templated against the trigger event.',
+        },
+        {
+            key: 'fields',
+            type: 'dictionary',
+            label: 'Fields to extract',
+            secret: false,
+            required: true,
+            default: {
+                sentiment: 'How the user feels about the issue (e.g. frustrated, neutral, satisfied).',
+                intent: 'What action the user wants to happen.',
+                urgency: 'How quickly this needs attention (e.g. low, medium, high).',
+            },
+            description:
+                'Each entry defines one value to extract. The key is the field name (available downstream as `extracted.<name>`); the value is the description the model uses to know what to extract. Every field is nullable — the model returns null when it cannot determine a value, so downstream `conditional_branch` steps always see a stable shape.',
+        },
+        {
+            key: 'sample_rate',
+            type: 'string',
+            label: 'Sample rate',
+            secret: false,
+            required: false,
+            default: '1.0',
+            description:
+                'Probability that this action runs on a triggered event (0.0 to 1.0). Default 1.0 runs every time. Use 0.1 to sample 10% of triggered events — handy for keeping LLM costs bounded on high-volume triggers. When sampled out, the action returns `{ sampled_out: true }` so downstream `conditional_branch` steps can detect and route accordingly. The decision is deterministic per event (derived from `sha256(event.uuid)`), so retries on the same event always make the same choice.',
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.test.ts
@@ -1,0 +1,138 @@
+import { DateTime } from 'luxon'
+
+import { parseJSON } from '~/utils/json-parse'
+
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './posthog-llm-summarize.template'
+
+describe('posthog-llm-summarize template', () => {
+    const tester = new TemplateTester(template)
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+        // Gateway URL + auth are resolved server-side; deterministic test values so we can assert
+        // they're not leaking to user-facing inputs and are routed via the workflows product path.
+        tester.setHubConfig({
+            LLM_GATEWAY_URL: 'http://gateway.test',
+            LLM_GATEWAY_API_KEY: 'service-key',
+        })
+        const fixedTime = DateTime.fromISO('2025-01-01T00:00:00Z').toJSDate()
+        jest.spyOn(Date, 'now').mockReturnValue(fixedTime.getTime())
+    })
+
+    const baseInputs = {
+        model: 'gpt-5-mini',
+        instructions: 'Summarize the support ticket.',
+        content: 'My invoice is wrong this month and I would like a refund please.',
+    }
+
+    it('does not expose gateway URL or API key as user-facing inputs', () => {
+        const keys = template.inputs_schema.map((field) => field.key)
+        expect(keys).not.toContain('api_key')
+        expect(keys).not.toContain('gateway_url')
+        expect(keys).not.toContain('user_distinct_id')
+        // The user-meaningful inputs the form should expose. Unlike classify there is no
+        // `categories` toggle — summarize is always structured into title + description.
+        expect(keys).toEqual(expect.arrayContaining(['model', 'instructions', 'content']))
+        expect(keys).not.toContain('categories')
+    })
+
+    it('builds a structured-output request enforcing { title, description }', async () => {
+        const response = await tester.invoke(baseInputs)
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(false)
+
+        const params = response.invocation.queueParameters as Record<string, any>
+        // Routed through the workflows product path on the configured gateway, with service auth
+        // — never the user-provided URL/key.
+        expect(params.url).toBe('http://gateway.test/workflows/v1/chat/completions')
+        expect(params.method).toBe('POST')
+        expect(params.headers).toEqual({
+            Authorization: 'Bearer service-key',
+            'Content-Type': 'application/json',
+        })
+        expect(params.timeout_ms).toBe(120_000)
+
+        const body = parseJSON(params.body)
+        expect(body.model).toBe('gpt-5-mini')
+        expect(body.messages).toEqual([
+            { role: 'system', content: 'Summarize the support ticket.' },
+            { role: 'user', content: 'My invoice is wrong this month and I would like a refund please.' },
+        ])
+        expect(body.response_format.type).toBe('json_schema')
+        expect(body.response_format.json_schema.name).toBe('summary')
+        expect(body.response_format.json_schema.strict).toBe(true)
+        expect(body.response_format.json_schema.schema.required).toEqual(['title', 'description'])
+        expect(body.response_format.json_schema.schema.properties.title.type).toBe('string')
+        expect(body.response_format.json_schema.schema.properties.description.type).toBe('string')
+        expect(body.response_format.json_schema.schema.additionalProperties).toBe(false)
+    })
+
+    it('parses the { title, description } payload from a successful response', async () => {
+        const initial = await tester.invoke(baseInputs)
+
+        const response = await tester.invokeFetchResponse(initial.invocation, {
+            status: 200,
+            body: {
+                choices: [
+                    {
+                        message: {
+                            content: JSON.stringify({
+                                title: 'Incorrect invoice',
+                                description: 'Customer reports a billing error and wants a refund.',
+                            }),
+                        },
+                    },
+                ],
+            },
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.execResult).toEqual({
+            title: 'Incorrect invoice',
+            description: 'Customer reports a billing error and wants a refund.',
+        })
+    })
+
+    it('omits the instructions message when instructions are blank', async () => {
+        const response = await tester.invoke({ ...baseInputs, instructions: '' })
+
+        const body = parseJSON((response.invocation.queueParameters as Record<string, any>).body)
+        expect(body.messages).toEqual([{ role: 'user', content: baseInputs.content }])
+        // Structured output is still enforced.
+        expect(body.response_format.json_schema.name).toBe('summary')
+    })
+
+    it('throws when content is missing', async () => {
+        const response = await tester.invoke({ ...baseInputs, content: '' })
+
+        expect(response.error).toMatch(/Content to summarize is required/)
+    })
+
+    it('throws when model is missing', async () => {
+        const response = await tester.invoke({ ...baseInputs, model: '' })
+
+        expect(response.error).toMatch(/Model is required/)
+    })
+
+    it('throws when the gateway is not configured', async () => {
+        tester.setHubConfig({ LLM_GATEWAY_URL: '', LLM_GATEWAY_API_KEY: '' })
+
+        const response = await tester.invoke(baseInputs)
+
+        expect(response.error).toMatch(/PostHog LLM gateway URL is not configured/)
+    })
+
+    it('throws on a gateway error response', async () => {
+        const initial = await tester.invoke(baseInputs)
+
+        const response = await tester.invokeFetchResponse(initial.invocation, {
+            status: 401,
+            body: { error: 'invalid api key' },
+        })
+
+        expect(response.error).toMatch(/LLM summarization failed with status 401/)
+    })
+})

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.test.ts
@@ -135,4 +135,26 @@ describe('posthog-llm-summarize template', () => {
 
         expect(response.error).toMatch(/LLM summarization failed with status 401/)
     })
+
+    it('skips the LLM call and returns sampled_out when sample_rate is 0', async () => {
+        // sample_rate='0' deterministically samples out (random() >= 0 is always true).
+        // Asserts no fetch was dispatched and the action returned the stable
+        // { sampled_out: true } shape downstream conditional_branch can read.
+        const response = await tester.invoke({ ...baseInputs, sample_rate: '0' })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.invocation.queueParameters).toBeUndefined()
+        expect(response.execResult).toEqual({ sampled_out: true })
+    })
+
+    it('runs normally when sample_rate is 1.0', async () => {
+        const response = await tester.invoke({ ...baseInputs, sample_rate: '1.0' })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(false)
+        expect((response.invocation.queueParameters as Record<string, any>).url).toBe(
+            'http://gateway.test/workflows/v1/chat/completions'
+        )
+    })
 })

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.ts
@@ -1,0 +1,94 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'hidden',
+    type: 'destination',
+    id: 'template-posthog-llm-summarize',
+    name: 'LLM summarize',
+    description: 'Summarize the triggering event with an LLM into a title and description for downstream steps',
+    icon_url: '/static/posthog-icon.svg',
+    category: ['Custom', 'AI'],
+    code_language: 'hog',
+    code: `
+if (empty(inputs.model)) {
+  throw Error('Model is required')
+}
+if (empty(inputs.content)) {
+  throw Error('Content to summarize is required')
+}
+
+let messages := []
+if (not empty(inputs.instructions)) {
+  messages := arrayPushBack(messages, {'role': 'system', 'content': inputs.instructions})
+}
+messages := arrayPushBack(messages, {'role': 'user', 'content': inputs.content})
+
+// Always force a structured { title, description } output so downstream steps can read
+// summary.title / summary.description without having to parse a free-form response.
+let request := {
+  'model': inputs.model,
+  'messages': messages,
+  'response_format': {
+    'type': 'json_schema',
+    'json_schema': {
+      'name': 'summary',
+      'strict': true,
+      'schema': {
+        'type': 'object',
+        'additionalProperties': false,
+        'required': ['title', 'description'],
+        'properties': {
+          'title': {'type': 'string'},
+          'description': {'type': 'string'}
+        }
+      }
+    }
+  }
+}
+
+let res := postHogLLMSummarize(request)
+
+if (res.status >= 400) {
+  throw Error(f'LLM summarization failed with status {res.status}: {res.body}')
+}
+
+let choices := res.body.choices
+if (empty(choices)) {
+  throw Error('LLM summarization returned no choices')
+}
+
+return jsonParse(choices[1].message.content)
+`,
+    inputs_schema: [
+        {
+            key: 'model',
+            type: 'string',
+            label: 'Model',
+            secret: false,
+            required: true,
+            default: 'gpt-5-mini',
+            description: 'Any model supported by the PostHog LLM gateway (OpenAI, Anthropic, OpenRouter, Fireworks).',
+        },
+        {
+            key: 'instructions',
+            type: 'string',
+            label: 'Instructions',
+            secret: false,
+            required: false,
+            default:
+                'Summarize the content below. Return a short title (under 80 chars) and a 1-2 sentence description.',
+            description:
+                'What the model should do. Example: "Summarize the support ticket below for a triage queue. Title should name the problem; description should give just enough context for routing."',
+        },
+        {
+            key: 'content',
+            type: 'string',
+            label: 'Content to summarize',
+            secret: false,
+            required: true,
+            default: '{event.event}: {jsonStringify(event.properties)}',
+            description: 'The data the model should look at. Templated against the trigger event.',
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.ts
@@ -67,7 +67,7 @@ return jsonParse(choices[1].message.content)
             label: 'Model',
             secret: false,
             required: true,
-            default: 'gpt-5-mini',
+            default: 'gpt-5.4-nano',
             description: 'Any model supported by the PostHog LLM gateway (OpenAI, Anthropic, OpenRouter, Fireworks).',
         },
         {

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.ts
@@ -18,6 +18,19 @@ if (empty(inputs.content)) {
   throw Error('Content to summarize is required')
 }
 
+// Probabilistic sampling — when sample_rate < 1, skip the LLM call on (1 - sample_rate)
+// of triggered events. Bucket is derived from sha256(event.uuid) so the decision is
+// deterministic per event (cyclotron retries on the same event get the same answer)
+// but pseudo-random across events. Returns a stable { sampled_out: true } shape so
+// downstream conditional_branch can read summary.sampled_out and route.
+let sample := toFloat(inputs.sample_rate)
+if (sample != null and sample < 1) {
+  let bucket := toInt(concat('0x', substring(sha256Hex(event.uuid), 1, 4)))
+  if (bucket >= sample * 65536) {
+    return {'sampled_out': true}
+  }
+}
+
 let messages := []
 if (not empty(inputs.instructions)) {
   messages := arrayPushBack(messages, {'role': 'system', 'content': inputs.instructions})
@@ -89,6 +102,16 @@ return jsonParse(choices[1].message.content)
             required: true,
             default: '{event.event}: {jsonStringify(event.properties)}',
             description: 'The data the model should look at. Templated against the trigger event.',
+        },
+        {
+            key: 'sample_rate',
+            type: 'string',
+            label: 'Sample rate',
+            secret: false,
+            required: false,
+            default: '1.0',
+            description:
+                'Probability that this action runs on a triggered event (0.0 to 1.0). Default 1.0 runs every time. Use 0.1 to sample 10% of triggered events — handy for keeping LLM costs bounded on high-volume triggers. When sampled out, the action returns `{ sampled_out: true }` so downstream `conditional_branch` steps can detect and route accordingly. The decision is deterministic per event (derived from `sha256(event.uuid)`), so retries on the same event always make the same choice.',
         },
     ],
 }

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-llm-summarize.template.ts
@@ -60,7 +60,7 @@ let request := {
   }
 }
 
-let res := postHogLLMSummarize(request)
+let res := postHogLLMChatCompletion(request)
 
 if (res.status >= 400) {
   throw Error(f'LLM summarization failed with status {res.status}: {res.body}')

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -22,6 +22,7 @@ import { template as posthogUpdatePersonPropertiesTemplate } from './_destinatio
 import { template as posthogGetTicketTemplate } from './_destinations/posthog_conversations/posthog-get-ticket.template'
 import { template as posthogUpdateTicketTemplate } from './_destinations/posthog_conversations/posthog-update-ticket.template'
 import { template as posthogLlmClassifyTemplate } from './_destinations/posthog_workflows/posthog-llm-classify.template'
+import { template as posthogLlmSummarizeTemplate } from './_destinations/posthog_workflows/posthog-llm-summarize.template'
 import { template as posthogSetHogflowVariableTemplate } from './_destinations/posthog_workflows/posthog-set-variable.template'
 import { template as redditAdsTemplate } from './_destinations/reddit_ads/reddit.template'
 import { template as snapchatAdsTemplate } from './_destinations/snapchat_ads/snapchat.template'
@@ -68,6 +69,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [
     posthogUpdatePersonPropertiesTemplate,
     posthogSetHogflowVariableTemplate,
     posthogLlmClassifyTemplate,
+    posthogLlmSummarizeTemplate,
     posthogGetTicketTemplate,
     posthogUpdateTicketTemplate,
     hubspotCompanyTemplate,

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -21,6 +21,7 @@ import { template as posthogGroupIdentifyTemplate } from './_destinations/postho
 import { template as posthogUpdatePersonPropertiesTemplate } from './_destinations/posthog_capture/posthog-update-person-properties.template'
 import { template as posthogGetTicketTemplate } from './_destinations/posthog_conversations/posthog-get-ticket.template'
 import { template as posthogUpdateTicketTemplate } from './_destinations/posthog_conversations/posthog-update-ticket.template'
+import { template as posthogLlmClassifyTemplate } from './_destinations/posthog_workflows/posthog-llm-classify.template'
 import { template as posthogSetHogflowVariableTemplate } from './_destinations/posthog_workflows/posthog-set-variable.template'
 import { template as redditAdsTemplate } from './_destinations/reddit_ads/reddit.template'
 import { template as snapchatAdsTemplate } from './_destinations/snapchat_ads/snapchat.template'
@@ -66,6 +67,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [
     posthogGroupIdentifyTemplate,
     posthogUpdatePersonPropertiesTemplate,
     posthogSetHogflowVariableTemplate,
+    posthogLlmClassifyTemplate,
     posthogGetTicketTemplate,
     posthogUpdateTicketTemplate,
     hubspotCompanyTemplate,

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -22,6 +22,7 @@ import { template as posthogUpdatePersonPropertiesTemplate } from './_destinatio
 import { template as posthogGetTicketTemplate } from './_destinations/posthog_conversations/posthog-get-ticket.template'
 import { template as posthogUpdateTicketTemplate } from './_destinations/posthog_conversations/posthog-update-ticket.template'
 import { template as posthogLlmClassifyTemplate } from './_destinations/posthog_workflows/posthog-llm-classify.template'
+import { template as posthogLlmExtractTemplate } from './_destinations/posthog_workflows/posthog-llm-extract.template'
 import { template as posthogLlmSummarizeTemplate } from './_destinations/posthog_workflows/posthog-llm-summarize.template'
 import { template as posthogSetHogflowVariableTemplate } from './_destinations/posthog_workflows/posthog-set-variable.template'
 import { template as redditAdsTemplate } from './_destinations/reddit_ads/reddit.template'
@@ -70,6 +71,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [
     posthogSetHogflowVariableTemplate,
     posthogLlmClassifyTemplate,
     posthogLlmSummarizeTemplate,
+    posthogLlmExtractTemplate,
     posthogGetTicketTemplate,
     posthogUpdateTicketTemplate,
     hubspotCompanyTemplate,

--- a/nodejs/src/cdp/templates/test/test-helpers.ts
+++ b/nodejs/src/cdp/templates/test/test-helpers.ts
@@ -186,6 +186,12 @@ export class TemplateTester {
         this.nativeExecutor = new NativeDestinationExecutorService(defaultConfig)
     }
 
+    setHubConfig(overrides: Partial<PluginsServerConfig>): void {
+        Object.assign(this.mockHub, overrides)
+        this.hogExecutor = this.createHogExecutor()
+        this.nativeExecutor = new NativeDestinationExecutorService(this.mockHub)
+    }
+
     private createHogExecutor(): HogExecutorService {
         const config = this.mockHub
         const hogInputsService = new HogInputsService(undefined as any, config.ENCRYPTION_SALT_KEYS, config.SITE_URL)
@@ -209,7 +215,12 @@ export class TemplateTester {
                 fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
             },
-            { teamManager: undefined as any, siteUrl: config.SITE_URL },
+            {
+                teamManager: undefined as any,
+                siteUrl: config.SITE_URL,
+                llmGatewayUrl: config.LLM_GATEWAY_URL,
+                llmGatewayApiKey: config.LLM_GATEWAY_API_KEY,
+            },
             hogInputsService,
             emailService,
             recipientTokensService

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -146,6 +146,11 @@ export type CommonConfig = BaseServerConfig & {
 
     // Shared services
     SITE_URL: string
+    // PostHog LLM gateway — used by built-in workflow / CDP actions that need an LLM call
+    // (e.g. template-posthog-llm-classify). Resolved server-side so users don't have to
+    // configure URLs or mint personal API keys for built-in nodes.
+    LLM_GATEWAY_URL: string
+    LLM_GATEWAY_API_KEY: string
     ENCRYPTION_SALT_KEYS: string
     CAPTURE_INTERNAL_URL: string
     CAPTURE_CONFIG_REDIS_HOST: string | null
@@ -308,6 +313,11 @@ export function getDefaultCommonConfig(): CommonConfig {
 
         // Shared services
         SITE_URL: isDevEnv() ? 'http://localhost:8000' : '',
+        // Local dev points at the in-tree services/llm-gateway uvicorn (port 3308).
+        // Prod / cloud sets LLM_GATEWAY_URL + LLM_GATEWAY_API_KEY via env to point at
+        // gateway.us / gateway.eu and the shared internal-service key.
+        LLM_GATEWAY_URL: isDevEnv() ? 'http://localhost:3308' : '',
+        LLM_GATEWAY_API_KEY: '',
         ENCRYPTION_SALT_KEYS: isDevEnv() || isTestEnv() ? '00beef0000beef0000beef0000beef00' : '',
         CAPTURE_INTERNAL_URL: isProdEnv()
             ? 'http://capture.posthog.svc.cluster.local:3000/capture'

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -316,8 +316,9 @@ export function getDefaultCommonConfig(): CommonConfig {
         // Local dev points at the in-tree services/llm-gateway uvicorn (port 3308).
         // Prod / cloud sets LLM_GATEWAY_URL + LLM_GATEWAY_API_KEY via env to point at
         // gateway.us / gateway.eu and the shared internal-service key.
+        // Dev default mirrors ee/settings.py DEV_API_KEY auto-provisioned by setup_local_api_key.
         LLM_GATEWAY_URL: isDevEnv() ? 'http://localhost:3308' : '',
-        LLM_GATEWAY_API_KEY: '',
+        LLM_GATEWAY_API_KEY: isDevEnv() ? 'phx_dev_local_test_api_key_1234567890abcdef' : '',
         ENCRYPTION_SALT_KEYS: isDevEnv() || isTestEnv() ? '00beef0000beef0000beef0000beef00' : '',
         CAPTURE_INTERNAL_URL: isProdEnv()
             ? 'http://capture.posthog.svc.cluster.local:3000/capture'

--- a/nodejs/src/schema/cyclotron.ts
+++ b/nodejs/src/schema/cyclotron.ts
@@ -68,6 +68,9 @@ export const CyclotronInvocationQueueParametersFetchSchema = z.object({
     body: z.union([z.string(), z.null()]).optional(),
     max_tries: z.number().optional(),
     headers: z.record(z.string(), z.string()).optional(),
+    // Per-request override for the fetch abort timeout. Defaults to EXTERNAL_REQUEST_TIMEOUT_MS
+    // (3s) which is too tight for LLM calls — those should set this explicitly.
+    timeout_ms: z.number().int().positive().optional(),
 })
 
 export const CyclotronInvocationQueueParametersEmailSchema = z.object({

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/ai.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/ai.ts
@@ -1,0 +1,18 @@
+import { registerActionNodeCategory } from 'products/workflows/frontend/Workflows/hogflows/registry/actions/actionNodeRegistry'
+
+registerActionNodeCategory({
+    label: 'AI',
+    nodes: [
+        {
+            type: 'function',
+            name: 'LLM classify',
+            description:
+                'Run an LLM classification on the triggering event and store the result for downstream branches.',
+            config: { template_id: 'template-posthog-llm-classify', inputs: {} },
+            // `spread: true` flattens the parsed `{ category, reasoning }` (or `{ content }` for
+            // free-form mode) onto the workflow variable so `conditional_branch` can compare
+            // `classification.category` directly without an extra unwrap step.
+            output_variable: { key: 'classification', result_path: null, spread: true },
+        },
+    ],
+})

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/ai.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/ai.ts
@@ -8,6 +8,9 @@ registerActionNodeCategory({
             name: 'LLM classify',
             description:
                 'Run an LLM classification on the triggering event and store the result for downstream branches.',
+            // User-facing inputs: model, instructions, content, categories. Gateway URL + auth are
+            // resolved server-side by the postHogLLMClassify async function so users never have to
+            // touch a personal API key or know which region the gateway lives in.
             config: { template_id: 'template-posthog-llm-classify', inputs: {} },
             // `spread: true` flattens the parsed `{ category, reasoning }` (or `{ content }` for
             // free-form mode) onto the workflow variable so `conditional_branch` can compare

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/ai.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/ai.ts
@@ -27,5 +27,16 @@ registerActionNodeCategory({
             // steps can read `summary.title` / `summary.description` directly.
             output_variable: { key: 'summary', result_path: null, spread: true },
         },
+        {
+            type: 'function',
+            name: 'LLM extract',
+            description:
+                'Run an LLM extraction on the triggering event for N user-defined fields and store each one for downstream steps.',
+            config: { template_id: 'template-posthog-llm-extract', inputs: {} },
+            // Spreads the parsed `{ <field_a>, <field_b>, ... }` onto the workflow variable so
+            // downstream steps can read `extracted.<field>` directly. Field names come from the
+            // user's `fields` dictionary on the template, so the schema is per-instance.
+            output_variable: { key: 'extracted', result_path: null, spread: true },
+        },
     ],
 })

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/ai.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/ai.ts
@@ -17,5 +17,15 @@ registerActionNodeCategory({
             // `classification.category` directly without an extra unwrap step.
             output_variable: { key: 'classification', result_path: null, spread: true },
         },
+        {
+            type: 'function',
+            name: 'LLM summarize',
+            description:
+                'Run an LLM summarization on the triggering event and store the title and description for downstream steps.',
+            config: { template_id: 'template-posthog-llm-summarize', inputs: {} },
+            // Spreads the parsed `{ title, description }` onto the workflow variable so downstream
+            // steps can read `summary.title` / `summary.description` directly.
+            output_variable: { key: 'summary', result_path: null, spread: true },
+        },
     ],
 })

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/index.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/index.ts
@@ -1,1 +1,2 @@
+import './ai'
 import './conversations'

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -131,6 +131,11 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allowed_models=frozenset({"gpt-4.1-mini"}),
         allow_api_keys=True,
     ),
+    "workflows": ProductConfig(
+        allowed_application_ids=None,
+        allowed_models=None,
+        allow_api_keys=True,
+    ),
 }
 
 


### PR DESCRIPTION
## Problem

Workflows (hogflows) had no way to enrich the triggering event with LLM output before branching. This PR adds three built-in action nodes — `LLM classify`, `LLM summarize`, and `LLM extract` — under a new `AI` category. Downstream `conditional_branch` steps can route on the structured output. Gateway URL and auth are resolved server-side so users never have to mint a personal API key or know which region the gateway lives in.

## Changes


https://github.com/user-attachments/assets/68bd5d46-aae2-4ee5-8eec-9de7d7ad4e33



### LLM summarization

<img width="2576" height="1500" alt="image" src="https://github.com/user-attachments/assets/9c397fc6-1262-406c-9e5c-6d903797ba82" />

<img width="1228" height="1248" alt="image" src="https://github.com/user-attachments/assets/b407382e-dfc2-4082-9667-81ada47568aa" />

<img width="2554" height="1340" alt="image" src="https://github.com/user-attachments/assets/2135a155-b53a-4081-8c1f-af85db6927fb" />

### LLM classification

<img width="2554" height="1482" alt="image" src="https://github.com/user-attachments/assets/3ceb408e-28de-40f1-aea7-c0f7397ab509" />

<img width="1218" height="1196" alt="image" src="https://github.com/user-attachments/assets/054dfe4c-c925-413e-9a30-d82849a059d8" />

<img width="2564" height="1262" alt="image" src="https://github.com/user-attachments/assets/6af452e2-402a-458f-9dfb-3510e0de390b" />

### LLM extract

<img width="1190" height="2132" alt="image" src="https://github.com/user-attachments/assets/a9959670-47ad-464f-9948-155d3b1ca5cf" />

<img width="4188" height="1114" alt="image" src="https://github.com/user-attachments/assets/1ff113f4-742e-417c-a0f3-c6e4953d77bb" />

**New Hog templates** (registered in `HOG_FUNCTION_TEMPLATES_DESTINATIONS`):

- `posthog-llm-classify.template.ts` — inputs: `model`, `instructions`, `content` (templated against trigger event), `categories` (comma-separated tag shorthand), `sample_rate` (optional, defaults to 1.0; see Cost controls below). Categories become an OpenAI `response_format: json_schema` enum that forces a `{ category, reasoning }` output; empty categories fall back to free-form `{ content }`.
- `posthog-llm-summarize.template.ts` — inputs: `model`, `instructions`, `content`, `sample_rate`. Always enforces a `{ title, description }` structured-output schema (no toggle — the whole point of the node is a stable downstream shape).
- `posthog-llm-extract.template.ts` — inputs: `model`, `instructions`, `content`, `fields` (a dictionary mapping field name → description), `sample_rate`. The Hog template builds a per-instance JSON-Schema from the `fields` dictionary at runtime: every property becomes `["string", "null"]` and is listed in `required`, so the model addresses each field (returning null when uncertain) and downstream `extracted.<field>` is always present with a stable shape. Use this when you want to pull multiple named values out of an event in one shot — `LLM classify` for "pick one bucket", `LLM extract` for "fill these blanks".

**Gateway plumbing** (`nodejs/src/cdp`):

- Single `postHogLLMChatCompletion` async function in `llm-gateway.ts` shared by all three templates. It resolves `LLM_GATEWAY_URL` + `LLM_GATEWAY_API_KEY` from `AsyncFunctionContext` and routes via `/workflows/v1/chat/completions` for per-product accounting. Mock content is derived from the caller's `response_format.json_schema.schema.properties` so a single mock works for any caller without per-template fixtures.
- `ALLOWED_LLM_TEMPLATE_IDS` gates by `hogFunction.template_id` — server-set from the `HogFunctionType` record, so user-authored destination Hog functions can't spoof a template id and consume the service key.
- Config plumbed through `CommonConfig → CdpCoreServicesConfig → HogExecutorAsyncContext → AsyncFunctionContext`. `workflows` is added to the llm-gateway product allowlist.
- `CyclotronInvocationQueueParametersFetchSchema` gains an optional `timeout_ms` so LLM fetches can override the default 3s external-request timeout (which was aborting completions mid-stream). The async function sets it to 120s.

**Frontend** (`products/workflows`):

- New `AI` action category in the hogflows registry exposes all three nodes. `LLM classify` spreads `{ category, reasoning }` onto a `classification` workflow variable; `LLM summarize` spreads `{ title, description }` onto `summary`; `LLM extract` spreads the user-defined `{ <field_a>, <field_b>, ... }` onto `extracted` so downstream steps read `extracted.<field>` directly.

**Defaults and dev tooling:**

- Default model on all three nodes is `gpt-5.4-nano` — cheaper and ~2–3x faster than `gpt-5-mini` while still producing reliable structured output. Users can override per-action.
- `hogli dev:api-key` now grants `llm_gateway:read` in addition to `*` because the gateway's `PersonalApiKeyAuthenticator` requires it explicitly and does not honor the wildcard for personal keys (intentional — a personal wildcard shouldn't silently grant LLM access). `bin/start-llm-gateway` already adds the scope via a background `--add-scopes` call but it races against Postgres migrations on cold start and can fail silently; baking it into the primary api-key command closes that gap. Upgrade path is automatic — an existing key with `['*']` is updated to `['*', 'llm_gateway:read']` on next run.

## Cost controls

All three LLM action nodes accept an optional `sample_rate` input (0.0 to 1.0, default 1.0) so a user can cap LLM spend on high-volume triggers without building a `random_cohort_branch` downstream. The bucket is derived from `sha256(event.uuid)`, so the decision is **deterministic per event** — cyclotron retries on the same event always make the same choice, but different events get pseudo-random treatment.

When sampled out, the action returns `{ sampled_out: true }` (a stable shape — downstream `conditional_branch` steps can read `classification.sampled_out` / `summary.sampled_out` / `extracted.sampled_out` to route accordingly). The cyclotron task and Hog VM still run for sampled-out invocations; only the LLM fetch is skipped. For deeper cost control, the trigger property filter is still the right lever — it drops events before any workflow infra spins up.

Other knobs that already exist on workflows but are worth being aware of for these nodes specifically:
- **Trigger property filter** — biggest lever; scope which events match the workflow at all.
- **`trigger_masking`** — Redis-backed throttle keyed on a hashed expression (e.g. `distinct_id`) with a TTL window. Underused in the current UI but works well for "at most once per user per hour" semantics.
- **Action `filters`** — per-action property gate; skip the LLM step conditionally.
- **Gateway-side product cost cap** — internal $1000/24h team-wide on the `workflows` product (`services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py:159-183`). Protects PostHog; not user-tunable.

What's not exposed today (worth flagging as follow-up product gaps): per-workflow dollar cap, per-action max-invocations/hour, native trigger-level `sample_rate`, cost alert thresholds.

## Billing

The new LLM action nodes bill through the **LLM analytics addon (`ai_credits` SKU)**, not the workflow destinations quota (`workflow_destinations_dispatched`). When a workflow runs `LLM classify`, `LLM summarize`, or `LLM extract`, the gateway request goes through `/workflows/v1/chat/completions` with `product: workflows` for internal cost attribution, but the customer-facing charge lands under LLM usage alongside HogAI and session summarization. This is the right model — LLM tokens belong with LLM billing — but worth knowing for docs: workflow quota does NOT cover LLM action calls. Customers using these nodes heavily will need the LLM addon enabled.

For background: workflow invocations themselves are tracked as `billable_invocation` in `app_metrics2` (`posthog/tasks/usage_report.py:1644-1659`) for analytics but not actually billed — only destination action types (email/SMS/push) count against `workflow_destinations_dispatched` (`quota_limiting.py:86`).

## How did you test this code?

I'm an agent; manual UI testing is limited to what's described below.

**Automated tests added/updated and run locally:**

- `posthog-llm-classify.template.test.ts` — 11 tests covering structured + free-form modes, category trimming, missing-input and gateway-error paths, the two `sample_rate` deterministic paths (`'0'` always sampled out, `'1.0'` always runs), and assertions that gateway URL / API key / user distinct_id are NOT user-facing inputs.
- `posthog-llm-summarize.template.test.ts` — 10 tests covering the always-structured `{ title, description }` schema, body shape, the same `sample_rate` deterministic paths, and the same auth-input absence assertions.
- `posthog-llm-extract.template.test.ts` — 12 tests covering the per-instance JSON Schema built from the `fields` dictionary (every property `["string", "null"]`, listed in `required`), parsing of partial extractions including null pass-through, the empty-`fields` validation error, the same `sample_rate` and auth-input absence assertions.
- `llm-gateway.test.ts` — parameterized allowlist tests across all three template IDs; rejects unauthorized template ids and accepts the built-in ones.
- 4 adjacent test files updated for the new `HogExecutorAsyncContext` shape.
- Whole-nodejs `tsc --noEmit` clean.

**End-to-end smoke on local phrocs (Hedgebox dev project):**

- Built three workflows (one per node, all triggered by a custom `support_event`), fired a single event with a realistic support ticket body via `localhost:8010/e/`. All three workflows ran cleanly off the same event:
  - **Classify** (2.5–9.5s): returned `classification_category` (e.g. `"support"`, `"sales"`) + `classification_reasoning`.
  - **Summarize** (2.6–8.6s): returned `summary_title` + `summary_description`.
  - **Extract** (1.9–12s): returned the four user-defined fields (`extracted_sentiment`, `extracted_urgency`, `extracted_category`, `extracted_intent`) — all populated correctly across events of different sentiment/urgency/category, including null pass-through when content didn't support a confident value.

## Publish to changelog?

No — needs dogfooding fisrt

## Docs update

Inkeep docs update is fine — all three nodes are new product surface that benefits from a docs pass.

## 🤖 Agent context

Authored across multiple sessions with Claude Code (Anthropic Opus + Sonnet). Working context lived in a session-spanning skill (`workflows-llm-step` on the PostHog skills store).

Notable decisions worth flagging:

- **Server-side gateway resolution.** Originally shipped as pure-Hog with `inputs.api_key` + `inputs.gateway_url` exposed on the action. That was wrong UX for a built-in node — internal callers like HogAI and session summarization don't ask users for keys either — so we pivoted to an async function that resolves both from `CommonConfig`. Users see only `model`, `instructions`, `content` (plus `categories` for classify or `fields` for extract).
- **Tag-list shorthand over JSON Schema for classify.** Classify's `categories` input is a comma-separated string that we wrap into an OpenAI structured-output enum server-side. Considered exposing raw JSON Schema as the user-facing knob but the shorthand wins for the 80% case.
- **`fields: dictionary` for extract.** Extract uses a `type: 'dictionary'` input where the key is the field name (also the downstream variable name) and the value is the description the model uses to know what to extract. Every field is `["string", "null"]` and listed in `required` so the model has to address each one — null when uncertain, never omitted — and downstream `conditional_branch` always sees a stable shape across extraction quality. String-only typing in v1; per-field enum is just per-field classify (use the classify node for that).
- **Three nodes collapsed to one shared async function.** Started with one wrapper per node (`postHogLLMClassify`, then `postHogLLMSummarize`). At three nodes, the per-template wrapper pattern was the smell — extract was the trigger to collapse them all into a single `postHogLLMChatCompletion`. Templates own their `response_format`. The mock content is derived from the caller's schema (`response_format.json_schema.schema.properties`), so a single mock works for classify, summarize, extract, and any future LLM action node. **Rule going forward:** new LLM action nodes register a `template_id` in the allowlist and call the shared function — no new wrappers.
- **Fetch timeout fix in cyclotron.** `cdpTrackedFetch` aborts at `EXTERNAL_REQUEST_TIMEOUT_MS=3000` while gateway calls regularly take 3.6–9s with reasoning models. When `fetchResponse` is null, `executeFetch` falls back to `status: 500, body: undefined` — which surfaced as a confusing `LLM classification failed with status 500: undefined` error. Fix: optional `timeout_ms` on `CyclotronInvocationQueueParametersFetchSchema`, threaded into `fetchParams.timeoutMs`. The shared async function sets 120s.

Reviewer-worthy gotcha caught during smoke testing: the gateway's `PersonalApiKeyAuthenticator` requires `llm_gateway:read` explicitly and rejects the `*` wildcard. This is intentional (a personal wildcard key shouldn't silently grant LLM access) but the dev key was provisioned with `['*']` only, so freshly set-up dev environments would 401 against the gateway. The `hogli dev:api-key` patch in this PR closes that footgun.
