### PR TITLE
fix(user-interviews): suppress Daily ejection error at normal call end

### DIFF
--- a/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
+++ b/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
@@ -262,10 +262,25 @@ export default function ExporterInterviewScene({
                     lastPhaseRef.current = next
                     setConversationPhase(next)
                 }
-                vapi.on('call-end', () => setState('ended'))
+                // Daily.co's normal end-of-call eviction surfaces as an `error` event in the
+                // Vapi SDK ("Meeting ended due to ejection: Meeting has ended"), often racing
+                // with the `call-end` event. Track whether the call has ended so we can
+                // suppress the spurious error transition that would otherwise flash an
+                // error panel right as the interview wraps up.
+                const callEndedRef = { current: false }
+                const isBenignEndOfCallError = (msg: string): boolean =>
+                    msg.includes('Meeting has ended') || msg.includes('Meeting ended due to ejection')
+                vapi.on('call-end', () => {
+                    callEndedRef.current = true
+                    setState('ended')
+                })
                 vapi.on('error', (e: unknown) => {
+                    const message = e instanceof Error ? e.message : ''
+                    if (callEndedRef.current || isBenignEndOfCallError(message)) {
+                        return
+                    }
                     vapi.stop()
-                    setErrorMessage(e instanceof Error ? e.message : 'Vapi reported an error during the call.')
+                    setErrorMessage(message || 'Vapi reported an error during the call.')
                     setState('error')
                 })
                 vapi.on('speech-start', () => {


### PR DESCRIPTION
## Problem

Daily.co fires an `error` event with the message *"Meeting ended due to ejection: Meeting has ended"* whenever the Vapi backend ends a call (e.g. via the `end_call_tool` we have wired up on the assistant). That race-condition with the `call-end` event was flashing the error panel for one render cycle right at the moment a normal interview wrapped up.

## Changes

In `ExporterInterviewScene`, the Vapi `error` handler now:

1. Tracks whether `call-end` has already fired via a local `callEndedRef`. If so, the error is suppressed and we stay in `'ended'` state.
2. Pattern-matches the known Daily ejection messages (`"Meeting has ended"`, `"Meeting ended due to ejection"`) as a defensive fallback in case the error event arrives before `call-end`.

Anything that isn't either of those still surfaces as an error normally — genuine connection/Vapi failures aren't masked.

## How did you test this code?

I'm an agent (PostHog Code). No tests in this scene (it's all memoized sub-components without coverage); reasoning by inspection of the handler ordering.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Follow-up to #58766 — discovered while user was recording a real interview and noticed the Daily ejection message in the console followed by a brief error-panel flash on the success path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*