### PR TITLE
feat(replay): adding tests for replay vision FE

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,7 +275,7 @@ importers:
         version: 3.12.1
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
       oxfmt:
         specifier: 'catalog:'
         version: 0.35.0
@@ -448,7 +448,7 @@ importers:
         version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/test-runner':
         specifier: ^0.16.0
-        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)
+        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       '@storybook/theming':
         specifier: ^7.6.4
         version: 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1309,7 +1309,7 @@ importers:
         version: 29.7.0
       jest-image-snapshot:
         specifier: ^6.1.0
-        version: 6.4.0(jest@29.7.0(@types/node@22.18.8))
+        version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)))
       kea-typegen:
         specifier: 3.6.2-leakfix.5
         version: 3.6.2-leakfix.5(typescript@6.0.3)
@@ -1804,7 +1804,7 @@ importers:
         version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.52.4)(typescript@6.0.3)(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
       '@storybook/test-runner':
         specifier: ^0.16.0
-        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)
+        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       '@storybook/theming':
         specifier: ^7.6.20
         version: 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1825,7 +1825,7 @@ importers:
         version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@22.18.8))
+        version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)))
       storybook:
         specifier: ^7.6.4
         version: 7.6.4(encoding@0.1.13)
@@ -3172,6 +3172,10 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+    devDependencies:
+      kea-test-utils:
+        specifier: 'catalog:'
+        version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
 
   products/revenue_analytics:
     dependencies:
@@ -29245,6 +29249,41 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.18.8
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -34680,7 +34719,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/test-runner@0.16.0(@types/node@22.18.8)(encoding@0.1.13)':
+  '@storybook/test-runner@0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -38662,6 +38701,21 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
+  create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
@@ -42135,6 +42189,25 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
@@ -42206,6 +42279,37 @@ snapshots:
       - canvas
       - supports-color
       - utf-8-validate
+
+  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.18.8
+      ts-node: 10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
@@ -42457,7 +42561,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@22.18.8)):
+  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -43112,6 +43216,18 @@ snapshots:
       - supports-color
       - ts-node
       - utf-8-validate
+
+  jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
@@ -49462,6 +49578,27 @@ snapshots:
       safe-stable-stringify: 2.5.0
       tslib: 2.8.1
       typescript: 6.0.3
+
+  ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 22.18.8
+      acorn: 8.15.0
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 6.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.11.4
+    optional: true
 
   ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3):
     dependencies:

--- a/products/replay_vision/frontend/replay_lenses/ReplayLens.tsx
+++ b/products/replay_vision/frontend/replay_lenses/ReplayLens.tsx
@@ -9,6 +9,7 @@ import {
     LemonSwitch,
     LemonTab,
     LemonTabs,
+    LemonTag,
     LemonTextArea,
 } from '@posthog/lemon-ui'
 
@@ -68,22 +69,32 @@ export function ReplayLensSceneComponent({ tabId }: { tabId: string }): JSX.Elem
                         <LemonTextArea placeholder="What this lens looks for and why." minRows={2} />
                     </Field>
 
-                    <Field name="lens_type" label="Lens type">
-                        <LemonSelect
-                            value={lens.lens_type}
-                            onChange={(v) => setLensType(v)}
-                            options={LENS_TYPE_OPTIONS.map((opt) => ({
-                                value: opt.value,
-                                label: opt.label,
-                                labelInMenu: (
-                                    <div className="flex flex-col">
-                                        <span className="font-medium">{opt.label}</span>
-                                        <span className="text-xs text-muted">{opt.description}</span>
-                                    </div>
-                                ),
-                            }))}
-                        />
-                    </Field>
+                    {isNew ? (
+                        <Field name="lens_type" label="Lens type">
+                            <LemonSelect
+                                value={lens.lens_type}
+                                onChange={(v) => setLensType(v)}
+                                options={LENS_TYPE_OPTIONS.map((opt) => ({
+                                    value: opt.value,
+                                    label: opt.label,
+                                    labelInMenu: (
+                                        <div className="flex flex-col">
+                                            <span className="font-medium">{opt.label}</span>
+                                            <span className="text-xs text-muted">{opt.description}</span>
+                                        </div>
+                                    ),
+                                }))}
+                            />
+                        </Field>
+                    ) : (
+                        <div className="space-y-1">
+                            <label className="block text-sm font-medium">Lens type</label>
+                            <LemonTag type="option">
+                                {LENS_TYPE_OPTIONS.find((o) => o.value === lens.lens_type)?.label ?? lens.lens_type}
+                            </LemonTag>
+                            <div className="text-xs text-muted">Lens type is fixed after creation.</div>
+                        </div>
+                    )}
 
                     <LensTypeConfigEditor lensId={lensId} tabId={tabId} />
 

--- a/products/replay_vision/frontend/replay_lenses/replayLensLogic.test.ts
+++ b/products/replay_vision/frontend/replay_lenses/replayLensLogic.test.ts
@@ -63,34 +63,41 @@ describe('replayLensLogic', () => {
     })
 
     describe('validation errors', () => {
-        it('flags missing name', () => {
-            expect(logic.values.lensValidationErrors).toMatchObject({ name: 'Name is required' })
-        })
-
-        it('flags missing prompt', () => {
-            expect(logic.values.lensValidationErrors).toMatchObject({
-                lens_config: expect.objectContaining({ prompt: 'Prompt is required' }),
-            })
-        })
-
-        it('flags sampling rate outside (0, 1]', async () => {
-            logic.actions.setLensValues({ sampling_rate: 0 })
-            await expectLogic(logic).toMatchValues({
-                lensValidationErrors: expect.objectContaining({
-                    sampling_rate: expect.any(String),
-                }),
-            })
-        })
-
-        it('flags scorer scale when min >= max', async () => {
-            logic.actions.setLensType('scorer')
-            logic.actions.setLensValues({
-                lens_config: { prompt: 'rate this', scale: { min: 10, max: 5 } } as ScorerLens['lens_config'],
-            })
-            await expectLogic(logic).toMatchValues({
-                lensValidationErrors: expect.objectContaining({
+        it.each([
+            {
+                name: 'flags missing name',
+                setup: () => undefined,
+                expectedErrors: { name: 'Name is required' },
+            },
+            {
+                name: 'flags missing prompt',
+                setup: () => undefined,
+                expectedErrors: { lens_config: expect.objectContaining({ prompt: 'Prompt is required' }) },
+            },
+            {
+                name: 'flags sampling rate outside (0, 1]',
+                setup: () => logic.actions.setLensValues({ sampling_rate: 0 }),
+                expectedErrors: { sampling_rate: expect.any(String) },
+            },
+            {
+                name: 'flags scorer scale when min >= max',
+                setup: () => {
+                    logic.actions.setLensType('scorer')
+                    logic.actions.setLensValues({
+                        lens_config: {
+                            prompt: 'rate this',
+                            scale: { min: 10, max: 5 },
+                        } as ScorerLens['lens_config'],
+                    })
+                },
+                expectedErrors: {
                     lens_config: expect.objectContaining({ scale: expect.stringContaining('greater than') }),
-                }),
+                },
+            },
+        ])('$name', async ({ setup, expectedErrors }) => {
+            setup()
+            await expectLogic(logic).toMatchValues({
+                lensValidationErrors: expect.objectContaining(expectedErrors),
             })
         })
 

--- a/products/replay_vision/frontend/replay_lenses/replayLensLogic.test.ts
+++ b/products/replay_vision/frontend/replay_lenses/replayLensLogic.test.ts
@@ -1,0 +1,135 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { replayLensLogic } from './replayLensLogic'
+import { ClassifierLens, ScorerLens } from './types'
+
+describe('replayLensLogic', () => {
+    let logic: ReturnType<typeof replayLensLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team/vision/lenses/:id/': () => [404, {}],
+                '/api/environments/:team/vision/lenses/:id/observations/': { results: [] },
+            },
+        })
+        initKeaTests()
+        logic = replayLensLogic({ id: 'new', tabId: 'test' })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    describe('form defaults', () => {
+        it('new lens starts as monitor with empty prompt and default sampling', () => {
+            expect(logic.values.lens).toMatchObject({
+                id: 'new',
+                name: '',
+                enabled: true,
+                lens_type: 'monitor',
+                lens_config: { prompt: '' },
+                sampling_rate: 1,
+            })
+        })
+    })
+
+    describe('setLensType', () => {
+        it.each([
+            { type: 'monitor' as const, expectedConfig: { prompt: '' } },
+            { type: 'summarizer' as const, expectedConfig: { prompt: '', length: 'medium' } },
+            { type: 'classifier' as const, expectedConfig: { prompt: '', tags: [], multi_label: true } },
+            { type: 'scorer' as const, expectedConfig: { prompt: '', scale: { min: 0, max: 10 } } },
+            { type: 'indexer' as const, expectedConfig: { prompt: '' } },
+        ])(
+            'switching to $type replaces lens_config with the default for that type',
+            async ({ type, expectedConfig }) => {
+                await expectLogic(logic, () => logic.actions.setLensType(type)).toMatchValues({
+                    lens: expect.objectContaining({ lens_type: type, lens_config: expectedConfig }),
+                })
+            }
+        )
+
+        it('does not preserve old prompt across type changes', async () => {
+            logic.actions.setLensValues({ lens_config: { prompt: 'Was there a refund?' } })
+            await expectLogic(logic, () => logic.actions.setLensType('summarizer')).toMatchValues({
+                lens: expect.objectContaining({ lens_config: { prompt: '', length: 'medium' } }),
+            })
+        })
+    })
+
+    describe('validation errors', () => {
+        it('flags missing name', () => {
+            expect(logic.values.lensValidationErrors).toMatchObject({ name: 'Name is required' })
+        })
+
+        it('flags missing prompt', () => {
+            expect(logic.values.lensValidationErrors).toMatchObject({
+                lens_config: expect.objectContaining({ prompt: 'Prompt is required' }),
+            })
+        })
+
+        it('flags sampling rate outside (0, 1]', async () => {
+            logic.actions.setLensValues({ sampling_rate: 0 })
+            await expectLogic(logic).toMatchValues({
+                lensValidationErrors: expect.objectContaining({
+                    sampling_rate: expect.any(String),
+                }),
+            })
+        })
+
+        it('flags scorer scale when min >= max', async () => {
+            logic.actions.setLensType('scorer')
+            logic.actions.setLensValues({
+                lens_config: { prompt: 'rate this', scale: { min: 10, max: 5 } } as ScorerLens['lens_config'],
+            })
+            await expectLogic(logic).toMatchValues({
+                lensValidationErrors: expect.objectContaining({
+                    lens_config: expect.objectContaining({ scale: expect.stringContaining('greater than') }),
+                }),
+            })
+        })
+
+        it('passes when all required fields are filled', async () => {
+            logic.actions.setLensType('classifier')
+            logic.actions.setLensValues({
+                name: 'My lens',
+                sampling_rate: 0.1,
+                lens_config: { prompt: 'Categorize', tags: ['a'], multi_label: true } as ClassifierLens['lens_config'],
+            })
+            await expectLogic(logic).toMatchValues({
+                isLensValid: true,
+            })
+        })
+    })
+
+    describe('hasUnsavedChanges', () => {
+        it('is false when no original lens is loaded', () => {
+            expect(logic.values.hasUnsavedChanges).toBe(false)
+        })
+
+        it('is false when current matches original', async () => {
+            logic.actions.loadLensSuccess({
+                ...logic.values.lens!,
+                id: 'abc',
+                name: 'Loaded',
+            })
+            await expectLogic(logic).toMatchValues({ hasUnsavedChanges: false })
+        })
+
+        it('is true after a form edit', async () => {
+            logic.actions.loadLensSuccess({
+                ...logic.values.lens!,
+                id: 'abc',
+                name: 'Loaded',
+            })
+            await expectLogic(logic, () => logic.actions.setLensValues({ name: 'Edited' })).toMatchValues({
+                hasUnsavedChanges: true,
+            })
+        })
+    })
+})

--- a/products/replay_vision/frontend/replay_lenses/replayLensSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_lenses/replayLensSceneLogic.ts
@@ -61,7 +61,8 @@ export const replayLensSceneLogic = kea<replayLensSceneLogicType>([
 
     tabAwareActionToUrl(({ values }) => ({
         setActiveTab: () => {
-            const tab = values.activeTab === 'configuration' ? undefined : values.activeTab
+            const defaultTab: EditorTab = values.lensId === 'new' ? 'configuration' : 'observations'
+            const tab = values.activeTab === defaultTab ? undefined : values.activeTab
             return [
                 urls.replayVision(values.lensId),
                 { ...router.values.searchParams, tab },
@@ -78,7 +79,8 @@ export const replayLensSceneLogic = kea<replayLensSceneLogicType>([
                 actions.setLensId(lensId)
             }
             const raw = typeof searchParams.tab === 'string' ? searchParams.tab : ''
-            const tab: EditorTab = (ALL_EDITOR_TABS as string[]).includes(raw) ? (raw as EditorTab) : 'configuration'
+            const defaultTab: EditorTab = lensId === 'new' ? 'configuration' : 'observations'
+            const tab: EditorTab = (ALL_EDITOR_TABS as string[]).includes(raw) ? (raw as EditorTab) : defaultTab
             if (tab !== values.activeTab) {
                 actions.setActiveTab(tab)
             }

--- a/products/replay_vision/frontend/replay_lenses/replayLensesLogic.test.ts
+++ b/products/replay_vision/frontend/replay_lenses/replayLensesLogic.test.ts
@@ -1,0 +1,120 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { replayLensesLogic } from './replayLensesLogic'
+import { LensType, ReplayLens } from './types'
+
+function makeLens(overrides: Partial<ReplayLens> = {}): ReplayLens {
+    return {
+        id: 'lens-1',
+        name: 'Confused checkout',
+        description: '',
+        enabled: true,
+        sampling_rate: 0.1,
+        query: null,
+        provider: 'google',
+        model: 'gemini-3-flash',
+        emits_signals: false,
+        lens_version: 1,
+        last_swept_at: '2026-05-12T00:00:00Z',
+        created_at: '2026-05-12T00:00:00Z',
+        updated_at: '2026-05-12T00:00:00Z',
+        created_by: null,
+        lens_type: 'monitor' as LensType,
+        lens_config: { prompt: 'Did the user struggle?' },
+        ...overrides,
+    } as ReplayLens
+}
+
+describe('replayLensesLogic', () => {
+    let logic: ReturnType<typeof replayLensesLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team/vision/lenses/': { results: [] },
+                '/api/environments/:team/vision/quota/': () => [404, {}],
+            },
+        })
+        initKeaTests()
+        logic = replayLensesLogic({ tabId: 'test' })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    const lenses: ReplayLens[] = [
+        makeLens({ id: 'a', name: 'Confused checkout', lens_type: 'monitor', enabled: true }),
+        makeLens({ id: 'b', name: 'Power user behavior', lens_type: 'classifier', enabled: false }),
+        makeLens({ id: 'c', name: 'Refund summarizer', lens_type: 'summarizer', enabled: true }),
+    ]
+
+    it.each([
+        { name: 'no filters returns all', search: '', enabled: [], types: [], expected: ['a', 'b', 'c'] },
+        { name: 'search by name', search: 'checkout', enabled: [], types: [], expected: ['a'] },
+        { name: 'search by prompt fragment', search: 'struggle', enabled: [], types: [], expected: ['a', 'b', 'c'] },
+        { name: 'enabled filter', search: '', enabled: ['enabled' as const], types: [], expected: ['a', 'c'] },
+        { name: 'disabled filter', search: '', enabled: ['disabled' as const], types: [], expected: ['b'] },
+        {
+            name: 'lens type filter',
+            search: '',
+            enabled: [],
+            types: ['classifier' as LensType, 'summarizer' as LensType],
+            expected: ['b', 'c'],
+        },
+        {
+            name: 'combined search + enabled',
+            search: 'refund',
+            enabled: ['enabled' as const],
+            types: [],
+            expected: ['c'],
+        },
+    ])('filteredLenses: $name', async ({ search, enabled, types, expected }) => {
+        await expectLogic(logic, () => {
+            logic.actions.loadLensesSuccess(lenses)
+            logic.actions.setSearch(search)
+            logic.actions.setEnabledFilter(enabled)
+            logic.actions.setLensTypeFilter(types)
+        }).toMatchValues({
+            filteredLenses: lenses.filter((l) => expected.includes(l.id)),
+        })
+    })
+
+    it('hasActiveFilters tracks any active filter', async () => {
+        await expectLogic(logic).toMatchValues({ hasActiveFilters: false })
+
+        await expectLogic(logic, () => logic.actions.setSearch('foo')).toMatchValues({ hasActiveFilters: true })
+        await expectLogic(logic, () => logic.actions.setSearch('')).toMatchValues({ hasActiveFilters: false })
+
+        await expectLogic(logic, () => logic.actions.setEnabledFilter(['enabled'])).toMatchValues({
+            hasActiveFilters: true,
+        })
+    })
+
+    it('clearFilters resets all filter state', async () => {
+        logic.actions.setSearch('foo')
+        logic.actions.setEnabledFilter(['enabled'])
+        logic.actions.setLensTypeFilter(['monitor'])
+        await expectLogic(logic).toMatchValues({ hasActiveFilters: true })
+
+        await expectLogic(logic, () => logic.actions.clearFilters()).toMatchValues({
+            search: '',
+            enabledFilter: [],
+            lensTypeFilter: [],
+            hasActiveFilters: false,
+        })
+    })
+
+    it('toggleLensEnabledSuccess flips the lens row', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadLensesSuccess(lenses)
+            logic.actions.toggleLensEnabledSuccess('a')
+        }).toMatchValues({
+            lenses: expect.arrayContaining([expect.objectContaining({ id: 'a', enabled: false })]),
+        })
+    })
+})

--- a/products/replay_vision/frontend/replay_lenses/replayLensesLogic.test.ts
+++ b/products/replay_vision/frontend/replay_lenses/replayLensesLogic.test.ts
@@ -4,10 +4,24 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { replayLensesLogic } from './replayLensesLogic'
-import { LensType, ReplayLens } from './types'
+import { LensConfig, LensType, ReplayLens } from './types'
+
+function defaultConfigForType(lensType: LensType): LensConfig {
+    if (lensType === 'summarizer') {
+        return { prompt: 'Summarize this session.', length: 'medium' }
+    }
+    if (lensType === 'classifier') {
+        return { prompt: 'Tag this session.', tags: [], multi_label: true }
+    }
+    if (lensType === 'scorer') {
+        return { prompt: 'Score this session.', scale: { min: 0, max: 10 } }
+    }
+    return { prompt: 'Did the user struggle?' }
+}
 
 function makeLens(overrides: Partial<ReplayLens> = {}): ReplayLens {
-    return {
+    const lensType: LensType = overrides.lens_type ?? 'monitor'
+    const base = {
         id: 'lens-1',
         name: 'Confused checkout',
         description: '',
@@ -22,10 +36,10 @@ function makeLens(overrides: Partial<ReplayLens> = {}): ReplayLens {
         created_at: '2026-05-12T00:00:00Z',
         updated_at: '2026-05-12T00:00:00Z',
         created_by: null,
-        lens_type: 'monitor' as LensType,
-        lens_config: { prompt: 'Did the user struggle?' },
-        ...overrides,
-    } as ReplayLens
+        lens_type: lensType,
+        lens_config: defaultConfigForType(lensType),
+    }
+    return { ...base, ...overrides } as ReplayLens
 }
 
 describe('replayLensesLogic', () => {
@@ -56,7 +70,7 @@ describe('replayLensesLogic', () => {
     it.each([
         { name: 'no filters returns all', search: '', enabled: [], types: [], expected: ['a', 'b', 'c'] },
         { name: 'search by name', search: 'checkout', enabled: [], types: [], expected: ['a'] },
-        { name: 'search by prompt fragment', search: 'struggle', enabled: [], types: [], expected: ['a', 'b', 'c'] },
+        { name: 'search by prompt fragment', search: 'struggle', enabled: [], types: [], expected: ['a'] },
         { name: 'enabled filter', search: '', enabled: ['enabled' as const], types: [], expected: ['a', 'c'] },
         { name: 'disabled filter', search: '', enabled: ['disabled' as const], types: [], expected: ['b'] },
         {

--- a/products/replay_vision/package.json
+++ b/products/replay_vision/package.json
@@ -8,6 +8,9 @@
         "kea-forms": "catalog:",
         "kea-router": "catalog:"
     },
+    "devDependencies": {
+        "kea-test-utils": "catalog:"
+    },
     "peerDependencies": {
         "@posthog/icons": "*",
         "@posthog/lemon-ui": "*",


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
The FE PR for replay vision was already enormous, decided to add testing as a follow-up

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Adding tests for replay vision frontend layers
- `lens_type` cannot be changed once created
- Clicking an existing lens lands on Observations. Clicking "New lens" lands on Configuration.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
