### PR TITLE
fix(frontend): handle nested chunk load failures

### DIFF
--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -116,22 +116,25 @@ function AppScene(): JSX.Element | null {
         sceneElement = <SpinnerOverlay sceneLevel visible={showingDelayedSpinner} />
     }
 
+    const sceneContent = activeExportedScene?.logic ? (
+        <BindLogic
+            key={`bind-${activeSceneLogicPropsWithTabId.tabId}`}
+            logic={activeExportedScene.logic}
+            props={activeSceneLogicPropsWithTabId}
+        >
+            {sceneElement}
+        </BindLogic>
+    ) : (
+        sceneElement
+    )
+
     const wrappedSceneElement = (
         <ErrorBoundary
             key={`error-${activeSceneLogicPropsWithTabId.tabId}`}
             exceptionProps={{ feature: activeSceneId }}
         >
-            {activeExportedScene?.logic ? (
-                <BindLogic
-                    key={`bind-${activeSceneLogicPropsWithTabId.tabId}`}
-                    logic={activeExportedScene.logic}
-                    props={activeSceneLogicPropsWithTabId}
-                >
-                    {sceneElement}
-                </BindLogic>
-            ) : (
-                sceneElement
-            )}
+            {/* Keep chunk-load failures out of the scene error reporter so stale assets reload once instead. */}
+            <ChunkLoadErrorBoundary>{sceneContent}</ChunkLoadErrorBoundary>
         </ErrorBoundary>
     )
 

--- a/frontend/src/scenes/ChunkLoadErrorBoundary.test.tsx
+++ b/frontend/src/scenes/ChunkLoadErrorBoundary.test.tsx
@@ -1,0 +1,98 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { Component, type ReactNode } from 'react'
+
+import { ChunkLoadErrorBoundary } from './ChunkLoadErrorBoundary'
+
+const RELOAD_GUARD_KEY = 'posthog-chunk-reload-at'
+
+class TestErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+    override state: { error: Error | null } = { error: null }
+
+    static getDerivedStateFromError(error: Error): { error: Error } {
+        return { error }
+    }
+
+    override render(): ReactNode {
+        if (this.state.error) {
+            return <div>{this.state.error.message}</div>
+        }
+
+        return this.props.children
+    }
+}
+
+function ThrowChunkError(): JSX.Element {
+    throw new TypeError('Failed to fetch dynamically imported module: /static/react-json-view.js')
+}
+
+function ThrowRegularError(): JSX.Element {
+    throw new Error('regular render failure')
+}
+
+describe('ChunkLoadErrorBoundary', () => {
+    let consoleErrorSpy: jest.SpyInstance
+    let consoleWarnSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        window.localStorage.clear()
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+        consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore()
+        consoleWarnSpy.mockRestore()
+        cleanup()
+    })
+
+    it('reloads for chunk errors before the parent error boundary catches them', () => {
+        const reload = jest.fn()
+
+        render(
+            <TestErrorBoundary>
+                <ChunkLoadErrorBoundary reload={reload}>
+                    <ThrowChunkError />
+                </ChunkLoadErrorBoundary>
+            </TestErrorBoundary>
+        )
+
+        expect(reload).toHaveBeenCalledTimes(1)
+        expect(screen.queryByText('Failed to fetch dynamically imported module')).not.toBeInTheDocument()
+        expect(Number(window.localStorage.getItem(RELOAD_GUARD_KEY))).toBeGreaterThan(0)
+    })
+
+    it('surfaces repeated chunk errors instead of reloading in a loop', () => {
+        const reload = jest.fn()
+        window.localStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
+
+        render(
+            <TestErrorBoundary>
+                <ChunkLoadErrorBoundary reload={reload}>
+                    <ThrowChunkError />
+                </ChunkLoadErrorBoundary>
+            </TestErrorBoundary>
+        )
+
+        expect(reload).not.toHaveBeenCalled()
+        expect(
+            screen.getByText('Failed to fetch dynamically imported module: /static/react-json-view.js')
+        ).toBeInTheDocument()
+    })
+
+    it('lets non-chunk errors bubble to the parent error boundary', () => {
+        const reload = jest.fn()
+
+        render(
+            <TestErrorBoundary>
+                <ChunkLoadErrorBoundary reload={reload}>
+                    <ThrowRegularError />
+                </ChunkLoadErrorBoundary>
+            </TestErrorBoundary>
+        )
+
+        expect(reload).not.toHaveBeenCalled()
+        expect(screen.getByText('regular render failure')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/ChunkLoadErrorBoundary.tsx
+++ b/frontend/src/scenes/ChunkLoadErrorBoundary.tsx
@@ -17,7 +17,12 @@ interface State {
  * rather than spinning forever. Non-chunk errors are re-thrown so the regular
  * error UI still renders.
  */
-export class ChunkLoadErrorBoundary extends Component<{ children: ReactNode }, State> {
+interface ChunkLoadErrorBoundaryProps {
+    children: ReactNode
+    reload?: () => void
+}
+
+export class ChunkLoadErrorBoundary extends Component<ChunkLoadErrorBoundaryProps, State> {
     override state: State = { error: null, surface: false }
 
     static getDerivedStateFromError(error: unknown): Partial<State> {
@@ -47,7 +52,11 @@ export class ChunkLoadErrorBoundary extends Component<{ children: ReactNode }, S
             // Skip the guard and reload anyway - without the timestamp the worst case is
             // a reload loop, which only happens if the chunk itself keeps failing.
         }
-        window.location.reload()
+        if (this.props.reload) {
+            this.props.reload()
+        } else {
+            window.location.reload()
+        }
     }
 
     override render(): ReactNode {


### PR DESCRIPTION
## Problem

Lazy-loaded scene children can fail to fetch a stale JS chunk after a deploy. The existing chunk-load boundary sat outside the scene error boundary, so nested lazy import failures were caught and reported by the scene boundary before the one-time reload handler could recover.

## Changes

- Wrap the bound scene content in `ChunkLoadErrorBoundary` inside the scene `ErrorBoundary`, so nested lazy chunk failures reload once before reaching the scene reporter
- Keep non-chunk errors and repeated chunk failures flowing to the regular error UI
- Unit coverage for first chunk failure, reload-loop guard, and non-chunk error bubbling