### PR TITLE
chore(web-analytics): Load Web Analytics immediately with skeletons

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5602,6 +5602,10 @@ snapshots:
         hash: v1.k794b7964.73d195932e14b7f1ed1492148f30bb401d83f5fe2195454d11b1f8a25d27cf18.b3y1l14OGUaGshoCcw-UeRucPusmKqg_P9hrSKkTVEc
     scenes-app-web-analytics--web-analytics-dashboard--light:
         hash: v1.k794b7964.d39a7db817febb31fd2e2f6be9478a531ed200cca876c15bb4471769321688a6.fuln1AuN_ed6kQrQmdORheyl1Mv0Gs3XE2MKkU6BXso
+    scenes-app-web-analytics--web-analytics-dashboard-loading--dark:
+        hash: v1.k794b7964.5b686cb6b3dc8f35afc5a40b19b54a5c65d5c62423bae2040b74ab8347bff101.m4Kq3_tjQi_x7bcj0cmphcuTIBT2QJt068bOJkJq_Pw
+    scenes-app-web-analytics--web-analytics-dashboard-loading--light:
+        hash: v1.k794b7964.c506ce14be8868021d46d08505c68b4aa02e8ba365c96b1846a6b0c29b8ef012.yiG8H3DQPa0nm5g6439G2rS9pQMzYdT-Pd92LODS_Hg
     scenes-other-billing--billing--dark:
         hash: v1.k794b7964.0fbd211a7ee299a4abb1afb6d3d1e0589eb349c82c59bd5997b16e434356ee18.HyWfDl8iMD41jnar9y2uxNCx2MJJ6DuHch0n18cCWBA
     scenes-other-billing--billing--light:
@@ -6202,6 +6206,26 @@ snapshots:
         hash: v1.k794b7964.c17be7ebf593bcdc6ad760d1ae2035be3dadad1e049d39ef6c72b9e093a03067.KVwJMpXcfhchvEMKnnqsNnyBE6EI5d9YIUWIB-08xfY
     utils-autocapture-preview-image--tab-relative-image-with-current-url--light:
         hash: v1.k794b7964.3e7d7a6fa83916bae8280f36864538241c45bd4122e167b299a046939c802b03.oW1U5X9JYmxSLcn72S6kPmgj_jxgZTKyJa0uZ1kbRJs
+    web-analytics-tile-skeletons--chart--dark:
+        hash: v1.k794b7964.7aa1344291af29b3bea21b1b4fc2962bf865899c63cb8137383d5d6e941a96bf.AElvCuEYtP-fom9VLZcolkkA-soqOxUPJLSlN1SB4NE
+    web-analytics-tile-skeletons--chart--light:
+        hash: v1.k794b7964.6c1e2180c137b29ba8be3d6553ef4b8deec9c22a38f55463e30cba14ed1d34c5.87b9nbXOYouiM_9xvTXn5HOfvNJbsUpzeqlZYeQ4mik
+    web-analytics-tile-skeletons--chart-without-legend--dark:
+        hash: v1.k794b7964.845f692ecaca80fe4356669e8c7a15d45ca4c58006264cb51a1163c487a4f309.JFzWDETTmtXIESeVUH8obYnqLS6Bak-Yjvd996KBGaw
+    web-analytics-tile-skeletons--chart-without-legend--light:
+        hash: v1.k794b7964.77408b3f8b309d4339f0417273a2a931c57029981195c44226f9bbb4d3afc9df.5Z8jDyt7Nwzw-ZNP0csEXunO2LMp7h-bNox6BwlmVJA
+    web-analytics-tile-skeletons--table--dark:
+        hash: v1.k794b7964.7e55e08e26710cb46f3d4c200c0027bc40a90589531bf934530fc6eebcf8d38a.njsC9nK1W0uexxQy20vBX7_elrP95KutZTslkqLm5Ek
+    web-analytics-tile-skeletons--table--light:
+        hash: v1.k794b7964.cea7909490517a00c0e428612fbf3a4d9a79b6ca7613de24b65148ea096df8e2.srWljrNqXjKXFVkZsK-_rKZ33m8DQv6JoivUONUPYDg
+    web-analytics-tile-skeletons--table-two-numeric-columns--dark:
+        hash: v1.k794b7964.ea84556f1ebfa8bc051d346eab11f997b7ed558f0613fa44d840a35e7c8d30f8.zQIheEK45WuwDxLUKqL3i9Yah_mUnLT3szAkkNNcIIw
+    web-analytics-tile-skeletons--table-two-numeric-columns--light:
+        hash: v1.k794b7964.fcc68a5033f618a5c4fb5049d0ca96ed581e769358698d116edba5247c1b23a3.cSZYj73vb-FcetmtYnJr0eVBxpHXOG_9t8u6oBUlYSE
+    web-analytics-tile-skeletons--world-map--dark:
+        hash: v1.k794b7964.8eb35c8f5612531f09bed081e0c6795c3f7f5d6d8937a0f6c990dd2da494ae15.g4cj5qqaLIK-ZaNi3i70I56WBA7L8DrXT5SpoCtfWEk
+    web-analytics-tile-skeletons--world-map--light:
+        hash: v1.k794b7964.7660b0d55f180f30895fa224cf38426bd02cffeebf5f66d95c43c47f2e565b9b.HzammpR2_GJwAwUiQ2IzFR61cI5ji6NA3PPwq6Auzl4
     web-analytics-tiles--browser--dark:
         hash: v1.k794b7964.f9113090553180b179c722ac50c23bccba78eccd9f52118e44d2e75508891caa._n7yHWlX4M5OdGHBMMtM9f5-Um0fVBOgTk0h_4yWY-E
     web-analytics-tiles--browser--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -506,6 +506,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_OPEN_URL: 'web-analytics-open-url', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_REGIONS_MAP: 'web-analytics-regions-map', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_SESSION_PROPERTY_CHARTS: 'web-analytics-session-property-charts', // owner: @lricoy #team-web-analytics
+    WEB_ANALYTICS_TILE_SKELETONS: 'web-analytics-tile-skeletons', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_TILE_TOGGLES: 'web-analytics-tile-toggles', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_TOOLTIP_COMPARISON_LABELS: 'web-analytics-tooltip-comparison-labels', // owner: @lricoy #team-web-analytics
     WORKFLOWS_BATCH_TRIGGERS: 'workflows-batch-triggers', // owner: #team-workflows

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.stories.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.stories.tsx
@@ -83,3 +83,33 @@ export function WebAnalyticsDashboard(): JSX.Element {
 
     return <App />
 }
+
+WebAnalyticsDashboardLoading.parameters = {
+    layout: 'fullscreen',
+    viewMode: 'story',
+    mockDate: '2023-02-01',
+    pageUrl: urls.webAnalytics(),
+    featureFlags: [FEATURE_FLAGS.WEB_ANALYTICS_FILTERS_V2, FEATURE_FLAGS.WEB_ANALYTICS_TILE_SKELETONS],
+    testOptions: {
+        includeNavigationInSnapshot: true,
+        waitForLoadersToDisappear: false,
+        waitForSelector: '[data-attr=web-analytics-skeleton-table], [data-attr=web-analytics-skeleton-chart]',
+    },
+    msw: {
+        handlers: [],
+    },
+}
+WebAnalyticsDashboardLoading.decorators = [
+    mswDecorator({
+        get: {
+            '/stats': () => [200, { users_on_product: 2387 }],
+            '/api/projects/:team_id/event_definitions': () => [200, { count: 5 }],
+        },
+        post: {
+            '/api/environments/:team_id/query/:kind': () => new Promise<never>(() => {}),
+        },
+    }),
+]
+export function WebAnalyticsDashboardLoading(): JSX.Element {
+    return <App />
+}

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
-import React, { useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+import React, { useEffect, useRef, useState } from 'react'
 
 import { IconExpand45, IconInfo, IconLineGraph, IconOpenSidebar, IconX } from '@posthog/icons'
 import { LemonSegmentedButton, LemonSegmentedDropdown, LemonSkeleton } from '@posthog/lemon-ui'
@@ -568,6 +569,7 @@ export const WebAnalyticsDashboard = (): JSX.Element => {
     return (
         <BindLogic logic={webAnalyticsLogic} props={{}}>
             <BindLogic logic={dataNodeCollectionLogic} props={{ key: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID }}>
+                <WebAnalyticsLoadTimeTracker />
                 <WebAnalyticsModal />
                 <WebAnalyticsSurveyModal />
                 <SceneContent className="WebAnalyticsDashboard gap-y-2">
@@ -583,6 +585,34 @@ export const WebAnalyticsDashboard = (): JSX.Element => {
             </BindLogic>
         </BindLogic>
     )
+}
+
+const WebAnalyticsLoadTimeTracker = (): null => {
+    const { areAnyLoading } = useValues(dataNodeCollectionLogic({ key: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID }))
+    const { featureFlags } = useValues(featureFlagLogic)
+    const mountStartRef = useRef<number>(performance.now())
+    const hasObservedLoadingRef = useRef<boolean>(false)
+    const hasCapturedLoadedRef = useRef<boolean>(false)
+
+    useOnMountEffect(() => {
+        posthog.capture('web_analytics_dashboard_mounted', {
+            tile_skeletons_enabled: !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_SKELETONS],
+        })
+    })
+
+    useEffect(() => {
+        if (areAnyLoading) {
+            hasObservedLoadingRef.current = true
+        } else if (hasObservedLoadingRef.current && !hasCapturedLoadedRef.current) {
+            hasCapturedLoadedRef.current = true
+            posthog.capture('web_analytics_dashboard_loaded', {
+                duration_ms: Math.round(performance.now() - mountStartRef.current),
+                tile_skeletons_enabled: !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_SKELETONS],
+            })
+        }
+    }, [areAnyLoading, featureFlags])
+
+    return null
 }
 
 const WebAnalyticsTabs = (): JSX.Element => {

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
-import posthog from 'posthog-js'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { IconExpand45, IconInfo, IconLineGraph, IconOpenSidebar, IconX } from '@posthog/icons'
 import { LemonSegmentedButton, LemonSegmentedDropdown, LemonSkeleton } from '@posthog/lemon-ui'
@@ -44,6 +43,7 @@ import { WebAnalyticsErrorTrackingTile } from 'scenes/web-analytics/tiles/WebAna
 import { WebAnalyticsRecordingsTile } from 'scenes/web-analytics/tiles/WebAnalyticsRecordings'
 import { WebQuery } from 'scenes/web-analytics/tiles/WebAnalyticsTile'
 import { WebAnalyticsHealthCheck } from 'scenes/web-analytics/WebAnalyticsHealthCheck'
+import { webAnalyticsLoadTimeLogic } from 'scenes/web-analytics/webAnalyticsLoadTimeLogic'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 import { WebAnalyticsModal } from 'scenes/web-analytics/WebAnalyticsModal'
 
@@ -588,30 +588,7 @@ export const WebAnalyticsDashboard = (): JSX.Element => {
 }
 
 const WebAnalyticsLoadTimeTracker = (): null => {
-    const { areAnyLoading } = useValues(dataNodeCollectionLogic({ key: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID }))
-    const { featureFlags } = useValues(featureFlagLogic)
-    const mountStartRef = useRef<number>(performance.now())
-    const hasObservedLoadingRef = useRef<boolean>(false)
-    const hasCapturedLoadedRef = useRef<boolean>(false)
-
-    useOnMountEffect(() => {
-        posthog.capture('web_analytics_dashboard_mounted', {
-            tile_skeletons_enabled: !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_SKELETONS],
-        })
-    })
-
-    useEffect(() => {
-        if (areAnyLoading) {
-            hasObservedLoadingRef.current = true
-        } else if (hasObservedLoadingRef.current && !hasCapturedLoadedRef.current) {
-            hasCapturedLoadedRef.current = true
-            posthog.capture('web_analytics_dashboard_loaded', {
-                duration_ms: Math.round(performance.now() - mountStartRef.current),
-                tile_skeletons_enabled: !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_SKELETONS],
-            })
-        }
-    }, [areAnyLoading, featureFlags])
-
+    useMountedLogic(webAnalyticsLoadTimeLogic)
     return null
 }
 

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -30,7 +30,6 @@ import {
     countryCodeToFlag,
     languageCodeToFlag,
 } from 'lib/utils/geography/country'
-import { StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -48,12 +47,18 @@ import {
     faviconUrl,
     webStatsBreakdownToPropertyName,
 } from 'scenes/web-analytics/common'
+import {
+    buildDataTableTileDataNodeLogicProps,
+    buildInsightVizTileDataNodeLogicProps,
+    ChartTileSkeleton,
+    TableTileSkeleton,
+    WebAnalyticsTileSkeletonGate,
+    WorldMapTileSkeleton,
+} from 'scenes/web-analytics/tiles/skeletons'
 import { webAnalyticsFilterLogic } from 'scenes/web-analytics/webAnalyticsFilterLogic'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 import { actionsModel } from '~/models/actionsModel'
-import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
-import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { Query } from '~/queries/Query/Query'
 import {
     DataTableNode,
@@ -641,6 +646,20 @@ export const WebStatsTrendTile = ({
     const regionPropertyName = webStatsBreakdownToPropertyName(WebStatsBreakdown.Region)?.key
     const showComparisonLabels = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TOOLTIP_COMPARISON_LABELS]
 
+    const isWorldMap =
+        query.source?.kind === NodeKind.TrendsQuery && query.source.trendsFilter?.display === ChartDisplayType.WorldMap
+    const insightPropsForQuery = useMemo(
+        (): InsightLogicProps => ({
+            ...insightProps,
+            query,
+        }),
+        [insightProps, query]
+    )
+    const dataNodeLogicProps = buildInsightVizTileDataNodeLogicProps({
+        query,
+        insightProps: insightPropsForQuery,
+    })
+
     const onWorldMapClick = useCallback(
         (breakdownValue: string) => {
             if (!worldMapPropertyName) {
@@ -674,8 +693,7 @@ export const WebStatsTrendTile = ({
         const baseContext: QueryContext = {
             ...webAnalyticsDataTableQueryContext,
             insightProps: {
-                ...insightProps,
-                query,
+                ...insightPropsForQuery,
             },
             compareFilter,
             onDateRangeZoom: isDragToZoomEnabled ? zoomIntoPeriod : undefined,
@@ -697,10 +715,6 @@ export const WebStatsTrendTile = ({
         }
 
         // World maps need custom click handler for country filtering, trend lines use default persons modal
-        const isWorldMap =
-            query.source?.kind === NodeKind.TrendsQuery &&
-            query.source.trendsFilter?.display === ChartDisplayType.WorldMap
-
         const isRegionMap =
             isWorldMap &&
             query.source?.kind === NodeKind.TrendsQuery &&
@@ -737,10 +751,11 @@ export const WebStatsTrendTile = ({
         onWorldMapClick,
         onRegionMapClick,
         zoomIntoPeriod,
-        insightProps,
+        insightPropsForQuery,
         query,
         showComparisonLabels,
         isDragToZoomEnabled,
+        isWorldMap,
     ])
 
     return (
@@ -762,7 +777,18 @@ export const WebStatsTrendTile = ({
                     </div>
                 </div>
             )}
-            <Query attachTo={attachTo} query={query} readOnly={true} context={context} />
+            <WebAnalyticsTileSkeletonGate
+                dataNodeLogicProps={dataNodeLogicProps}
+                skeleton={
+                    isWorldMap ? (
+                        <WorldMapTileSkeleton />
+                    ) : (
+                        <ChartTileSkeleton showLegendStrip={!showIntervalTile && !preZoomDateFilter} />
+                    )
+                }
+            >
+                <Query attachTo={attachTo} query={query} readOnly={true} context={context} />
+            </WebAnalyticsTileSkeletonGate>
         </div>
     )
 }
@@ -1018,16 +1044,29 @@ export const WebStatsTableTile = ({
         }
     }, [onClick, insightProps, breakdownBy, key, type, isCompoundBreakdown, query])
 
+    const numericColumns = PAGE_LIKE_BREAKDOWNS.has(breakdownBy) ? 3 : 2
+    const dataNodeLogicProps = buildDataTableTileDataNodeLogicProps({
+        query,
+        insightProps,
+        context,
+        uniqueKey: 'WebAnalytics.WebStatsTableTile',
+    })
+
     return (
         <div className="border rounded bg-surface-primary flex-1 flex flex-col">
             {control != null && <div className="flex flex-row items-center justify-end m-2 mr-4">{control}</div>}
-            <Query
-                uniqueKey="WebAnalytics.WebStatsTableTile"
-                attachTo={attachTo}
-                query={query}
-                readOnly={true}
-                context={context}
-            />
+            <WebAnalyticsTileSkeletonGate
+                dataNodeLogicProps={dataNodeLogicProps}
+                skeleton={<TableTileSkeleton numericColumns={numericColumns} />}
+            >
+                <Query
+                    uniqueKey="WebAnalytics.WebStatsTableTile"
+                    attachTo={attachTo}
+                    query={query}
+                    readOnly={true}
+                    context={context}
+                />
+            </WebAnalyticsTileSkeletonGate>
         </div>
     )
 }
@@ -1093,7 +1132,6 @@ export const WebGoalsTile = ({
 }: QueryWithInsightProps<DataTableNode>): JSX.Element | null => {
     const { actions, actionsLoading } = useValues(actionsModel)
     const { updateHasSeenProductIntroFor } = useActions(userLogic)
-    const { addProductIntentForCrossSell } = useActions(teamLogic)
 
     if (actionsLoading) {
         return null
@@ -1115,6 +1153,17 @@ export const WebGoalsTile = ({
         )
     }
 
+    return <WebGoalsTileContent query={query} insightProps={insightProps} attachTo={attachTo} />
+}
+
+const WebGoalsTileContent = ({ query, insightProps, attachTo }: QueryWithInsightProps<DataTableNode>): JSX.Element => {
+    const { addProductIntentForCrossSell } = useActions(teamLogic)
+
+    const context = useMemo((): QueryContext => {
+        return { ...webAnalyticsDataTableQueryContext, insightProps }
+    }, [insightProps])
+    const dataNodeLogicProps = buildDataTableTileDataNodeLogicProps({ query, insightProps, context })
+
     return (
         <div className="border rounded bg-surface-primary flex-1">
             <div className="flex flex-row-reverse p-2">
@@ -1134,12 +1183,12 @@ export const WebGoalsTile = ({
                     Manage actions
                 </LemonButton>
             </div>
-            <Query
-                attachTo={attachTo}
-                query={query}
-                readOnly={true}
-                context={{ ...webAnalyticsDataTableQueryContext, insightProps }}
-            />
+            <WebAnalyticsTileSkeletonGate
+                dataNodeLogicProps={dataNodeLogicProps}
+                skeleton={<TableTileSkeleton numericColumns={4} />}
+            >
+                <Query attachTo={attachTo} query={query} readOnly={true} context={context} />
+            </WebAnalyticsTileSkeletonGate>
         </div>
     )
 }
@@ -1153,6 +1202,11 @@ export const WebExternalClicksTile = ({
     const { setShouldStripQueryParams } = useActions(webAnalyticsLogic)
 
     const isPageReportsPage = productTab === ProductTab.PAGE_REPORTS
+
+    const context = useMemo((): QueryContext => {
+        return { ...webAnalyticsDataTableQueryContext, insightProps }
+    }, [insightProps])
+    const dataNodeLogicProps = buildDataTableTileDataNodeLogicProps({ query, insightProps, context })
 
     return (
         <div className="border rounded bg-surface-primary flex-1 flex flex-col">
@@ -1168,12 +1222,12 @@ export const WebExternalClicksTile = ({
                     </div>
                 </div>
             )}
-            <Query
-                attachTo={attachTo}
-                query={query}
-                readOnly={true}
-                context={{ ...webAnalyticsDataTableQueryContext, insightProps }}
-            />
+            <WebAnalyticsTileSkeletonGate
+                dataNodeLogicProps={dataNodeLogicProps}
+                skeleton={<TableTileSkeleton numericColumns={2} />}
+            >
+                <Query attachTo={attachTo} query={query} readOnly={true} context={context} />
+            </WebAnalyticsTileSkeletonGate>
         </div>
     )
 }
@@ -1230,18 +1284,6 @@ const BotHogQLTableTile = ({ uniqueKey, attachTo, query, insightProps, tileId }:
     const { setBotAnalyticsFilters } = useActions(botAnalyticsLogic)
     const { rawBotAnalyticsFilters } = useValues(botAnalyticsLogic)
 
-    // Mirror the props DataTable uses internally so we share the same dataNodeLogic instance —
-    // mounting it here lets us drive a richer initial loading state without triggering a duplicate fetch.
-    const dataNodeLogicKey = insightVizDataNodeKey(insightProps)
-    const { response, responseLoading, queryId, pollResponse } = useValues(
-        dataNodeLogic({
-            query: query.source,
-            key: dataNodeLogicKey,
-            dataNodeCollectionId: insightProps.dataNodeCollectionId || dataNodeLogicKey,
-        })
-    )
-    const isInitialLoading = responseLoading && !response
-
     const context = useMemo((): QueryContext => {
         // Single-select toggle: clicking the same value clears it, any other click replaces.
         const toggleFilter = (key: string, value: string): void => {
@@ -1285,16 +1327,16 @@ const BotHogQLTableTile = ({ uniqueKey, attachTo, query, insightProps, tileId }:
             },
         }
     }, [insightProps, tileId, rawBotAnalyticsFilters, setBotAnalyticsFilters])
+    const dataNodeLogicProps = buildDataTableTileDataNodeLogicProps({ query, insightProps, context, uniqueKey })
 
     return (
         <div className="border rounded bg-surface-primary flex-1 flex flex-col py-2 px-1">
-            {isInitialLoading ? (
-                <div className="flex flex-1 p-2 w-full justify-center items-center">
-                    <StatelessInsightLoadingState queryId={queryId} pollResponse={pollResponse} />
-                </div>
-            ) : (
+            <WebAnalyticsTileSkeletonGate
+                dataNodeLogicProps={dataNodeLogicProps}
+                skeleton={<TableTileSkeleton numericColumns={2} />}
+            >
                 <Query uniqueKey={uniqueKey} attachTo={attachTo} query={query} readOnly={true} context={context} />
-            )}
+            </WebAnalyticsTileSkeletonGate>
         </div>
     )
 }
@@ -1337,21 +1379,12 @@ export const WebQuery = ({
         // Handle Frustrating Pages tile specifically, which uses WebStatsTableQuery but is not wrapped by a WebAnalyticsTabTile
         if (query.source.breakdownBy === WebStatsBreakdown.FrustrationMetrics) {
             return (
-                <div className="border rounded bg-surface-primary flex-1 flex flex-col py-2 px-1">
-                    <Query
-                        attachTo={attachTo}
-                        query={query}
-                        key={uniqueKey}
-                        readOnly={true}
-                        context={{
-                            ...webAnalyticsDataTableQueryContext,
-                            insightProps,
-                            emptyStateHeading: '',
-                            emptyStateDetail: FrustrationMetricsEmptyState,
-                            emptyStateIcon: <></>,
-                        }}
-                    />
-                </div>
+                <FrustrationMetricsTile
+                    attachTo={attachTo}
+                    query={query}
+                    insightProps={insightProps}
+                    uniqueKey={uniqueKey}
+                />
             )
         }
 
@@ -1449,6 +1482,40 @@ export const WebQuery = ({
             readOnly={true}
             context={{ ...webAnalyticsDataTableQueryContext, insightProps }}
         />
+    )
+}
+
+const FrustrationMetricsTile = ({
+    query,
+    insightProps,
+    attachTo,
+    uniqueKey,
+}: {
+    query: DataTableNode
+    insightProps: InsightLogicProps
+    attachTo?: BuiltLogic | LogicWrapper
+    uniqueKey: string
+}): JSX.Element => {
+    const context = useMemo((): QueryContext => {
+        return {
+            ...webAnalyticsDataTableQueryContext,
+            insightProps,
+            emptyStateHeading: '',
+            emptyStateDetail: FrustrationMetricsEmptyState,
+            emptyStateIcon: <></>,
+        }
+    }, [insightProps])
+    const dataNodeLogicProps = buildDataTableTileDataNodeLogicProps({ query, insightProps, context })
+
+    return (
+        <div className="border rounded bg-surface-primary flex-1 flex flex-col py-2 px-1">
+            <WebAnalyticsTileSkeletonGate
+                dataNodeLogicProps={dataNodeLogicProps}
+                skeleton={<TableTileSkeleton numericColumns={3} />}
+            >
+                <Query attachTo={attachTo} query={query} key={uniqueKey} readOnly={true} context={context} />
+            </WebAnalyticsTileSkeletonGate>
+        </div>
     )
 }
 

--- a/frontend/src/scenes/web-analytics/tiles/skeletons/ChartTileSkeleton.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/skeletons/ChartTileSkeleton.tsx
@@ -1,0 +1,58 @@
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { range } from 'lib/utils'
+
+export interface ChartTileSkeletonProps {
+    bars?: number
+    showLegendStrip?: boolean
+}
+
+const BAR_HEIGHTS_PERCENT = [40, 55, 60, 50, 70, 80, 65, 75, 90, 70, 80, 95, 85, 75, 60, 70, 55, 65, 75, 80]
+const AXIS_TICK_COUNT = 6
+
+export function ChartTileSkeleton({ bars = 14, showLegendStrip = true }: ChartTileSkeletonProps): JSX.Element {
+    const heights = range(bars).map((i) => BAR_HEIGHTS_PERCENT[i % BAR_HEIGHTS_PERCENT.length])
+
+    return (
+        <div data-attr="web-analytics-skeleton-chart" className="flex flex-col flex-1 min-h-72">
+            {showLegendStrip && (
+                <div
+                    data-attr="web-analytics-skeleton-chart-legend"
+                    className="flex flex-row items-center justify-between px-4 py-3 gap-2"
+                >
+                    <div className="flex flex-row items-center gap-2">
+                        <LemonSkeleton.Circle className="h-3 w-3" />
+                        <LemonSkeleton className="h-3 w-24" />
+                    </div>
+                    <LemonSkeleton className="h-6 w-20" />
+                </div>
+            )}
+            <div
+                data-attr="web-analytics-skeleton-chart-bars"
+                className="relative flex-1 flex items-end gap-1 px-4 pb-8 pt-2 min-h-56"
+            >
+                {heights.map((height, i) => (
+                    <div
+                        key={i}
+                        data-attr="web-analytics-skeleton-chart-bar"
+                        className="flex-1 flex items-end"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ height: `${height}%` }}
+                    >
+                        <LemonSkeleton className="w-full h-full" />
+                    </div>
+                ))}
+                <div className="absolute bottom-6 left-4 right-4">
+                    <LemonSkeleton className="h-px w-full" />
+                </div>
+            </div>
+            <div
+                data-attr="web-analytics-skeleton-chart-axis-ticks"
+                className="flex flex-row items-center justify-between px-4 pb-3 gap-2"
+            >
+                {range(AXIS_TICK_COUNT).map((i) => (
+                    <LemonSkeleton key={i} className="h-2 w-8" />
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/web-analytics/tiles/skeletons/TableTileSkeleton.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/skeletons/TableTileSkeleton.tsx
@@ -1,0 +1,51 @@
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { range } from 'lib/utils'
+
+export interface TableTileSkeletonProps {
+    rows?: number
+    numericColumns?: number
+}
+
+const LABEL_WIDTHS = ['w-40', 'w-32', 'w-44', 'w-28', 'w-36', 'w-40', 'w-24', 'w-32']
+
+function rowLabelWidthClass(i: number): string {
+    return LABEL_WIDTHS[i % LABEL_WIDTHS.length]
+}
+
+export function TableTileSkeleton({ rows = 8, numericColumns = 3 }: TableTileSkeletonProps): JSX.Element {
+    return (
+        <div data-attr="web-analytics-skeleton-table" className="flex flex-col flex-1">
+            <div
+                data-attr="web-analytics-skeleton-table-header"
+                className="flex flex-row items-center justify-between border-b px-3 py-2 gap-4"
+            >
+                <LemonSkeleton className="h-3 w-24" />
+                <div
+                    data-attr="web-analytics-skeleton-table-header-numeric"
+                    className="flex flex-row items-center gap-4"
+                >
+                    {range(numericColumns).map((i) => (
+                        <LemonSkeleton key={i} className="h-3 w-12" />
+                    ))}
+                </div>
+            </div>
+            <div data-attr="web-analytics-skeleton-table-body" className="flex flex-col">
+                {range(rows).map((i) => (
+                    <div
+                        key={i}
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ opacity: 1 - i / (rows + 2) }}
+                        className="flex flex-row items-center justify-between px-3 py-2 gap-4"
+                    >
+                        <LemonSkeleton className={`h-3 ${rowLabelWidthClass(i)}`} />
+                        <div className="flex flex-row items-center gap-4">
+                            {range(numericColumns).map((j) => (
+                                <LemonSkeleton key={j} className="h-3 w-12" />
+                            ))}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/web-analytics/tiles/skeletons/WebAnalyticsTileSkeletons.stories.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/skeletons/WebAnalyticsTileSkeletons.stories.tsx
@@ -1,0 +1,67 @@
+import { Meta } from '@storybook/react'
+
+import { ChartTileSkeleton, TableTileSkeleton, WorldMapTileSkeleton } from './index'
+
+const meta: Meta = {
+    title: 'Web Analytics/Tile Skeletons',
+    parameters: {
+        layout: 'padded',
+        testOptions: {
+            waitForLoadersToDisappear: false,
+        },
+        docs: {
+            description: {
+                component:
+                    'Content-shaped loading skeletons used inside the web analytics dashboard while each tile fetches its data. ' +
+                    'They render in place of the inner `<Query>` when `responseLoading && !response` — filter refetches keep ' +
+                    'the previous data visible instead.',
+            },
+        },
+    },
+    tags: ['autodocs'],
+}
+export default meta
+
+function TileChrome({ children }: { children: React.ReactNode }): JSX.Element {
+    return <div className="border rounded bg-surface-primary flex-1 flex flex-col py-2 px-1 w-160">{children}</div>
+}
+
+export function Table(): JSX.Element {
+    return (
+        <TileChrome>
+            <TableTileSkeleton />
+        </TileChrome>
+    )
+}
+
+export function TableTwoNumericColumns(): JSX.Element {
+    return (
+        <TileChrome>
+            <TableTileSkeleton numericColumns={2} />
+        </TileChrome>
+    )
+}
+
+export function Chart(): JSX.Element {
+    return (
+        <TileChrome>
+            <ChartTileSkeleton />
+        </TileChrome>
+    )
+}
+
+export function ChartWithoutLegend(): JSX.Element {
+    return (
+        <TileChrome>
+            <ChartTileSkeleton showLegendStrip={false} />
+        </TileChrome>
+    )
+}
+
+export function WorldMap(): JSX.Element {
+    return (
+        <TileChrome>
+            <WorldMapTileSkeleton />
+        </TileChrome>
+    )
+}

--- a/frontend/src/scenes/web-analytics/tiles/skeletons/WorldMapTileSkeleton.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/skeletons/WorldMapTileSkeleton.tsx
@@ -1,0 +1,13 @@
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+
+export function WorldMapTileSkeleton(): JSX.Element {
+    return (
+        <div data-attr="web-analytics-skeleton-world-map" className="flex flex-col flex-1 px-4 py-4 gap-3">
+            <LemonSkeleton className="w-full aspect-[2/1] rounded-md" />
+            <div className="flex flex-row items-center justify-between">
+                <LemonSkeleton className="h-3 w-24" />
+                <LemonSkeleton className="h-3 w-32" />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/web-analytics/tiles/skeletons/index.ts
+++ b/frontend/src/scenes/web-analytics/tiles/skeletons/index.ts
@@ -1,0 +1,10 @@
+export { ChartTileSkeleton } from './ChartTileSkeleton'
+export type { ChartTileSkeletonProps } from './ChartTileSkeleton'
+export { TableTileSkeleton } from './TableTileSkeleton'
+export type { TableTileSkeletonProps } from './TableTileSkeleton'
+export {
+    buildDataTableTileDataNodeLogicProps,
+    buildInsightVizTileDataNodeLogicProps,
+    WebAnalyticsTileSkeletonGate,
+} from './useTileSkeletonLoading'
+export { WorldMapTileSkeleton } from './WorldMapTileSkeleton'

--- a/frontend/src/scenes/web-analytics/tiles/skeletons/skeletons.test.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/skeletons/skeletons.test.tsx
@@ -1,0 +1,149 @@
+import { render } from '@testing-library/react'
+
+import {
+    AnyResponseType,
+    DashboardFilter,
+    DataTableNode,
+    HogQLVariable,
+    InsightVizNode,
+    NodeKind,
+} from '~/queries/schema/schema-general'
+import { QueryContext } from '~/queries/types'
+import { getAllByDataAttr, getByDataAttr, queryByDataAttr } from '~/test/byDataAttr'
+import { InsightLogicProps } from '~/types'
+
+import {
+    buildDataTableTileDataNodeLogicProps,
+    buildInsightVizTileDataNodeLogicProps,
+    ChartTileSkeleton,
+    TableTileSkeleton,
+    WorldMapTileSkeleton,
+} from './index'
+
+describe('web analytics tile skeletons', () => {
+    describe('data node logic prop builders', () => {
+        test('preserves InsightViz data node props', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: { kind: NodeKind.TrendsQuery, series: [] },
+            } as InsightVizNode
+            const cachedResults = { result: [] } as unknown as AnyResponseType
+            const filtersOverride = { date_from: '-24h' } as DashboardFilter
+            const variablesOverride = {} as Record<string, HogQLVariable>
+            const onData = jest.fn()
+            const insightProps = {
+                dashboardItemId: 'trend-tile',
+                dataNodeCollectionId: 'web-analytics',
+                doNotLoad: true,
+                onData,
+                loadPriority: 3,
+            } as unknown as InsightLogicProps
+
+            expect(
+                buildInsightVizTileDataNodeLogicProps({
+                    query,
+                    insightProps,
+                    cachedResults,
+                    filtersOverride,
+                    variablesOverride,
+                    limitContext: 'posthog_ai',
+                })
+            ).toEqual({
+                query: query.source,
+                key: 'InsightViz.trend-tile',
+                cachedResults,
+                doNotLoad: true,
+                onData,
+                loadPriority: 3,
+                dataNodeCollectionId: 'web-analytics',
+                filtersOverride,
+                variablesOverride,
+                limitContext: 'posthog_ai',
+            })
+        })
+
+        test('preserves DataTable data node props from query context', () => {
+            const query = {
+                kind: NodeKind.DataTableNode,
+                source: { kind: NodeKind.HogQLQuery, query: 'select 1' },
+            } as DataTableNode
+            const cachedResults = { results: [] } as unknown as AnyResponseType
+            const insightProps = {
+                dashboardItemId: 'table-tile',
+                dataNodeCollectionId: 'web-analytics',
+            } as InsightLogicProps
+            const context: QueryContext = {
+                insightProps,
+                dataNodeLogicKey: 'custom-data-node-key',
+                refresh: 'force_async',
+                dataTableMaxPaginationLimit: 50,
+                limitContext: 'posthog_ai',
+            }
+
+            expect(
+                buildDataTableTileDataNodeLogicProps({
+                    query,
+                    insightProps,
+                    context,
+                    cachedResults,
+                    uniqueKey: 'WebAnalytics.WebStatsTableTile',
+                })
+            ).toEqual({
+                query: query.source,
+                key: 'custom-data-node-key',
+                cachedResults,
+                dataNodeCollectionId: 'web-analytics',
+                refresh: 'force_async',
+                maxPaginationLimit: 50,
+                limitContext: 'posthog_ai',
+            })
+        })
+    })
+
+    describe('TableTileSkeleton', () => {
+        test('renders the default 8 body rows', () => {
+            const { container } = render(<TableTileSkeleton />)
+            const body = getByDataAttr(container, 'web-analytics-skeleton-table-body')
+            expect(body.children.length).toBe(8)
+        })
+
+        test('honors the rows prop', () => {
+            const { container } = render(<TableTileSkeleton rows={3} />)
+            const body = getByDataAttr(container, 'web-analytics-skeleton-table-body')
+            expect(body.children.length).toBe(3)
+        })
+
+        test('honors numericColumns prop in the header', () => {
+            const { container } = render(<TableTileSkeleton numericColumns={5} />)
+            const numericContainer = getByDataAttr(container, 'web-analytics-skeleton-table-header-numeric')
+            expect(numericContainer.children.length).toBe(5)
+        })
+    })
+
+    describe('ChartTileSkeleton', () => {
+        test('renders 14 bars by default', () => {
+            const { container } = render(<ChartTileSkeleton />)
+            expect(getAllByDataAttr(container, 'web-analytics-skeleton-chart-bar').length).toBe(14)
+        })
+
+        test('honors the bars prop', () => {
+            const { container } = render(<ChartTileSkeleton bars={6} />)
+            expect(getAllByDataAttr(container, 'web-analytics-skeleton-chart-bar').length).toBe(6)
+        })
+
+        test('hides the legend strip when showLegendStrip=false', () => {
+            const { container } = render(<ChartTileSkeleton showLegendStrip={false} />)
+            expect(queryByDataAttr(container, 'web-analytics-skeleton-chart-legend')).toBeNull()
+        })
+
+        test('shows the legend strip by default', () => {
+            const { container } = render(<ChartTileSkeleton />)
+            expect(queryByDataAttr(container, 'web-analytics-skeleton-chart-legend')).not.toBeNull()
+        })
+    })
+
+    test('WorldMapTileSkeleton renders its root', () => {
+        const { container } = render(<WorldMapTileSkeleton />)
+        expect(getByDataAttr(container, 'web-analytics-skeleton-world-map')).toBeTruthy()
+    })
+})

--- a/frontend/src/scenes/web-analytics/tiles/skeletons/useTileSkeletonLoading.ts
+++ b/frontend/src/scenes/web-analytics/tiles/skeletons/useTileSkeletonLoading.ts
@@ -1,0 +1,116 @@
+import { useValues } from 'kea'
+import { createElement } from 'react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightVizDataCollectionId, insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import { getCachedResults } from '~/queries/nodes/InsightViz/utils'
+import {
+    AnyResponseType,
+    DashboardFilter,
+    DataTableNode,
+    HogQLVariable,
+    InsightVizNode,
+} from '~/queries/schema/schema-general'
+import { QueryContext } from '~/queries/types'
+import { InsightLogicProps } from '~/types'
+
+interface WebAnalyticsTileSkeletonGateProps {
+    dataNodeLogicProps: DataNodeLogicProps
+    skeleton: JSX.Element
+    children: JSX.Element
+}
+
+interface WebAnalyticsTileSkeletonLoaderProps {
+    dataNodeLogicProps: DataNodeLogicProps
+    skeleton: JSX.Element
+    children?: JSX.Element
+}
+
+interface BuildInsightVizTileDataNodeLogicPropsParams {
+    query: InsightVizNode
+    insightProps: InsightLogicProps
+    cachedResults?: AnyResponseType
+    filtersOverride?: DashboardFilter | null
+    variablesOverride?: Record<string, HogQLVariable> | null
+    limitContext?: QueryContext['limitContext']
+}
+
+interface BuildDataTableTileDataNodeLogicPropsParams {
+    query: DataTableNode
+    insightProps: InsightLogicProps
+    context?: QueryContext
+    cachedResults?: AnyResponseType
+    uniqueKey?: string | number
+}
+
+export function buildInsightVizTileDataNodeLogicProps({
+    query,
+    insightProps,
+    cachedResults,
+    filtersOverride,
+    variablesOverride,
+    limitContext,
+}: BuildInsightVizTileDataNodeLogicPropsParams): DataNodeLogicProps {
+    const dataNodeLogicKey = insightVizDataNodeKey(insightProps)
+
+    return {
+        query: query.source,
+        key: dataNodeLogicKey,
+        cachedResults: cachedResults || getCachedResults(insightProps.cachedInsight, query.source),
+        doNotLoad: insightProps.doNotLoad,
+        onData: insightProps.onData,
+        loadPriority: insightProps.loadPriority,
+        dataNodeCollectionId: insightVizDataCollectionId(insightProps, dataNodeLogicKey),
+        filtersOverride,
+        variablesOverride,
+        limitContext,
+    }
+}
+
+export function buildDataTableTileDataNodeLogicProps({
+    query,
+    insightProps,
+    context,
+    cachedResults,
+    uniqueKey,
+}: BuildDataTableTileDataNodeLogicPropsParams): DataNodeLogicProps {
+    const dataNodeLogicKey = insightVizDataNodeKey(insightProps)
+    const dataKey = uniqueKey === undefined ? dataNodeLogicKey : `DataNode.${uniqueKey}`
+
+    return {
+        query: query.source,
+        key: context?.dataNodeLogicKey ?? dataNodeLogicKey,
+        cachedResults,
+        dataNodeCollectionId: context?.insightProps?.dataNodeCollectionId || dataKey,
+        refresh: context?.refresh,
+        maxPaginationLimit: context?.dataTableMaxPaginationLimit,
+        limitContext: context?.limitContext,
+    }
+}
+
+export function WebAnalyticsTileSkeletonGate({
+    dataNodeLogicProps,
+    skeleton,
+    children,
+}: WebAnalyticsTileSkeletonGateProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    if (!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_SKELETONS]) {
+        return children
+    }
+
+    return createElement(WebAnalyticsTileSkeletonLoader, { dataNodeLogicProps, skeleton }, children)
+}
+
+function WebAnalyticsTileSkeletonLoader({
+    dataNodeLogicProps,
+    skeleton,
+    children,
+}: WebAnalyticsTileSkeletonLoaderProps): JSX.Element {
+    const { response, responseLoading } = useValues(dataNodeLogic(dataNodeLogicProps))
+
+    return responseLoading && !response ? skeleton : (children ?? skeleton)
+}

--- a/frontend/src/scenes/web-analytics/webAnalyticsLoadTimeLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLoadTimeLogic.test.ts
@@ -1,0 +1,100 @@
+import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
+
+import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
+import { initKeaTests } from '~/test/init'
+
+import { WEB_ANALYTICS_DATA_COLLECTION_NODE_ID } from './common'
+import { webAnalyticsLoadTimeLogic } from './webAnalyticsLoadTimeLogic'
+
+jest.mock('posthog-js')
+
+describe('webAnalyticsLoadTimeLogic', () => {
+    let logic: ReturnType<typeof webAnalyticsLoadTimeLogic.build>
+    let collection: ReturnType<typeof dataNodeCollectionLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        collection = dataNodeCollectionLogic({ key: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID })
+        collection.mount()
+        ;(posthog.capture as jest.Mock).mockClear()
+        logic = webAnalyticsLoadTimeLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        collection.unmount()
+    })
+
+    it('captures dashboard_mounted on mount', () => {
+        expect(posthog.capture).toHaveBeenCalledWith(
+            'web_analytics_dashboard_mounted',
+            expect.objectContaining({ tile_skeletons_enabled: expect.any(Boolean) })
+        )
+    })
+
+    it('captures dashboard_loaded once after first loading→idle transition', async () => {
+        await expectLogic(logic, () => {
+            collection.actions.collectionNodeLoadData('a')
+        }).toMatchValues({ areAnyLoading: true })
+
+        await expectLogic(logic, () => {
+            collection.actions.collectionNodeLoadDataSuccess('a')
+        }).toMatchValues({ areAnyLoading: false })
+
+        expect(posthog.capture).toHaveBeenCalledWith(
+            'web_analytics_dashboard_loaded',
+            expect.objectContaining({ duration_ms: expect.any(Number), tile_skeletons_enabled: expect.any(Boolean) })
+        )
+
+        const loadedCallsBefore = (posthog.capture as jest.Mock).mock.calls.filter(
+            ([event]) => event === 'web_analytics_dashboard_loaded'
+        ).length
+
+        collection.actions.collectionNodeLoadData('b')
+        collection.actions.collectionNodeLoadDataSuccess('b')
+
+        const loadedCallsAfter = (posthog.capture as jest.Mock).mock.calls.filter(
+            ([event]) => event === 'web_analytics_dashboard_loaded'
+        ).length
+        expect(loadedCallsAfter).toBe(loadedCallsBefore)
+    })
+
+    it('captures dashboard_loaded on the last finishing node, not the first', async () => {
+        collection.actions.collectionNodeLoadData('a')
+        collection.actions.collectionNodeLoadData('b')
+
+        const captureCount = (): number =>
+            (posthog.capture as jest.Mock).mock.calls.filter(([event]) => event === 'web_analytics_dashboard_loaded')
+                .length
+
+        collection.actions.collectionNodeLoadDataSuccess('a')
+        expect(captureCount()).toBe(0)
+
+        await expectLogic(logic, () => {
+            collection.actions.collectionNodeLoadDataSuccess('b')
+        }).toMatchValues({ areAnyLoading: false })
+        expect(captureCount()).toBe(1)
+    })
+
+    it('also captures dashboard_loaded when the last node fails', async () => {
+        collection.actions.collectionNodeLoadData('a')
+
+        await expectLogic(logic, () => {
+            collection.actions.collectionNodeLoadDataFailure('a')
+        }).toMatchValues({ areAnyLoading: false })
+
+        expect(posthog.capture).toHaveBeenCalledWith(
+            'web_analytics_dashboard_loaded',
+            expect.objectContaining({ duration_ms: expect.any(Number) })
+        )
+    })
+
+    it('does not capture dashboard_loaded if no loading was ever observed', () => {
+        const loadedCalls = (posthog.capture as jest.Mock).mock.calls.filter(
+            ([event]) => event === 'web_analytics_dashboard_loaded'
+        )
+        expect(loadedCalls).toHaveLength(0)
+    })
+})

--- a/frontend/src/scenes/web-analytics/webAnalyticsLoadTimeLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLoadTimeLogic.ts
@@ -1,0 +1,63 @@
+import { afterMount, connect, kea, listeners, path, reducers, selectors, sharedListeners } from 'kea'
+import posthog from 'posthog-js'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
+
+import { WEB_ANALYTICS_DATA_COLLECTION_NODE_ID } from './common'
+import type { webAnalyticsLoadTimeLogicType } from './webAnalyticsLoadTimeLogicType'
+
+export const webAnalyticsLoadTimeLogic = kea<webAnalyticsLoadTimeLogicType>([
+    path(['scenes', 'webAnalytics', 'webAnalyticsLoadTimeLogic']),
+    connect(() => ({
+        actions: [
+            dataNodeCollectionLogic({ key: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID }),
+            ['collectionNodeLoadData', 'collectionNodeLoadDataSuccess', 'collectionNodeLoadDataFailure'],
+        ],
+        values: [
+            dataNodeCollectionLogic({ key: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID }),
+            ['areAnyLoading'],
+            featureFlagLogic,
+            ['featureFlags'],
+        ],
+    })),
+    reducers({
+        hasObservedLoading: [
+            false,
+            {
+                collectionNodeLoadData: () => true,
+            },
+        ],
+    }),
+    selectors({
+        tileSkeletonsEnabled: [
+            (s) => [s.featureFlags],
+            (flags: FeatureFlagsSet): boolean => !!flags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_SKELETONS],
+        ],
+    }),
+    sharedListeners(({ cache, values }) => ({
+        maybeCaptureLoaded: () => {
+            if (values.areAnyLoading || !values.hasObservedLoading || cache.hasCapturedLoaded) {
+                return
+            }
+            cache.hasCapturedLoaded = true
+            posthog.capture('web_analytics_dashboard_loaded', {
+                duration_ms: Math.round(performance.now() - cache.mountStart),
+                tile_skeletons_enabled: values.tileSkeletonsEnabled,
+            })
+        },
+    })),
+    listeners(({ sharedListeners }) => ({
+        collectionNodeLoadDataSuccess: sharedListeners.maybeCaptureLoaded,
+        collectionNodeLoadDataFailure: sharedListeners.maybeCaptureLoaded,
+    })),
+    afterMount(({ cache, values }) => {
+        cache.mountStart = performance.now()
+        cache.hasCapturedLoaded = false
+        posthog.capture('web_analytics_dashboard_mounted', {
+            tile_skeletons_enabled: values.tileSkeletonsEnabled,
+        })
+    }),
+])


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
Initial loading of Web Analytics is slowed down by waiting for queries causing a long spinner animation 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Load the dashboard immediately while querying in the background. 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
