### PR TITLE
fix(llma): message actions menu crash on undefined content

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -839,7 +839,9 @@ export const LLMMessageDisplay = React.memo(
                                     explicitValue={typeof content === 'string' ? content : JSON.stringify(content)}
                                 />
                                 <MessageActionsMenu
-                                    content={typeof content === 'string' ? content : JSON.stringify(content, null, 2)}
+                                    content={
+                                        typeof content === 'string' ? content : (JSON.stringify(content, null, 2) ?? '')
+                                    }
                                     traceId={traceId}
                                 />
                             </>


### PR DESCRIPTION
## Problem

`MessageActionsMenu` could crash the trace view when messages have an empty body, like some tool call formats.

## Changes

Make it not crash the trace view by providing a default

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7) in a Claude Code session with Carlos.

Considered three fix locations:
1. Guard at the call site — chosen. The bug is a `content: string` prop being passed `undefined`; the caller is the conceptual home.
2. Move the in-component guard above the `messageActionsMenuLogic({ content })` build — works but leaves the prop contract implicitly broken.
3. Harden `hashString` to accept nullish — defensive, but masks the contract violation.

Chose (1) as the single, clear fix per Carlos's preference for one well-placed change over belt-and-braces.
