### PR TITLE
feat(signals): filter report list by priority

### DIFF
--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -206,6 +206,66 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["priority"] == "P0"
 
+    # --- priority filter ---
+
+    @parameterized.expand(
+        [
+            ("single", "P1", {"P1"}),
+            ("multiple", "P0,P2", {"P0", "P2"}),
+            ("case_insensitive", "p1", {"P1"}),
+        ]
+    )
+    def test_filter_by_priority(self, _name, query_value, expected_priorities):
+        reports_by_priority = {
+            "P0": self._create_report(title="P0 report"),
+            "P1": self._create_report(title="P1 report"),
+            "P2": self._create_report(title="P2 report"),
+        }
+        for priority, report in reports_by_priority.items():
+            self._priority_artefact(report, priority=priority)
+
+        response = self.client.get(self._list_url(priority=query_value))
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert ids == {str(reports_by_priority[p].id) for p in expected_priorities}
+
+    def test_filter_excludes_reports_without_priority(self):
+        self._create_report(title="No priority")
+        r_p1 = self._create_report(title="P1 report")
+        self._priority_artefact(r_p1, priority="P1")
+
+        response = self.client.get(self._list_url(priority="P1"))
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert ids == {str(r_p1.id)}
+
+    @parameterized.expand(
+        [
+            ("out_of_range", "P9"),
+            ("garbage", "not-a-priority"),
+            ("mixed_valid_and_invalid", "P0,P9"),
+        ]
+    )
+    def test_filter_priority_invalid_value_returns_400(self, _name, raw):
+        response = self.client.get(self._list_url(priority=raw))
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["attr"] == "priority"
+        assert body["code"] == "invalid_input"
+
+    def test_filter_priority_combines_with_ordering(self):
+        r_p2 = self._create_report(title="P2 report")
+        r_p0 = self._create_report(title="P0 report")
+        r_p1 = self._create_report(title="P1 report")
+        self._priority_artefact(r_p2, priority="P2")
+        self._priority_artefact(r_p0, priority="P0")
+        self._priority_artefact(r_p1, priority="P1")
+
+        response = self.client.get(self._list_url(priority="P0,P2", ordering="priority"))
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.json()["results"]]
+        assert ids == [str(r_p0.id), str(r_p2.id)]
+
     # --- ordering ---
 
     def test_ready_before_candidate_even_if_candidate_has_higher_weight(self):

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -53,6 +53,7 @@ from products.data_warehouse.backend.data_load.service import trigger_external_d
 from products.signals.backend.facade.api import emit_signal
 from products.signals.backend.implementation_pr import fetch_implementation_pr_urls_for_reports
 from products.signals.backend.models import (
+    AutonomyPriority,
     InvalidStatusTransition,
     SignalReport,
     SignalReportArtefact,
@@ -396,6 +397,7 @@ class SignalReportViewSet(
         qs = self._annotate_latest_actionability_value(qs)
         qs = self._annotate_signal_report_status_rank(qs)
         qs = self._annotate_signal_report_priority(qs)
+        qs = self._apply_signal_report_priority_filter(qs)
         qs = self._prefetch_signal_report_priority_artefacts(qs)
         qs = self._annotate_is_suggested_reviewer(qs)
         if self.action != "list":
@@ -482,6 +484,28 @@ class SignalReportViewSet(
                 )
             )
         )
+
+    def _apply_signal_report_priority_filter(self, queryset):
+        # Filters on the `priority_rank` annotation, which must be applied first.
+        # Reports without a priority artefact (coalesced to "~") are excluded when this filter is set.
+        priority_filter = self.request.query_params.get("priority")
+        if not priority_filter:
+            return queryset
+
+        values = [p.strip().upper() for p in priority_filter.split(",") if p.strip()]
+        if not values:
+            return queryset
+
+        allowed = set(AutonomyPriority.values)
+        invalid = [v for v in values if v not in allowed]
+        if invalid:
+            raise serializers.ValidationError(
+                {
+                    "priority": f"Invalid priority value(s): {', '.join(sorted(set(invalid)))}. Allowed: {', '.join(sorted(allowed))}."
+                }
+            )
+
+        return queryset.filter(priority_rank__in=values)
 
     def _annotate_signal_report_status_rank(self, queryset):
         # `ordering=status` uses semantic stage rank (annotation), not lexicographic `status` column order.
@@ -698,6 +722,16 @@ class SignalReportViewSet(
                 description=(
                     "Comma-separated list of PostHog user UUIDs. Reports are kept if their suggested reviewers "
                     "include any of the given users."
+                ),
+            ),
+            OpenApiParameter(
+                name="priority",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description=(
+                    "Comma-separated list of priorities to include. Valid values: P0, P1, P2, P3, P4. "
+                    "Reports without a priority assignment are excluded when this filter is set."
                 ),
             ),
             OpenApiParameter(

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -1090,6 +1090,10 @@ export type SignalsReportsListParams = {
      */
     ordering?: string
     /**
+     * Comma-separated list of priorities to include. Valid values: P0, P1, P2, P3, P4. Reports without a priority assignment are excluded when this filter is set.
+     */
+    priority?: string
+    /**
      * Case-insensitive substring match against report title and summary.
      */
     search?: string

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -49249,6 +49249,10 @@ export namespace Schemas {
      */
     ordering?: string;
     /**
+     * Comma-separated list of priorities to include. Valid values: P0, P1, P2, P3, P4. Reports without a priority assignment are excluded when this filter is set.
+     */
+    priority?: string;
+    /**
      * Case-insensitive substring match against report title and summary.
      */
     search?: string;

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -25,6 +25,12 @@ export const SignalsReportsListQueryParams = /* @__PURE__ */ zod.object({
         .describe(
             "Comma-separated ordering clauses. Each clause is a field name optionally prefixed with '-' for descending. Allowed fields: status, is_suggested_reviewer, signal_count, total_weight, priority, created_at, updated_at, id. Defaults to '-is_suggested_reviewer,status,-updated_at'."
         ),
+    priority: zod
+        .string()
+        .optional()
+        .describe(
+            'Comma-separated list of priorities to include. Valid values: P0, P1, P2, P3, P4. Reports without a priority assignment are excluded when this filter is set.'
+        ),
     search: zod.string().optional().describe('Case-insensitive substring match against report title and summary.'),
     source_product: zod
         .string()

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -38,6 +38,7 @@ const inboxReportsList = (): ToolBase<
                 limit: params.limit,
                 offset: params.offset,
                 ordering: params.ordering,
+                priority: params.priority,
                 search: params.search,
                 source_product: params.source_product,
                 status: params.status,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-reports-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-reports-list.json
@@ -13,6 +13,10 @@
             "description": "Comma-separated ordering clauses. Each clause is a field name optionally prefixed with '-' for descending. Allowed fields: status, is_suggested_reviewer, signal_count, total_weight, priority, created_at, updated_at, id. Defaults to '-is_suggested_reviewer,status,-updated_at'.",
             "type": "string"
         },
+        "priority": {
+            "description": "Comma-separated list of priorities to include. Valid values: P0, P1, P2, P3, P4. Reports without a priority assignment are excluded when this filter is set.",
+            "type": "string"
+        },
         "search": {
             "description": "Case-insensitive substring match against report title and summary.",
             "type": "string"


### PR DESCRIPTION
## Problem

The signals reports list endpoint (`GET /api/projects/<team_id>/signals/reports/`) already supports **sorting** by priority via `?ordering=priority`, but it has no way to **filter** by priority. Consumers (the Inbox UI, MCP tooling) that want to drill into "just the P0 and P1 reports" have to fetch a full page and filter client-side, which interacts badly with pagination.

## Changes

Adds a new `priority` query parameter to the list endpoint:

- Accepts a comma-separated list of `P0`–`P4` values (case-insensitive).
- Validated against `AutonomyPriority.values`; invalid values return `400` with a `priority` error field.
- Filters on the existing `priority_rank` annotation (used by sorting), so the logic is shared and the null-priority fallback (`"~"`) naturally excludes reports without a priority artefact when the filter is set.
- OpenAPI parameter added to the `@extend_schema` block for the list action so the generated TS types / MCP tool pick it up on the next `hogli build:openapi`.

Sorting by priority already worked end-to-end (`priority_rank` annotation with `P0 < … < P4 < null`); no behaviour change there.

## How did you test this code?

I'm an agent. The Claude Code Web environment doesn't have Postgres reachable, so the Django test DB setup couldn't start. I did not run the test suite. The Python files were syntax-checked with `ast.parse` and the module imports were spot-checked, but please run the suite locally before merging:

```
hogli test products/signals/backend/test/test_signal_report_api.py::TestSignalReportListAPI -v
```

Six new tests cover: single value, multiple values, exclusion of reports without a priority artefact, case-insensitive input, parameterized invalid-value 400s, and the filter combined with `ordering=priority`.

## Publish to changelog?

no

## Docs update

No docs update needed — this is a backend API addition; the parameter is documented in the OpenAPI schema and will surface in generated types.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). The user asked for filtering and sorting by report priority on the signals reports list. On inspection, sort-by-priority already existed (`_SIGNAL_REPORT_ORDERING_FIELDS` maps `priority → priority_rank`, with the `test_ordering_by_priority_sorts_p0_first` test covering it), so only the filter needed to be added.

Decision: stay consistent with the existing manual-filter style on `SignalReportViewSet` (no `DjangoFilterBackend` / `FilterSet` is wired up there — all filters are method-based on `safely_get_queryset`). Reused the existing `priority_rank` annotation rather than introducing a parallel one, and inserted the filter step immediately after the annotation step so the predicate has an annotated column to target.

Considered but skipped: a `priority=none`/`unassigned` sentinel for "reports without a priority". Left out for now — easy follow-up if needed.