### PR TITLE
fix(cohorts): drop redundant person join in count_cohort_members

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -1449,9 +1449,7 @@ def count_cohort_members(team_id: int, cohort_id: int, *, consistency: ReadConsi
         return 0
 
     def orm_fn() -> int:
-        qs = CohortPeople.objects.filter(  # nosemgrep: no-direct-persons-db-orm
-            cohort_id=cohort_id, person__team_id=team_id
-        )
+        qs = CohortPeople.objects.filter(cohort_id=cohort_id)  # nosemgrep: no-direct-persons-db-orm
         if consistency == "strong":
             from posthog.person_db_router import PERSONS_DB_FOR_WRITE
 

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -471,13 +471,19 @@ class TestCohort(BaseTest):
         assert isinstance(size, int), f"Expected int, got {type(size)}: {size}"
         assert size == 3, f"Expected 3 persons in cohort, got {size}"
 
-        # Test with team leakage - person from another team should not be counted
+        # Cross-team CohortPeople rows are counted: get_static_cohort_size scopes by
+        # cohort_id (gated by an upfront `Cohort.team_id == team_id` ownership check
+        # in count_cohort_members), not by person.team_id. The previous join through
+        # posthog_person was a hot per-PK lookup on the write replica that we
+        # dropped for IOPS reasons — production cannot reach this state via the
+        # supported APIs, and a raw M2M add() like the one below is what would have
+        # had to break for a count discrepancy to surface in real traffic.
         team2 = Team.objects.create(organization=self.organization)
         person4 = Person.objects.create(team=team2, distinct_ids=["person4"])
         cohort.people.add(person4)
 
         size = get_static_cohort_size(cohort_id=cohort.id, team_id=self.team.id)
-        assert size == 3, f"Expected 3 persons from team {self.team.id}, got {size}"
+        assert size == 4, f"Expected 4 cohort rows after cross-team add, got {size}"
 
     @pytest.mark.ee
     def test_calculate_people_ch_clears_realtime_type_when_exceeding_threshold(self):


### PR DESCRIPTION
## Problem

`count_cohort_members` runs once per static cohort sync with `consistency="strong"`. Its ORM fallback filtered by `cohort_id=cohort_id, person__team_id=team_id`, which Django expands to an `INNER JOIN posthog_person` purely to re-check the team. For an N-member cohort that is N PK lookups on `posthog_person` against the write replica — read IOPS that pganalyze flagged during large cohort syncs, and that degrades into heap visits whenever the visibility map for the hot partition isn't all-set.

The function already validates ownership immediately above via `Cohort.objects.filter(id=cohort_id, team_id=team_id).exists()`, and the personhog gRPC counterpart counts `posthog_cohortpeople` directly without the join — so the team-join was redundant in the supported code paths.

This was originally bundled into #58753, but the test changes here are scoped enough to warrant a separate PR — keeps the `DISTINCT ON` removal on #58753 unblocked.

## Changes

Drop the `person__team_id` join from the ORM fallback in `count_cohort_members`. Final per-sync COUNT now touches only `posthog_cohortpeople`.

Update `test_get_static_cohort_size` to reflect the new contract: `count_cohort_members` scopes by `cohort_id` (gated by the upfront cohort-ownership check), not by `person.team_id`. Cross-team rows in `posthog_cohortpeople` are not reachable via the supported product APIs — the raw `cohort.people.add()` in the test is what would have had to misbehave for a count discrepancy to surface in real traffic.

## How did you test this code?

I'm an agent. Automated checks I ran:

- `test_get_static_cohort_size` passes locally against the updated assertion (3 cohort rows → size 3; after cross-team add → size 4).
- `ruff check` + `ruff format` (via pre-commit) clean.
- `ty check` clean.

## Publish to changelog?

no

## Docs update

No docs change required.

## 🤖 Agent context

Split out of #58753 after CI surfaced `test_get_static_cohort_size` failing on the original PR. The test was added to exercise team-leakage defense, which the join was providing. Discussion in #58753 concluded:

- The util.py change is the larger IOPS win (per-PK lookups on a hot partition vs a one-shot Sort node), so dropping it from #58753 to unblock would have given up the primary value.
- Keeping the join "just in case" of cross-team rows papers over a problem that should be prevented at the M2M layer (`cohort.people.add` guard or a check constraint on `posthog_cohortpeople`), not in a hot count path.
- Test assertion updated rather than deleted: the team-leakage scenario is still documented as a known shape, just now codified as "we count what's there, the upfront ownership check is the contract."