### PR TITLE
feat(signals): add priority filter to inbox UI

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4923,6 +4923,7 @@ const api = {
             limit?: number
             offset?: number
             status?: string
+            priority?: string
             search?: string
             ordering?: string
         }): Promise<CountedPaginatedResponse<SignalReport>> {

--- a/frontend/src/scenes/inbox/InboxScene.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.tsx
@@ -57,7 +57,7 @@ import { SignalCard } from './SignalCard'
 import { SignalGraphTab } from './SignalGraphTab'
 import { signalSourcesLogic } from './signalSourcesLogic'
 import { SourcesModal } from './SourcesModal'
-import { EnrichedReviewer, SignalReport, SignalReportArtefact, SignalReportStatus } from './types'
+import { EnrichedReviewer, SignalReport, SignalReportArtefact, SignalReportPriority, SignalReportStatus } from './types'
 
 export const scene: SceneExport = {
     component: InboxScene,
@@ -161,6 +161,8 @@ const STATUS_LABELS: Record<SignalReportStatus, string> = {
     [SignalReportStatus.FAILED]: 'Failed',
 }
 
+const PRIORITY_OPTIONS = Object.values(SignalReportPriority)
+
 function StatusFilter(): JSX.Element {
     const { statusFilters } = useValues(inboxSceneLogic)
     const { setStatusFilters } = useActions(inboxSceneLogic)
@@ -240,6 +242,84 @@ function StatusFilter(): JSX.Element {
     )
 }
 
+function PriorityFilter(): JSX.Element {
+    const { priorityFilters } = useValues(inboxSceneLogic)
+    const { setPriorityFilters } = useActions(inboxSceneLogic)
+    const [showPopover, setShowPopover] = useState(false)
+
+    const isAllSelected = priorityFilters.length === PRIORITY_OPTIONS.length
+    const isSomeSelected = priorityFilters.length > 0 && priorityFilters.length < PRIORITY_OPTIONS.length
+
+    const handleToggleAll = (): void => {
+        if (isAllSelected || isSomeSelected) {
+            setPriorityFilters([])
+        } else {
+            setPriorityFilters([...PRIORITY_OPTIONS])
+        }
+    }
+
+    const handleTogglePriority = (priority: SignalReportPriority): void => {
+        const next = priorityFilters.includes(priority)
+            ? priorityFilters.filter((p) => p !== priority)
+            : [...priorityFilters, priority]
+        setPriorityFilters(next)
+    }
+
+    const displayValue = (): string => {
+        if (priorityFilters.length === 0 || isAllSelected) {
+            return 'All priorities'
+        }
+        if (priorityFilters.length === 1) {
+            return priorityFilters[0]
+        }
+        return `${priorityFilters.length} priorities`
+    }
+
+    return (
+        <LemonDropdown
+            closeOnClickInside={false}
+            visible={showPopover}
+            matchWidth={false}
+            actionable
+            onVisibilityChange={setShowPopover}
+            overlay={
+                <div className="max-w-60 space-y-px p-1">
+                    <LemonButton fullWidth size="small" onClick={handleToggleAll} className="justify-start">
+                        <span className="flex items-center gap-2">
+                            <LemonCheckbox checked={isAllSelected} className="pointer-events-none" />
+                            <span className="font-semibold">
+                                {isAllSelected || isSomeSelected ? 'Clear all' : 'Select all'}
+                            </span>
+                        </span>
+                    </LemonButton>
+                    <div className="border-t border-border my-1" />
+                    {PRIORITY_OPTIONS.map((priority) => (
+                        <LemonButton
+                            key={priority}
+                            fullWidth
+                            size="small"
+                            onClick={() => handleTogglePriority(priority)}
+                            className="justify-start"
+                        >
+                            <span className="flex items-center gap-2">
+                                <LemonCheckbox
+                                    checked={priorityFilters.includes(priority)}
+                                    className="pointer-events-none"
+                                />
+                                <span>{priority}</span>
+                            </span>
+                        </LemonButton>
+                    ))}
+                </div>
+            }
+        >
+            <LemonButton type="secondary" size="small" icon={<IconFilter />} className="bg-surface-primary">
+                {displayValue()}
+            </LemonButton>
+        </LemonDropdown>
+    )
+}
+
 function ReportListPane(): JSX.Element {
     const {
         filteredReports,
@@ -249,6 +329,7 @@ function ReportListPane(): JSX.Element {
         selectedReportId,
         shouldShowEnablingCtaOnMobile,
         statusFilters,
+        priorityFilters,
         reportsHasMore,
     } = useValues(inboxSceneLogic)
     const { hasNoSources } = useValues(signalSourcesLogic)
@@ -298,6 +379,7 @@ function ReportListPane(): JSX.Element {
                         }
                     />
                     <StatusFilter />
+                    <PriorityFilter />
                     <LemonButton
                         type="secondary"
                         size="small"
@@ -331,7 +413,7 @@ function ReportListPane(): JSX.Element {
                             <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-primary to-transparent" />
                             <div className="absolute inset-0 flex flex-col items-center justify-center">
                                 <p className="text-sm text-secondary font-medium m-0 cursor-default">
-                                    {searchQuery || statusFilters.length > 0
+                                    {searchQuery || statusFilters.length > 0 || priorityFilters.length > 0
                                         ? 'No reports matching filters.'
                                         : 'No reports yet.'}
                                 </p>

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -19,6 +19,7 @@ import {
     SignalReport,
     SignalReportArtefact,
     SignalReportArtefactResponse,
+    SignalReportPriority,
     SignalReportStatus,
 } from './types'
 
@@ -40,6 +41,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         setSelectedReportId: (id: string | null) => ({ id }),
         setSearchQuery: (query: string) => ({ query }),
         setStatusFilters: (statuses: SignalReportStatus[]) => ({ statuses }),
+        setPriorityFilters: (priorities: SignalReportPriority[]) => ({ priorities }),
         setActiveDetailTab: (tab: DetailTab) => ({ tab }),
         deleteReport: (reportId: string) => ({ reportId }),
         reingestReport: (reportId: string) => ({ reportId }),
@@ -57,6 +59,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                         limit: REPORTS_PAGE_SIZE,
                         offset: 0,
                         status: values.statusFilters.length > 0 ? values.statusFilters.join(',') : undefined,
+                        priority: values.priorityFilters.length > 0 ? values.priorityFilters.join(',') : undefined,
                         search: values.searchQuery.trim() || undefined,
                         ordering: '-is_suggested_reviewer,-signal_count',
                     })
@@ -67,6 +70,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                         limit: REPORTS_PAGE_SIZE,
                         offset: currentResults.length,
                         status: values.statusFilters.length > 0 ? values.statusFilters.join(',') : undefined,
+                        priority: values.priorityFilters.length > 0 ? values.priorityFilters.join(',') : undefined,
                         search: values.searchQuery.trim() || undefined,
                         ordering: '-is_suggested_reviewer,-signal_count',
                     })
@@ -120,6 +124,12 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             [SignalReportStatus.READY] as SignalReportStatus[],
             {
                 setStatusFilters: (_, { statuses }) => statuses,
+            },
+        ],
+        priorityFilters: [
+            [] as SignalReportPriority[],
+            {
+                setPriorityFilters: (_, { priorities }) => priorities,
             },
         ],
         activeDetailTab: [
@@ -213,6 +223,9 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             actions.loadReports()
         },
         setStatusFilters: () => {
+            actions.loadReports()
+        },
+        setPriorityFilters: () => {
             actions.loadReports()
         },
         setSelectedReportId: ({ id }) => {

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -34,6 +34,14 @@ export enum SignalReportStatus {
     FAILED = 'failed',
 }
 
+export enum SignalReportPriority {
+    P0 = 'P0',
+    P1 = 'P1',
+    P2 = 'P2',
+    P3 = 'P3',
+    P4 = 'P4',
+}
+
 export interface SignalReportArtefact {
     id: string
     type: string


### PR DESCRIPTION
## Problem

The signals reports list endpoint gained a `priority` query parameter in #58784, but the Inbox UI has no way to set it. Users who want to drill into specific priorities (e.g. "just P0 and P1") have to scroll or use the URL by hand.

## Changes

Adds a `PriorityFilter` dropdown next to the existing `StatusFilter` in the Inbox list pane. It multi-selects `P0`–`P4`, defaults to "All priorities" (no filter), and triggers a server reload via the new backend parameter on every change. The empty-state message ("No reports matching filters.") now also fires when only the priority filter is non-empty.

Files touched:
- `frontend/src/scenes/inbox/types.ts` — new `SignalReportPriority` enum (P0–P4).
- `frontend/src/lib/api.ts` — `signalReports.list` gains an optional `priority?: string` param.
- `frontend/src/scenes/inbox/inboxSceneLogic.ts` — `setPriorityFilters` action, `priorityFilters` reducer (default `[]`), listener that reloads, and the param threaded through `loadReports` / `loadMoreReports`.
- `frontend/src/scenes/inbox/InboxScene.tsx` — new `PriorityFilter` component mirroring `StatusFilter`, rendered next to it.

Depends on #58784 for the backend filter. Sorting by priority already worked end-to-end and is not exposed in the UI here (potential follow-up).

## How did you test this code?

I'm an agent. The PostHog Code sandbox has no local Postgres / Caddy / browser, so I did not exercise the UI in a browser. Verified:

- `pnpm --filter=@posthog/frontend typescript:check` reports zero errors in the four touched files (the kea-typegen output `inboxSceneLogicType.ts` was regenerated and now exposes `setPriorityFilters` / `priorityFilters`).
- `bin/hogli format:js` on the four staged files reports `Found 0 warnings and 0 errors.` and was re-run by the pre-commit hook.

Recommended local check before merging:

- Open `/inbox` with #58784 applied, toggle a single priority — list reloads and request shows `?…&priority=P1`. Toggle multiple — union. Clear — back to the status-filtered set. Empty filter combo shows "No reports matching filters.".

## Publish to changelog?

no

## Docs update

No docs update needed — the inbox UI is self-explanatory and the underlying backend addition is documented via the OpenAPI schema in #58784.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). The user asked me to update inbox filtering on the basis of #58784, which adds the backend `priority` parameter.

Decisions:
- **Modeled on the existing `StatusFilter`.** The inbox already has the exact pattern needed — a kea reducer/action/listener trio plus a multi-select `LemonDropdown` with select-all / clear-all. Cloning that pattern keeps the filter row consistent and avoids inventing a new control.
- **`priority?: string` in `lib/api.ts`** (not the enum). Matches the existing `status: string` convention where the call site joins values with `,` itself — keeps the param flexible at the boundary.
- **Default `[]`** for `priorityFilters` so omitting the param matches "show all priorities" — different from `statusFilters` (`[READY]`) because there's no obvious first-read subset.
- **Kept `signalReports.list` hand-rolled** in `lib/api.ts` rather than migrating to the generated client under `products/signals/frontend/generated/`. The rest of `signalReports` is hand-rolled and the migration is out of scope for this filter wiring.
- **Out of scope (deliberate):** showing priority on each report card, exposing priority sorting in the UI, URL persistence of the filter, and a `priority=none` / unassigned sentinel (the #58784 author noted this as a possible follow-up).