### PR TITLE
fix(data-warehouse): redirect legacy /data-management/data-warehouse

### DIFF
--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -644,6 +644,7 @@ export const redirects: Record<
     '/dashboards': urls.dashboards(),
     '/data-management': urls.eventDefinitions(),
     '/data-management/database': urls.sources(),
+    '/data-management/data-warehouse': urls.sources(),
     '/data-pipelines': urls.sources(),
     // TODO: Temporary redirect because of moving marketing Analytics out of web analytics. I will remove this after a month.
     '/web/marketing': (_, searchParams) => {


### PR DESCRIPTION
## Problem

A user was served a link to `/project/<id>/data-management/data-warehouse` and hit a 404. The data warehouse landing page moved to `/data-management/sources`, but `/data-management/data-warehouse` has no route or redirect, so stale bookmarks and any lingering external references break.

The sibling path `/data-management/database` already redirects to `urls.sources()` (`frontend/src/scenes/scenes.ts:646`). The `data-warehouse` variant was simply missed.

## Changes

- Add `/data-management/data-warehouse` → `urls.sources()` redirect in `frontend/src/scenes/scenes.ts`, mirroring the existing `/data-management/database` redirect.

## How did you test this code?

I'm an agent (PostHog Code). I made the smallest possible change — adding one entry to the existing `redirects` map — and did not run the dev server or write a new automated test.

Suggested manual verification:
- Visit `/project/<id>/data-management/data-warehouse` in a logged-in session and confirm it lands on `/project/<id>/data-management/sources`.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Tool: PostHog Code (this session).
- Investigation: traced the URL `/project/2/data-management/data-warehouse` through the FE router and found no matching route or redirect, while the analogous `/data-management/database` already redirects to `urls.sources()`.
- Decision: minimal mirror of the existing `database` redirect rather than introducing new helpers. A separate, deeper inconsistency exists in `products/data_warehouse/manifest.tsx` where `dataOps(tab)` generates `/data-warehouse?tab=...` despite `/data-warehouse` not being a registered route — left out of this PR to keep the fix narrowly scoped to the reported broken link.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*