### PR TITLE
fix(llma): coerce stringified ph-query attrs in tiptap_doc_to_text

### DIFF
--- a/ee/hogai/tools/create_notebook/test_tiptap.py
+++ b/ee/hogai/tools/create_notebook/test_tiptap.py
@@ -411,3 +411,134 @@ class TestTiptapDocToText(SimpleTestCase):
         assert "# Report" in result
         assert "Summary below." in result
         assert "- item" in result
+
+    def test_ph_query_node_with_stringified_query(self):
+        # Some persisted notebooks store `attrs.query` as a JSON-encoded string rather than a dict.
+        # The formatter must parse it instead of crashing with AttributeError.
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "ph-query",
+                    "attrs": {
+                        "title": "Pages les plus touchées",
+                        "query": '{"kind": "InsightVizNode", "source": {"kind": "TrendsQuery"}}',
+                    },
+                }
+            ],
+        }
+        result = tiptap_doc_to_text(doc)
+        assert '<insight title="Pages les plus touchées"' in result
+        assert 'query_kind="InsightVizNode"' in result
+        assert 'source_kind="TrendsQuery"' in result
+
+    def test_ph_query_node_with_unparseable_query_string(self):
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "ph-query",
+                    "attrs": {"title": "Broken", "query": "not-json"},
+                }
+            ],
+        }
+        result = tiptap_doc_to_text(doc)
+        assert '<insight title="Broken"' in result
+        assert 'query_kind="unknown"' in result
+        assert "source_kind=" not in result
+
+    def test_ph_query_node_with_string_source(self):
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "ph-query",
+                    "attrs": {
+                        "title": "Edgy",
+                        "query": {"kind": "InsightVizNode", "source": "TrendsQuery"},
+                    },
+                }
+            ],
+        }
+        result = tiptap_doc_to_text(doc)
+        assert 'query_kind="InsightVizNode"' in result
+        assert "source_kind=" not in result
+
+    def test_ph_query_node_missing_attrs(self):
+        doc = {"type": "doc", "content": [{"type": "ph-query"}]}
+        result = tiptap_doc_to_text(doc)
+        assert '<insight title="Untitled"' in result
+        assert 'query_kind="unknown"' in result
+
+    @parameterized.expand(
+        [
+            ("string_node", "stray string"),
+            ("none_node", None),
+            ("number_node", 42),
+            ("list_node", ["unexpected"]),
+        ]
+    )
+    def test_non_dict_top_level_node_is_skipped(self, _name, bad_node):
+        doc = {
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "before"}]},
+                bad_node,
+                {"type": "paragraph", "content": [{"type": "text", "text": "after"}]},
+            ],
+        }
+        result = tiptap_doc_to_text(doc)
+        assert "before" in result
+        assert "after" in result
+
+    def test_non_dict_inline_node_is_skipped(self):
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "kept"},
+                        "stray inline string",
+                        {"type": "text", "text": " also kept"},
+                    ],
+                },
+            ],
+        }
+        result = tiptap_doc_to_text(doc)
+        assert result == "kept also kept"
+
+    def test_non_dict_list_item_is_skipped(self):
+        doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "bulletList",
+                    "content": [
+                        "stray",
+                        {
+                            "type": "listItem",
+                            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "real"}]}],
+                        },
+                    ],
+                }
+            ],
+        }
+        result = tiptap_doc_to_text(doc)
+        assert "- real" in result
+
+    def test_string_attrs_are_coerced_or_ignored(self):
+        # Even if `attrs` itself is a string, we should not crash.
+        doc = {
+            "type": "doc",
+            "content": [
+                {"type": "ph-recording", "attrs": "not-a-dict"},
+                {
+                    "type": "ph-recording",
+                    "attrs": '{"id": "sess-json"}',
+                },
+            ],
+        }
+        result = tiptap_doc_to_text(doc)
+        assert '<session_replay id="unknown" />' in result
+        assert '<session_replay id="sess-json" />' in result

--- a/ee/hogai/tools/create_notebook/tiptap.py
+++ b/ee/hogai/tools/create_notebook/tiptap.py
@@ -323,11 +323,27 @@ def tiptap_doc_to_text(doc: dict | None) -> str:
     return "\n\n".join(parts)
 
 
-def _tiptap_node_to_text(node: dict) -> str:
+def _coerce_to_dict(value: Any) -> dict:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (ValueError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _tiptap_node_to_text(node: Any) -> str:
+    if not isinstance(node, dict):
+        return ""
+
     node_type = node.get("type", "")
+    attrs = _coerce_to_dict(node.get("attrs"))
 
     if node_type == "heading":
-        level = node.get("attrs", {}).get("level", 1)
+        level = attrs.get("level", 1)
         inline = _tiptap_inline_to_text(node.get("content", []))
         return f"{'#' * level} {inline}"
 
@@ -335,7 +351,7 @@ def _tiptap_node_to_text(node: dict) -> str:
         return _tiptap_inline_to_text(node.get("content", []))
 
     if node_type == "codeBlock":
-        lang = node.get("attrs", {}).get("language", "")
+        lang = attrs.get("language", "")
         code = _tiptap_inline_to_text(node.get("content", []))
         return f"```{lang}\n{code}\n```"
 
@@ -354,12 +370,13 @@ def _tiptap_node_to_text(node: dict) -> str:
         return "\n".join(items)
 
     if node_type == "ph-query":
-        attrs = node.get("attrs", {})
         title = attrs.get("title", "Untitled")
-        query = attrs.get("query", {})
+        # `attrs.query` is sometimes persisted as a JSON-encoded string rather than a dict,
+        # which used to crash the LangGraph root node when the agent surfaced a notebook.
+        query = _coerce_to_dict(attrs.get("query"))
         query_kind = query.get("kind", "unknown")
-        source = query.get("source", {})
-        source_kind = source.get("kind", "") if isinstance(source, dict) else ""
+        source = _coerce_to_dict(query.get("source"))
+        source_kind = source.get("kind", "")
         parts = [f'<insight title="{title}" query_kind="{query_kind}"']
         if source_kind:
             parts[0] += f' source_kind="{source_kind}"'
@@ -369,7 +386,6 @@ def _tiptap_node_to_text(node: dict) -> str:
         return "\n".join(parts)
 
     if node_type == "ph-recording":
-        attrs = node.get("attrs", {})
         session_id = attrs.get("id", "unknown")
         return f'<session_replay id="{session_id}" />'
 
@@ -380,7 +396,9 @@ def _tiptap_node_to_text(node: dict) -> str:
     return ""
 
 
-def _tiptap_list_item_to_text(item: dict) -> str:
+def _tiptap_list_item_to_text(item: Any) -> str:
+    if not isinstance(item, dict):
+        return ""
     children = item.get("content", [])
     parts = []
     for child in children:
@@ -388,9 +406,13 @@ def _tiptap_list_item_to_text(item: dict) -> str:
     return " ".join(p for p in parts if p)
 
 
-def _tiptap_inline_to_text(nodes: list[dict]) -> str:
+def _tiptap_inline_to_text(nodes: Any) -> str:
+    if not isinstance(nodes, list):
+        return ""
     parts: list[str] = []
     for node in nodes:
+        if not isinstance(node, dict):
+            continue
         if node.get("type") == "text":
             text = node.get("text", "")
             marks = node.get("marks", [])


### PR DESCRIPTION
## Problem

Fix for this feedback: https://posthog.slack.com/archives/C0ASU43UAMS/p1779090118254839

The Max LangGraph `root` node fails with `AttributeError: 'str' object has no attribute 'get'` whenever it formats a notebook that has a `ph-query` block whose `attrs.query` is stored as a JSON-encoded string instead of a dict. The bad path runs in two places:

- `ee/hogai/context/notebook/context.py` — when a notebook is attached to UI context for the chat agent (454 occurrences observed in error tracking, 185 affected users).
- `ee/hogai/tools/read_data/tool.py` — when the agent fetches a notebook via the `ReadDataTool`.

Both paths funnel into `tiptap_doc_to_text` → `_tiptap_node_to_text`, and crash at the `ph-query` branch on `query.get("kind", "unknown")`. Downstream LangGraph branches (e.g. `memory_collector`) are cancelled as a side effect.

## Changes

- `_tiptap_node_to_text`: coerce `node` to a dict at the entry point and use a new `_coerce_to_dict` helper for `attrs`, `attrs.query`, and `query.source`. The helper accepts dicts directly, parses strings as JSON when possible, and falls back to `{}` for anything else. `attrs.query` being a JSON string is now parsed correctly instead of raising.
- `_tiptap_list_item_to_text` and `_tiptap_inline_to_text`: skip non-dict entries defensively so a single malformed child can't crash the entire document conversion.

## How did you test this code?

Agent-authored. Ran the targeted unit test suite locally:

- `pytest ee/hogai/tools/create_notebook/test_tiptap.py` — 49 passed (38 existing + 11 new).
- `ruff check` and `ruff format --check` on both touched files — clean.

New tests cover:

- `ph-query` with `attrs.query` as a JSON string (the production failure).
- `ph-query` with an unparseable string for `query` (graceful fallback to `query_kind="unknown"`).
- `ph-query` with `query.source` as a string instead of a dict.
- `ph-query` with no `attrs` at all.
- Stray non-dict entries at the top level, inside `bulletList`, and inside inline content.
- `ph-recording` with `attrs` as a string (both garbage and JSON-encoded).

No manual UI testing performed.

## Publish to changelog?

no

## 🤖 Agent context

- Investigation started from an LLM trace reported by the user; the `root` span surfaced `AttributeError: 'str' object has no attribute 'get'` at 1.76 s.
- Error tracking surfaced two related issues with the resolved stack trace pointing at `tiptap.py:360` inside the `ph-query` branch — one via the `ReadDataTool` path and one via the UI-context path. Both share the root cause.
- Considered (a) parsing the JSON string, (b) only adding `isinstance` guards, (c) both. Chose both: parsing keeps the formatter useful (insight title, kind, and source kind still surface) and the guards limit blast radius for any other malformed nodes we haven't seen yet.
- Tools used: `posthog` MCP (`query-llm-trace`, `query-error-tracking-issues-list`, `query-error-tracking-issue-events`, `query-logs`) and standard Read/Edit/Bash/Grep.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*