### PR TITLE
feat(flags): evolve cache instrumentation

### DIFF
--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -32,7 +32,7 @@ pub mod writer;
 use anyhow::Result;
 use aws_config::BehaviorVersion;
 use aws_sdk_s3::Client as AwsS3SdkClient;
-use common_metrics::inc;
+use common_metrics::{histogram, inc};
 use common_redis::Client as RedisClient;
 #[cfg(all(test, feature = "mock-client"))]
 use common_s3::MockS3Client;
@@ -44,7 +44,7 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::fmt::{self, Display};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use thiserror::Error;
 use tokio::time::timeout;
 use tracing::debug;
@@ -54,6 +54,14 @@ pub const HYPERCACHE_COUNTER_NAME: &str = "posthog_hypercache_get_from_cache";
 
 /// Metric name for tracking Redis failure reasons (timeout, get_error, pickle_error, json_error)
 const HYPERCACHE_REDIS_MISS_REASON_COUNTER_NAME: &str = "posthog_hypercache_redis_miss_reason";
+
+/// Per-tier latency histogram for the Redis read inside `get_typed_with_source`.
+/// Labels: `namespace`, `value`, `outcome` (hit | miss | timeout | error).
+pub const HYPERCACHE_REDIS_OP_MS: &str = "posthog_hypercache_redis_op_ms";
+
+/// Per-tier latency histogram for the S3 read inside `get_typed_with_source`.
+/// Labels: `namespace`, `value`, `outcome` (hit | miss | timeout | error).
+pub const HYPERCACHE_S3_OP_MS: &str = "posthog_hypercache_s3_op_ms";
 
 /// Tombstone metric for tracking "impossible" failures that should never happen in production.
 /// This is duplicated from feature_flags::metrics::consts::TOMBSTONE_COUNTER because hypercache
@@ -477,12 +485,28 @@ impl HyperCacheReader {
         let mut infra_error: Option<HyperCacheError> = None;
 
         // Try Redis first
-        match timeout(
+        let redis_start = Instant::now();
+        let redis_result = timeout(
             self.config.redis_timeout,
             self.try_get_typed_from_redis::<T>(&redis_cache_key),
         )
-        .await
-        {
+        .await;
+        let redis_outcome = match &redis_result {
+            Ok(Ok(_)) => "hit",
+            Ok(Err(HyperCacheError::CacheMiss)) => "miss",
+            Ok(Err(_)) => "error",
+            Err(_) => "timeout",
+        };
+        histogram(
+            HYPERCACHE_REDIS_OP_MS,
+            &[
+                ("namespace".to_string(), self.config.namespace.clone()),
+                ("value".to_string(), self.config.object_name.clone()),
+                ("outcome".to_string(), redis_outcome.to_string()),
+            ],
+            redis_start.elapsed().as_secs_f64() * 1000.0,
+        );
+        match redis_result {
             Ok(Ok(Some(data))) => {
                 debug!(
                     cache_key = %redis_cache_key,
@@ -551,12 +575,28 @@ impl HyperCacheReader {
 
         // Try S3 fallback
         let s3_cache_key = self.config.get_s3_cache_key(key);
-        match timeout(
+        let s3_start = Instant::now();
+        let s3_result = timeout(
             self.config.s3_timeout,
             self.try_get_typed_from_s3::<T>(&s3_cache_key),
         )
-        .await
-        {
+        .await;
+        let s3_outcome = match &s3_result {
+            Ok(Ok(_)) => "hit",
+            Ok(Err(HyperCacheError::S3(S3Error::NotFound(_)))) => "miss",
+            Ok(Err(_)) => "error",
+            Err(_) => "timeout",
+        };
+        histogram(
+            HYPERCACHE_S3_OP_MS,
+            &[
+                ("namespace".to_string(), self.config.namespace.clone()),
+                ("value".to_string(), self.config.object_name.clone()),
+                ("outcome".to_string(), s3_outcome.to_string()),
+            ],
+            s3_start.elapsed().as_secs_f64() * 1000.0,
+        );
+        match s3_result {
             Ok(Ok(data)) => {
                 debug!(
                     cache_key = %s3_cache_key,

--- a/rust/feature-flags/src/metrics/buckets.rs
+++ b/rust/feature-flags/src/metrics/buckets.rs
@@ -106,5 +106,13 @@ pub fn bucket_overrides() -> Vec<(Matcher, &'static [f64])> {
             Matcher::Full("flags_definitions_inmem_load_ms".into()),
             INMEM_LOAD_BUCKETS_MS,
         ),
+        (
+            Matcher::Full("posthog_hypercache_redis_op_ms".into()),
+            INMEM_LOAD_BUCKETS_MS,
+        ),
+        (
+            Matcher::Full("posthog_hypercache_s3_op_ms".into()),
+            INMEM_LOAD_BUCKETS_MS,
+        ),
     ]
 }

--- a/rust/feature-flags/src/metrics/buckets.rs
+++ b/rust/feature-flags/src/metrics/buckets.rs
@@ -60,6 +60,16 @@ const INMEM_LOAD_BUCKETS_MS: &[f64] = &[
     0.05, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 5000.0, 10000.0,
 ];
 
+// HyperCache S3 read. Network-bound: warm S3 reads sit in the 5-50ms
+// band, so the sub-ms buckets that `INMEM_LOAD_BUCKETS_MS` carries for
+// Redis would be permanently empty here. 1ms floor still captures
+// immediate errors (short-circuit before any network call) without
+// losing them in an unbounded `<le_inf>` bucket. 10s ceiling covers the
+// 3s `s3_timeout` plus headroom for the post-timeout emission.
+const S3_OP_BUCKETS_MS: &[f64] = &[
+    1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0,
+];
+
 /// Returns the bucket-override matrix for the feature-flags recorder.
 ///
 /// `Matcher::Suffix` is used for `_queue_time_ms` / `_pre_handler_time_ms`
@@ -112,7 +122,7 @@ pub fn bucket_overrides() -> Vec<(Matcher, &'static [f64])> {
         ),
         (
             Matcher::Full("posthog_hypercache_s3_op_ms".into()),
-            INMEM_LOAD_BUCKETS_MS,
+            S3_OP_BUCKETS_MS,
         ),
     ]
 }


### PR DESCRIPTION
## Problem

The `/flags` `config_response` phase suffers multi-second p99/p999 spikes. The existing counters (`posthog_hypercache_get_from_cache`, `posthog_hypercache_redis_miss_reason`) tell us which tier served each read but not how long each tier took, so we cannot baseline current Redis and S3 latency distributions ahead of the upcoming writer fix or attribute residual spikes to a specific tier afterwards.

## Changes

Adds two purely additive latency histograms emitted from `get_typed_with_source` so per tier timing is observable in Prometheus.

* `rust/common/hypercache/src/lib.rs` declares `HYPERCACHE_REDIS_OP_MS = "posthog_hypercache_redis_op_ms"` and `HYPERCACHE_S3_OP_MS = "posthog_hypercache_s3_op_ms"` next to the existing counter constants. Each `timeout(...).await` in `get_typed_with_source` is now wrapped in `Instant::now()` plus a `common_metrics::histogram` emission with labels `namespace`, `value`, and `outcome`. The `outcome` label uses a coarse vocabulary: `hit`, `miss`, `timeout`, `error`. Existing match arms and control flow are untouched.
* `rust/feature-flags/src/metrics/buckets.rs` registers each metric via `Matcher::Full` against a ladder shaped for its tier. Redis lands on the existing `INMEM_LOAD_BUCKETS_MS` (0.05ms-10s) so warm Redis hits do not collapse into the default 1ms floor. S3 gets a dedicated `S3_OP_BUCKETS_MS` (1ms-10s) that drops the sub-ms buckets — network-bound S3 reads sit in the 5-50ms band at the floor, so the sub-ms buckets `INMEM_LOAD_BUCKETS_MS` carries for Redis would be permanently empty here. The 10s ceiling on both covers the 3s `s3_timeout` plus headroom. `hypercache-server` is intentionally not touched; the latency question is about feature flags traffic.

No behavior change. The two new histograms fire on every `get_typed_with_source` call from any consumer, but only the feature flags binary gets tuned buckets.

## How did you test this code?

* `cargo check -p common-hypercache -p feature-flags`: clean.
* `cargo test -p common-hypercache --lib`: 48 of 48 passed. Integration tests require a live Redis and S3 and are skipped locally; they share the same code path as the unit suite.
* `cargo clippy -p common-hypercache -p feature-flags --lib --tests --bins -- -D warnings`: clean. Preexisting `get_match` arity errors in `feature-flags/benches/flag_evaluation.rs` exist on master and are out of scope.

## Publish to changelog?

no

Decisions worth flagging.

* Metric names use the `posthog_hypercache_*` prefix to match the existing `posthog_hypercache_get_from_cache` and `posthog_hypercache_redis_miss_reason` constants in the same file, even though the investigation doc spelled them without the prefix.
* `outcome` is coarse (`hit | miss | timeout | error`) rather than mirroring the fine grained reasons in `posthog_hypercache_redis_miss_reason`. The fine reasons are still available on the existing counter; the histogram is for latency distribution, not failure attribution.
* Sentinel hits (`Ok(Ok(None))`) fold into `outcome="hit"` because the latency profile is identical to a real hit; the sentinel versus data distinction is preserved by the existing log lines and counters.
* No new tests. Histogram emission is non fallible and additive; the existing cascade tests already exercise every branch the new code reads. Label values and bucket boundaries verify post deploy via the `/metrics` endpoint.
* Bucket overrides land only in the feature flags binary. `hypercache-server` uses plain `setup_metrics_routes` and gets the default ladder, which is acceptable given its different traffic shape.
