### PR TITLE
fix(experiments): update saved metric relations in place instead of recreating.

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -1629,10 +1629,15 @@ class ExperimentService:
         saved_metrics_data: list[dict] = update_data.pop("saved_metrics_ids", []) or []
         update_data.pop("get_feature_flag_key", None)
 
-        # --- saved metrics replacement (delete-all / re-create) -----------
+        # --- saved metrics sync (update-in-place) -----------
         old_saved_metric_uuids: dict[str, set[str]] = {"primary": set(), "secondary": set()}
         if update_saved_metrics:
-            for link in experiment.experimenttosavedmetric_set.select_related("saved_metric").all():
+            existing_links = {
+                link.saved_metric_id: link
+                for link in experiment.experimenttosavedmetric_set.select_related("saved_metric").all()
+            }
+
+            for link in existing_links.values():
                 if link.saved_metric.query:
                     uuid = link.saved_metric.query.get("uuid")
                     if uuid:
@@ -1642,18 +1647,35 @@ class ExperimentService:
                         else:
                             old_saved_metric_uuids["secondary"].add(uuid)
 
-            experiment.experimenttosavedmetric_set.all().delete()
+            new_saved_metric_ids = {sm["id"] for sm in saved_metrics_data}
+            existing_saved_metric_ids = set(existing_links.keys())
+
+            # Delete links no longer in the list
+            to_delete = existing_saved_metric_ids - new_saved_metric_ids
+            if to_delete:
+                experiment.experimenttosavedmetric_set.filter(saved_metric_id__in=to_delete).delete()
+
+            # Update or create links
             for saved_metric_data in saved_metrics_data:
-                saved_metric_serializer = ExperimentToSavedMetricSerializer(
-                    data={
-                        "experiment": experiment.id,
-                        "saved_metric": saved_metric_data["id"],
-                        "metadata": saved_metric_data.get("metadata"),
-                    },
-                    context=context,
-                )
-                saved_metric_serializer.is_valid(raise_exception=True)
-                saved_metric_serializer.save()
+                saved_metric_id = saved_metric_data["id"]
+                new_metadata = saved_metric_data.get("metadata")
+
+                if saved_metric_id in existing_links:
+                    existing_link = existing_links[saved_metric_id]
+                    if existing_link.metadata != new_metadata:
+                        existing_link.metadata = new_metadata
+                        existing_link.save()
+                else:
+                    saved_metric_serializer = ExperimentToSavedMetricSerializer(
+                        data={
+                            "experiment": experiment.id,
+                            "saved_metric": saved_metric_id,
+                            "metadata": new_metadata,
+                        },
+                        context=context,
+                    )
+                    saved_metric_serializer.is_valid(raise_exception=True)
+                    saved_metric_serializer.save()
 
         # --- feature flag sync ------------------------------------------------
         # Draft experiments always sync parameters to the linked feature flag.

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -1650,21 +1650,21 @@ class ExperimentService:
             new_saved_metric_ids = {sm["id"] for sm in saved_metrics_data}
             existing_saved_metric_ids = set(existing_links.keys())
 
-            # Delete links no longer in the list
+            # Delete links no longer in the list (one by one to trigger activity logging)
             to_delete = existing_saved_metric_ids - new_saved_metric_ids
-            if to_delete:
-                experiment.experimenttosavedmetric_set.filter(saved_metric_id__in=to_delete).delete()
+            for saved_metric_id in to_delete:
+                existing_links[saved_metric_id].delete()
 
             # Update or create links
             for saved_metric_data in saved_metrics_data:
                 saved_metric_id = saved_metric_data["id"]
-                new_metadata = saved_metric_data.get("metadata")
+                new_metadata = saved_metric_data.get("metadata") or {}
 
                 if saved_metric_id in existing_links:
                     existing_link = existing_links[saved_metric_id]
-                    if existing_link.metadata != new_metadata:
+                    if (existing_link.metadata or {}) != new_metadata:
                         existing_link.metadata = new_metadata
-                        existing_link.save()
+                        existing_link.save(update_fields=["metadata", "updated_at"])
                 else:
                     saved_metric_serializer = ExperimentToSavedMetricSerializer(
                         data={


### PR DESCRIPTION
## Problem

When updating an experiment's saved metrics, the current implementation deletes all existing `ExperimentToSavedMetric` links and recreates them from scratch. This causes issues for activity logging: since the links are destroyed and recreated, any downstream logging that relies on tracking changes to existing records (rather than delete/create pairs) cannot distinguish between "metadata was updated" and "link was replaced."

This is the first PR in a stack that adds activity logging for saved metric metadata changes on experiments.

## Changes

**`products/experiments/backend/experiment_service.py`**

Changed the saved metrics sync from delete-all/recreate-all to update-in-place:

- Delete only links that are no longer in the new list, using individual `.delete()` calls instead of bulk `QuerySet.delete()`. This allows `ModelActivityMixin.delete()` to fire (once added in a later PR).
- For links that exist in both old and new lists, update metadata in place if changed, using `save(update_fields=["metadata", "updated_at"])`.
- Normalize metadata comparison to handle `None` vs `{}` edge cases.
- Only create new links for saved metrics not already linked.

## How did you test this code?

```bash
python -m pytest products/experiments/backend/test/test_experiment_service.py -k "saved_metric" -xvs
```

![cat-type-small](https://github.com/user-attachments/assets/bb032546-f899-4220-978a-5dac5a3225c1)

Do not publish to changelog.