### PR TITLE
chore(replay): Add tooltips for inspector lines

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -865,17 +865,17 @@ snapshots:
     components-pay-gate-mini--pay-gate-mini-without-background--light:
         hash: v1.k794b7964.9a2b166ce4c603be1ede586ac7867f3d31840f6116bd61854300a7c57bb3df7a._1tSFJYtbZ2I5i0evHjkEzSxJyTgj14QfRMPgT4YT5w
     components-playerinspector--default--dark:
-        hash: v1.k794b7964.6eff0ed89297215e8708241105e5030634823ad41719eeb4f36ddea68851d4e1.5e7vmvxuTjAujNINc7PjRpNpG68xrkFXcG7hZ5MVhXI
+        hash: v1.k794b7964.6efc71a468ea8cfe4d4d575a641a30a21f2bab9f6311638528970e5b1c548dc8.lcb8YdHYGtZei1DkblHfl1AuuwH_nBKRGwkn84wmThU
     components-playerinspector--default--light:
-        hash: v1.k794b7964.9f107b86c39ee6cbb15727e2b53ec0536e77c262dc3e06336f896cd46ad153f7.UhHTuWcCcKmD1rwJzgIBKSJ3o1ztLYICsXnzpTPhxDA
+        hash: v1.k794b7964.81c15efb893e451b59ba38fd200be8e1e19e1519848abc64fd194ac691104254.i5YV5J2T7R-9yKe6pT4NVr4qnYTspN8hNTGA7LnPPPM
     components-playerinspector--with-logs-filter--dark:
-        hash: v1.k794b7964.3851518dc979320cefe65f110005d44a492eec635285f8b2f9162c1e5dbed62b.MZINYfaQXNWzFZMzsPLtnLXpNYVcBMEC5PJnxMR-DlY
+        hash: v1.k794b7964.537624adca851ef7e40b2919c9a4f1210f889d52e7252a2d9872b7e5505699c4.FPTbSCzHxm_zEN6ukUKgJmKnxcxa8lUCeRMeXkiKQ6g
     components-playerinspector--with-logs-filter--light:
-        hash: v1.k794b7964.3f965eb579aca558761b47116e774eac610e48d3bb873449cc4983f605a8ca45.DLCkhgQmk3UBvQyFRVkTzptmeMWseH8Xne8252V6oJI
+        hash: v1.k794b7964.fc1e747bd67f854c0af094265d80864fbf4d5209a58f51ed3a687505e1f07ec1.D72cCuWMnCuMOTIlraogIRFg4FGpFNvO7dmSuiku2sc
     components-playerinspector--with-logs-filter-upsell--dark:
-        hash: v1.k794b7964.b60437cd8f4162932c1ab8b8b1651ddc2286ccdb27a07d09ee36d2c21524d046.jDIFGff9HT5T2P3bCEx9EO9M8uuInMfJd5Nrvbh1Vrg
+        hash: v1.k794b7964.31676235fb000d8f24fa2d59f359f5c873a51574d5d923738c276e783cf464de.Vcyb2UICIL3mRG4QCqh_Uz9cp7kLVRPTgsGJrDZ8R6E
     components-playerinspector--with-logs-filter-upsell--light:
-        hash: v1.k794b7964.403c5e2e028907216d406566cdcc3633a7400ce4b9ba53821f9648af8fa7e086.EwUI1BLkaVENli5YwNRDqdGcoSYGjQgqS-jwplNVKWE
+        hash: v1.k794b7964.ee8f395e1def6620351c03508e2af83e32deb26b62feb166eb4e278dde035c4d.xNKjsecE83x-rgiq6MxAeMHnTR_z3HI_LcwfGBslOGM
     components-playerinspector-itemcomment--annotation-comment--dark:
         hash: v1.k794b7964.d2eaad42c4d74ab148ba3075a6260d7aeda90562fbfdb49738afcc37fddacd73.DqxeQtB6IVGsvji5psBPT4qyAC-3MAkB4svhAvYak7w
     components-playerinspector-itemcomment--annotation-comment--light:

--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorBottomSettings.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorBottomSettings.tsx
@@ -124,6 +124,20 @@ function GroupRepeatedItems(): JSX.Element {
     )
 }
 
+function ShowLineTooltips(): JSX.Element {
+    const { showLineTooltips } = useValues(miniFiltersLogic)
+    const { setShowLineTooltips } = useActions(miniFiltersLogic)
+
+    return (
+        <SettingsToggle
+            title={showLineTooltips ? 'Hide hover tooltips on inspector lines' : 'Show the full line content on hover'}
+            label="Show line tooltips"
+            onClick={() => setShowLineTooltips(!showLineTooltips)}
+            active={showLineTooltips}
+        />
+    )
+}
+
 export function PlayerInspectorBottomSettings(): JSX.Element {
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
     const { collapseInspectorItems } = useValues(playerInspectorLogic(logicProps))
@@ -133,6 +147,7 @@ export function PlayerInspectorBottomSettings(): JSX.Element {
             <SyncScrolling />
             <ShowOnlyMatching />
             {collapseInspectorItems ? <GroupRepeatedItems /> : null}
+            <ShowLineTooltips />
             <HideProperties />
         </SettingsBar>
     )

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemAnyComment.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemAnyComment.tsx
@@ -10,6 +10,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { notebookPanelLogic } from 'scenes/notebooks/NotebookPanel/notebookPanelLogic'
 import { playerCommentModel } from 'scenes/session-recordings/player/commenting/playerCommentModel'
 import { RecordingCommentForm } from 'scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic'
+import { miniFiltersLogic } from 'scenes/session-recordings/player/inspector/miniFiltersLogic'
 import {
     InspectorListItemComment,
     InspectorListItemNotebookComment,
@@ -26,9 +27,10 @@ function isInspectorListItemNotebookComment(x: ItemCommentProps['item']): x is I
 }
 
 function ItemNotebookComment({ item }: { item: InspectorListItemNotebookComment }): JSX.Element {
+    const { showLineTooltips } = useValues(miniFiltersLogic)
     return (
         <div data-attr="item-notebook-comment" className="font-light w-full px-2 py-1 text-xs truncate text-ellipsis">
-            {item.data.comment.trim().length > 30 ? (
+            {showLineTooltips && item.data.comment.trim().length > 30 ? (
                 <Tooltip title={item.data.comment}>{item.data.comment}</Tooltip>
             ) : (
                 item.data.comment
@@ -38,6 +40,7 @@ function ItemNotebookComment({ item }: { item: InspectorListItemNotebookComment 
 }
 
 function ItemComment({ item }: { item: InspectorListItemComment }): JSX.Element {
+    const { showLineTooltips } = useValues(miniFiltersLogic)
     // lazy but good enough check for markdown image urls
     // we don't want to render markdown in the list row if there's an image since it won't fit
     const hasMarkdownImage = (item.data.content ?? '').includes('![')
@@ -52,7 +55,7 @@ function ItemComment({ item }: { item: InspectorListItemComment }): JSX.Element 
 
     return (
         <div data-attr="item-annotation-comment" className="font-light w-full px-2 py-1 text-xs truncate text-ellipsis">
-            {(item.data.content || '').trim().length > 30 ? (
+            {showLineTooltips && (item.data.content || '').trim().length > 30 ? (
                 <Tooltip
                     title={
                         item.data.rich_content ? (

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 
 import { LemonDivider } from '@posthog/lemon-ui'
 
@@ -11,6 +11,7 @@ import { ceilMsToClosestSecond } from 'lib/utils'
 
 import { ItemTimeDisplay } from '../../../components/ItemTimeDisplay'
 import { sessionRecordingPlayerLogic } from '../../sessionRecordingPlayerLogic'
+import { miniFiltersLogic } from '../miniFiltersLogic'
 import { InspectorListItemAppState, InspectorListItemConsole } from '../playerInspectorLogic'
 
 export interface ItemConsoleLogProps {
@@ -24,12 +25,13 @@ export interface ItemAppStateProps {
 }
 
 export function ItemConsoleLog({ item, groupCount }: ItemConsoleLogProps): JSX.Element {
+    const { showLineTooltips } = useValues(miniFiltersLogic)
     const count = groupCount ?? item.data.count
     const showBadge = count && count > 1
 
     return (
         <div className="w-full font-light flex items-center" data-attr="item-console-log">
-            <Tooltip title={item.data.content} placement="top">
+            <Tooltip title={showLineTooltips ? item.data.content : undefined}>
                 <div className="px-2 py-1 text-xs cursor-pointer truncate font-mono flex-1">{item.data.content}</div>
             </Tooltip>
             {showBadge ? (
@@ -110,9 +112,10 @@ export function ItemConsoleLogDetail({ item, groupedItems }: ItemConsoleLogProps
 }
 
 export function ItemAppState({ item }: ItemAppStateProps): JSX.Element {
+    const { showLineTooltips } = useValues(miniFiltersLogic)
     return (
         <div className="w-full font-light" data-attr="item-app-state">
-            <Tooltip title={item.action} placement="top">
+            <Tooltip title={showLineTooltips ? item.action : undefined}>
                 <div className="px-2 py-1 text-xs cursor-pointer truncate font-mono flex-1">{item.action}</div>
             </Tooltip>
         </div>

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.tsx
@@ -6,6 +6,7 @@ import { LemonDivider } from '@posthog/lemon-ui'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { SimpleKeyValueList } from 'lib/components/SimpleKeyValueList'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { ceilMsToClosestSecond } from 'lib/utils'
 
 import { ItemTimeDisplay } from '../../../components/ItemTimeDisplay'
@@ -28,7 +29,9 @@ export function ItemConsoleLog({ item, groupCount }: ItemConsoleLogProps): JSX.E
 
     return (
         <div className="w-full font-light flex items-center" data-attr="item-console-log">
-            <div className="px-2 py-1 text-xs cursor-pointer truncate font-mono flex-1">{item.data.content}</div>
+            <Tooltip title={item.data.content} placement="top">
+                <div className="px-2 py-1 text-xs cursor-pointer truncate font-mono flex-1">{item.data.content}</div>
+            </Tooltip>
             {showBadge ? (
                 <span
                     className={clsx(
@@ -109,7 +112,9 @@ export function ItemConsoleLogDetail({ item, groupedItems }: ItemConsoleLogProps
 export function ItemAppState({ item }: ItemAppStateProps): JSX.Element {
     return (
         <div className="w-full font-light" data-attr="item-app-state">
-            <div className="px-2 py-1 text-xs cursor-pointer truncate font-mono flex-1">{item.action}</div>
+            <Tooltip title={item.action} placement="top">
+                <div className="px-2 py-1 text-xs cursor-pointer truncate font-mono flex-1">{item.action}</div>
+            </Tooltip>
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemLog.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemLog.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { useValues } from 'kea'
 
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 
@@ -10,6 +11,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { urls } from 'scenes/urls'
 
 import { ItemTimeDisplay } from '../../../components/ItemTimeDisplay'
+import { miniFiltersLogic } from '../miniFiltersLogic'
 import { InspectorListItemLog } from '../playerInspectorLogic'
 
 export interface ItemLogProps {
@@ -29,12 +31,13 @@ const levelColors: Record<string, string> = {
 }
 
 export function ItemLog({ item, groupCount }: ItemLogProps): JSX.Element {
+    const { showLineTooltips } = useValues(miniFiltersLogic)
     const count = groupCount ?? 1
     const showBadge = count > 1
 
     return (
         <div className="w-full font-light flex items-center" data-attr="item-log">
-            <Tooltip title={item.data.body} placement="top">
+            <Tooltip title={showLineTooltips ? item.data.body : undefined}>
                 <div className="px-2 py-1 text-xs cursor-pointer truncate font-mono flex-1 flex items-center gap-2">
                     <span
                         className={clsx(

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemLog.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemLog.tsx
@@ -6,6 +6,7 @@ import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { SimpleKeyValueList } from 'lib/components/SimpleKeyValueList'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { urls } from 'scenes/urls'
 
 import { ItemTimeDisplay } from '../../../components/ItemTimeDisplay'
@@ -33,14 +34,19 @@ export function ItemLog({ item, groupCount }: ItemLogProps): JSX.Element {
 
     return (
         <div className="w-full font-light flex items-center" data-attr="item-log">
-            <div className="px-2 py-1 text-xs cursor-pointer truncate font-mono flex-1 flex items-center gap-2">
-                <span
-                    className={clsx('uppercase font-semibold text-xxs', levelColors[item.data.level] || 'text-primary')}
-                >
-                    {item.data.level}
-                </span>
-                <span className="truncate">{item.data.body}</span>
-            </div>
+            <Tooltip title={item.data.body} placement="top">
+                <div className="px-2 py-1 text-xs cursor-pointer truncate font-mono flex-1 flex items-center gap-2">
+                    <span
+                        className={clsx(
+                            'uppercase font-semibold text-xxs',
+                            levelColors[item.data.level] || 'text-primary'
+                        )}
+                    >
+                        {item.data.level}
+                    </span>
+                    <span className="truncate">{item.data.body}</span>
+                </div>
+            </Tooltip>
             {showBadge ? (
                 <span
                     className={clsx(

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PerformanceEventLabel.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PerformanceEventLabel.tsx
@@ -1,6 +1,5 @@
-import clsx from 'clsx'
-
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 export function PerformanceEventLabel({
     label,
@@ -11,16 +10,27 @@ export function PerformanceEventLabel({
     name: string | undefined
     label?: string | undefined
 }): JSX.Element {
-    return (
-        <span className={clsx('flex-1 overflow-hidden', !expanded && 'truncate')}>
-            {label}
-            {expanded ? (
+    if (expanded) {
+        return (
+            <span className="flex-1 overflow-hidden">
+                {label}
                 <CodeSnippet language={Language.Markup} wrap thing="performance event name">
                     {name}
                 </CodeSnippet>
-            ) : (
-                name
-            )}
-        </span>
+            </span>
+        )
+    }
+
+    if (!name) {
+        return <span className="flex-1 overflow-hidden truncate">{label}</span>
+    }
+
+    return (
+        <Tooltip title={name} placement="top">
+            <span className="flex-1 overflow-hidden truncate">
+                {label}
+                {name}
+            </span>
+        </Tooltip>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PerformanceEventLabel.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PerformanceEventLabel.tsx
@@ -1,5 +1,9 @@
+import { useValues } from 'kea'
+
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+import { miniFiltersLogic } from '../miniFiltersLogic'
 
 export function PerformanceEventLabel({
     label,
@@ -10,6 +14,8 @@ export function PerformanceEventLabel({
     name: string | undefined
     label?: string | undefined
 }): JSX.Element {
+    const { showLineTooltips } = useValues(miniFiltersLogic)
+
     if (expanded) {
         return (
             <span className="flex-1 overflow-hidden">
@@ -26,7 +32,7 @@ export function PerformanceEventLabel({
     }
 
     return (
-        <Tooltip title={name} placement="top">
+        <Tooltip title={showLineTooltips ? name : undefined}>
             <span className="flex-1 overflow-hidden truncate">
                 {label}
                 {name}

--- a/frontend/src/scenes/session-recordings/player/inspector/miniFiltersLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/miniFiltersLogic.ts
@@ -157,6 +157,7 @@ export const miniFiltersLogic = kea<miniFiltersLogicType>([
     actions({
         setShowOnlyMatching: (showOnlyMatching: boolean) => ({ showOnlyMatching }),
         setGroupRepeatedItems: (groupRepeatedItems: boolean) => ({ groupRepeatedItems }),
+        setShowLineTooltips: (showLineTooltips: boolean) => ({ showLineTooltips }),
         setMiniFilter: (key: MiniFilterKey, enabled: boolean) => ({ key, enabled }),
         setMiniFilters: (keys: MiniFilterKey[], enabled: boolean) => ({ keys, enabled }),
         setSearchQuery: (search: string) => ({ search }),
@@ -180,6 +181,14 @@ export const miniFiltersLogic = kea<miniFiltersLogicType>([
             { persist: true },
             {
                 setGroupRepeatedItems: (_, { groupRepeatedItems }) => groupRepeatedItems,
+            },
+        ],
+
+        showLineTooltips: [
+            true,
+            { persist: true },
+            {
+                setShowLineTooltips: (_, { showLineTooltips }) => showLineTooltips,
             },
         ],
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
It was difficult to quickly look through network requests / logs while on a laptop
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add an on hover tooltip that displays the inspector line's data 

https://github.com/user-attachments/assets/2a22b80e-76bd-4630-b036-2028cdb27dea


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally 
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
