### PR TITLE
fix(hog_flow): add scope_object_write_actions to HogFlowViewSet

### DIFF
--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -437,6 +437,18 @@ class HogFlowFilterSet(FilterSet):
 class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, viewsets.ModelViewSet):
     scope_object = "hog_flow"
     scope_object_read_actions = ["list", "retrieve", "logs", "metrics", "metrics_totals"]
+    scope_object_write_actions = [
+        "create",
+        "update",
+        "partial_update",
+        "destroy",
+        "invocations",
+        "user_blast_radius",
+        "bulk_delete",
+        "batch_jobs",
+        "schedules",
+        "schedule_detail",
+    ]
     queryset = HogFlow.objects.all()
     filter_backends = [DjangoFilterBackend]
     filterset_class = HogFlowFilterSet

--- a/products/workflows/backend/test/test_hog_flow_schedule.py
+++ b/products/workflows/backend/test/test_hog_flow_schedule.py
@@ -533,13 +533,14 @@ class TestHogFlowViewSetPersonalAPIKeyScopes(_HogFlowScheduleAPIHelpers, APIBase
         [
             # Each case proves an HogFlowViewSet @action is now reachable
             # by a personal API key with hog_flow:write scope.
-            # (case_name, http_method, url_builder, payload, expected_status)
+            # (case_name, http_method, url_builder, payload, expected_status, seed_schedule)
             (
                 "schedules_post",
                 "post",
                 lambda self, workflow: self._schedules_url(workflow["id"]),
                 SCHEDULE_DATA,
                 status.HTTP_201_CREATED,
+                False,
             ),
             (
                 "schedules_get",
@@ -547,6 +548,7 @@ class TestHogFlowViewSetPersonalAPIKeyScopes(_HogFlowScheduleAPIHelpers, APIBase
                 lambda self, workflow: self._schedules_url(workflow["id"]),
                 None,
                 status.HTTP_200_OK,
+                True,  # GET case needs an existing schedule to list
             ),
             (
                 "user_blast_radius_post",
@@ -554,15 +556,16 @@ class TestHogFlowViewSetPersonalAPIKeyScopes(_HogFlowScheduleAPIHelpers, APIBase
                 lambda self, workflow: f"/api/projects/{self.team.id}/hog_flows/user_blast_radius/",
                 {"filters": {}},
                 status.HTTP_200_OK,
+                False,
             ),
         ]
     )
     def test_write_scope_personal_api_key_can_reach_action(
-        self, case_name, http_method, url_builder, payload, expected_status
+        self, case_name, http_method, url_builder, payload, expected_status, seed_schedule
     ):
         workflow = self._create_batch_workflow()
-        # Seed one schedule via session auth so the GET case has something to list.
-        if case_name == "schedules_get":
+        if seed_schedule:
+            # Seed one schedule via session auth so the GET case has something to list.
             self.client.post(self._schedules_url(workflow["id"]), SCHEDULE_DATA)
 
         api_key = self.create_personal_api_key_with_scopes(["hog_flow:write"])

--- a/products/workflows/backend/test/test_hog_flow_schedule.py
+++ b/products/workflows/backend/test/test_hog_flow_schedule.py
@@ -26,7 +26,14 @@ SCHEDULE_DATA = {
 }
 
 
-class TestHogFlowScheduleAPI(APIBaseTest):
+class _HogFlowScheduleAPIHelpers:
+    """Shared helpers for HogFlow schedule API tests.
+
+    Lives outside any TestCase base so that test classes using it via
+    multiple inheritance do not pick up sibling tests (which would
+    happen if we inherited directly from another TestCase subclass).
+    """
+
     def _create_batch_workflow(self, workflow_status="active"):
         payload = {
             "name": "Test Batch Workflow",
@@ -50,6 +57,8 @@ class TestHogFlowScheduleAPI(APIBaseTest):
     def _schedule_detail_url(self, workflow_id, schedule_id):
         return f"/api/projects/{self.team.id}/hog_flows/{workflow_id}/schedules/{schedule_id}/"
 
+
+class TestHogFlowScheduleAPI(_HogFlowScheduleAPIHelpers, APIBaseTest):
     def test_create_schedule(self):
         workflow = self._create_batch_workflow()
         response = self.client.post(self._schedules_url(workflow["id"]), SCHEDULE_DATA)
@@ -499,7 +508,7 @@ class TestProcessDueScheduleTriggers(APIBaseTest):
         assert len(response.json()["processed"]) == 0
 
 
-class TestHogFlowViewSetPersonalAPIKeyScopes(APIBaseTest):
+class TestHogFlowViewSetPersonalAPIKeyScopes(_HogFlowScheduleAPIHelpers, APIBaseTest):
     """Regression test for HogFlowViewSet personal API key scope gating.
 
     Before this fix, every custom @action on HogFlowViewSet
@@ -514,41 +523,57 @@ class TestHogFlowViewSetPersonalAPIKeyScopes(APIBaseTest):
 
     These tests exercise the now-opened paths with both write and
     read-only personal API keys to verify the fix and prevent
-    regression.
+    regression. Uses _HogFlowScheduleAPIHelpers (shared with
+    TestHogFlowScheduleAPI) for batch-workflow and URL helpers
+    without inheriting from another TestCase, which would re-run
+    every parent test method.
     """
 
-    def _create_batch_workflow(self):
-        payload = {
-            "name": "Test Batch Workflow",
-            "status": "active",
-            "actions": [
-                {
-                    "id": "trigger_node",
-                    "name": "trigger",
-                    "type": "trigger",
-                    "config": BATCH_TRIGGER,
-                }
-            ],
-        }
-        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", payload)
-        assert response.status_code == status.HTTP_201_CREATED, response.json()
-        return response.json()
-
-    def _schedules_url(self, workflow_id):
-        return f"/api/projects/{self.team.id}/hog_flows/{workflow_id}/schedules/"
-
-    def test_create_schedule_with_personal_api_key_write_scope_succeeds(self):
+    @parameterized.expand(
+        [
+            # Each case proves an HogFlowViewSet @action is now reachable
+            # by a personal API key with hog_flow:write scope.
+            # (case_name, http_method, url_builder, payload, expected_status)
+            (
+                "schedules_post",
+                "post",
+                lambda self, workflow: self._schedules_url(workflow["id"]),
+                SCHEDULE_DATA,
+                status.HTTP_201_CREATED,
+            ),
+            (
+                "schedules_get",
+                "get",
+                lambda self, workflow: self._schedules_url(workflow["id"]),
+                None,
+                status.HTTP_200_OK,
+            ),
+            (
+                "user_blast_radius_post",
+                "post",
+                lambda self, workflow: f"/api/projects/{self.team.id}/hog_flows/user_blast_radius/",
+                {"filters": {}},
+                status.HTTP_200_OK,
+            ),
+        ]
+    )
+    def test_write_scope_personal_api_key_can_reach_action(
+        self, case_name, http_method, url_builder, payload, expected_status
+    ):
         workflow = self._create_batch_workflow()
+        # Seed one schedule via session auth so the GET case has something to list.
+        if case_name == "schedules_get":
+            self.client.post(self._schedules_url(workflow["id"]), SCHEDULE_DATA)
+
         api_key = self.create_personal_api_key_with_scopes(["hog_flow:write"])
+        url = url_builder(self, workflow)
+        kwargs = {"headers": {"authorization": f"Bearer {api_key}"}}
+        if payload is not None:
+            kwargs["content_type"] = "application/json"
 
-        response = self.client.post(
-            self._schedules_url(workflow["id"]),
-            SCHEDULE_DATA,
-            headers={"authorization": f"Bearer {api_key}"},
-        )
+        response = getattr(self.client, http_method)(url, payload, **kwargs)
 
-        assert response.status_code == status.HTTP_201_CREATED, response.json()
-        assert response.json()["rrule"] == SCHEDULE_DATA["rrule"]
+        assert response.status_code == expected_status, (case_name, response.json())
 
     def test_create_schedule_with_personal_api_key_read_scope_only_rejects_with_scope_error(self):
         workflow = self._create_batch_workflow()
@@ -574,41 +599,14 @@ class TestHogFlowViewSetPersonalAPIKeyScopes(APIBaseTest):
             "scope_object_write_actions on HogFlowViewSet may be missing again."
         )
 
-    def test_list_schedules_with_personal_api_key_write_scope_succeeds(self):
-        workflow = self._create_batch_workflow()
-        api_key = self.create_personal_api_key_with_scopes(["hog_flow:write"])
-
-        # First, create one via session auth so there is something to list.
-        self.client.post(self._schedules_url(workflow["id"]), SCHEDULE_DATA)
-
-        response = self.client.get(
-            self._schedules_url(workflow["id"]),
-            headers={"authorization": f"Bearer {api_key}"},
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.json()) == 1
-
-    def test_user_blast_radius_with_personal_api_key_write_scope_succeeds(self):
-        api_key = self.create_personal_api_key_with_scopes(["hog_flow:write"])
-
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/hog_flows/user_blast_radius/",
-            {"filters": {}},
-            headers={"authorization": f"Bearer {api_key}"},
-            content_type="application/json",
-        )
-
-        assert response.status_code == status.HTTP_200_OK, response.json()
-        body = response.json()
-        assert "users_affected" in body
-        assert "total_users" in body
-
     def test_bulk_delete_with_personal_api_key_write_scope_succeeds(self):
+        # Kept separate from the parameterized happy-path block above
+        # because bulk_delete returns 400 from its action body when the
+        # ids list is empty. The 400 is the proof — auth path opened,
+        # action body ran, and rejected on its own validation. A 403
+        # here would indicate the scope gate is still blocking.
         api_key = self.create_personal_api_key_with_scopes(["hog_flow:write"])
 
-        # Empty-ids should return 400 from the action body (not a 403),
-        # which proves the auth path is open and the action body ran.
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_flows/bulk_delete/",
             {"ids": []},

--- a/products/workflows/backend/test/test_hog_flow_schedule.py
+++ b/products/workflows/backend/test/test_hog_flow_schedule.py
@@ -497,3 +497,124 @@ class TestProcessDueScheduleTriggers(APIBaseTest):
         assert response.status_code == 200
         assert str(schedule.id) in response.json()["failed"]
         assert len(response.json()["processed"]) == 0
+
+
+class TestHogFlowViewSetPersonalAPIKeyScopes(APIBaseTest):
+    """Regression test for HogFlowViewSet personal API key scope gating.
+
+    Before this fix, every custom @action on HogFlowViewSet
+    (schedules, schedule_detail, user_blast_radius, bulk_delete,
+    batch_jobs, invocations) returned HTTP 403
+    "This action does not support personal API key access"
+    regardless of the key's scopes, because HogFlowViewSet did not
+    declare scope_object_write_actions. The default fallback
+    (["create", "update", "partial_update", "patch", "destroy"])
+    covered standard CRUD only, so any unlisted @action fell through
+    to None in _get_required_scopes and was rejected outright.
+
+    These tests exercise the now-opened paths with both write and
+    read-only personal API keys to verify the fix and prevent
+    regression.
+    """
+
+    def _create_batch_workflow(self):
+        payload = {
+            "name": "Test Batch Workflow",
+            "status": "active",
+            "actions": [
+                {
+                    "id": "trigger_node",
+                    "name": "trigger",
+                    "type": "trigger",
+                    "config": BATCH_TRIGGER,
+                }
+            ],
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", payload)
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        return response.json()
+
+    def _schedules_url(self, workflow_id):
+        return f"/api/projects/{self.team.id}/hog_flows/{workflow_id}/schedules/"
+
+    def test_create_schedule_with_personal_api_key_write_scope_succeeds(self):
+        workflow = self._create_batch_workflow()
+        api_key = self.create_personal_api_key_with_scopes(["hog_flow:write"])
+
+        response = self.client.post(
+            self._schedules_url(workflow["id"]),
+            SCHEDULE_DATA,
+            headers={"authorization": f"Bearer {api_key}"},
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert response.json()["rrule"] == SCHEDULE_DATA["rrule"]
+
+    def test_create_schedule_with_personal_api_key_read_scope_only_rejects_with_scope_error(self):
+        workflow = self._create_batch_workflow()
+        api_key = self.create_personal_api_key_with_scopes(["hog_flow:read"])
+
+        response = self.client.post(
+            self._schedules_url(workflow["id"]),
+            SCHEDULE_DATA,
+            headers={"authorization": f"Bearer {api_key}"},
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        # The rejection should reference the missing write scope, NOT
+        # the legacy "doesn't support personal API key access" message
+        # which would indicate the scope_object_write_actions attribute
+        # has gone missing again.
+        detail = response.json().get("detail", "")
+        assert "hog_flow:write" in detail, (
+            f"Expected error to mention required scope 'hog_flow:write', got: {detail!r}"
+        )
+        assert "does not support personal API key access" not in detail, (
+            "Got the legacy 'no PAK support' rejection — "
+            "scope_object_write_actions on HogFlowViewSet may be missing again."
+        )
+
+    def test_list_schedules_with_personal_api_key_write_scope_succeeds(self):
+        workflow = self._create_batch_workflow()
+        api_key = self.create_personal_api_key_with_scopes(["hog_flow:write"])
+
+        # First, create one via session auth so there is something to list.
+        self.client.post(self._schedules_url(workflow["id"]), SCHEDULE_DATA)
+
+        response = self.client.get(
+            self._schedules_url(workflow["id"]),
+            headers={"authorization": f"Bearer {api_key}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()) == 1
+
+    def test_user_blast_radius_with_personal_api_key_write_scope_succeeds(self):
+        api_key = self.create_personal_api_key_with_scopes(["hog_flow:write"])
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/user_blast_radius/",
+            {"filters": {}},
+            headers={"authorization": f"Bearer {api_key}"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        body = response.json()
+        assert "users_affected" in body
+        assert "total_users" in body
+
+    def test_bulk_delete_with_personal_api_key_write_scope_succeeds(self):
+        api_key = self.create_personal_api_key_with_scopes(["hog_flow:write"])
+
+        # Empty-ids should return 400 from the action body (not a 403),
+        # which proves the auth path is open and the action body ran.
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/bulk_delete/",
+            {"ids": []},
+            headers={"authorization": f"Bearer {api_key}"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["error"] == "A non-empty list of 'ids' is required"


### PR DESCRIPTION
Fixes #58806 — every custom `@action` on `HogFlowViewSet` currently rejects personal API key access with HTTP 403 because the viewset is missing the `scope_object_write_actions` attribute.

## Changes

**`posthog/api/hog_flow.py`** — declare `scope_object_write_actions` on `HogFlowViewSet` listing every custom `@action` declared in this file plus the standard CRUD verbs (which the base default would have covered, but `scope_object_write_actions` overrides that default when present).

**`products/workflows/backend/test/test_hog_flow_schedule.py`** — add `TestHogFlowViewSetPersonalAPIKeyScopes` class with regression tests that exercise the newly-opened paths with both `hog_flow:write` and `hog_flow:read`-only personal API keys.

Mirrors the pattern already used by `HogFunctionViewSet` (`posthog/api/hog_function.py:478`).

## Why

`posthog/permissions.py:434-461` (`_get_required_scopes`) returns `None` for any action not listed in `scope_object_read_actions` or `scope_object_write_actions`, which triggers `"This action does not support personal API key access"` at `posthog/permissions.py:497-499`. The CRUD actions work today because `ScopeBasePermission.write_actions` (the base default at `permissions.py:416`) covers them. Custom `@action` methods are never in the default list, so they all 403 unless the viewset explicitly opts them in.

Affected endpoints before this PR (all return 403 to personal API keys even with `hog_flow:write` scope):

- `POST   /api/projects/<pid>/hog_flows/<id>/schedules/`
- `GET    /api/projects/<pid>/hog_flows/<id>/schedules/`
- `PATCH  /api/projects/<pid>/hog_flows/<id>/schedules/<schedule_id>/`
- `DELETE /api/projects/<pid>/hog_flows/<id>/schedules/<schedule_id>/`
- `GET    /api/projects/<pid>/hog_flows/<id>/batch_jobs/`
- `POST   /api/projects/<pid>/hog_flows/<id>/batch_jobs/`
- `POST   /api/projects/<pid>/hog_flows/<id>/invocations/`
- `POST   /api/projects/<pid>/hog_flows/user_blast_radius/`
- `POST   /api/projects/<pid>/hog_flows/bulk_delete/`

## Test plan

- [x] Regression tests added in `products/workflows/backend/test/test_hog_flow_schedule.py::TestHogFlowViewSetPersonalAPIKeyScopes` covering:
  - `POST /schedules/` with `hog_flow:write` → 201
  - `POST /schedules/` with `hog_flow:read` only → 403, error message mentions `hog_flow:write` (NOT the legacy "doesn't support personal API key access" message)
  - `GET  /schedules/` with `hog_flow:write` → 200
  - `POST /user_blast_radius/` with `hog_flow:write` → 200
  - `POST /bulk_delete/` with `hog_flow:write` → 400 from the action body (empty `ids` list), confirming the auth path is open and the action body ran
- [ ] Existing `test_hog_flow_schedule.py` + `test_hog_flow.py` regression suites continue to pass (no behaviour change for session-cookie auth paths).
- [ ] Verify in CI: no other test relies on the legacy 403 message being returned for these endpoints.

## Notes

- `schedules` and `batch_jobs` are dual-method (GET + POST). `_get_required_scopes` resolves by action name only — putting them in `write_actions` means `hog_flow:read`-only keys cannot list them either. This matches the security posture for CRUD-shaped sub-resources where listing implies management, and mirrors how `HogFunctionViewSet` classifies its dual-method `invocations` action.
- `schedule_detail` is the `@action` with `url_path="schedules/(?P<schedule_id>[^/.]+)"` handling PATCH/DELETE on individual schedules — listed in `write_actions` accordingly.
- Pure additive change. Previously-broken endpoints become accessible to keys with the correct scope; no behaviour change for any currently-working path.

## Related

Similar class of issue: #25865 ("Ability to check Organization & Project Access for a Personal API Key") and #27656 ("'/session' endpoint auth errors") both involve under-declared personal-API-key gates on viewsets.