### PR TITLE
Fix scene tab overflow with horizontal scrolling

### DIFF
--- a/frontend/src/layout/scenes/SceneTabs.css
+++ b/frontend/src/layout/scenes/SceneTabs.css
@@ -1,3 +1,31 @@
+.scene-tab-row {
+    scroll-behavior: smooth;
+}
+
+/* Hide scrollbar but keep scrolling functionality on non-hover */
+.scene-tab-row::-webkit-scrollbar {
+    height: 6px;
+}
+
+.scene-tab-row::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.scene-tab-row::-webkit-scrollbar-thumb {
+    background: var(--color-border-secondary);
+    border-radius: 3px;
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+.scene-tab-row:hover::-webkit-scrollbar-thumb {
+    opacity: 1;
+}
+
+.scene-tab-row::-webkit-scrollbar-thumb:hover {
+    background: var(--color-border-primary);
+}
+
 .scene-tab--pinned {
     max-width: 36px;
     padding-right: 0.5rem;

--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -85,7 +85,7 @@ export function SceneTabs(): JSX.Element {
                     strategy={horizontalListSortingStrategy}
                 >
                     <div
-                        className="scene-tab-row gap-1 flex-1 min-w-0 items-center flex h-[var(--scene-layout-header-height)] lg:h-auto pr-2"
+                        className="scene-tab-row gap-1 flex-1 min-w-0 items-center flex h-[var(--scene-layout-header-height)] lg:h-auto pr-2 overflow-x-auto overflow-y-hidden"
                         onMouseLeave={clearFrozenWidths}
                     >
                         {tabs.map((tab, index) => {
@@ -179,7 +179,7 @@ function SortableSceneTab({
             {...attributes}
             {...listeners}
             className={cn(
-                isPinned ? 'shrink-0' : frozenWidth != null ? '' : 'w-full flex-1 min-w-[100px] max-w-[250px]'
+                isPinned ? 'shrink-0' : frozenWidth != null ? '' : 'w-full flex-1 min-w-[60px] max-w-[250px]'
             )}
             data-tab-id={tab.id}
         >


### PR DESCRIPTION
## Problem

When many scene tabs are open (~15+), tabs were being compressed and clipped instead of remaining accessible. This made it difficult to navigate or select older tabs.
(connected to the issue #56633)

## Changes

- Enabled horizontal scrolling on the scene tab container
- Prevented pinned tabs from shrinking using `shrink-0`
- Added min/max width constraints for normal tabs to maintain readability
- Ensured overflow behavior activates only when necessary

## How did you test this code?

- Tested locally with 15+ open tabs
- Verified horizontal scrolling works smoothly
- Checked pinned tab behavior remains stable
- Confirmed no clipping of tab content

## Docs update

no