### PR TITLE
fix(user-interviews): show Thinking until the agent's first speech-start

### DIFF
--- a/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
+++ b/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
@@ -212,11 +212,15 @@ export default function ExporterInterviewScene({
     accessToken?: string
 }): JSX.Element {
     const [state, setState] = useState<CallState>('idle')
-    const [conversationPhase, setConversationPhase] = useState<ConversationPhase>('listening')
+    // Default to 'thinking' — between connection-up and the agent's first speech-start
+    // the assistant is loading its opener, which can take a few seconds. After
+    // speech-end transitions us into 'listening', subsequent silent moments correctly
+    // read as listening (mic is open), and only the post-user-final gap re-enters thinking.
+    const [conversationPhase, setConversationPhase] = useState<ConversationPhase>('thinking')
     const [errorMessage, setErrorMessage] = useState<string | null>(null)
     const vapiRef = useRef<Vapi | null>(null)
     const agentTalkingRef = useRef<boolean>(false)
-    const lastPhaseRef = useRef<ConversationPhase>('listening')
+    const lastPhaseRef = useRef<ConversationPhase>('thinking')
     const isMountedRef = useRef<boolean>(true)
 
     useEffect(() => {
@@ -240,8 +244,8 @@ export default function ExporterInterviewScene({
         vapiRef.current?.stop()
         vapiRef.current = null
         agentTalkingRef.current = false
-        lastPhaseRef.current = 'listening'
-        setConversationPhase('listening')
+        lastPhaseRef.current = 'thinking'
+        setConversationPhase('thinking')
         setState('loading')
         void (async () => {
             try {


### PR DESCRIPTION
## Problem

The default `conversationPhase` was `'listening'`, so between connection-up and the agent's first `speech-start` event the UI read **👂 Listening** even though the agent is loading its opener and hasn't joined the call yet. That gap can be a few seconds — long enough that interviewees noticed nothing was happening and asked why nobody was speaking.

Earlier I argued the gap was sub-second and not worth a separate phase; in practice it's longer.

## Changes

Flip the initial state (and the `start()` reset) from `'listening'` to `'thinking'`. Net behaviour:

| moment | phase shown |
|---|---|
| connecting → first `speech-start` | **🧠 Thinking** *(was: 👂 Listening — wrong)* |
| agent speaking | 🎤 Talking |
| agent finishes (mic open, waiting on user) | 👂 Listening |
| user mid-utterance | 👂 Listening |
| user-final → next agent `speech-start` | 🧠 Thinking |
| user interrupts | 👂 Listening |

The `speech-end → 'listening'` transition is unchanged, so once the agent has spoken once the long silent gaps still correctly read as listening (which was the original bug).

## How did you test this code?

I'm an agent (PostHog Code). One-line state-transition change, no test coverage in the existing scene (it was lifted to memoized sub-components without any).

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

The earlier fix (#58730) flipped the post-`speech-end` state from Thinking to Listening because the original code defaulted everything to Thinking. This is the other side of that change — the *pre-first-speech* gap is genuinely a thinking moment (assistant is loading its opener) and should read that way, while the *between-turns* gaps are listening (mic open).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*