### PR TITLE
fix(frontend): pause notifications SSE on hidden tabs

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/notificationsSSE.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/notificationsSSE.ts
@@ -39,6 +39,16 @@ export function connectToNotificationsSSE(
             }
         },
         onError: (error) => {
+            // If the abort was triggered externally (e.g. by the pause-on-hidden
+            // disposable in sidePanelNotificationsLogic), surface it as a
+            // DOMException AbortError so retryWithBackoff (and the outer .catch on
+            // the caller) recognises it as clean cancellation rather than a
+            // connection failure to retry. Without this, every visibility-pause
+            // cycle would fire spurious livestream_sse_error + livestream_sse_max_errors
+            // telemetry and arm an unnecessary sseFocusReconnect listener.
+            if (signal.aborted) {
+                throw new DOMException('Aborted', 'AbortError')
+            }
             hooks.onError?.(error)
             throw new Error('SSE disconnected')
         },

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
@@ -255,14 +255,31 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
             // Reconnect from focus-on-give-up still uses a separate 'sseFocusReconnect'
             // disposable so users who stay on a foreground tab past max-attempts retry on
             // window refocus.
+            //
+            // Lifecycle telemetry now fires on every visibility cycle (the disposable's
+            // setup/teardown run on resume/pause), so we tag each capture with a `reason`
+            // so existing dashboards can still distinguish initial connects, team-driven
+            // reloads, focus-reconnects, and pure visibility transitions.
+            // `cache.nextStartReason` / `cache.nextStopReason` carry the caller's intent
+            // into the factory + teardown; the disposable plugin's pause/resume cycle
+            // doesn't go through this action so the cache values default to
+            // 'visibility_resume' / 'visibility_pause'.
+            const startReason = cache.nextStartReason ?? 'initial'
+            cache.nextStartReason = null
+            cache.nextStopReason = 'replaced'
             cache.disposables.dispose('sseFocusReconnect')
             cache.disposables.dispose('sseConnection')
+            cache.nextStopReason = null
+            cache.nextStartReason = startReason
 
             cache.disposables.add(
                 () => {
+                    const reason = cache.nextStartReason ?? 'visibility_resume'
+                    cache.nextStartReason = null
                     // TEMPORARY: lifecycle tracking for /notifications SSE connection.
                     // Remove together with livestream_401_debug once root cause is known.
                     posthog.capture('livestream_sse_startsse_called', {
+                        reason,
                         flag_enabled: values.realTimeNotificationsEnabled,
                         has_token: !!values.currentTeam?.live_events_token,
                         has_host: !!liveEventsHostOrigin(),
@@ -292,7 +309,7 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                     cache.sseConnection = abortController
                     cache.firstMessageLogged = false
 
-                    posthog.capture('livestream_sse_connecting', { url })
+                    posthog.capture('livestream_sse_connecting', { url, reason })
 
                     void retryWithBackoff(
                         () =>
@@ -350,6 +367,7 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                             () => {
                                 const onFocus = (): void => {
                                     posthog.capture('livestream_sse_refocus_reconnect', { url })
+                                    cache.nextStartReason = 'focus_reconnect'
                                     actions.startSSE()
                                 }
                                 window.addEventListener('focus', onFocus, { once: true })
@@ -361,9 +379,14 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                     })
 
                     return () => {
-                        // TEMPORARY: livestream SSE lifecycle tracking — captures both
-                        // explicit stop and pause-for-hidden teardowns.
+                        // TEMPORARY: livestream SSE lifecycle tracking. `reason` tags
+                        // whether this teardown was an explicit stop, a replacement by
+                        // a later startSSE call, or the disposable pausing for a
+                        // hidden tab so dashboards can still distinguish them.
+                        const stopReason = cache.nextStopReason ?? 'visibility_pause'
+                        cache.nextStopReason = null
                         posthog.capture('livestream_sse_stopped', {
+                            reason: stopReason,
                             had_connection: !!cache.sseConnection,
                         })
                         abortController.abort()
@@ -377,8 +400,10 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
             )
         },
         stopSSE: () => {
+            cache.nextStopReason = 'explicit_stop'
             cache.disposables.dispose('sseFocusReconnect')
             cache.disposables.dispose('sseConnection')
+            cache.nextStopReason = null
         },
         navigateToNotification: ({ notification }) => {
             const path = values.sourcePathForNotification(notification)
@@ -433,6 +458,7 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
         },
         loadCurrentTeamSuccess: () => {
             if (values.realTimeNotificationsEnabled && !cache.sseConnection) {
+                cache.nextStartReason = 'team_reload'
                 actions.startSSE()
             }
         },

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
@@ -247,116 +247,138 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
             }
         },
         startSSE: () => {
-            // Drop any pending focus-reconnect from a previous give-up; we're reconnecting now.
+            // The SSE connection is managed by a disposable named 'sseConnection' so the
+            // kea-disposables plugin auto-aborts it when the tab is hidden and reopens it
+            // on visibilitychange. This keeps an idle background tab from holding a
+            // long-lived streaming Response — that was accumulating in Blink's
+            // partition_alloc/buffer + blink_gc/<unspecified> on production tabs.
+            // Reconnect from focus-on-give-up still uses a separate 'sseFocusReconnect'
+            // disposable so users who stay on a foreground tab past max-attempts retry on
+            // window refocus.
             cache.disposables.dispose('sseFocusReconnect')
+            cache.disposables.dispose('sseConnection')
 
-            // TEMPORARY: lifecycle tracking for /notifications SSE connection.
-            // Remove together with livestream_401_debug once root cause is known.
-            posthog.capture('livestream_sse_startsse_called', {
-                flag_enabled: values.realTimeNotificationsEnabled,
-                has_token: !!values.currentTeam?.live_events_token,
-                has_host: !!liveEventsHostOrigin(),
-                had_prior_connection: !!cache.sseConnection,
-            })
+            cache.disposables.add(
+                () => {
+                    // TEMPORARY: lifecycle tracking for /notifications SSE connection.
+                    // Remove together with livestream_401_debug once root cause is known.
+                    posthog.capture('livestream_sse_startsse_called', {
+                        flag_enabled: values.realTimeNotificationsEnabled,
+                        has_token: !!values.currentTeam?.live_events_token,
+                        has_host: !!liveEventsHostOrigin(),
+                        had_prior_connection: !!cache.sseConnection,
+                    })
 
-            if (!values.realTimeNotificationsEnabled) {
-                posthog.capture('livestream_sse_startsse_skipped', { reason: 'flag_disabled' })
-                return
-            }
+                    if (!values.realTimeNotificationsEnabled) {
+                        posthog.capture('livestream_sse_startsse_skipped', { reason: 'flag_disabled' })
+                        return () => {}
+                    }
 
-            const token = values.currentTeam?.live_events_token
-            if (!token) {
-                posthog.capture('livestream_sse_startsse_skipped', { reason: 'no_token' })
-                return
-            }
+                    const token = values.currentTeam?.live_events_token
+                    if (!token) {
+                        posthog.capture('livestream_sse_startsse_skipped', { reason: 'no_token' })
+                        return () => {}
+                    }
 
-            const host = liveEventsHostOrigin()
-            if (!host) {
-                posthog.capture('livestream_sse_startsse_skipped', { reason: 'no_host' })
-                return
-            }
+                    const host = liveEventsHostOrigin()
+                    if (!host) {
+                        posthog.capture('livestream_sse_startsse_skipped', { reason: 'no_host' })
+                        return () => {}
+                    }
 
-            const url = `${host}/notifications`
+                    const url = `${host}/notifications`
 
-            cache.sseConnection?.abort()
-            const abortController = new AbortController()
-            cache.sseConnection = abortController
-            cache.firstMessageLogged = false
+                    const abortController = new AbortController()
+                    cache.sseConnection = abortController
+                    cache.firstMessageLogged = false
 
-            posthog.capture('livestream_sse_connecting', { url })
+                    posthog.capture('livestream_sse_connecting', { url })
 
-            void retryWithBackoff(
-                () =>
-                    connectToNotificationsSSE(
-                        url,
-                        token,
-                        abortController.signal,
-                        (notification) => {
-                            if (!values.isInitialLoadComplete) {
-                                return
-                            }
-                            actions.notificationReceived(notification)
-                            if (notification.priority === 'critical') {
-                                showCriticalNotificationToast(notification)
-                            }
-                        },
-                        {
-                            // TEMPORARY: livestream SSE lifecycle tracking.
-                            onFirstMessage: () => {
-                                if (!cache.firstMessageLogged) {
-                                    cache.firstMessageLogged = true
-                                    posthog.capture('livestream_sse_first_message', { url })
+                    void retryWithBackoff(
+                        () =>
+                            connectToNotificationsSSE(
+                                url,
+                                token,
+                                abortController.signal,
+                                (notification) => {
+                                    if (!values.isInitialLoadComplete) {
+                                        return
+                                    }
+                                    actions.notificationReceived(notification)
+                                    if (notification.priority === 'critical') {
+                                        showCriticalNotificationToast(notification)
+                                    }
+                                },
+                                {
+                                    // TEMPORARY: livestream SSE lifecycle tracking.
+                                    onFirstMessage: () => {
+                                        if (!cache.firstMessageLogged) {
+                                            cache.firstMessageLogged = true
+                                            posthog.capture('livestream_sse_first_message', { url })
+                                        }
+                                    },
+                                    onError: (error) => {
+                                        posthog.capture('livestream_sse_error', {
+                                            url,
+                                            error_name: (error as Error | undefined)?.name,
+                                            error_message: (error as Error | undefined)?.message,
+                                        })
+                                    },
                                 }
-                            },
-                            onError: (error) => {
-                                posthog.capture('livestream_sse_error', {
-                                    url,
-                                    error_name: (error as Error | undefined)?.name,
-                                    error_message: (error as Error | undefined)?.message,
-                                })
-                            },
+                            ),
+                        {
+                            maxAttempts: SSE_RETRY_ATTEMPTS,
+                            initialDelayMs: SSE_RETRY_INITIAL_DELAY_MS,
+                            backoffMultiplier: SSE_RETRY_BACKOFF_MULTIPLIER,
+                            signal: abortController.signal,
                         }
-                    ),
-                {
-                    maxAttempts: SSE_RETRY_ATTEMPTS,
-                    initialDelayMs: SSE_RETRY_INITIAL_DELAY_MS,
-                    backoffMultiplier: SSE_RETRY_BACKOFF_MULTIPLIER,
-                    signal: abortController.signal,
-                }
-            ).catch((error) => {
-                // retryWithBackoff rejects with AbortError on clean shutdown; only re-arm when it actually gave up.
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                // TEMPORARY: livestream SSE lifecycle tracking.
-                posthog.capture('livestream_sse_max_errors', {
-                    url,
-                    max_attempts: SSE_RETRY_ATTEMPTS,
-                })
-                // Re-arm SSE the next time the user focuses the window. pauseOnPageHidden must be false
-                // so the listener stays attached while the tab is backgrounded — that's exactly when we want it.
-                cache.disposables.add(
-                    () => {
-                        const onFocus = (): void => {
-                            posthog.capture('livestream_sse_refocus_reconnect', { url })
-                            actions.startSSE()
+                    ).catch((error) => {
+                        // retryWithBackoff rejects with AbortError on clean shutdown
+                        // (including when the disposable is paused for visibilitychange);
+                        // only re-arm when it actually gave up.
+                        if (error instanceof DOMException && error.name === 'AbortError') {
+                            return
                         }
-                        window.addEventListener('focus', onFocus, { once: true })
-                        return () => window.removeEventListener('focus', onFocus)
-                    },
-                    'sseFocusReconnect',
-                    { pauseOnPageHidden: false }
-                )
-            })
+                        // TEMPORARY: livestream SSE lifecycle tracking.
+                        posthog.capture('livestream_sse_max_errors', {
+                            url,
+                            max_attempts: SSE_RETRY_ATTEMPTS,
+                        })
+                        // Re-arm SSE the next time the user focuses the window. pauseOnPageHidden must be false
+                        // so the listener stays attached while the tab is backgrounded — that's exactly when we want it.
+                        cache.disposables.add(
+                            () => {
+                                const onFocus = (): void => {
+                                    posthog.capture('livestream_sse_refocus_reconnect', { url })
+                                    actions.startSSE()
+                                }
+                                window.addEventListener('focus', onFocus, { once: true })
+                                return () => window.removeEventListener('focus', onFocus)
+                            },
+                            'sseFocusReconnect',
+                            { pauseOnPageHidden: false }
+                        )
+                    })
+
+                    return () => {
+                        // TEMPORARY: livestream SSE lifecycle tracking — captures both
+                        // explicit stop and pause-for-hidden teardowns.
+                        posthog.capture('livestream_sse_stopped', {
+                            had_connection: !!cache.sseConnection,
+                        })
+                        abortController.abort()
+                        if (cache.sseConnection === abortController) {
+                            cache.sseConnection = null
+                        }
+                    }
+                },
+                'sseConnection',
+                { pauseOnPageHidden: true }
+            )
         },
         stopSSE: () => {
-            // TEMPORARY: livestream SSE lifecycle tracking.
-            posthog.capture('livestream_sse_stopped', {
-                had_connection: !!cache.sseConnection,
-            })
             cache.disposables.dispose('sseFocusReconnect')
-            cache.sseConnection?.abort()
-            cache.sseConnection = null
+            cache.disposables.dispose('sseConnection')
         },
         navigateToNotification: ({ notification }) => {
             const path = values.sourcePathForNotification(notification)


### PR DESCRIPTION
> 🧵 Part of the memory-leak investigation tracked in [#32479](https://github.com/PostHog/posthog/issues/32479).

Related to #32479 (browser memory leak investigation).
## Problem

The \`/notifications\` SSE connection in \`sidePanelNotificationsLogic\` was kept open for the entire tab lifetime, including when \`document.hidden = true\`. On backgrounded production tabs this accumulates real off-heap renderer memory:

- \`partition_alloc/buffer\` growing **~366 MB** on a backgrounded \`/feature_flags\` tab over 26 min, monotonic, no reclaim
- \`blink_gc/<unspecified>\` pinned at **~310 MB above baseline** on a backgrounded \`/error_tracking\` tab for the whole 30-min run

Both buckets release immediately when the streaming \`Response\` is aborted. The growth is invisible to V8 heap snapshots (JS heap stays ~100 MB) — only \`memory-infra\` traces surface it.

The polling fallback branch (when \`realTimeNotificationsEnabled\` is off) already pauses on \`visibilitychange\` via \`togglePolling\`. The SSE branch did not — every user with the live-events feature was keeping a long-lived streaming \`fetch()\` open per tab.

Mirrors the pattern shipped for \`unread_count\` polling in #58691.

## Changes

Wrap the SSE setup in \`cache.disposables.add('sseConnection', setup, { pauseOnPageHidden: true })\` so the kea-disposables plugin aborts and reopens the connection on \`visibilitychange\`.

- \`startSSE\` / \`stopSSE\` actions are kept (still called from \`afterMount\` + \`loadCurrentTeamSuccess\`); their bodies just add or dispose the disposable
- The existing \`sseFocusReconnect\` (window \`focus\` re-arm after max-attempts) is preserved for the visible-tab-still-on-screen-after-give-up case — \`pauseOnPageHidden\` only covers hidden tabs
- \`retryWithBackoff\` already takes the same \`abortController.signal\` so retries bail cleanly when the disposable is paused; the catch handler checks for \`AbortError\` and returns

## How did you test this code?

I'm an agent (PostHog Code). This change has been verified through automated diagnostic, not manual exploratory testing in a browser:

- \`tsc --noEmit\` — change typechecks clean; pre-existing errors in unrelated files only
- \`pnpm --filter=@posthog/frontend format\` — lint/format pass
- Production-realistic test pre-fix: 30-min headed Chromium run against \`us.posthog.com\` with 6 cmd-clicked tabs (5 hidden via \`document.hidden\` override). \`memory-infra\` trace shows \`partition_alloc/buffer\` and \`blink_gc/<unspecified>\` growing on hidden tabs while connection stays open
- Need a human to verify: re-run the same harness with this branch loaded and confirm the two allocator buckets stay flat on hidden tabs

The investigation harness lives outside the repo at \`~/leak-hunter/\` (bundled in the \`hunt-memory-leaks\` skill); not part of this PR.

## Publish to changelog?

No.

## Docs update

Not needed.

## 🤖 Agent context

Authored by PostHog Code as part of investigating the multi-GB-tab memory issue tracked in the \`hunt-memory-leaks\` skill.

Investigation flow that produced this fix:

1. Built a headed-Chromium harness (\`measure-cmdclick-instrumented.mjs\`) that opens production via persisted \`storageState\`, serially loads each sidebar item while foregrounded so backgrounded tabs are fully rendered, then applies \`document.hidden\` overrides on tabs 1..N. CDP \`Network.enable\` captures all requests from t=0; \`Tracing.start\` with the \`memory-infra\` category captures per-allocator memory dumps periodically and streams them to a single browser-wide \`trace.json\`.
2. A 30-min run produced a 347 MB \`memory-infra\` trace + per-tab RSS/heap/DOM samples in NDJSON.
3. Per-allocator timeline analysis (streamed via \`ijson\`) showed the spike isolated to \`partition_alloc/buffer\` on \`/feature_flags\` and \`blink_gc/<unspecified>\` on \`/error_tracking\`. Other allocators (\`v8\`, \`cc\`, \`malloc\`) were flat. Both growing tabs were hidden.
4. The 4 \`live.us.posthog.com/notifications\` requests per hidden tab pointed at the SSE connection. Reading \`sidePanelNotificationsLogic\` confirmed the SSE branch had no \`visibilitychange\` handler — the polling fallback branch did.
5. Fix mirrors PR #58691 (\`unread_count\` polling pause): wrap setup in \`cache.disposables.add\` with \`pauseOnPageHidden: true\`. Smallest viable refactor — keeps action names and call sites unchanged.

Decisions taken:
- Kept the \`sseFocusReconnect\` disposable instead of removing it. \`pauseOnPageHidden\` triggers on \`visibilitychange\`; the focus reconnect triggers on \`window.focus\`. They cover different cases (user comes back to tab vs user clicks back into browser window) and the focus path is still useful when the tab is visible but the browser was unfocused
- Did not introduce a new test. There's no existing kea logic test for this file (only \`notificationsSSE.test.ts\` covers the lower-level SSE connection helper). Worth following up with a behavioral test, but out of scope for the smallest-fix PR
- The \`cache.sseConnection\` reference is preserved and only cleared in the teardown when the controller matches, so external callers reading \`cache.sseConnection\` still work
