### PR TITLE
feat: send notificaions from all channels

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -1524,7 +1524,7 @@ def send_oauth_token_exposed(user_id: int, token_type: str, mask_value: str, mor
 
 @shared_task(**EMAIL_TASK_KWARGS)
 @skip_team_scope_audit
-def send_new_ticket_notification(ticket_id: str, team_id: int, first_message_content: str) -> None:
+def send_new_ticket_notification(ticket_id: str, team_id: int, first_message_content: str = "") -> None:
     if not is_email_available(with_absolute_urls=True):
         logger.warning("Skipping new ticket notification: email service not available")
         return
@@ -1560,6 +1560,15 @@ def send_new_ticket_notification(ticket_id: str, team_id: int, first_message_con
 
     if not memberships_to_email:
         return
+
+    # Fetch first message if not provided (signal-based callers don't pass it)
+    if not first_message_content:
+        first_comment = (
+            Comment.objects.filter(team=team, scope="conversations_ticket", item_id=ticket_id, deleted=False)
+            .order_by("created_at")
+            .first()
+        )
+        first_message_content = first_comment.content if first_comment else ""
 
     # Extract customer info from anonymous_traits
     traits = ticket.anonymous_traits or {}

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -1524,7 +1524,7 @@ def send_oauth_token_exposed(user_id: int, token_type: str, mask_value: str, mor
 
 @shared_task(**EMAIL_TASK_KWARGS)
 @skip_team_scope_audit
-def send_new_ticket_notification(ticket_id: str, team_id: int, first_message_content: str = "") -> None:
+def send_new_ticket_notification(ticket_id: str, team_id: int, first_message_content: str) -> None:
     if not is_email_available(with_absolute_urls=True):
         logger.warning("Skipping new ticket notification: email service not available")
         return
@@ -1560,15 +1560,6 @@ def send_new_ticket_notification(ticket_id: str, team_id: int, first_message_con
 
     if not memberships_to_email:
         return
-
-    # Fetch first message if not provided (signal-based callers don't pass it)
-    if not first_message_content:
-        first_comment = (
-            Comment.objects.filter(team=team, scope="conversations_ticket", item_id=ticket_id, deleted=False)
-            .order_by("created_at")
-            .first()
-        )
-        first_message_content = first_comment.content if first_comment else ""
 
     # Extract customer info from anonymous_traits
     traits = ticket.anonymous_traits or {}

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -29,7 +29,6 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 from posthog.models.comment import Comment
 from posthog.rate_limit import WidgetTeamThrottle, WidgetUserBurstThrottle
-from posthog.tasks.email import send_new_ticket_notification
 
 from products.conversations.backend.api.serializers import (
     WidgetMarkReadSerializer,
@@ -227,16 +226,6 @@ class WidgetMessageView(APIView):
         # via transaction.on_commit (see signals.py). Only unread_count needs
         # explicit invalidation here since the signal doesn't cover it.
         invalidate_unread_count_cache(team.id)
-
-        # Send email notification for new tickets
-        if not ticket_id:
-            conversations_settings = team.conversations_settings or {}
-            if conversations_settings.get("notification_recipients"):
-                send_new_ticket_notification.delay(
-                    ticket_id=str(ticket.id),
-                    team_id=team.id,
-                    first_message_content=message_content,
-                )
 
         return Response(
             {

--- a/products/conversations/backend/signals.py
+++ b/products/conversations/backend/signals.py
@@ -12,6 +12,7 @@ from posthog.event_usage import report_team_action, report_user_action
 from posthog.exceptions_capture import capture_exception
 from posthog.models import User
 from posthog.models.comment import Comment
+from posthog.tasks.email import send_new_ticket_notification
 
 from .cache import invalidate_messages_cache, invalidate_tickets_cache
 from .events import capture_message_received, capture_message_sent, capture_ticket_created
@@ -57,6 +58,16 @@ def emit_ticket_created_event(sender, instance: Ticket, created: bool, **kwargs)
     def do_emit():
         try:
             capture_ticket_created(instance)
+        except Exception as e:
+            capture_exception(e, {"ticket_id": str(instance.id)})
+
+        try:
+            conversations_settings = instance.team.conversations_settings or {}
+            if conversations_settings.get("notification_recipients"):
+                send_new_ticket_notification.delay(
+                    ticket_id=str(instance.id),
+                    team_id=instance.team_id,
+                )
         except Exception as e:
             capture_exception(e, {"ticket_id": str(instance.id)})
 

--- a/products/conversations/backend/signals.py
+++ b/products/conversations/backend/signals.py
@@ -61,16 +61,6 @@ def emit_ticket_created_event(sender, instance: Ticket, created: bool, **kwargs)
         except Exception as e:
             capture_exception(e, {"ticket_id": str(instance.id)})
 
-        try:
-            conversations_settings = instance.team.conversations_settings or {}
-            if conversations_settings.get("notification_recipients"):
-                send_new_ticket_notification.delay(
-                    ticket_id=str(instance.id),
-                    team_id=instance.team_id,
-                )
-        except Exception as e:
-            capture_exception(e, {"ticket_id": str(instance.id)})
-
     transaction.on_commit(do_emit)
 
 
@@ -147,6 +137,18 @@ def update_ticket_on_message(sender, instance: Comment, created: bool, **kwargs)
                     report_user_action(user, "support message sent", props, team=ticket.team)
             else:
                 report_team_action(ticket.team, "support message received", props)
+            # Send email notification on first customer message (i.e. new ticket)
+            if ticket.message_count == 1 and not is_team_message:
+                try:
+                    conversations_settings = ticket.team.conversations_settings or {}
+                    if conversations_settings.get("notification_recipients"):
+                        send_new_ticket_notification.delay(
+                            ticket_id=item_id,
+                            team_id=team_id,
+                            first_message_content=(content or "")[:500],
+                        )
+                except Exception as e:
+                    capture_exception(e, {"ticket_id": item_id})
         except Ticket.DoesNotExist:
             pass
         except Exception as e:


### PR DESCRIPTION
We send email notifications when a new ticket is created.
However, it was enabled only for tickets created via widget, but not other channels.
Move it from widget.py to signals.py