### PR TITLE
fix(mcp): skip org fetch on init when key lacks organization:read

### DIFF
--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -1,4 +1,5 @@
 import type { ApiClient, GroupType } from '@/api/client'
+import { hasScope } from '@/lib/api'
 import { getPostHogClient } from '@/lib/analytics'
 import { ErrorCode, MissingOrganizationContextError, MissingProjectContextError, wrapError } from '@/lib/errors'
 import { buildActiveEnvironmentContextPrompt } from '@/lib/instructions'
@@ -275,6 +276,14 @@ export class StateManager {
         // consent checks treat "no org" as "skip", not as a hard error.
         const orgId = await this._resolveOrganizationId()
         if (!orgId) {
+            return undefined
+        }
+        // `/api/organizations/{id}/` requires `organization:read`. Project-scoped
+        // personal API keys do not carry that scope, so the fetch would 403 on
+        // every session init and dogpile error tracking. Mirror the `group:read`
+        // gate in `mcp.ts` and skip the fetch when the scope is absent.
+        const apiKey = await this.getApiKey()
+        if (!hasScope(apiKey.scopes, 'organization:read')) {
             return undefined
         }
         return this.getOrFetchCached({

--- a/services/mcp/src/lib/instructions.ts
+++ b/services/mcp/src/lib/instructions.ts
@@ -20,11 +20,15 @@ export function buildActiveEnvironmentContextPrompt(
     if (org || project) {
         const projectName = project?.name ?? 'Unknown'
         const projectId = project?.id ?? 'unknown'
-        const orgName = org?.name ?? 'Unknown'
-        const orgId = org?.id ?? 'unknown'
-        lines.push(
-            `You are currently in project "${projectName}" (id: ${projectId}) within organization "${orgName}" (id: ${orgId}).`
-        )
+        if (org) {
+            const orgName = org.name ?? 'Unknown'
+            const orgId = org.id ?? 'unknown'
+            lines.push(
+                `You are currently in project "${projectName}" (id: ${projectId}) within organization "${orgName}" (id: ${orgId}).`
+            )
+        } else {
+            lines.push(`You are currently in project "${projectName}" (id: ${projectId}).`)
+        }
     }
     if (project) {
         lines.push(`Project timezone: ${project.timezone ?? 'UTC'}.`)

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -335,6 +335,53 @@ describe('StateManager', () => {
 
             expect(result).toBeUndefined()
         })
+
+        it('skips the org fetch when the API key lacks organization:read', async () => {
+            // Pre-#58726 behaviour: every MCP session init with a project-scoped
+            // personal API key would 403 on `/api/organizations/{id}/` and
+            // dogpile error tracking. The scope guard short-circuits before the
+            // HTTP call so no exception is captured and the org is treated as
+            // best-effort missing.
+            await cache.set('orgId', 'org-1')
+            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue({
+                scopes: ['project:read', 'insight:read'],
+                scoped_organizations: [],
+                scoped_teams: [456],
+            })
+            const orgGet = vi.fn()
+            ;(stateManager as any)._api = {
+                organizations: () => ({ get: orgGet }),
+            }
+
+            const result = await stateManager.getCachedOrFetchOrg()
+
+            expect(result).toBeUndefined()
+            expect(orgGet).not.toHaveBeenCalled()
+        })
+
+        it.each([['organization:read'], ['organization:write'], ['*']])(
+            'fetches the org when the API key carries %s',
+            async (scope) => {
+                await cache.set('orgId', 'org-1')
+                vi.spyOn(stateManager, 'getApiKey').mockResolvedValue({
+                    scopes: [scope],
+                    scoped_organizations: [],
+                    scoped_teams: [],
+                })
+                const orgGet = vi.fn().mockResolvedValue({
+                    success: true,
+                    data: { id: 'org-1', name: 'Org 1' },
+                })
+                ;(stateManager as any)._api = {
+                    organizations: () => ({ get: orgGet }),
+                }
+
+                const result = await stateManager.getCachedOrFetchOrg()
+
+                expect(orgGet).toHaveBeenCalledWith({ orgId: 'org-1' })
+                expect(result).toMatchObject({ id: 'org-1', name: 'Org 1' })
+            }
+        )
     })
 
     describe('getProjectId', () => {

--- a/services/mcp/tests/unit/instructions.test.ts
+++ b/services/mcp/tests/unit/instructions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { GroupType } from '@/api/client'
 import {
+    buildActiveEnvironmentContextPrompt,
     buildDefinedGroupsBlock,
     buildQueryToolsBlock,
     buildQueryToolsCompact,
@@ -10,6 +11,7 @@ import {
     QueryToolCatalog,
     type QueryToolInfo,
 } from '@/lib/instructions'
+import type { CachedOrg, CachedProject, CachedUser } from '@/tools/types'
 
 describe('buildDefinedGroupsBlock', () => {
     it('should format group types as a comma-separated list of group_type names', () => {
@@ -217,5 +219,52 @@ describe('QueryToolCatalog', () => {
             const tools: QueryToolInfo[] = [{ name: 'query-trends', title: 'Trends' }]
             expect(buildQueryToolsCompact(tools)).toBe('trends')
         })
+    })
+})
+
+describe('buildActiveEnvironmentContextPrompt', () => {
+    const project = {
+        id: 1,
+        name: 'My App',
+        timezone: 'America/New_York',
+        person_on_events_querying_enabled: false,
+    } as unknown as CachedProject
+    const org = { id: 'org_1', name: 'Acme' } as unknown as CachedOrg
+    const user = { first_name: 'Jane', last_name: 'Doe', email: 'jane@acme.com' } as unknown as CachedUser
+
+    it('renders the full project + org line when both are present', () => {
+        const result = buildActiveEnvironmentContextPrompt(user, org, project)
+        expect(result).toContain(
+            'You are currently in project "My App" (id: 1) within organization "Acme" (id: org_1).'
+        )
+    })
+
+    it('omits the organization clause when org is undefined (scope-gated path)', () => {
+        // Project-scoped personal API keys lack `organization:read`, so the org
+        // fetch is skipped. The line drops the "within organization …" tail
+        // rather than rendering a fabricated "Unknown" placeholder.
+        const result = buildActiveEnvironmentContextPrompt(user, undefined, project)
+        expect(result).toContain('You are currently in project "My App" (id: 1).')
+        expect(result).not.toContain('within organization')
+        expect(result).not.toContain('Unknown')
+        expect(result).not.toContain('unknown')
+    })
+
+    it('keeps the timezone and user lines when org is omitted', () => {
+        const result = buildActiveEnvironmentContextPrompt(user, undefined, project)
+        expect(result).toContain('Project timezone: America/New_York.')
+        expect(result).toContain("The user's name is Jane Doe (jane@acme.com).")
+    })
+
+    it('returns undefined when no context is available at all', () => {
+        expect(buildActiveEnvironmentContextPrompt(undefined, undefined, undefined)).toBeUndefined()
+    })
+
+    it('still renders an "Unknown" project when org is present but project is missing', () => {
+        // The org branch is unchanged — only the no-org branch was added.
+        const result = buildActiveEnvironmentContextPrompt(user, org, undefined)
+        expect(result).toContain(
+            'You are currently in project "Unknown" (id: unknown) within organization "Acme" (id: org_1).'
+        )
     })
 })

--- a/services/mcp/tests/workers/org-project-resolution.test.ts
+++ b/services/mcp/tests/workers/org-project-resolution.test.ts
@@ -194,6 +194,44 @@ describe('MCP org/project resolution inside the real Workers runtime', () => {
         })
     })
 
+    it('init completes for a project-scoped API key without organization:read (no org fetch)', async () => {
+        // Production scenario behind the dogpile silenced by #58726 and now
+        // fixed at the source: a personal API key scoped to a single project
+        // carries `project:read` but not `organization:read`. Pre-guard, every
+        // session init would still issue GET /api/organizations/{id}/ from
+        // both getEnvironmentPrompt and getAiConsentGiven and 403. The guard
+        // short-circuits the fetch so the request path completes without
+        // capturing the expected denial.
+        vi.spyOn(StateManager.prototype, 'getApiKey').mockResolvedValue({
+            scopes: ['project:read', 'insight:read'],
+            scoped_teams: [1],
+            scoped_organizations: [],
+        })
+        // Wrap, don't replace: the real implementation still runs and we
+        // observe its behavior. Without the guard this would resolve to the
+        // captured org fixture; with the guard it resolves to `undefined`.
+        const orgFetchSpy = vi.spyOn(StateManager.prototype, 'getCachedOrFetchOrg')
+
+        const stub = env.MCP_OBJECT.get(env.MCP_OBJECT.idFromName('session-project-scoped-no-org-read'))
+
+        await runInDurableObject(stub, async (mcp: MCP) => {
+            const bg = interceptWaitUntil(mcp)
+            ;(mcp as any).props = propsFor()
+
+            await expect(mcp.init()).resolves.toBeUndefined()
+
+            // getEnvironmentPrompt and getAiConsentGiven both go through the
+            // org fetcher — assert it was invoked and that each invocation
+            // returned `undefined` without throwing.
+            expect(orgFetchSpy).toHaveBeenCalled()
+            for (const call of orgFetchSpy.mock.results) {
+                await expect(call.value).resolves.toBeUndefined()
+            }
+
+            await bg.flush()
+        })
+    })
+
     it('getProjectId throws MissingProjectContextError with the scoped org when no project is resolvable', async () => {
         const stub = env.MCP_OBJECT.get(env.MCP_OBJECT.idFromName('session-missing-project'))
 


### PR DESCRIPTION
## Problem

PR #58726 stopped capturing the 5.5M `PostHogPermissionError` events/week from missing-scope MCP calls, but the underlying call still fires on every session init. `StateManager.getCachedOrFetchOrg` hits `GET /api/organizations/{id}/` from `getEnvironmentPrompt` and again from `getAiConsentGiven`. Project-scoped personal API keys don't carry `organization:read`, so the request 403s on every init — the response is now silently swallowed but it's still a round-trip we know will fail, and project-scoped keys end up with a partial system prompt that renders `organization "Unknown" (id: unknown)`.

## Changes

- `StateManager.getCachedOrFetchOrg` reads the API key scopes and returns `undefined` immediately when `organization:read` is absent, before issuing the HTTP call. This mirrors the existing `group:read` gate in `mcp.ts` that already protects the group-types fetch — same precedent, same shape.
- `buildActiveEnvironmentContextPrompt` drops the "within organization …" clause from the active environment line when `org` is undefined, instead of fabricating an `Unknown (id: unknown)` placeholder. Project name and id, timezone, person-on-events mode, and user identity continue to render unchanged.
- The two LLM analytics tools that declare `requires_ai_consent: true` (`llma-summarization-create`, `llma-evaluation-summary-create`) won't register for project-scoped keys — same observable behavior as today's post-#58726 silent-degrade path, but now intentional rather than incidental.

The `/api/projects/{id}/` fetch is project-scoped and unchanged. The conditional org-projects listing in `_getDefaultOrganizationAndProject` is only reachable when `scoped_organizations` is set, so project-scoped PAKs never hit it.

## How did you test this code?

I'm an agent. I did not exercise the MCP against a live PostHog. Automated tests added/updated:

- `services/mcp/tests/unit/StateManager.test.ts` — verifies `getCachedOrFetchOrg` skips the HTTP call when the key lacks `organization:read`, and parameterizes the proceed-path over `organization:read` / `organization:write` / `*`.
- `services/mcp/tests/unit/instructions.test.ts` — covers `buildActiveEnvironmentContextPrompt`: full line when org+project present, dropped clause when org is missing, preserved timezone/user lines, and unchanged behavior when project is missing but org is present.

`pnpm exec vitest run tests/unit/StateManager.test.ts tests/unit/instructions.test.ts` → 59/59 passing. Full unit project: 1176/1176 passing across 46 files (1 pre-existing setup failure in `exec.test.ts` from a missing generated `shared/guidelines.md`, unrelated). `pnpm exec tsc --noEmit` → clean.

## Publish to changelog?

no — internal MCP observability fix, no user-visible API change.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.7). The investigation traced the request path triggered by `MCP.init()`:

1. Inventoried every HTTP call made before tool dispatch. The only unconditional `organization:read` callers are `getCachedOrFetchOrg` (via `getEnvironmentPrompt`) and the same again via `getAiConsentGiven` during tool registration. Everything else (`/api/users/@me`, `/api/projects/{id}/`, `/api/projects/{id}/groups_types/`) is either user- or project-scoped.
2. Checked what depends on the cached `org` object: only the `org.name` / `org.id` rendering in `buildActiveEnvironmentContextPrompt` plus `is_ai_data_processing_approved` for the AI-consent gate. `org.name` is not used anywhere else (MCP analytics emits IDs only).
3. Considered exposing `is_ai_data_processing_approved` as a read-only passthrough on the Project serializer so project-scoped keys could keep AI-consent-gated tools. Deferred — it expands the change to a serializer + regenerated types and the two affected tools (`llma-summarization-create`, `llma-evaluation-summary-create`) already operate on org-level data, so their absence for project-scoped keys is not clearly wrong. Easy follow-up if it surfaces as a real ask.
4. Considered dropping the org fetch entirely and deriving the org id from `project.organization` (which the project endpoint returns). Rejected for this PR because we'd lose `org.name` in the prompt with no replacement path — the scope guard preserves it for org-scoped keys at zero cost.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*