### PR TITLE
fix(taxonomic-filter): make short search queries work

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1761,17 +1761,17 @@ snapshots:
     filters-taxonomic-filter--three-groups-default-layout--light:
         hash: v1.k794b7964.7d03de4d736f21437d1009fc19719734175f0c0822cd2ccdbc380ffa8f5e627c.lGDn7Z4UhsMOqLuuLQ9_TO9FuIbd45s3RKUs7A69z7s
     filters-taxonomic-filter-headless--events-and-actions--dark:
-        hash: v1.k794b7964.213467e7f830b0c9023dbdac9c1a3015e184e7085d7037edce62a29180badfa1.O54qNf00yRPwFinPNCaNIrIBpnE8MQwcaKoMxWkyB2o
+        hash: v1.k794b7964.436a55cc05c8639cfe43cec0115ff4b28a09aaf717f415a8a4f75e22e5c86b02.s62z6w_w-aaNelmqk2MfzzyjQMAOP-X2aGBt46K9CpQ
     filters-taxonomic-filter-headless--events-and-actions--light:
-        hash: v1.k794b7964.df52b9239063606edb4522016d7626ab4d67961f1cf14287b697e467969fe932.xr044YgPtb3G8tGrDNFsjWohsN7xaGdll9bENI4jBTg
+        hash: v1.k794b7964.4c46126fae8b4602d33f7dfaf8ba91fe8cb791a1503818af95781f7c56d7660b.ZFpzmwxeyS5PPX0nav7YjNFbxVB9gNyL1n5_a_q-ngk
     filters-taxonomic-filter-headless--properties--dark:
         hash: v1.k794b7964.d3d71ef038d250b734f23f1b0d99b9450ecd75dc5d0ac5cbc232332bd020a9c7.QHFTGF0-fDG4Vc_NRI041gOI9GFehTJ1cRfgO_q51RM
     filters-taxonomic-filter-headless--properties--light:
         hash: v1.k794b7964.589d2f8ed0cf686abd23d27b87ffdb992e7e7cf0ee5cc2735a594fa890f2a884.j7fICS44ODNnJK0T_k2qD7wwlodvUdms6mCi9nTmoYM
     filters-taxonomic-filter-headless--suggested-filters-with-recents--dark:
-        hash: v1.k794b7964.d8442f9a40a14588155ec4761cb04962a29578a3be99e07d32c6f6be594e1d2b.mLywCXOggV6IQvCI9OEpR2HoLOfginGqMXU4CUeeiek
+        hash: v1.k794b7964.c3a6cd419610bc486261efa753816547f080f00c838bde0b8720cf12067b3b22.nxBtExiDfJ3USkhV9RY1VPU_U2dGyEYCMFbhvtOcuVs
     filters-taxonomic-filter-headless--suggested-filters-with-recents--light:
-        hash: v1.k794b7964.698cb62280c95e89006f27deff5b9f0815f5d1d7708aad0656804c9abbafeaff.4_y9imo29homBpNLeJLJRjFQKXa2KDQhGgYDT86MaZg
+        hash: v1.k794b7964.4f32ff8f6d683e83acb75ed1d73c5a5b2ac7721e4d2ed465b00a9cad04c28ca9.QfKnCFIFEcOxhu-Psm9bnVF--BScHN_ZqPe_9XCL0sU
     filters-taxonomic-filter-menu-rebuild--data-warehouse-config--dark:
         hash: v1.k794b7964.08cb28ef771b07306b60e9b1921ae0e5b31ed750737708ba70094bbf58b781ea.kpx11ijYcolN6k7wlqbIeu2-g2fk7Wwb2h-vm4ipteY
     filters-taxonomic-filter-menu-rebuild--data-warehouse-config--light:

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicResource.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicResource.test.ts
@@ -151,6 +151,37 @@ describe('useTaxonomicResource', () => {
         expect(seenSignals[0].aborted).toBe(true)
     })
 
+    it('does not poison the cache key when an in-flight request is aborted', async () => {
+        // First call rejects with an AbortError when its signal aborts;
+        // second call (after re-mount) resolves normally.
+        const fn = jest
+            .fn()
+            .mockImplementationOnce(
+                ({ signal }: { signal: AbortSignal }) =>
+                    new Promise<string>((_resolve, reject) => {
+                        signal.addEventListener('abort', () =>
+                            reject(new DOMException('The operation was aborted.', 'AbortError'))
+                        )
+                    })
+            )
+            .mockResolvedValueOnce('second')
+
+        // Mount, then unmount before the request settles → aborts it.
+        const { unmount } = renderHook(() => useTaxonomicResource(['poison'], fn))
+        unmount()
+        // Let the abort rejection settle.
+        await act(async () => {
+            await Promise.resolve()
+        })
+
+        // Re-mounting the same key must re-fetch — the aborted request must
+        // not have stored an error that halts auto-fetch forever.
+        const r2 = renderHook(() => useTaxonomicResource(['poison'], fn))
+        await waitFor(() => expect(r2.result.current.data).toBe('second'))
+        expect(r2.result.current.error).toBeUndefined()
+        expect(fn).toHaveBeenCalledTimes(2)
+    })
+
     it('passes a fresh AbortSignal that is not aborted while a subscriber is mounted', async () => {
         const seen: AbortSignal[] = []
         const fn = jest.fn().mockImplementation(({ signal }: { signal: AbortSignal }) => {

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicResource.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicResource.ts
@@ -111,6 +111,19 @@ function execute<T>(hash: string, fn: ResourceQueryFn<T>): Promise<T> {
             if (entry.abort !== abort) {
                 throw err
             }
+            // An abort is not a real failure. Storing it as `entry.error`
+            // would poison this cache key — the error-halts-autofetch guard
+            // in the effect then refuses to ever re-fetch it, so revisiting
+            // the same query key (e.g. backspacing to a search term whose
+            // in-flight request was cancelled by the next keystroke) shows a
+            // permanently empty list. Leave the entry clean (no data, no
+            // error, ts untouched) so a later visit re-fetches.
+            if (abort.signal.aborted) {
+                entry.inflight = undefined
+                entry.abort = undefined
+                notify(entry)
+                throw err
+            }
             entry.error = err
             entry.inflight = undefined
             entry.abort = undefined


### PR DESCRIPTION
## Problem

In the headless TaxonomicFilter, searching often returned a permanently empty list — most reliably for 3-character queries against remote groups like Pageview URLs, Pageview events, Screens and Autocapture events. The same term that failed would sometimes work on a fresh open, making it look intermittent.

## Changes

Root cause is in `useTaxonomicResource` (the TaxonomicFilter's react-query-shaped data hook):

- When a consumer's cache key changes (every keystroke changes the search query → changes the key), the previous key's in-flight request is aborted once its last subscriber unsubscribes.
- The abort rejects the request, and the `catch` branch stored the `AbortError` as `entry.error`.
- The effect that kicks off fetches deliberately halts on `entry.error` (errors are not auto-retried — react-query semantics). So the aborted key was now poisoned: revisiting that exact search term (e.g. backspacing to it, or re-opening the picker) never re-fetched and showed an empty list.

Why 3-character queries reproduce it: groups with `minSearchQueryLength` (3 for pageview/screen/autocapture groups, 5 for email) only fire a remote request once the query is long enough. The 3-char query is therefore the *first* request that runs — and the very next keystroke aborts it, poisoning that key.

The fix: an abort is not a real failure. The `catch` branch now leaves the entry clean (no stored error, `ts` untouched, `inflight`/`abort` cleared) when `abort.signal.aborted` is set, so a later visit to the same key re-fetches normally. Genuine fetch errors still halt auto-fetch as before.

Added a regression test covering abort-then-remount.

## How did you test this code?

I'm an agent (Claude Code). Automated tests run locally:
- New test `does not poison the cache key when an in-flight request is aborted` — fails before the fix, passes after.
- `useTaxonomicResource.test.ts` — 16/16 pass.
- `useGroupList.test.tsx` + headless `headless.test.tsx` — 25/25 pass.
- `tsc` — clean.

Not manually verified in a browser.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code. Investigation: traced the empty-result symptom from the menu combobox → `useGroupList` → `fetchTaxonomicListPage` → `useTaxonomicResource`. Ruled out `minSearchQueryLength` gating (3-char query is not blocked by `< 3`), `combineUrl` query-param merging (kea-router merges, doesn't replace), and base-ui Autocomplete internal filtering (`mode="none"` disables it). The poisoned-cache-entry path in `useTaxonomicResource` is the actual cause. A first attempt also guarded the success path on `signal.aborted`, but that broke an existing test — a re-render transiently empties the subscriber set and spuriously aborts a still-live controller, yet the request resolves fine; that data should still be committed. Final fix is scoped to the `catch` branch only.