### PR TITLE
fix(insights): commit pseudo-event picks from the new series picker

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -202,6 +202,95 @@ export function ActionFilterRow({
         [updateFilterProperty, index]
     )
 
+    /**
+     * Shared selection handler for both the legacy `TaxonomicPopover` and the
+     * new `TaxonomicFilterMenu` / `TaxonomicAutocomplete`. The pseudo-event
+     * groups (Pageview / Screen / Autocapture events) and quick filters don't
+     * map to a plain `EntityType` — they expand into a base event plus a
+     * property filter. Keeping one handler guarantees the new picker behaves
+     * identically to the legacy one.
+     */
+    const applyTaxonomicSelection = useCallback(
+        (
+            taxonomicGroupType: TaxonomicFilterGroupType,
+            changedValue: string | number | null | undefined,
+            item: any
+        ): void => {
+            if (isQuickFilterItem(item)) {
+                if (item.eventName) {
+                    updateFilter({ type: EntityTypes.EVENTS, id: item.eventName, name: item.eventName, index })
+                }
+                updateFilterProperty({ index, properties: quickFilterToPropertyFilters(item) })
+                return
+            }
+            if (taxonomicGroupType === TaxonomicFilterGroupType.PageviewEvents) {
+                updateFilter({ type: EntityTypes.EVENTS, id: '$pageview', name: '$pageview', index })
+                updateFilterProperty({
+                    index,
+                    properties: [
+                        {
+                            key: '$current_url',
+                            value: changedValue ? String(changedValue) : '',
+                            operator: PropertyOperator.IContains,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                })
+                return
+            }
+            if (taxonomicGroupType === TaxonomicFilterGroupType.ScreenEvents) {
+                updateFilter({ type: EntityTypes.EVENTS, id: '$screen', name: '$screen', index })
+                updateFilterProperty({
+                    index,
+                    properties: [
+                        {
+                            key: '$screen_name',
+                            value: changedValue ? String(changedValue) : '',
+                            operator: PropertyOperator.Exact,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                })
+                return
+            }
+            if (taxonomicGroupType === TaxonomicFilterGroupType.AutocaptureEvents) {
+                updateFilter({ type: EntityTypes.EVENTS, id: '$autocapture', name: '$autocapture', index })
+                updateFilterProperty({
+                    index,
+                    properties: [
+                        {
+                            key: '$el_text',
+                            value: changedValue ? String(changedValue) : '',
+                            operator: PropertyOperator.Exact,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                })
+                return
+            }
+            const groupType = taxonomicFilterGroupTypeToEntityType(taxonomicGroupType)
+            if (groupType === EntityTypes.DATA_WAREHOUSE) {
+                const extraValues = Object.fromEntries(dataWarehousePopoverFields.map(({ key }) => [key, item?.[key]]))
+                updateFilter({
+                    type: groupType,
+                    id: changedValue ? String(changedValue) : null,
+                    name: item?.name ?? '',
+                    table_name: item?.name,
+                    index,
+                    ...extraValues,
+                })
+            } else {
+                updateFilter({
+                    type: groupType || undefined,
+                    id: changedValue ? String(changedValue) : null,
+                    name: item?.name ?? '',
+                    index,
+                })
+            }
+        },
+        [updateFilter, updateFilterProperty, index, dataWarehousePopoverFields]
+    )
+
     const onMathSelect = (_: unknown, selectedMath?: string): void => {
         let mathProperties
         if (selectedMath) {
@@ -291,104 +380,9 @@ export function ActionFilterRow({
             suggestedFiltersLabel={suggestedFiltersLabel}
             enableKeywordShortcuts
             selectingKeyOnly
-            onChange={(changedValue, taxonomicGroupType, item) => {
-                if (isQuickFilterItem(item)) {
-                    if (item.eventName) {
-                        updateFilter({
-                            type: EntityTypes.EVENTS,
-                            id: item.eventName,
-                            name: item.eventName,
-                            index,
-                        })
-                    }
-                    updateFilterProperty({
-                        index,
-                        properties: quickFilterToPropertyFilters(item),
-                    })
-                    return
-                }
-                if (taxonomicGroupType === TaxonomicFilterGroupType.PageviewEvents) {
-                    updateFilter({
-                        type: EntityTypes.EVENTS,
-                        id: '$pageview',
-                        name: '$pageview',
-                        index,
-                    })
-                    updateFilterProperty({
-                        index,
-                        properties: [
-                            {
-                                key: '$current_url',
-                                value: changedValue ? String(changedValue) : '',
-                                operator: PropertyOperator.IContains,
-                                type: PropertyFilterType.Event,
-                            },
-                        ],
-                    })
-                    return
-                }
-                if (taxonomicGroupType === TaxonomicFilterGroupType.ScreenEvents) {
-                    updateFilter({
-                        type: EntityTypes.EVENTS,
-                        id: '$screen',
-                        name: '$screen',
-                        index,
-                    })
-                    updateFilterProperty({
-                        index,
-                        properties: [
-                            {
-                                key: '$screen_name',
-                                value: changedValue ? String(changedValue) : '',
-                                operator: PropertyOperator.Exact,
-                                type: PropertyFilterType.Event,
-                            },
-                        ],
-                    })
-                    return
-                }
-                if (taxonomicGroupType === TaxonomicFilterGroupType.AutocaptureEvents) {
-                    updateFilter({
-                        type: EntityTypes.EVENTS,
-                        id: '$autocapture',
-                        name: '$autocapture',
-                        index,
-                    })
-                    updateFilterProperty({
-                        index,
-                        properties: [
-                            {
-                                key: '$el_text',
-                                value: changedValue ? String(changedValue) : '',
-                                operator: PropertyOperator.Exact,
-                                type: PropertyFilterType.Event,
-                            },
-                        ],
-                    })
-                    return
-                }
-                const groupType = taxonomicFilterGroupTypeToEntityType(taxonomicGroupType)
-                if (groupType === EntityTypes.DATA_WAREHOUSE) {
-                    const extraValues = Object.fromEntries(
-                        dataWarehousePopoverFields.map(({ key }) => [key, item?.[key]])
-                    )
-                    updateFilter({
-                        type: groupType,
-                        id: changedValue ? String(changedValue) : null,
-                        name: item?.name ?? '',
-                        table_name: item?.name,
-                        index,
-                        ...extraValues,
-                    })
-                } else {
-                    updateFilter({
-                        type: groupType || undefined,
-                        id: changedValue ? String(changedValue) : null,
-                        name: item?.name ?? '',
-                        index,
-                    })
-                }
-            }}
+            onChange={(changedValue, taxonomicGroupType, item) =>
+                applyTaxonomicSelection(taxonomicGroupType, changedValue, item)
+            }
             renderValue={() => <EntityFilterInfo filter={filter} showIcon />}
             groupTypes={effectiveActionsTaxonomicGroupTypes}
             placeholder="All events"
@@ -587,18 +581,9 @@ export function ActionFilterRow({
                                         // here, and traps Tab off the trigger.
                                         bindRootProps={false}
                                         taxonomicGroupTypes={effectiveActionsTaxonomicGroupTypes}
-                                        onChange={(group, changedValue, item) => {
-                                            const groupType = taxonomicFilterGroupTypeToEntityType(group.type)
-                                            if (!groupType) {
-                                                return
-                                            }
-                                            updateFilter({
-                                                type: groupType,
-                                                id: changedValue ? String(changedValue) : null,
-                                                name: item?.name ?? '',
-                                                index,
-                                            })
-                                        }}
+                                        onChange={(group, changedValue, item) =>
+                                            applyTaxonomicSelection(group.type, changedValue, item)
+                                        }
                                     >
                                         {useMenuRebuild ? (
                                             <TaxonomicFilterMenu


### PR DESCRIPTION
## Problem

In the new TaxonomicFilter series picker (`TaxonomicFilterMenu` / `TaxonomicAutocomplete`, behind `taxonomic-filter-menu-rebuild` / `taxonomic-filter-headless`), clicking a result from the **Pageview events**, **Screen events** or **Autocapture events** groups — or a quick filter — did nothing. The series row kept its previous value. The legacy `TaxonomicPopover` picker handled these correctly.

## Changes

The new picker's `onChange` was a stripped-down copy that only handled group types mapping to a plain `EntityType` (`events`, `actions`, `data_warehouse`) via `taxonomicFilterGroupTypeToEntityType`. For any other group it returned early and dropped the selection.

The pseudo-event groups don't map to an `EntityType` — they expand into a base event plus a property filter:

- Pageview events → `$pageview` + `$current_url` (icontains)
- Screen events → `$screen` + `$screen_name` (exact)
- Autocapture events → `$autocapture` + `$el_text` (exact)
- Quick filters → base event + `quickFilterToPropertyFilters`

The legacy `TaxonomicPopover` had all this in its inline `onChange`. This PR extracts that logic into a shared `applyTaxonomicSelection` callback and wires both pickers through it, so the new picker has full parity and the two can't drift again.

No behaviour change for the legacy picker — same logic, same code path.

## How did you test this code?

I'm an agent (Claude Code). Automated tests run locally:
- `ActionFilterRow.test.tsx` — 67/67 pass.
- `tsc` — clean.
- `oxlint` — clean.

Not manually verified in a browser.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code. Diagnosed by comparing the legacy `TaxonomicPopover` `onChange` against the new `TaxonomicFilterHeadless.Root` `onChange` in `ActionFilterRow`: the new one only kept the `taxonomicFilterGroupTypeToEntityType` branch and dropped the pseudo-event and quick-filter branches. Chose to extract a single shared handler rather than re-duplicate the branches into the new picker, since the original duplication is what let them diverge.