### PR TITLE
fix: person compose issue

### DIFF
--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -930,8 +930,11 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
         recipient_email = data["recipient_email"]
         distinct_id = data.get("recipient_distinct_id", "") or recipient_email
 
-        person = get_person_by_distinct_id(team.id, distinct_id)
-        if person is None and distinct_id == recipient_email:
+        person: Person | None = None
+        if distinct_id != recipient_email:
+            person = get_person_by_distinct_id(team.id, distinct_id)
+
+        if person is None:
             person = _get_persons_by_email(team, [recipient_email]).get(recipient_email.lower())
             if person is not None and person.distinct_ids:
                 distinct_id = person.distinct_ids[0]


### PR DESCRIPTION
1. distinct_id == recipient_email (no recipient_distinct_id provided): skip ORM, go straight to ClickHouse email lookup
2. distinct_id != recipient_email (explicit recipient_distinct_id): try fast distinct_id lookup first, fall back to email lookup if not found
3. Email fallback always uses the ClickHouse path which won't timeout