### PR TITLE
fix(user-interviews): only suppress ejection error after the call connected

### DIFF
--- a/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
+++ b/frontend/src/exporter/scenes/ExporterInterviewScene.tsx
@@ -264,10 +264,13 @@ export default function ExporterInterviewScene({
                 }
                 // Daily.co's normal end-of-call eviction surfaces as an `error` event in the
                 // Vapi SDK ("Meeting ended due to ejection: Meeting has ended"), often racing
-                // with the `call-end` event. Track whether the call has ended so we can
-                // suppress the spurious error transition that would otherwise flash an
-                // error panel right as the interview wraps up.
+                // with the `call-end` event. Suppress that race so the error panel doesn't
+                // flash as the interview wraps up — but ONLY when the call actually got off
+                // the ground. A pre-connection failure that happens to mention "Meeting has
+                // ended" (e.g. joining an already-ended room) must still surface as an
+                // error so the user gets the retry affordance.
                 const callEndedRef = { current: false }
+                const callConnectedRef = { current: false }
                 const isBenignEndOfCallError = (msg: string): boolean =>
                     msg.includes('Meeting has ended') || msg.includes('Meeting ended due to ejection')
                 vapi.on('call-end', () => {
@@ -276,7 +279,13 @@ export default function ExporterInterviewScene({
                 })
                 vapi.on('error', (e: unknown) => {
                     const message = e instanceof Error ? e.message : ''
-                    if (callEndedRef.current || isBenignEndOfCallError(message)) {
+                    // call-end already fired — definitely post-end, swallow.
+                    if (callEndedRef.current) {
+                        return
+                    }
+                    // Benign message + we'd reached in-call → call is ending, swallow.
+                    // Benign message but never connected → real failure, surface it.
+                    if (callConnectedRef.current && isBenignEndOfCallError(message)) {
                         return
                     }
                     vapi.stop()
@@ -315,6 +324,9 @@ export default function ExporterInterviewScene({
                     vapi.stop()
                     return
                 }
+                // Mark that the call actually connected — gates the benign-error suppression
+                // so pre-connection "Meeting has ended" failures still surface to the user.
+                callConnectedRef.current = true
                 setState((current) => (current === 'connecting' ? 'in-call' : current))
             } catch (e) {
                 if (!isMountedRef.current) {


### PR DESCRIPTION
## Problem

P1 finding on #58767: the `isBenignEndOfCallError` short-circuit suppressed any error whose message contained `"Meeting has ended"` or `"Meeting ended due to ejection"` regardless of where the call was in its lifecycle. A pre-connection failure that happened to produce one of those strings (joining an already-ended Daily room, a 410 from the room URL, etc.) would be silently swallowed — `state` would stay at `connecting` or `in-call`, no error panel, no retry button, and the user is stuck.

## Changes

Gate the benign-message suppression on a new `callConnectedRef` that only flips to `true` after `vapi.start()` resolves and we transition to `'in-call'`. The two suppression conditions are now:

- `callEndedRef.current` — `call-end` already fired, safe to swallow downstream errors. *(unchanged)*
- `callConnectedRef.current && isBenignEndOfCallError(message)` — we successfully connected and the error matches a known end-of-call pattern. *(new gating)*

A pre-connection error containing `"Meeting has ended"` now flows through to `setState('error')` normally and the user gets the retry affordance.

## How did you test this code?

I'm an agent (PostHog Code). One-line gating change, no test coverage on the existing scene. Verified by reading the call-state transition path: `'connecting'` → `await vapi.start()` resolves → `callConnectedRef = true` → `'in-call'`. Any error from `vapi.start()` itself rejects the promise and goes through the outer `try/catch`, bypassing the suppression entirely.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Follow-up to #58767 addressing a stamphog P1. The original PR's reasoning ("suppress this string because it's the normal end-of-call eviction") was right for the happy path but missed that the same string can appear from Daily/Vapi during connection failures.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*