### PR TITLE
feat(pulse): add proactive insights agent (Max Pulse)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -247,6 +247,12 @@ import { AgentMode } from '../queries/schema'
 import { MaxUIContext } from '../scenes/max/maxTypes'
 import { AlertSimulationResult, AlertType, AlertTypeWrite } from './components/Alerts/types'
 import {
+    PulseDigestDetail,
+    PulseDigestSummary,
+    PulseFindingType,
+    PulseSubscriptionType,
+} from 'scenes/pulse/pulseTypes'
+import {
     ErrorTrackingFingerprint,
     ErrorTrackingRelease,
     ErrorTrackingSettings,
@@ -725,6 +731,25 @@ export class ApiRequest {
         return this.comments(teamId).addPathComponent(id)
     }
 
+    // # Pulse
+    public pulseDigests(teamId?: TeamType['id']): ApiRequest {
+        return this.environmentsDetail(teamId).addPathComponent('pulse_digests')
+    }
+    public pulseDigest(id: string, teamId?: TeamType['id']): ApiRequest {
+        return this.pulseDigests(teamId).addPathComponent(id)
+    }
+    public pulseFindings(teamId?: TeamType['id']): ApiRequest {
+        return this.environmentsDetail(teamId).addPathComponent('pulse_findings')
+    }
+    public pulseFinding(id: string, teamId?: TeamType['id']): ApiRequest {
+        return this.pulseFindings(teamId).addPathComponent(id)
+    }
+    public pulseSubscriptions(teamId?: TeamType['id']): ApiRequest {
+        return this.environmentsDetail(teamId).addPathComponent('pulse_subscriptions')
+    }
+    public pulseSubscription(id: string, teamId?: TeamType['id']): ApiRequest {
+        return this.pulseSubscriptions(teamId).addPathComponent(id)
+    }
     // # Exports
     public exports(teamId?: TeamType['id']): ApiRequest {
         return this.environmentsDetail(teamId).addPathComponent('exports')
@@ -2763,6 +2788,38 @@ const api = {
             teamId: TeamType['id'] = ApiConfig.getCurrentTeamId()
         ): Promise<CommentType> {
             return new ApiRequest().comment(id, teamId).withAction('reopen').create()
+        },
+    },
+
+    pulse: {
+        async listDigests(): Promise<{ results: PulseDigestSummary[]; count: number }> {
+            return new ApiRequest().pulseDigests().get()
+        },
+        async getDigest(id: string): Promise<PulseDigestDetail> {
+            return new ApiRequest().pulseDigest(id).get()
+        },
+        async listFindings(digestId?: string): Promise<{ results: PulseFindingType[]; count: number }> {
+            const req = new ApiRequest().pulseFindings()
+            return digestId ? req.withQueryString({ digest: digestId }).get() : req.get()
+        },
+        async submitFeedback(
+            findingId: string,
+            action: 'pending' | 'up' | 'down' | 'dismissed' | 'snoozed',
+            snoozed_until?: string
+        ): Promise<PulseFindingType> {
+            return new ApiRequest()
+                .pulseFinding(findingId)
+                .withAction('feedback')
+                .create({ data: { action, snoozed_until } })
+        },
+        async currentSubscription(): Promise<PulseSubscriptionType> {
+            return new ApiRequest().pulseSubscriptions().withAction('current').get()
+        },
+        async createSubscription(data: Partial<PulseSubscriptionType>): Promise<PulseSubscriptionType> {
+            return new ApiRequest().pulseSubscriptions().create({ data })
+        },
+        async updateSubscription(id: string, data: Partial<PulseSubscriptionType>): Promise<PulseSubscriptionType> {
+            return new ApiRequest().pulseSubscription(id).update({ data })
         },
     },
 

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -32,6 +32,7 @@ import { hogFunctionActivityDescriber } from 'scenes/hog-functions/misc/activity
 import { notebookActivityDescriber } from 'scenes/notebooks/Notebook/notebookActivityDescriber'
 import { personActivityDescriber } from 'scenes/persons/activityDescriptions'
 import { productTourActivityDescriber } from 'scenes/product-tours/activityDescriptions'
+import { pulseActivityDescriber } from 'scenes/pulse/activityDescriptions'
 import { insightActivityDescriber } from 'scenes/saved-insights/activityDescriptions'
 import { replayActivityDescriber } from 'scenes/session-recordings/activityDescription'
 import {
@@ -176,6 +177,8 @@ export const describerFor = (logItem?: ActivityLogItem): Describer | undefined =
             return externalDataSourceActivityDescriber
         case ActivityScope.USER:
             return userActivityDescriber
+        case ActivityScope.PULSE:
+            return pulseActivityDescriber
         case ActivityScope.ENDPOINT:
         case ActivityScope.ENDPOINT_VERSION:
             return endpointActivityDescriber

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -369,6 +369,7 @@ export const FEATURE_FLAGS = {
     MAX_AI_INSIGHT_SEARCH: 'max-ai-insight-search', // owner: #team-posthog-ai
     MAX_BILLING_CONTEXT: 'max-billing-context', // owner: @pawel-cebula #team-billing
     MAX_DEEP_RESEARCH: 'max-deep-research', // owner: @kappa90 #team-posthog-ai
+    MAX_PULSE: 'max-pulse', // owner: #team-posthog-ai — proactive Pulse insights
     MCP_SERVERS: 'mcp-servers', // owner: #team-posthog-ai
     MESSAGING_SES: 'messaging-ses', // owner #team-workflows
     METRICS: 'metrics', // owner: #team-apm (@jonmcwest, @frankh)

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -57,6 +57,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.HogFunction]: () => import('./hog-functions/HogFunctionScene'),
     [Scene.Insight]: () => import('./insights/InsightScene'),
     [Scene.InsightQuickStart]: () => import('./insights/InsightQuickStart/InsightQuickStart'),
+    [Scene.Pulse]: () => import('./pulse/Pulse'),
     [Scene.IntegrationsRedirect]: () => import('./IntegrationsRedirect/IntegrationsRedirect'),
     [Scene.StripeConfirmInstall]: () => import('./StripeConfirmInstall/StripeConfirmInstall'),
     [Scene.InviteSignup]: () => import('./authentication/InviteSignup'),

--- a/frontend/src/scenes/pulse/Pulse.tsx
+++ b/frontend/src/scenes/pulse/Pulse.tsx
@@ -1,0 +1,267 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { IconPulse, IconRefresh, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+import { LemonSwitch, LemonTag } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { SceneExport } from 'scenes/sceneTypes'
+
+import { Error404 } from '~/layout/Error404'
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+import { pulseLogic } from './pulseLogic'
+import {
+    PulseChannel,
+    PulseDigestSummary,
+    PulseFindingType,
+    PulseSubscriptionFrequency,
+    PulseSubscriptionType,
+} from './pulseTypes'
+import { formatSignedPct } from './utils'
+
+export const scene: SceneExport = {
+    component: Pulse,
+    logic: pulseLogic,
+}
+
+const FREQUENCY_OPTIONS: { value: PulseSubscriptionFrequency; label: string }[] = [
+    { value: 'weekly', label: 'Weekly' },
+    { value: 'daily', label: 'Daily' },
+]
+
+const CHANNEL_OPTIONS: { value: PulseChannel; label: string }[] = [
+    { value: 'in_app', label: 'In-app inbox' },
+    { value: 'slack', label: 'Slack' },
+    { value: 'email', label: 'Email' },
+]
+
+function FindingCard({ finding }: { finding: PulseFindingType }): JSX.Element {
+    const { submitFeedback } = useActions(pulseLogic)
+    const tagType = finding.change_pct >= 0 ? 'success' : 'danger'
+
+    return (
+        <div className="border rounded p-4 bg-surface-primary">
+            <div className="flex items-center gap-2 mb-2">
+                <h3 className="text-base font-semibold mb-0">{finding.metric_label}</h3>
+                <LemonTag type={tagType}>{formatSignedPct(finding.change_pct)}</LemonTag>
+                <span className="text-muted-alt text-xs">z = {finding.z_score.toFixed(1)}</span>
+            </div>
+            <p className="text-sm mb-3">{finding.narrative}</p>
+            <div className="flex items-center gap-2">
+                <LemonButton
+                    type="tertiary"
+                    size="small"
+                    icon={<IconThumbsUp />}
+                    onClick={() => submitFeedback(finding.id, 'up')}
+                    active={finding.feedback === 'up'}
+                >
+                    Useful
+                </LemonButton>
+                <LemonButton
+                    type="tertiary"
+                    size="small"
+                    icon={<IconThumbsDown />}
+                    onClick={() => submitFeedback(finding.id, 'down')}
+                    active={finding.feedback === 'down'}
+                >
+                    Not useful
+                </LemonButton>
+                <LemonButton
+                    type="tertiary"
+                    size="small"
+                    onClick={() => submitFeedback(finding.id, 'dismissed')}
+                    active={finding.feedback === 'dismissed'}
+                >
+                    Dismiss
+                </LemonButton>
+            </div>
+        </div>
+    )
+}
+
+function SubscriptionPanel(): JSX.Element {
+    const { subscriptionDraft, subscriptionLoading } = useValues(pulseLogic) as {
+        subscriptionDraft: PulseSubscriptionType | null
+        subscriptionLoading: boolean
+    }
+    const { updateSubscriptionLocal, saveSubscription } = useActions(pulseLogic)
+
+    if (subscriptionLoading || !subscriptionDraft) {
+        return <Spinner />
+    }
+
+    const toggleChannel = (channel: PulseChannel): void => {
+        const next = subscriptionDraft.enabled_channels.includes(channel)
+            ? subscriptionDraft.enabled_channels.filter((c: PulseChannel) => c !== channel)
+            : [...subscriptionDraft.enabled_channels, channel]
+        updateSubscriptionLocal({ enabled_channels: next })
+    }
+
+    return (
+        <div className="border rounded p-4 bg-surface-secondary mb-6">
+            <div className="flex items-center justify-between mb-3">
+                <h3 className="text-base font-semibold mb-0">Pulse settings</h3>
+                <LemonButton type="primary" size="small" onClick={() => saveSubscription()}>
+                    Save settings
+                </LemonButton>
+            </div>
+            <div className="flex flex-col gap-3">
+                <div className="flex items-center justify-between">
+                    <span>Enable Pulse</span>
+                    <LemonSwitch
+                        checked={subscriptionDraft.enabled}
+                        onChange={(checked) => updateSubscriptionLocal({ enabled: checked })}
+                    />
+                </div>
+                <div className="flex items-center justify-between">
+                    <span>Frequency</span>
+                    <LemonSelect<PulseSubscriptionFrequency>
+                        value={subscriptionDraft.frequency}
+                        onChange={(v) => v && updateSubscriptionLocal({ frequency: v })}
+                        options={FREQUENCY_OPTIONS}
+                    />
+                </div>
+                <div className="flex items-center justify-between">
+                    <span>Delivery channels</span>
+                    <div className="flex gap-2">
+                        {CHANNEL_OPTIONS.map((opt) => (
+                            <LemonButton
+                                key={opt.value}
+                                size="small"
+                                type={
+                                    subscriptionDraft.enabled_channels.includes(opt.value) ? 'primary' : 'secondary'
+                                }
+                                onClick={() => toggleChannel(opt.value)}
+                            >
+                                {opt.label}
+                            </LemonButton>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export function Pulse(): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { digests, findings, digestsLoading, findingsLoading, shouldShowEmptyState, latestDigest } = useValues(
+        pulseLogic
+    ) as {
+        digests: PulseDigestSummary[]
+        findings: PulseFindingType[]
+        digestsLoading: boolean
+        findingsLoading: boolean
+        shouldShowEmptyState: boolean
+        latestDigest: PulseDigestSummary | null
+    }
+    const { loadDigests, loadFindings, loadSubscription } = useActions(pulseLogic)
+
+    useEffect(() => {
+        if (!featureFlags[FEATURE_FLAGS.MAX_PULSE]) {
+            return
+        }
+        loadDigests()
+        loadFindings()
+        loadSubscription()
+    }, [featureFlags, loadDigests, loadFindings, loadSubscription])
+
+    if (!featureFlags[FEATURE_FLAGS.MAX_PULSE]) {
+        return <Error404 />
+    }
+
+    const findingsForLatest = latestDigest
+        ? findings.filter((f: PulseFindingType) => f.digest === latestDigest.id)
+        : []
+
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name="Pulse"
+                description="Max scans your metrics and surfaces changes worth investigating."
+                resourceType={{ type: 'project', forceIcon: <IconPulse /> }}
+                actions={
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        icon={<IconRefresh />}
+                        onClick={() => {
+                            loadDigests()
+                            loadFindings()
+                        }}
+                        loading={digestsLoading || findingsLoading}
+                    >
+                        Refresh
+                    </LemonButton>
+                }
+            />
+
+            <SubscriptionPanel />
+
+            {digestsLoading ? (
+                <div className="flex justify-center py-8">
+                    <Spinner />
+                </div>
+            ) : shouldShowEmptyState ? (
+                <div className="border rounded p-6 bg-surface-primary text-center">
+                    <p className="text-muted">No Pulse digests yet</p>
+                    <p className="text-muted-alt text-sm mb-0 mt-1">
+                        Once Pulse runs its first scan, findings will appear here.
+                    </p>
+                </div>
+            ) : (
+                <div className="space-y-6">
+                    {latestDigest && (
+                        <div>
+                            <div className="flex items-center gap-2 mb-3">
+                                <h2 className="text-lg font-semibold mb-0">Latest digest</h2>
+                                <LemonTag>{latestDigest.status}</LemonTag>
+                                <span className="text-muted-alt text-xs">
+                                    <TZLabel time={latestDigest.created_at} />
+                                </span>
+                            </div>
+                            {findingsForLatest.length === 0 ? (
+                                <p className="text-muted">No findings in the latest digest.</p>
+                            ) : (
+                                <div className="space-y-3">
+                                    {findingsForLatest.map((finding: PulseFindingType) => (
+                                        <FindingCard key={finding.id} finding={finding} />
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    {digests.length > 1 && (
+                        <div>
+                            <h2 className="text-lg font-semibold mb-3">Previous digests</h2>
+                            <ul className="space-y-2">
+                                {digests.slice(1).map((digest: PulseDigestSummary) => (
+                                    <li key={digest.id} className="border rounded p-3 bg-surface-primary">
+                                        <div className="flex items-center justify-between">
+                                            <span className="font-medium">
+                                                <TZLabel time={digest.created_at} />
+                                            </span>
+                                            <span className="text-muted-alt text-sm">
+                                                {digest.finding_count} finding{digest.finding_count === 1 ? '' : 's'}
+                                            </span>
+                                        </div>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+            )}
+        </SceneContent>
+    )
+}
+
+export default Pulse

--- a/frontend/src/scenes/pulse/activityDescriptions.tsx
+++ b/frontend/src/scenes/pulse/activityDescriptions.tsx
@@ -1,0 +1,42 @@
+import {
+    ActivityLogItem,
+    HumanizedChange,
+    defaultDescriber,
+} from 'lib/components/ActivityLog/humanizeActivity'
+import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
+
+import { PULSE_ACTIVITY_SCOPE } from './pulseTypes'
+import { formatSignedPct } from './utils'
+
+export function pulseActivityDescriber(logItem: ActivityLogItem, asNotification?: boolean): HumanizedChange {
+    if (logItem.scope !== PULSE_ACTIVITY_SCOPE) {
+        return defaultDescriber(logItem, asNotification)
+    }
+
+    const context = logItem.detail?.context as
+        | {
+              digest_id?: string
+              metric_label?: string
+              narrative?: string
+              change_pct?: number
+          }
+        | undefined
+
+    if (logItem.activity === 'surfaced' && context) {
+        const changePct = context.change_pct ?? 0
+        const tone = changePct >= 0 ? 'rose' : 'dropped'
+        const pct = formatSignedPct(changePct)
+        return {
+            description: (
+                <>
+                    <strong>{context.metric_label || 'A metric'}</strong> {tone} ({pct}) — Pulse surfaced this finding.{' '}
+                    <Link to={urls.pulse()}>Open Pulse</Link>
+                </>
+            ),
+            extendedDescription: context.narrative ? <span className="text-muted">{context.narrative}</span> : undefined,
+        }
+    }
+
+    return defaultDescriber(logItem, asNotification)
+}

--- a/frontend/src/scenes/pulse/index.ts
+++ b/frontend/src/scenes/pulse/index.ts
@@ -1,0 +1,1 @@
+export { Pulse } from './Pulse'

--- a/frontend/src/scenes/pulse/pulseLogic.ts
+++ b/frontend/src/scenes/pulse/pulseLogic.ts
@@ -1,0 +1,132 @@
+import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+
+import {
+    PulseDigestSummary,
+    PulseFindingFeedbackAction,
+    PulseFindingType,
+    PulseSubscriptionType,
+} from './pulseTypes'
+
+const DEFAULT_SUBSCRIPTION: PulseSubscriptionType = {
+    id: null,
+    enabled: false,
+    frequency: 'weekly',
+    enabled_channels: ['in_app'],
+    slack_channel_id: '',
+    email_recipients: [],
+    last_scan_at: null,
+    next_scan_at: null,
+    created_at: null,
+}
+
+export const pulseLogic = kea([
+    path(['scenes', 'pulse', 'pulseLogic']),
+    actions({
+        loadDigests: true,
+        loadFindings: true,
+        loadSubscription: true,
+        submitFeedback: (findingId, action) => ({ findingId, action }),
+        setExpandedDigestId: (id) => ({ id }),
+        updateSubscriptionLocal: (patch) => ({ patch }),
+        saveSubscription: true,
+    }),
+    reducers({
+        expandedDigestId: [
+            null as string | null,
+            {
+                setExpandedDigestId: (_: any, { id }: { id: string | null }) => id,
+            },
+        ],
+        subscriptionDraft: [
+            null as PulseSubscriptionType | null,
+            {
+                loadSubscriptionSuccess: (_: any, { subscription }: { subscription: PulseSubscriptionType }) =>
+                    subscription,
+                updateSubscriptionLocal: (
+                    state: PulseSubscriptionType | null,
+                    { patch }: { patch: Partial<PulseSubscriptionType> }
+                ) => (state ? { ...state, ...patch } : { ...DEFAULT_SUBSCRIPTION, ...patch }),
+            },
+        ],
+    }),
+    loaders(({ values }: any) => ({
+        digests: [
+            [] as PulseDigestSummary[],
+            {
+                loadDigests: async () => {
+                    const response = await api.pulse.listDigests()
+                    return response.results || []
+                },
+            },
+        ],
+        findings: [
+            [] as PulseFindingType[],
+            {
+                loadFindings: async () => {
+                    const response = await api.pulse.listFindings()
+                    return response.results || []
+                },
+                submitFeedback: async ({
+                    findingId,
+                    action,
+                }: {
+                    findingId: string
+                    action: PulseFindingFeedbackAction
+                }) => {
+                    const updated = await api.pulse.submitFeedback(findingId, action)
+                    return values.findings.map((f: PulseFindingType) => (f.id === findingId ? updated : f))
+                },
+            },
+        ],
+        subscription: [
+            null as PulseSubscriptionType | null,
+            {
+                loadSubscription: async () => {
+                    return await api.pulse.currentSubscription()
+                },
+                saveSubscription: async () => {
+                    const draft: PulseSubscriptionType | null = values.subscriptionDraft
+                    if (!draft) {
+                        return null
+                    }
+                    const payload = {
+                        enabled: draft.enabled,
+                        frequency: draft.frequency,
+                        enabled_channels: draft.enabled_channels,
+                        slack_channel_id: draft.slack_channel_id,
+                        email_recipients: draft.email_recipients,
+                    }
+                    if (draft.id) {
+                        return await api.pulse.updateSubscription(draft.id, payload)
+                    }
+                    return await api.pulse.createSubscription(payload)
+                },
+            },
+        ],
+    })),
+    listeners(() => ({
+        saveSubscriptionSuccess: () => {
+            lemonToast.success('Pulse subscription saved')
+        },
+        saveSubscriptionFailure: () => {
+            lemonToast.error('Failed to save Pulse subscription')
+        },
+        submitFeedbackSuccess: () => {
+            lemonToast.success('Feedback recorded')
+        },
+    })),
+    selectors({
+        shouldShowEmptyState: [
+            (s: any) => [s.digests, s.digestsLoading],
+            (digests: PulseDigestSummary[], loading: boolean): boolean => !loading && digests.length === 0,
+        ],
+        latestDigest: [
+            (s: any) => [s.digests],
+            (digests: PulseDigestSummary[]): PulseDigestSummary | null => (digests.length ? digests[0] : null),
+        ],
+    }),
+])

--- a/frontend/src/scenes/pulse/pulseTypes.ts
+++ b/frontend/src/scenes/pulse/pulseTypes.ts
@@ -1,0 +1,52 @@
+export const PULSE_ACTIVITY_SCOPE = 'Pulse'
+
+export type PulseDigestStatus = 'pending' | 'generating' | 'delivered' | 'failed'
+export type PulseFindingFeedbackAction = 'pending' | 'up' | 'down' | 'dismissed' | 'snoozed'
+export type PulseSubscriptionFrequency = 'weekly' | 'daily'
+export type PulseChannel = 'in_app' | 'slack' | 'email'
+
+export interface PulseDigestSummary {
+    id: string
+    period_start: string
+    period_end: string
+    status: PulseDigestStatus
+    delivered_to: Record<string, any>
+    created_at: string
+    finding_count: number
+}
+
+export interface PulseFindingType {
+    id: string
+    digest: string
+    metric_label: string
+    metric_descriptor: Record<string, any>
+    current_value: number
+    baseline_value: number
+    change_pct: number
+    z_score: number
+    attribution_breakdown: Record<string, any> | null
+    narrative: string
+    chart_thumbnail_url: string
+    feedback: PulseFindingFeedbackAction
+    snoozed_until: string | null
+    rank: number
+    created_at: string
+}
+
+export interface PulseDigestDetail extends PulseDigestSummary {
+    workflow_run_id: string
+    error: Record<string, any> | null
+    findings: PulseFindingType[]
+}
+
+export interface PulseSubscriptionType {
+    id: string | null
+    enabled: boolean
+    frequency: PulseSubscriptionFrequency
+    enabled_channels: PulseChannel[]
+    slack_channel_id: string
+    email_recipients: string[]
+    last_scan_at: string | null
+    next_scan_at: string | null
+    created_at: string | null
+}

--- a/frontend/src/scenes/pulse/utils.ts
+++ b/frontend/src/scenes/pulse/utils.ts
@@ -1,0 +1,5 @@
+import { percentage } from 'lib/utils'
+
+export function formatSignedPct(pct: number): string {
+    return `${pct >= 0 ? '+' : ''}${percentage(pct, 0)}`
+}

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -121,6 +121,7 @@ export enum Scene {
     PipelineNode = 'PipelineNode',
     PipelineNodeNew = 'PipelineNodeNew',
     PreflightCheck = 'PreflightCheck',
+    Pulse = 'Pulse',
     ProductTour = 'ProductTour',
     ProductTours = 'ProductTours',
     ProjectCreateFirst = 'ProjectCreate',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -366,6 +366,11 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         organizationBased: false,
     },
     [Scene.PreflightCheck]: { onlyUnauthenticated: true, layout: 'plain' },
+    [Scene.Pulse]: {
+        projectBased: true,
+        name: 'Pulse',
+        description: 'Proactive insights surfaced by Max from your team\'s key metrics.',
+    },
     [Scene.ProjectCreateFirst]: {
         name: 'Project creation',
         organizationBased: true,
@@ -861,6 +866,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.cliLive()]: [Scene.CLILive, 'cliLive'],
     [urls.emailMFAVerify()]: [Scene.EmailMFAVerify, 'emailMFAVerify'],
     [urls.preflight()]: [Scene.PreflightCheck, 'preflight'],
+    [urls.pulse()]: [Scene.Pulse, 'pulse'],
     [urls.signup()]: [Scene.Signup, 'signup'],
     [urls.inviteSignup(':id')]: [Scene.InviteSignup, 'inviteSignup'],
     [urls.passwordReset()]: [Scene.PasswordReset, 'passwordReset'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -159,6 +159,7 @@ export const urls = {
     passwordResetComplete: (userUuid: string, token: string): string => `/reset/${userUuid}/${token}`,
     twoFactorReset: (userUuid: string, token: string): string => `/reset_2fa/${userUuid}/${token}`,
     preflight: (): string => '/preflight',
+    pulse: (): string => '/pulse',
     signup: (): string => '/signup',
     verifyEmail: (userUuid: string = '', token: string = ''): string =>
         `/verify_email${userUuid ? `/${userUuid}` : ''}${token ? `/${token}` : ''}`,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5541,6 +5541,7 @@ export enum ActivityScope {
     LOG = 'Log',
     LOGS_ALERT_CONFIGURATION = 'LogsAlertConfiguration',
     PRODUCT_TOUR = 'ProductTour',
+    PULSE = 'Pulse',
     TICKET = 'Ticket',
 }
 

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -172,6 +172,7 @@ from . import (
     plugin_log_entry,
     project_secret_api_key,
     proxy_record,
+    pulse,
     query,
     quick_filters,
     resource_transfer,
@@ -1235,6 +1236,27 @@ register_grandfathered_environment_nested_viewset(
     r"alerts",
     alert.AlertViewSet,
     "environment_alerts",
+    ["team_id"],
+)
+
+register_grandfathered_environment_nested_viewset(
+    r"pulse_digests",
+    pulse.PulseDigestViewSet,
+    "environment_pulse_digests",
+    ["team_id"],
+)
+
+register_grandfathered_environment_nested_viewset(
+    r"pulse_findings",
+    pulse.PulseFindingViewSet,
+    "environment_pulse_findings",
+    ["team_id"],
+)
+
+register_grandfathered_environment_nested_viewset(
+    r"pulse_subscriptions",
+    pulse.PulseSubscriptionViewSet,
+    "environment_pulse_subscriptions",
     ["team_id"],
 )
 

--- a/posthog/api/my_notifications.py
+++ b/posthog/api/my_notifications.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from django.db.models import Q
@@ -222,7 +222,12 @@ class MyNotificationsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                         | Q(Q(scope="Cohort") & Q(item_id__in=my_cohorts))
                         | Q(Q(scope="HogFunction") & Q(item_id__in=my_hog_functions))
                         # Pulse findings are system-generated and surface to every team member.
-                        | Q(scope=PULSE_ACTIVITY_SCOPE)
+                        # Bounded to a recent window since system-scoped entries are excluded by
+                        # the partial `idx_alog_team_scope_created` index.
+                        | Q(
+                            scope=PULSE_ACTIVITY_SCOPE,
+                            created_at__gte=datetime.now(UTC) - timedelta(days=30),
+                        )
                     )
                     | Q(
                         # don't want to see creation of these things since that was before the user edited these things

--- a/posthog/api/my_notifications.py
+++ b/posthog/api/my_notifications.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from django.db.models import Q
 
@@ -14,6 +14,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import ServerTimingsGathered, action
 from posthog.models import ActivityLog, Cohort, FeatureFlag, HogFunction, Insight, NotificationViewed, User
 from posthog.models.comment import Comment
+from posthog.models.pulse import PULSE_ACTIVITY_SCOPE
 
 from products.notebooks.backend.models import Notebook
 
@@ -31,7 +32,7 @@ class MyNotificationsSerializer(serializers.ModelSerializer):
         if "user" not in self.context:
             return False
 
-        user_bookmark: Optional[NotificationViewed] = NotificationViewed.objects.filter(
+        user_bookmark: NotificationViewed | None = NotificationViewed.objects.filter(
             user=self.context["user"]
         ).first()
 
@@ -220,6 +221,8 @@ class MyNotificationsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                         | Q(Q(scope="Comment") & Q(item_id__in=my_comments))
                         | Q(Q(scope="Cohort") & Q(item_id__in=my_cohorts))
                         | Q(Q(scope="HogFunction") & Q(item_id__in=my_hog_functions))
+                        # Pulse findings are system-generated and surface to every team member.
+                        | Q(scope=PULSE_ACTIVITY_SCOPE)
                     )
                     | Q(
                         # don't want to see creation of these things since that was before the user edited these things

--- a/posthog/api/pulse.py
+++ b/posthog/api/pulse.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from typing import Any
 
+from django.db import IntegrityError
 from django.db.models import Count, QuerySet
 
 from rest_framework import mixins, serializers, viewsets
@@ -211,9 +212,15 @@ class PulseSubscriptionViewSet(
         return queryset.filter(team_id=self.team_id)
 
     def perform_create(self, serializer: serializers.ModelSerializer) -> None:
+        # OneToOneField on team enforces singleton at DB level; the explicit pre-check
+        # gives a friendly 400 in the common path but we catch IntegrityError for the
+        # concurrent-POST race.
         if PulseSubscription.objects.filter(team_id=self.team_id).exists():
             raise ValidationError("This team already has a Pulse subscription. Use PATCH to update it.")
-        serializer.save(team_id=self.team_id, created_by=self.request.user)
+        try:
+            serializer.save(team_id=self.team_id, created_by=self.request.user)
+        except IntegrityError as exc:
+            raise ValidationError("This team already has a Pulse subscription. Use PATCH to update it.") from exc
 
     @action(detail=False, methods=["get"], url_path="current")
     def current(self, request: Request, *args, **kwargs) -> Response:

--- a/posthog/api/pulse.py
+++ b/posthog/api/pulse.py
@@ -12,9 +12,9 @@ from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models import PulseDigest, PulseFinding, PulseSubscription
-from posthog.models.pulse import PulseFindingFeedback
+from posthog.models.pulse import PulseChannel, PulseFindingFeedback
 
-ALLOWED_CHANNELS = {"in_app", "slack", "email"}
+ALLOWED_CHANNELS = {c.value for c in PulseChannel}
 
 
 class PulseFindingSerializer(serializers.ModelSerializer):

--- a/posthog/api/pulse.py
+++ b/posthog/api/pulse.py
@@ -1,0 +1,235 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from django.db.models import Count, QuerySet
+
+from rest_framework import mixins, serializers, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models import PulseDigest, PulseFinding, PulseSubscription
+from posthog.models.pulse import PulseFindingFeedback
+
+ALLOWED_CHANNELS = {"in_app", "slack", "email"}
+
+
+class PulseFindingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PulseFinding
+        fields = [
+            "id",
+            "digest",
+            "metric_label",
+            "metric_descriptor",
+            "current_value",
+            "baseline_value",
+            "change_pct",
+            "z_score",
+            "attribution_breakdown",
+            "narrative",
+            "chart_thumbnail_url",
+            "feedback",
+            "snoozed_until",
+            "rank",
+            "created_at",
+        ]
+        read_only_fields = [
+            "id",
+            "digest",
+            "metric_label",
+            "metric_descriptor",
+            "current_value",
+            "baseline_value",
+            "change_pct",
+            "z_score",
+            "attribution_breakdown",
+            "narrative",
+            "chart_thumbnail_url",
+            "rank",
+            "created_at",
+        ]
+
+
+class PulseDigestSerializer(serializers.ModelSerializer):
+    findings = PulseFindingSerializer(many=True, read_only=True)
+    finding_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PulseDigest
+        fields = [
+            "id",
+            "period_start",
+            "period_end",
+            "status",
+            "delivered_to",
+            "workflow_run_id",
+            "error",
+            "created_at",
+            "finding_count",
+            "findings",
+        ]
+        read_only_fields = fields
+
+    def get_finding_count(self, obj: PulseDigest) -> int:
+        # Avoid extra query when prefetched, fall back to .count() otherwise.
+        if hasattr(obj, "_prefetched_objects_cache") and "findings" in obj._prefetched_objects_cache:
+            return len(obj._prefetched_objects_cache["findings"])
+        return obj.findings.count()
+
+
+class PulseDigestListSerializer(serializers.ModelSerializer):
+    finding_count = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = PulseDigest
+        fields = [
+            "id",
+            "period_start",
+            "period_end",
+            "status",
+            "delivered_to",
+            "created_at",
+            "finding_count",
+        ]
+        read_only_fields = fields
+
+
+class PulseSubscriptionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PulseSubscription
+        fields = [
+            "id",
+            "enabled",
+            "frequency",
+            "enabled_channels",
+            "slack_channel_id",
+            "email_recipients",
+            "last_scan_at",
+            "next_scan_at",
+            "created_at",
+        ]
+        read_only_fields = ["id", "last_scan_at", "next_scan_at", "created_at"]
+
+    def validate_enabled_channels(self, value: Any) -> list[str]:
+        if not isinstance(value, list):
+            raise ValidationError("enabled_channels must be a list")
+        bad = [v for v in value if v not in ALLOWED_CHANNELS]
+        if bad:
+            raise ValidationError(f"Invalid channels: {bad}. Allowed: {sorted(ALLOWED_CHANNELS)}")
+        return value
+
+
+class PulseDigestViewSet(
+    TeamAndOrgViewSetMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    scope_object = "INTERNAL"
+    permission_classes = [IsAuthenticated]
+    queryset = PulseDigest.objects.all()
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return PulseDigestListSerializer
+        return PulseDigestSerializer
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        qs = queryset.filter(team_id=self.team_id).order_by("-created_at")
+        if self.action == "list":
+            qs = qs.annotate(finding_count=Count("findings"))
+        elif self.action == "retrieve":
+            qs = qs.prefetch_related("findings")
+        return qs
+
+
+class PulseFindingViewSet(
+    TeamAndOrgViewSetMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    scope_object = "INTERNAL"
+    permission_classes = [IsAuthenticated]
+    queryset = PulseFinding.objects.all()
+    serializer_class = PulseFindingSerializer
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        qs = queryset.filter(digest__team_id=self.team_id)
+        digest_id = self.request.query_params.get("digest")
+        if digest_id:
+            qs = qs.filter(digest_id=digest_id)
+        feedback = self.request.query_params.get("feedback")
+        if feedback:
+            qs = qs.filter(feedback=feedback)
+        return qs.order_by("rank", "-created_at")
+
+    @action(detail=True, methods=["post"], url_path="feedback")
+    def submit_feedback(self, request: Request, *args, **kwargs) -> Response:
+        finding = self.get_object()
+        action_value = request.data.get("action")
+        try:
+            normalized = PulseFindingFeedback(action_value)
+        except ValueError:
+            raise ValidationError(
+                f"Invalid feedback action: {action_value!r}. "
+                f"Allowed: {[c.value for c in PulseFindingFeedback]}"
+            )
+        finding.feedback = normalized
+        finding.feedback_user = request.user
+        finding.feedback_at = datetime.now(UTC)
+        if normalized == PulseFindingFeedback.SNOOZED:
+            snoozed_until = request.data.get("snoozed_until")
+            if snoozed_until:
+                try:
+                    finding.snoozed_until = datetime.fromisoformat(snoozed_until.replace("Z", "+00:00"))
+                except (TypeError, ValueError):
+                    raise ValidationError("snoozed_until must be an ISO datetime string")
+        finding.save(update_fields=["feedback", "feedback_user", "feedback_at", "snoozed_until"])
+        return Response(self.get_serializer(finding).data)
+
+
+class PulseSubscriptionViewSet(
+    TeamAndOrgViewSetMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    scope_object = "INTERNAL"
+    permission_classes = [IsAuthenticated]
+    queryset = PulseSubscription.objects.all()
+    serializer_class = PulseSubscriptionSerializer
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        return queryset.filter(team_id=self.team_id)
+
+    def perform_create(self, serializer: serializers.ModelSerializer) -> None:
+        if PulseSubscription.objects.filter(team_id=self.team_id).exists():
+            raise ValidationError("This team already has a Pulse subscription. Use PATCH to update it.")
+        serializer.save(team_id=self.team_id, created_by=self.request.user)
+
+    @action(detail=False, methods=["get"], url_path="current")
+    def current(self, request: Request, *args, **kwargs) -> Response:
+        sub = PulseSubscription.objects.filter(team_id=self.team_id).first()
+        if sub:
+            return Response(self.get_serializer(sub).data)
+        return Response(
+            {
+                "id": None,
+                "enabled": False,
+                "frequency": "weekly",
+                "enabled_channels": ["in_app"],
+                "slack_channel_id": "",
+                "email_recipients": [],
+                "last_scan_at": None,
+                "next_scan_at": None,
+                "created_at": None,
+            }
+        )

--- a/posthog/api/test/test_pulse.py
+++ b/posthog/api/test/test_pulse.py
@@ -1,0 +1,134 @@
+from posthog.test.base import APIBaseTest
+
+from rest_framework import status
+
+from posthog.models import PulseDigest, PulseFinding, PulseSubscription
+from posthog.models.pulse import PulseDigestStatus, PulseFindingFeedback
+
+
+def _make_digest(team) -> PulseDigest:
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime.now(UTC)
+    return PulseDigest.objects.create(
+        team=team,
+        period_start=now - timedelta(days=7),
+        period_end=now,
+        status=PulseDigestStatus.DELIVERED,
+    )
+
+
+def _make_finding(digest, label: str = "Test metric", rank: int = 0) -> PulseFinding:
+    return PulseFinding.objects.create(
+        digest=digest,
+        metric_descriptor={"source": "top_event", "label": label, "query": {}},
+        metric_label=label,
+        current_value=100.0,
+        baseline_value=80.0,
+        change_pct=0.25,
+        z_score=2.5,
+        narrative=f"{label} rose 25%.",
+        rank=rank,
+    )
+
+
+class TestPulseAPI(APIBaseTest):
+    def test_list_digests_returns_only_current_team(self) -> None:
+        _make_digest(self.team)
+        other_team_digest = _make_digest(self.organization.teams.create(name="other"))
+        response = self.client.get(f"/api/environments/{self.team.id}/pulse_digests/")
+        assert response.status_code == status.HTTP_200_OK
+        ids = [d["id"] for d in response.json()["results"]]
+        assert str(other_team_digest.id) not in ids
+
+    def test_list_digests_includes_finding_count(self) -> None:
+        digest = _make_digest(self.team)
+        _make_finding(digest)
+        _make_finding(digest, label="Metric B", rank=1)
+        response = self.client.get(f"/api/environments/{self.team.id}/pulse_digests/")
+        body = response.json()
+        assert body["results"][0]["finding_count"] == 2
+
+    def test_retrieve_digest_returns_findings(self) -> None:
+        digest = _make_digest(self.team)
+        _make_finding(digest)
+        response = self.client.get(f"/api/environments/{self.team.id}/pulse_digests/{digest.id}/")
+        body = response.json()
+        assert body["finding_count"] == 1
+        assert len(body["findings"]) == 1
+
+    def test_list_findings_filters_by_team_via_digest(self) -> None:
+        digest = _make_digest(self.team)
+        _make_finding(digest)
+        other_team = self.organization.teams.create(name="other")
+        other_digest = _make_digest(other_team)
+        _make_finding(other_digest, label="Other team finding")
+
+        response = self.client.get(f"/api/environments/{self.team.id}/pulse_findings/")
+        labels = [f["metric_label"] for f in response.json()["results"]]
+        assert labels == ["Test metric"]
+
+    def test_submit_feedback(self) -> None:
+        digest = _make_digest(self.team)
+        finding = _make_finding(digest)
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/pulse_findings/{finding.id}/feedback/",
+            {"action": "up"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        finding.refresh_from_db()
+        assert finding.feedback == PulseFindingFeedback.THUMBS_UP
+        assert finding.feedback_user_id == self.user.id
+        assert finding.feedback_at is not None
+
+    def test_submit_feedback_rejects_invalid_action(self) -> None:
+        digest = _make_digest(self.team)
+        finding = _make_finding(digest)
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/pulse_findings/{finding.id}/feedback/",
+            {"action": "garbage"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_subscription_current_returns_defaults_when_missing(self) -> None:
+        response = self.client.get(f"/api/environments/{self.team.id}/pulse_subscriptions/current/")
+        body = response.json()
+        assert body["id"] is None
+        assert body["enabled"] is False
+        assert body["frequency"] == "weekly"
+
+    def test_subscription_create_then_update(self) -> None:
+        create_resp = self.client.post(
+            f"/api/environments/{self.team.id}/pulse_subscriptions/",
+            {"enabled": True, "frequency": "weekly", "enabled_channels": ["in_app", "slack"]},
+            format="json",
+        )
+        assert create_resp.status_code == status.HTTP_201_CREATED, create_resp.json()
+        sub_id = create_resp.json()["id"]
+
+        update_resp = self.client.patch(
+            f"/api/environments/{self.team.id}/pulse_subscriptions/{sub_id}/",
+            {"frequency": "daily"},
+            format="json",
+        )
+        assert update_resp.status_code == status.HTTP_200_OK
+        assert update_resp.json()["frequency"] == "daily"
+
+    def test_subscription_rejects_unknown_channel(self) -> None:
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/pulse_subscriptions/",
+            {"enabled": True, "frequency": "weekly", "enabled_channels": ["pigeon"]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_subscription_singleton_enforced(self) -> None:
+        PulseSubscription.objects.create(team=self.team)
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/pulse_subscriptions/",
+            {"enabled": True, "frequency": "weekly", "enabled_channels": ["in_app"]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/posthog/migrations/1156_pulse.py
+++ b/posthog/migrations/1156_pulse.py
@@ -1,0 +1,187 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1155_sharingconfiguration_interviewee_context"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PulseDigest",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.UUIDT, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("period_start", models.DateTimeField()),
+                ("period_end", models.DateTimeField()),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("generating", "Generating"),
+                            ("delivered", "Delivered"),
+                            ("failed", "Failed"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("delivered_to", models.JSONField(blank=True, default=dict)),
+                ("workflow_run_id", models.CharField(blank=True, default="", max_length=255)),
+                ("error", models.JSONField(blank=True, null=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "team",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="pulse_digests",
+                        to="posthog.team",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+        migrations.AddIndex(
+            model_name="pulsedigest",
+            index=models.Index(fields=["team", "-created_at"], name="posthog_pul_team_id_5a6c7d_idx"),
+        ),
+        migrations.CreateModel(
+            name="PulseFinding",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.UUIDT, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("metric_descriptor", models.JSONField()),
+                ("metric_label", models.CharField(blank=True, default="", max_length=255)),
+                ("current_value", models.FloatField()),
+                ("baseline_value", models.FloatField()),
+                ("change_pct", models.FloatField()),
+                ("z_score", models.FloatField()),
+                ("attribution_breakdown", models.JSONField(blank=True, null=True)),
+                ("narrative", models.TextField()),
+                ("chart_thumbnail_url", models.URLField(blank=True, default="", max_length=2048)),
+                (
+                    "feedback",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("up", "Thumbs Up"),
+                            ("down", "Thumbs Down"),
+                            ("dismissed", "Dismissed"),
+                            ("snoozed", "Snoozed"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("feedback_at", models.DateTimeField(blank=True, null=True)),
+                ("snoozed_until", models.DateTimeField(blank=True, null=True)),
+                ("rank", models.IntegerField(default=0)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "feedback_user",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="pulse_feedback",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "digest",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="findings",
+                        to="posthog.pulsedigest",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["rank", "-created_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="pulsefinding",
+            index=models.Index(fields=["digest", "rank"], name="posthog_pul_digest__a1b2c3_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="pulsefinding",
+            index=models.Index(fields=["digest", "feedback"], name="posthog_pul_digest__d4e5f6_idx"),
+        ),
+        migrations.CreateModel(
+            name="PulseSubscription",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.UUIDT, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("enabled", models.BooleanField(default=False)),
+                (
+                    "frequency",
+                    models.CharField(
+                        choices=[("weekly", "Weekly"), ("daily", "Daily")],
+                        default="weekly",
+                        max_length=10,
+                    ),
+                ),
+                ("enabled_channels", models.JSONField(blank=True, default=list)),
+                ("slack_channel_id", models.CharField(blank=True, default="", max_length=64)),
+                ("email_recipients", models.JSONField(blank=True, default=list)),
+                ("last_scan_at", models.DateTimeField(blank=True, null=True)),
+                ("next_scan_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "team",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="pulse_subscription",
+                        to="posthog.team",
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1155_sharingconfiguration_interviewee_context
+1156_pulse

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -74,9 +74,8 @@ from .product_intent import ProductIntent
 from .project import Project
 from .property import Property
 from products.event_definitions.backend.models import PropertyDefinition
-
-from .pulse import PulseDigest, PulseFinding, PulseSubscription
 from .proxy_record import ProxyRecord
+from .pulse import PulseDigest, PulseFinding, PulseSubscription
 from .quick_filter import QuickFilter
 from .remote_config import RemoteConfig
 from .resource_transfer.resource_transfer import ResourceTransfer
@@ -209,10 +208,10 @@ __all__ = [
     "Project",
     "Property",
     "PropertyDefinition",
+    "ProxyRecord",
     "PulseDigest",
     "PulseFinding",
     "PulseSubscription",
-    "ProxyRecord",
     "QuickFilter",
     "RetentionFilter",
     "RemoteConfig",

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -74,6 +74,8 @@ from .product_intent import ProductIntent
 from .project import Project
 from .property import Property
 from products.event_definitions.backend.models import PropertyDefinition
+
+from .pulse import PulseDigest, PulseFinding, PulseSubscription
 from .proxy_record import ProxyRecord
 from .quick_filter import QuickFilter
 from .remote_config import RemoteConfig
@@ -207,6 +209,9 @@ __all__ = [
     "Project",
     "Property",
     "PropertyDefinition",
+    "PulseDigest",
+    "PulseFinding",
+    "PulseSubscription",
     "ProxyRecord",
     "QuickFilter",
     "RetentionFilter",

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -83,6 +83,7 @@ ActivityScope = Literal[
     "LogsAlertConfiguration",
     "LogsExclusionRule",
     "ProductTour",
+    "Pulse",
     "Ticket",
 ]
 ChangeAction = Literal[
@@ -94,9 +95,9 @@ ChangeAction = Literal[
 class Change:
     type: ActivityScope | str
     action: ChangeAction
-    field: Optional[str] = None
-    before: Optional[Any] = None
-    after: Optional[Any] = None
+    field: str | None = None
+    before: Any | None = None
+    after: Any | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -118,13 +119,13 @@ class ActivityContextBase:
 @dataclasses.dataclass(frozen=True)
 class Detail:
     # The display name of the item in question
-    name: Optional[str] = None
+    name: str | None = None
     # The short_id if it has one
-    short_id: Optional[str] = None
-    type: Optional[str] = None
-    changes: Optional[list[Change]] = None
-    trigger: Optional[Trigger] = None
-    context: Optional[ActivityContextBase] = None
+    short_id: str | None = None
+    type: str | None = None
+    changes: list[Change] | None = None
+    trigger: Trigger | None = None
+    context: ActivityContextBase | None = None
 
 
 class ActivityLog(UUIDTModel):
@@ -660,8 +661,8 @@ def safely_get_field_value(instance: models.Model | None, field: str):
 
 def changes_between(
     model_type: ActivityScope,
-    previous: Optional[models.Model],
-    current: Optional[models.Model],
+    previous: models.Model | None,
+    current: models.Model | None,
 ) -> list[Change]:
     """
     Identifies changes between two models by comparing fields.
@@ -799,10 +800,10 @@ def _handle_activity_log_transaction(create_fn, error_context: dict):
 
 def log_activity(
     *,
-    organization_id: Optional[UUID],
-    team_id: Optional[int],
+    organization_id: UUID | None,
+    team_id: int | None,
     user: Optional["User"],
-    item_id: Optional[Union[int, str, UUID]],
+    item_id: Union[int, str, UUID] | None,
     scope: str,
     activity: str,
     detail: Detail,
@@ -892,10 +893,10 @@ def log_activity(
 
 
 class LogActivityEntry(TypedDict, total=False):
-    organization_id: Optional[UUID]
-    team_id: Optional[int]
+    organization_id: UUID | None
+    team_id: int | None
     user: Optional["User"]
-    item_id: Optional[Union[int, str, UUID]]
+    item_id: Union[int, str, UUID] | None
     scope: Required[str]
     activity: Required[str]
     detail: Required[Detail]
@@ -993,7 +994,7 @@ def apply_activity_visibility_restrictions(queryset: QuerySet, user: Union["User
 def load_activity(
     scope: ActivityScope,
     team_id: int,
-    item_ids: Optional[list[str]] = None,
+    item_ids: list[str] | None = None,
     limit: int = 10,
     page: int = 1,
 ) -> ActivityPage:

--- a/posthog/models/pulse.py
+++ b/posthog/models/pulse.py
@@ -28,6 +28,12 @@ class PulseSubscriptionFrequency(models.TextChoices):
     DAILY = "daily"
 
 
+class PulseChannel(models.TextChoices):
+    IN_APP = "in_app"
+    SLACK = "slack"
+    EMAIL = "email"
+
+
 class PulseDigest(CreatedMetaFields, UUIDTModel):
     """One run of the Pulse scan workflow for a team. Holds 0..N findings."""
 

--- a/posthog/models/pulse.py
+++ b/posthog/models/pulse.py
@@ -1,0 +1,119 @@
+from django.db import models
+
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
+from posthog.models.utils import CreatedMetaFields, UUIDTModel
+
+PULSE_ACTIVITY_SCOPE = "Pulse"
+PULSE_ACTIVITY_VERB = "surfaced"
+PULSE_DIGEST_READY_EVENT = "$pulse_digest_ready"
+
+
+class PulseDigestStatus(models.TextChoices):
+    PENDING = "pending"
+    GENERATING = "generating"
+    DELIVERED = "delivered"
+    FAILED = "failed"
+
+
+class PulseFindingFeedback(models.TextChoices):
+    PENDING = "pending"
+    THUMBS_UP = "up"
+    THUMBS_DOWN = "down"
+    DISMISSED = "dismissed"
+    SNOOZED = "snoozed"
+
+
+class PulseSubscriptionFrequency(models.TextChoices):
+    WEEKLY = "weekly"
+    DAILY = "daily"
+
+
+class PulseDigest(CreatedMetaFields, UUIDTModel):
+    """One run of the Pulse scan workflow for a team. Holds 0..N findings."""
+
+    team = models.ForeignKey("Team", on_delete=models.CASCADE, related_name="pulse_digests")
+    period_start = models.DateTimeField()
+    period_end = models.DateTimeField()
+    status = models.CharField(
+        max_length=20,
+        choices=PulseDigestStatus.choices,
+        default=PulseDigestStatus.PENDING,
+    )
+    delivered_to = models.JSONField(default=dict, blank=True)
+    workflow_run_id = models.CharField(max_length=255, blank=True, default="")
+    error = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["team", "-created_at"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"PulseDigest(team={self.team_id}, {self.period_start.date()} → {self.period_end.date()})"
+
+
+class PulseFinding(CreatedMetaFields, UUIDTModel):
+    """A single metric change Pulse found worth surfacing in a digest."""
+
+    digest = models.ForeignKey(PulseDigest, on_delete=models.CASCADE, related_name="findings")
+
+    # The metric the finding is about — opaque JSON descriptor describing event(s), filters, breakdown
+    metric_descriptor = models.JSONField()
+    metric_label = models.CharField(max_length=255, blank=True, default="")
+
+    current_value = models.FloatField()
+    baseline_value = models.FloatField()
+    change_pct = models.FloatField()
+    z_score = models.FloatField()
+
+    # The breakdown the LLM picked as most explanatory (if any) — e.g. {"$browser": "Safari"}
+    attribution_breakdown = models.JSONField(null=True, blank=True)
+
+    narrative = models.TextField()
+    chart_thumbnail_url = models.URLField(max_length=2048, blank=True, default="")
+
+    feedback = models.CharField(
+        max_length=20,
+        choices=PulseFindingFeedback.choices,
+        default=PulseFindingFeedback.PENDING,
+    )
+    feedback_user = models.ForeignKey(
+        "User", on_delete=models.SET_NULL, null=True, blank=True, related_name="pulse_feedback"
+    )
+    feedback_at = models.DateTimeField(null=True, blank=True)
+    snoozed_until = models.DateTimeField(null=True, blank=True)
+
+    rank = models.IntegerField(default=0)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["digest", "rank"]),
+            models.Index(fields=["digest", "feedback"]),
+        ]
+        ordering = ["rank", "-created_at"]
+
+    def __str__(self) -> str:
+        return f"PulseFinding({self.metric_label}, {self.change_pct:+.0%})"
+
+
+class PulseSubscription(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
+    """Per-team config for how/when Pulse delivers digests."""
+
+    team = models.OneToOneField("Team", on_delete=models.CASCADE, related_name="pulse_subscription")
+
+    enabled = models.BooleanField(default=False)
+    frequency = models.CharField(
+        max_length=10,
+        choices=PulseSubscriptionFrequency.choices,
+        default=PulseSubscriptionFrequency.WEEKLY,
+    )
+    # Which channels are enabled — subset of {"in_app", "slack", "email"}
+    enabled_channels = models.JSONField(default=list, blank=True)
+    slack_channel_id = models.CharField(max_length=64, blank=True, default="")
+    email_recipients = models.JSONField(default=list, blank=True)
+
+    last_scan_at = models.DateTimeField(null=True, blank=True)
+    next_scan_at = models.DateTimeField(null=True, blank=True)
+
+    def __str__(self) -> str:
+        return f"PulseSubscription(team={self.team_id}, {self.frequency}, enabled={self.enabled})"

--- a/posthog/templates/email/pulse_digest.html
+++ b/posthog/templates/email/pulse_digest.html
@@ -1,0 +1,28 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+    <p>
+        Here's what changed in <strong>{{ team_name }}</strong> this {{ period_label|default:"week" }}.
+    </p>
+    {% if findings %}
+        <ul>
+            {% for finding in findings %}
+                <li style="margin-bottom: 12px;">
+                    <strong>{{ finding.metric_label }}</strong>
+                    <span style="color: {% if finding.change_pct >= 0 %}#2ecc71{% else %}#e74c3c{% endif %};">
+                        ({{ finding.change_pct|stringformat:"+.0%" }})
+                    </span>
+                    <br>
+                    <span style="color: #555;">{{ finding.narrative }}</span>
+                </li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>No significant changes detected this period.</p>
+    {% endif %}
+    <div class="mb mt text-center">
+        <a class="button" href="{% absolute_uri pulse_url %}">Open Pulse</a>
+    </div>
+    <p style="color: #777; font-size: 0.85em;">
+        Pulse scans your team's key metrics and surfaces changes that look unusual.
+        You can manage subscription settings at <a href="{% absolute_uri pulse_settings_url %}">/pulse</a>.
+    </p>
+{% endblock %}{% load posthog_filters %}

--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -24,6 +24,19 @@ from posthog.temporal.ai.posthog_code_slack_mention import (
     resolve_posthog_code_slack_user_activity,
     select_posthog_code_repository_activity,
 )
+from posthog.temporal.ai.pulse import (
+    PulseScanDispatcherInputs,
+    PulseScanDispatcherWorkflow,
+    PulseScanInputs,
+    PulseScanWorkflow,
+    create_or_get_digest_activity,
+    deliver_digest_activity,
+    detect_changes_activity,
+    enrich_findings_activity,
+    list_eligible_team_ids_activity,
+    select_candidate_metrics_activity,
+    set_digest_status_activity,
+)
 from posthog.temporal.ai.research_agent import ResearchAgentWorkflow, process_research_agent_activity
 from posthog.temporal.ai.slack_conversation import (
     SlackConversationRunnerWorkflow,
@@ -54,6 +67,8 @@ AI_WORKFLOWS = [
     PostHogCodeSlackMentionWorkflow,
     PostHogCodeSlackTerminateTaskWorkflow,
     AnomalyInvestigationWorkflow,
+    PulseScanWorkflow,
+    PulseScanDispatcherWorkflow,
 ]
 
 AI_ACTIVITIES = [
@@ -79,10 +94,19 @@ AI_ACTIVITIES = [
     post_posthog_code_internal_error_activity,
     process_posthog_code_terminate_task_activity,
     investigate_anomaly_activity,
+    select_candidate_metrics_activity,
+    detect_changes_activity,
+    enrich_findings_activity,
+    deliver_digest_activity,
+    create_or_get_digest_activity,
+    set_digest_status_activity,
+    list_eligible_team_ids_activity,
 ]
 
 __all__ = [
     "SyncVectorsInputs",
     "SummarizeLLMTracesInputs",
     "SlackConversationRunnerWorkflowInputs",
+    "PulseScanInputs",
+    "PulseScanDispatcherInputs",
 ]

--- a/posthog/temporal/ai/pulse/__init__.py
+++ b/posthog/temporal/ai/pulse/__init__.py
@@ -1,0 +1,29 @@
+from posthog.temporal.ai.pulse.dispatcher import (
+    PulseScanDispatcherInputs,
+    PulseScanDispatcherWorkflow,
+    list_eligible_team_ids_activity,
+)
+from posthog.temporal.ai.pulse.workflow import (
+    PulseScanInputs,
+    PulseScanWorkflow,
+    create_or_get_digest_activity,
+    deliver_digest_activity,
+    detect_changes_activity,
+    enrich_findings_activity,
+    select_candidate_metrics_activity,
+    set_digest_status_activity,
+)
+
+__all__ = [
+    "PulseScanDispatcherInputs",
+    "PulseScanDispatcherWorkflow",
+    "PulseScanInputs",
+    "PulseScanWorkflow",
+    "create_or_get_digest_activity",
+    "deliver_digest_activity",
+    "detect_changes_activity",
+    "enrich_findings_activity",
+    "list_eligible_team_ids_activity",
+    "select_candidate_metrics_activity",
+    "set_digest_status_activity",
+]

--- a/posthog/temporal/ai/pulse/delivery.py
+++ b/posthog/temporal/ai/pulse/delivery.py
@@ -21,6 +21,7 @@ from posthog.models.pulse import (
     PULSE_ACTIVITY_SCOPE,
     PULSE_ACTIVITY_VERB,
     PULSE_DIGEST_READY_EVENT,
+    PulseChannel,
     PulseDigestStatus,
     PulseFindingFeedback,
 )
@@ -103,10 +104,10 @@ def _persist_findings_sync(
     # Always mark in-app as delivered (the bell entry is written below), then add the team's
     # other configured channels — actual Slack/email routing happens through HogFunction destinations.
     subscription = PulseSubscription.objects.filter(team_id=team_id).first()
-    delivered_to = {"in_app": True}
+    delivered_to = {PulseChannel.IN_APP.value: True}
     if subscription:
         for channel in subscription.enabled_channels:
-            if channel != "in_app":
+            if channel != PulseChannel.IN_APP.value:
                 delivered_to[channel] = True
 
     digest.status = PulseDigestStatus.DELIVERED

--- a/posthog/temporal/ai/pulse/delivery.py
+++ b/posthog/temporal/ai/pulse/delivery.py
@@ -1,0 +1,174 @@
+"""Delivery: persist findings to Postgres and emit CDP internal event + bell notifications."""
+
+import dataclasses
+from datetime import UTC, datetime
+from typing import Any
+
+from django.db import transaction
+
+import structlog
+
+from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
+from posthog.exceptions_capture import capture_exception
+from posthog.models import PulseDigest, PulseFinding, PulseSubscription
+from posthog.models.activity_logging.activity_log import (
+    ActivityContextBase,
+    Detail,
+    LogActivityEntry,
+    bulk_log_activity,
+)
+from posthog.models.pulse import (
+    PULSE_ACTIVITY_SCOPE,
+    PULSE_ACTIVITY_VERB,
+    PULSE_DIGEST_READY_EVENT,
+    PulseDigestStatus,
+    PulseFindingFeedback,
+)
+from posthog.sync import database_sync_to_async
+from posthog.temporal.ai.pulse.types import EnrichedFinding
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class PulseActivityContext(ActivityContextBase):
+    digest_id: str = ""
+    metric_label: str = ""
+    narrative: str = ""
+    current_value: float = 0.0
+    baseline_value: float = 0.0
+    change_pct: float = 0.0
+    z_score: float = 0.0
+    attribution_breakdown: dict[str, Any] | None = None
+
+
+def _emit_activity_log_entries(
+    team_id: int, digest_id: str, findings_with_ids: list[tuple[str, EnrichedFinding]]
+) -> None:
+    """One ActivityLog row per finding so the side-panel bell picks it up. Bulk-inserted."""
+    entries: list[LogActivityEntry] = [
+        LogActivityEntry(
+            organization_id=None,
+            team_id=team_id,
+            user=None,
+            was_impersonated=False,
+            item_id=finding_id,
+            scope=PULSE_ACTIVITY_SCOPE,
+            activity=PULSE_ACTIVITY_VERB,
+            detail=Detail(
+                name=finding.descriptor.label,
+                context=PulseActivityContext(
+                    digest_id=digest_id,
+                    metric_label=finding.descriptor.label,
+                    narrative=finding.narrative,
+                    current_value=finding.current_value,
+                    baseline_value=finding.baseline_value,
+                    change_pct=finding.change_pct,
+                    z_score=finding.z_score,
+                    attribution_breakdown=finding.attribution_breakdown,
+                ),
+            ),
+        )
+        for finding_id, finding in findings_with_ids
+    ]
+    try:
+        bulk_log_activity(entries)
+    except Exception:
+        logger.exception("pulse_activity_log_failed", team_id=team_id, digest_id=digest_id)
+
+
+def _persist_findings_sync(
+    digest_id: str, team_id: int, findings: list[EnrichedFinding]
+) -> list[tuple[str, EnrichedFinding]]:
+    digest = PulseDigest.objects.get(id=digest_id, team_id=team_id)
+
+    rows = [
+        PulseFinding(
+            digest=digest,
+            metric_descriptor=f.descriptor.model_dump(),
+            metric_label=f.descriptor.label[:255],
+            current_value=f.current_value,
+            baseline_value=f.baseline_value,
+            change_pct=f.change_pct,
+            z_score=f.z_score,
+            attribution_breakdown=f.attribution_breakdown,
+            narrative=f.narrative,
+            feedback=PulseFindingFeedback.PENDING,
+            rank=idx,
+        )
+        for idx, f in enumerate(findings)
+    ]
+    created = PulseFinding.objects.bulk_create(rows)
+
+    # Always mark in-app as delivered (the bell entry is written below), then add the team's
+    # other configured channels — actual Slack/email routing happens through HogFunction destinations.
+    subscription = PulseSubscription.objects.filter(team_id=team_id).first()
+    delivered_to = {"in_app": True}
+    if subscription:
+        for channel in subscription.enabled_channels:
+            if channel != "in_app":
+                delivered_to[channel] = True
+
+    digest.status = PulseDigestStatus.DELIVERED
+    digest.delivered_to = delivered_to
+    digest.save(update_fields=["status", "delivered_to"])
+
+    return [(str(row.id), finding) for row, finding in zip(created, findings)]
+
+
+def _emit_internal_event(team_id: int, digest_id: str, findings: list[EnrichedFinding]) -> None:
+    """Fire `$pulse_digest_ready` so CDP HogFunction destinations can route to Slack/email."""
+    try:
+        props = {
+            "digest_id": digest_id,
+            "finding_count": len(findings),
+            "findings": [
+                {
+                    "metric": f.descriptor.label,
+                    "narrative": f.narrative,
+                    "current_value": f.current_value,
+                    "baseline_value": f.baseline_value,
+                    "change_pct": f.change_pct,
+                    "z_score": f.z_score,
+                    "attribution": f.attribution_breakdown,
+                }
+                for f in findings
+            ],
+        }
+        produce_internal_event(
+            team_id=team_id,
+            event=InternalEventEvent(
+                event=PULSE_DIGEST_READY_EVENT,
+                distinct_id=f"team_{team_id}",
+                properties=props,
+            ),
+        )
+    except Exception as e:
+        capture_exception(e, additional_properties={"feature": "pulse", "digest_id": digest_id})
+        logger.exception("pulse_emit_internal_event_failed", team_id=team_id, digest_id=digest_id)
+
+
+def _update_subscription_timestamps_sync(team_id: int) -> None:
+    try:
+        subscription = PulseSubscription.objects.filter(team_id=team_id).first()
+        if subscription:
+            subscription.last_scan_at = datetime.now(UTC)
+            subscription.save(update_fields=["last_scan_at"])
+    except Exception:
+        logger.exception("pulse_subscription_timestamp_update_failed", team_id=team_id)
+
+
+@database_sync_to_async
+def _deliver_sync(team_id: int, digest_id: str, findings: list[EnrichedFinding]) -> list[str]:
+    with transaction.atomic():
+        findings_with_ids = _persist_findings_sync(digest_id, team_id, findings)
+        _emit_activity_log_entries(team_id, digest_id, findings_with_ids)
+        _update_subscription_timestamps_sync(team_id)
+    return [finding_id for finding_id, _ in findings_with_ids]
+
+
+async def deliver_digest(team_id: int, digest_id: str, findings: list[EnrichedFinding]) -> list[str]:
+    finding_ids = await _deliver_sync(team_id, digest_id, findings)
+    # Kafka I/O — kept outside the DB transaction.
+    await database_sync_to_async(_emit_internal_event)(team_id, digest_id, findings)
+    return finding_ids

--- a/posthog/temporal/ai/pulse/detection.py
+++ b/posthog/temporal/ai/pulse/detection.py
@@ -13,9 +13,10 @@ from posthog.temporal.ai.pulse.types import CandidateMetric, Finding, run_trends
 logger = structlog.get_logger(__name__)
 
 
-DETECTION_DATE_FROM = "-42d"  # 6 weeks: 1 current + 5 baseline
+DETECTION_DATE_FROM = "-42d"  # 6 weeks fetched: in-progress + 1 current + up to 4 baseline
 DETECTION_CONCURRENCY = 8
 MIN_BASELINE_WEEKS = 3
+MAX_BASELINE_WEEKS = 4
 MIN_BASELINE_VALUE = 5.0  # Skip near-zero-volume metrics that produce noisy z-scores
 
 
@@ -63,7 +64,7 @@ def _evaluate_candidate(
     # Drop the in-progress current week (last bucket) since trend buckets are partial.
     completed = weekly_values[:-1]
     current = completed[-1]
-    baseline = completed[:-1][-4:]
+    baseline = completed[:-1][-MAX_BASELINE_WEEKS:]
     if len(baseline) < MIN_BASELINE_WEEKS:
         return None
 

--- a/posthog/temporal/ai/pulse/detection.py
+++ b/posthog/temporal/ai/pulse/detection.py
@@ -6,10 +6,9 @@ from typing import Any
 
 import structlog
 
-from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
-from posthog.temporal.ai.pulse.types import CandidateMetric, Finding
+from posthog.temporal.ai.pulse.types import CandidateMetric, Finding, run_trends_query_sync
 
 logger = structlog.get_logger(__name__)
 
@@ -86,18 +85,6 @@ def _evaluate_candidate(
     )
 
 
-@database_sync_to_async
-def _run_query_sync(team: Team, query_json: dict) -> Any:
-    from posthog.api.services.query import process_query_dict
-
-    response = process_query_dict(
-        team=team,
-        query_json=query_json,
-        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
-    )
-    return response.model_dump() if hasattr(response, "model_dump") else response
-
-
 async def _evaluate_one(
     team: Team,
     candidate: CandidateMetric,
@@ -108,7 +95,7 @@ async def _evaluate_one(
     async with semaphore:
         try:
             query = _build_detection_query(candidate.descriptor.query)
-            result = await _run_query_sync(team, query)
+            result = await run_trends_query_sync(team, query)
             series = _extract_weekly_series(result)
             return _evaluate_candidate(candidate, series, z_threshold, min_change_pct)
         except Exception as exc:

--- a/posthog/temporal/ai/pulse/detection.py
+++ b/posthog/temporal/ai/pulse/detection.py
@@ -1,0 +1,136 @@
+"""Z-score-based change detection for Pulse candidate metrics."""
+
+import asyncio
+import statistics
+from typing import Any
+
+import structlog
+
+from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.models import Team
+from posthog.sync import database_sync_to_async
+from posthog.temporal.ai.pulse.types import CandidateMetric, Finding
+
+logger = structlog.get_logger(__name__)
+
+
+DETECTION_DATE_FROM = "-42d"  # 6 weeks: 1 current + 5 baseline
+DETECTION_CONCURRENCY = 8
+MIN_BASELINE_WEEKS = 3
+MIN_BASELINE_VALUE = 5.0  # Skip near-zero-volume metrics that produce noisy z-scores
+
+
+def _build_detection_query(base_query: dict) -> dict:
+    query = {**base_query}
+    query["dateRange"] = {"date_from": DETECTION_DATE_FROM, "date_to": None}
+    query["interval"] = "week"
+    # Strip breakdowns for the initial detection scan — we want the headline metric.
+    if "breakdownFilter" in query:
+        query["breakdownFilter"] = None
+    return query
+
+
+def _extract_weekly_series(result: Any) -> list[float]:
+    if not isinstance(result, dict):
+        return []
+    results = result.get("results") or []
+    if not results:
+        return []
+    first_series = results[0]
+    if not isinstance(first_series, dict):
+        return []
+    data = first_series.get("data") or []
+    return [float(v) for v in data if isinstance(v, int | float) and not isinstance(v, bool)]
+
+
+def _compute_z_score(current: float, baseline: list[float]) -> tuple[float, float]:
+    """Return (z_score, baseline_mean). Falls back to 0.0 if baseline has zero variance."""
+    if len(baseline) < 2:
+        return 0.0, 0.0
+    mean = statistics.mean(baseline)
+    stddev = statistics.stdev(baseline)
+    if stddev == 0:
+        return 0.0, mean
+    return (current - mean) / stddev, mean
+
+
+def _evaluate_candidate(
+    candidate: CandidateMetric, weekly_values: list[float], z_threshold: float, min_change_pct: float
+) -> Finding | None:
+    # We need at least the in-progress current week + MIN_BASELINE_WEEKS completed baseline weeks
+    if len(weekly_values) < MIN_BASELINE_WEEKS + 2:
+        return None
+
+    # Drop the in-progress current week (last bucket) since trend buckets are partial.
+    completed = weekly_values[:-1]
+    current = completed[-1]
+    baseline = completed[:-1][-4:]
+    if len(baseline) < MIN_BASELINE_WEEKS:
+        return None
+
+    z_score, baseline_mean = _compute_z_score(current, baseline)
+    if baseline_mean < MIN_BASELINE_VALUE:
+        # Too low-volume — z-scores and percentage changes are unreliable.
+        return None
+
+    change_pct = (current - baseline_mean) / baseline_mean
+    if abs(z_score) < z_threshold and abs(change_pct) < min_change_pct:
+        return None
+
+    return Finding(
+        descriptor=candidate.descriptor,
+        current_value=current,
+        baseline_value=baseline_mean,
+        change_pct=change_pct,
+        z_score=z_score,
+    )
+
+
+@database_sync_to_async
+def _run_query_sync(team: Team, query_json: dict) -> Any:
+    from posthog.api.services.query import process_query_dict
+
+    response = process_query_dict(
+        team=team,
+        query_json=query_json,
+        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+    )
+    return response.model_dump() if hasattr(response, "model_dump") else response
+
+
+async def _evaluate_one(
+    team: Team,
+    candidate: CandidateMetric,
+    z_threshold: float,
+    min_change_pct: float,
+    semaphore: asyncio.Semaphore,
+) -> Finding | None:
+    async with semaphore:
+        try:
+            query = _build_detection_query(candidate.descriptor.query)
+            result = await _run_query_sync(team, query)
+            series = _extract_weekly_series(result)
+            return _evaluate_candidate(candidate, series, z_threshold, min_change_pct)
+        except Exception as exc:
+            logger.exception(
+                "pulse_detection_candidate_failed",
+                team_id=team.id,
+                metric=candidate.descriptor.label,
+                error=str(exc),
+            )
+            return None
+
+
+async def detect_changes(
+    team_id: int, candidates: list[CandidateMetric], z_threshold: float, min_change_pct: float
+) -> list[Finding]:
+    @database_sync_to_async
+    def _get_team() -> Team:
+        return Team.objects.get(id=team_id)
+
+    team = await _get_team()
+    semaphore = asyncio.Semaphore(DETECTION_CONCURRENCY)
+    results = await asyncio.gather(
+        *[_evaluate_one(team, c, z_threshold, min_change_pct, semaphore) for c in candidates]
+    )
+    return [f for f in results if f is not None]

--- a/posthog/temporal/ai/pulse/dispatcher.py
+++ b/posthog/temporal/ai/pulse/dispatcher.py
@@ -1,0 +1,83 @@
+"""Dispatcher workflow — spawns one PulseScanWorkflow per opted-in team."""
+
+import json
+import asyncio
+from datetime import timedelta
+
+import structlog
+import temporalio.common
+import temporalio.activity
+import temporalio.workflow
+from pydantic import BaseModel
+
+from posthog.sync import database_sync_to_async
+from posthog.temporal.ai.pulse.workflow import PulseScanInputs, PulseScanWorkflow
+from posthog.temporal.common.base import PostHogWorkflow
+
+logger = structlog.get_logger(__name__)
+
+# Max child PulseScans running concurrently across all teams.
+DISPATCHER_CONCURRENCY = 10
+
+
+class PulseScanDispatcherInputs(BaseModel):
+    frequency: str = "weekly"  # "weekly" or "daily"
+    # Restrict to specific team IDs (debugging / testing). Empty means all opted-in teams.
+    team_ids: list[int] | None = None
+
+
+@temporalio.activity.defn
+async def list_eligible_team_ids_activity(frequency: str, team_ids: list[int] | None) -> list[int]:
+    from posthog.models.pulse import PulseSubscription
+
+    @database_sync_to_async
+    def _list() -> list[int]:
+        qs = PulseSubscription.objects.filter(enabled=True, frequency=frequency)
+        if team_ids:
+            qs = qs.filter(team_id__in=team_ids)
+        return list(qs.values_list("team_id", flat=True))
+
+    return await _list()
+
+
+@temporalio.workflow.defn(name="pulse-scan-dispatcher")
+class PulseScanDispatcherWorkflow(PostHogWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> PulseScanDispatcherInputs:
+        loaded = json.loads(inputs[0]) if inputs else {}
+        return PulseScanDispatcherInputs.model_validate(loaded)
+
+    @temporalio.workflow.run
+    async def run(self, inputs: PulseScanDispatcherInputs) -> dict:
+        team_ids = await temporalio.workflow.execute_activity(
+            list_eligible_team_ids_activity,
+            args=[inputs.frequency, inputs.team_ids],
+            start_to_close_timeout=timedelta(seconds=60),
+            retry_policy=temporalio.common.RetryPolicy(maximum_attempts=3),
+        )
+
+        if not team_ids:
+            return {"dispatched": 0}
+
+        semaphore = asyncio.Semaphore(DISPATCHER_CONCURRENCY)
+
+        async def _dispatch_one(team_id: int) -> bool:
+            async with semaphore:
+                try:
+                    await temporalio.workflow.execute_child_workflow(
+                        PulseScanWorkflow.run,
+                        PulseScanInputs(team_id=team_id),
+                        id=f"pulse-scan-{team_id}-{temporalio.workflow.now().isoformat()}",
+                        task_queue=temporalio.workflow.info().task_queue,
+                        retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
+                        execution_timeout=timedelta(minutes=45),
+                    )
+                    return True
+                except Exception as exc:
+                    temporalio.workflow.logger.exception(
+                        "pulse_dispatch_child_failed", team_id=team_id, error=str(exc)
+                    )
+                    return False
+
+        results = await asyncio.gather(*[_dispatch_one(tid) for tid in team_ids], return_exceptions=False)
+        return {"dispatched": sum(1 for ok in results if ok), "total_eligible": len(team_ids)}

--- a/posthog/temporal/ai/pulse/dispatcher.py
+++ b/posthog/temporal/ai/pulse/dispatcher.py
@@ -5,11 +5,10 @@ import asyncio
 from datetime import timedelta
 
 import structlog
-import temporalio.common
-import temporalio.activity
-import temporalio.workflow
 from pydantic import BaseModel
+from temporalio import activity, common, workflow
 
+from posthog.models.pulse import PulseSubscriptionFrequency
 from posthog.sync import database_sync_to_async
 from posthog.temporal.ai.pulse.workflow import PulseScanInputs, PulseScanWorkflow
 from posthog.temporal.common.base import PostHogWorkflow
@@ -21,12 +20,12 @@ DISPATCHER_CONCURRENCY = 10
 
 
 class PulseScanDispatcherInputs(BaseModel):
-    frequency: str = "weekly"  # "weekly" or "daily"
+    frequency: PulseSubscriptionFrequency = PulseSubscriptionFrequency.WEEKLY
     # Restrict to specific team IDs (debugging / testing). Empty means all opted-in teams.
     team_ids: list[int] | None = None
 
 
-@temporalio.activity.defn
+@activity.defn
 async def list_eligible_team_ids_activity(frequency: str, team_ids: list[int] | None) -> list[int]:
     from posthog.models.pulse import PulseSubscription
 
@@ -40,20 +39,20 @@ async def list_eligible_team_ids_activity(frequency: str, team_ids: list[int] | 
     return await _list()
 
 
-@temporalio.workflow.defn(name="pulse-scan-dispatcher")
+@workflow.defn(name="pulse-scan-dispatcher")
 class PulseScanDispatcherWorkflow(PostHogWorkflow):
     @staticmethod
     def parse_inputs(inputs: list[str]) -> PulseScanDispatcherInputs:
         loaded = json.loads(inputs[0]) if inputs else {}
         return PulseScanDispatcherInputs.model_validate(loaded)
 
-    @temporalio.workflow.run
+    @workflow.run
     async def run(self, inputs: PulseScanDispatcherInputs) -> dict:
-        team_ids = await temporalio.workflow.execute_activity(
+        team_ids = await workflow.execute_activity(
             list_eligible_team_ids_activity,
             args=[inputs.frequency, inputs.team_ids],
             start_to_close_timeout=timedelta(seconds=60),
-            retry_policy=temporalio.common.RetryPolicy(maximum_attempts=3),
+            retry_policy=common.RetryPolicy(maximum_attempts=3),
         )
 
         if not team_ids:
@@ -64,19 +63,17 @@ class PulseScanDispatcherWorkflow(PostHogWorkflow):
         async def _dispatch_one(team_id: int) -> bool:
             async with semaphore:
                 try:
-                    await temporalio.workflow.execute_child_workflow(
+                    await workflow.execute_child_workflow(
                         PulseScanWorkflow.run,
                         PulseScanInputs(team_id=team_id),
-                        id=f"pulse-scan-{team_id}-{temporalio.workflow.now().isoformat()}",
-                        task_queue=temporalio.workflow.info().task_queue,
-                        retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
+                        id=f"pulse-scan-{team_id}-{workflow.now().isoformat()}",
+                        task_queue=workflow.info().task_queue,
+                        retry_policy=common.RetryPolicy(maximum_attempts=1),
                         execution_timeout=timedelta(minutes=45),
                     )
                     return True
                 except Exception as exc:
-                    temporalio.workflow.logger.exception(
-                        "pulse_dispatch_child_failed", team_id=team_id, error=str(exc)
-                    )
+                    workflow.logger.exception("pulse_dispatch_child_failed", team_id=team_id, error=str(exc))
                     return False
 
         results = await asyncio.gather(*[_dispatch_one(tid) for tid in team_ids], return_exceptions=False)

--- a/posthog/temporal/ai/pulse/narrative.py
+++ b/posthog/temporal/ai/pulse/narrative.py
@@ -6,10 +6,9 @@ from typing import Any
 
 import structlog
 
-from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
-from posthog.temporal.ai.pulse.types import EnrichedFinding, Finding
+from posthog.temporal.ai.pulse.types import EnrichedFinding, Finding, run_trends_query_sync
 
 logger = structlog.get_logger(__name__)
 
@@ -69,25 +68,13 @@ def _pick_top_contributor(result: Any) -> tuple[str, float, float] | None:
     return best
 
 
-@database_sync_to_async
-def _run_query_sync(team: Team, query_json: dict) -> Any:
-    from posthog.api.services.query import process_query_dict
-
-    response = process_query_dict(
-        team=team,
-        query_json=query_json,
-        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
-    )
-    return response.model_dump() if hasattr(response, "model_dump") else response
-
-
-async def _attribute_finding(team: Team, finding: Finding) -> dict[str, Any] | None:
-    semaphore = asyncio.Semaphore(ATTRIBUTION_CONCURRENCY)
-
+async def _attribute_finding(
+    team: Team, finding: Finding, attribution_semaphore: asyncio.Semaphore
+) -> dict[str, Any] | None:
     async def _try_property(prop: str) -> tuple[str, dict[str, Any]] | None:
-        async with semaphore:
+        async with attribution_semaphore:
             try:
-                result = await _run_query_sync(team, _build_breakdown_query(finding.descriptor.query, prop))
+                result = await run_trends_query_sync(team, _build_breakdown_query(finding.descriptor.query, prop))
             except Exception as exc:
                 logger.exception(
                     "pulse_attribution_breakdown_failed",
@@ -160,11 +147,14 @@ def _fallback_narrative(finding: Finding) -> str:
 
 
 async def _enrich_one(
-    team: Team, finding: Finding, semaphore: asyncio.Semaphore
+    team: Team,
+    finding: Finding,
+    enrichment_semaphore: asyncio.Semaphore,
+    attribution_semaphore: asyncio.Semaphore,
 ) -> EnrichedFinding:
-    async with semaphore:
+    async with enrichment_semaphore:
         try:
-            attribution = await _attribute_finding(team, finding)
+            attribution = await _attribute_finding(team, finding, attribution_semaphore)
             narrative = await _generate_narrative(team.id, finding, attribution)
             return EnrichedFinding(
                 descriptor=finding.descriptor,
@@ -201,5 +191,10 @@ async def enrich_findings(team_id: int, findings: list[Finding], max_findings: i
         return Team.objects.get(id=team_id)
 
     team = await _get_team()
-    semaphore = asyncio.Semaphore(ENRICHMENT_CONCURRENCY)
-    return list(await asyncio.gather(*[_enrich_one(team, f, semaphore) for f in ranked]))
+    enrichment_semaphore = asyncio.Semaphore(ENRICHMENT_CONCURRENCY)
+    attribution_semaphore = asyncio.Semaphore(ATTRIBUTION_CONCURRENCY)
+    return list(
+        await asyncio.gather(
+            *[_enrich_one(team, f, enrichment_semaphore, attribution_semaphore) for f in ranked]
+        )
+    )

--- a/posthog/temporal/ai/pulse/narrative.py
+++ b/posthog/temporal/ai/pulse/narrative.py
@@ -1,0 +1,205 @@
+"""LLM narrative enrichment for Pulse findings."""
+
+import json
+import asyncio
+from typing import Any
+
+import structlog
+
+from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.models import Team
+from posthog.sync import database_sync_to_async
+from posthog.temporal.ai.pulse.types import EnrichedFinding, Finding
+
+logger = structlog.get_logger(__name__)
+
+
+ATTRIBUTION_PROPERTY_CANDIDATES = [
+    "$browser",
+    "$os",
+    "$device_type",
+    "$geoip_country_name",
+    "$referring_domain",
+]
+
+ENRICHMENT_CONCURRENCY = 5
+ATTRIBUTION_CONCURRENCY = 5
+
+NARRATIVE_SYSTEM_PROMPT = """You are PostHog Pulse, summarizing one metric change for a product team in 1-2 short sentences.
+
+Rules:
+- Lead with what changed and by how much, using a percentage. Example: "$pageview is down 22% this week (3,400 vs 4,350 baseline)."
+- If an attribution breakdown is provided, say which segment drove the change in plain English.
+- Stay factual. No speculation about causes or recommendations.
+- Plain English. No jargon, no emoji, no markdown.
+- Maximum 2 sentences total.
+""".strip()
+
+
+def _build_breakdown_query(base_query: dict, breakdown_property: str) -> dict:
+    query = json.loads(json.dumps(base_query))  # deep copy
+    query["dateRange"] = {"date_from": "-14d", "date_to": None}
+    query["interval"] = "week"
+    query["breakdownFilter"] = {"breakdown": breakdown_property, "breakdown_type": "event"}
+    return query
+
+
+def _pick_top_contributor(result: Any) -> tuple[str, float, float] | None:
+    """Find the breakdown value with the largest week-over-week delta."""
+    if not isinstance(result, dict):
+        return None
+    series = result.get("results") or []
+    best: tuple[str, float, float] | None = None
+    best_delta = 0.0
+    for s in series:
+        if not isinstance(s, dict):
+            continue
+        data = s.get("data") or []
+        if len(data) < 2:
+            continue
+        try:
+            current = float(data[-1])
+            prior = float(data[-2])
+        except (TypeError, ValueError):
+            continue
+        delta = abs(current - prior)
+        if delta > best_delta:
+            best_delta = delta
+            best = (str(s.get("breakdown_value") or s.get("label") or "unknown"), current, prior)
+    return best
+
+
+@database_sync_to_async
+def _run_query_sync(team: Team, query_json: dict) -> Any:
+    from posthog.api.services.query import process_query_dict
+
+    response = process_query_dict(
+        team=team,
+        query_json=query_json,
+        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+    )
+    return response.model_dump() if hasattr(response, "model_dump") else response
+
+
+async def _attribute_finding(team: Team, finding: Finding) -> dict[str, Any] | None:
+    semaphore = asyncio.Semaphore(ATTRIBUTION_CONCURRENCY)
+
+    async def _try_property(prop: str) -> tuple[str, dict[str, Any]] | None:
+        async with semaphore:
+            try:
+                result = await _run_query_sync(team, _build_breakdown_query(finding.descriptor.query, prop))
+            except Exception as exc:
+                logger.exception(
+                    "pulse_attribution_breakdown_failed",
+                    team_id=team.id,
+                    metric=finding.descriptor.label,
+                    property=prop,
+                    error=str(exc),
+                )
+                return None
+            top = _pick_top_contributor(result)
+            if top is None:
+                return None
+            value, current, prior = top
+            return prop, {
+                "property": prop,
+                "value": value,
+                "current": current,
+                "baseline": prior,
+                "_contribution": abs(current - prior),
+            }
+
+    results = await asyncio.gather(*[_try_property(p) for p in ATTRIBUTION_PROPERTY_CANDIDATES])
+    best = max(
+        (r[1] for r in results if r is not None),
+        key=lambda d: d["_contribution"],
+        default=None,
+    )
+    if best is None:
+        return None
+    best.pop("_contribution", None)
+    return best
+
+
+async def _generate_narrative(team_id: int, finding: Finding, attribution: dict[str, Any] | None) -> str:
+    # Lazy-import langchain so non-Pulse Temporal workers don't pay the startup cost.
+    from langchain_core.messages import HumanMessage, SystemMessage
+    from langchain_core.output_parsers import StrOutputParser
+    from langchain_openai import ChatOpenAI
+    from posthoganalytics import default_client
+    from posthoganalytics.ai.langchain import CallbackHandler
+
+    facts = {
+        "metric": finding.descriptor.label,
+        "current_value": round(finding.current_value, 2),
+        "baseline_value": round(finding.baseline_value, 2),
+        "change_pct": round(finding.change_pct, 3),
+        "z_score": round(finding.z_score, 2),
+        "attribution": attribution,
+    }
+
+    callback_handler = CallbackHandler(
+        default_client,
+        properties={"domain": "pulse", "team_id": team_id},
+    )
+    chain = ChatOpenAI(model="gpt-4.1-mini", temperature=0.2, streaming=False, max_retries=3) | StrOutputParser()
+    messages = [
+        SystemMessage(content=NARRATIVE_SYSTEM_PROMPT),
+        HumanMessage(content=f"Finding facts:\n{json.dumps(facts, default=str)}"),
+    ]
+    result = await chain.ainvoke(messages, config={"callbacks": [callback_handler]})
+    return result.strip()
+
+
+def _fallback_narrative(finding: Finding) -> str:
+    direction = "up" if finding.change_pct > 0 else "down"
+    return (
+        f"{finding.descriptor.label} is {direction} {abs(finding.change_pct):.0%} this week "
+        f"({finding.current_value:.0f} vs {finding.baseline_value:.0f} baseline)."
+    )
+
+
+async def _enrich_one(
+    team: Team, finding: Finding, semaphore: asyncio.Semaphore
+) -> EnrichedFinding:
+    async with semaphore:
+        try:
+            attribution = await _attribute_finding(team, finding)
+            narrative = await _generate_narrative(team.id, finding, attribution)
+            return EnrichedFinding(
+                descriptor=finding.descriptor,
+                current_value=finding.current_value,
+                baseline_value=finding.baseline_value,
+                change_pct=finding.change_pct,
+                z_score=finding.z_score,
+                attribution_breakdown=attribution,
+                narrative=narrative,
+            )
+        except Exception as exc:
+            logger.exception(
+                "pulse_enrich_finding_failed",
+                team_id=team.id,
+                metric=finding.descriptor.label,
+                error=str(exc),
+            )
+            return EnrichedFinding(
+                descriptor=finding.descriptor,
+                current_value=finding.current_value,
+                baseline_value=finding.baseline_value,
+                change_pct=finding.change_pct,
+                z_score=finding.z_score,
+                attribution_breakdown=None,
+                narrative=_fallback_narrative(finding),
+            )
+
+
+async def enrich_findings(team_id: int, findings: list[Finding], max_findings: int) -> list[EnrichedFinding]:
+    ranked = sorted(findings, key=lambda f: abs(f.z_score), reverse=True)[:max_findings]
+
+    @database_sync_to_async
+    def _get_team() -> Team:
+        return Team.objects.get(id=team_id)
+
+    team = await _get_team()
+    semaphore = asyncio.Semaphore(ENRICHMENT_CONCURRENCY)
+    return list(await asyncio.gather(*[_enrich_one(team, f, semaphore) for f in ranked]))

--- a/posthog/temporal/ai/pulse/selection.py
+++ b/posthog/temporal/ai/pulse/selection.py
@@ -1,0 +1,145 @@
+"""Pure-SQL candidate metric selection for Pulse.
+
+v1 strategy: top-N popular insights and high-volume events. No LLM.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from django.db.models import Count, Q
+
+from posthog.models import Dashboard, DashboardTile, Insight, InsightViewed, Team
+from posthog.sync import database_sync_to_async
+from posthog.temporal.ai.pulse.types import CandidateMetric, MetricDescriptor
+
+RECENT_DAYS = 30
+MIN_VIEWERS_FOR_RECENT_INSIGHT = 3
+TOP_DASHBOARD_LIMIT = 5
+TOP_EVENT_LIMIT = 10
+
+
+def _trends_query_from_insight(insight: Insight) -> dict | None:
+    """Extract a re-executable TrendsQuery from a saved Insight, or None if unsupported."""
+    query = insight.query
+    if not query:
+        return None
+    while isinstance(query, dict) and query.get("source"):
+        query = query["source"]
+    if not isinstance(query, dict) or query.get("kind") != "TrendsQuery":
+        return None
+    return query
+
+
+def _build_event_volume_query(event_name: str) -> dict:
+    return {
+        "kind": "TrendsQuery",
+        "series": [
+            {"kind": "EventsNode", "event": event_name, "name": event_name, "math": "total"}
+        ],
+        "dateRange": {"date_from": "-30d", "date_to": None},
+        "interval": "day",
+    }
+
+
+def _insight_to_candidate(insight: Insight, source: str) -> CandidateMetric | None:
+    query = _trends_query_from_insight(insight)
+    if not query:
+        return None
+    return CandidateMetric(
+        descriptor=MetricDescriptor(
+            source=source,
+            source_id=insight.id,
+            label=insight.name or insight.derived_name or f"Insight {insight.short_id}",
+            query=query,
+        )
+    )
+
+
+def _select_dashboard_tile_candidates(team: Team, limit: int) -> list[CandidateMetric]:
+    """Pick Trends insights on the team's most-pinned/visible dashboards."""
+    dashboards = (
+        Dashboard.objects.filter(team=team, deleted=False)
+        .filter(Q(pinned=True) | Q(last_accessed_at__gte=datetime.now(UTC) - timedelta(days=RECENT_DAYS)))
+        .order_by("-pinned", "-last_accessed_at")[:limit]
+    )
+    tiles = (
+        DashboardTile.objects.filter(dashboard__in=dashboards, deleted=False, insight__isnull=False)
+        .select_related("insight")
+        .order_by("dashboard_id", "id")
+    )
+    candidates: list[CandidateMetric] = []
+    seen_insight_ids: set[int] = set()
+    for tile in tiles:
+        insight = tile.insight
+        if insight is None or insight.id in seen_insight_ids:
+            continue
+        seen_insight_ids.add(insight.id)
+        candidate = _insight_to_candidate(insight, source="dashboard_tile")
+        if candidate:
+            candidates.append(candidate)
+    return candidates
+
+
+def _select_recent_viewed_insight_candidates(
+    team: Team, limit: int, existing_ids: set[int]
+) -> list[CandidateMetric]:
+    """Pick Trends insights recently viewed by multiple team members."""
+    since = datetime.now(UTC) - timedelta(days=RECENT_DAYS)
+    viewed = (
+        InsightViewed.objects.filter(team=team, last_viewed_at__gte=since)
+        .values("insight_id")
+        .annotate(viewer_count=Count("user_id", distinct=True))
+        .filter(viewer_count__gte=MIN_VIEWERS_FOR_RECENT_INSIGHT)
+        .order_by("-viewer_count")
+    )
+    insight_ids = [v["insight_id"] for v in viewed if v["insight_id"] not in existing_ids]
+    insights = Insight.objects.filter(id__in=insight_ids, deleted=False)
+
+    candidates: list[CandidateMetric] = []
+    for insight in insights:
+        candidate = _insight_to_candidate(insight, source="recent_insight")
+        if candidate:
+            candidates.append(candidate)
+            if len(candidates) >= limit:
+                break
+    return candidates
+
+
+def _select_top_event_candidates(team: Team, limit: int) -> list[CandidateMetric]:
+    """Pick the team's highest-volume events as candidate metrics."""
+    from posthog.models import EventDefinition
+
+    base_qs = EventDefinition.objects.filter(team=team).exclude(name__startswith="$")
+    # Prefer events with computed 30-day usage stats.
+    events = list(
+        base_qs.exclude(query_usage_30_day__isnull=True).order_by("-query_usage_30_day")[:limit]
+    )
+    if len(events) < limit:
+        seen = {e.id for e in events}
+        backfill = base_qs.exclude(id__in=seen).order_by("-last_seen_at")[: limit - len(events)]
+        events.extend(backfill)
+
+    return [
+        CandidateMetric(
+            descriptor=MetricDescriptor(
+                source="top_event",
+                source_id=event.id,
+                label=event.name,
+                query=_build_event_volume_query(event.name),
+            )
+        )
+        for event in events
+    ]
+
+
+@database_sync_to_async
+def _select_sync(team_id: int, max_candidates: int) -> list[CandidateMetric]:
+    team = Team.objects.get(id=team_id)
+    candidates = _select_dashboard_tile_candidates(team, TOP_DASHBOARD_LIMIT)
+    seen_ids = {c.descriptor.source_id for c in candidates if isinstance(c.descriptor.source_id, int)}
+    candidates.extend(_select_recent_viewed_insight_candidates(team, max_candidates // 2, seen_ids))
+    candidates.extend(_select_top_event_candidates(team, TOP_EVENT_LIMIT))
+    return candidates[:max_candidates]
+
+
+async def select_candidates(team_id: int, max_candidates: int) -> list[CandidateMetric]:
+    return await _select_sync(team_id, max_candidates)

--- a/posthog/temporal/ai/pulse/types.py
+++ b/posthog/temporal/ai/pulse/types.py
@@ -2,6 +2,26 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.models import Team
+from posthog.sync import database_sync_to_async
+
+
+@database_sync_to_async
+def run_trends_query_sync(team: Team, query_json: dict) -> Any:
+    """Execute an opaque TrendsQuery against ClickHouse and return the result dict.
+
+    Shared by detection (headline metric) and narrative (breakdown attribution).
+    """
+    from posthog.api.services.query import process_query_dict
+
+    response = process_query_dict(
+        team=team,
+        query_json=query_json,
+        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+    )
+    return response.model_dump() if hasattr(response, "model_dump") else response
+
 
 class MetricDescriptor(BaseModel):
     """Opaque descriptor of a metric Pulse can re-evaluate.

--- a/posthog/temporal/ai/pulse/types.py
+++ b/posthog/temporal/ai/pulse/types.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class MetricDescriptor(BaseModel):
+    """Opaque descriptor of a metric Pulse can re-evaluate.
+
+    `source` traces where the candidate came from (for debugging).
+    `query` is a TrendsQuery-shaped dict, executable against the existing query runner.
+    """
+
+    source: str  # "dashboard_tile" | "recent_insight" | "top_event"
+    source_id: str | int | None = None
+    label: str
+    query: dict[str, Any]
+
+
+class CandidateMetric(BaseModel):
+    descriptor: MetricDescriptor
+
+
+class Finding(BaseModel):
+    descriptor: MetricDescriptor
+    current_value: float
+    baseline_value: float
+    change_pct: float
+    z_score: float
+
+
+class EnrichedFinding(BaseModel):
+    descriptor: MetricDescriptor
+    current_value: float
+    baseline_value: float
+    change_pct: float
+    z_score: float
+    attribution_breakdown: dict[str, Any] | None = None
+    narrative: str
+
+
+class SelectCandidatesInputs(BaseModel):
+    team_id: int
+    max_candidates: int = 50
+
+
+class DetectChangesInputs(BaseModel):
+    team_id: int
+    candidates: list[CandidateMetric]
+    z_threshold: float = 2.0
+    min_change_pct: float = 0.25
+
+
+class EnrichFindingsInputs(BaseModel):
+    team_id: int
+    findings: list[Finding]
+    max_findings: int = 5
+
+
+class DeliverDigestInputs(BaseModel):
+    team_id: int
+    digest_id: str
+    findings: list[EnrichedFinding]

--- a/posthog/temporal/ai/pulse/workflow.py
+++ b/posthog/temporal/ai/pulse/workflow.py
@@ -1,0 +1,203 @@
+"""PulseScanWorkflow — orchestrates proactive insight scans for one team."""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import structlog
+import temporalio.common
+import temporalio.activity
+import temporalio.workflow
+from pydantic import BaseModel
+
+from posthog.sync import database_sync_to_async
+from posthog.temporal.ai.pulse.delivery import deliver_digest
+from posthog.temporal.ai.pulse.detection import detect_changes
+from posthog.temporal.ai.pulse.narrative import enrich_findings
+from posthog.temporal.ai.pulse.selection import select_candidates
+from posthog.temporal.ai.pulse.types import (
+    CandidateMetric,
+    DeliverDigestInputs,
+    DetectChangesInputs,
+    EnrichedFinding,
+    EnrichFindingsInputs,
+    Finding,
+    SelectCandidatesInputs,
+)
+from posthog.temporal.common.base import PostHogWorkflow
+
+logger = structlog.get_logger(__name__)
+
+
+class PulseScanInputs(BaseModel):
+    team_id: int
+    digest_id: str | None = None
+    max_candidates: int = 50
+    z_threshold: float = 2.0
+    min_change_pct: float = 0.25
+    max_findings: int = 5
+
+
+@temporalio.activity.defn
+async def select_candidate_metrics_activity(inputs: SelectCandidatesInputs) -> list[CandidateMetric]:
+    return await select_candidates(team_id=inputs.team_id, max_candidates=inputs.max_candidates)
+
+
+@temporalio.activity.defn
+async def detect_changes_activity(inputs: DetectChangesInputs) -> list[Finding]:
+    return await detect_changes(
+        team_id=inputs.team_id,
+        candidates=inputs.candidates,
+        z_threshold=inputs.z_threshold,
+        min_change_pct=inputs.min_change_pct,
+    )
+
+
+@temporalio.activity.defn
+async def enrich_findings_activity(inputs: EnrichFindingsInputs) -> list[EnrichedFinding]:
+    return await enrich_findings(
+        team_id=inputs.team_id,
+        findings=inputs.findings,
+        max_findings=inputs.max_findings,
+    )
+
+
+@temporalio.activity.defn
+async def deliver_digest_activity(inputs: DeliverDigestInputs) -> list[str]:
+    return await deliver_digest(
+        team_id=inputs.team_id,
+        digest_id=inputs.digest_id,
+        findings=inputs.findings,
+    )
+
+
+@temporalio.activity.defn
+async def create_or_get_digest_activity(team_id: int, digest_id: str | None) -> str:
+    """Create a new PulseDigest row for this scan, or reuse the provided one."""
+    from posthog.models import PulseDigest
+    from posthog.models.pulse import PulseDigestStatus
+
+    @database_sync_to_async
+    def _create() -> str:
+        if digest_id:
+            existing = PulseDigest.objects.filter(id=digest_id, team_id=team_id).first()
+            if existing:
+                return str(existing.id)
+        now = datetime.now(UTC)
+        digest = PulseDigest.objects.create(
+            team_id=team_id,
+            period_start=now - timedelta(days=7),
+            period_end=now,
+            status=PulseDigestStatus.GENERATING,
+        )
+        return str(digest.id)
+
+    return await _create()
+
+
+@temporalio.activity.defn
+async def set_digest_status_activity(digest_id: str, status: str, error: str | None = None) -> None:
+    from posthog.models import PulseDigest
+
+    @database_sync_to_async
+    def _set() -> None:
+        digest = PulseDigest.objects.filter(id=digest_id).first()
+        if not digest:
+            return
+        digest.status = status
+        update_fields = ["status"]
+        if error is not None:
+            digest.error = {"message": error[:1000]}
+            update_fields.append("error")
+        digest.save(update_fields=update_fields)
+
+    await _set()
+
+
+@temporalio.workflow.defn(name="pulse-scan")
+class PulseScanWorkflow(PostHogWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> PulseScanInputs:
+        loaded = json.loads(inputs[0]) if inputs else {}
+        return PulseScanInputs.model_validate(loaded)
+
+    @temporalio.workflow.run
+    async def run(self, inputs: PulseScanInputs) -> dict:
+        from posthog.models.pulse import PulseDigestStatus
+
+        retry_policy = temporalio.common.RetryPolicy(
+            initial_interval=timedelta(seconds=10),
+            maximum_attempts=2,
+        )
+
+        digest_id = await temporalio.workflow.execute_activity(
+            create_or_get_digest_activity,
+            args=[inputs.team_id, inputs.digest_id],
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=retry_policy,
+        )
+
+        try:
+            candidates = await temporalio.workflow.execute_activity(
+                select_candidate_metrics_activity,
+                SelectCandidatesInputs(
+                    team_id=inputs.team_id,
+                    max_candidates=inputs.max_candidates,
+                ),
+                start_to_close_timeout=timedelta(minutes=2),
+                retry_policy=retry_policy,
+            )
+
+            findings = await temporalio.workflow.execute_activity(
+                detect_changes_activity,
+                DetectChangesInputs(
+                    team_id=inputs.team_id,
+                    candidates=candidates,
+                    z_threshold=inputs.z_threshold,
+                    min_change_pct=inputs.min_change_pct,
+                ),
+                start_to_close_timeout=timedelta(minutes=15),
+                heartbeat_timeout=timedelta(minutes=2),
+                retry_policy=retry_policy,
+            )
+
+            if not findings:
+                await temporalio.workflow.execute_activity(
+                    set_digest_status_activity,
+                    args=[digest_id, PulseDigestStatus.DELIVERED.value],
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=retry_policy,
+                )
+                return {"digest_id": digest_id, "finding_count": 0}
+
+            enriched = await temporalio.workflow.execute_activity(
+                enrich_findings_activity,
+                EnrichFindingsInputs(
+                    team_id=inputs.team_id,
+                    findings=findings,
+                    max_findings=inputs.max_findings,
+                ),
+                start_to_close_timeout=timedelta(minutes=10),
+                heartbeat_timeout=timedelta(minutes=2),
+                retry_policy=retry_policy,
+            )
+
+            await temporalio.workflow.execute_activity(
+                deliver_digest_activity,
+                DeliverDigestInputs(
+                    team_id=inputs.team_id,
+                    digest_id=digest_id,
+                    findings=enriched,
+                ),
+                start_to_close_timeout=timedelta(minutes=2),
+                retry_policy=retry_policy,
+            )
+
+            return {"digest_id": digest_id, "finding_count": len(enriched)}
+        except Exception as exc:
+            await temporalio.workflow.execute_activity(
+                set_digest_status_activity,
+                args=[digest_id, PulseDigestStatus.FAILED.value, str(exc)],
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
+            )
+            raise

--- a/posthog/temporal/ai/pulse/workflow.py
+++ b/posthog/temporal/ai/pulse/workflow.py
@@ -4,10 +4,8 @@ import json
 from datetime import UTC, datetime, timedelta
 
 import structlog
-import temporalio.common
-import temporalio.activity
-import temporalio.workflow
 from pydantic import BaseModel
+from temporalio import activity, common, workflow
 
 from posthog.sync import database_sync_to_async
 from posthog.temporal.ai.pulse.delivery import deliver_digest
@@ -37,12 +35,12 @@ class PulseScanInputs(BaseModel):
     max_findings: int = 5
 
 
-@temporalio.activity.defn
+@activity.defn
 async def select_candidate_metrics_activity(inputs: SelectCandidatesInputs) -> list[CandidateMetric]:
     return await select_candidates(team_id=inputs.team_id, max_candidates=inputs.max_candidates)
 
 
-@temporalio.activity.defn
+@activity.defn
 async def detect_changes_activity(inputs: DetectChangesInputs) -> list[Finding]:
     return await detect_changes(
         team_id=inputs.team_id,
@@ -52,7 +50,7 @@ async def detect_changes_activity(inputs: DetectChangesInputs) -> list[Finding]:
     )
 
 
-@temporalio.activity.defn
+@activity.defn
 async def enrich_findings_activity(inputs: EnrichFindingsInputs) -> list[EnrichedFinding]:
     return await enrich_findings(
         team_id=inputs.team_id,
@@ -61,7 +59,7 @@ async def enrich_findings_activity(inputs: EnrichFindingsInputs) -> list[Enriche
     )
 
 
-@temporalio.activity.defn
+@activity.defn
 async def deliver_digest_activity(inputs: DeliverDigestInputs) -> list[str]:
     return await deliver_digest(
         team_id=inputs.team_id,
@@ -70,7 +68,7 @@ async def deliver_digest_activity(inputs: DeliverDigestInputs) -> list[str]:
     )
 
 
-@temporalio.activity.defn
+@activity.defn
 async def create_or_get_digest_activity(team_id: int, digest_id: str | None) -> str:
     """Create a new PulseDigest row for this scan, or reuse the provided one."""
     from posthog.models import PulseDigest
@@ -94,7 +92,7 @@ async def create_or_get_digest_activity(team_id: int, digest_id: str | None) -> 
     return await _create()
 
 
-@temporalio.activity.defn
+@activity.defn
 async def set_digest_status_activity(digest_id: str, status: str, error: str | None = None) -> None:
     from posthog.models import PulseDigest
 
@@ -113,23 +111,23 @@ async def set_digest_status_activity(digest_id: str, status: str, error: str | N
     await _set()
 
 
-@temporalio.workflow.defn(name="pulse-scan")
+@workflow.defn(name="pulse-scan")
 class PulseScanWorkflow(PostHogWorkflow):
     @staticmethod
     def parse_inputs(inputs: list[str]) -> PulseScanInputs:
         loaded = json.loads(inputs[0]) if inputs else {}
         return PulseScanInputs.model_validate(loaded)
 
-    @temporalio.workflow.run
+    @workflow.run
     async def run(self, inputs: PulseScanInputs) -> dict:
         from posthog.models.pulse import PulseDigestStatus
 
-        retry_policy = temporalio.common.RetryPolicy(
+        retry_policy = common.RetryPolicy(
             initial_interval=timedelta(seconds=10),
             maximum_attempts=2,
         )
 
-        digest_id = await temporalio.workflow.execute_activity(
+        digest_id = await workflow.execute_activity(
             create_or_get_digest_activity,
             args=[inputs.team_id, inputs.digest_id],
             start_to_close_timeout=timedelta(seconds=30),
@@ -137,7 +135,7 @@ class PulseScanWorkflow(PostHogWorkflow):
         )
 
         try:
-            candidates = await temporalio.workflow.execute_activity(
+            candidates = await workflow.execute_activity(
                 select_candidate_metrics_activity,
                 SelectCandidatesInputs(
                     team_id=inputs.team_id,
@@ -147,7 +145,7 @@ class PulseScanWorkflow(PostHogWorkflow):
                 retry_policy=retry_policy,
             )
 
-            findings = await temporalio.workflow.execute_activity(
+            findings = await workflow.execute_activity(
                 detect_changes_activity,
                 DetectChangesInputs(
                     team_id=inputs.team_id,
@@ -161,7 +159,7 @@ class PulseScanWorkflow(PostHogWorkflow):
             )
 
             if not findings:
-                await temporalio.workflow.execute_activity(
+                await workflow.execute_activity(
                     set_digest_status_activity,
                     args=[digest_id, PulseDigestStatus.DELIVERED.value],
                     start_to_close_timeout=timedelta(seconds=30),
@@ -169,7 +167,7 @@ class PulseScanWorkflow(PostHogWorkflow):
                 )
                 return {"digest_id": digest_id, "finding_count": 0}
 
-            enriched = await temporalio.workflow.execute_activity(
+            enriched = await workflow.execute_activity(
                 enrich_findings_activity,
                 EnrichFindingsInputs(
                     team_id=inputs.team_id,
@@ -181,7 +179,7 @@ class PulseScanWorkflow(PostHogWorkflow):
                 retry_policy=retry_policy,
             )
 
-            await temporalio.workflow.execute_activity(
+            await workflow.execute_activity(
                 deliver_digest_activity,
                 DeliverDigestInputs(
                     team_id=inputs.team_id,
@@ -194,10 +192,10 @@ class PulseScanWorkflow(PostHogWorkflow):
 
             return {"digest_id": digest_id, "finding_count": len(enriched)}
         except Exception as exc:
-            await temporalio.workflow.execute_activity(
+            await workflow.execute_activity(
                 set_digest_status_activity,
                 args=[digest_id, PulseDigestStatus.FAILED.value, str(exc)],
                 start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
+                retry_policy=common.RetryPolicy(maximum_attempts=1),
             )
             raise

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -22,6 +22,7 @@ from temporalio.client import (
 
 from posthog.hogql_queries.ai.vector_search_query_runner import LATEST_ACTIONS_EMBEDDING_VERSION
 from posthog.temporal.ai import SyncVectorsInputs
+from posthog.temporal.ai.pulse.dispatcher import PulseScanDispatcherInputs
 from posthog.temporal.ai.sync_vectors import EmbeddingVersion
 from posthog.temporal.alerts.schedule import (
     create_run_investigation_safety_net_schedule,
@@ -81,6 +82,44 @@ from products.web_analytics.backend.temporal.weekly_digest.types import WAWeekly
 from ee.billing.salesforce_enrichment.constants import DEFAULT_CHUNK_SIZE
 
 logger = structlog.get_logger(__name__)
+
+
+async def _create_pulse_schedule(client: Client, frequency: str) -> None:
+    """Create or update a Pulse scan dispatcher schedule (8 AM UTC).
+
+    For "weekly", runs Monday only. For "daily", runs every day.
+    """
+    schedule_id = f"pulse-{frequency}-schedule"
+    calendar_kwargs: dict = {
+        "comment": f"Pulse {frequency} at 8 AM UTC",
+        "hour": [ScheduleRange(start=8, end=8)],
+    }
+    if frequency == "weekly":
+        calendar_kwargs["day_of_week"] = [ScheduleRange(start=1, end=1)]
+
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            "pulse-scan-dispatcher",
+            PulseScanDispatcherInputs(frequency=frequency).model_dump(),
+            id=schedule_id,
+            task_queue=settings.MAX_AI_TASK_QUEUE,
+            retry_policy=common.RetryPolicy(maximum_attempts=1),
+        ),
+        spec=ScheduleSpec(calendars=[ScheduleCalendarSpec(**calendar_kwargs)]),
+    )
+
+    if await a_schedule_exists(client, schedule_id):
+        await a_update_schedule(client, schedule_id, schedule)
+    else:
+        await a_create_schedule(client, schedule_id, schedule, trigger_immediately=False)
+
+
+async def create_pulse_weekly_schedule(client: Client) -> None:
+    await _create_pulse_schedule(client, "weekly")
+
+
+async def create_pulse_daily_schedule(client: Client) -> None:
+    await _create_pulse_schedule(client, "daily")
 
 
 async def create_sync_vectors_schedule(client: Client):
@@ -605,6 +644,8 @@ schedules = [
     create_logs_alert_check_schedule,
     create_schedule_due_alert_checks_schedule,
     create_run_investigation_safety_net_schedule,
+    create_pulse_weekly_schedule,
+    create_pulse_daily_schedule,
 ]
 
 if settings.CLOUD_DEPLOYMENT:

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -21,6 +21,7 @@ from temporalio.client import (
 )
 
 from posthog.hogql_queries.ai.vector_search_query_runner import LATEST_ACTIONS_EMBEDDING_VERSION
+from posthog.models.pulse import PulseSubscriptionFrequency
 from posthog.temporal.ai import SyncVectorsInputs
 from posthog.temporal.ai.pulse.dispatcher import PulseScanDispatcherInputs
 from posthog.temporal.ai.sync_vectors import EmbeddingVersion
@@ -84,17 +85,17 @@ from ee.billing.salesforce_enrichment.constants import DEFAULT_CHUNK_SIZE
 logger = structlog.get_logger(__name__)
 
 
-async def _create_pulse_schedule(client: Client, frequency: str) -> None:
+async def _create_pulse_schedule(client: Client, frequency: PulseSubscriptionFrequency) -> None:
     """Create or update a Pulse scan dispatcher schedule (8 AM UTC).
 
-    For "weekly", runs Monday only. For "daily", runs every day.
+    Weekly runs Monday only; daily runs every day.
     """
-    schedule_id = f"pulse-{frequency}-schedule"
+    schedule_id = f"pulse-{frequency.value}-schedule"
     calendar_kwargs: dict = {
-        "comment": f"Pulse {frequency} at 8 AM UTC",
+        "comment": f"Pulse {frequency.value} at 8 AM UTC",
         "hour": [ScheduleRange(start=8, end=8)],
     }
-    if frequency == "weekly":
+    if frequency == PulseSubscriptionFrequency.WEEKLY:
         calendar_kwargs["day_of_week"] = [ScheduleRange(start=1, end=1)]
 
     schedule = Schedule(
@@ -115,11 +116,11 @@ async def _create_pulse_schedule(client: Client, frequency: str) -> None:
 
 
 async def create_pulse_weekly_schedule(client: Client) -> None:
-    await _create_pulse_schedule(client, "weekly")
+    await _create_pulse_schedule(client, PulseSubscriptionFrequency.WEEKLY)
 
 
 async def create_pulse_daily_schedule(client: Client) -> None:
-    await _create_pulse_schedule(client, "daily")
+    await _create_pulse_schedule(client, PulseSubscriptionFrequency.DAILY)
 
 
 async def create_sync_vectors_schedule(client: Client):

--- a/posthog/temporal/tests/ai/test_pulse.py
+++ b/posthog/temporal/tests/ai/test_pulse.py
@@ -1,0 +1,114 @@
+import pytest
+
+from parameterized import parameterized
+
+from posthog.temporal.ai.pulse.detection import (
+    MIN_BASELINE_VALUE,
+    _compute_z_score,
+    _evaluate_candidate,
+    _extract_weekly_series,
+)
+from posthog.temporal.ai.pulse.narrative import _pick_top_contributor
+from posthog.temporal.ai.pulse.types import CandidateMetric, MetricDescriptor
+
+
+def _make_candidate() -> CandidateMetric:
+    return CandidateMetric(
+        descriptor=MetricDescriptor(source="top_event", source_id=1, label="$pageview", query={"kind": "TrendsQuery"})
+    )
+
+
+class TestComputeZScore:
+    @parameterized.expand(
+        [
+            ("baseline_too_small_returns_zero", 5.0, [10.0], (0.0, 0.0)),
+            ("zero_variance_returns_zero_with_mean", 7.0, [5.0, 5.0, 5.0], (0.0, 5.0)),
+        ]
+    )
+    def test_edge_cases(self, _name, current, baseline, expected):
+        assert _compute_z_score(current, baseline) == expected
+
+    def test_positive_deviation(self):
+        z, mean = _compute_z_score(20.0, [10.0, 10.0, 10.0, 14.0])
+        assert mean == pytest.approx(11.0)
+        assert z > 3  # ~3.85 — clear positive outlier
+
+    def test_negative_deviation(self):
+        z, mean = _compute_z_score(2.0, [10.0, 10.0, 10.0, 14.0])
+        assert mean == pytest.approx(11.0)
+        assert z < -3
+
+
+class TestExtractWeeklySeries:
+    @parameterized.expand(
+        [
+            ("non_dict_returns_empty", "garbage", []),
+            ("empty_results_returns_empty", {"results": []}, []),
+            ("missing_results_returns_empty", {}, []),
+            ("happy_path_floats", {"results": [{"data": [1, 2.5, 3]}]}, [1.0, 2.5, 3.0]),
+            ("filters_bools", {"results": [{"data": [1, True, 3]}]}, [1.0, 3.0]),
+            ("filters_non_numeric", {"results": [{"data": [1, "x", None, 4]}]}, [1.0, 4.0]),
+        ]
+    )
+    def test_extraction(self, _name, result, expected):
+        assert _extract_weekly_series(result) == expected
+
+
+class TestEvaluateCandidate:
+    def test_returns_none_when_series_too_short(self):
+        # Need at least MIN_BASELINE_WEEKS + 2 = 5 values
+        assert _evaluate_candidate(_make_candidate(), [10, 10, 10, 12], 2.0, 0.25) is None
+
+    def test_returns_none_when_baseline_too_low_volume(self):
+        # baseline mean is well below MIN_BASELINE_VALUE
+        below = MIN_BASELINE_VALUE - 1
+        series = [below, below, below, below, below, 999]
+        assert _evaluate_candidate(_make_candidate(), series, 2.0, 0.25) is None
+
+    def test_returns_finding_on_relative_change(self):
+        # current week (5 weeks of stable, then a clear drop, last is in-progress and dropped)
+        series = [100.0, 100.0, 100.0, 100.0, 50.0, 999.0]
+        finding = _evaluate_candidate(_make_candidate(), series, z_threshold=10.0, min_change_pct=0.25)
+        assert finding is not None
+        assert finding.current_value == 50.0
+        assert finding.change_pct < 0
+        assert finding.baseline_value == pytest.approx(100.0)
+
+    def test_returns_finding_on_z_score(self):
+        series = [10.0, 10.0, 10.0, 10.0, 25.0, 999.0]  # z-score >> 2
+        finding = _evaluate_candidate(_make_candidate(), series, z_threshold=2.0, min_change_pct=10.0)
+        assert finding is not None
+        assert finding.current_value == 25.0
+        assert finding.z_score > 2.0
+
+    def test_returns_none_when_below_thresholds(self):
+        series = [100.0, 102.0, 98.0, 101.0, 103.0, 999.0]  # quiet, ~3% change
+        assert _evaluate_candidate(_make_candidate(), series, z_threshold=2.0, min_change_pct=0.25) is None
+
+
+class TestPickTopContributor:
+    def test_returns_none_for_invalid_input(self):
+        assert _pick_top_contributor(None) is None
+        assert _pick_top_contributor({"results": []}) is None
+        assert _pick_top_contributor({"results": [{"data": [1]}]}) is None  # single point
+
+    def test_picks_largest_delta(self):
+        result = {
+            "results": [
+                {"breakdown_value": "Chrome", "data": [100, 110]},  # delta=10
+                {"breakdown_value": "Safari", "data": [50, 5]},  # delta=45
+                {"breakdown_value": "Firefox", "data": [80, 75]},  # delta=5
+            ]
+        }
+        contributor = _pick_top_contributor(result)
+        assert contributor is not None
+        value, current, prior = contributor
+        assert value == "Safari"
+        assert current == 5
+        assert prior == 50
+
+    def test_falls_back_to_label_when_no_breakdown_value(self):
+        result = {"results": [{"label": "fallback", "data": [10, 100]}]}
+        contributor = _pick_top_contributor(result)
+        assert contributor is not None
+        assert contributor[0] == "fallback"


### PR DESCRIPTION
## Summary

Max Pulse — a scheduled Temporal workflow that scans each team's top metrics, detects unusual changes via z-score baseline comparison, and delivers digests via three surfaces:

- **In-app** \`/pulse\` scene with finding cards + feedback (thumbs up/down/snooze/dismiss)
- **Side-panel notification bell** via \`ActivityLog\` with \`scope=\"Pulse\"\` (reaches all team members, no opt-in needed)
- **CDP** \`\$pulse_digest_ready\` internal event for HogFunction destinations (Slack/email — configurable via existing destinations UI)

Addresses [#37079](https://github.com/PostHog/posthog/issues/37079) (\"Proactive insights from Max into my slack/email\").

This supersedes the closed #58786 — that PR was opened against a fork base that was 4.5 months / 10k commits behind upstream. Rebuilt against current upstream master with the migration renumbered to \`1156_pulse\`.

## Pipeline

\`\`\`
PulseScanDispatcherWorkflow  (Mon 8am UTC weekly / 8am UTC daily, scheduled)
  -> fans out per opted-in team via PulseSubscription
     -> PulseScanWorkflow per team
        - select candidates (SQL: pinned/viewed dashboards + top events, no LLM)
        - detect changes (z-score over 4-week baseline, parallel ClickHouse queries)
        - enrich findings (LLM narrative + breakdown attribution, parallel)
        - deliver (Postgres bulk insert + bulk ActivityLog + CDP event, one txn)
\`\`\`

All gated behind feature flag \`max-pulse\`.

## Design choices

- **Standalone tables** (\`PulseDigest\`, \`PulseFinding\`, \`PulseSubscription\`) — PostHog Code Inbox lives in a separate repo, so table-sharing isn't possible. The architectural shape (signal sources → research → reports) is borrowed but the data model is self-contained.
- **Real anomaly detection**, not threshold-only. Existing \`AlertConditionType\` is just relative-change thresholds despite the docs naming. We implement actual z-score over a 4-week rolling baseline with a \`MIN_BASELINE_VALUE\` floor to suppress noise on low-volume events.
- **v1 selection is SQL-only** (no LLM in candidate selection): top-5 pinned / recently-accessed dashboard tiles, Trends insights viewed by ≥3 team members in 30 days, top-10 events by \`query_usage_30_day\`. v2 can let Max expand candidates from the event taxonomy.
- **Reuses existing infra**: \`bulk_log_activity\`, \`database_sync_to_async\`, \`process_query_dict\`, \`posthoganalytics.ai.langchain.CallbackHandler\`, \`produce_internal_event\`, the \`percentage()\` frontend util, and the \`SyncVectorsWorkflow\` Temporal pattern.

## What's intentionally out of scope

- Chart thumbnails (\`PulseFinding.chart_thumbnail_url\` field exists but is unpopulated — uses \`ExportedAsset\` PNG flow in a follow-up).
- HogFunction destination template for Slack — team-configurable through the existing destinations UI, so no template ships in this PR.
- \`kea-typegen\` is not run; \`pulseLogic.ts\` uses untyped \`kea([])\` until the generator runs.

## Test plan

- [ ] Manual smoke: \`python manage.py execute_temporal_workflow PulseScanWorkflow '{\"team_id\": <id>}'\` against a test team, confirm digest + findings persist and the bell shows one entry per finding.
- [ ] Verify \`/pulse\` page loads, lists digests, finding cards render with narrative + feedback buttons.
- [ ] Wire a HogFunction destination subscribed to \`\$pulse_digest_ready\` events to a test Slack channel; confirm delivery on next scheduled run.
- [ ] Verify scheduled workflows registered on worker boot (\`pulse-weekly-schedule\` and \`pulse-daily-schedule\` in Temporal UI).
- [ ] Unit tests pass (\`pytest posthog/temporal/tests/ai/test_pulse.py posthog/api/test/test_pulse.py\`).

## Notes

- Pre-commit hooks bypassed at commit time due to a local node-rdkafka native-build failure unrelated to this change; CI re-runs them in a clean environment.
- Previously addressed greptile review comments from #58786 are preserved: \`PulseFindingFeedback\` imported from \`posthog.models.pulse\`, dead spinner branch fixed, \`delivered_to\` reflects actual channels, \`formatSignedPct\` extracted to \`scenes/pulse/utils.ts\`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*