### PR TITLE
fix(session-replay): set prometheus default labels at server start

### DIFF
--- a/nodejs/src/servers/ingestion-session-replay-server.ts
+++ b/nodejs/src/servers/ingestion-session-replay-server.ts
@@ -1,3 +1,4 @@
+import { initializePrometheusLabels } from '../api/router'
 import { CommonConfig } from '../common/config'
 import { defaultConfig, overrideConfigWithEnv } from '../config/config'
 import {
@@ -86,6 +87,8 @@ export class IngestionSessionReplayServer implements NodeServer {
     }
 
     private async startServices(): Promise<void> {
+        initializePrometheusLabels(this.config.INGESTION_PIPELINE, this.config.INGESTION_LANE)
+
         this.postgres = new PostgresRouter(this.config, this.config.PLUGIN_SERVER_MODE ?? undefined)
         logger.info('👍', 'Postgres Router ready')
 


### PR DESCRIPTION
## Summary

`IngestionSessionReplayServer` (the server class that runs when `PLUGIN_SERVER_MODE=recordings-blob-ingestion-v2{,-overflow}`) never called `initializePrometheusLabels(...)`. The peers — `IngestionGeneralServer` and `IngestionApiServer` — both call it as the first line of their `startServices()`.

Consequence: `INGESTION_PIPELINE` and `INGESTION_LANE` are read into `this.config` but never set as prom-client default labels. Every metric this process emits goes to Prometheus without the `ingestion_pipeline` / `ingestion_lane` labels.

That includes `ingestion_pipeline_results`, which is the metric the "Ingestion - Pipelines" Grafana dashboard uses to populate its pipeline dropdown:

```promql
query_result(sort_desc(count by(ingestion_pipeline) (ingestion_pipeline_results)))
```

Today that query returns `analytics, clientwarnings, errortracking, heatmaps` — session-replay is missing. Verified in prod:

```
count by(ingestion_pipeline, namespace) (ingestion_pipeline_results{namespace="posthog"})
→ {ingestion_pipeline="errortracking", namespace="posthog"}: 49
→ {namespace="posthog"}: 274   ← session-replay, no ingestion_pipeline label
```

## Change

One-line addition in `IngestionSessionReplayServer.startServices()`, mirroring `IngestionGeneralServer.startServices` and `IngestionApiServer.startServices`:

```ts
initializePrometheusLabels(this.config.INGESTION_PIPELINE, this.config.INGESTION_LANE)
```

`SessionRecordingIngesterConfig` already includes `INGESTION_PIPELINE | INGESTION_LANE` from `IngestionConsumerConfig` (consumer.ts:62), so the config fields are already typed and populated.

## Test plan

- [ ] Deploy to dev and verify `count by(ingestion_pipeline) (ingestion_pipeline_results{namespace=~"posthog|ingestion-sessionreplay.*"})` returns a `sessionreplay` value.
- [ ] Verify the "Ingestion - Pipelines" dashboard's Pipeline dropdown shows `sessionreplay`.