### PR TITLE
fix(rbac): gate features on ROLE_BASED_ACCESS

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -493,17 +493,10 @@ class AccessControlViewSetMixin(_GenericViewSet):
                 else:
                     role_resource_overrides[(str(role_id), resource_type)] = level
 
-        # Resource-level role overrides only take effect if the organization has the
-        # ROLE_BASED_ACCESS feature; otherwise role rows in the DB are inert for
-        # resource access and we must not surface them as the effective access level.
-        # NOTE: project-level role overrides are intentionally NOT gated here because
-        # UserTeamPermissions.effective_membership_level_for_parent_membership honors
-        # role-backed project AccessControl rows whenever ACCESS_CONTROL is
-        # enabled (no ROLE_BASED_ACCESS check), so gating the preview here would lie
-        # about a user's actual project access.
-        role_based_resource_access_supported = team.organization.is_feature_available(
-            AvailableFeature.ROLE_BASED_ACCESS
-        )
+        # Role overrides (project- and resource-level) only take effect if the
+        # organization has the ROLE_BASED_ACCESS feature; otherwise role rows in the
+        # DB are inert and we must not surface them as the effective access level.
+        role_based_access_supported = team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
 
         # Build results for each role
         roles = Role.objects.filter(organization=team.organization)
@@ -512,7 +505,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
         for role in roles:
             rid = str(role.id)
 
-            project_role_level = role_project_overrides.get(rid)
+            project_role_level = role_project_overrides.get(rid) if role_based_access_supported else None
             project_result = get_effective_access_level_for_role(
                 resource="project",
                 default_level=project_default_level,
@@ -522,7 +515,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
             resource_entries: dict[str, dict] = {}
             for resource in ACCESS_CONTROL_RESOURCES:
                 resource_role_level = (
-                    role_resource_overrides.get((rid, resource)) if role_based_resource_access_supported else None
+                    role_resource_overrides.get((rid, resource)) if role_based_access_supported else None
                 )
                 resource_default = resource_default_levels.get(resource)
                 resource_result = get_effective_access_level_for_role(
@@ -605,17 +598,10 @@ class AccessControlViewSetMixin(_GenericViewSet):
                 else:
                     member_resource_overrides[(str(member_id), resource_type)] = level
 
-        # Resource-level role overrides only take effect if the organization has the
-        # ROLE_BASED_ACCESS feature; otherwise role rows in the DB are inert for
-        # resource access and we must not let them influence members' effective
-        # resource access level. NOTE: project-level role overrides are intentionally
-        # NOT gated here because UserTeamPermissions.effective_membership_level_for_
-        # parent_membership honors role-backed project AccessControl rows whenever
-        # ACCESS_CONTROL is enabled (no ROLE_BASED_ACCESS check), so gating the
-        # preview here would lie about a user's actual project access.
-        role_based_resource_access_supported = team.organization.is_feature_available(
-            AvailableFeature.ROLE_BASED_ACCESS
-        )
+        # Role overrides (project- and resource-level) only take effect if the
+        # organization has the ROLE_BASED_ACCESS feature; otherwise role rows in the
+        # DB are inert and we must not let them influence members' effective access.
+        role_based_access_supported = team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
 
         # Build results for each member
         memberships = (
@@ -631,9 +617,11 @@ class AccessControlViewSetMixin(_GenericViewSet):
             member_role_ids = [str(rm.role_id) for rm in membership.role_memberships.all()]
 
             project_member_level = member_project_overrides.get(mid)
-            project_role_levels: list[AccessControlLevel] = [
-                role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides
-            ]
+            project_role_levels: list[AccessControlLevel] = (
+                [role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides]
+                if role_based_access_supported
+                else []
+            )
             project_result = get_effective_access_level_for_member(
                 resource="project",
                 default_level=project_default_level,
@@ -652,7 +640,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
                         for rid in member_role_ids
                         if (rid, resource) in role_resource_overrides
                     ]
-                    if role_based_resource_access_supported
+                    if role_based_access_supported
                     else []
                 )
                 resource_result = get_effective_access_level_for_member(

--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -619,14 +619,15 @@ class AccessControlViewSetMixin(_GenericViewSet):
         for membership in memberships:
             mid = str(membership.id)
             is_org_admin = membership.level >= OrganizationMembership.Level.ADMIN
-            member_role_ids = [str(rm.role_id) for rm in membership.role_memberships.all()]
+            # Role memberships only contribute when ROLE_BASED_ACCESS is enabled.
+            member_role_ids = (
+                [str(rm.role_id) for rm in membership.role_memberships.all()] if role_based_access_supported else []
+            )
 
             project_member_level = member_project_overrides.get(mid)
-            project_role_levels: list[AccessControlLevel] = (
-                [role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides]
-                if role_based_access_supported
-                else []
-            )
+            project_role_levels: list[AccessControlLevel] = [
+                role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides
+            ]
             project_result = get_effective_access_level_for_member(
                 resource="project",
                 default_level=project_default_level,
@@ -639,15 +640,11 @@ class AccessControlViewSetMixin(_GenericViewSet):
             for resource in ACCESS_CONTROL_RESOURCES:
                 resource_member_level = member_resource_overrides.get((mid, resource))
                 resource_default = resource_default_levels.get(resource)
-                resource_role_levels: list[AccessControlLevel] = (
-                    [
-                        role_resource_overrides[(rid, resource)]
-                        for rid in member_role_ids
-                        if (rid, resource) in role_resource_overrides
-                    ]
-                    if role_based_access_supported
-                    else []
-                )
+                resource_role_levels: list[AccessControlLevel] = [
+                    role_resource_overrides[(rid, resource)]
+                    for rid in member_role_ids
+                    if (rid, resource) in role_resource_overrides
+                ]
                 resource_result = get_effective_access_level_for_member(
                     resource=resource,
                     default_level=resource_default,

--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -134,6 +134,11 @@ class AccessControlSerializer(serializers.ModelSerializer):
         team = context["view"].team
         the_object = context["view"].get_object()
 
+        # Role-backed access controls require the ROLE_BASED_ACCESS feature — same gate
+        # as the UI's "Roles" blocks and the runtime enforcement in UserTeamPermissions.
+        if data.get("role") and not team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS):
+            raise exceptions.PermissionDenied("Role-based access controls require the Role-based access feature.")
+
         if resource_id:
             if str(the_object.pk) != str(resource_id):
                 raise exceptions.PermissionDenied(

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -125,6 +125,26 @@ class TestAccessControlProjectLevelAPI(BaseAccessControlTest):
         assert "organization member id" in res.json()["detail"]
         assert "/api/organizations/" in res.json()["detail"]
 
+    def test_role_based_access_control_rejected_without_role_based_access_feature(self):
+        # Drop ROLE_BASED_ACCESS, keep ACCESS_CONTROL — same shape as the UI gate
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+        ]
+        self.organization.save()
+
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+        role = Role.objects.create(name="Engineering", organization=self.organization)
+
+        res = self._put_project_access_control({"role": str(role.id), "access_level": "admin"})
+        assert res.status_code == status.HTTP_403_FORBIDDEN, res.json()
+        assert "Role-based access" in res.json()["detail"]
+
+        # Member-level writes still work — only the role-backed write is blocked
+        res = self._put_project_access_control(
+            {"organization_member": str(self.organization_membership.id), "access_level": "admin"}
+        )
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
 
 class TestAccessControlMinimumLevelValidation(BaseAccessControlTest):
     def test_action_access_level_cannot_be_below_viewer(self):

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -1677,11 +1677,10 @@ class TestAccessControlRolesEndpoint(BaseAccessControlTest):
         role_data = self._find_role(res.json()["results"], self.role.id)
         assert role_data["project"]["access_level"] == "member"
 
-    def test_resource_role_overrides_ignored_when_role_based_access_not_available(self):
-        """Without ROLE_BASED_ACCESS, role-based resource overrides are inert at runtime,
-        so the per-role preview must show the resource default as the effective level.
-        Project-level role overrides remain effective (runtime still honors them via
-        UserTeamPermissions when ACCESS_CONTROL is enabled)."""
+    def test_role_overrides_ignored_when_role_based_access_not_available(self):
+        """Without ROLE_BASED_ACCESS, role-based overrides (project- and resource-level)
+        are inert at runtime, so the per-role preview must show the resource/project
+        default as the effective level."""
         self.organization.available_product_features = [
             {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
         ]
@@ -1703,10 +1702,10 @@ class TestAccessControlRolesEndpoint(BaseAccessControlTest):
         assert dashboard["inherited_access_level"] == "viewer"
         assert dashboard["inherited_access_level_reason"] == "project_default"
 
-        # Project-level role override is still effective (mirrors runtime)
+        # Project-level role override must also be ignored — falls back to project default
         project = role_data["project"]
-        assert project["access_level"] == "admin"
-        assert project["effective_access_level"] == "admin"
+        assert project["access_level"] is None
+        assert project["effective_access_level"] == "member"
 
 
 class TestAccessControlMembersEndpoint(BaseAccessControlTest):
@@ -1847,16 +1846,10 @@ class TestAccessControlMembersEndpoint(BaseAccessControlTest):
         assert ff["effective_access_level"] is None
         assert ff["inherited_access_level"] is None
 
-    def test_resource_role_overrides_ignored_when_role_based_access_not_available(self):
+    def test_role_overrides_ignored_when_role_based_access_not_available(self):
         """When the organization does not have the ROLE_BASED_ACCESS feature, role-based
-        *resource* overrides must not influence a member's effective resource access level.
-        The member should fall back to the resource default.
-
-        Project-level role overrides are deliberately NOT gated by this feature, because
-        UserTeamPermissions.effective_membership_level_for_parent_membership honors
-        role-backed project AccessControl rows whenever ACCESS_CONTROL is enabled
-        (no ROLE_BASED_ACCESS check). The preview must match that runtime behaviour.
-        """
+        overrides (project- and resource-level) must not influence a member's effective
+        access. The member should fall back to the default at each level."""
         # Remove the ROLE_BASED_ACCESS feature, keep ACCESS_CONTROL
         self.organization.available_product_features = [
             {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
@@ -1886,11 +1879,11 @@ class TestAccessControlMembersEndpoint(BaseAccessControlTest):
         assert dashboard["inherited_access_level"] == "viewer"
         assert dashboard["inherited_access_level_reason"] == "project_default"
 
-        # Project-level: role override IS still honored at runtime, so the preview must reflect it
+        # Project-level: role override must also be ignored, fall back to project default
         project = member_data["project"]
-        assert project["effective_access_level"] == "admin"
-        assert project["inherited_access_level"] == "admin"
-        assert project["inherited_access_level_reason"] == "role_override"
+        assert project["effective_access_level"] == "member"
+        assert project["inherited_access_level"] == "member"
+        assert project["inherited_access_level_reason"] == "project_default"
 
     def test_only_returns_current_team_member_overrides(self):
         """Member overrides from other teams are not included."""

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -1061,7 +1061,6 @@ class Team(UUIDTClassicModel):
 
             # Role-backed access only contributes when the org has ROLE_BASED_ACCESS —
             # same gate as the UI's "Roles" block on the project access settings page.
-            role_user_ids: QuerySet[Any] | list[Any] = []
             if self.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS):
                 roles_with_access = AccessControl.objects.filter(
                     team_id=self.id,
@@ -1076,6 +1075,9 @@ class Team(UUIDTClassicModel):
                     .values_list("organization_member__user_id", flat=True)
                     .distinct()
                 )
+            else:
+                # Empty queryset (not a list) so `.union()` keeps working.
+                role_user_ids = RoleMembership.objects.none().values_list("organization_member__user_id", flat=True)
 
             # Union all sets of user IDs
             user_ids_queryset = cast(Any, admin_user_ids).union(member_access_user_ids, role_user_ids)

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -1005,11 +1005,20 @@ class Team(UUIDTClassicModel):
         create_data_for_demo_team.delay(self.id, initiating_user.id, cache_key)
 
     def all_users_with_access(self) -> QuerySet["User"]:
+        from posthog.constants import AvailableFeature
         from posthog.models.organization import OrganizationMembership
         from posthog.models.user import User
 
         from ee.models.rbac.access_control import AccessControl
         from ee.models.rbac.role import RoleMembership
+
+        # Without ACCESS_CONTROL there is no notion of private teams — all org members have access.
+        # Mirrors User.teams and UserTeamPermissions.effective_membership_level_for_parent_membership.
+        if not self.organization.is_feature_available(AvailableFeature.ACCESS_CONTROL):
+            user_ids_queryset = OrganizationMembership.objects.filter(organization_id=self.organization_id).values_list(
+                "user_id", flat=True
+            )
+            return User.objects.filter(is_active=True, id__in=user_ids_queryset)
 
         # First, check if the team is private
         team_is_private = AccessControl.objects.filter(
@@ -1050,21 +1059,23 @@ class Team(UUIDTClassicModel):
                 id__in=org_memberships_with_access
             ).values_list("user_id", flat=True)
 
-            # Get roles with access to this team
-            roles_with_access = AccessControl.objects.filter(
-                team_id=self.id,
-                resource="project",
-                resource_id=str(self.id),
-                role__isnull=False,
-                access_level__in=["member", "admin"],
-            ).values_list("role", flat=True)
+            # Role-backed access only contributes when the org has ROLE_BASED_ACCESS —
+            # same gate as the UI's "Roles" block on the project access settings page.
+            role_user_ids: QuerySet[Any] | list[Any] = []
+            if self.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS):
+                roles_with_access = AccessControl.objects.filter(
+                    team_id=self.id,
+                    resource="project",
+                    resource_id=str(self.id),
+                    role__isnull=False,
+                    access_level__in=["member", "admin"],
+                ).values_list("role", flat=True)
 
-            # Get users who have these roles
-            role_user_ids = (
-                RoleMembership.objects.filter(role_id__in=roles_with_access)
-                .values_list("organization_member__user_id", flat=True)
-                .distinct()
-            )
+                role_user_ids = (
+                    RoleMembership.objects.filter(role_id__in=roles_with_access)
+                    .values_list("organization_member__user_id", flat=True)
+                    .distinct()
+                )
 
             # Union all sets of user IDs
             user_ids_queryset = cast(Any, admin_user_ids).union(member_access_user_ids, role_user_ids)

--- a/posthog/models/test/test_team_model.py
+++ b/posthog/models/test/test_team_model.py
@@ -280,3 +280,61 @@ class TestTeam(BaseTest):
 
         # Both users should have access
         assert sorted(all_user_with_access_ids) == sorted([self.user.id, member_user.id])
+
+    def test_all_users_with_access_returns_all_org_members_without_access_control_feature(self):
+        """Without ACCESS_CONTROL there are no private teams — every org member has access,
+        even if AccessControl rows exist in the DB."""
+        # No features enabled
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="none",
+        )
+        member_user = User.objects.create_and_join(
+            self.organization,
+            email="member-no-feature@posthog.com",
+            first_name="first_name",
+            password=None,
+            level=OrganizationMembership.Level.MEMBER,
+        )
+
+        all_user_with_access_ids = list(self.team.all_users_with_access().values_list("id", flat=True))
+        # Both users in, despite the private AccessControl row
+        assert sorted(all_user_with_access_ids) == sorted([self.user.id, member_user.id])
+
+    def test_all_users_with_access_role_access_inert_without_role_based_access_feature(self):
+        """With ACCESS_CONTROL but no ROLE_BASED_ACCESS, role-backed AccessControl rows
+        must not grant access — mirrors the UI gate and User.teams behaviour."""
+        self._enable_access_control()  # ACCESS_CONTROL only
+
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="none",
+        )
+        member_user = User.objects.create_and_join(
+            self.organization,
+            email="member-no-rbac@posthog.com",
+            first_name="first_name",
+            password=None,
+            level=OrganizationMembership.Level.MEMBER,
+        )
+        member_org_membership = OrganizationMembership.objects.get(organization=self.organization, user=member_user)
+        role = Role.objects.create(name="Test Role", organization=self.organization)
+        RoleMembership.objects.create(role=role, user=member_user, organization_member=member_org_membership)
+        AccessControl.objects.create(
+            team=self.team, resource="project", resource_id=str(self.team.id), role=role, access_level="member"
+        )
+
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        all_user_with_access_ids = list(self.team.all_users_with_access().values_list("id", flat=True))
+        # Only the org admin gets access — the role-backed member does not
+        assert all_user_with_access_ids == [self.user.id]

--- a/posthog/models/test/test_team_model.py
+++ b/posthog/models/test/test_team_model.py
@@ -112,6 +112,15 @@ class TestCoreEvent(BaseTest):
 
 
 class TestTeam(BaseTest):
+    def _enable_access_control(self, role_based: bool = False) -> None:
+        from posthog.constants import AvailableFeature
+
+        features = [{"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}]
+        if role_based:
+            features.append({"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS})
+        self.organization.available_product_features = features
+        self.organization.save()
+
     def test_all_users_with_access_simple_org_membership(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
@@ -153,6 +162,7 @@ class TestTeam(BaseTest):
 
     def test_all_users_with_access_new_access_control_private_team(self):
         """Test that only users with specific access have access to a private team with the new access control system"""
+        self._enable_access_control()
 
         # Make the team private
         AccessControl.objects.create(
@@ -185,6 +195,7 @@ class TestTeam(BaseTest):
 
     def test_all_users_with_access_new_access_control_private_team_with_member_access(self):
         """Test that users with specific member access have access to a private team with the new access control system"""
+        self._enable_access_control()
 
         # Make the team private
         AccessControl.objects.create(
@@ -227,6 +238,7 @@ class TestTeam(BaseTest):
 
     def test_all_users_with_access_new_access_control_private_team_with_role_access(self):
         """Test that users with role-based access have access to a private team with the new access control system"""
+        self._enable_access_control(role_based=True)
 
         # Make the team private
         AccessControl.objects.create(

--- a/posthog/models/test/test_user_teams_access_control.py
+++ b/posthog/models/test/test_user_teams_access_control.py
@@ -18,9 +18,10 @@ class TestUserTeamsAccessControl(BaseTest):
 
     def setUp(self):
         super().setUp()
-        # Enable access control for the organization
+        # Enable access control and role-based access for the organization
         self.organization.available_product_features = [
-            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
         ]
         self.organization.save()
 
@@ -138,6 +139,45 @@ class TestUserTeamsAccessControl(BaseTest):
         self.assertEqual(user_teams.count(), 2)
         self.assertIn(self.team, user_teams)
         self.assertIn(private_team, user_teams)
+
+    def test_user_teams_role_based_access_inert_without_role_based_access_feature(self):
+        """Role-backed project AccessControl rows must NOT grant team visibility when the
+        org lacks ROLE_BASED_ACCESS — mirrors the UI gate."""
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}
+        ]
+        self.organization.save()
+
+        private_team = Team.objects.create(organization=self.organization, name="Private Team")
+        AccessControl.objects.create(
+            team=private_team,
+            resource="project",
+            resource_id=str(private_team.id),
+            access_level="none",
+            organization_member=None,
+            role=None,
+        )
+
+        role = Role.objects.create(name="Developer", organization=self.organization)
+        RoleMembership.objects.create(
+            role=role,
+            user=self.user,
+            organization_member=self.organization_membership,
+        )
+        AccessControl.objects.create(
+            team=private_team,
+            resource="project",
+            resource_id=str(private_team.id),
+            access_level="admin",
+            organization_member=None,
+            role=role,
+        )
+
+        self.user.__dict__.pop("teams", None)  # bust cached_property if it was set
+        user_teams = self.user.teams.all()
+        self.assertEqual(user_teams.count(), 1)
+        self.assertIn(self.team, user_teams)
+        self.assertNotIn(private_team, user_teams)
 
     def test_organization_admin_sees_all_teams(self):
         """Test that organization admins can see all teams, including private ones."""

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -327,20 +327,28 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
                         ).values_list("team_id", flat=True)
                     )
 
-                    # Get teams where user has role-based access
-                    try:
-                        from ee.models.rbac.role import RoleMembership
+                    # Get teams where user has role-based access. Only honored when the
+                    # org has ROLE_BASED_ACCESS — same gate as the UI's "Roles" block on
+                    # the project access settings page (and as resource-level role overrides).
+                    role_based_access_supported = (
+                        AvailableFeature.ROLE_BASED_ACCESS in org_available_product_feature_keys
+                    )
+                    if role_based_access_supported:
+                        try:
+                            from ee.models.rbac.role import RoleMembership
 
-                        user_roles = RoleMembership.objects.filter(
-                            user=self, organization_member__in=[membership.id for membership in org_memberships]
-                        ).values_list("role_id", flat=True)
+                            user_roles = RoleMembership.objects.filter(
+                                user=self, organization_member__in=[membership.id for membership in org_memberships]
+                            ).values_list("role_id", flat=True)
 
-                        role_accessible_team_ids = set(
-                            AccessControl.objects.filter(
-                                resource="project", access_level__in=["member", "admin"], role__in=user_roles
-                            ).values_list("team_id", flat=True)
-                        )
-                    except ImportError:
+                            role_accessible_team_ids = set(
+                                AccessControl.objects.filter(
+                                    resource="project", access_level__in=["member", "admin"], role__in=user_roles
+                                ).values_list("team_id", flat=True)
+                            )
+                        except ImportError:
+                            role_accessible_team_ids = set()
+                    else:
                         role_accessible_team_ids = set()
 
                     # Get organizations where user is admin or owner (have implicit access to all teams)

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -28,7 +28,11 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
             {
                 "name": AvailableFeature.ACCESS_CONTROL,
                 "key": AvailableFeature.ACCESS_CONTROL,
-            }
+            },
+            {
+                "name": AvailableFeature.ROLE_BASED_ACCESS,
+                "key": AvailableFeature.ROLE_BASED_ACCESS,
+            },
         ]
         self.organization.save()
 
@@ -309,6 +313,44 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
         # Check effective membership level
         with self.assertNumQueries(3):
             assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.ADMIN
+
+    def test_team_effective_membership_level_role_based_access_inert_without_role_based_access_feature(self):
+        """Role-backed project AccessControl rows must NOT take effect when the org lacks
+        ROLE_BASED_ACCESS — mirrors the UI gate on the project access settings page."""
+        from ee.models.rbac.access_control import AccessControl
+        from ee.models.rbac.role import Role, RoleMembership
+
+        # Drop ROLE_BASED_ACCESS, keep ACCESS_CONTROL
+        self.organization.available_product_features = [
+            {"name": AvailableFeature.ACCESS_CONTROL, "key": AvailableFeature.ACCESS_CONTROL}
+        ]
+        self.organization.save()
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        role = Role.objects.create(name="Test Role", organization=self.organization)
+        RoleMembership.objects.create(role=role, user=self.user, organization_member=self.organization_membership)
+
+        # Make the team private and grant the role admin via project-level role override
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="none",
+        )
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            role=role,
+            access_level="admin",
+        )
+
+        # Without ROLE_BASED_ACCESS the role override is inert, so the private-team default ("none") applies
+        assert self.permissions().current_team.effective_membership_level is None
 
     def test_team_effective_membership_level_lower_project_membership_than_org_membership(self):
         """Test that users with admin org access maintain their admin level even with lower member project access"""

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -225,10 +225,13 @@ class UserTeamPermissions:
             for ac in access_controls
         )
 
-        # Check role-based access before returning any member level
+        # Role-backed project AccessControl rows only take effect if the organization has
+        # the ROLE_BASED_ACCESS feature — same gate as the UI's "Roles" block on the
+        # project access settings page (and as resource-level role overrides).
+        role_based_access_supported = organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
         user_roles = self.p._prefetched_role_memberships.get(organization_membership.id, [])
 
-        if user_roles:
+        if user_roles and role_based_access_supported:
             role_has_admin_access = any(
                 ac["resource_id"] == str(self.team.id) and ac["role_id"] in user_roles and ac["access_level"] == "admin"
                 for ac in access_controls


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Follow-up to #56976

The UI gates role-backed access controls behind `ROLE_BASED_ACCES`, but the runtime, write API, and preview endpoints only check `ACCESS_CONTRO`. Role-based access controls keep applying at runtime even after a customer downgrades from the Enterprise plan. 

- The "Roles" tab and "Roles" blocks disappear from `Settings → Access control` — the UI correctly gates on `ROLE_BASED_ACCESS`.
- But users with the role _still_ have admin access to the project (based on role override), because the backend never checked `ROLE_BASED_ACCESS`
- The admin can't see this hidden grant anywhere in the UI, can't remove it (the UI to manage roles is gone), and can't explain why a user without explicit access still sees a private project.
- The weekly digest still emails those role-only users dashboards they "have access to," even though they can't navigate to them in their session
- The per-member preview in access control settings shows them as having admin via role override, while the user's own `My teams` list omits the team
- If the admin tries to clean things up via API, `PUT /api/projects/<id>/access_controls` with a `role` field happily 200s and writes another row.

## Changes

Five gates added, all `is_feature_available(ROLE_BASED_ACCESS)`:

- **Runtime project elevation** (`UserTeamPermissions.effective_membership_level_for_parent_membership`) — role-backed admin/member elevation is skipped when the feature is off. 
- **`User.teams`** — private teams a user only reaches via role are removed from their visible-teams list, so the UI matches enforcement.
- **`Team.all_users_with_access`** — role-only users no longer appear in the "who has access" list, fixing weekly digests, replay summarization, data imports, and growth dags. Also short-circuits when `ACCESS_CONTROL` itself is off (returns all org members).
- **Preview endpoints** (`access_control_roles`, `access_control_members`) — role overrides are shown as inert, so the preview matches what the runtime actually does.
- **Write API** (`AccessControlSerializer.validate`) — `PUT` with a `role` field returns 403 with a clear message instead of silently storing rows.

Runtime gates are defense in depth: they handle stale rows already in the DB from before the downgrade, direct DB writes, and old workers running pre-fix code. The serializer gate gives the customer a clear 403 at write time.

## How did you test this code?

New tests:

- `test_team_effective_membership_level_role_based_access_inert_without_role_based_access_feature` 
- `test_user_teams_role_based_access_inert_without_role_based_access_feature`
- `test_all_users_with_access_returns_all_org_members_without_access_control_feature`
- `test_all_users_with_access_role_access_inert_without_role_based_access_feature`
- `test_role_based_access_control_rejected_without_role_based_access_feature`

Existing tests that relied on the old asymmetric behavior were updated to grant both features in their setup.

## Publish to changelog?

No

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->