### PR TITLE
fix(settings): avoid double history push on selectSetting

### DIFF
--- a/frontend/src/scenes/settings/settingsLogic.ts
+++ b/frontend/src/scenes/settings/settingsLogic.ts
@@ -622,8 +622,15 @@ export const settingsLogic = kea<settingsLogicType>([
             },
         ],
     }),
-    actionToUrl(() => ({
+    actionToUrl(({ props }) => ({
+        // Skip the URL update in the full settings scene — settingsSceneLogic already pushes
+        // the canonical URL with the section path + setting hash. Without this guard, both
+        // subscriptions fire on selectSetting and produce two history entries per click.
+        // Embedded usages (replay, logs) keep the `selectedSetting` hash for deep-linking.
         selectSetting: ({ setting }) => {
+            if (props.logicKey === 'settingsScene') {
+                return
+            }
             return [
                 router.values.location.pathname,
                 router.values.searchParams,


### PR DESCRIPTION
## Problem

Follow-up to [#58746](https://github.com/PostHog/posthog/pull/58746). Greptile flagged a double history push on `selectSetting` in that PR; the fix was deferred pending discussion because the maintainer thought it might be intentional. Opening this as a separate PR so the fix can land (or be rejected) on its own merits.

Both `settingsLogic.actionToUrl` and `settingsSceneLogic.actionToUrl` subscribe to `selectSetting` and each call `router.push` — with different hash keys (`selectedSetting` vs `setting`). Result: every setting click in the full settings scene creates two history entries instead of one. Pressing back lands on the intermediate URL (only one hash present), and no `urlToAction` handler recognises that state, so the highlighted setting is lost mid-session.

Previously `settingsSceneLogic` used `replace: true`, which overwrote the first push and netted one entry. #58746 switched it to `push` so the back button works between settings — correct intent, but the redundant push from `settingsLogic` was missed.

## Changes

Gate `settingsLogic.actionToUrl.selectSetting` on `props.logicKey`. In the full settings scene (`logicKey === 'settingsScene'`), `settingsSceneLogic` owns the URL and we skip the push. Embedded usages (`replay/settings`, `logs`) retain the `selectedSetting` hash for deep-linking — their `urlToAction` handlers in `settingsLogic` are unchanged.

## How did you test this code?

Authored by an agent (Claude Code). Automated checks:

- `pnpm --filter=@posthog/frontend typescript:check` — clean for settings files.
- `pnpm --filter=@posthog/frontend typegen:write` — clean.

No manual browser testing performed by the agent. Please verify:

- Full settings scene: back/forward between settings produces exactly one entry per click; back from a deep `#setting=X` URL returns to the previous selection.
- Replay settings (embedded): `#selectedSetting=...` deep-linking still works.
- Logs scene (embedded): `#selectedSetting=...` and `?setting=...` deep-linking still works.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 Agent context

Claude Code session. Considered three approaches:

1. Use `replace: true` in `settingsSceneLogic.selectSetting` — restores pre-#58746 behavior but loses the explicit back-button history that PR set out to add.
2. Drop `selectSetting` from `settingsSceneLogic.actionToUrl` entirely — would lose the canonical pathname update (jumping to a setting in a different section).
3. Gate `settingsLogic` push on `logicKey` (chosen) — keeps each logic's intent intact; the scene-level logic owns scene URLs, embedded logics own their own hash. Minimal blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)