### PR TITLE
feat(llma): URL-driven dynamic tag vocabularies for LLM taggers

### DIFF
--- a/posthog/temporal/llm_analytics/dynamic_tags.py
+++ b/posthog/temporal/llm_analytics/dynamic_tags.py
@@ -1,0 +1,297 @@
+"""Dynamic tag-vocabulary resolution for LLM analytics taggers.
+
+When a tagger has ``tag_source == "dynamic"`` it doesn't ship with a fixed
+tag list — instead it carries a URL plus an extraction prompt, and at run
+time we fetch the URL, convert it to markdown, and ask the LLM to derive a
+``list[TagDefinition]`` from it. The result is cached in Redis so we only
+hit the URL + LLM once per tagger per cache window.
+
+Failure modes return ``None`` from :func:`resolve_dynamic_tags` and set a
+``skip_reason`` on the supplied result holder. The caller decides whether
+to surface that as a workflow ``skipped`` outcome.
+"""
+
+import gzip
+import json
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import html2text
+import structlog
+from pydantic import BaseModel, Field
+from temporalio.exceptions import ApplicationError
+
+from posthog.redis import get_async_client
+
+from products.llm_analytics.backend.llm import Client, CompletionRequest
+from products.llm_analytics.backend.llm.errors import (
+    AuthenticationError,
+    ModelNotFoundError,
+    ModelPermissionError,
+    QuotaExceededError,
+    RateLimitError,
+    StructuredOutputParseError,
+)
+from products.llm_analytics.backend.models.provider_keys import LLMProviderKey
+from products.llm_analytics.backend.models.taggers import TagDefinition
+
+logger = structlog.get_logger(__name__)
+
+REDIS_KEY_PREFIX = "llma:tagger"
+REDIS_TTL_SECONDS = 24 * 60 * 60  # 24h, matches D3 from the workflows-llm-step skill
+FETCH_TIMEOUT_SECONDS = 10.0
+FETCH_MAX_BYTES = 1_048_576  # 1 MiB — anything larger is a sign the URL isn't a reasonable tag source
+
+EXTRACTION_SYSTEM_PROMPT = """You are extracting a tag vocabulary from a source document.
+Given the document content and the user's extraction instruction, produce a list of
+distinct tag definitions. Each tag has a short snake_case-friendly `name` and an
+optional `description` that helps the downstream classifier decide when the tag applies.
+
+Rules:
+- Names must be unique and concise (1-3 words, no punctuation other than dashes/underscores).
+- Descriptions should be one sentence and explain *what kind of input* maps to this tag.
+- Do not invent tags that aren't grounded in the document. If the document is empty or
+  unrelated, return an empty list.
+"""
+
+
+def cache_key(tagger_id: str) -> str:
+    """Single cache key per tagger.
+
+    The tagger's saved post_save signal busts this key, so we don't need to vary the
+    key by URL or prompt — those changes go hand-in-hand with a save anyway.
+    """
+    return f"{REDIS_KEY_PREFIX}:{tagger_id}:dynamic_tags"
+
+
+def fingerprint(url: str, prompt: str) -> str:
+    """Short fingerprint of the URL+prompt pair stored alongside the cached tags.
+
+    Used to invalidate the cache when the URL or prompt changes without an explicit
+    tagger save (defense-in-depth — the save signal should already invalidate, but
+    if a worker reads a stale cache entry post-save we still recover).
+    """
+    h = hashlib.sha256()
+    h.update(url.encode("utf-8"))
+    h.update(b"\0")
+    h.update(prompt.encode("utf-8"))
+    return h.hexdigest()[:16]
+
+
+class _ExtractedTags(BaseModel):
+    """LLM-side response shape for tag-vocabulary extraction."""
+
+    tags: list[TagDefinition] = Field(default_factory=list)
+
+
+@dataclass
+class DynamicTagResult:
+    """Outcome of resolving a tagger's dynamic tag vocabulary.
+
+    Either ``tags`` is populated (success) or ``skip_reason`` is set (caller should
+    short-circuit the tagger run with a workflow ``skipped`` outcome).
+    """
+
+    tags: list[dict[str, str]] | None = None
+    extraction_llm_used: bool = False
+    extraction_input_tokens: int = 0
+    extraction_output_tokens: int = 0
+    skip_reason: str | None = None
+    skip_message: str | None = None
+
+
+async def _fetch_url_as_markdown(url: str) -> str:
+    """Fetch ``url`` and convert HTML → markdown.
+
+    Raises ``ApplicationError(error_type="tag_source_fetch_failed")`` on any
+    network / content error so the caller can map it to a workflow skip.
+    """
+    try:
+        async with httpx.AsyncClient(
+            timeout=FETCH_TIMEOUT_SECONDS,
+            follow_redirects=True,
+            max_redirects=5,
+            headers={"User-Agent": "PostHog-Tagger/1.0 (+https://posthog.com)"},
+        ) as client:
+            response = await client.get(url)
+    except httpx.HTTPError as exc:
+        raise ApplicationError(
+            f"Failed to fetch tag source URL: {exc}",
+            {"error_type": "tag_source_fetch_failed", "url": url},
+            non_retryable=True,
+        ) from exc
+
+    if response.status_code >= 400:
+        raise ApplicationError(
+            f"Tag source URL returned HTTP {response.status_code}",
+            {"error_type": "tag_source_fetch_failed", "url": url, "status_code": response.status_code},
+            non_retryable=True,
+        )
+
+    body = response.content[:FETCH_MAX_BYTES]
+    # Decode with fallback so we don't blow up on misconfigured Content-Type headers.
+    try:
+        text = body.decode(response.encoding or "utf-8", errors="replace")
+    except LookupError:
+        text = body.decode("utf-8", errors="replace")
+
+    converter = html2text.HTML2Text()
+    converter.ignore_images = True
+    converter.ignore_links = False
+    converter.body_width = 0  # don't hard-wrap; markdown lines stay logical
+    markdown = converter.handle(text)
+    return markdown.strip()
+
+
+async def _load_cached_tags(tagger_id: str, expected_fingerprint: str) -> list[dict[str, str]] | None:
+    """Load tags from Redis if the entry matches ``expected_fingerprint``.
+
+    Stale entries (different fingerprint) are ignored and overwritten on next set.
+    """
+    redis = await get_async_client()
+    try:
+        raw = await redis.get(cache_key(tagger_id))
+    except Exception:
+        logger.warning("Failed to read dynamic-tag cache; falling back to LLM call", tagger_id=tagger_id, exc_info=True)
+        return None
+
+    if raw is None:
+        return None
+
+    try:
+        decoded = json.loads(gzip.decompress(raw).decode("utf-8"))
+    except Exception:
+        logger.warning("Corrupt dynamic-tag cache entry; ignoring", tagger_id=tagger_id, exc_info=True)
+        return None
+
+    if decoded.get("fingerprint") != expected_fingerprint:
+        return None
+
+    tags = decoded.get("tags")
+    if not isinstance(tags, list):
+        return None
+    return tags
+
+
+async def _store_cached_tags(tagger_id: str, fp: str, tags: list[dict[str, str]]) -> None:
+    redis = await get_async_client()
+    payload = json.dumps({"fingerprint": fp, "tags": tags}).encode("utf-8")
+    try:
+        await redis.setex(cache_key(tagger_id), REDIS_TTL_SECONDS, gzip.compress(payload))
+    except Exception:
+        # A cache write failure is non-fatal — the LLM call already succeeded and the
+        # workflow can proceed. Next run will re-derive the tags.
+        logger.warning("Failed to write dynamic-tag cache", tagger_id=tagger_id, exc_info=True)
+
+
+async def invalidate_cached_tags(tagger_id: str) -> None:
+    """Bust the dynamic-tag cache for a tagger.
+
+    Called from the ``Tagger`` post_save signal so URL/prompt edits take effect on
+    the next tagger run instead of waiting for the 24h TTL to expire.
+    """
+    redis = await get_async_client()
+    try:
+        await redis.delete(cache_key(tagger_id))
+    except Exception:
+        logger.warning("Failed to invalidate dynamic-tag cache", tagger_id=tagger_id, exc_info=True)
+
+
+async def resolve_dynamic_tags(
+    *,
+    tagger_id: str,
+    tag_source_url: str,
+    tag_source_prompt: str,
+    provider: str,
+    model: str,
+    provider_key: LLMProviderKey | None,
+    eval_config: Any,
+) -> DynamicTagResult:
+    """Resolve the working tag vocabulary for a dynamic-source tagger.
+
+    Returns either a populated ``DynamicTagResult.tags`` (cache hit or fresh LLM
+    extraction) or a result with ``skip_reason`` set if anything went wrong in a
+    way the caller should surface as a workflow skip.
+
+    LLM/auth errors that look like infrastructure problems (rate limits, etc.)
+    are re-raised so the surrounding activity retry policy can handle them.
+    """
+    fp = fingerprint(tag_source_url, tag_source_prompt)
+    cached = await _load_cached_tags(tagger_id, fp)
+    if cached is not None:
+        logger.debug("Dynamic-tag cache hit", tagger_id=tagger_id)
+        return DynamicTagResult(tags=cached, extraction_llm_used=False)
+
+    try:
+        markdown = await _fetch_url_as_markdown(tag_source_url)
+    except ApplicationError as exc:
+        details = exc.details[0] if exc.details else {}
+        return DynamicTagResult(
+            skip_reason=details.get("error_type", "tag_source_fetch_failed"),
+            skip_message=str(exc.message),
+        )
+
+    if not markdown:
+        return DynamicTagResult(
+            skip_reason="tag_source_empty",
+            skip_message=f"Tag source URL {tag_source_url} returned no readable content",
+        )
+
+    user_prompt = f"""Extraction instruction:
+{tag_source_prompt}
+
+Source document (markdown):
+{markdown}
+"""
+
+    client = Client(
+        provider_key=provider_key,
+        config=eval_config if provider_key is None else None,
+        capture_analytics=False,
+    )
+
+    try:
+        response = client.complete(
+            CompletionRequest(
+                model=model,
+                system=EXTRACTION_SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": user_prompt}],
+                provider=provider,
+                response_format=_ExtractedTags,
+            )
+        )
+    except (AuthenticationError, ModelPermissionError, QuotaExceededError, RateLimitError, ModelNotFoundError):
+        # Bubble up — these have the same recovery semantics as the classification call
+        # and the existing run_tagger activity error handling maps them to ApplicationErrors.
+        raise
+    except StructuredOutputParseError as exc:
+        return DynamicTagResult(
+            skip_reason="tag_source_extract_failed",
+            skip_message=f"LLM extraction returned unparseable output: {exc}",
+        )
+
+    parsed = response.parsed
+    if parsed is None or not isinstance(parsed, _ExtractedTags):
+        return DynamicTagResult(
+            skip_reason="tag_source_extract_failed",
+            skip_message="LLM extraction returned no structured response",
+        )
+
+    if not parsed.tags:
+        return DynamicTagResult(
+            skip_reason="tag_source_empty",
+            skip_message="LLM extraction produced no tags from the source document",
+        )
+
+    tags_serialised = [{"name": t.name, "description": t.description} for t in parsed.tags]
+    await _store_cached_tags(tagger_id, fp, tags_serialised)
+
+    usage = response.usage
+    return DynamicTagResult(
+        tags=tags_serialised,
+        extraction_llm_used=True,
+        extraction_input_tokens=usage.input_tokens if usage else 0,
+        extraction_output_tokens=usage.output_tokens if usage else 0,
+    )

--- a/posthog/temporal/llm_analytics/run_tagger.py
+++ b/posthog/temporal/llm_analytics/run_tagger.py
@@ -14,6 +14,7 @@ from posthog.api.capture import capture_internal
 from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.llm_analytics.dynamic_tags import resolve_dynamic_tags
 from posthog.temporal.llm_analytics.message_utils import extract_text_from_messages
 from posthog.temporal.llm_analytics.run_evaluation import extract_event_io
 
@@ -202,8 +203,9 @@ async def execute_tagger_activity(inputs: ExecuteTaggerInputs) -> dict[str, Any]
     if not prompt:
         raise ApplicationError("Missing prompt in tagger_config", non_retryable=True)
 
+    tag_source = tagger_config.get("tag_source", "static")
     tags = tagger_config.get("tags", [])
-    if not tags:
+    if tag_source == "static" and not tags:
         raise ApplicationError("No tags defined in tagger_config", non_retryable=True)
 
     min_tags = tagger_config.get("min_tags", 0)
@@ -268,6 +270,44 @@ async def execute_tagger_activity(inputs: ExecuteTaggerInputs) -> dict[str, Any]
     is_byok = provider_key is not None
     key_id = str(provider_key.id) if provider_key else None
 
+    eval_config = get_eval_config(provider) if provider_key is None else None
+
+    extraction_llm_used = False
+    extraction_input_tokens = 0
+    extraction_output_tokens = 0
+    if tag_source == "dynamic":
+        tag_source_url = tagger_config.get("tag_source_url")
+        tag_source_prompt = tagger_config.get("tag_source_prompt")
+        if not tag_source_url or not tag_source_prompt:
+            raise ApplicationError(
+                "Dynamic tag source requires tag_source_url and tag_source_prompt",
+                {"error_type": "tag_source_misconfigured"},
+                non_retryable=True,
+            )
+
+        dynamic_result = await resolve_dynamic_tags(
+            tagger_id=str(tagger["id"]),
+            tag_source_url=tag_source_url,
+            tag_source_prompt=tag_source_prompt,
+            provider=provider,
+            model=model,
+            provider_key=provider_key,
+            eval_config=eval_config,
+        )
+
+        if dynamic_result.skip_reason is not None:
+            raise ApplicationError(
+                dynamic_result.skip_message or "Dynamic tag resolution failed",
+                {"error_type": dynamic_result.skip_reason},
+                non_retryable=True,
+            )
+
+        assert dynamic_result.tags is not None  # narrowing for type-checker; skip_reason guarded above
+        tags = dynamic_result.tags
+        extraction_llm_used = dynamic_result.extraction_llm_used
+        extraction_input_tokens = dynamic_result.extraction_input_tokens
+        extraction_output_tokens = dynamic_result.extraction_output_tokens
+
     # Build context from event
     event_type = event_data["event"]
     properties = event_data["properties"]
@@ -286,11 +326,9 @@ async def execute_tagger_activity(inputs: ExecuteTaggerInputs) -> dict[str, Any]
 
 Output: {output_data}"""
 
-    config = get_eval_config(provider) if provider_key is None else None
-
     client = Client(
         provider_key=provider_key,
-        config=config,
+        config=eval_config,
         capture_analytics=False,
     )
 
@@ -387,6 +425,9 @@ Output: {output_data}"""
         "key_id": key_id,
         "model": model,
         "provider": provider,
+        "extraction_llm_used": extraction_llm_used,
+        "extraction_input_tokens": extraction_input_tokens,
+        "extraction_output_tokens": extraction_output_tokens,
     }
 
 
@@ -661,7 +702,19 @@ class RunTaggerWorkflow(PostHogWorkflow):
                     details = e.cause.details[0]
                     error_type = details.get("error_type")
 
-                    if error_type in ("trial_limit_reached", "key_invalid", "parse_error", "model_not_allowed"):
+                    if error_type in (
+                        "trial_limit_reached",
+                        "key_invalid",
+                        "parse_error",
+                        "model_not_allowed",
+                        # Dynamic-tag resolution failures — skip this run, don't fail the workflow.
+                        # Transient (fetch) and persistent (misconfigured) reasons both surface here;
+                        # the surrounding $ai_tag event is simply not emitted for this event.
+                        "tag_source_fetch_failed",
+                        "tag_source_empty",
+                        "tag_source_extract_failed",
+                        "tag_source_misconfigured",
+                    ):
                         if error_type in ("trial_limit_reached", "model_not_allowed"):
                             await temporalio.workflow.execute_activity(
                                 disable_tagger_activity,
@@ -712,7 +765,9 @@ class RunTaggerWorkflow(PostHogWorkflow):
                         )
                 raise
 
-        # Increment trial counter if using PostHog key (LLM taggers only — Hog taggers have no LLM cost)
+        # Increment trial counter if using PostHog key (LLM taggers only — Hog taggers have no LLM cost).
+        # Dynamic-source taggers that hit the LLM for tag extraction count that as an additional
+        # trial use, matching Q1: extraction and classification are independent LLM spend.
         if tagger_type != "hog" and not result.get("is_byok"):
             from posthog.temporal.llm_analytics.run_evaluation import (
                 SendTrialUsageEmailInputs,
@@ -720,13 +775,16 @@ class RunTaggerWorkflow(PostHogWorkflow):
                 send_trial_usage_email_activity,
             )
 
-            threshold_pct = await temporalio.workflow.execute_activity(
-                increment_trial_eval_count_activity,
-                tagger["team_id"],
-                activity_id=f"increment-trial-tagger-{tagger['id']}",
-                schedule_to_close_timeout=timedelta(seconds=10),
-                retry_policy=RetryPolicy(maximum_attempts=2),
-            )
+            increments = 2 if result.get("extraction_llm_used") else 1
+            threshold_pct = None
+            for i in range(increments):
+                threshold_pct = await temporalio.workflow.execute_activity(
+                    increment_trial_eval_count_activity,
+                    tagger["team_id"],
+                    activity_id=f"increment-trial-tagger-{tagger['id']}-{i}",
+                    schedule_to_close_timeout=timedelta(seconds=10),
+                    retry_policy=RetryPolicy(maximum_attempts=2),
+                )
 
             if threshold_pct is not None and temporalio.workflow.patched("trial-usage-email"):
                 try:

--- a/posthog/temporal/llm_analytics/test_dynamic_tags.py
+++ b/posthog/temporal/llm_analytics/test_dynamic_tags.py
@@ -1,0 +1,277 @@
+import gzip
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from posthog.temporal.llm_analytics.dynamic_tags import (
+    DynamicTagResult,
+    _ExtractedTags,
+    cache_key,
+    fingerprint,
+    invalidate_cached_tags,
+    resolve_dynamic_tags,
+)
+
+from products.llm_analytics.backend.models.taggers import TagDefinition
+
+
+def test_cache_key_is_stable():
+    assert cache_key("abc") == "llma:tagger:abc:dynamic_tags"
+
+
+def test_fingerprint_changes_when_url_or_prompt_change():
+    fp1 = fingerprint("https://a.example", "prompt-a")
+    fp2 = fingerprint("https://a.example", "prompt-b")
+    fp3 = fingerprint("https://b.example", "prompt-a")
+    assert fp1 != fp2
+    assert fp1 != fp3
+    assert fp2 != fp3
+    # Same inputs → same fingerprint
+    assert fingerprint("https://a.example", "prompt-a") == fp1
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_cached_tags_on_hit():
+    cached_tags = [{"name": "alice", "description": "billing"}, {"name": "bob", "description": "analytics"}]
+    fp = fingerprint("https://x.example", "find owners")
+    payload = gzip.compress(json.dumps({"fingerprint": fp, "tags": cached_tags}).encode("utf-8"))
+
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = payload
+
+    with patch("posthog.temporal.llm_analytics.dynamic_tags.get_async_client", AsyncMock(return_value=redis_mock)):
+        result = await resolve_dynamic_tags(
+            tagger_id="tagger-1",
+            tag_source_url="https://x.example",
+            tag_source_prompt="find owners",
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=None,
+            eval_config=None,
+        )
+
+    assert result.tags == cached_tags
+    assert result.extraction_llm_used is False
+    assert result.skip_reason is None
+    # No extraction call happened — no token counts
+    assert result.extraction_input_tokens == 0
+    assert result.extraction_output_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_ignores_cache_when_fingerprint_mismatches():
+    """A stale cache entry (different URL/prompt) must be skipped, not served."""
+    stale_payload = gzip.compress(json.dumps({"fingerprint": "deadbeef", "tags": [{"name": "old"}]}).encode("utf-8"))
+
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = stale_payload
+
+    extracted = _ExtractedTags(tags=[TagDefinition(name="new", description="fresh")])
+    llm_response = MagicMock()
+    llm_response.parsed = extracted
+    llm_response.usage = MagicMock(input_tokens=50, output_tokens=10)
+
+    llm_client = MagicMock()
+    llm_client.complete.return_value = llm_response
+
+    with (
+        patch("posthog.temporal.llm_analytics.dynamic_tags.get_async_client", AsyncMock(return_value=redis_mock)),
+        patch("posthog.temporal.llm_analytics.dynamic_tags.Client", return_value=llm_client),
+        patch(
+            "posthog.temporal.llm_analytics.dynamic_tags._fetch_url_as_markdown",
+            AsyncMock(return_value="# Owners\n\n- new"),
+        ),
+    ):
+        result = await resolve_dynamic_tags(
+            tagger_id="tagger-1",
+            tag_source_url="https://x.example",
+            tag_source_prompt="find owners",
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=None,
+            eval_config=None,
+        )
+
+    assert result.tags == [{"name": "new", "description": "fresh"}]
+    assert result.extraction_llm_used is True
+    assert result.extraction_input_tokens == 50
+    assert result.extraction_output_tokens == 10
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_skip_when_url_fetch_fails():
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = None
+
+    with (
+        patch("posthog.temporal.llm_analytics.dynamic_tags.get_async_client", AsyncMock(return_value=redis_mock)),
+        patch("httpx.AsyncClient") as mock_async_client_cls,
+    ):
+        mock_client_ctx = AsyncMock()
+        mock_client_ctx.get.side_effect = httpx.ConnectError("network down")
+        mock_async_client_cls.return_value.__aenter__.return_value = mock_client_ctx
+
+        result = await resolve_dynamic_tags(
+            tagger_id="t",
+            tag_source_url="https://broken.example",
+            tag_source_prompt="extract",
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=None,
+            eval_config=None,
+        )
+
+    assert result.skip_reason == "tag_source_fetch_failed"
+    assert result.tags is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_skip_when_url_returns_4xx():
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = None
+
+    response = MagicMock()
+    response.status_code = 404
+    response.content = b""
+    response.encoding = "utf-8"
+
+    with (
+        patch("posthog.temporal.llm_analytics.dynamic_tags.get_async_client", AsyncMock(return_value=redis_mock)),
+        patch("httpx.AsyncClient") as mock_async_client_cls,
+    ):
+        mock_client_ctx = AsyncMock()
+        mock_client_ctx.get.return_value = response
+        mock_async_client_cls.return_value.__aenter__.return_value = mock_client_ctx
+
+        result = await resolve_dynamic_tags(
+            tagger_id="t",
+            tag_source_url="https://example.com/missing",
+            tag_source_prompt="extract",
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=None,
+            eval_config=None,
+        )
+
+    assert result.skip_reason == "tag_source_fetch_failed"
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_skip_when_extraction_yields_empty_list():
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = None
+
+    llm_client = MagicMock()
+    llm_response = MagicMock()
+    llm_response.parsed = _ExtractedTags(tags=[])
+    llm_response.usage = None
+    llm_client.complete.return_value = llm_response
+
+    with (
+        patch("posthog.temporal.llm_analytics.dynamic_tags.get_async_client", AsyncMock(return_value=redis_mock)),
+        patch(
+            "posthog.temporal.llm_analytics.dynamic_tags._fetch_url_as_markdown",
+            AsyncMock(return_value="# Page with no tags"),
+        ),
+        patch("posthog.temporal.llm_analytics.dynamic_tags.Client", return_value=llm_client),
+    ):
+        result = await resolve_dynamic_tags(
+            tagger_id="t",
+            tag_source_url="https://x.example",
+            tag_source_prompt="extract",
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=None,
+            eval_config=None,
+        )
+
+    assert result.skip_reason == "tag_source_empty"
+    assert result.tags is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_skip_on_empty_markdown():
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = None
+
+    with (
+        patch("posthog.temporal.llm_analytics.dynamic_tags.get_async_client", AsyncMock(return_value=redis_mock)),
+        patch("posthog.temporal.llm_analytics.dynamic_tags._fetch_url_as_markdown", AsyncMock(return_value="")),
+    ):
+        result = await resolve_dynamic_tags(
+            tagger_id="t",
+            tag_source_url="https://blank.example",
+            tag_source_prompt="extract",
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=None,
+            eval_config=None,
+        )
+
+    assert result.skip_reason == "tag_source_empty"
+
+
+@pytest.mark.asyncio
+async def test_resolve_caches_extracted_tags_after_llm_call():
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = None
+
+    llm_client = MagicMock()
+    llm_response = MagicMock()
+    llm_response.parsed = _ExtractedTags(tags=[TagDefinition(name="x")])
+    llm_response.usage = MagicMock(input_tokens=1, output_tokens=1)
+    llm_client.complete.return_value = llm_response
+
+    with (
+        patch("posthog.temporal.llm_analytics.dynamic_tags.get_async_client", AsyncMock(return_value=redis_mock)),
+        patch(
+            "posthog.temporal.llm_analytics.dynamic_tags._fetch_url_as_markdown",
+            AsyncMock(return_value="# Has x"),
+        ),
+        patch("posthog.temporal.llm_analytics.dynamic_tags.Client", return_value=llm_client),
+    ):
+        await resolve_dynamic_tags(
+            tagger_id="t",
+            tag_source_url="https://x.example",
+            tag_source_prompt="extract",
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=None,
+            eval_config=None,
+        )
+
+    redis_mock.setex.assert_called_once()
+    args, _ = redis_mock.setex.call_args
+    assert args[0] == cache_key("t")
+    assert args[1] == 24 * 60 * 60  # 24h TTL
+    # Stored payload contains the fingerprint and tag list
+    decoded = json.loads(gzip.decompress(args[2]).decode("utf-8"))
+    assert decoded["fingerprint"] == fingerprint("https://x.example", "extract")
+    assert decoded["tags"] == [{"name": "x", "description": ""}]
+
+
+@pytest.mark.asyncio
+async def test_invalidate_cached_tags_deletes_the_key():
+    redis_mock = AsyncMock()
+    with patch("posthog.temporal.llm_analytics.dynamic_tags.get_async_client", AsyncMock(return_value=redis_mock)):
+        await invalidate_cached_tags("t")
+    redis_mock.delete.assert_called_once_with(cache_key("t"))
+
+
+@pytest.mark.asyncio
+async def test_invalidate_swallows_redis_errors():
+    redis_mock = AsyncMock()
+    redis_mock.delete.side_effect = Exception("redis down")
+    with patch("posthog.temporal.llm_analytics.dynamic_tags.get_async_client", AsyncMock(return_value=redis_mock)):
+        # Must not raise
+        await invalidate_cached_tags("t")
+
+
+def test_dynamic_tag_result_defaults():
+    r = DynamicTagResult()
+    assert r.tags is None
+    assert r.extraction_llm_used is False
+    assert r.skip_reason is None

--- a/posthog/temporal/llm_analytics/test_run_tagger.py
+++ b/posthog/temporal/llm_analytics/test_run_tagger.py
@@ -316,6 +316,143 @@ class TestRunTaggerWorkflow:
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)
+    async def test_execute_tagger_dynamic_source_uses_resolved_tags(self, setup_data):
+        """Dynamic-source tagger must use tags returned by resolve_dynamic_tags, not the static tag list."""
+        from posthog.temporal.llm_analytics.dynamic_tags import DynamicTagResult
+
+        tagger_obj = setup_data["tagger"]
+        team = setup_data["team"]
+
+        tagger = {
+            "id": str(tagger_obj.id),
+            "name": "Dynamic Tagger",
+            "tagger_config": {
+                "prompt": "Pick the right owner.",
+                "tags": [],
+                "tag_source": "dynamic",
+                "tag_source_url": "https://example.com/owners",
+                "tag_source_prompt": "Extract feature owners.",
+            },
+            "team_id": team.id,
+        }
+
+        event_data = create_mock_event_data(
+            team.id,
+            properties={
+                "$ai_input": [{"role": "user", "content": "Billing question"}],
+                "$ai_output_choices": [{"role": "assistant", "content": "..."}],
+            },
+        )
+
+        resolved = DynamicTagResult(
+            tags=[{"name": "alice", "description": "billing"}, {"name": "bob", "description": "analytics"}],
+            extraction_llm_used=True,
+            extraction_input_tokens=70,
+            extraction_output_tokens=12,
+        )
+
+        with patch(
+            "posthog.temporal.llm_analytics.run_tagger.resolve_dynamic_tags", return_value=resolved
+        ) as mock_resolve:
+            with patch("posthog.temporal.llm_analytics.run_tagger.Client") as mock_client_class:
+                mock_client = MagicMock()
+                mock_client_class.return_value = mock_client
+
+                mock_response = MagicMock()
+                mock_response.parsed = TagResult(tags=["alice"], reasoning="Billing → Alice")
+                mock_response.usage = MagicMock(input_tokens=200, output_tokens=10, total_tokens=210)
+                mock_client.complete.return_value = mock_response
+
+                with patch("posthog.temporal.llm_analytics.run_tagger.EvaluationConfig") as mock_eval_config:
+                    mock_config = MagicMock()
+                    mock_config.trial_evals_used = 0
+                    mock_config.trial_eval_limit = 100
+                    mock_eval_config.objects.get_or_create.return_value = (mock_config, False)
+
+                    result = await execute_tagger_activity(ExecuteTaggerInputs(tagger=tagger, event_data=event_data))
+
+        assert result["tags"] == ["alice"]
+        assert result["extraction_llm_used"] is True
+        assert result["extraction_input_tokens"] == 70
+        assert result["extraction_output_tokens"] == 12
+        # The classification call sees the resolved tags, not the static (empty) list
+        mock_resolve.assert_called_once()
+        _, kwargs = mock_resolve.call_args
+        assert kwargs["tag_source_url"] == "https://example.com/owners"
+        assert kwargs["tag_source_prompt"] == "Extract feature owners."
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_execute_tagger_dynamic_source_skip_reason_surfaces_as_application_error(self, setup_data):
+        """A skip_reason from resolve_dynamic_tags must surface as a non-retryable ApplicationError."""
+        from posthog.temporal.llm_analytics.dynamic_tags import DynamicTagResult
+
+        tagger_obj = setup_data["tagger"]
+        team = setup_data["team"]
+
+        tagger = {
+            "id": str(tagger_obj.id),
+            "name": "Dynamic Tagger",
+            "tagger_config": {
+                "prompt": "Tag this.",
+                "tags": [],
+                "tag_source": "dynamic",
+                "tag_source_url": "https://broken.example",
+                "tag_source_prompt": "extract",
+            },
+            "team_id": team.id,
+        }
+
+        event_data = create_mock_event_data(team.id)
+
+        skip = DynamicTagResult(skip_reason="tag_source_fetch_failed", skip_message="network down")
+
+        with patch("posthog.temporal.llm_analytics.run_tagger.resolve_dynamic_tags", return_value=skip):
+            with patch("posthog.temporal.llm_analytics.run_tagger.EvaluationConfig") as mock_eval_config:
+                mock_config = MagicMock()
+                mock_config.trial_evals_used = 0
+                mock_config.trial_eval_limit = 100
+                mock_eval_config.objects.get_or_create.return_value = (mock_config, False)
+
+                with pytest.raises(ApplicationError) as excinfo:
+                    await execute_tagger_activity(ExecuteTaggerInputs(tagger=tagger, event_data=event_data))
+
+        assert excinfo.value.non_retryable is True
+        assert excinfo.value.details[0]["error_type"] == "tag_source_fetch_failed"
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_execute_tagger_dynamic_source_requires_url_and_prompt(self, setup_data):
+        tagger_obj = setup_data["tagger"]
+        team = setup_data["team"]
+
+        tagger = {
+            "id": str(tagger_obj.id),
+            "name": "Misconfigured Tagger",
+            "tagger_config": {
+                "prompt": "Tag this.",
+                "tags": [],
+                "tag_source": "dynamic",
+                # tag_source_url and tag_source_prompt deliberately missing
+            },
+            "team_id": team.id,
+        }
+
+        event_data = create_mock_event_data(team.id)
+
+        with patch("posthog.temporal.llm_analytics.run_tagger.EvaluationConfig") as mock_eval_config:
+            mock_config = MagicMock()
+            mock_config.trial_evals_used = 0
+            mock_config.trial_eval_limit = 100
+            mock_eval_config.objects.get_or_create.return_value = (mock_config, False)
+
+            with pytest.raises(ApplicationError) as excinfo:
+                await execute_tagger_activity(ExecuteTaggerInputs(tagger=tagger, event_data=event_data))
+
+        assert excinfo.value.details[0]["error_type"] == "tag_source_misconfigured"
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
     async def test_execute_tagger_no_tags_defined(self, setup_data):
         tagger_obj = setup_data["tagger"]
         team = setup_data["team"]

--- a/products/llm_analytics/backend/models/taggers.py
+++ b/products/llm_analytics/backend/models/taggers.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 import structlog
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
 
 from posthog.models.utils import UUIDTModel
 
@@ -16,6 +16,11 @@ logger = structlog.get_logger(__name__)
 class TaggerType(models.TextChoices):
     LLM = "llm", "LLM"
     HOG = "hog", "Hog"
+
+
+class TagSource(models.TextChoices):
+    STATIC = "static", "Static"
+    DYNAMIC = "dynamic", "Dynamic"
 
 
 class TagDefinition(BaseModel):
@@ -36,9 +41,25 @@ class LLMTaggerConfig(BaseModel):
     """Configuration for LLM-based taggers."""
 
     prompt: str = Field(..., min_length=1, description="Prompt instructing the LLM how to tag generations")
-    tags: list[TagDefinition] = Field(..., min_length=1, description="Available tags")
+    # tags is required when tag_source == 'static' and optional when 'dynamic' — the
+    # dynamic flow populates the working tag set at runtime from a URL. Default to []
+    # so a dynamic tagger can save without first writing throwaway static tags.
+    tags: list[TagDefinition] = Field(default_factory=list, description="Available tags (static mode)")
     min_tags: int = Field(default=0, ge=0, description="Minimum tags to apply")
     max_tags: int | None = Field(default=None, ge=1, description="Maximum tags to apply (null = no limit)")
+
+    tag_source: str = Field(
+        default=TagSource.STATIC.value,
+        description="Where the tag vocabulary comes from: 'static' (use the tags list) or 'dynamic' (fetch tag_source_url and derive tags at runtime)",
+    )
+    tag_source_url: str | None = Field(
+        default=None,
+        description="URL to fetch the source document from when tag_source == 'dynamic'",
+    )
+    tag_source_prompt: str | None = Field(
+        default=None,
+        description="Prompt that tells the LLM how to extract tag definitions from the fetched URL content",
+    )
 
     @field_validator("prompt")
     @classmethod
@@ -55,13 +76,43 @@ class LLMTaggerConfig(BaseModel):
             raise ValueError("Tag names must be unique")
         return v
 
+    @field_validator("tag_source")
+    @classmethod
+    def validate_tag_source(cls, v: str) -> str:
+        valid = {choice.value for choice in TagSource}
+        if v not in valid:
+            raise ValueError(f"tag_source must be one of {sorted(valid)}")
+        return v
+
+    @field_validator("tag_source_url")
+    @classmethod
+    def validate_tag_source_url(cls, v: str | None) -> str | None:
+        if v is None or v == "":
+            return None
+        # Reuse pydantic HttpUrl for shape validation but store as plain str so we
+        # don't churn JSON serialization downstream.
+        HttpUrl(v)
+        return v
+
     @model_validator(mode="after")
     def validate_tag_count_bounds(self) -> "LLMTaggerConfig":
-        if self.max_tags is not None:
-            if self.min_tags > self.max_tags:
+        if self.tag_source == TagSource.STATIC.value:
+            if not self.tags:
+                raise ValueError("tags is required when tag_source is 'static'")
+            if self.max_tags is not None:
+                if self.min_tags > self.max_tags:
+                    raise ValueError("min_tags cannot be greater than max_tags")
+                if self.max_tags > len(self.tags):
+                    raise ValueError("max_tags cannot exceed the number of defined tags")
+        else:
+            # Dynamic mode: tag list is derived at runtime, so max_tags can't be
+            # bounded against len(tags). Only enforce min <= max.
+            if self.max_tags is not None and self.min_tags > self.max_tags:
                 raise ValueError("min_tags cannot be greater than max_tags")
-            if self.max_tags > len(self.tags):
-                raise ValueError("max_tags cannot exceed the number of defined tags")
+            if not self.tag_source_url:
+                raise ValueError("tag_source_url is required when tag_source is 'dynamic'")
+            if not self.tag_source_prompt or not self.tag_source_prompt.strip():
+                raise ValueError("tag_source_prompt is required when tag_source is 'dynamic'")
         return self
 
 
@@ -187,3 +238,25 @@ def tagger_saved(sender, instance, created, **kwargs):
     # Defer the workers notification until the surrounding transaction commits.
     # Otherwise a rolled-back create would tell workers to reload a tagger that never existed.
     transaction.on_commit(lambda: reload_taggers_on_workers(team_id=instance.team_id, tagger_ids=[str(instance.id)]))
+
+    # Invalidate the dynamic-tag cache so URL/prompt edits take effect on the next
+    # tagger run instead of waiting for the 24h TTL. Synchronous Redis call here
+    # (the API process saving the tagger) — the workflow uses the async client.
+    transaction.on_commit(lambda: _invalidate_dynamic_tag_cache(str(instance.id)))
+
+
+def _invalidate_dynamic_tag_cache(tagger_id: str) -> None:
+    """Delete the dynamic-tag Redis cache entry for ``tagger_id``.
+
+    Mirrors the key built by ``posthog.temporal.llm_analytics.dynamic_tags.cache_key``.
+    Done in-process via the sync Redis client because this runs in the request path,
+    not inside a Temporal activity.
+    """
+    try:
+        from posthog.redis import get_client
+        from posthog.temporal.llm_analytics.dynamic_tags import cache_key
+
+        get_client().delete(cache_key(tagger_id))
+    except Exception:
+        # A cache-bust failure isn't fatal — the worst case is staleness up to the TTL.
+        logger.warning("Failed to invalidate dynamic-tag cache on tagger save", tagger_id=tagger_id, exc_info=True)

--- a/products/llm_analytics/backend/models/test/test_taggers.py
+++ b/products/llm_analytics/backend/models/test/test_taggers.py
@@ -79,6 +79,91 @@ class TestLLMTaggerConfig(BaseTest):
         )
         assert config.max_tags is None
 
+    def test_tag_source_defaults_to_static(self):
+        config = LLMTaggerConfig(
+            prompt="Test",
+            tags=[TagDefinition(name="a")],
+        )
+        assert config.tag_source == "static"
+        assert config.tag_source_url is None
+        assert config.tag_source_prompt is None
+
+    def test_dynamic_tag_source_requires_url_and_prompt(self):
+        with self.assertRaises(Exception):
+            LLMTaggerConfig(
+                prompt="Tag this",
+                tags=[],
+                tag_source="dynamic",
+            )
+
+    def test_dynamic_tag_source_requires_url(self):
+        with self.assertRaises(Exception):
+            LLMTaggerConfig(
+                prompt="Tag this",
+                tags=[],
+                tag_source="dynamic",
+                tag_source_prompt="extract owners",
+            )
+
+    def test_dynamic_tag_source_requires_prompt(self):
+        with self.assertRaises(Exception):
+            LLMTaggerConfig(
+                prompt="Tag this",
+                tags=[],
+                tag_source="dynamic",
+                tag_source_url="https://example.com/owners",
+            )
+
+    def test_dynamic_tag_source_allows_empty_tags(self):
+        config = LLMTaggerConfig(
+            prompt="Tag this support ticket with the right owner",
+            tags=[],
+            tag_source="dynamic",
+            tag_source_url="https://posthog.com/handbook/engineering/feature-ownership",
+            tag_source_prompt="Extract the list of feature owners from this page.",
+        )
+        assert config.tag_source == "dynamic"
+        assert config.tags == []
+
+    def test_static_tag_source_requires_tags(self):
+        with self.assertRaises(Exception):
+            LLMTaggerConfig(
+                prompt="Tag this",
+                tags=[],
+                tag_source="static",
+            )
+
+    def test_invalid_tag_source_value_rejected(self):
+        with self.assertRaises(Exception):
+            LLMTaggerConfig(
+                prompt="Tag this",
+                tags=[TagDefinition(name="a")],
+                tag_source="bogus",
+            )
+
+    def test_dynamic_tag_source_rejects_non_http_url(self):
+        with self.assertRaises(Exception):
+            LLMTaggerConfig(
+                prompt="Tag this",
+                tags=[],
+                tag_source="dynamic",
+                tag_source_url="not-a-url",
+                tag_source_prompt="extract owners",
+            )
+
+    def test_dynamic_tag_source_allows_max_tags_above_static_count(self):
+        # In dynamic mode the static tag list might be empty but max_tags can still
+        # be set to bound the final classification call's selections.
+        config = LLMTaggerConfig(
+            prompt="Tag this",
+            tags=[],
+            tag_source="dynamic",
+            tag_source_url="https://example.com/owners",
+            tag_source_prompt="extract owners",
+            max_tags=10,
+        )
+        assert config.max_tags == 10
+
 
 class TestTaggerModel(BaseTest):
     def _make_tagger_config(self, **overrides):

--- a/products/llm_analytics/frontend/tags/LLMAnalyticsTag.tsx
+++ b/products/llm_analytics/frontend/tags/LLMAnalyticsTag.tsx
@@ -5,6 +5,7 @@ import { IconArrowLeft, IconCopy, IconPlus, IconTrash } from '@posthog/icons'
 import {
     LemonButton,
     LemonInput,
+    LemonSegmentedButton,
     LemonSelect,
     LemonSkeleton,
     LemonSwitch,
@@ -97,6 +98,134 @@ function TagDefinitionsEditor({ id }: { id: string }): JSX.Element {
                     />
                 </div>
             ))}
+        </div>
+    )
+}
+
+function TagSourceSection({ id }: { id: string }): JSX.Element {
+    const { taggerForm } = useValues(llmTaggerLogic({ id }))
+    const { setTaggerFormValues } = useActions(llmTaggerLogic({ id }))
+
+    const config = taggerForm.tagger_config
+    const tagSource: 'static' | 'dynamic' =
+        'tag_source' in config && config.tag_source === 'dynamic' ? 'dynamic' : 'static'
+    const tagSourceUrl = ('tag_source_url' in config && config.tag_source_url) || ''
+    const tagSourcePrompt = ('tag_source_prompt' in config && config.tag_source_prompt) || ''
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <label className="font-semibold">Tag source</label>
+                <p className="text-muted text-sm mb-2">
+                    Define a fixed tag list, or generate the tag vocabulary at run time from a public URL (e.g. a
+                    handbook page).
+                </p>
+                <LemonSegmentedButton
+                    value={tagSource}
+                    onChange={(value) =>
+                        setTaggerFormValues({
+                            tagger_config: {
+                                ...config,
+                                tag_source: value,
+                            },
+                        })
+                    }
+                    options={[
+                        { value: 'static', label: 'Static list' },
+                        { value: 'dynamic', label: 'Generate from URL' },
+                    ]}
+                    fullWidth
+                />
+            </div>
+
+            {tagSource === 'static' ? (
+                <TagDefinitionsEditor id={id} />
+            ) : (
+                <>
+                    <div>
+                        <label className="font-semibold">Source URL</label>
+                        <p className="text-muted text-sm mb-1">
+                            The page is fetched and converted to markdown, then the LLM extracts a tag list from it
+                            using the prompt below.
+                        </p>
+                        <LemonInput
+                            type="url"
+                            placeholder="https://posthog.com/handbook/engineering/feature-ownership"
+                            value={tagSourceUrl}
+                            onChange={(value) =>
+                                setTaggerFormValues({
+                                    tagger_config: {
+                                        ...config,
+                                        tag_source_url: value || null,
+                                    },
+                                })
+                            }
+                        />
+                    </div>
+                    <div>
+                        <label className="font-semibold">Extraction prompt</label>
+                        <p className="text-muted text-sm mb-1">
+                            Instructions for the LLM on how to derive tags from the fetched content.
+                        </p>
+                        <LemonTextArea
+                            placeholder="e.g. Extract one tag per team listed on this page. Use the team's short name as the tag name and a one-sentence description."
+                            value={tagSourcePrompt}
+                            onChange={(value) =>
+                                setTaggerFormValues({
+                                    tagger_config: {
+                                        ...config,
+                                        tag_source_prompt: value || null,
+                                    },
+                                })
+                            }
+                            minRows={3}
+                        />
+                    </div>
+                </>
+            )}
+
+            <div className="flex gap-4 items-start">
+                <div>
+                    <label className="font-semibold">Min tags</label>
+                    <LemonInput
+                        type="number"
+                        min={0}
+                        value={'min_tags' in config ? config.min_tags : 0}
+                        onChange={(value) =>
+                            setTaggerFormValues({
+                                tagger_config: {
+                                    ...config,
+                                    min_tags: value ?? 0,
+                                },
+                            })
+                        }
+                        size="small"
+                        className="w-24"
+                    />
+                </div>
+                <div>
+                    <label className="font-semibold">Max tags</label>
+                    <LemonInput
+                        type="number"
+                        min={1}
+                        value={'max_tags' in config ? (config.max_tags ?? undefined) : undefined}
+                        onChange={(value) =>
+                            setTaggerFormValues({
+                                tagger_config: {
+                                    ...config,
+                                    max_tags: value ?? null,
+                                },
+                            })
+                        }
+                        size="small"
+                        className="w-24"
+                        placeholder="No limit"
+                    />
+                </div>
+                {tagSource === 'dynamic' && (
+                    <p className="text-muted text-xs mt-6">Bounds apply to the LLM-derived tag list at run time.</p>
+                )}
+            </div>
         </div>
     )
 }
@@ -439,6 +568,9 @@ function LLMAnalyticsTaggerForm({ id }: { id: string }): JSX.Element {
                                                 tags: taggerForm.tagger_config.tags,
                                                 min_tags: 0,
                                                 max_tags: null,
+                                                tag_source: 'static',
+                                                tag_source_url: null,
+                                                tag_source_prompt: null,
                                             },
                                         })
                                     }
@@ -513,57 +645,7 @@ function LLMAnalyticsTaggerForm({ id }: { id: string }): JSX.Element {
                             </div>
                         )}
 
-                        {taggerForm.tagger_type !== 'hog' && <TagDefinitionsEditor id={id} />}
-
-                        {taggerForm.tagger_type !== 'hog' && (
-                            <div className="flex gap-4">
-                                <div>
-                                    <label className="font-semibold">Min tags</label>
-                                    <LemonInput
-                                        type="number"
-                                        min={0}
-                                        value={
-                                            'min_tags' in taggerForm.tagger_config
-                                                ? taggerForm.tagger_config.min_tags
-                                                : 0
-                                        }
-                                        onChange={(value) =>
-                                            setTaggerFormValues({
-                                                tagger_config: {
-                                                    ...taggerForm.tagger_config,
-                                                    min_tags: value ?? 0,
-                                                },
-                                            })
-                                        }
-                                        size="small"
-                                        className="w-24"
-                                    />
-                                </div>
-                                <div>
-                                    <label className="font-semibold">Max tags</label>
-                                    <LemonInput
-                                        type="number"
-                                        min={1}
-                                        value={
-                                            'max_tags' in taggerForm.tagger_config
-                                                ? (taggerForm.tagger_config.max_tags ?? undefined)
-                                                : undefined
-                                        }
-                                        onChange={(value) =>
-                                            setTaggerFormValues({
-                                                tagger_config: {
-                                                    ...taggerForm.tagger_config,
-                                                    max_tags: value ?? null,
-                                                },
-                                            })
-                                        }
-                                        size="small"
-                                        className="w-24"
-                                        placeholder="No limit"
-                                    />
-                                </div>
-                            </div>
-                        )}
+                        {taggerForm.tagger_type !== 'hog' && <TagSourceSection id={id} />}
                     </div>
 
                     {/* Model Configuration (LLM only) */}

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts
@@ -114,6 +114,9 @@ describe('llmTaggerLogic', () => {
                     tags: [{ name: '', description: '' }],
                     min_tags: 0,
                     max_tags: null,
+                    tag_source: 'static',
+                    tag_source_url: null,
+                    tag_source_prompt: null,
                 },
                 model_configuration: null,
             })
@@ -384,6 +387,103 @@ describe('llmTaggerLogic', () => {
                 const errors = await submitAndGetErrors()
                 expect(errors.name).toBeUndefined()
                 expect(errors.tagger_config.prompt).toBeUndefined()
+                expect(errors.tagger_config.tags).toBeUndefined()
+            })
+        })
+
+        describe('LLM tagger with dynamic tag source', () => {
+            beforeEach(() => {
+                logic = llmTaggerLogic({ id: 'new' })
+                logic.mount()
+                logic.actions.setTaggerFormValues({
+                    name: 'Dynamic Tagger',
+                    tagger_config: {
+                        prompt: 'Tag this',
+                        tags: [],
+                        min_tags: 0,
+                        max_tags: null,
+                        tag_source: 'dynamic',
+                        tag_source_url: null,
+                        tag_source_prompt: null,
+                    },
+                })
+            })
+
+            it('skips static-tags validation when dynamic', async () => {
+                const errors = await submitAndGetErrors()
+                expect(errors.tagger_config.tags).toBeUndefined()
+            })
+
+            it('requires tag_source_url', async () => {
+                const errors = await submitAndGetErrors()
+                expect(errors.tagger_config.tag_source_url).toBe('URL is required')
+            })
+
+            it('rejects an invalid URL', async () => {
+                logic.actions.setTaggerFormValues({
+                    tagger_config: {
+                        prompt: 'Tag this',
+                        tags: [],
+                        min_tags: 0,
+                        max_tags: null,
+                        tag_source: 'dynamic',
+                        tag_source_url: 'not a url',
+                        tag_source_prompt: 'Extract tags',
+                    },
+                })
+                const errors = await submitAndGetErrors()
+                expect(errors.tagger_config.tag_source_url).toBe('Enter a valid URL')
+            })
+
+            it('rejects a non-http(s) URL', async () => {
+                logic.actions.setTaggerFormValues({
+                    tagger_config: {
+                        prompt: 'Tag this',
+                        tags: [],
+                        min_tags: 0,
+                        max_tags: null,
+                        tag_source: 'dynamic',
+                        tag_source_url: 'ftp://example.com/page',
+                        tag_source_prompt: 'Extract tags',
+                    },
+                })
+                const errors = await submitAndGetErrors()
+                expect(errors.tagger_config.tag_source_url).toBe('URL must start with http:// or https://')
+            })
+
+            it('requires tag_source_prompt', async () => {
+                logic.actions.setTaggerFormValues({
+                    tagger_config: {
+                        prompt: 'Tag this',
+                        tags: [],
+                        min_tags: 0,
+                        max_tags: null,
+                        tag_source: 'dynamic',
+                        tag_source_url: 'https://posthog.com/handbook',
+                        tag_source_prompt: null,
+                    },
+                })
+                const errors = await submitAndGetErrors()
+                expect(errors.tagger_config.tag_source_prompt).toBe('Extraction prompt is required')
+            })
+
+            it('clears errors with a valid dynamic configuration', async () => {
+                logic.actions.setTaggerFormValues({
+                    tagger_config: {
+                        prompt: 'Tag this',
+                        tags: [],
+                        min_tags: 0,
+                        max_tags: null,
+                        tag_source: 'dynamic',
+                        tag_source_url: 'https://posthog.com/handbook/engineering/feature-ownership',
+                        tag_source_prompt: 'Extract one tag per owner',
+                    },
+                })
+                const errors = await submitAndGetErrors()
+                expect(errors.name).toBeUndefined()
+                expect(errors.tagger_config.prompt).toBeUndefined()
+                expect(errors.tagger_config.tag_source_url).toBeUndefined()
+                expect(errors.tagger_config.tag_source_prompt).toBeUndefined()
                 expect(errors.tagger_config.tags).toBeUndefined()
             })
         })

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
@@ -54,6 +54,9 @@ const DEFAULT_TAGGER_CONFIG: TaggerConfig = {
     tags: [{ name: '', description: '' }],
     min_tags: 0,
     max_tags: null,
+    tag_source: 'static',
+    tag_source_url: null,
+    tag_source_prompt: null,
 }
 
 const DEFAULT_CONDITION: TaggerConditionSet = {
@@ -232,41 +235,92 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
     forms(({ props }) => ({
         taggerForm: {
             defaults: DEFAULT_FORM,
-            errors: (values: TaggerForm) => ({
-                name: !values.name ? 'Name is required' : undefined,
-                tagger_config:
-                    values.tagger_type === 'hog'
-                        ? {
-                              source: !('source' in values.tagger_config && values.tagger_config.source?.trim())
-                                  ? 'Hog source code is required'
+            errors: (values: TaggerForm) => {
+                if (values.tagger_type === 'hog') {
+                    return {
+                        name: !values.name ? 'Name is required' : undefined,
+                        tagger_config: {
+                            source: !('source' in values.tagger_config && values.tagger_config.source?.trim())
+                                ? 'Hog source code is required'
+                                : undefined,
+                        },
+                    }
+                }
+                // LLM tagger — branch on tag_source. Missing tag_source (legacy taggers)
+                // behaves like 'static' so existing forms stay valid.
+                const tagSource = ('tag_source' in values.tagger_config && values.tagger_config.tag_source) || 'static'
+                const promptError = !('prompt' in values.tagger_config && values.tagger_config.prompt)
+                    ? 'Prompt is required'
+                    : undefined
+                if (tagSource === 'dynamic') {
+                    const url = ('tag_source_url' in values.tagger_config && values.tagger_config.tag_source_url) || ''
+                    const extractionPrompt =
+                        ('tag_source_prompt' in values.tagger_config && values.tagger_config.tag_source_prompt) || ''
+                    let urlError: string | undefined
+                    if (!url.trim()) {
+                        urlError = 'URL is required'
+                    } else {
+                        try {
+                            const parsed = new URL(url)
+                            if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+                                urlError = 'URL must start with http:// or https://'
+                            }
+                        } catch {
+                            urlError = 'Enter a valid URL'
+                        }
+                    }
+                    return {
+                        name: !values.name ? 'Name is required' : undefined,
+                        tagger_config: {
+                            prompt: promptError,
+                            tag_source_url: urlError,
+                            tag_source_prompt: !extractionPrompt.trim() ? 'Extraction prompt is required' : undefined,
+                        },
+                    }
+                }
+                return {
+                    name: !values.name ? 'Name is required' : undefined,
+                    tagger_config: {
+                        prompt: promptError,
+                        // kea-forms expects per-tag errors as an array matching tags[]. The
+                        // array type does not allow `undefined` slots, so use `{}` for
+                        // tags with no error. Synthesize a single-entry error for the
+                        // empty-tags case so the form stays invalid (the UI guardrail
+                        // blocks reaching this state, but a programmatic removeTag could).
+                        tags:
+                            values.tagger_config.tags.length === 0
+                                ? [{ name: 'At least one tag is required' }]
+                                : values.tagger_config.tags.some((t) => !t.name.trim())
+                                  ? values.tagger_config.tags.map((t) =>
+                                        !t.name.trim() ? { name: 'All tags must have a name' } : {}
+                                    )
                                   : undefined,
-                          }
-                        : {
-                              prompt: !('prompt' in values.tagger_config && values.tagger_config.prompt)
-                                  ? 'Prompt is required'
-                                  : undefined,
-                              // kea-forms expects per-tag errors as an array matching tags[]. The
-                              // array type does not allow `undefined` slots, so use `{}` for
-                              // tags with no error. Synthesize a single-entry error for the
-                              // empty-tags case so the form stays invalid (the UI guardrail
-                              // blocks reaching this state, but a programmatic removeTag could).
-                              tags:
-                                  values.tagger_config.tags.length === 0
-                                      ? [{ name: 'At least one tag is required' }]
-                                      : values.tagger_config.tags.some((t) => !t.name.trim())
-                                        ? values.tagger_config.tags.map((t) =>
-                                              !t.name.trim() ? { name: 'All tags must have a name' } : {}
-                                          )
-                                        : undefined,
-                          },
-            }),
+                    },
+                }
+            },
             submit: async (values: TaggerForm) => {
+                const isDynamic =
+                    values.tagger_type === 'llm' &&
+                    'tag_source' in values.tagger_config &&
+                    values.tagger_config.tag_source === 'dynamic'
                 const payload = {
                     ...values,
-                    tagger_config: {
-                        ...values.tagger_config,
-                        tags: values.tagger_config.tags.filter((t) => t.name.trim()),
-                    },
+                    tagger_config: isDynamic
+                        ? {
+                              // Dynamic mode: tag list is derived at runtime, so don't persist
+                              // any half-typed static tags alongside it.
+                              ...values.tagger_config,
+                              tags: [],
+                          }
+                        : {
+                              ...values.tagger_config,
+                              tags: values.tagger_config.tags.filter((t) => t.name.trim()),
+                              // Static (or hog) mode: clear the dynamic fields so we don't
+                              // leave dead URL/prompt config on the saved tagger.
+                              ...(values.tagger_type === 'llm'
+                                  ? { tag_source_url: null, tag_source_prompt: null }
+                                  : {}),
+                          },
                 }
 
                 if (props.id === 'new') {

--- a/products/llm_analytics/frontend/tags/types.ts
+++ b/products/llm_analytics/frontend/tags/types.ts
@@ -35,11 +35,18 @@ export interface TagDefinition {
 
 export type TaggerType = 'llm' | 'hog'
 
+export type TagSource = 'static' | 'dynamic'
+
 export interface LLMTaggerConfig {
     prompt: string
     tags: TagDefinition[]
     min_tags: number
     max_tags: number | null
+    // Optional on the type so taggers persisted before the dynamic-tag flow shipped
+    // still parse. UI defaults a missing value to 'static'.
+    tag_source?: TagSource
+    tag_source_url?: string | null
+    tag_source_prompt?: string | null
 }
 
 export interface HogTaggerConfig {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.42",
+    "html2text==2025.4.15",
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-08T13:58:42.986529031Z"
+exclude-newer = "2026-05-10T21:30:17.936188Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -3010,6 +3010,15 @@ wheels = [
 ]
 
 [[package]]
+name = "html2text"
+version = "2025.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316, upload-time = "2025-04-15T04:02:30.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656, upload-time = "2025-04-15T04:02:28.44Z" },
+]
+
+[[package]]
 name = "htmldate"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -5258,6 +5267,7 @@ dependencies = [
     { name = "grpcio" },
     { name = "gspread" },
     { name = "hogql-parser" },
+    { name = "html2text" },
     { name = "humanize" },
     { name = "infi-clickhouse-orm" },
     { name = "jsonref" },
@@ -5522,6 +5532,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.42" },
+    { name = "html2text", specifier = "==2025.4.15" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },


### PR DESCRIPTION
## Problem

Existing LLM analytics taggers classify `$ai_generation` events against a **fixed** `tags: list[TagDefinition]`. There's no way to derive the tag vocabulary at runtime from a reference document — every tag has to be hand-entered when the tagger is created.

Driving use case: tag support-ticket messages with the right owner by pointing the tagger at the engineering feature-ownership handbook page. The LLM scrapes that page into a tag list (one tag per owner), then the existing classification path tags the ticket against that derived list. Owners change weekly; nobody wants to re-edit the tagger every time.

This PR adds a `tag_source: static | dynamic` discriminator to the tagger config so a tagger can point at a URL + extraction prompt instead of a static list. Existing static taggers are unchanged.

(This is the LLM analytics half of a 2-PR split. The Phase 2 workflows LLM action nodes ship in a sibling PR.)

## Changes

**Backend** (`products/llm_analytics`, `posthog/temporal/llm_analytics`):

- `LLMTaggerConfig` gains `tag_source` (`static` | `dynamic`), `tag_source_url`, `tag_source_prompt`. The discriminator lives inside the existing `tagger_config` JSONField so there's no DB migration. Existing static behavior is bit-for-bit unchanged; existing taggers default to `tag_source='static'`.
- New `dynamic_tags.py` helper module: fetches the URL, converts HTML to markdown via `html2text`, runs an LLM extraction call to produce the tag list, caches the result in Redis keyed on `(tagger_id, url, prompt_hash)` with a 24h TTL. Cache invalidated on tagger save via a post_save signal.
- `execute_tagger_activity` consumes the helper when `tag_source == 'dynamic'`; failure modes (`tag_source_fetch_failed`, `tag_source_empty`, `tag_source_extract_failed`, `tag_source_misconfigured`) surface as workflow `skipped` results with a `skip_reason` rather than workflow failures, so a transient fetch issue doesn't block downstream taggers.
- Trial-quota counter double-increments on extraction cache miss so the second LLM call (extraction) is accounted for alongside the classification call.
- New `html2text==2025.4.15` dependency.

**Frontend** (`products/llm_analytics/frontend/tags`):

- `LLMTaggerConfig` (TS) extended with optional `tag_source` / `tag_source_url` / `tag_source_prompt`.
- `llmTaggerLogic` defaults to `tag_source: 'static'`, branches form validation (URL shape + non-empty extraction prompt for dynamic, skips the static-tags rule), and the submit payload now zeroes the irrelevant fields per mode (empty `tags` when dynamic, nulled URL/prompt when static).
- `LLMAnalyticsTag.tsx` gains a `TagSourceSection` with a `LemonSegmentedButton` toggle. Static mode renders the existing `TagDefinitionsEditor`; dynamic mode renders URL + extraction-prompt inputs. `min_tags` / `max_tags` stay visible in both modes with an explanatory note in dynamic mode.

## How did you test this code?

I'm an agent; manual UI testing is limited to what's described below.

**Automated tests added/updated and run locally:**

- `posthog/temporal/llm_analytics/test_dynamic_tags.py` (new, 277 lines) — covers URL fetch, html2text conversion, LLM extraction, Redis cache hit/miss, fingerprint guard, and the four failure modes (`fetch_failed`, `empty`, `extract_failed`, `misconfigured`).
- `posthog/temporal/llm_analytics/test_run_tagger.py` — new test cases for `execute_tagger_activity` invoking the dynamic resolver, trial-quota double-increment on cache miss, and skip-reason surfacing in workflow results. Full 85-test tagger suite green.
- `products/llm_analytics/backend/models/test/test_taggers.py` — pydantic + Django model tests for the new fields, including the per-mode validation differences.
- `products/llm_analytics/frontend/tags/llmTaggerLogic.test.ts` — 6 new validation tests; full 42-test logic suite green.

**Not tested:** End-to-end smoke on phrocs (live tagger run against a real handbook URL). Unit-level paths all pass but no live run yet.

## Publish to changelog?

Yes — user-visible new mode for LLM taggers. I'll post in #changelog when this merges.

## Docs update

Inkeep docs update is fine — the new dynamic mode benefits from a docs pass on the LLM analytics taggers section.

## 🤖 Agent context

Authored across multiple sessions with Claude Code (Anthropic Opus + Sonnet). Working context lived in a session-spanning skill (`workflows-llm-step` on the PostHog skills store).

Notable decisions worth flagging:

- **`tag_source` discriminator inside `tagger_config` JSONField.** No DB migration needed — `LLMTaggerConfig` is a Pydantic model living inside a JSONField. Existing static taggers default to `tag_source='static'` and behave identically. Rolling this back is a code-only revert.
- **24h Redis cache on extracted tag lists.** Keyed on `(tagger_id, url, prompt_hash)`. Avoids re-extracting on every tagger run (which would double the per-event LLM cost). Cache busts on tagger save so an edit to the URL or prompt is reflected immediately.
- **Failure modes are workflow skips, not failures.** Taggers run on every matched event and a transient URL fetch failure shouldn't poison the workflow. We surface the specific reason (`tag_source_fetch_failed` / `_empty` / `_extract_failed` / `_misconfigured`) on the skip result so users can see what went wrong without paging anyone.
- **Trial-quota double-increment on extraction cache miss.** When both extraction and classification use the PostHog key, the trial counter increments twice on cache miss (once for each LLM call). Cache hits don't re-bill extraction. This was an explicit Q1 decision — alternative was to only count classification, but that would let users get free extraction calls indefinitely.

Reviewer focus area: `dynamic_tags.py` is the new failure surface. The four skip reasons cover what I could enumerate; would appreciate a second pair of eyes on whether there are unhandled exception classes from `httpx` / `html2text` / the LLM extraction call that would leak through as workflow failures instead of skips.