### PR TITLE
chore(rbac): add ACCESS_CONTROL to ENTERPRISE_FEATURES

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -74,6 +74,7 @@ class License(models.Model):
     ENTERPRISE_FEATURES = [
         *SCALE_FEATURES,
         AvailableFeature.ADVANCED_PERMISSIONS,
+        AvailableFeature.ACCESS_CONTROL,
         AvailableFeature.SAML,
         AvailableFeature.SCIM,
         AvailableFeature.SSO_ENFORCEMENT,

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -74,11 +74,10 @@ class ProductFeature(TypedDict):
 def _enterprise_only_feature_keys() -> frozenset[str]:
     """Enterprise-plan-only feature keys, computed once per process.
 
-    Sourced from `License.ENTERPRISE_FEATURES - SCALE_FEATURES`, plus `ACCESS_CONTROL`
-    (the successor to `ADVANCED_PERMISSIONS` per the `AvailableFeature` enum) which
-    isn't reflected in `License.ENTERPRISE_FEATURES` yet but should classify the same way.
+    Sourced from `License.ENTERPRISE_FEATURES - SCALE_FEATURES`. Returns an empty
+    set when the ee package isn't importable.
     """
-    keys: set[str] = {str(AvailableFeature.ACCESS_CONTROL)}
+    keys: set[str] = set()
     try:
         from ee.models.license import License
 
@@ -346,12 +345,10 @@ class Organization(ModelActivityMixin, UUIDTModel):  # type: ignore[django-manag
         """Best-effort plan tier derived from `available_product_features`.
 
         "enterprise" if any Enterprise-only feature is present (per `License.ENTERPRISE_FEATURES`
-        minus `SCALE_FEATURES`, plus `access_control` — the successor to `advanced_permissions`
-        per `AvailableFeature` in constants.py — which is not yet reflected in `License`).
-        "paid" if any feature is present, otherwise "free". Paid uses "any feature present"
-        rather than an allow-list because the billing service grants features (alerts,
-        surveys_styling, ...) that postdate `License.SCALE_FEATURES`, and an allow-list
-        silently downgrades those orgs to free.
+        minus `SCALE_FEATURES`). "paid" if any feature is present, otherwise "free". Paid uses
+        "any feature present" rather than an allow-list because the billing service grants
+        features (alerts, surveys_styling, ...) that postdate `License.SCALE_FEATURES`, and an
+        allow-list silently downgrades those orgs to free.
         """
         available_keys = {
             feature.get("key") for feature in (self.available_product_features or []) if feature and feature.get("key")


### PR DESCRIPTION


## Problem

Prereq for #56976 

That PR swaps the four backend gates from `ADVANCED_PERMISSIONS` to `ACCESS_CONTROL`, but on self-hosted a deploy doesn't refresh `Organization.available_product_features` until the next hourly sync at :30 — so existing Enterprise orgs lose those gates for up to an hour.

Shipping this small PR first, waiting for the hourly sync to run everywhere, then landing #56976 closes that window.

## Changes

- Add `AvailableFeature.ACCESS_CONTROL` alongside `ADVANCED_PERMISSIONS` in `License.ENTERPRISE_FEATURES`. No gate changes — every existing check still reads `ADVANCED_PERMISSIONS`, so behavior is unchanged.
- Drop the standalone `ACCESS_CONTROL` seed in `_enterprise_only_feature_keys()` and the now-stale docstrings in `_enterprise_only_feature_keys` / `get_plan_tier` — the key now flows in via `ENTERPRISE_FEATURES`.

PostHog Cloud is unaffected (features come from the billing API, not the License model).

## How did you test this code?

Existing tests

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->