### PR TITLE
chore: hook up provisioning_welcome Customer.io template

### DIFF
--- a/posthog/email.py
+++ b/posthog/email.py
@@ -119,6 +119,7 @@ CUSTOMER_IO_TEMPLATE_ID_MAP = {
     "conversation_restore": "63",
     "proxy_provisioned": "64",
     "delegation_invite": "66",
+    "provisioning_welcome": "67",
 }
 
 

--- a/posthog/test/test_email.py
+++ b/posthog/test/test_email.py
@@ -322,3 +322,43 @@ class TestEmail(BaseTest):
 
             # Raw email should remain unchanged
             self.assertEqual(message.to[0]["raw_email"], "test@example.com")
+
+    def test_all_http_templates_are_registered_in_customer_io_map(self) -> None:
+        # Every EmailMessage(use_http=True, template_name="X", ...) call in
+        # posthog/tasks/email.py needs "X" in CUSTOMER_IO_TEMPLATE_ID_MAP.
+        # The Customer.io HTTP sender raises "Unknown template name" if it
+        # isn't, and the Celery task wrapper swallows the exception via
+        # capture_exception. Without this test, a new transactional email
+        # added with a forgotten map entry sends zero emails and surfaces
+        # nothing user-visible.
+        import ast
+        from pathlib import Path
+
+        import posthog.tasks.email as email_tasks
+
+        source = Path(email_tasks.__file__).read_text()
+        tree = ast.parse(source)
+
+        missing: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not (isinstance(node.func, ast.Name) and node.func.id == "EmailMessage"):
+                continue
+            kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg is not None}
+            use_http = kwargs.get("use_http")
+            if not (isinstance(use_http, ast.Constant) and use_http.value is True):
+                continue
+            template_name = kwargs.get("template_name")
+            if isinstance(template_name, ast.Constant) and isinstance(template_name.value, str):
+                if template_name.value not in CUSTOMER_IO_TEMPLATE_ID_MAP:
+                    missing.append(template_name.value)
+
+        self.assertEqual(
+            sorted(set(missing)),
+            [],
+            "These template_name values use use_http=True in posthog/tasks/email.py but are "
+            "missing from CUSTOMER_IO_TEMPLATE_ID_MAP in posthog/email.py. Add a map entry "
+            "pointing to the Customer.io transactional message ID, otherwise the sender will "
+            "raise 'Unknown template name' at runtime and the Celery task will swallow it.",
+        )

--- a/posthog/test/test_email.py
+++ b/posthog/test/test_email.py
@@ -325,7 +325,7 @@ class TestEmail(BaseTest):
 
     def test_all_http_templates_are_registered_in_customer_io_map(self) -> None:
         # Every EmailMessage(use_http=True, template_name="X", ...) call in
-        # posthog/tasks/email.py needs "X" in CUSTOMER_IO_TEMPLATE_ID_MAP.
+        # production code under posthog/ needs "X" in CUSTOMER_IO_TEMPLATE_ID_MAP.
         # The Customer.io HTTP sender raises "Unknown template name" if it
         # isn't, and the Celery task wrapper swallows the exception via
         # capture_exception. Without this test, a new transactional email
@@ -334,31 +334,40 @@ class TestEmail(BaseTest):
         import ast
         from pathlib import Path
 
-        import posthog.tasks.email as email_tasks
+        import posthog as posthog_pkg
 
-        source = Path(email_tasks.__file__).read_text()
-        tree = ast.parse(source)
+        posthog_root = Path(posthog_pkg.__file__).parent
+        sources = sorted(
+            p
+            for p in posthog_root.rglob("*.py")
+            if "/test/" not in str(p) and "/tests/" not in str(p) and not p.name.startswith("test_")
+        )
 
-        missing: list[str] = []
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
+        missing: dict[str, str] = {}  # template_name -> first source path that uses it
+        for source_path in sources:
+            try:
+                tree = ast.parse(source_path.read_text())
+            except SyntaxError:
                 continue
-            if not (isinstance(node.func, ast.Name) and node.func.id == "EmailMessage"):
-                continue
-            kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg is not None}
-            use_http = kwargs.get("use_http")
-            if not (isinstance(use_http, ast.Constant) and use_http.value is True):
-                continue
-            template_name = kwargs.get("template_name")
-            if isinstance(template_name, ast.Constant) and isinstance(template_name.value, str):
-                if template_name.value not in CUSTOMER_IO_TEMPLATE_ID_MAP:
-                    missing.append(template_name.value)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if not (isinstance(node.func, ast.Name) and node.func.id == "EmailMessage"):
+                    continue
+                kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg is not None}
+                use_http = kwargs.get("use_http")
+                if not (isinstance(use_http, ast.Constant) and use_http.value is True):
+                    continue
+                template_name = kwargs.get("template_name")
+                if isinstance(template_name, ast.Constant) and isinstance(template_name.value, str):
+                    if template_name.value not in CUSTOMER_IO_TEMPLATE_ID_MAP:
+                        missing.setdefault(template_name.value, str(source_path.relative_to(posthog_root.parent)))
 
         self.assertEqual(
-            sorted(set(missing)),
-            [],
-            "These template_name values use use_http=True in posthog/tasks/email.py but are "
-            "missing from CUSTOMER_IO_TEMPLATE_ID_MAP in posthog/email.py. Add a map entry "
-            "pointing to the Customer.io transactional message ID, otherwise the sender will "
-            "raise 'Unknown template name' at runtime and the Celery task will swallow it.",
+            missing,
+            {},
+            "These template_name values use use_http=True in production code but are missing "
+            "from CUSTOMER_IO_TEMPLATE_ID_MAP in posthog/email.py. Add a map entry pointing to "
+            "the Customer.io transactional message ID, otherwise the sender will raise "
+            "'Unknown template name' at runtime and capture_exception will swallow it.",
         )


### PR DESCRIPTION
## Problem

The welcome email for provisioned users (sent by `send_provisioning_welcome` in `posthog/tasks/email.py:382`) was silently dropped in production. `EmailMessage(use_http=True, template_name="provisioning_welcome", ...)` routes through the Customer.io HTTP sender, which calls `get_customer_io_template_id("provisioning_welcome")` and raises `Unknown template name` because that template was never added to `CUSTOMER_IO_TEMPLATE_ID_MAP` in `posthog/email.py`. The exception is caught and `capture_exception`-d at `views.py:658-662`, so provisioning succeeds with zero user-visible signal that the email failed.

## Changes

- Add `"provisioning_welcome": "67"` to `CUSTOMER_IO_TEMPLATE_ID_MAP`.
- Add a regression test that walks every `.py` under `posthog/` (skipping `test_*.py` and `test/` dirs) via `ast` and asserts every `EmailMessage(use_http=True, template_name="X")` has `"X"` in the map. Stops the same silent-failure pattern from recurring when future transactional emails are added — covers `posthog/tasks/email.py`, `posthog/temporal/proxy_service/common.py`, `posthog/approvals/notifications.py`, and anything new.

Template 67 is [Welcome to PostHog - set your password](https://fly.customer.io/workspaces/127208/journeys/transactional/67/overview) in the EU Customer.io workspace. Variables match what `send_provisioning_welcome` passes (`link`, `site_url`, `preheader`, `partner_name`, `cloud`).

<img width="1077" height="808" alt="image" src="https://github.com/user-attachments/assets/ece1cc84-78ca-4ff5-acd6-2571dca15150" />


## How did you test this code?

Agent author. Tests run:

- `pytest posthog/test/test_email.py::TestEmail::test_all_http_templates_are_registered_in_customer_io_map` — passes locally.
- Used the `cio` CLI to send a live transactional message via template 67 to `matt@posthog.com` with the exact payload shape `send_provisioning_welcome` produces. Delivery confirmed (id `ROjhBwUAAZ47Xh8nfKVYBN2BYD_FVg==`, state `sent`).

## Publish to changelog?

No.

## 🤖 Agent context

Co-authored by Claude (Opus 4.7). Surfaced in a session triaging security ticket #669 (CIMD pre-account-takeover). Three stacked PRs are planned to land:

- **PR A (this PR)**: hook up the Customer.io template so the welcome email actually sends.
- **PR B**: flip `is_email_verified` to True on password reset (proves email ownership via the unique token from the reset link).
- **PR C**: credential review interstitial on first post-provisioning login so users can revoke any partner-issued API key they don't recognize.

A and B have no code dependency; both are conceptually prerequisites for C. Stacked via Graphite. Decisions made: chose an AST-parse regression test over an enumerated list of template names so the check stays correct when new transactional emails are added; placed the test in `posthog/test/test_email.py` rather than `posthog/tasks/test/test_email.py` since the assertion is about `CUSTOMER_IO_TEMPLATE_ID_MAP` (defined in `posthog/email.py`).
