### PR TITLE
feat(hogql): postgres wire service

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -417,11 +417,11 @@ procs:
 
     hogql-service:
         shell: |-
-            uv sync --active && \
             bin/wait-for-docker && \
-            HOGQL_SERVICE_HOST="${HOGQL_SERVICE_HOST:-127.0.0.1}" \
-            HOGQL_SERVICE_SHARED_SECRET="${HOGQL_SERVICE_SHARED_SECRET-posthog}" \
             python manage.py run_hogql_service
+        env:
+            HOGQL_SERVICE_HOST: '127.0.0.1'
+            HOGQL_SERVICE_SHARED_SECRET: 'posthog'
         capability: hogql_service
         ready_pattern: 'HogQL Postgres wire service listening'
         groups:

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -415,6 +415,19 @@ procs:
             layer: Product services
             tech: Frontend
 
+    hogql-service:
+        shell: |-
+            uv sync --active && \
+            bin/wait-for-docker && \
+            HOGQL_SERVICE_HOST="${HOGQL_SERVICE_HOST:-127.0.0.1}" \
+            HOGQL_SERVICE_SHARED_SECRET="${HOGQL_SERVICE_SHARED_SECRET-posthog}" \
+            python manage.py run_hogql_service
+        capability: hogql_service
+        ready_pattern: 'HogQL Postgres wire service listening'
+        groups:
+            layer: Product services
+            tech: Python
+
     mcp-inspector:
         shell: 'cd services/mcp && pnpm run inspector'
         capability: mcp_server

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -190,6 +190,11 @@ capabilities:
         requires: [core_infra]
         docker_profiles: []
 
+    hogql_service:
+        description: 'Postgres wire-compatible HogQL query service'
+        requires: [core_infra, duckgres]
+        docker_profiles: []
+
     stripe_app:
         description: 'Stripe app for PostHog integration'
         requires: [core_infra]
@@ -323,6 +328,10 @@ intents:
     mcp:
         description: 'MCP server for AI assistant integration'
         capabilities: [mcp_server]
+
+    hogql:
+        description: 'Postgres wire-compatible HogQL query service'
+        capabilities: [hogql_service]
 
     stripe:
         description: 'Stripe app for PostHog integration'

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -119,6 +119,9 @@ metadata:
         phrocs:
             name: phrocs
             about: PostHog's custom process runner (replaces mprocs).
+        hogql:
+            name: HogQL service
+            about: Postgres wire-compatible service for querying HogQL from SQL clients.
 devbox:
     devbox:
         click: hogli_commands.devbox.cli:devbox_help

--- a/posthog/hogql/service.py
+++ b/posthog/hogql/service.py
@@ -2286,9 +2286,13 @@ def rewrite_catalog_table_references(sql: str, context: HogQLServiceSessionConte
                 rf"(?:{quoted_or_unquoted_identifier_pattern(table_name)})"
                 rf"(?=\s|$)"
             )
+
+            def replace_table_reference(match: re.Match[str], replacement: str = hogql_name) -> str:
+                return f"{match.group(1)}{replacement}"
+
             rewritten_sql = re.sub(
                 pattern,
-                lambda match, replacement=hogql_name: f"{match.group(1)}{replacement}",
+                replace_table_reference,
                 rewritten_sql,
             )
     return rewritten_sql

--- a/posthog/hogql/service.py
+++ b/posthog/hogql/service.py
@@ -1,0 +1,987 @@
+from __future__ import annotations
+
+import os
+import re
+import hmac
+import json
+import struct
+import asyncio
+import logging
+import secrets
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import UUID
+
+from django.utils import timezone
+
+import sqlparse
+from rest_framework.exceptions import AuthenticationFailed
+
+from posthog.schema import HogQLQueryResponse
+
+from posthog.hogql.constants import LimitContext
+from posthog.hogql.errors import ExposedHogQLError, QueryError, ResolutionError
+from posthog.hogql.escape_sql import escape_hogql_string
+from posthog.hogql.parser import CacheOrigin, parse_select
+from posthog.hogql.query import execute_hogql_query
+from posthog.hogql.user_query_validator import validate_user_query
+
+from posthog.auth import PersonalAPIKeyAuthentication
+from posthog.constants import AvailableFeature
+from posthog.models import OrganizationMembership, Team, User
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.user_permissions import UserPermissions
+
+logger = logging.getLogger(__name__)
+
+PROTOCOL_VERSION_3 = 196608
+SSL_REQUEST_CODE = 80877103
+GSSENC_REQUEST_CODE = 80877104
+CANCEL_REQUEST_CODE = 80877102
+
+AUTHENTICATION_OK = 0
+AUTHENTICATION_CLEARTEXT_PASSWORD = 3
+
+POSTGRES_TEXT_OID = 25
+POSTGRES_INT8_OID = 20
+POSTGRES_INT4_OID = 23
+POSTGRES_INT2_OID = 21
+POSTGRES_BOOL_OID = 16
+POSTGRES_FLOAT4_OID = 700
+POSTGRES_FLOAT8_OID = 701
+POSTGRES_NUMERIC_OID = 1700
+POSTGRES_DATE_OID = 1082
+POSTGRES_TIMESTAMP_OID = 1114
+POSTGRES_TIMESTAMPTZ_OID = 1184
+POSTGRES_JSON_OID = 114
+POSTGRES_UUID_OID = 2950
+
+SQLSTATE_INVALID_PASSWORD = "28P01"
+SQLSTATE_INSUFFICIENT_PRIVILEGE = "42501"
+SQLSTATE_SYNTAX_ERROR = "42601"
+SQLSTATE_PROTOCOL_VIOLATION = "08P01"
+SQLSTATE_INTERNAL_ERROR = "XX000"
+
+
+class HogQLServiceError(Exception):
+    sqlstate = SQLSTATE_INTERNAL_ERROR
+
+
+class HogQLServiceAuthenticationError(HogQLServiceError):
+    sqlstate = SQLSTATE_INVALID_PASSWORD
+
+
+class HogQLServicePermissionError(HogQLServiceError):
+    sqlstate = SQLSTATE_INSUFFICIENT_PRIVILEGE
+
+
+class HogQLServiceQueryError(HogQLServiceError):
+    sqlstate = SQLSTATE_SYNTAX_ERROR
+
+
+class HogQLServiceProtocolError(HogQLServiceError):
+    sqlstate = SQLSTATE_PROTOCOL_VIOLATION
+
+
+@dataclass(frozen=True)
+class HogQLServiceConfig:
+    host: str = "0.0.0.0"
+    port: int = 6543
+    shared_secret: str | None = None
+    max_query_bytes: int = 1024 * 1024
+
+    @classmethod
+    def from_env(cls) -> HogQLServiceConfig:
+        return cls(
+            host=os.environ.get("HOGQL_SERVICE_HOST", "0.0.0.0"),
+            port=int(os.environ.get("HOGQL_SERVICE_PORT", "6543")),
+            shared_secret=os.environ.get("HOGQL_SERVICE_SHARED_SECRET") or None,
+            max_query_bytes=int(os.environ.get("HOGQL_SERVICE_MAX_QUERY_BYTES", str(1024 * 1024))),
+        )
+
+
+@dataclass(frozen=True)
+class HogQLServiceSessionContext:
+    database_user: str
+    database: str
+    user: User
+    team: Team
+    authenticated_by: Literal["shared_secret", "personal_api_key"]
+    personal_api_key_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ResultColumn:
+    name: str
+    type_oid: int = POSTGRES_TEXT_OID
+    type_size: int = -1
+    type_modifier: int = -1
+    format_code: int = 0
+
+
+@dataclass(frozen=True)
+class QueryResult:
+    columns: list[ResultColumn]
+    rows: list[tuple[Any, ...]]
+    command_tag: str
+
+
+@dataclass(frozen=True)
+class PgParameter:
+    value: Any
+
+
+@dataclass
+class PreparedStatement:
+    name: str
+    query: str
+    parameter_type_oids: list[int]
+
+
+@dataclass
+class BoundPortal:
+    name: str
+    statement_name: str
+    query: str
+    parameters: list[PgParameter]
+    result_formats: list[int]
+    result: QueryResult | None = None
+    row_description_sent: bool = False
+
+
+class HogQLServiceAuthenticator:
+    def __init__(self, shared_secret: str | None = None):
+        self.shared_secret = shared_secret
+
+    def authenticate(self, database_user: str, database: str, password: str) -> HogQLServiceSessionContext:
+        team = self._get_team(database)
+
+        if self.shared_secret and hmac.compare_digest(password, self.shared_secret):
+            user = self._get_database_user(database_user)
+            self._validate_user_team_access(user, team)
+            return HogQLServiceSessionContext(
+                database_user=database_user,
+                database=database,
+                user=user,
+                team=team,
+                authenticated_by="shared_secret",
+            )
+
+        personal_api_key = self._validate_personal_api_key(password)
+        user = personal_api_key.user
+        if user is None:
+            raise HogQLServiceAuthenticationError("Invalid personal API key.")
+        if not self._database_user_matches_user(database_user, user):
+            raise HogQLServiceAuthenticationError("Database user does not match the personal API key owner.")
+
+        self._validate_personal_api_key_access(personal_api_key, team)
+        self._validate_user_team_access(user, team)
+        self._mark_personal_api_key_used(personal_api_key)
+        return HogQLServiceSessionContext(
+            database_user=database_user,
+            database=database,
+            user=user,
+            team=team,
+            authenticated_by="personal_api_key",
+            personal_api_key_id=personal_api_key.id,
+        )
+
+    def _get_team(self, database: str) -> Team:
+        try:
+            team_id = int(database)
+        except ValueError as error:
+            raise HogQLServiceAuthenticationError("Database must be a PostHog team_id.") from error
+
+        try:
+            return Team.objects.select_related("organization").get(pk=team_id)
+        except Team.DoesNotExist as error:
+            raise HogQLServiceAuthenticationError("Database must be a PostHog team_id.") from error
+
+    def _get_database_user(self, database_user: str) -> User:
+        username = database_user.strip()
+        if not username:
+            raise HogQLServiceAuthenticationError("Database user is required.")
+
+        user = self._find_database_user(username)
+        if user is None or not user.is_active:
+            raise HogQLServiceAuthenticationError("Database user is invalid.")
+        return user
+
+    def _find_database_user(self, username: str) -> User | None:
+        if username.isdecimal():
+            user = User.objects.filter(is_active=True, pk=int(username)).first()
+            if user is not None:
+                return user
+
+        try:
+            user_uuid = UUID(username)
+        except ValueError:
+            user_uuid = None
+
+        if user_uuid is not None:
+            user = User.objects.filter(is_active=True, uuid=user_uuid).first()
+            if user is not None:
+                return user
+
+        try:
+            return User.objects.get_by_natural_key(username)
+        except User.DoesNotExist:
+            return None
+
+    def _validate_personal_api_key(self, password: str) -> PersonalAPIKey:
+        try:
+            return PersonalAPIKeyAuthentication.validate_key((password, PersonalAPIKeyAuthentication.SOURCE_HEADER))
+        except AuthenticationFailed as error:
+            raise HogQLServiceAuthenticationError("Invalid personal API key.") from error
+
+    def _validate_personal_api_key_access(self, personal_api_key: PersonalAPIKey, team: Team) -> None:
+        scopes = personal_api_key.scopes or []
+        if "*" not in scopes and "query:read" not in scopes and "query:write" not in scopes:
+            raise HogQLServicePermissionError("Personal API key is missing the query:read scope.")
+
+        scoped_teams = personal_api_key.scoped_teams or []
+        if scoped_teams and team.id not in scoped_teams:
+            raise HogQLServicePermissionError("Personal API key does not have access to this project.")
+
+        scoped_organizations = personal_api_key.scoped_organizations or []
+        if scoped_organizations and str(team.organization_id) not in scoped_organizations:
+            raise HogQLServicePermissionError("Personal API key does not have access to this organization.")
+
+        organization = team.organization
+        if not organization.is_feature_available(AvailableFeature.ORGANIZATION_SECURITY_SETTINGS):
+            return
+
+        membership = OrganizationMembership.objects.filter(
+            user=personal_api_key.user, organization=organization
+        ).first()
+        if (
+            membership is not None
+            and not organization.members_can_use_personal_api_keys
+            and membership.level < OrganizationMembership.Level.ADMIN
+        ):
+            raise HogQLServicePermissionError(
+                f"Organization '{organization.name}' does not allow using personal API keys."
+            )
+
+    def _validate_user_team_access(self, user: User, team: Team) -> None:
+        membership_level = UserPermissions(user, team=team).current_team.effective_membership_level
+        if membership_level is None:
+            raise HogQLServicePermissionError("Database user does not have access to this project.")
+
+    def _mark_personal_api_key_used(self, personal_api_key: PersonalAPIKey) -> None:
+        now = timezone.now()
+        if personal_api_key.last_used_at is None or now - personal_api_key.last_used_at > timedelta(hours=1):
+            personal_api_key.last_used_at = now
+            personal_api_key.save(update_fields=["last_used_at"])
+
+    def _database_user_matches_user(self, database_user: str, user: User) -> bool:
+        username = database_user.strip()
+        if username == str(user.pk) or username == str(user.uuid):
+            return True
+        return username.casefold() == user.email.casefold()
+
+
+class HogQLServiceQueryExecutor:
+    def execute(self, sql: str, context: HogQLServiceSessionContext) -> QueryResult:
+        stripped_sql = sql.strip()
+        if not stripped_sql:
+            return QueryResult(columns=[], rows=[], command_tag="")
+
+        builtin_result = self._execute_builtin_query(stripped_sql, context)
+        if builtin_result is not None:
+            return builtin_result
+
+        try:
+            query_ast = parse_select(stripped_sql, cache_origin=CacheOrigin.USER)
+            validate_user_query(query_ast, team=context.team)
+            response = execute_hogql_query(
+                query=query_ast,
+                team=context.team,
+                user=context.user,
+                query_type="hogql_service",
+                limit_context=LimitContext.QUERY,
+                pretty=False,
+            )
+        except (ExposedHogQLError, QueryError, ResolutionError, ValueError) as error:
+            raise HogQLServiceQueryError(str(error)) from error
+
+        if response.error:
+            raise HogQLServiceQueryError(response.error)
+
+        return self._response_to_query_result(response)
+
+    def _response_to_query_result(self, response: HogQLQueryResponse) -> QueryResult:
+        rows = [tuple(row) if isinstance(row, (list, tuple)) else (row,) for row in response.results or []]
+        columns = self._response_columns(response)
+        return QueryResult(columns=columns, rows=rows, command_tag=f"SELECT {len(rows)}")
+
+    def _response_columns(self, response: HogQLQueryResponse) -> list[ResultColumn]:
+        if response.types:
+            return [
+                ResultColumn(name=name, type_oid=clickhouse_type_to_postgres_oid(clickhouse_type))
+                for name, clickhouse_type in response.types
+            ]
+
+        return [ResultColumn(name=column) for column in response.columns or []]
+
+    def _execute_builtin_query(self, sql: str, context: HogQLServiceSessionContext) -> QueryResult | None:
+        normalized = normalize_sql(sql)
+
+        if normalized in {"begin", "start transaction"}:
+            return QueryResult(columns=[], rows=[], command_tag="BEGIN")
+        if normalized in {"commit", "end"}:
+            return QueryResult(columns=[], rows=[], command_tag="COMMIT")
+        if normalized == "rollback":
+            return QueryResult(columns=[], rows=[], command_tag="ROLLBACK")
+        if normalized.startswith("set ") or normalized.startswith("reset ") or normalized.startswith("discard "):
+            return QueryResult(columns=[], rows=[], command_tag="SET")
+
+        show_value = self._show_value(normalized, context)
+        if show_value is not None:
+            parameter_name, value = show_value
+            return QueryResult(
+                columns=[ResultColumn(name=parameter_name)],
+                rows=[(value,)],
+                command_tag="SHOW",
+            )
+
+        builtin_select = self._builtin_select(normalized, context)
+        if builtin_select is not None:
+            columns, rows = builtin_select
+            return QueryResult(
+                columns=[ResultColumn(name=column) for column in columns],
+                rows=rows,
+                command_tag=f"SELECT {len(rows)}",
+            )
+
+        return None
+
+    def _show_value(self, normalized: str, context: HogQLServiceSessionContext) -> tuple[str, str] | None:
+        values = {
+            "server_version": "16.0 (PostHog HogQL service)",
+            "server_encoding": "UTF8",
+            "client_encoding": "UTF8",
+            "datestyle": "ISO, MDY",
+            "standard_conforming_strings": "on",
+            "integer_datetimes": "on",
+            "timezone": context.team.timezone,
+            "transaction_isolation": "read committed",
+            "default_transaction_read_only": "on",
+        }
+        match = re.fullmatch(r"show\s+([a-zA-Z_][a-zA-Z0-9_]*)", normalized)
+        if not match:
+            return None
+        parameter_name = match.group(1)
+        value = values.get(parameter_name)
+        if value is None:
+            return None
+        return parameter_name, value
+
+    def _builtin_select(
+        self, normalized: str, context: HogQLServiceSessionContext
+    ) -> tuple[list[str], list[tuple[Any, ...]]] | None:
+        if normalized in {"select version()", "select pg_catalog.version()"}:
+            return ["version"], [("PostgreSQL 16.0 compatible PostHog HogQL service",)]
+        if normalized in {"select current_database()", "select pg_catalog.current_database()"}:
+            return ["current_database"], [(context.database,)]
+        if normalized in {"select current_schema()", "select pg_catalog.current_schema()"}:
+            return ["current_schema"], [("public",)]
+        if normalized in {"select current_user", "select session_user"}:
+            return ["current_user"], [(context.database_user,)]
+        return None
+
+
+class PostgresWireCodec:
+    @staticmethod
+    def message(message_type: bytes, payload: bytes = b"") -> bytes:
+        return message_type + struct.pack("!I", len(payload) + 4) + payload
+
+    @staticmethod
+    def authentication_cleartext_password() -> bytes:
+        return PostgresWireCodec.message(b"R", struct.pack("!I", AUTHENTICATION_CLEARTEXT_PASSWORD))
+
+    @staticmethod
+    def authentication_ok() -> bytes:
+        return PostgresWireCodec.message(b"R", struct.pack("!I", AUTHENTICATION_OK))
+
+    @staticmethod
+    def parameter_status(name: str, value: str) -> bytes:
+        return PostgresWireCodec.message(b"S", encode_cstring(name) + encode_cstring(value))
+
+    @staticmethod
+    def backend_key_data(process_id: int, secret_key: int) -> bytes:
+        return PostgresWireCodec.message(b"K", struct.pack("!II", process_id, secret_key))
+
+    @staticmethod
+    def ready_for_query(status: bytes = b"I") -> bytes:
+        return PostgresWireCodec.message(b"Z", status)
+
+    @staticmethod
+    def error_response(message: str, sqlstate: str = SQLSTATE_INTERNAL_ERROR, severity: str = "ERROR") -> bytes:
+        payload = (
+            b"S" + encode_cstring(severity) + b"C" + encode_cstring(sqlstate) + b"M" + encode_cstring(message) + b"\x00"
+        )
+        return PostgresWireCodec.message(b"E", payload)
+
+    @staticmethod
+    def parse_complete() -> bytes:
+        return PostgresWireCodec.message(b"1")
+
+    @staticmethod
+    def bind_complete() -> bytes:
+        return PostgresWireCodec.message(b"2")
+
+    @staticmethod
+    def close_complete() -> bytes:
+        return PostgresWireCodec.message(b"3")
+
+    @staticmethod
+    def no_data() -> bytes:
+        return PostgresWireCodec.message(b"n")
+
+    @staticmethod
+    def empty_query_response() -> bytes:
+        return PostgresWireCodec.message(b"I")
+
+    @staticmethod
+    def command_complete(command_tag: str) -> bytes:
+        return PostgresWireCodec.message(b"C", encode_cstring(command_tag))
+
+    @staticmethod
+    def row_description(columns: list[ResultColumn]) -> bytes:
+        payload = struct.pack("!H", len(columns))
+        for column in columns:
+            payload += encode_cstring(column.name)
+            payload += struct.pack(
+                "!IhIhih", 0, 0, column.type_oid, column.type_size, column.type_modifier, column.format_code
+            )
+        return PostgresWireCodec.message(b"T", payload)
+
+    @staticmethod
+    def data_row(row: tuple[Any, ...]) -> bytes:
+        payload = struct.pack("!H", len(row))
+        for value in row:
+            if value is None:
+                payload += struct.pack("!i", -1)
+                continue
+            encoded_value = serialize_value(value).encode("utf-8")
+            payload += struct.pack("!I", len(encoded_value)) + encoded_value
+        return PostgresWireCodec.message(b"D", payload)
+
+
+class HogQLPostgresWireSession:
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        authenticator: HogQLServiceAuthenticator,
+        query_executor: HogQLServiceQueryExecutor,
+        max_query_bytes: int,
+    ):
+        self.reader = reader
+        self.writer = writer
+        self.authenticator = authenticator
+        self.query_executor = query_executor
+        self.max_query_bytes = max_query_bytes
+        self.context: HogQLServiceSessionContext | None = None
+        self.prepared_statements: dict[str, PreparedStatement] = {}
+        self.bound_portals: dict[str, BoundPortal] = {}
+        self.skip_until_sync = False
+
+    async def run(self) -> None:
+        try:
+            startup_parameters = await self._read_startup_parameters()
+            if startup_parameters is None:
+                return
+
+            await self._authenticate(startup_parameters)
+            await self._send_startup_ready()
+            await self._message_loop()
+        except (asyncio.IncompleteReadError, ConnectionResetError):
+            return
+        except HogQLServiceError as error:
+            self.writer.write(PostgresWireCodec.error_response(str(error), error.sqlstate))
+            await self.writer.drain()
+        except Exception:
+            logger.exception("Unhandled HogQL service connection error")
+            self.writer.write(
+                PostgresWireCodec.error_response("Internal HogQL service error.", SQLSTATE_INTERNAL_ERROR)
+            )
+            await self.writer.drain()
+        finally:
+            self.writer.close()
+            await self.writer.wait_closed()
+
+    async def _read_startup_parameters(self) -> dict[str, str] | None:
+        while True:
+            length_bytes = await self.reader.readexactly(4)
+            length = struct.unpack("!I", length_bytes)[0]
+            if length < 8:
+                raise HogQLServiceProtocolError("Invalid startup packet.")
+
+            payload = await self.reader.readexactly(length - 4)
+            request_code = struct.unpack("!I", payload[:4])[0]
+            if request_code == SSL_REQUEST_CODE or request_code == GSSENC_REQUEST_CODE:
+                self.writer.write(b"N")
+                await self.writer.drain()
+                continue
+            if request_code == CANCEL_REQUEST_CODE:
+                return None
+            if request_code != PROTOCOL_VERSION_3:
+                raise HogQLServiceProtocolError("Unsupported Postgres protocol version.")
+            return parse_startup_parameters(payload[4:])
+
+    async def _authenticate(self, startup_parameters: dict[str, str]) -> None:
+        database_user = startup_parameters.get("user", "")
+        database = startup_parameters.get("database") or database_user
+
+        self.writer.write(PostgresWireCodec.authentication_cleartext_password())
+        await self.writer.drain()
+
+        message = await self._read_message()
+        if message is None or message[0] != b"p":
+            raise HogQLServiceAuthenticationError("Password is required.")
+
+        password = message[1].rstrip(b"\x00").decode("utf-8", "replace")
+        self.context = await asyncio.to_thread(self.authenticator.authenticate, database_user, database, password)
+
+    async def _send_startup_ready(self) -> None:
+        assert self.context is not None
+        secret_key = secrets.randbits(32)
+        messages = [
+            PostgresWireCodec.authentication_ok(),
+            PostgresWireCodec.parameter_status("server_version", "16.0"),
+            PostgresWireCodec.parameter_status("server_encoding", "UTF8"),
+            PostgresWireCodec.parameter_status("client_encoding", "UTF8"),
+            PostgresWireCodec.parameter_status("DateStyle", "ISO, MDY"),
+            PostgresWireCodec.parameter_status("integer_datetimes", "on"),
+            PostgresWireCodec.parameter_status("standard_conforming_strings", "on"),
+            PostgresWireCodec.parameter_status("TimeZone", self.context.team.timezone),
+            PostgresWireCodec.parameter_status("application_name", "posthog-hogql-service"),
+            PostgresWireCodec.backend_key_data(os.getpid(), secret_key),
+            PostgresWireCodec.ready_for_query(),
+        ]
+        for message in messages:
+            self.writer.write(message)
+        await self.writer.drain()
+
+    async def _message_loop(self) -> None:
+        while True:
+            message = await self._read_message()
+            if message is None:
+                return
+
+            message_type, payload = message
+            if message_type == b"X":
+                return
+
+            if self.skip_until_sync and message_type != b"S":
+                continue
+
+            try:
+                await self._handle_message(message_type, payload)
+            except HogQLServiceError as error:
+                self.writer.write(PostgresWireCodec.error_response(str(error), error.sqlstate))
+                if message_type != b"Q":
+                    self.skip_until_sync = True
+                else:
+                    self.writer.write(PostgresWireCodec.ready_for_query())
+                await self.writer.drain()
+
+    async def _read_message(self) -> tuple[bytes, bytes] | None:
+        message_type = await self.reader.read(1)
+        if not message_type:
+            return None
+        length_bytes = await self.reader.readexactly(4)
+        length = struct.unpack("!I", length_bytes)[0]
+        if length < 4:
+            raise HogQLServiceProtocolError("Invalid message length.")
+        payload = await self.reader.readexactly(length - 4)
+        return message_type, payload
+
+    async def _handle_message(self, message_type: bytes, payload: bytes) -> None:
+        if message_type == b"Q":
+            await self._handle_simple_query(payload)
+        elif message_type == b"P":
+            self._handle_parse(payload)
+        elif message_type == b"B":
+            self._handle_bind(payload)
+        elif message_type == b"D":
+            await self._handle_describe(payload)
+        elif message_type == b"E":
+            await self._handle_execute(payload)
+        elif message_type == b"C":
+            self._handle_close(payload)
+        elif message_type == b"H":
+            await self.writer.drain()
+        elif message_type == b"S":
+            self.skip_until_sync = False
+            self.writer.write(PostgresWireCodec.ready_for_query())
+            await self.writer.drain()
+        else:
+            raise HogQLServiceProtocolError(f"Unsupported Postgres message type: {message_type!r}.")
+
+    async def _handle_simple_query(self, payload: bytes) -> None:
+        sql = payload.rstrip(b"\x00").decode("utf-8", "replace")
+        statements = sqlparse.split(sql)
+        if not statements:
+            self.writer.write(PostgresWireCodec.empty_query_response())
+            self.writer.write(PostgresWireCodec.ready_for_query())
+            await self.writer.drain()
+            return
+
+        for statement in statements:
+            await self._send_query_result(statement, send_row_description=True)
+
+        self.writer.write(PostgresWireCodec.ready_for_query())
+        await self.writer.drain()
+
+    def _handle_parse(self, payload: bytes) -> None:
+        statement_name, offset = read_cstring(payload, 0)
+        query, offset = read_cstring(payload, offset)
+        if len(query.encode("utf-8")) > self.max_query_bytes:
+            raise HogQLServiceProtocolError("Query is too large.")
+
+        parameter_count = read_uint16(payload, offset)
+        offset += 2
+        parameter_type_oids = []
+        for _ in range(parameter_count):
+            parameter_type_oids.append(read_uint32(payload, offset))
+            offset += 4
+
+        self.prepared_statements[statement_name] = PreparedStatement(
+            name=statement_name,
+            query=query,
+            parameter_type_oids=parameter_type_oids,
+        )
+        self.writer.write(PostgresWireCodec.parse_complete())
+
+    def _handle_bind(self, payload: bytes) -> None:
+        portal_name, offset = read_cstring(payload, 0)
+        statement_name, offset = read_cstring(payload, offset)
+        statement = self.prepared_statements.get(statement_name)
+        if statement is None:
+            raise HogQLServiceProtocolError("Prepared statement does not exist.")
+
+        parameter_format_count = read_uint16(payload, offset)
+        offset += 2
+        parameter_formats = []
+        for _ in range(parameter_format_count):
+            parameter_formats.append(read_uint16(payload, offset))
+            offset += 2
+
+        parameter_count = read_uint16(payload, offset)
+        offset += 2
+        parameters = []
+        for index in range(parameter_count):
+            parameter_length = read_int32(payload, offset)
+            offset += 4
+            if parameter_length == -1:
+                parameters.append(PgParameter(None))
+                continue
+            parameter_bytes = payload[offset : offset + parameter_length]
+            offset += parameter_length
+            format_code = (
+                parameter_formats[index]
+                if len(parameter_formats) > index
+                else (parameter_formats[0] if parameter_formats else 0)
+            )
+            type_oid = (
+                statement.parameter_type_oids[index]
+                if len(statement.parameter_type_oids) > index
+                else POSTGRES_TEXT_OID
+            )
+            parameters.append(PgParameter(decode_parameter(parameter_bytes, format_code, type_oid)))
+
+        result_format_count = read_uint16(payload, offset)
+        offset += 2
+        result_formats = []
+        for _ in range(result_format_count):
+            result_formats.append(read_uint16(payload, offset))
+            offset += 2
+
+        self.bound_portals[portal_name] = BoundPortal(
+            name=portal_name,
+            statement_name=statement_name,
+            query=statement.query,
+            parameters=parameters,
+            result_formats=result_formats,
+        )
+        self.writer.write(PostgresWireCodec.bind_complete())
+
+    async def _handle_describe(self, payload: bytes) -> None:
+        describe_target = payload[:1]
+        name = payload[1:].rstrip(b"\x00").decode("utf-8", "replace")
+        if describe_target == b"S":
+            self.writer.write(PostgresWireCodec.no_data())
+            return
+        if describe_target != b"P":
+            raise HogQLServiceProtocolError("Invalid describe target.")
+
+        portal = self.bound_portals.get(name)
+        if portal is None:
+            raise HogQLServiceProtocolError("Portal does not exist.")
+        result = await self._execute_portal(portal)
+        if result.columns:
+            self.writer.write(PostgresWireCodec.row_description(result.columns))
+            portal.row_description_sent = True
+        else:
+            self.writer.write(PostgresWireCodec.no_data())
+
+    async def _handle_execute(self, payload: bytes) -> None:
+        portal_name, offset = read_cstring(payload, 0)
+        _max_rows = read_uint32(payload, offset)
+        portal = self.bound_portals.get(portal_name)
+        if portal is None:
+            raise HogQLServiceProtocolError("Portal does not exist.")
+
+        result = await self._execute_portal(portal)
+        await self._send_result(result, send_row_description=not portal.row_description_sent)
+
+    def _handle_close(self, payload: bytes) -> None:
+        close_target = payload[:1]
+        name = payload[1:].rstrip(b"\x00").decode("utf-8", "replace")
+        if close_target == b"S":
+            self.prepared_statements.pop(name, None)
+        elif close_target == b"P":
+            self.bound_portals.pop(name, None)
+        else:
+            raise HogQLServiceProtocolError("Invalid close target.")
+        self.writer.write(PostgresWireCodec.close_complete())
+
+    async def _execute_portal(self, portal: BoundPortal) -> QueryResult:
+        if portal.result is not None:
+            return portal.result
+
+        query = bind_parameters_to_query(portal.query, portal.parameters)
+        portal.result = await self._execute_query(query)
+        return portal.result
+
+    async def _send_query_result(self, sql: str, send_row_description: bool) -> None:
+        result = await self._execute_query(sql)
+        await self._send_result(result, send_row_description=send_row_description)
+
+    async def _execute_query(self, sql: str) -> QueryResult:
+        assert self.context is not None
+        if len(sql.encode("utf-8")) > self.max_query_bytes:
+            raise HogQLServiceProtocolError("Query is too large.")
+        return await asyncio.to_thread(self.query_executor.execute, sql, self.context)
+
+    async def _send_result(self, result: QueryResult, send_row_description: bool) -> None:
+        if send_row_description and result.columns:
+            self.writer.write(PostgresWireCodec.row_description(result.columns))
+        for row in result.rows:
+            self.writer.write(PostgresWireCodec.data_row(row))
+        self.writer.write(PostgresWireCodec.command_complete(result.command_tag))
+        await self.writer.drain()
+
+
+class HogQLPostgresServer:
+    def __init__(self, config: HogQLServiceConfig):
+        self.config = config
+        self.authenticator = HogQLServiceAuthenticator(shared_secret=config.shared_secret)
+        self.query_executor = HogQLServiceQueryExecutor()
+
+    async def serve_forever(self) -> None:
+        server = await asyncio.start_server(self._handle_client, self.config.host, self.config.port)
+        addresses = ", ".join(str(socket.getsockname()) for socket in server.sockets or [])
+        logger.info("HogQL Postgres wire service listening", extra={"addresses": addresses})
+        async with server:
+            await server.serve_forever()
+
+    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        session = HogQLPostgresWireSession(
+            reader=reader,
+            writer=writer,
+            authenticator=self.authenticator,
+            query_executor=self.query_executor,
+            max_query_bytes=self.config.max_query_bytes,
+        )
+        await session.run()
+
+
+def normalize_sql(sql: str) -> str:
+    without_comments = sqlparse.format(sql.strip().rstrip(";"), strip_comments=True)
+    return re.sub(r"\s+", " ", without_comments).strip().lower()
+
+
+def clickhouse_type_to_postgres_oid(clickhouse_type: str) -> int:
+    lowered = clickhouse_type.lower()
+    if lowered.startswith("nullable("):
+        lowered = lowered.removeprefix("nullable(").removesuffix(")")
+    if lowered.startswith("array("):
+        return POSTGRES_TEXT_OID
+    if lowered.startswith("bool"):
+        return POSTGRES_BOOL_OID
+    if lowered.startswith("uint") or lowered.startswith("int"):
+        return POSTGRES_INT8_OID
+    if lowered.startswith("float"):
+        return POSTGRES_FLOAT8_OID
+    if lowered.startswith("decimal"):
+        return POSTGRES_NUMERIC_OID
+    if lowered.startswith("date32") or lowered == "date":
+        return POSTGRES_DATE_OID
+    if lowered.startswith("datetime64") or lowered.startswith("datetime"):
+        return POSTGRES_TIMESTAMPTZ_OID
+    if lowered.startswith("uuid"):
+        return POSTGRES_UUID_OID
+    if lowered.startswith("json"):
+        return POSTGRES_JSON_OID
+    return POSTGRES_TEXT_OID
+
+
+def bind_parameters_to_query(query: str, parameters: list[PgParameter]) -> str:
+    output: list[str] = []
+    index = 0
+    state: Literal["normal", "single", "double", "backtick", "line_comment", "block_comment"] = "normal"
+
+    while index < len(query):
+        char = query[index]
+        next_char = query[index + 1] if index + 1 < len(query) else ""
+
+        if state == "normal":
+            if char == "'":
+                state = "single"
+                output.append(char)
+                index += 1
+                continue
+            if char == '"':
+                state = "double"
+                output.append(char)
+                index += 1
+                continue
+            if char == "`":
+                state = "backtick"
+                output.append(char)
+                index += 1
+                continue
+            if char == "-" and next_char == "-":
+                state = "line_comment"
+                output.append(char)
+                output.append(next_char)
+                index += 2
+                continue
+            if char == "/" and next_char == "*":
+                state = "block_comment"
+                output.append(char)
+                output.append(next_char)
+                index += 2
+                continue
+            if char == "$" and next_char.isdecimal():
+                end = index + 2
+                while end < len(query) and query[end].isdecimal():
+                    end += 1
+                parameter_index = int(query[index + 1 : end]) - 1
+                if parameter_index < 0 or parameter_index >= len(parameters):
+                    raise HogQLServiceProtocolError(f"Missing bind parameter ${parameter_index + 1}.")
+                output.append(escape_hogql_string(parameters[parameter_index].value))
+                index = end
+                continue
+        elif state == "single":
+            if char == "\\":
+                output.append(char)
+                if next_char:
+                    output.append(next_char)
+                    index += 2
+                    continue
+            elif char == "'" and next_char == "'":
+                output.append(char)
+                output.append(next_char)
+                index += 2
+                continue
+            elif char == "'":
+                state = "normal"
+        elif state == "double" and char == '"':
+            state = "normal"
+        elif state == "backtick" and char == "`":
+            state = "normal"
+        elif state == "line_comment" and char in {"\n", "\r"}:
+            state = "normal"
+        elif state == "block_comment" and char == "*" and next_char == "/":
+            state = "normal"
+            output.append(char)
+            output.append(next_char)
+            index += 2
+            continue
+
+        output.append(char)
+        index += 1
+
+    return "".join(output)
+
+
+def decode_parameter(data: bytes, format_code: int, type_oid: int) -> Any:
+    if format_code == 0:
+        return data.decode("utf-8")
+    if format_code != 1:
+        raise HogQLServiceProtocolError("Unsupported bind parameter format.")
+
+    if type_oid == POSTGRES_BOOL_OID:
+        return data != b"\x00"
+    if type_oid == POSTGRES_INT2_OID:
+        return struct.unpack("!h", data)[0]
+    if type_oid == POSTGRES_INT4_OID:
+        return struct.unpack("!i", data)[0]
+    if type_oid == POSTGRES_INT8_OID:
+        return struct.unpack("!q", data)[0]
+    if type_oid == POSTGRES_FLOAT4_OID:
+        return struct.unpack("!f", data)[0]
+    if type_oid == POSTGRES_FLOAT8_OID:
+        return struct.unpack("!d", data)[0]
+    if type_oid in {POSTGRES_TEXT_OID, 1042, 1043}:
+        return data.decode("utf-8")
+
+    raise HogQLServiceProtocolError(f"Unsupported binary bind parameter type OID: {type_oid}.")
+
+
+def serialize_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "t" if value else "f"
+    if isinstance(value, datetime):
+        return value.isoformat(sep=" ")
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, (list, tuple, dict)):
+        return json.dumps(value, default=str)
+    return str(value)
+
+
+def parse_startup_parameters(payload: bytes) -> dict[str, str]:
+    parts = payload.split(b"\x00")
+    parameters: dict[str, str] = {}
+    index = 0
+    while index + 1 < len(parts) and parts[index]:
+        key = parts[index].decode("utf-8", "replace")
+        value = parts[index + 1].decode("utf-8", "replace")
+        parameters[key] = value
+        index += 2
+    return parameters
+
+
+def encode_cstring(value: str) -> bytes:
+    return value.encode("utf-8") + b"\x00"
+
+
+def read_cstring(payload: bytes, offset: int) -> tuple[str, int]:
+    end = payload.find(b"\x00", offset)
+    if end == -1:
+        raise HogQLServiceProtocolError("Expected null-terminated string.")
+    return payload[offset:end].decode("utf-8", "replace"), end + 1
+
+
+def read_uint16(payload: bytes, offset: int) -> int:
+    return struct.unpack("!H", payload[offset : offset + 2])[0]
+
+
+def read_uint32(payload: bytes, offset: int) -> int:
+    return struct.unpack("!I", payload[offset : offset + 4])[0]
+
+
+def read_int32(payload: bytes, offset: int) -> int:
+    return struct.unpack("!i", payload[offset : offset + 4])[0]

--- a/posthog/hogql/service.py
+++ b/posthog/hogql/service.py
@@ -8,6 +8,7 @@ import struct
 import asyncio
 import logging
 import secrets
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from decimal import Decimal
@@ -828,15 +829,19 @@ class HogQLPostgresWireSession:
 
 
 class HogQLPostgresServer:
-    def __init__(self, config: HogQLServiceConfig):
+    def __init__(self, config: HogQLServiceConfig, on_listening: Callable[[str], None] | None = None):
         self.config = config
+        self.on_listening = on_listening
         self.authenticator = HogQLServiceAuthenticator(shared_secret=config.shared_secret)
         self.query_executor = HogQLServiceQueryExecutor()
 
     async def serve_forever(self) -> None:
         server = await asyncio.start_server(self._handle_client, self.config.host, self.config.port)
         addresses = ", ".join(str(socket.getsockname()) for socket in server.sockets or [])
-        logger.info("HogQL Postgres wire service listening", extra={"addresses": addresses})
+        message = f"HogQL Postgres wire service listening on {addresses}"
+        logger.info(message)
+        if self.on_listening is not None:
+            self.on_listening(message)
         async with server:
             await server.serve_forever()
 

--- a/posthog/hogql/service.py
+++ b/posthog/hogql/service.py
@@ -103,12 +103,20 @@ class HogQLServiceConfig:
 
 
 @dataclass(frozen=True)
+class HogQLServiceDatabaseTarget:
+    raw_database: str
+    team: Team
+    connection_id: str | None = None
+
+
+@dataclass(frozen=True)
 class HogQLServiceSessionContext:
     database_user: str
     database: str
     user: User
     team: Team
     authenticated_by: Literal["shared_secret", "personal_api_key"]
+    connection_id: str | None = None
     personal_api_key_id: str | None = None
 
 
@@ -156,17 +164,18 @@ class HogQLServiceAuthenticator:
         self.shared_secret = shared_secret
 
     def authenticate(self, database_user: str, database: str, password: str) -> HogQLServiceSessionContext:
-        team = self._get_team(database)
+        database_target = self._get_database_target(database)
 
         if self.shared_secret and hmac.compare_digest(password, self.shared_secret):
             user = self._get_database_user(database_user)
-            self._validate_user_team_access(user, team)
+            self._validate_user_team_access(user, database_target.team)
             return HogQLServiceSessionContext(
                 database_user=database_user,
-                database=database,
+                database=database_target.raw_database,
                 user=user,
-                team=team,
+                team=database_target.team,
                 authenticated_by="shared_secret",
+                connection_id=database_target.connection_id,
             )
 
         personal_api_key = self._validate_personal_api_key(password)
@@ -176,28 +185,67 @@ class HogQLServiceAuthenticator:
         if not self._database_user_matches_user(database_user, user):
             raise HogQLServiceAuthenticationError("Database user does not match the personal API key owner.")
 
-        self._validate_personal_api_key_access(personal_api_key, team)
-        self._validate_user_team_access(user, team)
+        self._validate_personal_api_key_access(personal_api_key, database_target.team)
+        self._validate_user_team_access(user, database_target.team)
         self._mark_personal_api_key_used(personal_api_key)
         return HogQLServiceSessionContext(
             database_user=database_user,
-            database=database,
+            database=database_target.raw_database,
             user=user,
-            team=team,
+            team=database_target.team,
             authenticated_by="personal_api_key",
+            connection_id=database_target.connection_id,
             personal_api_key_id=personal_api_key.id,
         )
 
-    def _get_team(self, database: str) -> Team:
+    def _get_database_target(self, database: str) -> HogQLServiceDatabaseTarget:
+        normalized_database = database.strip()
+        team_id, connection_id = parse_database_name(normalized_database)
+        team = self._get_team(team_id)
+        if connection_id is not None:
+            self._validate_connection_id(team, connection_id)
+        return HogQLServiceDatabaseTarget(
+            raw_database=normalized_database,
+            team=team,
+            connection_id=connection_id,
+        )
+
+    def _get_team(self, team_id: str) -> Team:
         try:
-            team_id = int(database)
+            parsed_team_id = int(team_id)
         except ValueError as error:
-            raise HogQLServiceAuthenticationError("Database must be a PostHog team_id.") from error
+            raise HogQLServiceAuthenticationError(
+                "Database must be a PostHog team_id or team_id/connection_id."
+            ) from error
 
         try:
-            return Team.objects.select_related("organization").get(pk=team_id)
+            return Team.objects.select_related("organization").get(pk=parsed_team_id)
         except Team.DoesNotExist as error:
-            raise HogQLServiceAuthenticationError("Database must be a PostHog team_id.") from error
+            raise HogQLServiceAuthenticationError(
+                "Database must be a PostHog team_id or team_id/connection_id."
+            ) from error
+
+    def _validate_connection_id(self, team: Team, connection_id: str) -> None:
+        try:
+            source_uuid = UUID(connection_id)
+        except ValueError as error:
+            raise HogQLServiceAuthenticationError("Connection id must be a valid UUID.") from error
+
+        from products.data_warehouse.backend.models import ExternalDataSource
+
+        source = (
+            ExternalDataSource.objects.filter(
+                team_id=team.pk,
+                id=source_uuid,
+                access_method=ExternalDataSource.AccessMethod.DIRECT,
+            )
+            .exclude(deleted=True)
+            .first()
+        )
+        if source is None:
+            raise HogQLServiceAuthenticationError("Connection id is invalid for this team.")
+        if not source.is_direct_postgres:
+            raise HogQLServiceAuthenticationError("Connection id must reference a direct Postgres connection.")
 
     def _get_database_user(self, database_user: str) -> User:
         username = database_user.strip()
@@ -302,6 +350,7 @@ class HogQLServiceQueryExecutor:
                 user=context.user,
                 query_type="hogql_service",
                 limit_context=LimitContext.QUERY,
+                connection_id=context.connection_id,
                 pretty=False,
             )
         except (ExposedHogQLError, QueryError, ResolutionError, ValueError) as error:
@@ -805,6 +854,20 @@ class HogQLPostgresServer:
 def normalize_sql(sql: str) -> str:
     without_comments = sqlparse.format(sql.strip().rstrip(";"), strip_comments=True)
     return re.sub(r"\s+", " ", without_comments).strip().lower()
+
+
+def parse_database_name(database: str) -> tuple[str, str | None]:
+    if not database:
+        raise HogQLServiceAuthenticationError("Database must be a PostHog team_id or team_id/connection_id.")
+
+    if "/" not in database:
+        return database, None
+
+    team_id, connection_id = database.split("/", 1)
+    if not team_id or not connection_id or "/" in connection_id:
+        raise HogQLServiceAuthenticationError("Database must be a PostHog team_id or team_id/connection_id.")
+
+    return team_id, connection_id
 
 
 def clickhouse_type_to_postgres_oid(clickhouse_type: str) -> int:

--- a/posthog/hogql/service.py
+++ b/posthog/hogql/service.py
@@ -9,6 +9,7 @@ import struct
 import asyncio
 import logging
 import secrets
+import ipaddress
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
@@ -44,6 +45,8 @@ PROTOCOL_VERSION_3 = 196608
 SSL_REQUEST_CODE = 80877103
 GSSENC_REQUEST_CODE = 80877104
 CANCEL_REQUEST_CODE = 80877102
+MAX_STARTUP_PACKET_BYTES = 64 * 1024
+MAX_UNAUTHENTICATED_MESSAGE_BYTES = 64 * 1024
 
 AUTHENTICATION_OK = 0
 AUTHENTICATION_CLEARTEXT_PASSWORD = 3
@@ -96,7 +99,7 @@ class HogQLServiceProtocolError(HogQLServiceError):
 
 @dataclass(frozen=True)
 class HogQLServiceConfig:
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 6543
     shared_secret: str | None = None
     max_query_bytes: int = 1024 * 1024
@@ -104,7 +107,7 @@ class HogQLServiceConfig:
     @classmethod
     def from_env(cls) -> HogQLServiceConfig:
         return cls(
-            host=os.environ.get("HOGQL_SERVICE_HOST", "0.0.0.0"),
+            host=os.environ.get("HOGQL_SERVICE_HOST", "127.0.0.1"),
             port=int(os.environ.get("HOGQL_SERVICE_PORT", "6543")),
             shared_secret=os.environ.get("HOGQL_SERVICE_SHARED_SECRET") or None,
             max_query_bytes=int(os.environ.get("HOGQL_SERVICE_MAX_QUERY_BYTES", str(1024 * 1024))),
@@ -350,6 +353,26 @@ class HogQLServiceAuthenticator:
         return username.casefold() == user.email.casefold()
 
 
+def _setting_values(context: HogQLServiceSessionContext) -> dict[str, str]:
+    return {
+        "server_version": "16.0 (PostHog HogQL service)",
+        "server_version_num": "160000",
+        "server_encoding": "UTF8",
+        "client_encoding": "UTF8",
+        "datestyle": "ISO, MDY",
+        "standard_conforming_strings": "on",
+        "integer_datetimes": "on",
+        "timezone": context.team.timezone,
+        "transaction_isolation": "read committed",
+        "default_transaction_read_only": "on",
+        "search_path": "public",
+        "statement_timeout": "0",
+        "lock_timeout": "0",
+        "idle_in_transaction_session_timeout": "0",
+        "extra_float_digits": "1",
+    }
+
+
 class HogQLServiceQueryExecutor:
     def execute(self, sql: str, context: HogQLServiceSessionContext) -> QueryResult:
         stripped_sql = sql.strip()
@@ -410,7 +433,7 @@ class HogQLServiceQueryExecutor:
         if normalized.startswith("set ") or normalized.startswith("reset ") or normalized.startswith("discard "):
             return QueryResult(columns=[], rows=[], command_tag="SET")
         if normalized == "show all":
-            rows = [(name, value, "") for name, value in self._setting_values(context).items()]
+            rows = [(name, value, "") for name, value in _setting_values(context).items()]
             return QueryResult(
                 columns=[ResultColumn(name="name"), ResultColumn(name="setting"), ResultColumn(name="description")],
                 rows=rows,
@@ -457,7 +480,7 @@ class HogQLServiceQueryExecutor:
         return None
 
     def _show_value(self, normalized: str, context: HogQLServiceSessionContext) -> tuple[str, str] | None:
-        values = self._setting_values(context)
+        values = _setting_values(context)
         match = re.fullmatch(r"show\s+([a-zA-Z_][a-zA-Z0-9_]*|transaction\s+isolation\s+level)", normalized)
         if not match:
             return None
@@ -468,25 +491,6 @@ class HogQLServiceQueryExecutor:
         if value is None:
             return None
         return parameter_name, value
-
-    def _setting_values(self, context: HogQLServiceSessionContext) -> dict[str, str]:
-        return {
-            "server_version": "16.0 (PostHog HogQL service)",
-            "server_version_num": "160000",
-            "server_encoding": "UTF8",
-            "client_encoding": "UTF8",
-            "datestyle": "ISO, MDY",
-            "standard_conforming_strings": "on",
-            "integer_datetimes": "on",
-            "timezone": context.team.timezone,
-            "transaction_isolation": "read committed",
-            "default_transaction_read_only": "on",
-            "search_path": "public",
-            "statement_timeout": "0",
-            "lock_timeout": "0",
-            "idle_in_transaction_session_timeout": "0",
-            "extra_float_digits": "1",
-        }
 
     def _builtin_select(
         self, normalized: str, context: HogQLServiceSessionContext
@@ -518,7 +522,7 @@ class HogQLServiceQueryExecutor:
         )
         if current_setting_match:
             setting_name = current_setting_match.group(1).replace(" ", "_")
-            return ["current_setting"], [(self._setting_values(context).get(setting_name),)]
+            return ["current_setting"], [(_setting_values(context).get(setting_name),)]
         return None
 
     def _builtin_no_from_select(
@@ -707,7 +711,7 @@ class HogQLPostgresWireSession:
         except (asyncio.IncompleteReadError, ConnectionResetError):
             return
         except HogQLServiceError as error:
-            self._log_service_error(error, message_type=None)
+            await self._log_service_error(error, message_type=None)
             self.writer.write(PostgresWireCodec.error_response(str(error), error.sqlstate))
             await self.writer.drain()
         except Exception:
@@ -724,7 +728,7 @@ class HogQLPostgresWireSession:
         while True:
             length_bytes = await self.reader.readexactly(4)
             length = struct.unpack("!I", length_bytes)[0]
-            if length < 8:
+            if length < 8 or length > MAX_STARTUP_PACKET_BYTES:
                 raise HogQLServiceProtocolError("Invalid startup packet.")
 
             payload = await self.reader.readexactly(length - 4)
@@ -789,7 +793,7 @@ class HogQLPostgresWireSession:
             try:
                 await self._handle_message(message_type, payload)
             except HogQLServiceError as error:
-                self._log_service_error(error, message_type=message_type)
+                await self._log_service_error(error, message_type=message_type)
                 self.writer.write(PostgresWireCodec.error_response(str(error), error.sqlstate))
                 if message_type != b"Q":
                     self.skip_until_sync = True
@@ -797,9 +801,9 @@ class HogQLPostgresWireSession:
                     self.writer.write(PostgresWireCodec.ready_for_query())
                 await self.writer.drain()
 
-    def _log_service_error(self, error: HogQLServiceError, message_type: bytes | None) -> None:
+    async def _log_service_error(self, error: HogQLServiceError, message_type: bytes | None) -> None:
         context = self.context
-        append_service_log(
+        await append_service_log_async(
             f"ERROR sqlstate={error.sqlstate} message_type={message_type!r} "
             f"database={context.database if context else None} team_id={context.team.id if context else None} "
             f"connection_id={context.connection_id if context else None} user={context.database_user if context else None} "
@@ -829,7 +833,11 @@ class HogQLPostgresWireSession:
         length = struct.unpack("!I", length_bytes)[0]
         if length < 4:
             raise HogQLServiceProtocolError("Invalid message length.")
-        payload = await self.reader.readexactly(length - 4)
+        payload_length = length - 4
+        max_payload_bytes = self.max_query_bytes if self.context is not None else MAX_UNAUTHENTICATED_MESSAGE_BYTES
+        if payload_length > max_payload_bytes:
+            raise HogQLServiceProtocolError("Message is too large.")
+        payload = await self.reader.readexactly(payload_length)
         return message_type, payload
 
     async def _handle_message(self, message_type: bytes, payload: bytes) -> None:
@@ -998,7 +1006,7 @@ class HogQLPostgresWireSession:
         assert self.context is not None
         if len(sql.encode("utf-8")) > self.max_query_bytes:
             raise HogQLServiceProtocolError("Query is too large.")
-        append_service_log(
+        await append_service_log_async(
             f"QUERY database={self.context.database} team_id={self.context.team.id} "
             f"connection_id={self.context.connection_id} user={self.context.database_user} query={sql!r}"
         )
@@ -1015,7 +1023,7 @@ class HogQLPostgresWireSession:
         )
         try:
             result = await asyncio.to_thread(self.query_executor.execute, sql, self.context)
-            self._log_query_result(result)
+            await self._log_query_result(result)
             return result
         except HogQLServiceError as error:
             if error.query is None:
@@ -1035,7 +1043,7 @@ class HogQLPostgresWireSession:
             )
             raise
 
-    def _log_query_result(self, result: QueryResult) -> None:
+    async def _log_query_result(self, result: QueryResult) -> None:
         assert self.context is not None
         column_names = [column.name for column in result.columns[:20]]
         null_columns = [
@@ -1043,7 +1051,7 @@ class HogQLPostgresWireSession:
             for column_index, column in enumerate(result.columns[:20])
             if any(column_index >= len(row) or row[column_index] is None for row in result.rows[:50])
         ]
-        append_service_log(
+        await append_service_log_async(
             f"RESULT database={self.context.database} team_id={self.context.team.id} "
             f"connection_id={self.context.connection_id} user={self.context.database_user} "
             f"command={result.command_tag!r} row_count={len(result.rows)} columns={column_names!r} "
@@ -1070,14 +1078,28 @@ class HogQLPostgresServer:
         server = await asyncio.start_server(self._handle_client, self.config.host, self.config.port)
         addresses = ", ".join(str(socket.getsockname()) for socket in server.sockets or [])
         message = f"HogQL Postgres wire service listening on {addresses}"
-        append_service_log(message)
+        await append_service_log_async(message)
         logger.info(message)
+        if not is_loopback_host(self.config.host):
+            warning = (
+                "HogQL service is running without TLS on a non-loopback bind address; "
+                "non-loopback client connections will be rejected."
+            )
+            await append_service_log_async(warning)
+            logger.warning(warning)
         if self.on_listening is not None:
             self.on_listening(message)
         async with server:
             await server.serve_forever()
 
     async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        peername = writer.get_extra_info("peername")
+        if not is_loopback_peer(peername):
+            logger.warning("Rejected non-loopback HogQL service connection: peername=%r", peername)
+            writer.close()
+            await writer.wait_closed()
+            return
+
         session = HogQLPostgresWireSession(
             reader=reader,
             writer=writer,
@@ -1107,6 +1129,36 @@ def parse_database_name(database: str) -> tuple[str, str | None]:
     return team_id, connection_id
 
 
+def is_loopback_host(host: str) -> bool:
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return True
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return address.is_loopback
+
+
+def is_loopback_peer(peername: object) -> bool:
+    if not isinstance(peername, tuple) or not peername:
+        return False
+
+    host = peername[0]
+    if not isinstance(host, str):
+        return False
+
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return host == "localhost"
+
+    if address.is_loopback:
+        return True
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped is not None:
+        return address.ipv4_mapped.is_loopback
+    return False
+
+
 def append_service_log(message: str) -> None:
     log_file = os.environ.get("HOGQL_SERVICE_LOG_FILE", "/tmp/posthog-hogql-service.log")
     try:
@@ -1114,6 +1166,10 @@ def append_service_log(message: str) -> None:
             file.write(f"{timezone.now().isoformat()} {message}\n")
     except OSError:
         logger.debug("Failed to write HogQL service log file", exc_info=True)
+
+
+async def append_service_log_async(message: str) -> None:
+    await asyncio.to_thread(append_service_log, message)
 
 
 INFORMATION_SCHEMA_SCHEMATA_COLUMNS = [
@@ -1436,7 +1492,7 @@ def evaluate_builtin_expression(expression: str, context: HogQLServiceSessionCon
     if normalized.startswith("current_setting(") or normalized.startswith("pg_catalog.current_setting("):
         setting_match = re.match(r"(?:pg_catalog\.)?current_setting\('([^']+)'(?:,\s*true)?\)", normalized)
         if setting_match:
-            return HogQLServiceQueryExecutor()._setting_values(context).get(setting_match.group(1).replace(" ", "_"))
+            return _setting_values(context).get(setting_match.group(1).replace(" ", "_"))
     if normalized == "null":
         return None
     if normalized in {"true", "'yes'"}:

--- a/posthog/hogql/service.py
+++ b/posthog/hogql/service.py
@@ -4,6 +4,7 @@ import os
 import re
 import hmac
 import json
+import zlib
 import struct
 import asyncio
 import logging
@@ -20,13 +21,15 @@ from django.utils import timezone
 import sqlparse
 from rest_framework.exceptions import AuthenticationFailed
 
-from posthog.schema import HogQLQueryResponse
+from posthog.schema import DatabaseSchemaField, DatabaseSerializedFieldType, HogQLQueryResponse
 
 from posthog.hogql.constants import LimitContext
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
 from posthog.hogql.errors import ExposedHogQLError, QueryError, ResolutionError
 from posthog.hogql.escape_sql import escape_hogql_string
 from posthog.hogql.parser import CacheOrigin, parse_select
-from posthog.hogql.query import execute_hogql_query
+from posthog.hogql.query import create_default_modifiers_for_team, execute_hogql_query
 from posthog.hogql.user_query_validator import validate_user_query
 
 from posthog.auth import PersonalAPIKeyAuthentication
@@ -68,6 +71,11 @@ SQLSTATE_INTERNAL_ERROR = "XX000"
 
 class HogQLServiceError(Exception):
     sqlstate = SQLSTATE_INTERNAL_ERROR
+    query: str | None
+
+    def __init__(self, message: str, *, query: str | None = None):
+        super().__init__(message)
+        self.query = query
 
 
 class HogQLServiceAuthenticationError(HogQLServiceError):
@@ -140,6 +148,15 @@ class QueryResult:
 @dataclass(frozen=True)
 class PgParameter:
     value: Any
+
+
+@dataclass(frozen=True)
+class CatalogTable:
+    oid: int
+    schema: str
+    name: str
+    table_type: str
+    fields: list[DatabaseSchemaField]
 
 
 @dataclass
@@ -342,8 +359,9 @@ class HogQLServiceQueryExecutor:
         if builtin_result is not None:
             return builtin_result
 
+        hogql_sql = strip_public_schema_references(stripped_sql)
         try:
-            query_ast = parse_select(stripped_sql, cache_origin=CacheOrigin.USER)
+            query_ast = parse_select(hogql_sql, cache_origin=CacheOrigin.USER)
             validate_user_query(query_ast, team=context.team)
             response = execute_hogql_query(
                 query=query_ast,
@@ -355,10 +373,10 @@ class HogQLServiceQueryExecutor:
                 pretty=False,
             )
         except (ExposedHogQLError, QueryError, ResolutionError, ValueError) as error:
-            raise HogQLServiceQueryError(str(error)) from error
+            raise HogQLServiceQueryError(str(error), query=stripped_sql) from error
 
         if response.error:
-            raise HogQLServiceQueryError(response.error)
+            raise HogQLServiceQueryError(response.error, query=stripped_sql)
 
         return self._response_to_query_result(response)
 
@@ -387,6 +405,25 @@ class HogQLServiceQueryExecutor:
             return QueryResult(columns=[], rows=[], command_tag="ROLLBACK")
         if normalized.startswith("set ") or normalized.startswith("reset ") or normalized.startswith("discard "):
             return QueryResult(columns=[], rows=[], command_tag="SET")
+        if normalized == "show all":
+            rows = [(name, value, "") for name, value in self._setting_values(context).items()]
+            return QueryResult(
+                columns=[ResultColumn(name="name"), ResultColumn(name="setting"), ResultColumn(name="description")],
+                rows=rows,
+                command_tag=f"SHOW {len(rows)}",
+            )
+
+        compatibility_select = self._compatibility_select(normalized)
+        if compatibility_select is not None:
+            columns, rows = compatibility_select
+            return QueryResult(
+                columns=[
+                    ResultColumn(name=column, type_oid=python_value_to_postgres_oid(row_value(rows, column_index)))
+                    for column_index, column in enumerate(columns)
+                ],
+                rows=rows,
+                command_tag=f"SELECT {len(rows)}",
+            )
 
         show_value = self._show_value(normalized, context)
         if show_value is not None:
@@ -397,11 +434,18 @@ class HogQLServiceQueryExecutor:
                 command_tag="SHOW",
             )
 
+        catalog_result = self._catalog_query(sql, normalized, context)
+        if catalog_result is not None:
+            return catalog_result
+
         builtin_select = self._builtin_select(normalized, context)
         if builtin_select is not None:
             columns, rows = builtin_select
             return QueryResult(
-                columns=[ResultColumn(name=column) for column in columns],
+                columns=[
+                    ResultColumn(name=column, type_oid=python_value_to_postgres_oid(row_value(rows, column_index)))
+                    for column_index, column in enumerate(columns)
+                ],
                 rows=rows,
                 command_tag=f"SELECT {len(rows)}",
             )
@@ -409,8 +453,22 @@ class HogQLServiceQueryExecutor:
         return None
 
     def _show_value(self, normalized: str, context: HogQLServiceSessionContext) -> tuple[str, str] | None:
-        values = {
+        values = self._setting_values(context)
+        match = re.fullmatch(r"show\s+([a-zA-Z_][a-zA-Z0-9_]*|transaction\s+isolation\s+level)", normalized)
+        if not match:
+            return None
+        parameter_name = match.group(1).replace(" ", "_")
+        if parameter_name == "transaction_isolation_level":
+            parameter_name = "transaction_isolation"
+        value = values.get(parameter_name)
+        if value is None:
+            return None
+        return parameter_name, value
+
+    def _setting_values(self, context: HogQLServiceSessionContext) -> dict[str, str]:
+        return {
             "server_version": "16.0 (PostHog HogQL service)",
+            "server_version_num": "160000",
             "server_encoding": "UTF8",
             "client_encoding": "UTF8",
             "datestyle": "ISO, MDY",
@@ -419,28 +477,118 @@ class HogQLServiceQueryExecutor:
             "timezone": context.team.timezone,
             "transaction_isolation": "read committed",
             "default_transaction_read_only": "on",
+            "search_path": "public",
+            "statement_timeout": "0",
+            "lock_timeout": "0",
+            "idle_in_transaction_session_timeout": "0",
+            "extra_float_digits": "1",
         }
-        match = re.fullmatch(r"show\s+([a-zA-Z_][a-zA-Z0-9_]*)", normalized)
-        if not match:
-            return None
-        parameter_name = match.group(1)
-        value = values.get(parameter_name)
-        if value is None:
-            return None
-        return parameter_name, value
 
     def _builtin_select(
         self, normalized: str, context: HogQLServiceSessionContext
     ) -> tuple[list[str], list[tuple[Any, ...]]] | None:
+        no_from_select = self._builtin_no_from_select(normalized, context)
+        if no_from_select is not None:
+            return no_from_select
+
         if normalized in {"select version()", "select pg_catalog.version()"}:
             return ["version"], [("PostgreSQL 16.0 compatible PostHog HogQL service",)]
         if normalized in {"select current_database()", "select pg_catalog.current_database()"}:
             return ["current_database"], [(context.database,)]
-        if normalized in {"select current_schema()", "select pg_catalog.current_schema()"}:
+        if normalized in {"select current_catalog"}:
+            return ["current_catalog"], [(context.database,)]
+        if normalized in {"select current_schema()", "select pg_catalog.current_schema()", "select current_schema"}:
             return ["current_schema"], [("public",)]
+        if normalized in {"select current_schemas(false)", "select pg_catalog.current_schemas(false)"}:
+            return ["current_schemas"], [(["public"],)]
+        if normalized in {"select current_schemas(true)", "select pg_catalog.current_schemas(true)"}:
+            return ["current_schemas"], [(["pg_catalog", "public"],)]
         if normalized in {"select current_user", "select session_user"}:
             return ["current_user"], [(context.database_user,)]
+        if normalized in {"select pg_backend_pid()", "select pg_catalog.pg_backend_pid()"}:
+            return ["pg_backend_pid"], [(os.getpid(),)]
+
+        current_setting_match = re.fullmatch(
+            r"select\s+(?:pg_catalog\.)?current_setting\('([^']+)'(?:,\s*true)?\)",
+            normalized,
+        )
+        if current_setting_match:
+            setting_name = current_setting_match.group(1).replace(" ", "_")
+            return ["current_setting"], [(self._setting_values(context).get(setting_name),)]
         return None
+
+    def _builtin_no_from_select(
+        self, normalized: str, context: HogQLServiceSessionContext
+    ) -> tuple[list[str], list[tuple[Any, ...]]] | None:
+        if not normalized.startswith("select ") or find_top_level_keyword(normalized, "from") is not None:
+            return None
+
+        select_items = [parse_select_item(item) for item in split_top_level_commas(normalized.removeprefix("select "))]
+        values: list[Any] = []
+        for expression, _label in select_items:
+            value = evaluate_builtin_expression(expression, context)
+            if value is UNHANDLED_BUILTIN_EXPRESSION:
+                return None
+            values.append(value)
+        return [label for _expression, label in select_items], [tuple(values)]
+
+    def _compatibility_select(self, normalized: str) -> tuple[list[str], list[tuple[Any, ...]]] | None:
+        timestamp_sources = (
+            r"now\(\)|current_timestamp|transaction_timestamp\(\)|statement_timestamp\(\)|clock_timestamp\(\)"
+        )
+        if re.match(r"select\s+round\s*\(\s*extract\s*\(\s*epoch\s+from\b", normalized):
+            return ["round"], [(round(timezone.now().timestamp() * 1000),)]
+        if re.match(r"select\s+extract\s*\(\s*epoch\s+from\b", normalized):
+            return ["extract"], [(timezone.now().timestamp(),)]
+        if re.fullmatch(
+            rf"select\s+round\(extract\(epoch\s+from\s+({timestamp_sources})\)\s*\*\s*1000\)",
+            normalized,
+        ):
+            return ["round"], [(round(timezone.now().timestamp() * 1000),)]
+        if re.fullmatch(rf"select\s+extract\(epoch\s+from\s+({timestamp_sources})\)", normalized):
+            return ["extract"], [(timezone.now().timestamp(),)]
+        return None
+
+    def _catalog_query(self, sql: str, normalized: str, context: HogQLServiceSessionContext) -> QueryResult | None:
+        source = catalog_source(normalized)
+        if source is None:
+            return None
+
+        rows, default_columns = self._catalog_rows(source, context)
+        rows = filter_catalog_rows(rows, normalized)
+        columns, result_rows = project_catalog_rows(sql, rows, default_columns, context)
+        result_columns = [
+            ResultColumn(name=column, type_oid=python_value_to_postgres_oid(row_value(result_rows, column_index)))
+            for column_index, column in enumerate(columns)
+        ]
+        return QueryResult(columns=result_columns, rows=result_rows, command_tag=f"SELECT {len(result_rows)}")
+
+    def _catalog_rows(self, source: str, context: HogQLServiceSessionContext) -> tuple[list[dict[str, Any]], list[str]]:
+        tables = load_catalog_tables(context)
+        schemas = sorted({table.schema for table in tables} | {"information_schema", "pg_catalog", "public"})
+
+        if source == "information_schema.schemata":
+            return information_schema_schemata_rows(context, schemas), INFORMATION_SCHEMA_SCHEMATA_COLUMNS
+        if source == "information_schema.tables":
+            return information_schema_table_rows(context, tables), INFORMATION_SCHEMA_TABLE_COLUMNS
+        if source == "information_schema.columns":
+            return information_schema_column_rows(context, tables), INFORMATION_SCHEMA_COLUMN_COLUMNS
+        if source == "pg_catalog.pg_namespace":
+            return pg_namespace_rows(schemas), PG_NAMESPACE_COLUMNS
+        if source == "pg_catalog.pg_class":
+            return pg_class_rows(tables), PG_CLASS_COLUMNS
+        if source == "pg_catalog.pg_attribute":
+            return pg_attribute_rows(tables), PG_ATTRIBUTE_COLUMNS
+        if source == "pg_catalog.pg_type":
+            return pg_type_rows(), PG_TYPE_COLUMNS
+        if source == "pg_catalog.pg_database":
+            return pg_database_rows(context), PG_DATABASE_COLUMNS
+        if source == "pg_catalog.pg_roles":
+            return pg_roles_rows(context), EMPTY_CATALOG_COLUMNS["pg_catalog.pg_roles"]
+        if source == "pg_user":
+            return pg_user_rows(context), EMPTY_CATALOG_COLUMNS["pg_user"]
+
+        return [], EMPTY_CATALOG_COLUMNS.get(source, [])
 
 
 class PostgresWireCodec:
@@ -552,6 +700,7 @@ class HogQLPostgresWireSession:
         except (asyncio.IncompleteReadError, ConnectionResetError):
             return
         except HogQLServiceError as error:
+            self._log_service_error(error, message_type=None)
             self.writer.write(PostgresWireCodec.error_response(str(error), error.sqlstate))
             await self.writer.drain()
         except Exception:
@@ -633,12 +782,37 @@ class HogQLPostgresWireSession:
             try:
                 await self._handle_message(message_type, payload)
             except HogQLServiceError as error:
+                self._log_service_error(error, message_type=message_type)
                 self.writer.write(PostgresWireCodec.error_response(str(error), error.sqlstate))
                 if message_type != b"Q":
                     self.skip_until_sync = True
                 else:
                     self.writer.write(PostgresWireCodec.ready_for_query())
                 await self.writer.drain()
+
+    def _log_service_error(self, error: HogQLServiceError, message_type: bytes | None) -> None:
+        context = self.context
+        append_service_log(
+            f"ERROR sqlstate={error.sqlstate} message_type={message_type!r} "
+            f"database={context.database if context else None} team_id={context.team.id if context else None} "
+            f"connection_id={context.connection_id if context else None} user={context.database_user if context else None} "
+            f"query={error.query!r} error={error!s}"
+        )
+        logger.warning(
+            "HogQL service error: sqlstate=%s query=%r",
+            error.sqlstate,
+            error.query,
+            extra={
+                "hogql_service_sqlstate": error.sqlstate,
+                "hogql_service_message_type": message_type.decode("ascii", "replace") if message_type else None,
+                "hogql_service_query": error.query,
+                "hogql_service_database": context.database if context else None,
+                "hogql_service_team_id": context.team.id if context else None,
+                "hogql_service_connection_id": context.connection_id if context else None,
+                "hogql_service_user": context.database_user if context else None,
+            },
+            exc_info=True,
+        )
 
     async def _read_message(self) -> tuple[bytes, bytes] | None:
         message_type = await self.reader.read(1)
@@ -817,7 +991,40 @@ class HogQLPostgresWireSession:
         assert self.context is not None
         if len(sql.encode("utf-8")) > self.max_query_bytes:
             raise HogQLServiceProtocolError("Query is too large.")
-        return await asyncio.to_thread(self.query_executor.execute, sql, self.context)
+        append_service_log(
+            f"QUERY database={self.context.database} team_id={self.context.team.id} "
+            f"connection_id={self.context.connection_id} user={self.context.database_user} query={sql!r}"
+        )
+        logger.info(
+            "HogQL service query: %r",
+            sql,
+            extra={
+                "hogql_service_query": sql,
+                "hogql_service_database": self.context.database,
+                "hogql_service_team_id": self.context.team.id,
+                "hogql_service_connection_id": self.context.connection_id,
+                "hogql_service_user": self.context.database_user,
+            },
+        )
+        try:
+            return await asyncio.to_thread(self.query_executor.execute, sql, self.context)
+        except HogQLServiceError as error:
+            if error.query is None:
+                error.query = sql
+            raise
+        except Exception:
+            logger.exception(
+                "Unhandled HogQL service query error: query=%r",
+                sql,
+                extra={
+                    "hogql_service_query": sql,
+                    "hogql_service_database": self.context.database,
+                    "hogql_service_team_id": self.context.team.id,
+                    "hogql_service_connection_id": self.context.connection_id,
+                    "hogql_service_user": self.context.database_user,
+                },
+            )
+            raise
 
     async def _send_result(self, result: QueryResult, send_row_description: bool) -> None:
         if send_row_description and result.columns:
@@ -839,6 +1046,7 @@ class HogQLPostgresServer:
         server = await asyncio.start_server(self._handle_client, self.config.host, self.config.port)
         addresses = ", ".join(str(socket.getsockname()) for socket in server.sockets or [])
         message = f"HogQL Postgres wire service listening on {addresses}"
+        append_service_log(message)
         logger.info(message)
         if self.on_listening is not None:
             self.on_listening(message)
@@ -873,6 +1081,939 @@ def parse_database_name(database: str) -> tuple[str, str | None]:
         raise HogQLServiceAuthenticationError("Database must be a PostHog team_id or team_id/connection_id.")
 
     return team_id, connection_id
+
+
+def append_service_log(message: str) -> None:
+    log_file = os.environ.get("HOGQL_SERVICE_LOG_FILE", "/tmp/posthog-hogql-service.log")
+    try:
+        with open(log_file, "a") as file:
+            file.write(f"{timezone.now().isoformat()} {message}\n")
+    except OSError:
+        logger.debug("Failed to write HogQL service log file", exc_info=True)
+
+
+INFORMATION_SCHEMA_SCHEMATA_COLUMNS = [
+    "catalog_name",
+    "schema_name",
+    "schema_owner",
+    "default_character_set_catalog",
+    "default_character_set_schema",
+    "default_character_set_name",
+    "sql_path",
+]
+INFORMATION_SCHEMA_TABLE_COLUMNS = [
+    "table_catalog",
+    "table_schema",
+    "table_name",
+    "table_type",
+    "self_referencing_column_name",
+    "reference_generation",
+    "user_defined_type_catalog",
+    "user_defined_type_schema",
+    "user_defined_type_name",
+    "is_insertable_into",
+    "is_typed",
+    "commit_action",
+]
+INFORMATION_SCHEMA_COLUMN_COLUMNS = [
+    "table_catalog",
+    "table_schema",
+    "table_name",
+    "column_name",
+    "ordinal_position",
+    "column_default",
+    "is_nullable",
+    "data_type",
+    "character_maximum_length",
+    "character_octet_length",
+    "numeric_precision",
+    "numeric_precision_radix",
+    "numeric_scale",
+    "datetime_precision",
+    "interval_type",
+    "interval_precision",
+    "character_set_catalog",
+    "character_set_schema",
+    "character_set_name",
+    "collation_catalog",
+    "collation_schema",
+    "collation_name",
+    "domain_catalog",
+    "domain_schema",
+    "domain_name",
+    "udt_catalog",
+    "udt_schema",
+    "udt_name",
+    "scope_catalog",
+    "scope_schema",
+    "scope_name",
+    "maximum_cardinality",
+    "dtd_identifier",
+    "is_self_referencing",
+    "is_identity",
+    "identity_generation",
+    "identity_start",
+    "identity_increment",
+    "identity_maximum",
+    "identity_minimum",
+    "identity_cycle",
+    "is_generated",
+    "generation_expression",
+    "is_updatable",
+]
+PG_NAMESPACE_COLUMNS = ["oid", "nspname", "nspowner", "nspacl"]
+PG_CLASS_COLUMNS = [
+    "oid",
+    "relname",
+    "relnamespace",
+    "reltype",
+    "relowner",
+    "relkind",
+    "relpages",
+    "reltuples",
+    "relhasindex",
+    "relisshared",
+    "relpersistence",
+    "relchecks",
+    "relhasrules",
+    "relhastriggers",
+    "relhassubclass",
+    "relrowsecurity",
+    "relforcerowsecurity",
+    "relispopulated",
+    "reloptions",
+    "nspname",
+    "table_schema",
+    "table_name",
+    "table_type",
+]
+PG_ATTRIBUTE_COLUMNS = [
+    "attrelid",
+    "attname",
+    "atttypid",
+    "attstattarget",
+    "attlen",
+    "attnum",
+    "attndims",
+    "attcacheoff",
+    "atttypmod",
+    "attbyval",
+    "attstorage",
+    "attalign",
+    "attnotnull",
+    "atthasdef",
+    "attidentity",
+    "attgenerated",
+    "attisdropped",
+    "attislocal",
+    "attinhcount",
+    "attcollation",
+    "nspname",
+    "relname",
+    "typname",
+    "format_type",
+    "data_type",
+    "table_schema",
+    "table_name",
+    "column_name",
+    "ordinal_position",
+]
+PG_TYPE_COLUMNS = [
+    "oid",
+    "typname",
+    "typnamespace",
+    "typowner",
+    "typlen",
+    "typbyval",
+    "typtype",
+    "typcategory",
+    "typispreferred",
+    "typisdefined",
+    "typdelim",
+    "typrelid",
+    "typelem",
+    "typarray",
+    "typinput",
+    "typoutput",
+    "typreceive",
+    "typsend",
+    "typmodin",
+    "typmodout",
+    "typanalyze",
+    "typalign",
+    "typstorage",
+    "typnotnull",
+    "typbasetype",
+    "typtypmod",
+    "typndims",
+    "typcollation",
+]
+PG_DATABASE_COLUMNS = [
+    "oid",
+    "datname",
+    "datdba",
+    "encoding",
+    "datcollate",
+    "datctype",
+    "datistemplate",
+    "datallowconn",
+]
+EMPTY_CATALOG_COLUMNS = {
+    "information_schema.table_constraints": [
+        "constraint_catalog",
+        "constraint_schema",
+        "constraint_name",
+        "table_schema",
+        "table_name",
+        "constraint_type",
+    ],
+    "information_schema.key_column_usage": [
+        "constraint_catalog",
+        "constraint_schema",
+        "constraint_name",
+        "table_schema",
+        "table_name",
+        "column_name",
+        "ordinal_position",
+    ],
+    "information_schema.constraint_column_usage": [
+        "constraint_catalog",
+        "constraint_schema",
+        "constraint_name",
+        "table_schema",
+        "table_name",
+        "column_name",
+    ],
+    "information_schema.views": ["table_catalog", "table_schema", "table_name", "view_definition"],
+    "information_schema.routines": ["specific_catalog", "specific_schema", "specific_name", "routine_name"],
+    "information_schema.parameters": ["specific_catalog", "specific_schema", "specific_name", "parameter_name"],
+    "information_schema.sequences": ["sequence_catalog", "sequence_schema", "sequence_name"],
+    "pg_catalog.pg_index": ["indexrelid", "indrelid", "indisunique", "indisprimary", "indisexclusion", "indkey"],
+    "pg_catalog.pg_constraint": ["oid", "conname", "contype", "conrelid", "confrelid", "conkey"],
+    "pg_catalog.pg_description": ["objoid", "classoid", "objsubid", "description"],
+    "pg_catalog.pg_attrdef": ["adrelid", "adnum", "adbin"],
+    "pg_catalog.pg_inherits": ["inhrelid", "inhparent", "inhseqno"],
+    "pg_catalog.pg_proc": ["oid", "proname", "pronamespace", "prorettype"],
+    "pg_catalog.pg_roles": ["oid", "rolname", "rolsuper", "rolinherit", "rolcreaterole", "rolcreatedb", "rolcanlogin"],
+    "pg_catalog.pg_trigger": ["oid", "tgrelid", "tgname", "tgfoid", "tgenabled"],
+    "pg_catalog.pg_am": ["oid", "amname", "amhandler", "amtype"],
+    "pg_catalog.pg_enum": ["oid", "enumtypid", "enumsortorder", "enumlabel"],
+    "pg_catalog.pg_auth_members": ["roleid", "member", "grantor", "admin_option"],
+    "pg_catalog.pg_locks": ["locktype", "database", "relation", "transactionid", "pid", "mode", "granted"],
+    "pg_catalog.pg_shdescription": ["objoid", "classoid", "description"],
+    "pg_catalog.pg_tablespace": ["oid", "spcname", "spcowner", "spcacl", "spcoptions", "xmin"],
+    "pg_catalog.pg_timezone_names": ["name", "abbrev", "utc_offset", "is_dst"],
+    "pg_user": [
+        "usename",
+        "usesysid",
+        "usecreatedb",
+        "usesuper",
+        "userepl",
+        "usebypassrls",
+        "passwd",
+        "valuntil",
+        "useconfig",
+    ],
+}
+CATALOG_ALIAS_KEYS = {
+    "table_cat": "table_catalog",
+    "table_schem": "table_schema",
+    "table_schema": "table_schema",
+    "table_name": "table_name",
+    "table_type": "table_type",
+    "remarks": "description",
+    "column_name": "column_name",
+    "data_type": "data_type",
+    "type_name": "data_type",
+    "column_size": "character_maximum_length",
+    "decimal_digits": "numeric_scale",
+    "num_prec_radix": "numeric_precision_radix",
+    "nullable": "nullable",
+    "is_nullable": "is_nullable",
+    "schema_name": "schema_name",
+    "table_oid": "oid",
+    "column_oid": "attrelid",
+}
+UNHANDLED_BUILTIN_EXPRESSION = object()
+
+
+def evaluate_builtin_expression(expression: str, context: HogQLServiceSessionContext) -> Any:
+    normalized = normalize_catalog_expression(expression)
+    if normalized in {"current_database()", "pg_catalog.current_database()"}:
+        return context.database
+    if normalized in {"current_catalog"}:
+        return context.database
+    if normalized in {"current_schema()", "pg_catalog.current_schema()", "current_schema"}:
+        return "public"
+    if normalized in {"current_schemas(false)", "pg_catalog.current_schemas(false)"}:
+        return ["public"]
+    if normalized in {"current_schemas(true)", "pg_catalog.current_schemas(true)"}:
+        return ["pg_catalog", "public"]
+    if normalized in {"current_user", "session_user"}:
+        return context.database_user
+    if normalized in {"pg_backend_pid()", "pg_catalog.pg_backend_pid()"}:
+        return os.getpid()
+    if normalized.startswith("current_setting(") or normalized.startswith("pg_catalog.current_setting("):
+        setting_match = re.match(r"(?:pg_catalog\.)?current_setting\('([^']+)'(?:,\s*true)?\)", normalized)
+        if setting_match:
+            return HogQLServiceQueryExecutor()._setting_values(context).get(setting_match.group(1).replace(" ", "_"))
+    if normalized == "null":
+        return None
+    if normalized in {"true", "'yes'"}:
+        return True
+    if normalized in {"false", "'no'"}:
+        return False
+    if re.fullmatch(r"-?\d+", normalized):
+        return int(normalized)
+    if normalized.startswith("'") and normalized.endswith("'"):
+        return normalized[1:-1].replace("''", "'")
+    return UNHANDLED_BUILTIN_EXPRESSION
+
+
+def catalog_source(normalized: str) -> str | None:
+    if re.search(r"\bfrom\s+information_schema\.schemata\b", normalized):
+        return "information_schema.schemata"
+    if re.search(r"\bfrom\s+information_schema\.tables\b", normalized):
+        return "information_schema.tables"
+    if re.search(r"\bfrom\s+information_schema\.columns\b", normalized):
+        return "information_schema.columns"
+
+    for source in EMPTY_CATALOG_COLUMNS:
+        if re.search(rf"\bfrom\s+{re.escape(source)}\b", normalized):
+            return source
+
+    if re.search(r"\b(pg_catalog\.)?pg_attribute\b", normalized):
+        return "pg_catalog.pg_attribute"
+    if re.search(r"\b(pg_catalog\.)?pg_class\b", normalized):
+        return "pg_catalog.pg_class"
+    if re.search(r"\b(pg_catalog\.)?pg_namespace\b", normalized):
+        return "pg_catalog.pg_namespace"
+    if re.search(r"\b(pg_catalog\.)?pg_type\b", normalized):
+        return "pg_catalog.pg_type"
+    if re.search(r"\b(pg_catalog\.)?pg_database\b", normalized):
+        return "pg_catalog.pg_database"
+    if re.search(r"\b(pg_catalog\.)?pg_roles\b", normalized):
+        return "pg_catalog.pg_roles"
+    return None
+
+
+def load_catalog_tables(context: HogQLServiceSessionContext) -> list[CatalogTable]:
+    modifiers = create_default_modifiers_for_team(context.team)
+    database = Database.create_for(
+        team=context.team,
+        user=context.user,
+        modifiers=modifiers,
+        connection_id=context.connection_id,
+    )
+    hogql_context = HogQLContext(
+        team=context.team,
+        user=context.user,
+        database=database,
+        modifiers=modifiers,
+    )
+    serialized_tables = database.serialize(hogql_context)
+    tables: list[CatalogTable] = []
+    for table_name, table in serialized_tables.items():
+        schema_name, relation_name = split_catalog_table_name(table_name)
+        tables.append(
+            CatalogTable(
+                oid=stable_catalog_oid(f"table:{schema_name}.{relation_name}"),
+                schema=schema_name,
+                name=relation_name,
+                table_type=postgres_table_type(str(table.type)),
+                fields=list(table.fields.values()),
+            )
+        )
+    return sorted(tables, key=lambda table: (table.schema, table.name))
+
+
+def split_catalog_table_name(table_name: str) -> tuple[str, str]:
+    if "." not in table_name:
+        return "public", table_name
+    schema_name, relation_name = table_name.split(".", 1)
+    return schema_name or "public", relation_name
+
+
+def postgres_table_type(table_type: str) -> str:
+    if table_type in {"view", "managed_view", "materialized_view", "endpoint"}:
+        return "VIEW"
+    return "BASE TABLE"
+
+
+def information_schema_schemata_rows(context: HogQLServiceSessionContext, schemas: list[str]) -> list[dict[str, Any]]:
+    return [
+        {
+            "catalog_name": context.database,
+            "schema_name": schema,
+            "schema_owner": context.database_user,
+            "default_character_set_catalog": None,
+            "default_character_set_schema": None,
+            "default_character_set_name": "UTF8",
+            "sql_path": None,
+            "nspname": schema,
+            "oid": stable_catalog_oid(f"schema:{schema}"),
+        }
+        for schema in schemas
+    ]
+
+
+def information_schema_table_rows(
+    context: HogQLServiceSessionContext, tables: list[CatalogTable]
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "table_catalog": context.database,
+            "table_schema": table.schema,
+            "table_name": table.name,
+            "table_type": table.table_type,
+            "self_referencing_column_name": None,
+            "reference_generation": None,
+            "user_defined_type_catalog": None,
+            "user_defined_type_schema": None,
+            "user_defined_type_name": None,
+            "is_insertable_into": "NO",
+            "is_typed": "NO",
+            "commit_action": None,
+            "oid": table.oid,
+            "nspname": table.schema,
+            "relname": table.name,
+            "description": None,
+        }
+        for table in tables
+    ]
+
+
+def information_schema_column_rows(
+    context: HogQLServiceSessionContext, tables: list[CatalogTable]
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for table in tables:
+        for ordinal_position, field in enumerate(table.fields, start=1):
+            pg_type = postgres_type_for_field(field)
+            rows.append(
+                {
+                    "table_catalog": context.database,
+                    "table_schema": table.schema,
+                    "table_name": table.name,
+                    "column_name": field.name,
+                    "ordinal_position": ordinal_position,
+                    "column_default": None,
+                    "is_nullable": "YES",
+                    "data_type": pg_type["data_type"],
+                    "character_maximum_length": pg_type["character_maximum_length"],
+                    "character_octet_length": pg_type["character_octet_length"],
+                    "numeric_precision": pg_type["numeric_precision"],
+                    "numeric_precision_radix": pg_type["numeric_precision_radix"],
+                    "numeric_scale": pg_type["numeric_scale"],
+                    "datetime_precision": pg_type["datetime_precision"],
+                    "interval_type": None,
+                    "interval_precision": None,
+                    "character_set_catalog": None,
+                    "character_set_schema": None,
+                    "character_set_name": None,
+                    "collation_catalog": None,
+                    "collation_schema": None,
+                    "collation_name": None,
+                    "domain_catalog": None,
+                    "domain_schema": None,
+                    "domain_name": None,
+                    "udt_catalog": context.database,
+                    "udt_schema": "pg_catalog",
+                    "udt_name": pg_type["udt_name"],
+                    "scope_catalog": None,
+                    "scope_schema": None,
+                    "scope_name": None,
+                    "maximum_cardinality": None,
+                    "dtd_identifier": str(ordinal_position),
+                    "is_self_referencing": "NO",
+                    "is_identity": "NO",
+                    "identity_generation": None,
+                    "identity_start": None,
+                    "identity_increment": None,
+                    "identity_maximum": None,
+                    "identity_minimum": None,
+                    "identity_cycle": "NO",
+                    "is_generated": "NEVER",
+                    "generation_expression": None,
+                    "is_updatable": "NO",
+                    "attrelid": table.oid,
+                    "attname": field.name,
+                    "atttypid": pg_type["oid"],
+                    "attnum": ordinal_position,
+                    "typname": pg_type["udt_name"],
+                    "format_type": pg_type["data_type"],
+                    "nullable": 1,
+                    "description": None,
+                }
+            )
+    return rows
+
+
+def pg_namespace_rows(schemas: list[str]) -> list[dict[str, Any]]:
+    return [
+        {
+            "oid": stable_catalog_oid(f"schema:{schema}"),
+            "nspname": schema,
+            "schema_name": schema,
+            "nspowner": 10,
+            "nspacl": None,
+        }
+        for schema in schemas
+    ]
+
+
+def pg_class_rows(tables: list[CatalogTable]) -> list[dict[str, Any]]:
+    return [
+        {
+            "oid": table.oid,
+            "relname": table.name,
+            "relnamespace": stable_catalog_oid(f"schema:{table.schema}"),
+            "reltype": stable_catalog_oid(f"type:{table.schema}.{table.name}"),
+            "relowner": 10,
+            "relkind": "v" if table.table_type == "VIEW" else "r",
+            "relpages": 0,
+            "reltuples": -1.0,
+            "relhasindex": False,
+            "relisshared": False,
+            "relpersistence": "p",
+            "relchecks": 0,
+            "relhasrules": False,
+            "relhastriggers": False,
+            "relhassubclass": False,
+            "relrowsecurity": False,
+            "relforcerowsecurity": False,
+            "relispopulated": True,
+            "reloptions": None,
+            "nspname": table.schema,
+            "table_schema": table.schema,
+            "table_name": table.name,
+            "table_type": table.table_type,
+            "description": None,
+        }
+        for table in tables
+    ]
+
+
+def pg_attribute_rows(tables: list[CatalogTable]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for table in tables:
+        for ordinal_position, field in enumerate(table.fields, start=1):
+            pg_type = postgres_type_for_field(field)
+            rows.append(
+                {
+                    "attrelid": table.oid,
+                    "attname": field.name,
+                    "atttypid": pg_type["oid"],
+                    "attstattarget": -1,
+                    "attlen": -1,
+                    "attnum": ordinal_position,
+                    "attndims": 0,
+                    "attcacheoff": -1,
+                    "atttypmod": -1,
+                    "attbyval": False,
+                    "attstorage": "x",
+                    "attalign": "i",
+                    "attnotnull": False,
+                    "atthasdef": False,
+                    "attidentity": "",
+                    "attgenerated": "",
+                    "attisdropped": False,
+                    "attislocal": True,
+                    "attinhcount": 0,
+                    "attcollation": 0,
+                    "nspname": table.schema,
+                    "relname": table.name,
+                    "typname": pg_type["udt_name"],
+                    "format_type": pg_type["data_type"],
+                    "data_type": pg_type["data_type"],
+                    "table_schema": table.schema,
+                    "table_name": table.name,
+                    "column_name": field.name,
+                    "ordinal_position": ordinal_position,
+                    "nullable": 1,
+                    "description": None,
+                }
+            )
+    return rows
+
+
+def pg_type_rows() -> list[dict[str, Any]]:
+    rows = []
+    for type_oid, typname in [
+        (POSTGRES_BOOL_OID, "bool"),
+        (POSTGRES_INT8_OID, "int8"),
+        (POSTGRES_INT4_OID, "int4"),
+        (POSTGRES_INT2_OID, "int2"),
+        (POSTGRES_FLOAT4_OID, "float4"),
+        (POSTGRES_FLOAT8_OID, "float8"),
+        (POSTGRES_NUMERIC_OID, "numeric"),
+        (POSTGRES_DATE_OID, "date"),
+        (POSTGRES_TIMESTAMP_OID, "timestamp"),
+        (POSTGRES_TIMESTAMPTZ_OID, "timestamptz"),
+        (POSTGRES_JSON_OID, "json"),
+        (POSTGRES_UUID_OID, "uuid"),
+        (POSTGRES_TEXT_OID, "text"),
+    ]:
+        rows.append(
+            {
+                "oid": type_oid,
+                "typname": typname,
+                "typnamespace": stable_catalog_oid("schema:pg_catalog"),
+                "typowner": 10,
+                "typlen": -1,
+                "typbyval": False,
+                "typtype": "b",
+                "typcategory": "S",
+                "typispreferred": typname == "text",
+                "typisdefined": True,
+                "typdelim": ",",
+                "typrelid": 0,
+                "typelem": 0,
+                "typarray": 0,
+                "typinput": None,
+                "typoutput": None,
+                "typreceive": None,
+                "typsend": None,
+                "typmodin": None,
+                "typmodout": None,
+                "typanalyze": None,
+                "typalign": "i",
+                "typstorage": "x",
+                "typnotnull": False,
+                "typbasetype": 0,
+                "typtypmod": -1,
+                "typndims": 0,
+                "typcollation": 0,
+            }
+        )
+    return rows
+
+
+def pg_database_rows(context: HogQLServiceSessionContext) -> list[dict[str, Any]]:
+    return [
+        {
+            "oid": stable_catalog_oid(f"database:{context.database}"),
+            "datname": context.database,
+            "datdba": 10,
+            "encoding": 6,
+            "datcollate": "C",
+            "datctype": "C",
+            "datistemplate": False,
+            "datallowconn": True,
+        }
+    ]
+
+
+def pg_roles_rows(context: HogQLServiceSessionContext) -> list[dict[str, Any]]:
+    return [
+        {
+            "oid": stable_catalog_oid(f"role:{context.database_user}"),
+            "rolname": context.database_user,
+            "rolsuper": False,
+            "rolinherit": True,
+            "rolcreaterole": False,
+            "rolcreatedb": False,
+            "rolcanlogin": True,
+        }
+    ]
+
+
+def pg_user_rows(context: HogQLServiceSessionContext) -> list[dict[str, Any]]:
+    return [
+        {
+            "usename": context.database_user,
+            "usesysid": stable_catalog_oid(f"role:{context.database_user}"),
+            "usecreatedb": False,
+            "usesuper": False,
+            "userepl": False,
+            "usebypassrls": False,
+            "passwd": None,
+            "valuntil": None,
+            "useconfig": None,
+        }
+    ]
+
+
+def postgres_type_for_field(field: DatabaseSchemaField) -> dict[str, Any]:
+    field_type = str(field.type)
+    if field_type == DatabaseSerializedFieldType.INTEGER.value:
+        return postgres_type("bigint", "int8", POSTGRES_INT8_OID, numeric_precision=64, numeric_scale=0)
+    if field_type == DatabaseSerializedFieldType.FLOAT.value:
+        return postgres_type("double precision", "float8", POSTGRES_FLOAT8_OID, numeric_precision=53)
+    if field_type == DatabaseSerializedFieldType.DECIMAL.value:
+        return postgres_type("numeric", "numeric", POSTGRES_NUMERIC_OID)
+    if field_type == DatabaseSerializedFieldType.DATETIME.value:
+        return postgres_type("timestamp with time zone", "timestamptz", POSTGRES_TIMESTAMPTZ_OID, datetime_precision=6)
+    if field_type == DatabaseSerializedFieldType.DATE.value:
+        return postgres_type("date", "date", POSTGRES_DATE_OID)
+    if field_type == DatabaseSerializedFieldType.BOOLEAN.value:
+        return postgres_type("boolean", "bool", POSTGRES_BOOL_OID)
+    if field_type == DatabaseSerializedFieldType.JSON.value:
+        return postgres_type("json", "json", POSTGRES_JSON_OID)
+    return postgres_type("text", "text", POSTGRES_TEXT_OID, character_maximum_length=None)
+
+
+def postgres_type(
+    data_type: str,
+    udt_name: str,
+    oid: int,
+    *,
+    character_maximum_length: int | None = None,
+    numeric_precision: int | None = None,
+    numeric_scale: int | None = None,
+    datetime_precision: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "data_type": data_type,
+        "udt_name": udt_name,
+        "oid": oid,
+        "character_maximum_length": character_maximum_length,
+        "character_octet_length": character_maximum_length,
+        "numeric_precision": numeric_precision,
+        "numeric_precision_radix": 2 if numeric_precision is not None else None,
+        "numeric_scale": numeric_scale,
+        "datetime_precision": datetime_precision,
+    }
+
+
+def filter_catalog_rows(rows: list[dict[str, Any]], normalized: str) -> list[dict[str, Any]]:
+    if not rows:
+        return rows
+    if re.search(r"\bwhere\s+(false|1\s*=\s*0)\b", normalized):
+        return []
+
+    filters = [
+        (("table_schema", "nspname", "schema_name"), extract_equality_filters(normalized, ["table_schema", "nspname"])),
+        (("table_name", "relname"), extract_equality_filters(normalized, ["table_name", "relname"])),
+        (("column_name", "attname"), extract_equality_filters(normalized, ["column_name", "attname"])),
+    ]
+    filtered_rows = rows
+    for keys, values in filters:
+        if not values:
+            continue
+        filtered_rows = [
+            row
+            for row in filtered_rows
+            if any(str(row.get(key, "")).casefold() in values for key in keys if row.get(key) is not None)
+        ]
+    return filtered_rows
+
+
+def extract_equality_filters(normalized: str, names: list[str]) -> set[str]:
+    values: set[str] = set()
+    for name in names:
+        pattern = rf"(?:\b[a-z_][a-z0-9_]*\.)?{re.escape(name)}\s*=\s*'([^']*)'"
+        values.update(match.group(1).casefold() for match in re.finditer(pattern, normalized))
+    return values
+
+
+def project_catalog_rows(
+    sql: str,
+    rows: list[dict[str, Any]],
+    default_columns: list[str],
+    context: HogQLServiceSessionContext,
+) -> tuple[list[str], list[tuple[Any, ...]]]:
+    if re.search(r"\bcount\s*\(\s*\*\s*\)", sql, flags=re.IGNORECASE):
+        return ["count"], [(len(rows),)]
+
+    select_items = parse_select_items(sql)
+    if not select_items or any(expression == "*" or expression.endswith(".*") for expression, _label in select_items):
+        return default_columns, [tuple(row.get(column) for column in default_columns) for row in rows]
+
+    columns = [label for _expression, label in select_items]
+    result_rows = [
+        tuple(evaluate_catalog_expression(expression, label, row, context) for expression, label in select_items)
+        for row in rows
+    ]
+    return columns, result_rows
+
+
+def parse_select_items(sql: str) -> list[tuple[str, str]]:
+    select_list = extract_select_list(sql)
+    if select_list is None:
+        return []
+    select_list = re.sub(r"^\s*distinct\s+", "", select_list, flags=re.IGNORECASE)
+    return [parse_select_item(item) for item in split_top_level_commas(select_list)]
+
+
+def extract_select_list(sql: str) -> str | None:
+    match = re.search(r"\bselect\b", sql, flags=re.IGNORECASE)
+    if not match:
+        return None
+    from_index = find_top_level_keyword(sql, "from", start=match.end())
+    if from_index is None:
+        return None
+    return sql[match.end() : from_index].strip()
+
+
+def parse_select_item(item: str) -> tuple[str, str]:
+    stripped_item = item.strip()
+    alias_match = re.search(r"\s+as\s+((?:\"[^\"]+\")|(?:[a-zA-Z_][a-zA-Z0-9_$]*))\s*$", stripped_item, re.IGNORECASE)
+    if alias_match:
+        expression = stripped_item[: alias_match.start()].strip()
+        return expression, clean_identifier(alias_match.group(1))
+
+    trailing_alias_match = re.search(r"\s+((?:\"[^\"]+\")|(?:[a-zA-Z_][a-zA-Z0-9_$]*))\s*$", stripped_item)
+    if trailing_alias_match and not stripped_item[: trailing_alias_match.start()].strip().lower().endswith("::"):
+        expression = stripped_item[: trailing_alias_match.start()].strip()
+        if expression and not expression.lower().endswith(("null", "true", "false")):
+            return expression, clean_identifier(trailing_alias_match.group(1))
+
+    return stripped_item, label_from_expression(stripped_item)
+
+
+def evaluate_catalog_expression(
+    expression: str,
+    label: str,
+    row: dict[str, Any],
+    context: HogQLServiceSessionContext,
+) -> Any:
+    label_key = CATALOG_ALIAS_KEYS.get(label.casefold(), label.casefold())
+    if label_key in row:
+        return row[label_key]
+
+    normalized_expression = normalize_catalog_expression(expression)
+    expression_key = CATALOG_ALIAS_KEYS.get(normalized_expression, normalized_expression)
+    if expression_key in row:
+        return row[expression_key]
+
+    if normalized_expression in {"current_database()", "pg_catalog.current_database()"}:
+        return context.database
+    if normalized_expression in {"current_schema()", "pg_catalog.current_schema()"}:
+        return "public"
+    if normalized_expression.startswith("pg_catalog.format_type(") or normalized_expression.startswith("format_type("):
+        return row.get("format_type") or row.get("data_type")
+    if "obj_description(" in normalized_expression or "col_description(" in normalized_expression:
+        return row.get("description")
+    if normalized_expression == "null":
+        return None
+    if normalized_expression in {"true", "'yes'"}:
+        return True
+    if normalized_expression in {"false", "'no'"}:
+        return False
+    if re.fullmatch(r"-?\d+", normalized_expression):
+        return int(normalized_expression)
+    if normalized_expression.startswith("'") and normalized_expression.endswith("'"):
+        return normalized_expression[1:-1].replace("''", "'")
+    return None
+
+
+def normalize_catalog_expression(expression: str) -> str:
+    normalized = expression.strip()
+    normalized = re.sub(r"::\s*[a-zA-Z_][a-zA-Z0-9_.]*(?:\[\])?", "", normalized)
+    normalized = normalized.strip().casefold()
+    normalized = normalized.replace('"', "")
+    if "." in normalized and re.fullmatch(r"[a-z_][a-z0-9_$]*\.[a-z_][a-z0-9_$]*", normalized):
+        return normalized.rsplit(".", 1)[1]
+    return normalized
+
+
+def label_from_expression(expression: str) -> str:
+    normalized = normalize_catalog_expression(expression)
+    if normalized in {"current_database()", "pg_catalog.current_database()"}:
+        return "current_database"
+    if normalized in {"current_schema()", "pg_catalog.current_schema()"}:
+        return "current_schema"
+    if normalized.startswith("pg_catalog.format_type(") or normalized.startswith("format_type("):
+        return "format_type"
+    if normalized == "null":
+        return "?column?"
+    return clean_identifier(normalized.rsplit(".", 1)[-1])
+
+
+def split_top_level_commas(value: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if quote is not None:
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth = max(depth - 1, 0)
+        elif char == "," and depth == 0:
+            parts.append(value[start:index].strip())
+            start = index + 1
+        index += 1
+    parts.append(value[start:].strip())
+    return [part for part in parts if part]
+
+
+def find_top_level_keyword(sql: str, keyword: str, start: int = 0) -> int | None:
+    depth = 0
+    quote: str | None = None
+    index = start
+    lowered = sql.casefold()
+    while index < len(sql):
+        char = sql[index]
+        if quote is not None:
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth = max(depth - 1, 0)
+        elif depth == 0 and lowered.startswith(keyword, index):
+            before = lowered[index - 1] if index > 0 else " "
+            after_index = index + len(keyword)
+            after = lowered[after_index] if after_index < len(lowered) else " "
+            if not (before.isalnum() or before == "_") and not (after.isalnum() or after == "_"):
+                return index
+        index += 1
+    return None
+
+
+def clean_identifier(identifier: str) -> str:
+    stripped = identifier.strip()
+    if stripped.startswith('"') and stripped.endswith('"'):
+        return stripped[1:-1].replace('""', '"')
+    return stripped.casefold()
+
+
+def stable_catalog_oid(key: str) -> int:
+    return 10000 + (zlib.crc32(key.encode("utf-8")) & 0x3FFFFFFF)
+
+
+def row_value(rows: list[tuple[Any, ...]], column_index: int) -> Any:
+    for row in rows:
+        if column_index < len(row) and row[column_index] is not None:
+            return row[column_index]
+    return None
+
+
+def python_value_to_postgres_oid(value: Any) -> int:
+    if isinstance(value, bool):
+        return POSTGRES_BOOL_OID
+    if isinstance(value, int):
+        return POSTGRES_INT8_OID
+    if isinstance(value, float):
+        return POSTGRES_FLOAT8_OID
+    if isinstance(value, Decimal):
+        return POSTGRES_NUMERIC_OID
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return POSTGRES_DATE_OID
+    if isinstance(value, datetime):
+        return POSTGRES_TIMESTAMPTZ_OID
+    if isinstance(value, (dict, list)):
+        return POSTGRES_JSON_OID
+    return POSTGRES_TEXT_OID
+
+
+def strip_public_schema_references(sql: str) -> str:
+    return re.sub(r'(?i)(\bfrom\s+|\bjoin\s+)(?:"public"|public)\.', r"\1", sql)
 
 
 def clickhouse_type_to_postgres_oid(clickhouse_type: str) -> int:

--- a/posthog/hogql/service.py
+++ b/posthog/hogql/service.py
@@ -155,6 +155,7 @@ class CatalogTable:
     oid: int
     schema: str
     name: str
+    hogql_name: str
     table_type: str
     fields: list[DatabaseSchemaField]
 
@@ -359,7 +360,10 @@ class HogQLServiceQueryExecutor:
         if builtin_result is not None:
             return builtin_result
 
-        hogql_sql = strip_public_schema_references(stripped_sql)
+        hogql_sql = rewrite_catalog_table_references(
+            rewrite_postgres_pseudo_columns(strip_public_schema_references(stripped_sql)),
+            context,
+        )
         try:
             query_ast = parse_select(hogql_sql, cache_origin=CacheOrigin.USER)
             validate_user_query(query_ast, team=context.team)
@@ -564,6 +568,13 @@ class HogQLServiceQueryExecutor:
         return QueryResult(columns=result_columns, rows=result_rows, command_tag=f"SELECT {len(result_rows)}")
 
     def _catalog_rows(self, source: str, context: HogQLServiceSessionContext) -> tuple[list[dict[str, Any]], list[str]]:
+        if source == "pg_catalog.pg_roles":
+            return pg_roles_rows(context), EMPTY_CATALOG_COLUMNS["pg_catalog.pg_roles"]
+        if source == "pg_user":
+            return pg_user_rows(context), EMPTY_CATALOG_COLUMNS["pg_user"]
+        if source in EMPTY_CATALOG_COLUMNS:
+            return [], EMPTY_CATALOG_COLUMNS[source]
+
         tables = load_catalog_tables(context)
         schemas = sorted({table.schema for table in tables} | {"information_schema", "pg_catalog", "public"})
 
@@ -583,12 +594,8 @@ class HogQLServiceQueryExecutor:
             return pg_type_rows(), PG_TYPE_COLUMNS
         if source == "pg_catalog.pg_database":
             return pg_database_rows(context), PG_DATABASE_COLUMNS
-        if source == "pg_catalog.pg_roles":
-            return pg_roles_rows(context), EMPTY_CATALOG_COLUMNS["pg_catalog.pg_roles"]
-        if source == "pg_user":
-            return pg_user_rows(context), EMPTY_CATALOG_COLUMNS["pg_user"]
 
-        return [], EMPTY_CATALOG_COLUMNS.get(source, [])
+        return [], GENERIC_EMPTY_CATALOG_COLUMNS
 
 
 class PostgresWireCodec:
@@ -1007,7 +1014,9 @@ class HogQLPostgresWireSession:
             },
         )
         try:
-            return await asyncio.to_thread(self.query_executor.execute, sql, self.context)
+            result = await asyncio.to_thread(self.query_executor.execute, sql, self.context)
+            self._log_query_result(result)
+            return result
         except HogQLServiceError as error:
             if error.query is None:
                 error.query = sql
@@ -1025,6 +1034,21 @@ class HogQLPostgresWireSession:
                 },
             )
             raise
+
+    def _log_query_result(self, result: QueryResult) -> None:
+        assert self.context is not None
+        column_names = [column.name for column in result.columns[:20]]
+        null_columns = [
+            column.name
+            for column_index, column in enumerate(result.columns[:20])
+            if any(column_index >= len(row) or row[column_index] is None for row in result.rows[:50])
+        ]
+        append_service_log(
+            f"RESULT database={self.context.database} team_id={self.context.team.id} "
+            f"connection_id={self.context.connection_id} user={self.context.database_user} "
+            f"command={result.command_tag!r} row_count={len(result.rows)} columns={column_names!r} "
+            f"null_columns={null_columns!r}"
+        )
 
     async def _send_result(self, result: QueryResult, send_row_description: bool) -> None:
         if send_row_description and result.columns:
@@ -1299,10 +1323,55 @@ EMPTY_CATALOG_COLUMNS = {
     "pg_catalog.pg_am": ["oid", "amname", "amhandler", "amtype"],
     "pg_catalog.pg_enum": ["oid", "enumtypid", "enumsortorder", "enumlabel"],
     "pg_catalog.pg_auth_members": ["roleid", "member", "grantor", "admin_option"],
+    "pg_catalog.pg_available_extensions": ["name", "default_version", "installed_version", "comment"],
+    "pg_catalog.pg_cast": ["oid", "castsource", "casttarget", "castfunc", "castcontext", "castmethod"],
+    "pg_catalog.pg_collation": ["oid", "collname", "collnamespace", "collowner", "collencoding"],
+    "pg_catalog.pg_conversion": ["oid", "conname", "connamespace", "conowner", "conforencoding", "contoencoding"],
+    "pg_catalog.pg_db_role_setting": ["setdatabase", "setrole", "setconfig"],
+    "pg_catalog.pg_depend": ["classid", "objid", "objsubid", "refclassid", "refobjid", "refobjsubid", "deptype"],
+    "pg_catalog.pg_event_trigger": ["oid", "evtname", "evtevent", "evtowner", "evtfoid", "evtenabled", "evttags"],
+    "pg_catalog.pg_extension": ["oid", "extname", "extowner", "extnamespace", "extrelocatable", "extversion"],
+    "pg_catalog.pg_foreign_data_wrapper": ["oid", "fdwname", "fdwowner", "fdwhandler", "fdwvalidator", "fdwoptions"],
+    "pg_catalog.pg_foreign_server": ["oid", "srvname", "srvowner", "srvfdw", "srvtype", "srvversion", "srvoptions"],
     "pg_catalog.pg_locks": ["locktype", "database", "relation", "transactionid", "pid", "mode", "granted"],
+    "pg_catalog.pg_language": ["oid", "lanname", "lanowner", "lanispl", "lanpltrusted", "lanplcallfoid"],
+    "pg_catalog.pg_opclass": ["oid", "opcmethod", "opcname", "opcnamespace", "opcowner", "opcfamily", "opcintype"],
+    "pg_catalog.pg_operator": ["oid", "oprname", "oprnamespace", "oprowner", "oprkind", "oprcanmerge", "oprcanhash"],
+    "pg_catalog.pg_opfamily": ["oid", "opfmethod", "opfname", "opfnamespace", "opfowner"],
+    "pg_catalog.pg_policy": ["oid", "polname", "polrelid", "polcmd", "polpermissive", "polroles"],
+    "pg_catalog.pg_publication": ["oid", "pubname", "pubowner", "puballtables", "pubinsert", "pubupdate", "pubdelete"],
+    "pg_catalog.pg_rewrite": ["oid", "rulename", "ev_class", "ev_type", "ev_enabled", "is_instead"],
+    "pg_catalog.pg_sequence": ["seqrelid", "seqtypid", "seqstart", "seqincrement", "seqmax", "seqmin", "seqcache"],
     "pg_catalog.pg_shdescription": ["objoid", "classoid", "description"],
+    "pg_catalog.pg_stat_activity": [
+        "datid",
+        "datname",
+        "pid",
+        "leader_pid",
+        "usesysid",
+        "usename",
+        "application_name",
+        "client_addr",
+        "client_hostname",
+        "client_port",
+        "backend_start",
+        "xact_start",
+        "query_start",
+        "state_change",
+        "wait_event_type",
+        "wait_event",
+        "state",
+        "backend_xid",
+        "backend_xmin",
+        "query_id",
+        "query",
+        "backend_type",
+    ],
+    "pg_catalog.pg_subscription": ["oid", "subdbid", "subname", "subowner", "subenabled", "subconninfo"],
     "pg_catalog.pg_tablespace": ["oid", "spcname", "spcowner", "spcacl", "spcoptions", "xmin"],
+    "pg_catalog.pg_timezone_abbrevs": ["abbrev", "utc_offset", "is_dst"],
     "pg_catalog.pg_timezone_names": ["name", "abbrev", "utc_offset", "is_dst"],
+    "pg_catalog.pg_user_mapping": ["oid", "umuser", "umserver", "umoptions"],
     "pg_user": [
         "usename",
         "usesysid",
@@ -1315,6 +1384,7 @@ EMPTY_CATALOG_COLUMNS = {
         "useconfig",
     ],
 }
+GENERIC_EMPTY_CATALOG_COLUMNS = ["oid"]
 CATALOG_ALIAS_KEYS = {
     "table_cat": "table_catalog",
     "table_schem": "table_schema",
@@ -1331,8 +1401,11 @@ CATALOG_ALIAS_KEYS = {
     "nullable": "nullable",
     "is_nullable": "is_nullable",
     "schema_name": "schema_name",
+    "schemaid": "relnamespace",
     "table_oid": "oid",
     "column_oid": "attrelid",
+    "majoroid": "attrelid",
+    "position": "attnum",
 }
 UNHANDLED_BUILTIN_EXPRESSION = object()
 
@@ -1353,6 +1426,13 @@ def evaluate_builtin_expression(expression: str, context: HogQLServiceSessionCon
         return context.database_user
     if normalized in {"pg_backend_pid()", "pg_catalog.pg_backend_pid()"}:
         return os.getpid()
+    if normalized in {"pg_is_in_recovery()", "pg_catalog.pg_is_in_recovery()"}:
+        return False
+    if normalized in {"txid_current()", "pg_catalog.txid_current()"}:
+        return 0
+    if normalized.startswith("case when pg_catalog.pg_is_in_recovery() then null else"):
+        if "pg_catalog.txid_current()" in normalized:
+            return 0
     if normalized.startswith("current_setting(") or normalized.startswith("pg_catalog.current_setting("):
         setting_match = re.match(r"(?:pg_catalog\.)?current_setting\('([^']+)'(?:,\s*true)?\)", normalized)
         if setting_match:
@@ -1371,29 +1451,29 @@ def evaluate_builtin_expression(expression: str, context: HogQLServiceSessionCon
 
 
 def catalog_source(normalized: str) -> str | None:
-    if re.search(r"\bfrom\s+information_schema\.schemata\b", normalized):
-        return "information_schema.schemata"
-    if re.search(r"\bfrom\s+information_schema\.tables\b", normalized):
-        return "information_schema.tables"
-    if re.search(r"\bfrom\s+information_schema\.columns\b", normalized):
-        return "information_schema.columns"
+    source_pattern = r"\b(?:from|join)\s+(?:(information_schema|pg_catalog)\.)?([a-z_][a-z0-9_]*)\b"
 
-    for source in EMPTY_CATALOG_COLUMNS:
-        if re.search(rf"\bfrom\s+{re.escape(source)}\b", normalized):
-            return source
+    outer_select_index = find_top_level_keyword(normalized, "select")
+    if outer_select_index is not None:
+        outer_from_index = find_top_level_keyword(normalized, "from", start=outer_select_index + len("select"))
+        if outer_from_index is not None:
+            outer_source = catalog_source_from_fragment(normalized[outer_from_index:], source_pattern)
+            if outer_source is not None:
+                return outer_source
 
-    if re.search(r"\b(pg_catalog\.)?pg_attribute\b", normalized):
-        return "pg_catalog.pg_attribute"
-    if re.search(r"\b(pg_catalog\.)?pg_class\b", normalized):
-        return "pg_catalog.pg_class"
-    if re.search(r"\b(pg_catalog\.)?pg_namespace\b", normalized):
-        return "pg_catalog.pg_namespace"
-    if re.search(r"\b(pg_catalog\.)?pg_type\b", normalized):
-        return "pg_catalog.pg_type"
-    if re.search(r"\b(pg_catalog\.)?pg_database\b", normalized):
-        return "pg_catalog.pg_database"
-    if re.search(r"\b(pg_catalog\.)?pg_roles\b", normalized):
-        return "pg_catalog.pg_roles"
+    return catalog_source_from_fragment(normalized, source_pattern)
+
+
+def catalog_source_from_fragment(fragment: str, source_pattern: str) -> str | None:
+    for source_match in re.finditer(source_pattern, fragment):
+        schema_name = source_match.group(1)
+        table_name = source_match.group(2)
+        if schema_name == "information_schema":
+            return f"information_schema.{table_name}"
+        if table_name == "pg_user":
+            return "pg_user"
+        if schema_name == "pg_catalog" or table_name.startswith("pg_"):
+            return f"pg_catalog.{table_name}"
     return None
 
 
@@ -1414,12 +1494,13 @@ def load_catalog_tables(context: HogQLServiceSessionContext) -> list[CatalogTabl
     serialized_tables = database.serialize(hogql_context)
     tables: list[CatalogTable] = []
     for table_name, table in serialized_tables.items():
-        schema_name, relation_name = split_catalog_table_name(table_name)
+        schema_name, relation_name = catalog_table_name(table_name)
         tables.append(
             CatalogTable(
-                oid=stable_catalog_oid(f"table:{schema_name}.{relation_name}"),
+                oid=stable_catalog_oid(f"table:{table_name}"),
                 schema=schema_name,
                 name=relation_name,
+                hogql_name=table_name,
                 table_type=postgres_table_type(str(table.type)),
                 fields=list(table.fields.values()),
             )
@@ -1427,11 +1508,19 @@ def load_catalog_tables(context: HogQLServiceSessionContext) -> list[CatalogTabl
     return sorted(tables, key=lambda table: (table.schema, table.name))
 
 
-def split_catalog_table_name(table_name: str) -> tuple[str, str]:
+def catalog_table_name(table_name: str) -> tuple[str, str]:
     if "." not in table_name:
-        return "public", table_name
-    schema_name, relation_name = table_name.split(".", 1)
+        return "public", catalog_safe_identifier(table_name)
+
+    parts = table_name.split(".")
+    schema_name = catalog_safe_identifier("_".join(parts[:-1]))
+    relation_name = catalog_safe_identifier(parts[-1])
     return schema_name or "public", relation_name
+
+
+def catalog_safe_identifier(identifier: str) -> str:
+    safe_identifier = re.sub(r"[^a-zA-Z0-9_]+", "_", identifier).strip("_")
+    return safe_identifier or "unnamed"
 
 
 def postgres_table_type(table_type: str) -> str:
@@ -1553,6 +1642,7 @@ def pg_namespace_rows(schemas: list[str]) -> list[dict[str, Any]]:
     return [
         {
             "oid": stable_catalog_oid(f"schema:{schema}"),
+            "xmin": 1,
             "nspname": schema,
             "schema_name": schema,
             "nspowner": 10,
@@ -1566,8 +1656,12 @@ def pg_class_rows(tables: list[CatalogTable]) -> list[dict[str, Any]]:
     return [
         {
             "oid": table.oid,
+            "xmin": 1,
             "relname": table.name,
+            "name": table.name,
             "relnamespace": stable_catalog_oid(f"schema:{table.schema}"),
+            "schemaid": stable_catalog_oid(f"schema:{table.schema}"),
+            "majoroid": table.oid,
             "reltype": stable_catalog_oid(f"type:{table.schema}.{table.name}"),
             "relowner": 10,
             "relkind": "v" if table.table_type == "VIEW" else "r",
@@ -1597,16 +1691,29 @@ def pg_class_rows(tables: list[CatalogTable]) -> list[dict[str, Any]]:
 def pg_attribute_rows(tables: list[CatalogTable]) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for table in tables:
+        schema_oid = stable_catalog_oid(f"schema:{table.schema}")
+        relkind = "v" if table.table_type == "VIEW" else "r"
         for ordinal_position, field in enumerate(table.fields, start=1):
             pg_type = postgres_type_for_field(field)
             rows.append(
                 {
+                    "table_id": table.oid,
+                    "majoroid": table.oid,
+                    "relnamespace": schema_oid,
+                    "schemaid": schema_oid,
+                    "relkind": relkind,
                     "attrelid": table.oid,
+                    "oid": table.oid,
+                    "object_id": table.oid,
+                    "xmin": 1,
                     "attname": field.name,
+                    "name": field.name,
                     "atttypid": pg_type["oid"],
                     "attstattarget": -1,
                     "attlen": -1,
                     "attnum": ordinal_position,
+                    "position": ordinal_position,
+                    "attr_position": ordinal_position,
                     "attndims": 0,
                     "attcacheoff": -1,
                     "atttypmod": -1,
@@ -1615,12 +1722,14 @@ def pg_attribute_rows(tables: list[CatalogTable]) -> list[dict[str, Any]]:
                     "attalign": "i",
                     "attnotnull": False,
                     "atthasdef": False,
+                    "attfdwoptions": None,
                     "attidentity": "",
                     "attgenerated": "",
                     "attisdropped": False,
                     "attislocal": True,
                     "attinhcount": 0,
                     "attcollation": 0,
+                    "attacl": None,
                     "nspname": table.schema,
                     "relname": table.name,
                     "typname": pg_type["udt_name"],
@@ -1657,6 +1766,7 @@ def pg_type_rows() -> list[dict[str, Any]]:
         rows.append(
             {
                 "oid": type_oid,
+                "xmin": 1,
                 "typname": typname,
                 "typnamespace": stable_catalog_oid("schema:pg_catalog"),
                 "typowner": 10,
@@ -1693,6 +1803,7 @@ def pg_database_rows(context: HogQLServiceSessionContext) -> list[dict[str, Any]
     return [
         {
             "oid": stable_catalog_oid(f"database:{context.database}"),
+            "xmin": 1,
             "datname": context.database,
             "datdba": 10,
             "encoding": 6,
@@ -1708,6 +1819,7 @@ def pg_roles_rows(context: HogQLServiceSessionContext) -> list[dict[str, Any]]:
     return [
         {
             "oid": stable_catalog_oid(f"role:{context.database_user}"),
+            "xmin": 1,
             "rolname": context.database_user,
             "rolsuper": False,
             "rolinherit": True,
@@ -1796,6 +1908,22 @@ def filter_catalog_rows(rows: list[dict[str, Any]], normalized: str) -> list[dic
             for row in filtered_rows
             if any(str(row.get(key, "")).casefold() in values for key in keys if row.get(key) is not None)
         ]
+
+    namespace_oids = extract_oid_filters(normalized, ["relnamespace", "typnamespace", "pronamespace", "collnamespace"])
+    n_oid_filters = extract_oid_filters(normalized, ["n.oid"])
+    if namespace_oids or n_oid_filters:
+        wanted_oids = namespace_oids | n_oid_filters
+        filtered_rows = [
+            row
+            for row in filtered_rows
+            if row_matches_any_oid(
+                row, ["relnamespace", "typnamespace", "pronamespace", "collnamespace", "oid"], wanted_oids
+            )
+        ]
+
+    relkinds = extract_string_in_filters(normalized, "relkind")
+    if relkinds:
+        filtered_rows = [row for row in filtered_rows if str(row.get("relkind", "")).casefold() in relkinds]
     return filtered_rows
 
 
@@ -1804,6 +1932,34 @@ def extract_equality_filters(normalized: str, names: list[str]) -> set[str]:
     for name in names:
         pattern = rf"(?:\b[a-z_][a-z0-9_]*\.)?{re.escape(name)}\s*=\s*'([^']*)'"
         values.update(match.group(1).casefold() for match in re.finditer(pattern, normalized))
+    return values
+
+
+def extract_oid_filters(normalized: str, names: list[str]) -> set[int]:
+    values: set[int] = set()
+    for name in names:
+        escaped_name = re.escape(name).replace(r"\.", r"\s*\.\s*")
+        equality_pattern = rf"(?:\b[a-z_][a-z0-9_]*\.)?{escaped_name}\s*=\s*(\d+)(?:::oid)?"
+        in_pattern = rf"(?:\b[a-z_][a-z0-9_]*\.)?{escaped_name}\s+in\s*\(([^)]*)\)"
+        values.update(int(match.group(1)) for match in re.finditer(equality_pattern, normalized))
+        for match in re.finditer(in_pattern, normalized):
+            values.update(int(value) for value in re.findall(r"\d+", match.group(1)))
+    return values
+
+
+def row_matches_any_oid(row: dict[str, Any], keys: list[str], wanted_oids: set[int]) -> bool:
+    for key in keys:
+        value = row.get(key)
+        if isinstance(value, int) and value in wanted_oids:
+            return True
+    return False
+
+
+def extract_string_in_filters(normalized: str, name: str) -> set[str]:
+    values: set[str] = set()
+    pattern = rf"(?:\b[a-z_][a-z0-9_]*\.)?{re.escape(name)}\s+in\s*\(([^)]*)\)"
+    for match in re.finditer(pattern, normalized):
+        values.update(value.casefold() for value in re.findall(r"'([^']*)'", match.group(1)))
     return values
 
 
@@ -1837,13 +1993,13 @@ def parse_select_items(sql: str) -> list[tuple[str, str]]:
 
 
 def extract_select_list(sql: str) -> str | None:
-    match = re.search(r"\bselect\b", sql, flags=re.IGNORECASE)
-    if not match:
+    select_index = find_top_level_keyword(sql, "select")
+    if select_index is None:
         return None
-    from_index = find_top_level_keyword(sql, "from", start=match.end())
+    from_index = find_top_level_keyword(sql, "from", start=select_index + len("select"))
     if from_index is None:
         return None
-    return sql[match.end() : from_index].strip()
+    return sql[select_index + len("select") : from_index].strip()
 
 
 def parse_select_item(item: str) -> tuple[str, str]:
@@ -1881,6 +2037,18 @@ def evaluate_catalog_expression(
         return context.database
     if normalized_expression in {"current_schema()", "pg_catalog.current_schema()"}:
         return "public"
+    if normalized_expression.startswith("pg_catalog.pg_get_userbyid(") or normalized_expression.startswith(
+        "pg_get_userbyid("
+    ):
+        return context.database_user
+    if normalized_expression.startswith("not "):
+        value = evaluate_catalog_expression(expression.strip()[4:], label, row, context)
+        if isinstance(value, bool):
+            return not value
+        return None
+    translated_value = evaluate_translate_expression(normalized_expression, row)
+    if translated_value is not None:
+        return translated_value
     if normalized_expression.startswith("pg_catalog.format_type(") or normalized_expression.startswith("format_type("):
         return row.get("format_type") or row.get("data_type")
     if "obj_description(" in normalized_expression or "col_description(" in normalized_expression:
@@ -1896,6 +2064,26 @@ def evaluate_catalog_expression(
     if normalized_expression.startswith("'") and normalized_expression.endswith("'"):
         return normalized_expression[1:-1].replace("''", "'")
     return None
+
+
+def evaluate_translate_expression(normalized_expression: str, row: dict[str, Any]) -> str | None:
+    match = re.fullmatch(
+        r"(?:pg_catalog\.)?translate\(([^,]+),\s*'([^']*)',\s*'([^']*)'\)",
+        normalized_expression,
+    )
+    if not match:
+        return None
+
+    source_expression = normalize_catalog_expression(match.group(1))
+    source_key = CATALOG_ALIAS_KEYS.get(source_expression, source_expression)
+    source_value = row.get(source_key)
+    if source_value is None and source_expression == "kind":
+        source_value = row.get("relkind")
+    if source_value is None and source_expression.startswith("'") and source_expression.endswith("'"):
+        source_value = source_expression[1:-1].replace("''", "'")
+    if source_value is None:
+        return None
+    return str(source_value).translate(str.maketrans(match.group(2), match.group(3)))
 
 
 def normalize_catalog_expression(expression: str) -> str:
@@ -2014,6 +2202,46 @@ def python_value_to_postgres_oid(value: Any) -> int:
 
 def strip_public_schema_references(sql: str) -> str:
     return re.sub(r'(?i)(\bfrom\s+|\bjoin\s+)(?:"public"|public)\.', r"\1", sql)
+
+
+def rewrite_postgres_pseudo_columns(sql: str) -> str:
+    sql = re.sub(r"(?i)(\bselect\s+)(?:[a-z_][a-z0-9_]*\.)?ctid(\s*,)", r"\1NULL AS ctid\2", sql)
+    return re.sub(r"(?i)(,\s*)(?:[a-z_][a-z0-9_]*\.)?ctid\b", r"\1NULL AS ctid", sql)
+
+
+def rewrite_catalog_table_references(sql: str, context: HogQLServiceSessionContext) -> str:
+    rewritten_sql = sql
+    for table in load_catalog_tables(context):
+        hogql_name = table.hogql_name
+        catalog_reference = f"{table.schema}.{table.name}"
+        replacements: list[tuple[str, str]] = []
+        if catalog_reference != hogql_name:
+            replacements.append((table.schema, table.name))
+
+        hogql_parts = hogql_name.split(".")
+        if len(hogql_parts) > 2:
+            replacements.append((hogql_parts[0], ".".join(hogql_parts[1:])))
+
+        for schema_name, table_name in replacements:
+            pattern = (
+                rf"(?i)(\b(?:from|join)\s+)"
+                rf"(?:{quoted_or_unquoted_identifier_pattern(schema_name)})"
+                rf"\."
+                rf"(?:{quoted_or_unquoted_identifier_pattern(table_name)})"
+                rf"(?=\s|$)"
+            )
+            rewritten_sql = re.sub(
+                pattern,
+                lambda match, replacement=hogql_name: f"{match.group(1)}{replacement}",
+                rewritten_sql,
+            )
+    return rewritten_sql
+
+
+def quoted_or_unquoted_identifier_pattern(identifier: str) -> str:
+    escaped_identifier = re.escape(identifier)
+    escaped_quoted_identifier = re.escape(identifier.replace('"', '""'))
+    return rf'"{escaped_quoted_identifier}"|{escaped_identifier}'
 
 
 def clickhouse_type_to_postgres_oid(clickhouse_type: str) -> int:

--- a/posthog/hogql/test/test_service.py
+++ b/posthog/hogql/test/test_service.py
@@ -476,7 +476,7 @@ class TestHogQLServiceParameters(BaseTest):
             )
 
 
-class FakeAuthenticator:
+class FakeAuthenticator(HogQLServiceAuthenticator):
     def authenticate(self, database_user: str, database: str, password: str) -> HogQLServiceSessionContext:
         return HogQLServiceSessionContext(
             database_user=database_user,
@@ -487,7 +487,7 @@ class FakeAuthenticator:
         )
 
 
-class FakeQueryExecutor:
+class FakeQueryExecutor(HogQLServiceQueryExecutor):
     def execute(self, sql: str, context: HogQLServiceSessionContext) -> QueryResult:
         return QueryResult(
             columns=[ResultColumn(name="answer", type_oid=POSTGRES_INT8_OID)],

--- a/posthog/hogql/test/test_service.py
+++ b/posthog/hogql/test/test_service.py
@@ -1,3 +1,5 @@
+import os
+import struct
 import asyncio
 from types import SimpleNamespace
 from typing import Any, cast
@@ -7,16 +9,21 @@ from posthog.test.base import BaseTest
 from unittest.mock import patch
 
 import psycopg
+from parameterized import parameterized
 
 from posthog.schema import HogQLQueryResponse
 
 from posthog.hogql.service import (
+    MAX_STARTUP_PACKET_BYTES,
+    MAX_UNAUTHENTICATED_MESSAGE_BYTES,
     POSTGRES_INT8_OID,
     CatalogTable,
     HogQLPostgresWireSession,
     HogQLServiceAuthenticationError,
     HogQLServiceAuthenticator,
+    HogQLServiceConfig,
     HogQLServicePermissionError,
+    HogQLServiceProtocolError,
     HogQLServiceQueryExecutor,
     HogQLServiceSessionContext,
     PgParameter,
@@ -24,6 +31,8 @@ from posthog.hogql.service import (
     ResultColumn,
     bind_parameters_to_query,
     catalog_table_name,
+    is_loopback_host,
+    is_loopback_peer,
     parse_database_name,
     rewrite_catalog_table_references,
     rewrite_postgres_pseudo_columns,
@@ -375,6 +384,11 @@ class TestHogQLServiceQueryExecutor(BaseTest):
 
 
 class TestHogQLServiceParameters(BaseTest):
+    def test_config_defaults_to_loopback_host(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            assert HogQLServiceConfig().host == "127.0.0.1"
+            assert HogQLServiceConfig.from_env().host == "127.0.0.1"
+
     def test_parse_database_name_accepts_team_id(self) -> None:
         assert parse_database_name("123") == ("123", None)
 
@@ -409,6 +423,30 @@ class TestHogQLServiceParameters(BaseTest):
 
     def test_catalog_table_name_flattens_hogql_multipart_names(self) -> None:
         assert catalog_table_name("bigquery.bqds.sometable") == ("bigquery_bqds", "sometable")
+
+    @parameterized.expand(
+        [
+            ("localhost", True),
+            ("127.0.0.1", True),
+            ("::1", True),
+            ("0.0.0.0", False),
+            ("192.168.1.10", False),
+        ]
+    )
+    def test_is_loopback_host(self, host: str, expected: bool) -> None:
+        assert is_loopback_host(host) is expected
+
+    @parameterized.expand(
+        [
+            (("127.0.0.1", 5432), True),
+            (("::1", 5432, 0, 0), True),
+            (("::ffff:127.0.0.1", 5432, 0, 0), True),
+            (("192.168.1.10", 5432), False),
+            (None, False),
+        ]
+    )
+    def test_is_loopback_peer(self, peername: object, expected: bool) -> None:
+        assert is_loopback_peer(peername) is expected
 
     def test_rewrite_catalog_table_references_accepts_safe_and_cached_multipart_names(self) -> None:
         table = CatalogTable(
@@ -456,6 +494,73 @@ class FakeQueryExecutor:
             rows=[(42,)],
             command_tag="SELECT 1",
         )
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.writes: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
+
+    def get_extra_info(self, name: str) -> object:
+        if name == "peername":
+            return ("127.0.0.1", 5432)
+        return None
+
+
+def _session_with_wire_data(data: bytes, *, max_query_bytes: int = 1024) -> HogQLPostgresWireSession:
+    reader = asyncio.StreamReader()
+    reader.feed_data(data)
+    reader.feed_eof()
+    return HogQLPostgresWireSession(
+        reader=reader,
+        writer=cast(asyncio.StreamWriter, FakeWriter()),
+        authenticator=FakeAuthenticator(),
+        query_executor=FakeQueryExecutor(),
+        max_query_bytes=max_query_bytes,
+    )
+
+
+@pytest.mark.asyncio
+async def test_postgres_wire_session_rejects_oversized_startup_packet_before_payload_read() -> None:
+    session = _session_with_wire_data(struct.pack("!I", MAX_STARTUP_PACKET_BYTES + 1))
+
+    with pytest.raises(HogQLServiceProtocolError, match="Invalid startup packet"):
+        await session._read_startup_parameters()
+
+
+@pytest.mark.asyncio
+async def test_postgres_wire_session_rejects_oversized_unauthenticated_message_before_payload_read() -> None:
+    length = MAX_UNAUTHENTICATED_MESSAGE_BYTES + 5
+    session = _session_with_wire_data(b"p" + struct.pack("!I", length))
+
+    with pytest.raises(HogQLServiceProtocolError, match="Message is too large"):
+        await session._read_message()
+
+
+@pytest.mark.asyncio
+async def test_postgres_wire_session_rejects_authenticated_message_above_query_limit_before_payload_read() -> None:
+    session = _session_with_wire_data(b"Q" + struct.pack("!I", 15), max_query_bytes=10)
+    session.context = HogQLServiceSessionContext(
+        database_user="user@example.com",
+        database="1",
+        user=cast(User, SimpleNamespace(email="user@example.com")),
+        team=cast(Team, SimpleNamespace(id=1, timezone="UTC")),
+        authenticated_by="shared_secret",
+    )
+
+    with pytest.raises(HogQLServiceProtocolError, match="Message is too large"):
+        await session._read_message()
 
 
 @pytest.mark.asyncio

--- a/posthog/hogql/test/test_service.py
+++ b/posthog/hogql/test/test_service.py
@@ -22,10 +22,14 @@ from posthog.hogql.service import (
     QueryResult,
     ResultColumn,
     bind_parameters_to_query,
+    parse_database_name,
 )
 
 from posthog.models import Organization, PersonalAPIKey, Team, User
 from posthog.models.utils import generate_random_token_personal, hash_key_value
+
+from products.data_warehouse.backend.models import ExternalDataSource
+from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 class TestHogQLServiceAuthenticator(BaseTest):
@@ -51,6 +55,46 @@ class TestHogQLServiceAuthenticator(BaseTest):
         assert context.user == self.user
         assert context.team == self.team
         assert context.authenticated_by == "shared_secret"
+        assert context.connection_id is None
+
+    def test_shared_secret_accepts_database_with_direct_connection_id(self) -> None:
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="source",
+            connection_id="connection",
+            destination_id="destination",
+            status=ExternalDataSource.Status.RUNNING,
+            source_type=ExternalDataSourceType.POSTGRES,
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            job_inputs={},
+        )
+
+        context = HogQLServiceAuthenticator(shared_secret="secret").authenticate(
+            self.user.email, f"{self.team.id}/{source.id}", "secret"
+        )
+
+        assert context.user == self.user
+        assert context.team == self.team
+        assert context.database == f"{self.team.id}/{source.id}"
+        assert context.connection_id == str(source.id)
+
+    def test_shared_secret_rejects_connection_id_from_another_team(self) -> None:
+        other_team = Team.objects.create(organization=self.organization)
+        source = ExternalDataSource.objects.create(
+            team=other_team,
+            source_id="source",
+            connection_id="connection",
+            destination_id="destination",
+            status=ExternalDataSource.Status.RUNNING,
+            source_type=ExternalDataSourceType.POSTGRES,
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            job_inputs={},
+        )
+
+        with self.assertRaises(HogQLServiceAuthenticationError):
+            HogQLServiceAuthenticator(shared_secret="secret").authenticate(
+                self.user.email, f"{self.team.id}/{source.id}", "secret"
+            )
 
     def test_shared_secret_rejects_user_without_project_access(self) -> None:
         organization = Organization.objects.create(name="Other")
@@ -120,9 +164,39 @@ class TestHogQLServiceQueryExecutor(BaseTest):
         assert mock_execute_hogql_query.call_args.kwargs["team"] == self.team
         assert mock_execute_hogql_query.call_args.kwargs["user"] == self.user
         assert mock_execute_hogql_query.call_args.kwargs["query_type"] == "hogql_service"
+        assert mock_execute_hogql_query.call_args.kwargs["connection_id"] is None
+
+    @patch("posthog.hogql.service.execute_hogql_query")
+    def test_hogql_query_passes_connection_id(self, mock_execute_hogql_query) -> None:
+        mock_execute_hogql_query.return_value = HogQLQueryResponse(results=[(1,)], columns=["one"])
+
+        context = HogQLServiceSessionContext(
+            database_user=self.user.email,
+            database=f"{self.team.id}/018f0000-0000-7000-8000-000000000000",
+            user=self.user,
+            team=self.team,
+            authenticated_by="shared_secret",
+            connection_id="018f0000-0000-7000-8000-000000000000",
+        )
+        HogQLServiceQueryExecutor().execute("SELECT 1 AS one", context)
+
+        assert mock_execute_hogql_query.call_args.kwargs["connection_id"] == "018f0000-0000-7000-8000-000000000000"
 
 
 class TestHogQLServiceParameters(BaseTest):
+    def test_parse_database_name_accepts_team_id(self) -> None:
+        assert parse_database_name("123") == ("123", None)
+
+    def test_parse_database_name_accepts_team_id_and_connection_id(self) -> None:
+        assert parse_database_name("123/018f0000-0000-7000-8000-000000000000") == (
+            "123",
+            "018f0000-0000-7000-8000-000000000000",
+        )
+
+    def test_parse_database_name_rejects_invalid_combo(self) -> None:
+        with self.assertRaises(HogQLServiceAuthenticationError):
+            parse_database_name("123/")
+
     def test_bind_parameters_replaces_numbered_placeholders_outside_literals(self) -> None:
         query = "SELECT $1, '$1', \"$1\", `$1`, -- $1\n$2"
 

--- a/posthog/hogql/test/test_service.py
+++ b/posthog/hogql/test/test_service.py
@@ -12,6 +12,7 @@ from posthog.schema import HogQLQueryResponse
 
 from posthog.hogql.service import (
     POSTGRES_INT8_OID,
+    CatalogTable,
     HogQLPostgresWireSession,
     HogQLServiceAuthenticationError,
     HogQLServiceAuthenticator,
@@ -22,7 +23,11 @@ from posthog.hogql.service import (
     QueryResult,
     ResultColumn,
     bind_parameters_to_query,
+    catalog_table_name,
     parse_database_name,
+    rewrite_catalog_table_references,
+    rewrite_postgres_pseudo_columns,
+    stable_catalog_oid,
 )
 
 from posthog.models import Organization, PersonalAPIKey, Team, User
@@ -187,6 +192,146 @@ class TestHogQLServiceQueryExecutor(BaseTest):
         assert [column.name for column in result.columns] == ["table_cat", "table_schem", "table_name", "table_type"]
         assert (None, "public", "events", "BASE TABLE") in result.rows
 
+    def test_pg_catalog_class_ignores_empty_joined_catalog_tables(self) -> None:
+        result = HogQLServiceQueryExecutor().execute(
+            "SELECT c.relname AS TABLE_NAME, d.description AS REMARKS "
+            "FROM pg_catalog.pg_class c "
+            "LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid "
+            "WHERE c.relname = 'events'",
+            self._context(),
+        )
+
+        assert ("events", None) in result.rows
+
+    def test_unknown_pg_catalog_table_returns_empty_result(self) -> None:
+        result = HogQLServiceQueryExecutor().execute(
+            "SELECT * FROM pg_catalog.pg_stat_activity",
+            self._context(),
+        )
+
+        assert [column.name for column in result.columns] == [
+            "datid",
+            "datname",
+            "pid",
+            "leader_pid",
+            "usesysid",
+            "usename",
+            "application_name",
+            "client_addr",
+            "client_hostname",
+            "client_port",
+            "backend_start",
+            "xact_start",
+            "query_start",
+            "state_change",
+            "wait_event_type",
+            "wait_event",
+            "state",
+            "backend_xid",
+            "backend_xmin",
+            "query_id",
+            "query",
+            "backend_type",
+        ]
+        assert result.rows == []
+
+    def test_catalog_source_detection_skips_nested_from_expression(self) -> None:
+        result = HogQLServiceQueryExecutor().execute(
+            "SELECT E.oid AS id, array(SELECT unnest FROM unnest(available_versions)) AS available_updates "
+            "FROM pg_catalog.pg_extension E",
+            self._context(),
+        )
+
+        assert [column.name for column in result.columns] == ["id", "available_updates"]
+        assert result.rows == []
+
+    def test_pg_catalog_class_translates_relkind_for_object_list(self) -> None:
+        schema_oid = stable_catalog_oid("schema:public")
+        result = HogQLServiceQueryExecutor().execute(
+            f"SELECT T.oid AS oid, relnamespace AS schemaId, "
+            "pg_catalog.translate(relkind, 'rmvpfS', 'rmvrfS') AS kind, relname AS name "
+            "FROM pg_catalog.pg_class T "
+            f"WHERE relnamespace IN ( {schema_oid} ) AND relkind IN ('r', 'm', 'v', 'p', 'f', 'S')",
+            self._context(),
+        )
+
+        assert [column.name for column in result.columns] == ["oid", "schemaid", "kind", "name"]
+        assert any(row[3] == "events" for row in result.rows)
+        assert all(row[1] == schema_oid for row in result.rows)
+        assert {row[2] for row in result.rows} <= {"r", "m", "v", "f", "S"}
+
+    def test_pg_catalog_namespace_returns_non_null_state_number(self) -> None:
+        result = HogQLServiceQueryExecutor().execute(
+            "SELECT N.oid::bigint AS id, N.xmin AS state_number, nspname AS name FROM pg_catalog.pg_namespace N",
+            self._context(),
+        )
+
+        assert ("public",) in [(row[2],) for row in result.rows]
+        assert all(isinstance(row[1], int) for row in result.rows)
+
+    def test_pg_catalog_attribute_cte_uses_outer_select_list(self) -> None:
+        schema_oid = stable_catalog_oid("schema:public")
+        result = HogQLServiceQueryExecutor().execute(
+            "WITH T AS ( SELECT DISTINCT T.oid AS table_id, T.relname AS table_name "
+            "FROM pg_catalog.pg_class T, pg_catalog.pg_attribute A "
+            f"WHERE T.relnamespace = {schema_oid}::oid AND T.relkind IN ('r', 'm', 'v', 'f', 'p') "
+            "AND A.attrelid = T.oid ) "
+            "SELECT T.table_id, C.attnum AS column_position, C.attname AS column_name, "
+            "C.xmin AS column_state_number, pg_catalog.format_type(C.atttypid, C.atttypmod) AS type_spec, "
+            "NOT C.attislocal AS column_is_inherited "
+            "FROM T JOIN pg_catalog.pg_attribute C ON T.table_id = C.attrelid "
+            "WHERE attnum > 0 ORDER BY table_id, attnum",
+            self._context(),
+        )
+
+        assert [column.name for column in result.columns] == [
+            "table_id",
+            "column_position",
+            "column_name",
+            "column_state_number",
+            "type_spec",
+            "column_is_inherited",
+        ]
+        assert any(row[2] == "event" and row[3] == 1 and row[5] is False for row in result.rows)
+
+    def test_pg_catalog_attribute_cte_returns_schema_id_for_object_list_columns(self) -> None:
+        schema_oid = stable_catalog_oid("schema:public")
+        result = HogQLServiceQueryExecutor().execute(
+            "WITH T AS ( SELECT T.oid AS oid, T.relkind AS kind, T.relnamespace AS schemaId "
+            "FROM pg_catalog.pg_class T "
+            f"WHERE T.relnamespace IN ( {schema_oid} ) AND T.relkind IN ('r', 'm', 'v', 'f', 'p') ) "
+            "SELECT T.schemaId AS schemaId, T.oid AS majorOid, "
+            "pg_catalog.translate(T.kind, 'rmvpf', 'rmvrf') AS kind, "
+            "C.attnum AS position, C.attname AS name "
+            "FROM T JOIN pg_catalog.pg_attribute C ON T.oid = C.attrelid "
+            "WHERE C.attnum > 0 AND NOT C.attisdropped "
+            "ORDER BY schemaId, majorOid",
+            self._context(),
+        )
+
+        assert [column.name for column in result.columns] == ["schemaid", "majoroid", "kind", "position", "name"]
+        assert any(row[4] == "event" for row in result.rows)
+        assert all(row[0] == schema_oid for row in result.rows)
+        assert all(row[1] is not None for row in result.rows)
+
+    def test_pg_user_privilege_probe_returns_current_user(self) -> None:
+        result = HogQLServiceQueryExecutor().execute(
+            "SELECT usesuper FROM pg_user WHERE usename = current_user",
+            self._context(),
+        )
+
+        assert result.rows == [(False,)]
+
+    def test_builtin_current_txid_probe_returns_zero(self) -> None:
+        result = HogQLServiceQueryExecutor().execute(
+            "select case when pg_catalog.pg_is_in_recovery() then null "
+            "else (pg_catalog.txid_current() % 4294967296)::varchar::bigint end as current_txid",
+            self._context(),
+        )
+
+        assert [column.name for column in result.columns] == ["current_txid"]
+        assert result.rows == [(0,)]
+
     @patch("posthog.hogql.service.execute_hogql_query")
     def test_hogql_query_executes_as_connection_user_and_team(self, mock_execute_hogql_query) -> None:
         mock_execute_hogql_query.return_value = HogQLQueryResponse(
@@ -195,7 +340,7 @@ class TestHogQLServiceQueryExecutor(BaseTest):
             types=[("one", "Int64")],
         )
 
-        result = HogQLServiceQueryExecutor().execute("SELECT 1 AS one", self._context())
+        result = HogQLServiceQueryExecutor().execute("SELECT event FROM events LIMIT 1", self._context())
 
         assert result.rows == [(1,)]
         assert result.columns[0].name == "one"
@@ -216,9 +361,17 @@ class TestHogQLServiceQueryExecutor(BaseTest):
             authenticated_by="shared_secret",
             connection_id="018f0000-0000-7000-8000-000000000000",
         )
-        HogQLServiceQueryExecutor().execute("SELECT 1 AS one", context)
+        HogQLServiceQueryExecutor().execute("SELECT event FROM events LIMIT 1", context)
 
         assert mock_execute_hogql_query.call_args.kwargs["connection_id"] == "018f0000-0000-7000-8000-000000000000"
+
+    @patch("posthog.hogql.service.execute_hogql_query")
+    def test_hogql_query_rewrites_postgres_ctid_pseudo_column(self, mock_execute_hogql_query) -> None:
+        mock_execute_hogql_query.return_value = HogQLQueryResponse(results=[(None,)], columns=["ctid"])
+
+        HogQLServiceQueryExecutor().execute("SELECT t.*, CTID FROM public.events t LIMIT 501", self._context())
+
+        assert mock_execute_hogql_query.call_args.kwargs["team"] == self.team
 
 
 class TestHogQLServiceParameters(BaseTest):
@@ -247,6 +400,42 @@ class TestHogQLServiceParameters(BaseTest):
             bind_parameters_to_query("SELECT $2", [PgParameter("one")])
 
         assert "Missing bind parameter $2" in str(error.exception)
+
+    def test_rewrite_postgres_pseudo_columns_replaces_ctid(self) -> None:
+        assert (
+            rewrite_postgres_pseudo_columns("SELECT t.*, CTID FROM public.events t LIMIT 501")
+            == "SELECT t.*, NULL AS ctid FROM public.events t LIMIT 501"
+        )
+
+    def test_catalog_table_name_flattens_hogql_multipart_names(self) -> None:
+        assert catalog_table_name("bigquery.bqds.sometable") == ("bigquery_bqds", "sometable")
+
+    def test_rewrite_catalog_table_references_accepts_safe_and_cached_multipart_names(self) -> None:
+        table = CatalogTable(
+            oid=1,
+            schema="bigquery_bqds",
+            name="sometable33",
+            hogql_name="bigquery.bqds.sometable33",
+            table_type="BASE TABLE",
+            fields=[],
+        )
+        context = HogQLServiceSessionContext(
+            database_user="user@example.com",
+            database="1",
+            user=cast(User, SimpleNamespace(email="user@example.com")),
+            team=cast(Team, SimpleNamespace(id=1, timezone="UTC")),
+            authenticated_by="shared_secret",
+        )
+
+        with patch("posthog.hogql.service.load_catalog_tables", return_value=[table]):
+            assert (
+                rewrite_catalog_table_references("SELECT * FROM bigquery_bqds.sometable33 t", context)
+                == "SELECT * FROM bigquery.bqds.sometable33 t"
+            )
+            assert (
+                rewrite_catalog_table_references('SELECT * FROM bigquery."bqds.sometable33" t', context)
+                == "SELECT * FROM bigquery.bqds.sometable33 t"
+            )
 
 
 class FakeAuthenticator:

--- a/posthog/hogql/test/test_service.py
+++ b/posthog/hogql/test/test_service.py
@@ -1,0 +1,196 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+import psycopg
+
+from posthog.schema import HogQLQueryResponse
+
+from posthog.hogql.service import (
+    POSTGRES_INT8_OID,
+    HogQLPostgresWireSession,
+    HogQLServiceAuthenticationError,
+    HogQLServiceAuthenticator,
+    HogQLServicePermissionError,
+    HogQLServiceQueryExecutor,
+    HogQLServiceSessionContext,
+    PgParameter,
+    QueryResult,
+    ResultColumn,
+    bind_parameters_to_query,
+)
+
+from posthog.models import Organization, PersonalAPIKey, Team, User
+from posthog.models.utils import generate_random_token_personal, hash_key_value
+
+
+class TestHogQLServiceAuthenticator(BaseTest):
+    def _create_personal_api_key(
+        self, scopes: list[str], scoped_teams: list[int] | None = None, scoped_organizations: list[str] | None = None
+    ) -> str:
+        token = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="HogQL service",
+            user=self.user,
+            secure_value=hash_key_value(token),
+            scopes=scopes,
+            scoped_teams=scoped_teams,
+            scoped_organizations=scoped_organizations,
+        )
+        return token
+
+    def test_shared_secret_authenticates_database_user_for_database_team_id(self) -> None:
+        context = HogQLServiceAuthenticator(shared_secret="secret").authenticate(
+            self.user.email, str(self.team.id), "secret"
+        )
+
+        assert context.user == self.user
+        assert context.team == self.team
+        assert context.authenticated_by == "shared_secret"
+
+    def test_shared_secret_rejects_user_without_project_access(self) -> None:
+        organization = Organization.objects.create(name="Other")
+        team = Team.objects.create(organization=organization)
+
+        with self.assertRaises(HogQLServicePermissionError):
+            HogQLServiceAuthenticator(shared_secret="secret").authenticate(self.user.email, str(team.id), "secret")
+
+    def test_personal_api_key_authenticates_user_with_query_scope(self) -> None:
+        token = self._create_personal_api_key(["query:read"])
+
+        context = HogQLServiceAuthenticator().authenticate(self.user.email, str(self.team.id), token)
+
+        assert context.user == self.user
+        assert context.team == self.team
+        assert context.authenticated_by == "personal_api_key"
+
+    def test_personal_api_key_rejects_database_user_mismatch(self) -> None:
+        token = self._create_personal_api_key(["query:read"])
+
+        with self.assertRaises(HogQLServiceAuthenticationError):
+            HogQLServiceAuthenticator().authenticate("someone@example.com", str(self.team.id), token)
+
+    def test_personal_api_key_requires_query_scope(self) -> None:
+        token = self._create_personal_api_key(["dashboard:read"])
+
+        with self.assertRaises(HogQLServicePermissionError):
+            HogQLServiceAuthenticator().authenticate(self.user.email, str(self.team.id), token)
+
+    def test_personal_api_key_respects_scoped_teams(self) -> None:
+        other_team = Team.objects.create(organization=self.organization)
+        token = self._create_personal_api_key(["query:read"], scoped_teams=[other_team.id])
+
+        with self.assertRaises(HogQLServicePermissionError):
+            HogQLServiceAuthenticator().authenticate(self.user.email, str(self.team.id), token)
+
+
+class TestHogQLServiceQueryExecutor(BaseTest):
+    def _context(self) -> HogQLServiceSessionContext:
+        return HogQLServiceSessionContext(
+            database_user=self.user.email,
+            database=str(self.team.id),
+            user=self.user,
+            team=self.team,
+            authenticated_by="shared_secret",
+        )
+
+    def test_builtin_show_query_returns_postgres_wire_setting(self) -> None:
+        result = HogQLServiceQueryExecutor().execute("SHOW server_version;", self._context())
+
+        assert [column.name for column in result.columns] == ["server_version"]
+        assert result.rows == [("16.0 (PostHog HogQL service)",)]
+        assert result.command_tag == "SHOW"
+
+    @patch("posthog.hogql.service.execute_hogql_query")
+    def test_hogql_query_executes_as_connection_user_and_team(self, mock_execute_hogql_query) -> None:
+        mock_execute_hogql_query.return_value = HogQLQueryResponse(
+            results=[(1,)],
+            columns=["one"],
+            types=[("one", "Int64")],
+        )
+
+        result = HogQLServiceQueryExecutor().execute("SELECT 1 AS one", self._context())
+
+        assert result.rows == [(1,)]
+        assert result.columns[0].name == "one"
+        assert mock_execute_hogql_query.call_args.kwargs["team"] == self.team
+        assert mock_execute_hogql_query.call_args.kwargs["user"] == self.user
+        assert mock_execute_hogql_query.call_args.kwargs["query_type"] == "hogql_service"
+
+
+class TestHogQLServiceParameters(BaseTest):
+    def test_bind_parameters_replaces_numbered_placeholders_outside_literals(self) -> None:
+        query = "SELECT $1, '$1', \"$1\", `$1`, -- $1\n$2"
+
+        bound = bind_parameters_to_query(query, [PgParameter("a'b"), PgParameter(42)])
+
+        assert bound == "SELECT 'a\\'b', '$1', \"$1\", `$1`, -- $1\n42"
+
+    def test_bind_parameters_rejects_missing_parameter(self) -> None:
+        with self.assertRaises(Exception) as error:
+            bind_parameters_to_query("SELECT $2", [PgParameter("one")])
+
+        assert "Missing bind parameter $2" in str(error.exception)
+
+
+class FakeAuthenticator:
+    def authenticate(self, database_user: str, database: str, password: str) -> HogQLServiceSessionContext:
+        return HogQLServiceSessionContext(
+            database_user=database_user,
+            database=database,
+            user=cast(User, SimpleNamespace(email=database_user)),
+            team=cast(Team, SimpleNamespace(id=int(database), timezone="UTC")),
+            authenticated_by="shared_secret",
+        )
+
+
+class FakeQueryExecutor:
+    def execute(self, sql: str, context: HogQLServiceSessionContext) -> QueryResult:
+        return QueryResult(
+            columns=[ResultColumn(name="answer", type_oid=POSTGRES_INT8_OID)],
+            rows=[(42,)],
+            command_tag="SELECT 1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_postgres_wire_session_accepts_psycopg_extended_query() -> None:
+    async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        session = HogQLPostgresWireSession(
+            reader=reader,
+            writer=writer,
+            authenticator=FakeAuthenticator(),
+            query_executor=FakeQueryExecutor(),
+            max_query_bytes=1024,
+        )
+        await session.run()
+
+    server = await asyncio.start_server(handle_client, "127.0.0.1", 0)
+    assert server.sockets is not None
+    port = server.sockets[0].getsockname()[1]
+
+    def run_query() -> tuple[list[tuple[Any, ...]], list[str]]:
+        with psycopg.connect(
+            host="127.0.0.1",
+            port=port,
+            dbname="1",
+            user="user@example.com",
+            password="secret",
+            sslmode="disable",
+        ) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 42 AS answer")
+                return cursor.fetchall(), [column.name for column in cursor.description or []]
+
+    try:
+        rows, columns = await asyncio.to_thread(run_query)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert rows == [(42,)]
+    assert columns == ["answer"]

--- a/posthog/hogql/test/test_service.py
+++ b/posthog/hogql/test/test_service.py
@@ -149,6 +149,44 @@ class TestHogQLServiceQueryExecutor(BaseTest):
         assert result.rows == [("16.0 (PostHog HogQL service)",)]
         assert result.command_tag == "SHOW"
 
+    def test_builtin_timestamp_probe_supports_postgres_extract_epoch(self) -> None:
+        result = HogQLServiceQueryExecutor().execute(
+            "select round(extract(epoch from current_timestamp) * 1000)",
+            self._context(),
+        )
+
+        assert [column.name for column in result.columns] == ["round"]
+        assert isinstance(result.rows[0][0], int)
+
+    def test_information_schema_tables_lists_hogql_tables(self) -> None:
+        result = HogQLServiceQueryExecutor().execute(
+            "SELECT table_schema, table_name, table_type FROM information_schema.tables WHERE table_schema = 'public'",
+            self._context(),
+        )
+
+        assert ("public", "events", "BASE TABLE") in result.rows
+
+    def test_information_schema_columns_lists_hogql_columns(self) -> None:
+        result = HogQLServiceQueryExecutor().execute(
+            "SELECT table_schema, table_name, column_name, data_type FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = 'events'",
+            self._context(),
+        )
+
+        assert ("public", "events", "event", "text") in result.rows
+
+    def test_pg_catalog_class_projection_uses_requested_aliases(self) -> None:
+        result = HogQLServiceQueryExecutor().execute(
+            "SELECT NULL AS TABLE_CAT, n.nspname AS TABLE_SCHEM, c.relname AS TABLE_NAME, "
+            "CASE c.relkind WHEN 'v' THEN 'VIEW' ELSE 'TABLE' END AS TABLE_TYPE "
+            "FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname = 'public'",
+            self._context(),
+        )
+
+        assert [column.name for column in result.columns] == ["table_cat", "table_schem", "table_name", "table_type"]
+        assert (None, "public", "events", "BASE TABLE") in result.rows
+
     @patch("posthog.hogql.service.execute_hogql_query")
     def test_hogql_query_executes_as_connection_user_and_team(self, mock_execute_hogql_query) -> None:
         mock_execute_hogql_query.return_value = HogQLQueryResponse(

--- a/posthog/management/commands/run_hogql_service.py
+++ b/posthog/management/commands/run_hogql_service.py
@@ -1,0 +1,48 @@
+import asyncio
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
+
+from posthog.hogql.service import HogQLPostgresServer, HogQLServiceConfig
+
+
+class Command(BaseCommand):
+    help = "Run the HogQL Postgres wire-compatible service"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("--host", default=None, help="Host to bind. Defaults to HOGQL_SERVICE_HOST or 0.0.0.0.")
+        parser.add_argument(
+            "--port", type=int, default=None, help="Port to bind. Defaults to HOGQL_SERVICE_PORT or 6543."
+        )
+        parser.add_argument(
+            "--shared-secret",
+            default=None,
+            help="Shared secret for impersonation auth. Defaults to HOGQL_SERVICE_SHARED_SECRET.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        config = HogQLServiceConfig.from_env()
+        if options["host"] is not None:
+            config = HogQLServiceConfig(
+                host=options["host"],
+                port=config.port,
+                shared_secret=config.shared_secret,
+                max_query_bytes=config.max_query_bytes,
+            )
+        if options["port"] is not None:
+            config = HogQLServiceConfig(
+                host=config.host,
+                port=options["port"],
+                shared_secret=config.shared_secret,
+                max_query_bytes=config.max_query_bytes,
+            )
+        if options["shared_secret"] is not None:
+            config = HogQLServiceConfig(
+                host=config.host,
+                port=config.port,
+                shared_secret=options["shared_secret"],
+                max_query_bytes=config.max_query_bytes,
+            )
+
+        self.stdout.write(f"Starting HogQL service on {config.host}:{config.port}")
+        asyncio.run(HogQLPostgresServer(config).serve_forever())

--- a/posthog/management/commands/run_hogql_service.py
+++ b/posthog/management/commands/run_hogql_service.py
@@ -45,4 +45,4 @@ class Command(BaseCommand):
             )
 
         self.stdout.write(f"Starting HogQL service on {config.host}:{config.port}")
-        asyncio.run(HogQLPostgresServer(config).serve_forever())
+        asyncio.run(HogQLPostgresServer(config, on_listening=self.stdout.write).serve_forever())

--- a/posthog/management/commands/run_hogql_service.py
+++ b/posthog/management/commands/run_hogql_service.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 import logging
+import dataclasses
 from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser
@@ -14,7 +15,7 @@ class Command(BaseCommand):
     help = "Run the HogQL Postgres wire-compatible service"
 
     def add_arguments(self, parser: CommandParser) -> None:
-        parser.add_argument("--host", default=None, help="Host to bind. Defaults to HOGQL_SERVICE_HOST or 0.0.0.0.")
+        parser.add_argument("--host", default=None, help="Host to bind. Defaults to HOGQL_SERVICE_HOST or 127.0.0.1.")
         parser.add_argument(
             "--port", type=int, default=None, help="Port to bind. Defaults to HOGQL_SERVICE_PORT or 6543."
         )
@@ -30,26 +31,11 @@ class Command(BaseCommand):
 
         config = HogQLServiceConfig.from_env()
         if options["host"] is not None:
-            config = HogQLServiceConfig(
-                host=options["host"],
-                port=config.port,
-                shared_secret=config.shared_secret,
-                max_query_bytes=config.max_query_bytes,
-            )
+            config = dataclasses.replace(config, host=options["host"])
         if options["port"] is not None:
-            config = HogQLServiceConfig(
-                host=config.host,
-                port=options["port"],
-                shared_secret=config.shared_secret,
-                max_query_bytes=config.max_query_bytes,
-            )
+            config = dataclasses.replace(config, port=options["port"])
         if options["shared_secret"] is not None:
-            config = HogQLServiceConfig(
-                host=config.host,
-                port=config.port,
-                shared_secret=options["shared_secret"],
-                max_query_bytes=config.max_query_bytes,
-            )
+            config = dataclasses.replace(config, shared_secret=options["shared_secret"])
 
         self.stdout.write(f"Starting HogQL service on {config.host}:{config.port}")
         self.stdout.write(f"HogQL service logs: {log_file}")

--- a/posthog/management/commands/run_hogql_service.py
+++ b/posthog/management/commands/run_hogql_service.py
@@ -1,9 +1,13 @@
+import os
 import asyncio
+import logging
 from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser
 
 from posthog.hogql.service import HogQLPostgresServer, HogQLServiceConfig
+
+logger = logging.getLogger("posthog.hogql.service")
 
 
 class Command(BaseCommand):
@@ -21,6 +25,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
+        log_file = os.environ.get("HOGQL_SERVICE_LOG_FILE", "/tmp/posthog-hogql-service.log")
+        self._configure_file_logging(log_file)
+
         config = HogQLServiceConfig.from_env()
         if options["host"] is not None:
             config = HogQLServiceConfig(
@@ -45,4 +52,22 @@ class Command(BaseCommand):
             )
 
         self.stdout.write(f"Starting HogQL service on {config.host}:{config.port}")
+        self.stdout.write(f"HogQL service logs: {log_file}")
+        self._write_log_line(log_file, f"Starting HogQL service on {config.host}:{config.port}")
+        logger.info("Starting HogQL service", extra={"hogql_service_log_file": log_file})
         asyncio.run(HogQLPostgresServer(config, on_listening=self.stdout.write).serve_forever())
+
+    def _configure_file_logging(self, log_file: str) -> None:
+        for handler in logger.handlers:
+            if isinstance(handler, logging.FileHandler) and handler.baseFilename == log_file:
+                return
+
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+        logger.addHandler(file_handler)
+        logger.disabled = False
+        logger.setLevel(logging.INFO)
+
+    def _write_log_line(self, log_file: str, message: str) -> None:
+        with open(log_file, "a") as file:
+            file.write(f"{message}\n")

--- a/tools/hogli-commands/hogli_commands/tests/test_devenv.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devenv.py
@@ -580,6 +580,19 @@ class TestMprocsGeneratorRegression:
         assert "property-defs-rs" in config.procs
         assert "docker-compose" in config.procs
 
+    def test_hogql_intent_starts_hogql_service(self) -> None:
+        intent_map = load_intent_map()
+        registry = create_mprocs_registry()
+        resolver = IntentResolver(intent_map, registry)
+        resolved = resolver.resolve(["hogql"])
+        config = MprocsGenerator(registry).generate(resolved)
+
+        assert "hogql-service" in resolved.units
+        assert "hogql-service" in config.procs
+        assert config.procs["hogql-service"].get("capability") == "hogql_service"
+        assert config.procs["hogql-service"].get("autostart") is not False
+        assert "duckgres" in resolved.docker_profiles
+
 
 class TestMprocsGeneratorPreservesCapability:
     """Generated procs retain `capability:` so phrocs can group by capability.


### PR DESCRIPTION
## Problem

HogQL can be queried from PostHog, but SQL tools expect a PostgreSQL wire-compatible endpoint for authentication, schema discovery, and query execution. Developers need to connect tools like PyCharm to a project by team ID,
optionally scoped to a direct warehouse connection, and introspect available HogQL tables without catalog-query failures.

## Changes

<img width="1434" height="949" alt="2026-05-18 16 59 15" src="https://github.com/user-attachments/assets/28162730-423d-41fc-85a1-bb29ecf4fcd3" />

<img width="1530" height="1051" alt="2026-05-18 17 00 19" src="https://github.com/user-attachments/assets/79059b80-9e35-4199-8364-0339807ae6f1" />


Adds a HogQL PostgreSQL wire service that:

- authenticates with either a shared secret or the user's personal API key
- accepts the database name as `team_id` or `team_id/connection_id`
- treats the username as the database user, supporting email, UUID, and numeric user ID
- executes HogQL queries with the authenticated user, team, and optional direct connection ID
- exposes PostgreSQL-compatible catalog and `information_schema` responses for schema introspection
- handles common SQL-client compatibility probes used by PyCharm
- adds `run_hogql_service` and wires the service into `hogli start` / phrocs

## How did you test this code?

As an agent, I ran:

- `hogli test posthog/hogql/test/test_service.py`
- `uv run ruff check posthog/hogql/service.py posthog/hogql/test/test_service.py`

I also watched the local HogQL service logs while connecting from PyCharm and used the observed catalog/introspection errors to add compatibility coverage.

## Publish to changelog?

no

## Docs update

No docs update. This is developer tooling for the local HogQL service.

## 🤖 Agent context

Implemented with Codex. The main design choice was to keep this as a separate PostgreSQL wire-compatible service rather than changing existing HogQL APIs, so SQL clients can use standard database connection settings.

Compatibility work was driven by PostgreSQL metadata queries emitted by PyCharm. The service now returns synthetic PostgreSQL catalog rows for schemas, tables, columns, roles, database metadata, and unsupported catalog tables where
clients expect a result shape rather than a query failure.
