### PR TITLE
fix(llma): reject completed eval/tagger workflow id reuse on replay

### DIFF
--- a/nodejs/src/llm-analytics/services/temporal.service.test.ts
+++ b/nodejs/src/llm-analytics/services/temporal.service.test.ts
@@ -108,6 +108,7 @@ describe('TemporalService', () => {
                 taskQueue: 'llm-analytics-evals-task-queue',
                 workflowId: 'llma-llm-eval-eval-123-event-456-ingestion',
                 workflowIdConflictPolicy: 'USE_EXISTING',
+                workflowIdReusePolicy: 'ALLOW_DUPLICATE_FAILED_ONLY',
                 workflowTaskTimeout: '2 minutes',
                 args: [
                     {
@@ -172,6 +173,7 @@ describe('TemporalService', () => {
                 taskQueue: 'llm-analytics-evals-task-queue',
                 workflowId: 'llma-tagger-tagger-123-event-456-ingestion',
                 workflowIdConflictPolicy: 'USE_EXISTING',
+                workflowIdReusePolicy: 'ALLOW_DUPLICATE_FAILED_ONLY',
                 workflowTaskTimeout: '2 minutes',
                 args: [
                     {

--- a/nodejs/src/llm-analytics/services/temporal.service.ts
+++ b/nodejs/src/llm-analytics/services/temporal.service.ts
@@ -124,6 +124,7 @@ export class TemporalService {
             taskQueue: EVALUATION_TASK_QUEUE,
             workflowId,
             workflowIdConflictPolicy: 'USE_EXISTING',
+            workflowIdReusePolicy: 'ALLOW_DUPLICATE_FAILED_ONLY',
             workflowTaskTimeout: '2 minutes',
         })
 
@@ -154,6 +155,7 @@ export class TemporalService {
             taskQueue: EVALUATION_TASK_QUEUE,
             workflowId,
             workflowIdConflictPolicy: 'USE_EXISTING',
+            workflowIdReusePolicy: 'ALLOW_DUPLICATE_FAILED_ONLY',
             workflowTaskTimeout: '2 minutes',
         })
 


### PR DESCRIPTION
## Problem

We want calls to evaluation workflows to be idempotent, so we generate the ID based on the event ID and the evaluation ID, like so:
```
llma-llm-eval-019afee9-c9fc-0000-5fd9-4ff9710065d6-834391b1-be8a-4dbd-96dd-bfad84b52ae3-ingestion
```
However we only set `workflowIdConflictPolicy: 'USE_EXISTING'`, which dedupes against still-RUNNING workflows. `workflowIdReusePolicy` was left at the default `ALLOW_DUPLICATE`, which permits a fresh run when the existing workflow has CLOSED. We want calls to be idempotent

## Changes

Set `workflowIdReusePolicy: 'ALLOW_DUPLICATE_FAILED_ONLY'` on both `startEvaluationRunWorkflow` and `startTaggerRunWorkflow`. After this:

- RUNNING duplicate → returns the existing handle (unchanged).
- CLOSED-completed/cancelled/terminated duplicate → start_workflow errors, scheduler's `.catch()` logs it, no fresh run, no LLM cost.
- CLOSED-failed duplicate → fresh run (retry semantics preserved).

## How did you test this code?

## Publish to changelog?

no

## 🤖 Agent context

Built with Claude Code (carlos@posthog.com pairing). Discovered while monitoring the AI events topic rollout: USE_EXISTING is documented as a conflict-policy (RUNNING workflows), not a reuse-policy (CLOSED workflows). The two are independent fields and you need both to make replay idempotent. Default `workflowIdReusePolicy` is `ALLOW_DUPLICATE`, which silently allowed re-runs.
