### PR TITLE
fix(tasks): show spinners while task and logs load

### DIFF
--- a/products/tasks/frontend/components/TaskDetailPage.tsx
+++ b/products/tasks/frontend/components/TaskDetailPage.tsx
@@ -3,6 +3,7 @@ import { useActions, useValues } from 'kea'
 import { IconArchive, IconExternal, IconGithub, IconPlay } from '@posthog/icons'
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
+import { NotFound } from 'lib/components/NotFound'
 import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { TZLabel } from 'lib/components/TZLabel'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -39,14 +40,33 @@ export interface TaskDetailPageProps {
 
 export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
     const sceneLogic = taskDetailSceneLogic({ taskId })
-    const { task, runs, selectedRunId, selectedRun, runsLoading, logs, shouldPoll, streamEntries, isStreaming } =
-        useValues(sceneLogic)
+    const {
+        task,
+        taskLoading,
+        runs,
+        selectedRunId,
+        selectedRun,
+        runsLoading,
+        logs,
+        logsLoading,
+        shouldPoll,
+        streamEntries,
+        isStreaming,
+    } = useValues(sceneLogic)
     const { setSelectedRunId, runTask, deleteTask } = useActions(sceneLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
 
+    if (taskLoading && !task) {
+        return (
+            <div className="flex items-center justify-center h-32">
+                <Spinner />
+            </div>
+        )
+    }
+
     if (!task) {
-        return <div className="text-center py-8 text-muted">Task not found</div>
+        return <NotFound object="task" />
     }
 
     const hasBeenRun = runs.length > 0
@@ -207,6 +227,7 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
                 <div className="flex-1 overflow-hidden">
                     <TaskSessionView
                         logs={logs}
+                        logsLoading={logsLoading}
                         streamEntries={streamEntries}
                         isPolling={shouldPoll}
                         isStreaming={isStreaming}

--- a/products/tasks/frontend/components/TaskSessionView.tsx
+++ b/products/tasks/frontend/components/TaskSessionView.tsx
@@ -53,6 +53,7 @@ function HedgehogStatus(): JSX.Element {
 
 interface TaskSessionViewProps {
     logs: string
+    logsLoading: boolean
     streamEntries: LogEntry[]
     isPolling: boolean
     isStreaming: boolean
@@ -200,6 +201,7 @@ function LogEntryRenderer({ entry }: { entry: LogEntry }): JSX.Element | null {
 
 export function TaskSessionView({
     logs,
+    logsLoading,
     streamEntries,
     isPolling,
     isStreaming,
@@ -221,6 +223,13 @@ export function TaskSessionView({
     }
 
     if (entries.length === 0) {
+        if (logsLoading) {
+            return (
+                <div className="flex items-center justify-center h-32">
+                    <Spinner />
+                </div>
+            )
+        }
         return (
             <div className="p-4 text-center text-muted">
                 <p>No logs available yet</p>

--- a/products/tasks/frontend/logics/taskDetailSceneLogic.ts
+++ b/products/tasks/frontend/logics/taskDetailSceneLogic.ts
@@ -83,7 +83,7 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
     key((props) => props.taskId),
 
     connect((props: TaskDetailSceneLogicProps) => ({
-        values: [taskLogic(props), ['task'], teamLogic, ['currentProjectId']],
+        values: [taskLogic(props), ['task', 'taskLoading'], teamLogic, ['currentProjectId']],
         actions: [
             taskLogic(props),
             ['loadTask', 'loadTaskSuccess', 'runTask', 'runTaskSuccess', 'deleteTask', 'updateTask'],


### PR DESCRIPTION
## Problem

The task detail scene flashed two misleading empty states on first load: "Task not found" while the task fetch was in flight, and "No logs available yet" while the logs fetch was in flight. On a slow connection users would see the wrong message for the full duration of the request.

## Changes

- `taskDetailSceneLogic.ts` — connect `taskLoading` from `taskLogic` so the scene knows when the fetch is in flight
- `TaskDetailPage.tsx` — render a `Spinner` while `taskLoading` is true; only fall through to `NotFound` once loading has finished and there's still no task. Pass `logsLoading` down to `TaskSessionView`
- `TaskSessionView.tsx` — accept `logsLoading`; when there are no entries, show a `Spinner` while logs are still loading and fall back to "No logs available yet" only once the request has settled

## How did you test this code?

I'm an agent. I did not run the app manually — please verify on a throttled connection that:
- The task detail page shows a spinner instead of "Task not found" while the task is loading
- The session view shows a spinner instead of "No logs available yet" while logs are loading

No automated tests were added — this is a presentational guard around existing kea loading flags.

## Publish to changelog?

no

## 🤖 Agent context

Agent-authored via PostHog Code. The previous cloud session committed the change locally on \`posthog-code/fix-tasks-loading-states\` (commit \`089c182d710\`) but the run froze before the push/PR step — this PR is the missing tail of that task. No logic was changed in this follow-up; the branch was pushed and the PR opened as-is.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*