### PR TITLE
fix(experiments): respect metric goal in timeseries chart colors

### DIFF
--- a/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
+++ b/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
@@ -20,7 +20,7 @@ import { Experiment, ExperimentIdType } from '~/types'
 
 import type { experimentTimeseriesLogicType } from './experimentTimeseriesLogicType'
 import { COLORS } from './MetricsView/shared/colors'
-import { getVariantInterval } from './MetricsView/shared/utils'
+import { getMetricColors, getVariantInterval } from './MetricsView/shared/utils'
 
 export interface ProcessedTimeseriesDataPoint {
     date: string
@@ -249,11 +249,14 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
 
         // Generate Chart.js-ready datasets
         chartData: [
-            (s, props) => [s.processedVariantData, props.experiment],
+            (s, props) => [s.processedVariantData, props.experiment, props.metric],
             (
                 processedVariantData: (variantKey: string) => ProcessedTimeseriesDataPoint[],
-                experiment: Experiment
+                experiment: Experiment,
+                metric: ExperimentMetric | undefined
             ): ((variantKey: string) => ProcessedChartData | null) => {
+                // Swap positive/negative colors when the metric goal is "decrease"
+                const goalColors = getMetricColors(COLORS, metric?.goal)
                 return (variantKey: string) => {
                     const processedData = processedVariantData(variantKey)
                     if (processedData.length === 0) {
@@ -323,11 +326,10 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
                                 const index = context.dataIndex
                                 const dataPoint = trimmedData[index]
                                 if (dataPoint?.significant) {
-                                    // Check if delta is positive or negative
                                     const isPositive = dataPoint.value !== null && dataPoint.value > 0
                                     return isPositive
-                                        ? hexToRGBA(COLORS.BAR_POSITIVE, 0.15)
-                                        : hexToRGBA(COLORS.BAR_NEGATIVE, 0.15)
+                                        ? hexToRGBA(goalColors.positive, 0.15)
+                                        : hexToRGBA(goalColors.negative, 0.15)
                                 }
                                 return hexToRGBA(COLORS.BAR_DEFAULT, 0.1)
                             }
@@ -338,11 +340,10 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
                                 const index = ctx.p0DataIndex
                                 const dataPoint = trimmedData[index]
                                 if (dataPoint?.significant) {
-                                    // Check if delta is positive or negative
                                     const isPositive = dataPoint.value !== null && dataPoint.value > 0
                                     return isPositive
-                                        ? hexToRGBA(COLORS.BAR_POSITIVE, 0.15)
-                                        : hexToRGBA(COLORS.BAR_NEGATIVE, 0.15)
+                                        ? hexToRGBA(goalColors.positive, 0.15)
+                                        : hexToRGBA(goalColors.negative, 0.15)
                                 }
                                 return hexToRGBA(COLORS.BAR_DEFAULT, 0.1)
                             },

--- a/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
+++ b/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
@@ -52,7 +52,7 @@ export interface ProcessedChartData {
 
 export interface ExperimentTimeseriesLogicProps {
     experiment: Experiment
-    metric?: ExperimentMetric
+    metric: ExperimentMetric | undefined
 }
 
 export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([


### PR DESCRIPTION
## Problem

The fill color on the experiment timeseries chart was hardcoded — green for positive deltas and red for negative — regardless of the metric's goal. For a metric with goal `decrease` (e.g., bounce rate, churn), a negative delta is the desired outcome, so it should render green, not red. This made the timeseries chart misleading and inconsistent with the static delta charts, which already render goal-aware colors via `getMetricColors`.

## Changes

In `frontend/src/scenes/experiments/experimentTimeseriesLogic.ts`:

- Added `props.metric` to the `chartData` selector dependencies.
- Computed `goalColors = getMetricColors(COLORS, metric?.goal)` once and used `goalColors.positive` / `goalColors.negative` in both `backgroundColor` and `segment.backgroundColor` callbacks (the two places that previously referenced `COLORS.BAR_POSITIVE` / `COLORS.BAR_NEGATIVE`).
- `BAR_DEFAULT` (non-significant fill) is unchanged — it stays neutral grey regardless of goal.

The helper `getMetricColors` is the same one already powering `ChartGradients` and the static delta charts, so the timeseries chart now matches their behavior.

## How did you test this code?

I'm an agent — no manual UI testing was performed. Verified that the diff is minimal, that the file's TypeScript errors are pre-existing (same errors appear on master), and that `oxfmt` ran clean on the file. A human reviewer should sanity-check the chart in the browser with both `increase` and `decrease` goals.

## Publish to changelog?

no

## Docs update

No docs change needed — internal chart-coloring fix.

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7).
- Located the timeseries chart fill logic in `experimentTimeseriesLogic.ts` and confirmed it ignored `metric.goal`.
- Found the existing goal-aware helper `getMetricColors` in `MetricsView/shared/utils.ts`, already consumed by `ChartGradients` for the static delta CI bar.
- Chose to reuse `getMetricColors` rather than introduce new logic, keeping the timeseries chart consistent with the rest of the experiments UI.
- Comments above the previous `isPositive` checks ("Check if delta is positive or negative") were removed since they only narrated the next line.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*