### PR TITLE
feat(taxonomic-filter): roll out the rebuilt menu with an opt-out toggle

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1773,9 +1773,9 @@ snapshots:
     filters-taxonomic-filter-headless--suggested-filters-with-recents--light:
         hash: v1.k794b7964.4f32ff8f6d683e83acb75ed1d73c5a5b2ac7721e4d2ed465b00a9cad04c28ca9.QfKnCFIFEcOxhu-Psm9bnVF--BScHN_ZqPe_9XCL0sU
     filters-taxonomic-filter-menu-rebuild--data-warehouse-config--dark:
-        hash: v1.k794b7964.08cb28ef771b07306b60e9b1921ae0e5b31ed750737708ba70094bbf58b781ea.kpx11ijYcolN6k7wlqbIeu2-g2fk7Wwb2h-vm4ipteY
+        hash: v1.k794b7964.f1d2c7596e53807e921bfa1944efc0c9a20f26f0b50bb18aca3498d0bd889727.OIMOUsR6EvqjY-lg26ZZ8h5vkQZTRcN9O-ZEoXYERz0
     filters-taxonomic-filter-menu-rebuild--data-warehouse-config--light:
-        hash: v1.k794b7964.6867eac73493be009f6e5c587313077edf9673190cc3236cf5d3f4ee5455d14a.YGBBjhWUR6xO7ZhT_-tRjvCh_RJHnhuQfES_44jmL3Y
+        hash: v1.k794b7964.36ea70583a6f09a4c2c1e8df79a1e5a4670dffa2bd3e83ff3c5cc7d7bfc8460a.VKeT4L01rkXtfdtBZxGy0swHFqxkuDO_LXzh04f1YGs
     filters-taxonomic-filter-menu-rebuild--events-and-actions--dark:
         hash: v1.k794b7964.28409752a51540006c6e81a3310dd3d66e34c938d1953ce75df53c6badd0beed.qCGpVbB_xHTb6c2fI8ryY6w6WspAfdah8dgFjTrrwNQ
     filters-taxonomic-filter-menu-rebuild--events-and-actions--light:
@@ -5371,9 +5371,9 @@ snapshots:
     scenes-app-settings-environment--settings-environment-integrations--light:
         hash: v1.k794b7964.890a014778fc2e9f90f1faf88e5919334f7dfdc57c0f90df447f16a74850020b.PwiqQk3v8tXwX0WJI1IeJU8i2uSmInkL7jgoALtYuKY
     scenes-app-settings-environment--settings-environment-marketing-analytics--dark:
-        hash: v1.k794b7964.8f809a1e807a37d5bceed69ead493c2dec13fa91f52a9b13e26d1a8494d75145.R2LM4gUQ_9q_CVXqPbZVETPrl4vhvEyZx73oa-Rh9e4
+        hash: v1.k794b7964.d4266b3b53ffb3dd0e67891408f6fff88bddb7161627465f6cf7bfb6c19c9cdd.qrb7xVXZDaldjmUh0iqQlK8Y0BCZpDLKv8NL2w9gh-w
     scenes-app-settings-environment--settings-environment-marketing-analytics--light:
-        hash: v1.k794b7964.98f07f468748ec2bfcaf52325b0d034b806e50f1474319b82964a2c78bbcdf5f.kw-Ms9ndXzEvYsR6bVxfxaumn3L_xfRWFEB452Yfmw0
+        hash: v1.k794b7964.c2e83757cfce06870a43dde2d71852b5e1819ca4fe1ad2688ff82ca6decb77d3.matXZU-xSKU5FsxJNe--OXA5_-UD-sOFswO7hde0KEM
     scenes-app-settings-environment--settings-environment-max--dark:
         hash: v1.k794b7964.7f9ad96ce4e77fe72e9b4de4a19035c6c9e92957bf42a91e856d679a116b9e27.8oJcf9Wo_9CsnKB9etwiCGICC77s6d6KoE1gXDWeNQU
     scenes-app-settings-environment--settings-environment-max--light:

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -24,6 +24,11 @@ import {
     TaxonomicFilterValue,
     isKeyOnlyForGroup,
 } from 'lib/components/TaxonomicFilter/types'
+import { taxonomicMenuPreferenceLogic } from 'lib/components/TaxonomicPopover/taxonomicMenuPreferenceLogic'
+import { TaxonomicMenuToggle } from 'lib/components/TaxonomicPopover/TaxonomicMenuToggle'
+import { TaxonomicPopoverMenu } from 'lib/components/TaxonomicPopover/TaxonomicPopoverMenu'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isOperatorMulti, isOperatorRegex, toParams } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -129,6 +134,9 @@ export function TaxonomicPropertyFilter({
     const { cohortsById } = useValues(cohortsModel)
     const { columnsJoinedToPersons } = useValues(joinsLogic)
     const { currentTeamId } = useValues(teamLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { useNewMenu } = useValues(taxonomicMenuPreferenceLogic)
+    const menuRebuildEnabled = !!featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_MENU_REBUILD]
 
     // We don't support array filter values here. Multiple-cohort only supported in TaxonomicBreakdownFilter.
     // This is mostly to make TypeScript happy.
@@ -249,6 +257,81 @@ export function TaxonomicPropertyFilter({
                       />
                   )
 
+    const legacyDropdown = (
+        <LemonDropdown
+            overlay={taxonomicFilter}
+            placement="bottom-start"
+            visible={dropdownOpen}
+            onClickOutside={closeDropdown}
+        >
+            <LemonButton
+                type="secondary"
+                icon={!valuePresent ? <IconPlusSmall /> : undefined}
+                data-attr={'property-select-toggle-' + index}
+                sideIcon={null} // The null sideIcon is here on purpose - it prevents the dropdown caret
+                onClick={() => (dropdownOpen ? closeDropdown() : openDropdown())}
+                size={size}
+                truncate={true}
+                tooltip={
+                    <>
+                        {filterContent ?? (addText || 'Add filter')}
+                        {addFilterDocLink && (
+                            <>
+                                <br />
+                                <Link to={addFilterDocLink} target="_blank">
+                                    Read the docs
+                                </Link>
+                            </>
+                        )}
+                    </>
+                }
+            >
+                {filterContent ?? (addText || 'Add filter')}
+            </LemonButton>
+        </LemonDropdown>
+    )
+
+    // The rebuilt menu is a self-contained popover, so it only replaces the
+    // dropdown variant — not the inline-search mode, and not when the picker
+    // is already nested inside another dropdown (`disablePopover`).
+    const editablePicker =
+        menuRebuildEnabled && !disablePopover ? (
+            <span className="relative inline-flex min-w-0">
+                {useNewMenu ? (
+                    <TaxonomicPopoverMenu
+                        groupType={filterTaxonomicGroupType ?? groupTypes[0]}
+                        value={cohortOrOtherValue}
+                        groupTypes={groupTypes}
+                        onChange={(value, _groupType, item, group) => taxonomicOnChange(group, value, item)}
+                        renderValue={() => <span className="truncate">{filterContent}</span>}
+                        placeholder={addText || 'Add filter'}
+                        metadataSource={metadataSource}
+                        eventNames={eventNames}
+                        schemaColumns={schemaColumns}
+                        excludedProperties={excludedProperties}
+                        propertyAllowList={propertyAllowList}
+                        optionsFromProp={taxonomicFilterOptionsFromProp}
+                        hideBehavioralCohorts={hideBehavioralCohorts}
+                        endpointFilters={endpointFilters}
+                        hogQLGlobals={hogQLGlobals}
+                        enableKeywordShortcuts
+                        triggerButtonProps={{
+                            type: 'secondary',
+                            size,
+                            truncate: true,
+                            sideIcon: null,
+                            icon: !valuePresent ? <IconPlusSmall /> : undefined,
+                        }}
+                    />
+                ) : (
+                    legacyDropdown
+                )}
+                <TaxonomicMenuToggle />
+            </span>
+        ) : (
+            legacyDropdown
+        )
+
     return (
         <div
             className={clsx('TaxonomicPropertyFilter', {
@@ -295,41 +378,7 @@ export function TaxonomicPropertyFilter({
                     )}
                     <div className="TaxonomicPropertyFilter__row-items">
                         {showOperatorValueSelect && placeOperatorValueSelectOnLeft && operatorValueSelect}
-                        {editable ? (
-                            <LemonDropdown
-                                overlay={taxonomicFilter}
-                                placement="bottom-start"
-                                visible={dropdownOpen}
-                                onClickOutside={closeDropdown}
-                            >
-                                <LemonButton
-                                    type="secondary"
-                                    icon={!valuePresent ? <IconPlusSmall /> : undefined}
-                                    data-attr={'property-select-toggle-' + index}
-                                    sideIcon={null} // The null sideIcon is here on purpose - it prevents the dropdown caret
-                                    onClick={() => (dropdownOpen ? closeDropdown() : openDropdown())}
-                                    size={size}
-                                    truncate={true}
-                                    tooltip={
-                                        <>
-                                            {filterContent ?? (addText || 'Add filter')}
-                                            {addFilterDocLink && (
-                                                <>
-                                                    <br />
-                                                    <Link to={addFilterDocLink} target="_blank">
-                                                        Read the docs
-                                                    </Link>
-                                                </>
-                                            )}
-                                        </>
-                                    }
-                                >
-                                    {filterContent ?? (addText || 'Add filter')}
-                                </LemonButton>
-                            </LemonDropdown>
-                        ) : (
-                            filterContent
-                        )}
+                        {editable ? editablePicker : filterContent}
                         {showOperatorValueSelect && !placeOperatorValueSelectOnLeft && operatorValueSelect}
                     </div>
                 </div>

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -295,41 +295,43 @@ export function TaxonomicPropertyFilter({
     // row-branch dropdown variant. The truly inline mode is already routed
     // away via `showInitialSearchInline`; `disablePopover` still renders a
     // button + dropdown here, so it's fine to swap.
-    const editablePicker = menuRebuildEnabled ? (
-        <span className="relative inline-flex min-w-0">
-            {useNewMenu ? (
-                <TaxonomicPopoverMenu
-                    groupType={filterTaxonomicGroupType ?? groupTypes[0]}
-                    value={cohortOrOtherValue}
-                    groupTypes={groupTypes}
-                    onChange={(value, _groupType, item, group) => taxonomicOnChange(group, value, item)}
-                    renderValue={() => <span className="truncate">{filterContent}</span>}
-                    placeholder={addText || 'Add filter'}
-                    metadataSource={metadataSource}
-                    eventNames={eventNames}
-                    schemaColumns={schemaColumns}
-                    excludedProperties={excludedProperties}
-                    propertyAllowList={propertyAllowList}
-                    optionsFromProp={taxonomicFilterOptionsFromProp}
-                    hideBehavioralCohorts={hideBehavioralCohorts}
-                    endpointFilters={endpointFilters}
-                    hogQLGlobals={hogQLGlobals}
-                    enableKeywordShortcuts
-                    triggerButtonProps={{
-                        type: 'secondary',
-                        size,
-                        truncate: true,
-                        sideIcon: null,
-                        icon: !valuePresent ? <IconPlusSmall /> : undefined,
-                    }}
-                />
-            ) : (
-                legacyDropdown
-            )}
+    //
+    // The rebuilt menu carries its own toggle inside its trigger wrapper, so
+    // it needs no extra DOM and inherits the row's layout exactly. The
+    // legacy path gets a thin positioned wrapper to host the floating toggle.
+    const editablePicker = !menuRebuildEnabled ? (
+        legacyDropdown
+    ) : useNewMenu ? (
+        <TaxonomicPopoverMenu
+            groupType={filterTaxonomicGroupType ?? groupTypes[0]}
+            value={cohortOrOtherValue}
+            groupTypes={groupTypes}
+            onChange={(value, _groupType, item, group) => taxonomicOnChange(group, value, item)}
+            renderValue={() => <span className="truncate">{filterContent}</span>}
+            placeholder={addText || 'Add filter'}
+            metadataSource={metadataSource}
+            eventNames={eventNames}
+            schemaColumns={schemaColumns}
+            excludedProperties={excludedProperties}
+            propertyAllowList={propertyAllowList}
+            optionsFromProp={taxonomicFilterOptionsFromProp}
+            hideBehavioralCohorts={hideBehavioralCohorts}
+            endpointFilters={endpointFilters}
+            hogQLGlobals={hogQLGlobals}
+            enableKeywordShortcuts
+            triggerButtonProps={{
+                type: 'secondary',
+                size,
+                truncate: true,
+                sideIcon: null,
+                icon: !valuePresent ? <IconPlusSmall /> : undefined,
+            }}
+        />
+    ) : (
+        <span className="relative inline-flex max-w-full min-w-0">
+            {legacyDropdown}
             <TaxonomicMenuToggle />
         </span>
-    ) : (
-        legacyDropdown
     )
 
     return (

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -292,45 +292,45 @@ export function TaxonomicPropertyFilter({
     )
 
     // The rebuilt menu is a self-contained popover, so it only replaces the
-    // dropdown variant — not the inline-search mode, and not when the picker
-    // is already nested inside another dropdown (`disablePopover`).
-    const editablePicker =
-        menuRebuildEnabled && !disablePopover ? (
-            <span className="relative inline-flex min-w-0">
-                {useNewMenu ? (
-                    <TaxonomicPopoverMenu
-                        groupType={filterTaxonomicGroupType ?? groupTypes[0]}
-                        value={cohortOrOtherValue}
-                        groupTypes={groupTypes}
-                        onChange={(value, _groupType, item, group) => taxonomicOnChange(group, value, item)}
-                        renderValue={() => <span className="truncate">{filterContent}</span>}
-                        placeholder={addText || 'Add filter'}
-                        metadataSource={metadataSource}
-                        eventNames={eventNames}
-                        schemaColumns={schemaColumns}
-                        excludedProperties={excludedProperties}
-                        propertyAllowList={propertyAllowList}
-                        optionsFromProp={taxonomicFilterOptionsFromProp}
-                        hideBehavioralCohorts={hideBehavioralCohorts}
-                        endpointFilters={endpointFilters}
-                        hogQLGlobals={hogQLGlobals}
-                        enableKeywordShortcuts
-                        triggerButtonProps={{
-                            type: 'secondary',
-                            size,
-                            truncate: true,
-                            sideIcon: null,
-                            icon: !valuePresent ? <IconPlusSmall /> : undefined,
-                        }}
-                    />
-                ) : (
-                    legacyDropdown
-                )}
-                <TaxonomicMenuToggle />
-            </span>
-        ) : (
-            legacyDropdown
-        )
+    // row-branch dropdown variant. The truly inline mode is already routed
+    // away via `showInitialSearchInline`; `disablePopover` still renders a
+    // button + dropdown here, so it's fine to swap.
+    const editablePicker = menuRebuildEnabled ? (
+        <span className="relative inline-flex min-w-0">
+            {useNewMenu ? (
+                <TaxonomicPopoverMenu
+                    groupType={filterTaxonomicGroupType ?? groupTypes[0]}
+                    value={cohortOrOtherValue}
+                    groupTypes={groupTypes}
+                    onChange={(value, _groupType, item, group) => taxonomicOnChange(group, value, item)}
+                    renderValue={() => <span className="truncate">{filterContent}</span>}
+                    placeholder={addText || 'Add filter'}
+                    metadataSource={metadataSource}
+                    eventNames={eventNames}
+                    schemaColumns={schemaColumns}
+                    excludedProperties={excludedProperties}
+                    propertyAllowList={propertyAllowList}
+                    optionsFromProp={taxonomicFilterOptionsFromProp}
+                    hideBehavioralCohorts={hideBehavioralCohorts}
+                    endpointFilters={endpointFilters}
+                    hogQLGlobals={hogQLGlobals}
+                    enableKeywordShortcuts
+                    triggerButtonProps={{
+                        type: 'secondary',
+                        size,
+                        truncate: true,
+                        sideIcon: null,
+                        icon: !valuePresent ? <IconPlusSmall /> : undefined,
+                    }}
+                />
+            ) : (
+                legacyDropdown
+            )}
+            <TaxonomicMenuToggle />
+        </span>
+    ) : (
+        legacyDropdown
+    )
 
     return (
         <div

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -296,12 +296,16 @@ export function TaxonomicPropertyFilter({
     // away via `showInitialSearchInline`; `disablePopover` still renders a
     // button + dropdown here, so it's fine to swap.
     //
+    // `selectingKeyOnly` rows keep the classic filter — the rebuilt menu
+    // doesn't model key-only selection semantics yet, and silently swapping
+    // would change what `onChange` commits.
+    //
     // The rebuilt menu carries its own toggle inside its trigger wrapper, so
     // it needs no extra DOM and inherits the row's layout exactly. The
     // legacy path gets a thin positioned wrapper to host the floating toggle.
     const editablePicker = !menuRebuildEnabled ? (
         legacyDropdown
-    ) : useNewMenu ? (
+    ) : useNewMenu && !selectingKeyOnly ? (
         <TaxonomicPopoverMenu
             groupType={filterTaxonomicGroupType ?? groupTypes[0]}
             value={cohortOrOtherValue}

--- a/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
@@ -304,9 +304,9 @@ export function MenuFilterDwhConfig({
                     so we get scroll shadows and edge-overflow data
                     attrs for free. The viewport already gets
                     `padding-block: 1rem` from Quill's body styling, so
-                    the inner stack just needs row gap + min-width
-                    bound for the LemonTable. */}
-                <DialogBody className="w-full max-w-[700px] overflow-auto">
+                    the inner stack just needs a row gap. Fills the full
+                    `size="wide"` dialog width — no max-width clamp. */}
+                <DialogBody className="w-full overflow-auto">
                     <div className="flex flex-col gap-4 min-w-0">
                         <FieldDescription className="!mt-0">
                             Table: <Badge variant="info">{tableName}</Badge>

--- a/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
@@ -184,14 +184,17 @@ export function MenuFilterDwhConfig({
     }, [activeFieldKey, columns])
 
     const activeFieldValue = values[activeFieldKey] ?? ''
-    // HogQL mode — true whenever the active value isn't a real column on the
-    // table (including `''`, the sentinel for "user picked SQL expression
-    // but hasn't typed anything yet"). Keeping the truthy guard off this
-    // check is what surfaces the Monaco editor as soon as the user selects
-    // `SQL expression` from the dropdown.
+    // HogQL mode — true whenever the active value isn't one of the field's
+    // *selectable* options (including `''`, the sentinel for "user picked
+    // SQL expression but hasn't typed anything yet"). Checked against
+    // `activeFieldOptions` — the same type-filtered set `ColumnSelect` uses
+    // — so the editor and the dropdown agree: when the dropdown shows "SQL
+    // expression", the editor renders. A value that's a real column but of
+    // a disallowed type for this field counts as HogQL, matching the
+    // dropdown.
     const activeFieldIsHogQL = useMemo(
-        () => !!activeField?.allowHogQL && !columns.some((c) => c.name === activeFieldValue),
-        [activeField, activeFieldValue, columns]
+        () => !!activeField?.allowHogQL && !activeFieldOptions.some((c) => c.name === activeFieldValue),
+        [activeField, activeFieldValue, activeFieldOptions]
     )
 
     // ---- preview -------------------------------------------------------

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -82,6 +82,12 @@ export interface TaxonomicFilterMenuProps {
      */
     fullWidthTrigger?: boolean
     /**
+     * Open the menu immediately on mount. Used by consumers that lazily
+     * mount this component on the user's first trigger click — without it
+     * the click that mounts the component wouldn't also open it.
+     */
+    defaultOpen?: boolean
+    /**
      * Extra node rendered inside the trigger wrapper (which is `relative`),
      * e.g. an absolutely-positioned corner badge. Kept inside the wrapper so
      * callers don't need to add another positioned ancestor of their own.
@@ -105,6 +111,7 @@ export function TaxonomicFilterMenu({
     dataWarehousePopoverFields,
     insightProps,
     fullWidthTrigger = false,
+    defaultOpen = false,
     triggerAccessory,
 }: TaxonomicFilterMenuProps): JSX.Element {
     const { groups, selectItem, inputProps, searchQuery } = useTaxonomicFilterContext()
@@ -186,6 +193,16 @@ export function TaxonomicFilterMenu({
         // bouncing back to the dropdown menu.
         return { kind: 'combobox', drillTo: 'all' }
     }, [selected])
+
+    // Open on mount when the consumer lazily mounts this component in
+    // response to the user's first click (see `TaxonomicPopoverMenu`).
+    // Runs once — opening is a one-shot mount concern, not reactive.
+    useEffect(() => {
+        if (defaultOpen) {
+            setState(resolveOpenState())
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     // -- Recent / Pinned shortcuts -- read from kea so menu items reflect
     // the live counts. Mapped back to entries via source group.

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -74,6 +74,19 @@ export interface TaxonomicFilterMenuProps {
     dataWarehousePopoverFields?: import('../types').DataWarehousePopoverField[]
     /** Insight context for the DWH config — when set, the aggregation-target tab reads `funnelDataLogic` for funnel-aware copy. */
     insightProps?: import('~/types').InsightLogicProps
+    /**
+     * Stretch the trigger to its parent's full width. When false (default)
+     * the trigger sizes to its content and caps at the parent — matching a
+     * plain inline button so it truncates instead of overflowing a shared
+     * flex row. Set true for dedicated full-width trigger columns.
+     */
+    fullWidthTrigger?: boolean
+    /**
+     * Extra node rendered inside the trigger wrapper (which is `relative`),
+     * e.g. an absolutely-positioned corner badge. Kept inside the wrapper so
+     * callers don't need to add another positioned ancestor of their own.
+     */
+    triggerAccessory?: import('react').ReactNode
 }
 
 export interface TriggerState {
@@ -91,6 +104,8 @@ export function TaxonomicFilterMenu({
     comboboxTitle,
     dataWarehousePopoverFields,
     insightProps,
+    fullWidthTrigger = false,
+    triggerAccessory,
 }: TaxonomicFilterMenuProps): JSX.Element {
     const { groups, selectItem, inputProps, searchQuery } = useTaxonomicFilterContext()
     const [state, setState] = useState<MenuFilterState>({ kind: 'closed' })
@@ -403,11 +418,15 @@ export function TaxonomicFilterMenu({
                  * names then bleed past the parity wrapper instead of
                  * truncating like the legacy trigger.
                  */}
-                <span ref={triggerWrapRef} className="relative flex min-w-0 w-full">
+                <span
+                    ref={triggerWrapRef}
+                    className={cn('relative flex min-w-0', fullWidthTrigger ? 'w-full' : 'max-w-full')}
+                >
                     <DropdownMenuTrigger render={triggerEl} data-attr="taxonomic-filter-menu-trigger" />
                     <PopoverTrigger
                         render={<span aria-hidden tabIndex={-1} className="absolute inset-0 pointer-events-none" />}
                     />
+                    {triggerAccessory}
                 </span>
                 <PopoverContent
                     align="start"

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicMenuToggle.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicMenuToggle.tsx
@@ -20,7 +20,9 @@ export function TaxonomicMenuToggle(): JSX.Element {
     const { useNewMenu } = useValues(taxonomicMenuPreferenceLogic)
     const { setUseNewMenu } = useActions(taxonomicMenuPreferenceLogic)
 
-    const label = useNewMenu ? 'Switch back to the classic filter' : 'Try the new filter (beta)'
+    // Symmetric, state-neutral labels — the rebuilt menu is the default, so
+    // framing it as "beta / try" would mislabel the primary experience.
+    const label = useNewMenu ? 'Switch to the classic filter' : 'Switch to the new filter'
 
     return (
         <Tooltip title={label}>
@@ -31,6 +33,7 @@ export function TaxonomicMenuToggle(): JSX.Element {
                 onClick={(e) => {
                     // Don't let the click fall through to the trigger button
                     // underneath (which would open the picker).
+                    e.preventDefault()
                     e.stopPropagation()
                     setUseNewMenu(!useNewMenu)
                 }}

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicMenuToggle.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicMenuToggle.tsx
@@ -12,7 +12,9 @@ import { taxonomicMenuPreferenceLogic } from './taxonomicMenuPreferenceLogic'
  * on. Flips the global `taxonomicMenuPreferenceLogic` so the user can opt
  * in/out of the rebuilt menu everywhere at once.
  *
- * Positioned `absolute` top-right — the parent must be `relative`.
+ * Positioned `absolute` inside the trigger's top-right corner — the parent
+ * must be `relative`. Kept inside the trigger box (no negative offset) so
+ * an `overflow-hidden` ancestor can't clip it.
  */
 export function TaxonomicMenuToggle(): JSX.Element {
     const { useNewMenu } = useValues(taxonomicMenuPreferenceLogic)
@@ -32,9 +34,9 @@ export function TaxonomicMenuToggle(): JSX.Element {
                     e.stopPropagation()
                     setUseNewMenu(!useNewMenu)
                 }}
-                className="absolute -top-1.5 -right-1.5 z-10 flex size-4 items-center justify-center rounded-full border border-accent bg-surface-primary text-accent shadow-sm transition-opacity hover:opacity-70"
+                className="absolute top-0 right-0 z-10 flex size-3.5 items-center justify-center rounded-full rounded-tr-sm border border-accent bg-surface-primary text-accent shadow-sm transition-opacity hover:opacity-70"
             >
-                {useNewMenu ? <IconClockRewind className="size-3" /> : <IconFlask className="size-3" />}
+                {useNewMenu ? <IconClockRewind className="size-2.5" /> : <IconFlask className="size-2.5" />}
             </button>
         </Tooltip>
     )

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicMenuToggle.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicMenuToggle.tsx
@@ -1,0 +1,31 @@
+import { useActions, useValues } from 'kea'
+
+import { IconClockRewind, IconFlask } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+
+import { taxonomicMenuPreferenceLogic } from './taxonomicMenuPreferenceLogic'
+
+/**
+ * Small, deliberately visible toggle rendered next to every taxonomic
+ * filter trigger (legacy or rebuilt) wherever the
+ * `taxonomic-filter-menu-rebuild` flag is on. Flips the global
+ * `taxonomicMenuPreferenceLogic` so the user can opt in/out of the new
+ * menu everywhere at once.
+ */
+export function TaxonomicMenuToggle(): JSX.Element {
+    const { useNewMenu } = useValues(taxonomicMenuPreferenceLogic)
+    const { setUseNewMenu } = useActions(taxonomicMenuPreferenceLogic)
+
+    return (
+        <LemonButton
+            size="small"
+            type="secondary"
+            icon={useNewMenu ? <IconClockRewind /> : <IconFlask className="text-accent" />}
+            tooltip={useNewMenu ? 'Switch back to the classic filter' : 'Try the new filter (beta)'}
+            aria-label={useNewMenu ? 'Switch back to the classic filter' : 'Try the new filter'}
+            data-attr="taxonomic-menu-toggle"
+            onClick={() => setUseNewMenu(!useNewMenu)}
+        />
+    )
+}

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicMenuToggle.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicMenuToggle.tsx
@@ -2,30 +2,40 @@ import { useActions, useValues } from 'kea'
 
 import { IconClockRewind, IconFlask } from '@posthog/icons'
 
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { Tooltip } from 'lib/lemon-ui/Tooltip/Tooltip'
 
 import { taxonomicMenuPreferenceLogic } from './taxonomicMenuPreferenceLogic'
 
 /**
- * Small, deliberately visible toggle rendered next to every taxonomic
- * filter trigger (legacy or rebuilt) wherever the
- * `taxonomic-filter-menu-rebuild` flag is on. Flips the global
- * `taxonomicMenuPreferenceLogic` so the user can opt in/out of the new
- * menu everywhere at once.
+ * Floating corner badge rendered over every taxonomic filter trigger
+ * (legacy or rebuilt) wherever the `taxonomic-filter-menu-rebuild` flag is
+ * on. Flips the global `taxonomicMenuPreferenceLogic` so the user can opt
+ * in/out of the rebuilt menu everywhere at once.
+ *
+ * Positioned `absolute` top-right — the parent must be `relative`.
  */
 export function TaxonomicMenuToggle(): JSX.Element {
     const { useNewMenu } = useValues(taxonomicMenuPreferenceLogic)
     const { setUseNewMenu } = useActions(taxonomicMenuPreferenceLogic)
 
+    const label = useNewMenu ? 'Switch back to the classic filter' : 'Try the new filter (beta)'
+
     return (
-        <LemonButton
-            size="small"
-            type="secondary"
-            icon={useNewMenu ? <IconClockRewind /> : <IconFlask className="text-accent" />}
-            tooltip={useNewMenu ? 'Switch back to the classic filter' : 'Try the new filter (beta)'}
-            aria-label={useNewMenu ? 'Switch back to the classic filter' : 'Try the new filter'}
-            data-attr="taxonomic-menu-toggle"
-            onClick={() => setUseNewMenu(!useNewMenu)}
-        />
+        <Tooltip title={label}>
+            <button
+                type="button"
+                aria-label={label}
+                data-attr="taxonomic-menu-toggle"
+                onClick={(e) => {
+                    // Don't let the click fall through to the trigger button
+                    // underneath (which would open the picker).
+                    e.stopPropagation()
+                    setUseNewMenu(!useNewMenu)
+                }}
+                className="absolute -top-1.5 -right-1.5 z-10 flex size-4 items-center justify-center rounded-full border border-accent bg-surface-primary text-accent shadow-sm transition-opacity hover:opacity-70"
+            >
+                {useNewMenu ? <IconClockRewind className="size-3" /> : <IconFlask className="size-3" />}
+            </button>
+        </Tooltip>
     )
 }

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -1,4 +1,5 @@
 import { Placement } from '@floating-ui/react'
+import { useValues } from 'kea'
 import { Ref, forwardRef, useEffect, useState } from 'react'
 
 import { IconX } from '@posthog/icons'
@@ -12,12 +13,16 @@ import {
     TaxonomicFilterGroupType,
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton, LemonButtonProps } from 'lib/lemon-ui/LemonButton'
 import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { LocalFilter } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
 
 import { AnyDataNode, DatabaseSchemaField } from '~/queries/schema/schema-general'
+
+import { TaxonomicPopoverMenu } from './TaxonomicPopoverMenu'
 
 export interface TaxonomicPopoverProps<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue> extends Omit<
     LemonButtonProps,
@@ -101,6 +106,9 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
     }: TaxonomicPopoverProps<ValueType>,
     ref: Ref<HTMLButtonElement>
 ): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const showMenuParity = !!featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_MENU_REBUILD]
+
     const [localValue, setLocalValue] = useState<ValueType>(value || ('' as ValueType))
     const [visible, setVisible] = useState(false)
 
@@ -126,7 +134,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
         }
     }, [value]) // oxlint-disable-line react-hooks/exhaustive-deps
 
-    return (
+    const legacyEl = (
         <LemonDropdown
             overlay={
                 <TaxonomicFilter
@@ -183,6 +191,39 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
                 <LemonButton {...buttonPropsFinal} {...(sideIcon !== undefined && { sideIcon })} ref={ref} />
             )}
         </LemonDropdown>
+    )
+
+    if (!showMenuParity) {
+        return legacyEl
+    }
+
+    // Parity mode — render the legacy popover next to the rebuilt
+    // TaxonomicFilterMenu so the new picker can be verified against the old
+    // one at every call site. Gated by `taxonomic-filter-menu-rebuild`.
+    return (
+        <span className="inline-flex items-center gap-1 min-w-0">
+            {legacyEl}
+            <TaxonomicPopoverMenu<ValueType>
+                groupType={groupType}
+                value={value}
+                groupTypes={groupTypes}
+                onChange={onChange}
+                renderValue={renderValue}
+                placeholder={placeholder}
+                eventNames={eventNames}
+                schemaColumns={schemaColumns}
+                metadataSource={metadataSource}
+                excludedProperties={excludedProperties}
+                selectedProperties={selectedProperties}
+                showNumericalPropsOnly={showNumericalPropsOnly}
+                dataWarehousePopoverFields={dataWarehousePopoverFields}
+                maxContextOptions={maxContextOptions}
+                allowNonCapturedEvents={allowNonCapturedEvents}
+                suggestedFiltersLabel={suggestedFiltersLabel}
+                enableKeywordShortcuts={enableKeywordShortcuts}
+                disabledReason={buttonPropsRest.disabledReason}
+            />
+        </span>
     )
 }) as <ValueType extends TaxonomicFilterValue = TaxonomicFilterValue>(
     props: TaxonomicPopoverProps<ValueType> & { ref?: Ref<HTMLButtonElement> }

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -205,7 +205,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
     // lets the user swap back to the classic filter and forward again.
     // Gated by `taxonomic-filter-menu-rebuild`.
     return (
-        <span className="inline-flex items-center gap-1 min-w-0">
+        <span className="relative inline-flex min-w-0">
             {useNewMenu ? (
                 <TaxonomicPopoverMenu<ValueType>
                     groupType={groupType}

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -228,7 +228,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
                     enableKeywordShortcuts={enableKeywordShortcuts}
                     triggerButtonProps={{
                         icon: buttonPropsRest.icon,
-                        sideIcon: sideIcon ?? undefined,
+                        sideIcon: sideIcon,
                         fullWidth: buttonPropsRest.fullWidth,
                         size: buttonPropsRest.size,
                         type: buttonPropsRest.type ?? 'secondary',

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -209,7 +209,18 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
     // so it's rendered with no extra DOM around it — the trigger inherits
     // the call site's layout exactly. The legacy path needs a thin
     // positioned wrapper to host the floating toggle.
-    if (useNewMenu) {
+    //
+    // The rebuilt menu doesn't model these legacy capabilities yet, so a
+    // call site that needs any of them stays on the classic filter (still
+    // with the toggle) — no behaviour is silently lost:
+    //   - `allowClear`            — the clear (X) affordance
+    //   - `selectingKeyOnly`      — key-only selection semantics
+    //   - `definitionPopoverRenderer` — custom definition popover
+    //   - `closeOnChange={false}` — keep-open-after-select
+    //   - a forwarded `ref`       — the rebuilt trigger can't receive it
+    const newMenuSupportsCallSite =
+        !allowClear && !selectingKeyOnly && !definitionPopoverRenderer && closeOnChange && ref == null
+    if (useNewMenu && newMenuSupportsCallSite) {
         return (
             <TaxonomicPopoverMenu<ValueType>
                 groupType={groupType}

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -204,41 +204,47 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
     // visible toggle (persisted per-user via `taxonomicMenuPreferenceLogic`)
     // lets the user swap back to the classic filter and forward again.
     // Gated by `taxonomic-filter-menu-rebuild`.
+    //
+    // The rebuilt menu carries its own toggle (inside its trigger wrapper),
+    // so it's rendered with no extra DOM around it — the trigger inherits
+    // the call site's layout exactly. The legacy path needs a thin
+    // positioned wrapper to host the floating toggle.
+    if (useNewMenu) {
+        return (
+            <TaxonomicPopoverMenu<ValueType>
+                groupType={groupType}
+                value={value}
+                groupTypes={groupTypes}
+                onChange={onChange}
+                renderValue={renderValue}
+                placeholder={placeholder}
+                placeholderClass={placeholderClass}
+                eventNames={eventNames}
+                schemaColumns={schemaColumns}
+                metadataSource={metadataSource}
+                excludedProperties={excludedProperties}
+                selectedProperties={selectedProperties}
+                showNumericalPropsOnly={showNumericalPropsOnly}
+                dataWarehousePopoverFields={dataWarehousePopoverFields}
+                maxContextOptions={maxContextOptions}
+                allowNonCapturedEvents={allowNonCapturedEvents}
+                suggestedFiltersLabel={suggestedFiltersLabel}
+                enableKeywordShortcuts={enableKeywordShortcuts}
+                triggerButtonProps={{
+                    icon: buttonPropsRest.icon,
+                    sideIcon: sideIcon,
+                    fullWidth: buttonPropsRest.fullWidth,
+                    size: buttonPropsRest.size,
+                    type: buttonPropsRest.type ?? 'secondary',
+                    className: buttonPropsRest.className,
+                    disabledReason: buttonPropsRest.disabledReason,
+                }}
+            />
+        )
+    }
     return (
-        <span className="relative inline-flex min-w-0">
-            {useNewMenu ? (
-                <TaxonomicPopoverMenu<ValueType>
-                    groupType={groupType}
-                    value={value}
-                    groupTypes={groupTypes}
-                    onChange={onChange}
-                    renderValue={renderValue}
-                    placeholder={placeholder}
-                    placeholderClass={placeholderClass}
-                    eventNames={eventNames}
-                    schemaColumns={schemaColumns}
-                    metadataSource={metadataSource}
-                    excludedProperties={excludedProperties}
-                    selectedProperties={selectedProperties}
-                    showNumericalPropsOnly={showNumericalPropsOnly}
-                    dataWarehousePopoverFields={dataWarehousePopoverFields}
-                    maxContextOptions={maxContextOptions}
-                    allowNonCapturedEvents={allowNonCapturedEvents}
-                    suggestedFiltersLabel={suggestedFiltersLabel}
-                    enableKeywordShortcuts={enableKeywordShortcuts}
-                    triggerButtonProps={{
-                        icon: buttonPropsRest.icon,
-                        sideIcon: sideIcon,
-                        fullWidth: buttonPropsRest.fullWidth,
-                        size: buttonPropsRest.size,
-                        type: buttonPropsRest.type ?? 'secondary',
-                        className: buttonPropsRest.className,
-                        disabledReason: buttonPropsRest.disabledReason,
-                    }}
-                />
-            ) : (
-                legacyEl
-            )}
+        <span className="relative inline-flex max-w-full min-w-0">
+            {legacyEl}
             <TaxonomicMenuToggle />
         </span>
     )

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -214,6 +214,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
                     onChange={onChange}
                     renderValue={renderValue}
                     placeholder={placeholder}
+                    placeholderClass={placeholderClass}
                     eventNames={eventNames}
                     schemaColumns={schemaColumns}
                     metadataSource={metadataSource}
@@ -225,10 +226,15 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
                     allowNonCapturedEvents={allowNonCapturedEvents}
                     suggestedFiltersLabel={suggestedFiltersLabel}
                     enableKeywordShortcuts={enableKeywordShortcuts}
-                    fullWidth={buttonPropsRest.fullWidth}
-                    size={buttonPropsRest.size}
-                    triggerType={buttonPropsRest.type}
-                    disabledReason={buttonPropsRest.disabledReason}
+                    triggerButtonProps={{
+                        icon: buttonPropsRest.icon,
+                        sideIcon: sideIcon ?? undefined,
+                        fullWidth: buttonPropsRest.fullWidth,
+                        size: buttonPropsRest.size,
+                        type: buttonPropsRest.type ?? 'secondary',
+                        className: buttonPropsRest.className,
+                        disabledReason: buttonPropsRest.disabledReason,
+                    }}
                 />
             ) : (
                 legacyEl

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -22,6 +22,8 @@ import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
 
 import { AnyDataNode, DatabaseSchemaField } from '~/queries/schema/schema-general'
 
+import { taxonomicMenuPreferenceLogic } from './taxonomicMenuPreferenceLogic'
+import { TaxonomicMenuToggle } from './TaxonomicMenuToggle'
 import { TaxonomicPopoverMenu } from './TaxonomicPopoverMenu'
 
 export interface TaxonomicPopoverProps<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue> extends Omit<
@@ -107,7 +109,8 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
     ref: Ref<HTMLButtonElement>
 ): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
-    const showMenuParity = !!featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_MENU_REBUILD]
+    const { useNewMenu } = useValues(taxonomicMenuPreferenceLogic)
+    const menuRebuildEnabled = !!featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_MENU_REBUILD]
 
     const [localValue, setLocalValue] = useState<ValueType>(value || ('' as ValueType))
     const [visible, setVisible] = useState(false)
@@ -193,36 +196,44 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
         </LemonDropdown>
     )
 
-    if (!showMenuParity) {
+    if (!menuRebuildEnabled) {
         return legacyEl
     }
 
-    // Parity mode — render the legacy popover next to the rebuilt
-    // TaxonomicFilterMenu so the new picker can be verified against the old
-    // one at every call site. Gated by `taxonomic-filter-menu-rebuild`.
+    // Menu-rebuild rollout — the rebuilt menu is rendered by default; a
+    // visible toggle (persisted per-user via `taxonomicMenuPreferenceLogic`)
+    // lets the user swap back to the classic filter and forward again.
+    // Gated by `taxonomic-filter-menu-rebuild`.
     return (
         <span className="inline-flex items-center gap-1 min-w-0">
-            {legacyEl}
-            <TaxonomicPopoverMenu<ValueType>
-                groupType={groupType}
-                value={value}
-                groupTypes={groupTypes}
-                onChange={onChange}
-                renderValue={renderValue}
-                placeholder={placeholder}
-                eventNames={eventNames}
-                schemaColumns={schemaColumns}
-                metadataSource={metadataSource}
-                excludedProperties={excludedProperties}
-                selectedProperties={selectedProperties}
-                showNumericalPropsOnly={showNumericalPropsOnly}
-                dataWarehousePopoverFields={dataWarehousePopoverFields}
-                maxContextOptions={maxContextOptions}
-                allowNonCapturedEvents={allowNonCapturedEvents}
-                suggestedFiltersLabel={suggestedFiltersLabel}
-                enableKeywordShortcuts={enableKeywordShortcuts}
-                disabledReason={buttonPropsRest.disabledReason}
-            />
+            {useNewMenu ? (
+                <TaxonomicPopoverMenu<ValueType>
+                    groupType={groupType}
+                    value={value}
+                    groupTypes={groupTypes}
+                    onChange={onChange}
+                    renderValue={renderValue}
+                    placeholder={placeholder}
+                    eventNames={eventNames}
+                    schemaColumns={schemaColumns}
+                    metadataSource={metadataSource}
+                    excludedProperties={excludedProperties}
+                    selectedProperties={selectedProperties}
+                    showNumericalPropsOnly={showNumericalPropsOnly}
+                    dataWarehousePopoverFields={dataWarehousePopoverFields}
+                    maxContextOptions={maxContextOptions}
+                    allowNonCapturedEvents={allowNonCapturedEvents}
+                    suggestedFiltersLabel={suggestedFiltersLabel}
+                    enableKeywordShortcuts={enableKeywordShortcuts}
+                    fullWidth={buttonPropsRest.fullWidth}
+                    size={buttonPropsRest.size}
+                    triggerType={buttonPropsRest.type}
+                    disabledReason={buttonPropsRest.disabledReason}
+                />
+            ) : (
+                legacyEl
+            )}
+            <TaxonomicMenuToggle />
         </span>
     )
 }) as <ValueType extends TaxonomicFilterValue = TaxonomicFilterValue>(

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -13,6 +13,7 @@
  *   - the headless `onChange(group, value, item)` → the legacy
  *     `onChange(value, groupType, item)`.
  */
+import { useValues } from 'kea'
 import { useMemo } from 'react'
 
 import { IconChevronDown } from '@posthog/icons'
@@ -27,6 +28,7 @@ import {
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
 import { LemonButton, LemonButtonProps } from 'lib/lemon-ui/LemonButton'
+import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
 
 import { AnyDataNode, DatabaseSchemaField } from '~/queries/schema/schema-general'
@@ -93,6 +95,11 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     enableKeywordShortcuts,
     triggerButtonProps,
 }: TaxonomicPopoverMenuProps<ValueType>): JSX.Element {
+    // Data warehouse tables carry their column schema (`fields`) in
+    // `databaseTableListLogic`, not in the bare popover value — needed so
+    // the DWH config form can render its column dropdowns / preview.
+    const { dataWarehouseTablesMap } = useValues(databaseTableListLogic)
+
     // The group a synthetic `selected` entry should claim. `groupType` is
     // the popover's *default tab*, not the value's real category — and it's
     // often a non-selectable shortcut group. Fall back to the first real
@@ -107,13 +114,21 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     // Synthetic entry — the menu reads `group.type` to route the initial
     // open and `name` to highlight the matching row. A full
     // `TaxonomicFilterGroup` isn't needed; the orchestrator's resolved group
-    // is used once the user commits.
+    // is used once the user commits. For a data warehouse value, merge in
+    // the resolved table schema so re-opening lands on a populated config
+    // form (column dropdowns, preview) rather than an empty one.
     const selected = useMemo<MenuFilterEntry | null>(() => {
         if (value == null || value === '') {
             return null
         }
+        const isDataWarehouse = selectedGroupType === TaxonomicFilterGroupType.DataWarehouse
+        const item = {
+            id: value,
+            name: String(value),
+            ...(isDataWarehouse ? dataWarehouseTablesMap[String(value)] : {}),
+        }
         return {
-            item: { id: value, name: String(value) },
+            item,
             group: {
                 type: selectedGroupType,
                 getName: (t: any) => t?.name,
@@ -121,7 +136,7 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
             },
             name: String(value),
         } as unknown as MenuFilterEntry
-    }, [value, selectedGroupType])
+    }, [value, selectedGroupType, dataWarehouseTablesMap])
 
     return (
         <TaxonomicFilterHeadless.Root

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -15,8 +15,6 @@
  */
 import { useMemo } from 'react'
 
-import { IconChevronDown } from '@posthog/icons'
-
 import { TaxonomicFilterHeadless } from 'lib/components/TaxonomicFilter/headless'
 import { MenuFilterEntry, TaxonomicFilterMenu } from 'lib/components/TaxonomicFilter/menu'
 import {
@@ -52,6 +50,7 @@ export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValu
     onChange: (value: ValueType, groupType: TaxonomicFilterGroupType, item: any) => void
     renderValue?: (value: ValueType) => JSX.Element | null
     placeholder?: React.ReactNode
+    placeholderClass?: string
     eventNames?: string[]
     schemaColumns?: DatabaseSchemaField[]
     metadataSource?: AnyDataNode
@@ -63,12 +62,12 @@ export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValu
     allowNonCapturedEvents?: boolean
     suggestedFiltersLabel?: string
     enableKeywordShortcuts?: boolean
-    disabledReason?: string
     /** Trigger button styling, forwarded so the rebuilt menu's trigger
      *  matches the legacy `TaxonomicPopover` button at the call site. */
-    fullWidth?: boolean
-    size?: LemonButtonProps['size']
-    triggerType?: LemonButtonProps['type']
+    triggerButtonProps?: Pick<
+        LemonButtonProps,
+        'icon' | 'sideIcon' | 'fullWidth' | 'size' | 'type' | 'className' | 'disabledReason'
+    >
 }
 
 export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue>({
@@ -78,6 +77,7 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     onChange,
     renderValue,
     placeholder = 'Please select',
+    placeholderClass,
     eventNames = [],
     schemaColumns,
     metadataSource,
@@ -89,10 +89,7 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     allowNonCapturedEvents,
     suggestedFiltersLabel,
     enableKeywordShortcuts,
-    disabledReason,
-    fullWidth = true,
-    size,
-    triggerType = 'secondary',
+    triggerButtonProps,
 }: TaxonomicPopoverMenuProps<ValueType>): JSX.Element {
     // The group a synthetic `selected` entry should claim. `groupType` is
     // the popover's *default tab*, not the value's real category — and it's
@@ -153,18 +150,15 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
                     // Mirrors the proven ActionFilterRow series-picker trigger.
                     <div className="relative inline-flex min-w-0">
                         <LemonButton
-                            type={triggerType}
-                            fullWidth={fullWidth}
-                            size={size}
+                            type="secondary"
+                            {...triggerButtonProps}
                             active={open}
-                            disabledReason={disabledReason}
-                            sideIcon={<IconChevronDown />}
                             data-attr="taxonomic-popover-menu-trigger"
                         >
                             {value ? (
                                 (renderValue?.(value) ?? <span>{String(value)}</span>)
                             ) : (
-                                <span className="text-secondary">{placeholder}</span>
+                                <span className={placeholderClass ?? 'text-secondary'}>{placeholder}</span>
                             )}
                         </LemonButton>
                     </div>

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -135,7 +135,9 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     // the resolved table schema so re-opening lands on a populated config
     // form (column dropdowns, preview) rather than an empty one.
     const selected = useMemo<MenuFilterEntry | null>(() => {
-        if (value == null || value === '') {
+        // Only a primitive scalar can become a synthetic entry — a stray
+        // array/object value would stringify to junk ("[object Object]").
+        if (value == null || value === '' || (typeof value !== 'string' && typeof value !== 'number')) {
             return null
         }
         const isDataWarehouse = selectedGroupType === TaxonomicFilterGroupType.DataWarehouse
@@ -181,7 +183,15 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
             allowNonCapturedEvents={allowNonCapturedEvents}
             suggestedFiltersLabel={suggestedFiltersLabel}
             enableKeywordShortcuts={enableKeywordShortcuts}
-            onChange={(group, changedValue, item) => onChange(changedValue as ValueType, group.type, item, group)}
+            onChange={(group, changedValue, item) => {
+                // Defensive — the orchestrator always resolves a real group
+                // on commit, but a missing one would crash consumers that
+                // dereference `group.type`.
+                if (!group) {
+                    return
+                }
+                onChange(changedValue as ValueType, group.type, item, group)
+            }}
         >
             <TaxonomicFilterMenu
                 selected={selected}

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -2,19 +2,24 @@
  * Central bridge from the legacy `TaxonomicPopover` API to the rebuilt
  * `TaxonomicFilterMenu` (dropdown + preview-pane UI).
  *
- * `TaxonomicPopover` renders this alongside the legacy popover whenever the
- * `taxonomic-filter-menu-rebuild` flag is on, so every popover call site can
- * be compared against the new picker without per-site wiring.
+ * `TaxonomicPopover` renders this whenever the `taxonomic-filter-menu-rebuild`
+ * flag is on and the user prefers the new menu, at every popover call site.
  *
  * The adapter translates `TaxonomicPopover`'s `(value, groupType, item)`
  * shape into the headless orchestrator + menu:
  *   - `value` → a synthetic `MenuFilterEntry` so the trigger reflects the
  *     current selection and re-opening routes into the right panel.
  *   - the headless `onChange(group, value, item)` → the legacy
- *     `onChange(value, groupType, item)`.
+ *     `onChange(value, groupType, item, group)`.
+ *
+ * Lazy mount: the headless orchestrator (`buildTaxonomicGroups` + several
+ * kea subscriptions) is expensive and the picker is rendered at many call
+ * sites. So until the user first clicks the trigger, only a lightweight
+ * placeholder button is rendered — the heavy `ArmedTaxonomicPopoverMenu` is
+ * mounted on first click and opened immediately via `defaultOpen`.
  */
 import { useValues } from 'kea'
-import { useMemo } from 'react'
+import { ReactElement, useMemo, useState } from 'react'
 
 import { IconChevronDown } from '@posthog/icons'
 
@@ -52,6 +57,11 @@ const NON_SELECTABLE_GROUP_TYPES: ReadonlySet<TaxonomicFilterGroupType> = new Se
     TaxonomicFilterGroupType.Empty,
 ])
 
+type TriggerButtonProps = Pick<
+    LemonButtonProps,
+    'icon' | 'sideIcon' | 'fullWidth' | 'size' | 'type' | 'className' | 'disabledReason' | 'truncate'
+>
+
 export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue> {
     groupType: TaxonomicFilterGroupType
     value?: ValueType | null
@@ -80,19 +90,82 @@ export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValu
     enableKeywordShortcuts?: boolean
     /** Trigger button styling, forwarded so the rebuilt menu's trigger
      *  matches the legacy `TaxonomicPopover` button at the call site. */
-    triggerButtonProps?: Pick<
-        LemonButtonProps,
-        'icon' | 'sideIcon' | 'fullWidth' | 'size' | 'type' | 'className' | 'disabledReason' | 'truncate'
-    >
+    triggerButtonProps?: TriggerButtonProps
 }
 
-export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue>({
+/**
+ * Builds the trigger `LemonButton` element — shared by the lazy placeholder
+ * and the live menu trigger so the two are visually identical. Returns a
+ * bare `LemonButton` (no wrapper) so base-ui's `DropdownMenuTrigger` can
+ * render onto it directly and the DOM matches a plain button.
+ */
+function buildTriggerButton(args: {
+    value: TaxonomicFilterValue | null | undefined
+    renderValue?: (value: any) => JSX.Element | null
+    placeholder?: React.ReactNode
+    placeholderClass?: string
+    triggerButtonProps?: TriggerButtonProps
+    open?: boolean
+    onClick?: () => void
+}): ReactElement {
+    const { value, renderValue, placeholder, placeholderClass, triggerButtonProps, open, onClick } = args
+    return (
+        <LemonButton
+            type="secondary"
+            {...triggerButtonProps}
+            // LemonButton only auto-adds the dropdown chevron inside a
+            // LemonDropdown; this trigger isn't, so default it explicitly
+            // (legacy parity). A caller passing `sideIcon={null}` still
+            // suppresses it.
+            sideIcon={triggerButtonProps?.sideIcon === undefined ? <IconChevronDown /> : triggerButtonProps.sideIcon}
+            active={open}
+            onClick={onClick}
+            data-attr="taxonomic-popover-menu-trigger"
+        >
+            {value ? (
+                (renderValue?.(value) ?? <span>{String(value)}</span>)
+            ) : (
+                <span className={placeholderClass ?? 'text-secondary'}>{placeholder}</span>
+            )}
+        </LemonButton>
+    )
+}
+
+export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue>(
+    props: TaxonomicPopoverMenuProps<ValueType>
+): JSX.Element {
+    // Lazy mount — until the user first clicks the trigger, render only the
+    // placeholder button. Mounting the orchestrator for pickers the user
+    // never opens would multiply mount cost across every call site on a page.
+    const [armed, setArmed] = useState(false)
+
+    if (armed) {
+        return <ArmedTaxonomicPopoverMenu {...props} />
+    }
+
+    const { value, renderValue, placeholder = 'Select', placeholderClass, triggerButtonProps } = props
+    return (
+        <span className="relative inline-flex max-w-full min-w-0">
+            {buildTriggerButton({
+                value,
+                renderValue,
+                placeholder,
+                placeholderClass,
+                triggerButtonProps,
+                onClick: () => setArmed(true),
+            })}
+            <TaxonomicMenuToggle />
+        </span>
+    )
+}
+
+function ArmedTaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue>({
     groupType,
     value,
     groupTypes,
     onChange,
     renderValue,
-    placeholder = 'Please select',
+    placeholder = 'Select',
     placeholderClass,
     eventNames = [],
     schemaColumns,
@@ -114,7 +187,9 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
 }: TaxonomicPopoverMenuProps<ValueType>): JSX.Element {
     // Data warehouse tables carry their column schema (`fields`) in
     // `databaseTableListLogic`, not in the bare popover value — needed so
-    // the DWH config form can render its column dropdowns / preview.
+    // the DWH config form can render its column dropdowns / preview. Read
+    // here (not in the lazy outer component) so non-opened pickers don't
+    // subscribe to it.
     const { dataWarehouseTablesMap } = useValues(databaseTableListLogic)
 
     // The group a synthetic `selected` entry should claim. `groupType` is
@@ -198,34 +273,12 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
                 dataWarehousePopoverFields={dataWarehousePopoverFields}
                 fullWidthTrigger={!!triggerButtonProps?.fullWidth}
                 triggerAccessory={<TaxonomicMenuToggle />}
-                // The trigger is a bare LemonButton — base-ui's
-                // DropdownMenuTrigger renders onto it directly, so the DOM
-                // matches a plain button and inherits the call site's layout.
-                trigger={({ open }) => (
-                    <LemonButton
-                        type="secondary"
-                        {...triggerButtonProps}
-                        // LemonButton only auto-adds the dropdown chevron
-                        // inside a LemonDropdown; this trigger isn't, so
-                        // default it explicitly (legacy parity). A caller
-                        // passing `sideIcon={null}` still suppresses it.
-                        sideIcon={
-                            triggerButtonProps?.sideIcon === undefined ? (
-                                <IconChevronDown />
-                            ) : (
-                                triggerButtonProps.sideIcon
-                            )
-                        }
-                        active={open}
-                        data-attr="taxonomic-popover-menu-trigger"
-                    >
-                        {value ? (
-                            (renderValue?.(value) ?? <span>{String(value)}</span>)
-                        ) : (
-                            <span className={placeholderClass ?? 'text-secondary'}>{placeholder}</span>
-                        )}
-                    </LemonButton>
-                )}
+                // Open immediately — this component is mounted in response
+                // to the user's first trigger click (see `TaxonomicPopoverMenu`).
+                defaultOpen
+                trigger={({ open }) =>
+                    buildTriggerButton({ value, renderValue, placeholder, placeholderClass, triggerButtonProps, open })
+                }
             />
         </TaxonomicFilterHeadless.Root>
     )

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -36,6 +36,8 @@ import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
 
 import { AnyDataNode, DatabaseSchemaField } from '~/queries/schema/schema-general'
 
+import { TaxonomicMenuToggle } from './TaxonomicMenuToggle'
+
 /**
  * Shortcut/aggregator groups that have no real items of their own — a
  * selection never genuinely "belongs" to one. `TaxonomicPopover.groupType`
@@ -155,6 +157,9 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
 
     return (
         <TaxonomicFilterHeadless.Root
+            // `display: contents` — the Root wrapper div must not affect
+            // layout, so the trigger sizes exactly as a bare button would.
+            className="contents"
             // Skip the legacy rootProps keydown handler — it intercepts
             // Tab/Arrow for the old list UI we don't render here.
             bindRootProps={false}
@@ -181,35 +186,35 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
             <TaxonomicFilterMenu
                 selected={selected}
                 dataWarehousePopoverFields={dataWarehousePopoverFields}
+                fullWidthTrigger={!!triggerButtonProps?.fullWidth}
+                triggerAccessory={<TaxonomicMenuToggle />}
+                // The trigger is a bare LemonButton — base-ui's
+                // DropdownMenuTrigger renders onto it directly, so the DOM
+                // matches a plain button and inherits the call site's layout.
                 trigger={({ open }) => (
-                    // base-ui's DropdownMenuTrigger spreads its props onto
-                    // this wrapper; the LemonButton inside is presentational.
-                    // Mirrors the proven ActionFilterRow series-picker trigger.
-                    <div className="relative inline-flex min-w-0">
-                        <LemonButton
-                            type="secondary"
-                            {...triggerButtonProps}
-                            // LemonButton only auto-adds the dropdown chevron
-                            // inside a LemonDropdown; this trigger isn't, so
-                            // default it explicitly (legacy parity). A caller
-                            // passing `sideIcon={null}` still suppresses it.
-                            sideIcon={
-                                triggerButtonProps?.sideIcon === undefined ? (
-                                    <IconChevronDown />
-                                ) : (
-                                    triggerButtonProps.sideIcon
-                                )
-                            }
-                            active={open}
-                            data-attr="taxonomic-popover-menu-trigger"
-                        >
-                            {value ? (
-                                (renderValue?.(value) ?? <span>{String(value)}</span>)
+                    <LemonButton
+                        type="secondary"
+                        {...triggerButtonProps}
+                        // LemonButton only auto-adds the dropdown chevron
+                        // inside a LemonDropdown; this trigger isn't, so
+                        // default it explicitly (legacy parity). A caller
+                        // passing `sideIcon={null}` still suppresses it.
+                        sideIcon={
+                            triggerButtonProps?.sideIcon === undefined ? (
+                                <IconChevronDown />
                             ) : (
-                                <span className={placeholderClass ?? 'text-secondary'}>{placeholder}</span>
-                            )}
-                        </LemonButton>
-                    </div>
+                                triggerButtonProps.sideIcon
+                            )
+                        }
+                        active={open}
+                        data-attr="taxonomic-popover-menu-trigger"
+                    >
+                        {value ? (
+                            (renderValue?.(value) ?? <span>{String(value)}</span>)
+                        ) : (
+                            <span className={placeholderClass ?? 'text-secondary'}>{placeholder}</span>
+                        )}
+                    </LemonButton>
                 )}
             />
         </TaxonomicFilterHeadless.Root>

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -1,0 +1,141 @@
+/**
+ * Central bridge from the legacy `TaxonomicPopover` API to the rebuilt
+ * `TaxonomicFilterMenu` (dropdown + preview-pane UI).
+ *
+ * `TaxonomicPopover` renders this alongside the legacy popover whenever the
+ * `taxonomic-filter-menu-rebuild` flag is on, so every popover call site can
+ * be compared against the new picker without per-site wiring.
+ *
+ * The adapter translates `TaxonomicPopover`'s `(value, groupType, item)`
+ * shape into the headless orchestrator + menu:
+ *   - `value` → a synthetic `MenuFilterEntry` so the trigger reflects the
+ *     current selection and re-opening routes into the right panel.
+ *   - the headless `onChange(group, value, item)` → the legacy
+ *     `onChange(value, groupType, item)`.
+ */
+import { useMemo } from 'react'
+
+import { IconChevronDown } from '@posthog/icons'
+
+import { TaxonomicFilterHeadless } from 'lib/components/TaxonomicFilter/headless'
+import { MenuFilterEntry, TaxonomicFilterMenu } from 'lib/components/TaxonomicFilter/menu'
+import {
+    DataWarehousePopoverField,
+    ExcludedProperties,
+    SelectedProperties,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterValue,
+} from 'lib/components/TaxonomicFilter/types'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
+
+import { AnyDataNode, DatabaseSchemaField } from '~/queries/schema/schema-general'
+
+export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue> {
+    groupType: TaxonomicFilterGroupType
+    value?: ValueType | null
+    groupTypes?: TaxonomicFilterGroupType[]
+    onChange: (value: ValueType, groupType: TaxonomicFilterGroupType, item: any) => void
+    renderValue?: (value: ValueType) => JSX.Element | null
+    placeholder?: React.ReactNode
+    eventNames?: string[]
+    schemaColumns?: DatabaseSchemaField[]
+    metadataSource?: AnyDataNode
+    excludedProperties?: ExcludedProperties
+    selectedProperties?: SelectedProperties
+    showNumericalPropsOnly?: boolean
+    dataWarehousePopoverFields?: DataWarehousePopoverField[]
+    maxContextOptions?: MaxContextTaxonomicFilterOption[]
+    allowNonCapturedEvents?: boolean
+    suggestedFiltersLabel?: string
+    enableKeywordShortcuts?: boolean
+    disabledReason?: string
+}
+
+export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue>({
+    groupType,
+    value,
+    groupTypes,
+    onChange,
+    renderValue,
+    placeholder = 'Please select',
+    eventNames = [],
+    schemaColumns,
+    metadataSource,
+    excludedProperties,
+    selectedProperties,
+    showNumericalPropsOnly,
+    dataWarehousePopoverFields,
+    maxContextOptions,
+    allowNonCapturedEvents,
+    suggestedFiltersLabel,
+    enableKeywordShortcuts,
+    disabledReason,
+}: TaxonomicPopoverMenuProps<ValueType>): JSX.Element {
+    // Synthetic entry — the menu reads `group.type` to route the initial
+    // open and `name` to highlight the matching row. A full
+    // `TaxonomicFilterGroup` isn't needed; the orchestrator's resolved group
+    // is used once the user commits.
+    const selected = useMemo<MenuFilterEntry | null>(() => {
+        if (value == null || value === '') {
+            return null
+        }
+        return {
+            item: { id: value, name: String(value) },
+            group: {
+                type: groupType,
+                getName: (t: any) => t?.name,
+                getValue: (t: any) => t?.name ?? t?.id,
+            },
+            name: String(value),
+        } as unknown as MenuFilterEntry
+    }, [value, groupType])
+
+    return (
+        <TaxonomicFilterHeadless.Root
+            // Skip the legacy rootProps keydown handler — it intercepts
+            // Tab/Arrow for the old list UI we don't render here.
+            bindRootProps={false}
+            taxonomicGroupTypes={groupTypes ?? [groupType]}
+            groupType={groupType}
+            value={value ?? undefined}
+            eventNames={eventNames}
+            schemaColumns={schemaColumns}
+            metadataSource={metadataSource}
+            excludedProperties={excludedProperties}
+            selectedProperties={selectedProperties}
+            showNumericalPropsOnly={showNumericalPropsOnly}
+            maxContextOptions={maxContextOptions}
+            allowNonCapturedEvents={allowNonCapturedEvents}
+            suggestedFiltersLabel={suggestedFiltersLabel}
+            enableKeywordShortcuts={enableKeywordShortcuts}
+            onChange={(group, changedValue, item) => onChange(changedValue as ValueType, group.type, item)}
+        >
+            <TaxonomicFilterMenu
+                selected={selected}
+                dataWarehousePopoverFields={dataWarehousePopoverFields}
+                trigger={({ open }) => (
+                    // base-ui's DropdownMenuTrigger spreads its props onto
+                    // this wrapper; the LemonButton inside is presentational.
+                    // Mirrors the proven ActionFilterRow series-picker trigger.
+                    <div className="relative inline-flex min-w-0">
+                        <LemonButton
+                            type="secondary"
+                            fullWidth
+                            active={open}
+                            disabledReason={disabledReason}
+                            sideIcon={<IconChevronDown />}
+                            data-attr="taxonomic-popover-menu-trigger"
+                        >
+                            {value ? (
+                                (renderValue?.(value) ?? <span>{String(value)}</span>)
+                            ) : (
+                                <span className="text-secondary">{placeholder}</span>
+                            )}
+                        </LemonButton>
+                    </div>
+                )}
+            />
+        </TaxonomicFilterHeadless.Root>
+    )
+}

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -31,6 +31,20 @@ import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
 
 import { AnyDataNode, DatabaseSchemaField } from '~/queries/schema/schema-general'
 
+/**
+ * Shortcut/aggregator groups that have no real items of their own — a
+ * selection never genuinely "belongs" to one. `TaxonomicPopover.groupType`
+ * often defaults to `SuggestedFilters` (e.g. the insights series picker),
+ * so a synthetic entry stamped with it would lock the combobox to that
+ * near-empty group instead of opening on the value's real category.
+ */
+const NON_SELECTABLE_GROUP_TYPES: ReadonlySet<TaxonomicFilterGroupType> = new Set([
+    TaxonomicFilterGroupType.SuggestedFilters,
+    TaxonomicFilterGroupType.RecentFilters,
+    TaxonomicFilterGroupType.PinnedFilters,
+    TaxonomicFilterGroupType.Empty,
+])
+
 export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue> {
     groupType: TaxonomicFilterGroupType
     value?: ValueType | null
@@ -72,6 +86,17 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     enableKeywordShortcuts,
     disabledReason,
 }: TaxonomicPopoverMenuProps<ValueType>): JSX.Element {
+    // The group a synthetic `selected` entry should claim. `groupType` is
+    // the popover's *default tab*, not the value's real category — and it's
+    // often a non-selectable shortcut group. Fall back to the first real
+    // group in `groupTypes` so the menu opens on a browsable category.
+    const selectedGroupType = useMemo<TaxonomicFilterGroupType>(() => {
+        if (!NON_SELECTABLE_GROUP_TYPES.has(groupType)) {
+            return groupType
+        }
+        return (groupTypes ?? []).find((t) => !NON_SELECTABLE_GROUP_TYPES.has(t)) ?? groupType
+    }, [groupType, groupTypes])
+
     // Synthetic entry — the menu reads `group.type` to route the initial
     // open and `name` to highlight the matching row. A full
     // `TaxonomicFilterGroup` isn't needed; the orchestrator's resolved group
@@ -83,13 +108,13 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
         return {
             item: { id: value, name: String(value) },
             group: {
-                type: groupType,
+                type: selectedGroupType,
                 getName: (t: any) => t?.name,
                 getValue: (t: any) => t?.name ?? t?.id,
             },
             name: String(value),
         } as unknown as MenuFilterEntry
-    }, [value, groupType])
+    }, [value, selectedGroupType])
 
     return (
         <TaxonomicFilterHeadless.Root

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -15,6 +15,8 @@
  */
 import { useMemo } from 'react'
 
+import { IconChevronDown } from '@posthog/icons'
+
 import { TaxonomicFilterHeadless } from 'lib/components/TaxonomicFilter/headless'
 import { MenuFilterEntry, TaxonomicFilterMenu } from 'lib/components/TaxonomicFilter/menu'
 import {
@@ -152,6 +154,17 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
                         <LemonButton
                             type="secondary"
                             {...triggerButtonProps}
+                            // LemonButton only auto-adds the dropdown chevron
+                            // inside a LemonDropdown; this trigger isn't, so
+                            // default it explicitly (legacy parity). A caller
+                            // passing `sideIcon={null}` still suppresses it.
+                            sideIcon={
+                                triggerButtonProps?.sideIcon === undefined ? (
+                                    <IconChevronDown />
+                                ) : (
+                                    triggerButtonProps.sideIcon
+                                )
+                            }
                             active={open}
                             data-attr="taxonomic-popover-menu-trigger"
                         >

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -26,7 +26,7 @@ import {
     TaxonomicFilterGroupType,
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonButton, LemonButtonProps } from 'lib/lemon-ui/LemonButton'
 import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
 
 import { AnyDataNode, DatabaseSchemaField } from '~/queries/schema/schema-general'
@@ -64,6 +64,11 @@ export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValu
     suggestedFiltersLabel?: string
     enableKeywordShortcuts?: boolean
     disabledReason?: string
+    /** Trigger button styling, forwarded so the rebuilt menu's trigger
+     *  matches the legacy `TaxonomicPopover` button at the call site. */
+    fullWidth?: boolean
+    size?: LemonButtonProps['size']
+    triggerType?: LemonButtonProps['type']
 }
 
 export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue>({
@@ -85,6 +90,9 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     suggestedFiltersLabel,
     enableKeywordShortcuts,
     disabledReason,
+    fullWidth = true,
+    size,
+    triggerType = 'secondary',
 }: TaxonomicPopoverMenuProps<ValueType>): JSX.Element {
     // The group a synthetic `selected` entry should claim. `groupType` is
     // the popover's *default tab*, not the value's real category — and it's
@@ -145,8 +153,9 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
                     // Mirrors the proven ActionFilterRow series-picker trigger.
                     <div className="relative inline-flex min-w-0">
                         <LemonButton
-                            type="secondary"
-                            fullWidth
+                            type={triggerType}
+                            fullWidth={fullWidth}
+                            size={size}
                             active={open}
                             disabledReason={disabledReason}
                             sideIcon={<IconChevronDown />}

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -21,9 +21,12 @@ import { IconChevronDown } from '@posthog/icons'
 import { TaxonomicFilterHeadless } from 'lib/components/TaxonomicFilter/headless'
 import { MenuFilterEntry, TaxonomicFilterMenu } from 'lib/components/TaxonomicFilter/menu'
 import {
+    AllowedProperties,
     DataWarehousePopoverField,
     ExcludedProperties,
     SelectedProperties,
+    SimpleOption,
+    TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
@@ -51,7 +54,9 @@ export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValu
     groupType: TaxonomicFilterGroupType
     value?: ValueType | null
     groupTypes?: TaxonomicFilterGroupType[]
-    onChange: (value: ValueType, groupType: TaxonomicFilterGroupType, item: any) => void
+    /** The 4th arg is the orchestrator's resolved group — consumers that
+     *  need the full `TaxonomicFilterGroup` (not just its type) can use it. */
+    onChange: (value: ValueType, groupType: TaxonomicFilterGroupType, item: any, group: TaxonomicFilterGroup) => void
     renderValue?: (value: ValueType) => JSX.Element | null
     placeholder?: React.ReactNode
     placeholderClass?: string
@@ -60,6 +65,11 @@ export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValu
     metadataSource?: AnyDataNode
     excludedProperties?: ExcludedProperties
     selectedProperties?: SelectedProperties
+    propertyAllowList?: AllowedProperties
+    optionsFromProp?: Partial<Record<TaxonomicFilterGroupType, SimpleOption[]>>
+    hideBehavioralCohorts?: boolean
+    endpointFilters?: Record<string, any>
+    hogQLGlobals?: Record<string, any>
     showNumericalPropsOnly?: boolean
     dataWarehousePopoverFields?: DataWarehousePopoverField[]
     maxContextOptions?: MaxContextTaxonomicFilterOption[]
@@ -70,7 +80,7 @@ export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValu
      *  matches the legacy `TaxonomicPopover` button at the call site. */
     triggerButtonProps?: Pick<
         LemonButtonProps,
-        'icon' | 'sideIcon' | 'fullWidth' | 'size' | 'type' | 'className' | 'disabledReason'
+        'icon' | 'sideIcon' | 'fullWidth' | 'size' | 'type' | 'className' | 'disabledReason' | 'truncate'
     >
 }
 
@@ -87,6 +97,11 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     metadataSource,
     excludedProperties,
     selectedProperties,
+    propertyAllowList,
+    optionsFromProp,
+    hideBehavioralCohorts,
+    endpointFilters,
+    hogQLGlobals,
     showNumericalPropsOnly,
     dataWarehousePopoverFields,
     maxContextOptions,
@@ -151,12 +166,17 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
             metadataSource={metadataSource}
             excludedProperties={excludedProperties}
             selectedProperties={selectedProperties}
+            propertyAllowList={propertyAllowList}
+            optionsFromProp={optionsFromProp}
+            hideBehavioralCohorts={hideBehavioralCohorts}
+            endpointFilters={endpointFilters}
+            hogQLGlobals={hogQLGlobals}
             showNumericalPropsOnly={showNumericalPropsOnly}
             maxContextOptions={maxContextOptions}
             allowNonCapturedEvents={allowNonCapturedEvents}
             suggestedFiltersLabel={suggestedFiltersLabel}
             enableKeywordShortcuts={enableKeywordShortcuts}
-            onChange={(group, changedValue, item) => onChange(changedValue as ValueType, group.type, item)}
+            onChange={(group, changedValue, item) => onChange(changedValue as ValueType, group.type, item, group)}
         >
             <TaxonomicFilterMenu
                 selected={selected}

--- a/frontend/src/lib/components/TaxonomicPopover/taxonomicMenuPreferenceLogic.ts
+++ b/frontend/src/lib/components/TaxonomicPopover/taxonomicMenuPreferenceLogic.ts
@@ -1,0 +1,33 @@
+import { actions, kea, listeners, path, reducers } from 'kea'
+import posthog from 'posthog-js'
+
+import type { taxonomicMenuPreferenceLogicType } from './taxonomicMenuPreferenceLogicType'
+
+/**
+ * Global, persisted preference for which taxonomic filter UI to render
+ * wherever the `taxonomic-filter-menu-rebuild` flag is enabled.
+ *
+ * Defaults to the rebuilt menu; the toggle in `TaxonomicMenuToggle` lets a
+ * user opt back to the classic filter (and forward again). One logic
+ * instance, so flipping it anywhere flips every picker at once.
+ */
+export const taxonomicMenuPreferenceLogic = kea<taxonomicMenuPreferenceLogicType>([
+    path(['lib', 'components', 'TaxonomicPopover', 'taxonomicMenuPreferenceLogic']),
+    actions({
+        setUseNewMenu: (useNewMenu: boolean) => ({ useNewMenu }),
+    }),
+    reducers({
+        useNewMenu: [
+            true,
+            { persist: true },
+            {
+                setUseNewMenu: (_, { useNewMenu }) => useNewMenu,
+            },
+        ],
+    }),
+    listeners(() => ({
+        setUseNewMenu: ({ useNewMenu }) => {
+            posthog.capture('taxonomic filter menu preference changed', { useNewMenu })
+        },
+    })),
+])

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.scss
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.scss
@@ -29,6 +29,7 @@
         flex-wrap: wrap;
         gap: 0.5rem;
         min-width: 0;
+        overflow: hidden;
     }
 }
 

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.scss
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.scss
@@ -29,7 +29,6 @@
         flex-wrap: wrap;
         gap: 0.5rem;
         min-width: 0;
-        overflow: hidden;
     }
 }
 

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -8,21 +8,11 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useCallback } from 'react'
 
-import {
-    IconChevronDown,
-    IconCopy,
-    IconFilter,
-    IconGroupIntersect,
-    IconInfo,
-    IconPencil,
-    IconTrash,
-} from '@posthog/icons'
+import { IconCopy, IconFilter, IconGroupIntersect, IconPencil, IconTrash } from '@posthog/icons'
 
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { SeriesGlyph, SeriesLetter } from 'lib/components/SeriesGlyph'
-import { TaxonomicAutocomplete, TaxonomicFilterHeadless } from 'lib/components/TaxonomicFilter/headless'
-import { MenuFilterEntry, TaxonomicFilterMenu } from 'lib/components/TaxonomicFilter/menu'
 import { defaultDataWarehousePopoverFields } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import {
     DataWarehousePopoverField,
@@ -31,11 +21,8 @@ import {
     quickFilterToPropertyFilters,
 } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicPopover, TaxonomicPopoverProps } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { IconWithCount, SortableDragIcon } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { Tooltip } from 'lib/lemon-ui/Tooltip/Tooltip'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getEventNamesForAction } from 'lib/utils'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
@@ -144,15 +131,6 @@ export function ActionFilterRow({
     const { actions } = useValues(actionsModel)
     const { mathDefinitions } = useValues(mathsLogic)
     const { dataWarehouseTablesMap } = useValues(databaseTableListLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const useMenuRebuild = !!featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_MENU_REBUILD]
-    const useHeadlessAutocomplete = !!featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_HEADLESS]
-    // The new picker ramps in via either flag — `useNewPicker` gates the
-    // entire wrapper so users with both flags off see only the legacy
-    // `filterElement`. Without this guard the parity widget mounts for
-    // every user (even outside the rollout), which contradicts the
-    // "legacy path unchanged" promise.
-    const useNewPicker = useMenuRebuild || useHeadlessAutocomplete
 
     const mountedInsightDataLogic = insightDataLogic.findMounted({ dashboardItemId: typeKey })
     const query = mountedInsightDataLogic?.values?.query
@@ -559,195 +537,6 @@ export function ActionFilterRow({
                             )}
                         >
                             <div className="flex-1 min-w-36 overflow-hidden">{filterElement}</div>
-                            {/* Production-testing variant: the new
-                                TaxonomicFilterMenu (column / preview-pane
-                                view) renders alongside the legacy
-                                TaxonomicPopover so we can ramp it as the
-                                series-row picker. Gated behind either
-                                rollout flag so the parity wrapper +
-                                `TaxonomicFilterHeadless.Root` orchestrator
-                                aren't mounted for users outside the
-                                ramp — preserves the "legacy path
-                                unchanged" promise from the PR. */}
-                            {useNewPicker && (
-                                <div
-                                    className="flex-1 min-w-36 overflow-hidden"
-                                    data-attr={`series-parity-autocomplete-${index}`}
-                                >
-                                    <TaxonomicFilterHeadless.Root
-                                        // Skip the legacy rootProps wrapper —
-                                        // its onKeyDown intercepts Tab/Arrow
-                                        // for the old list UI we don't render
-                                        // here, and traps Tab off the trigger.
-                                        bindRootProps={false}
-                                        taxonomicGroupTypes={effectiveActionsTaxonomicGroupTypes}
-                                        onChange={(group, changedValue, item) =>
-                                            applyTaxonomicSelection(group.type, changedValue, item)
-                                        }
-                                    >
-                                        {useMenuRebuild ? (
-                                            <TaxonomicFilterMenu
-                                                triggerLabel="All events"
-                                                comboboxTitle="Choose series filter"
-                                                // Synthetic entry — the menu only
-                                                // reads `group.type` (to route
-                                                // the initial open) and `name` /
-                                                // `friendlyLabel` (for the
-                                                // trigger label). A full
-                                                // `TaxonomicFilterGroup` isn't
-                                                // needed here.
-                                                selected={
-                                                    // DWH filters often have `filter.id == null`
-                                                    // (the table name lives on `filter.name`),
-                                                    // so gate on whichever of id/name is present
-                                                    // — otherwise the trigger label falls back to
-                                                    // the default and ignores the active selection.
-                                                    filter.type && (filter.id != null || filter.name)
-                                                        ? ({
-                                                              // DWH filters need the saved column
-                                                              // mapping (`id_field` /
-                                                              // `timestamp_field` /
-                                                              // `distinct_id_field` etc.) on the
-                                                              // `item` so re-opening the menu
-                                                              // routes into `dwh-config` with the
-                                                              // form pre-filled. Spread the whole
-                                                              // filter for DWH; events/actions
-                                                              // only need id + name.
-                                                              item:
-                                                                  filter.type === EntityTypes.DATA_WAREHOUSE
-                                                                      ? {
-                                                                            // `...filter` already provides
-                                                                            // `name`; DWH `getValue` reads
-                                                                            // it. Pull in the resolved
-                                                                            // schema (`fields` etc.) from
-                                                                            // `dataWarehouseTablesMap` so
-                                                                            // re-opening the menu routes
-                                                                            // into `dwh-config` with the
-                                                                            // form pre-filled.
-                                                                            ...filter,
-                                                                            ...dataWarehouseTablesMap[
-                                                                                String(filter.name)
-                                                                            ],
-                                                                        }
-                                                                      : { id: filter.id, name: filter.name },
-                                                              group: {
-                                                                  type:
-                                                                      filter.type === EntityTypes.ACTIONS
-                                                                          ? TaxonomicFilterGroupType.Actions
-                                                                          : filter.type === EntityTypes.DATA_WAREHOUSE
-                                                                            ? TaxonomicFilterGroupType.DataWarehouse
-                                                                            : TaxonomicFilterGroupType.Events,
-                                                                  // DWH config form reads `getName`
-                                                                  // / `getValue` off `selected.group`
-                                                                  // when re-opening, so provide them
-                                                                  // for the DWH branch. Events /
-                                                                  // Actions don't need them — the
-                                                                  // resolved orchestrator group is
-                                                                  // used for those once the user
-                                                                  // commits.
-                                                                  getName: (t: any) => t?.name,
-                                                                  getValue: (t: any) => t?.name,
-                                                              },
-                                                              name: String(name ?? filter.name ?? filter.id),
-                                                              friendlyLabel: name ? String(name) : undefined,
-                                                          } as unknown as MenuFilterEntry)
-                                                        : null
-                                                }
-                                                trigger={({ selected, label, open }) => (
-                                                    // `min-w-0` lets the truncate inside the button
-                                                    // actually clip — without it the flex child grows
-                                                    // to its content's intrinsic width and the row
-                                                    // overflows the parent column.
-                                                    <div className="relative min-w-0 border border-dashed border-accent p-1 rounded-sm">
-                                                        <LemonButton
-                                                            type="secondary"
-                                                            fullWidth
-                                                            data-attr={`series-parity-autocomplete-trigger-${index}`}
-                                                            aria-expanded={open}
-                                                            sideIcon={<IconChevronDown />}
-                                                            truncate
-                                                        >
-                                                            {selected ? (
-                                                                <EntityFilterInfo
-                                                                    filter={filter}
-                                                                    showIcon
-                                                                    allowWrap={false}
-                                                                />
-                                                            ) : (
-                                                                <span className="text-secondary truncate">{label}</span>
-                                                            )}
-                                                        </LemonButton>
-                                                        <div className="absolute -top-1 -right-1">
-                                                            <Tooltip
-                                                                title={
-                                                                    <>
-                                                                        INTERNAL ONLY
-                                                                        <br />
-                                                                        The new TaxonomicFilterMenu. <br />
-                                                                        Try it out, leave feedback/wishlist!
-                                                                        <br />
-                                                                        Owned by <b>#platform-ux</b>
-                                                                    </>
-                                                                }
-                                                            >
-                                                                <IconInfo className="size-4 text-accent bg-surface-primary" />
-                                                            </Tooltip>
-                                                        </div>
-                                                    </div>
-                                                )}
-                                            />
-                                        ) : (
-                                            <TaxonomicAutocomplete.Root
-                                                key={`${filter.type}:${String(filter.id ?? '')}`}
-                                                triggerLabel="All events"
-                                                defaultSelected={
-                                                    filter.id != null && filter.type
-                                                        ? {
-                                                              groupType:
-                                                                  filter.type === EntityTypes.ACTIONS
-                                                                      ? TaxonomicFilterGroupType.Actions
-                                                                      : TaxonomicFilterGroupType.Events,
-                                                              value: value ?? null,
-                                                              name: String(name ?? filter.id),
-                                                              friendlyLabel: name ? String(name) : undefined,
-                                                          }
-                                                        : null
-                                                }
-                                            >
-                                                <TaxonomicAutocomplete.Popover>
-                                                    <TaxonomicAutocomplete.Trigger>
-                                                        {({ selected, label, open }) => (
-                                                            <LemonButton
-                                                                type="secondary"
-                                                                fullWidth
-                                                                data-attr={`series-parity-autocomplete-trigger-${index}`}
-                                                                aria-expanded={open}
-                                                                sideIcon={<IconChevronDown />}
-                                                            >
-                                                                {selected ? (
-                                                                    <EntityFilterInfo filter={filter} showIcon />
-                                                                ) : (
-                                                                    <span className="text-secondary">{label}</span>
-                                                                )}
-                                                            </LemonButton>
-                                                        )}
-                                                    </TaxonomicAutocomplete.Trigger>
-                                                    <TaxonomicAutocomplete.Content>
-                                                        <TaxonomicAutocomplete.Header rootTitle="Pick event or action" />
-                                                        <TaxonomicAutocomplete.RootView>
-                                                            <div className="p-1">
-                                                                <TaxonomicAutocomplete.Input />
-                                                            </div>
-                                                            <TaxonomicAutocomplete.Chips />
-                                                            <TaxonomicAutocomplete.List />
-                                                        </TaxonomicAutocomplete.RootView>
-                                                    </TaxonomicAutocomplete.Content>
-                                                </TaxonomicAutocomplete.Popover>
-                                            </TaxonomicAutocomplete.Root>
-                                        )}
-                                    </TaxonomicFilterHeadless.Root>
-                                </div>
-                            )}
                             {customRowSuffix !== undefined && <>{suffix}</>}
                             {mathAvailability !== MathAvailability.None &&
                                 mathAvailability !== MathAvailability.FunnelsOnly && (

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -536,13 +536,13 @@ export function ActionFilterRow({
                                     '@max-[400px]/editor-panel:basis-full @max-[400px]/editor-panel:order-1 @max-[400px]/editor-panel:min-w-0 @max-[400px]/editor-panel:[&>*]:basis-full'
                             )}
                         >
-                            <div className="flex-1 min-w-36">{filterElement}</div>
+                            <div className="flex-1 min-w-36 overflow-hidden">{filterElement}</div>
                             {customRowSuffix !== undefined && <>{suffix}</>}
                             {mathAvailability !== MathAvailability.None &&
                                 mathAvailability !== MathAvailability.FunnelsOnly && (
                                     <>
                                         {mathAvailability !== MathAvailability.BoxPlotOnly && (
-                                            <div className="@min-[0px]/editor-panel:shrink @min-[0px]/editor-panel:min-w-28">
+                                            <div className="@min-[0px]/editor-panel:shrink @min-[0px]/editor-panel:min-w-28 @min-[0px]/editor-panel:overflow-hidden">
                                                 <MathSelector
                                                     math={math}
                                                     mathGroupTypeIndex={mathGroupTypeIndex}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -536,13 +536,13 @@ export function ActionFilterRow({
                                     '@max-[400px]/editor-panel:basis-full @max-[400px]/editor-panel:order-1 @max-[400px]/editor-panel:min-w-0 @max-[400px]/editor-panel:[&>*]:basis-full'
                             )}
                         >
-                            <div className="flex-1 min-w-36 overflow-hidden">{filterElement}</div>
+                            <div className="flex-1 min-w-36">{filterElement}</div>
                             {customRowSuffix !== undefined && <>{suffix}</>}
                             {mathAvailability !== MathAvailability.None &&
                                 mathAvailability !== MathAvailability.FunnelsOnly && (
                                     <>
                                         {mathAvailability !== MathAvailability.BoxPlotOnly && (
-                                            <div className="@min-[0px]/editor-panel:shrink @min-[0px]/editor-panel:min-w-28 @min-[0px]/editor-panel:overflow-hidden">
+                                            <div className="@min-[0px]/editor-panel:shrink @min-[0px]/editor-panel:min-w-28">
                                                 <MathSelector
                                                     math={math}
                                                     mathGroupTypeIndex={mathGroupTypeIndex}


### PR DESCRIPTION
## Problem

The rebuilt TaxonomicFilter menu (`TaxonomicFilterMenu` — dropdown + preview-pane UI) was wired into one place only: the insights series-row picker, via a bespoke block. To roll it out and gather feedback it needs to reach every taxonomic filter, with an easy way for users to fall back if something's off.

## Changes

When the `taxonomic-filter-menu-rebuild` flag is on, `TaxonomicPopover` / `TaxonomicStringPopover` and `TaxonomicPropertyFilter` render the rebuilt menu by default. Flag off → legacy path completely unchanged.

- **`TaxonomicPopoverMenu`** — adapter mapping the legacy `(value, groupType, item)` API onto the headless orchestrator + menu. Builds a synthetic `MenuFilterEntry` from `(groupType, value)`, resolving past non-selectable shortcut groups so the menu opens on a real category. **Lazy-mounted**: only a placeholder button renders until the user's first click, then the orchestrator (`buildTaxonomicGroups` + kea subscriptions) mounts and opens via `TaxonomicFilterMenu defaultOpen`.
- **`TaxonomicMenuToggle`** — small floating corner badge, pinned inside the trigger. One click flips the rebuilt vs classic filter.
- **`taxonomicMenuPreferenceLogic`** — global `persist`-backed preference; the choice sticks per-user and applies to every picker at once.
- **`ActionFilterRow`** — bespoke parity block removed (~210 lines); its `TaxonomicPopover` inherits the central path.
- DWH-config and HogQL-editor fixes in the menu internals (`DwhFlow`, `TaxonomicFilterMenu`).

A multi-agent QA review was run; all 5 HIGH findings and several MEDIUM/LOW are resolved (see below).

## Safe fallbacks — no silent regressions

A call site stays on the **classic filter** (with the toggle still shown) when it uses a capability the rebuilt menu doesn't model yet: `allowClear`, `selectingKeyOnly`, `definitionPopoverRenderer`, `closeOnChange={false}`, or a forwarded `ref`. So no behaviour is silently dropped on flag flip.

## ⚠️ Known limitations & risks (for future reference)

**Scope boundaries (intentional):**
- Only `TaxonomicPopover`-shaped call sites are covered. The ~18 bare inline `<TaxonomicFilter>` sites (breakdown popover, some property selectors) are **not** — the menu is a popover widget and can't drop into someone else's popover.
- `TaxonomicPropertyFilter`'s inline-search mode (`showInitialSearchInline`) stays legacy — no trigger to hang a popover on.
- Call sites using `allowClear` / `selectingKeyOnly` / `definitionPopoverRenderer` / `closeOnChange={false}` / a `ref` stay legacy until the rebuilt menu models those.

**Open follow-ups (QA findings, non-blocking — tracked in `QAREPORT.md`):**
- 🟡 Toggle badge is `absolute` in the trigger's top-right and overlaps the chevron / truncated label, worse on `size="small"` triggers.
- 🟡 DWH config re-population depends on `databaseTableListLogic` having loaded; self-heals via a `useMemo` dep but can briefly render an empty form.
- 🟡 `taxonomicGroupTypes={[]}` (all-meta groups) locks the synthetic entry to a non-selectable group — rare edge.
- 🟢 Persisted `useNewMenu` is read without boolean coercion — a corrupt localStorage value would degrade every picker for that user.
- 🟢 `changedValue as ValueType` is an unchecked cast in the `onChange` shim.
- 🟢 The toggle adds one focusable tab stop per picker (~33/page).
- 🟢 `DwhFlow` `activeFieldIsHogQL` now checks type-filtered options — a saved column of a now-disallowed type re-opens in SQL-expression mode.

**Verification gaps:**
- base-ui's `DropdownMenuTrigger` renders directly onto a bare `LemonButton` — verify the menu opens and ARIA attributes land.
- No unit tests exercise the new-menu path (tests run flag-off). Needs manual QA across call sites before widening the flag.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run locally:
- `tsc` + `oxlint` — clean.
- 193 tests pass (`TaxonomicPopover`, `PropertyFilters`, `TaxonomicFilter/menu`, `ActionFilterRow`).
- Multi-agent QA review (security / reliability / performance / frontend / copy + 2 generalists) — all HIGH findings fixed.

Not browser-verified — the new-menu path needs manual QA across call sites.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code over an iterative session. Started as side-by-side parity, moved to a hard swap with a persisted opt-out toggle per product direction. `ActionFilterRow`'s hand-wiring was generalized into the reusable `TaxonomicPopoverMenu` adapter and deleted. A multi-agent QA review surfaced prop-parity regressions (fixed via legacy fallback) and an eager-mount perf regression (fixed via lazy-mount). Remaining QA items are MEDIUM/LOW and tracked above.