### PR TITLE
chore(workflows): clarify distinct_id input description on update person properties

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/posthog_capture/posthog-update-person-properties.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_capture/posthog-update-person-properties.template.ts
@@ -33,7 +33,8 @@ postHogCapture({
             secret: false,
             hidden: false,
             default: '{event.distinct_id}',
-            description: 'The distinct ID associated with the Person.',
+            description:
+                'The distinct ID or persisted person UUID to target. Use `{event.distinct_id}` for event-triggered workflows, or `{person.id}` for batch workflows (where no event distinct ID is resolved).',
         },
         {
             type: 'dictionary',

--- a/nodejs/src/cdp/templates/_destinations/posthog_capture/posthog-update-person-properties.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_capture/posthog-update-person-properties.template.ts
@@ -34,7 +34,7 @@ postHogCapture({
             hidden: false,
             default: '{event.distinct_id}',
             description:
-                'The distinct ID or persisted person UUID to target. Use `{event.distinct_id}` for event-triggered workflows, or `{person.id}` for batch workflows (where no event distinct ID is resolved).',
+                'Which person to update. Use `{event.distinct_id}` for event-triggered workflows, or `{person.id}` for batch workflows.',
         },
         {
             type: 'dictionary',


### PR DESCRIPTION
## Problem

The `Update person property` destination (template `template-posthog-update-person-properties`) throws `Error('Distinct ID is required')` when used inside a batch workflow. Users naturally try `{person.distinct_id}` to fix it (matching the `person.properties.email` pattern they already use elsewhere), but that field doesn't exist on `CyclotronPerson` and silently resolves to empty — so the error reappears.

Root cause: batch hog flow invocations don't resolve a distinct ID. `convertBatchHogFlowRequestToHogFunctionInvocationGlobals` (`nodejs/src/cdp/utils.ts`) explicitly sets `event.distinct_id` to `''` and only populates `person.id` (the persisted person UUID). The existing input description (`"The distinct ID associated with the Person."`) gave users no hint that batch workflows need `{person.id}` instead.

## Changes

Update the description of the `distinct_id` input on the `Update person property` template to spell out which value to use:

- event-triggered workflows → `{event.distinct_id}` (still the default)
- batch workflows → `{person.id}` (the persisted person UUID, accepted by `postHogCapture` as a distinct ID)

No behavior change — text only.

## How did you test this code?

I'm an agent. No automated tests were added or run for this change. The edit is to a string literal in a template input description; the surrounding template tests (`posthog-update-person-properties.template.test.ts`) don't assert on this field's description.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- Investigation traced the `Distinct ID is required` error from the template guard (`posthog-update-person-properties.template.ts`) back through the executor (`hog-executor.service.ts`), the batch consumer (`cdp-batch-hogflow.consumer.ts`), the globals builder (`utils.ts`), and the Django blast-radius query (`posthog/models/feature_flag/user_blast_radius.py`) — which selects `persons.id`, not distinct IDs.
- Considered three options for the underlying problem:
  1. Change the input default to `{person.id}` — rejected, would regress event-triggered flows where `person.id` may not exist.
  2. Populate `event.distinct_id` with the person UUID in batch globals — rejected, semantically misleading (a UUID isn't a distinct ID).
  3. Have the batch consumer fetch a real distinct ID per person — deferred, adds a per-batch query cost and is a larger change.
- Chosen scope for this PR: documentation-only fix to surface the correct guidance to users today. The deeper fix can be a follow-up if we want to support `{person.distinct_id}` natively.