### PR TITLE
chore(user-interviews): TEMP log raw Vapi webhook body on auth failure

### DIFF
--- a/products/user_interviews/backend/webhooks.py
+++ b/products/user_interviews/backend/webhooks.py
@@ -302,8 +302,10 @@ def vapi_webhook(request: Request) -> Response:
         body_bytes=len(request.body),
     )
     if not (provided and expected and hmac.compare_digest(provided, expected)):
-        # Log prefixes (first 8 chars of one-way hashes — safe to log; do not leak secrets) to diagnose
-        # whether the failure is wrong-secret vs different-body vs case-mismatch.
+        # TODO: REMOVE — temporary diagnostic dump of the raw body and the
+        # provided signature so we can locally reproduce Vapi's HMAC and find
+        # the byte-level mismatch that's causing 100% signature_failed. Safe
+        # only because user_interviews is not yet shipped to real users.
         logger.warning(
             "user_interviews_vapi_webhook_signature_failed",
             has_provided_signature=bool(provided),
@@ -311,6 +313,8 @@ def vapi_webhook(request: Request) -> Response:
             provided_prefix=provided[:8] if provided else None,
             provided_length=len(provided) if provided else 0,
             body_bytes=len(request.body),
+            provided_signature=provided,
+            raw_body=request.body.decode("utf-8", errors="replace"),
         )
         return Response({"error": "invalid signature"}, status=status.HTTP_401_UNAUTHORIZED)
 


### PR DESCRIPTION
## Problem

The HMAC verification path is rejecting 100% of real Vapi webhook deliveries — `expected_prefix` (what we compute) and `provided_prefix` (what Vapi sends) come back entirely uncorrelated. We've ruled out scheme, encoding, case, and length. We can't reproduce the signature using the body shown in Vapi's dashboard, which means the dashboard view doesn't reflect the exact bytes that hit our pod.

## Changes

Temporarily log the raw `request.body` and the full `provided` signature on the `user_interviews_vapi_webhook_signature_failed` warning branch. With those two values for a single failed delivery, we can locally compute `hmac_sha256(secret, body)` and figure out whether the bytes Vapi signs differ from what reaches us — and if so, how.

Marked `TODO: REMOVE` in the code. This must be ripped out as soon as we have the answer.

## How did you test this code?

I'm an agent (PostHog Code). Syntax + ruff clean. No tests changed — this is diagnostic-only logging on an existing branch.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

`user_interviews` is not yet shipped to real users — the only deliveries hitting prod webhook are internal demo interviews, so the privacy cost of logging body content for a short window is acceptable. Body contents include the assistant's system prompt plus the demo interviewee's transcript. Reverting commit will be filed as soon as the root cause is identified.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*