### PR TITLE
chore(insights): move unordered funnel partial exclusion check to validation rules

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel.py
+++ b/posthog/hogql_queries/insights/funnels/funnel.py
@@ -205,15 +205,11 @@ class FunnelUDF(FunnelUDFMixin, FunnelBase):
         return inner_select
 
     def get_query(self) -> ast.SelectQuery:
-        max_steps = self.context.max_steps
         funnelsFilter = self.context.funnelsFilter
 
         inner_select = self._inner_aggregation_query()
 
         if funnelsFilter.funnelOrderType == StepOrderValue.UNORDERED:
-            for exclusion in funnelsFilter.exclusions or []:
-                if exclusion.funnelFromStep != 0 or exclusion.funnelToStep != max_steps - 1:
-                    raise ValidationError("Partial Exclusions not allowed in unordered funnels")
             if (
                 funnelsFilter.breakdownAttributionType == BreakdownAttributionType.STEP
                 and funnelsFilter.breakdownAttributionValue != 0

--- a/posthog/hogql_queries/insights/funnels/funnel_validation_rules.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_validation_rules.py
@@ -60,11 +60,22 @@ class ValidateFunnelExclusions:
     code = "funnel_exclusions_invalid"
 
     def validate(self, context: QueryValidationContext[FunnelsQuery]) -> None:
-        exclusions = context.query.funnelsFilter.exclusions if context.query.funnelsFilter is not None else None
+        funnels_filter = context.query.funnelsFilter
+        exclusions = funnels_filter.exclusions if funnels_filter is not None else None
         if exclusions is None:
             return
 
         series = context.query.series
+        max_step_index = len(series) - 1
+
+        if funnels_filter.funnelOrderType == StepOrderValue.UNORDERED:
+            for exclusion in exclusions:
+                if exclusion.funnelFromStep != 0 or exclusion.funnelToStep != max_step_index:
+                    raise ValidationError(
+                        "Partial Exclusions not allowed in unordered funnels",
+                        code=self.code,
+                    )
+
         for exclusion in exclusions:
             if exclusion.funnelFromStep >= exclusion.funnelToStep:
                 raise ValidationError(

--- a/posthog/hogql_queries/insights/funnels/funnel_validation_rules.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_validation_rules.py
@@ -61,7 +61,9 @@ class ValidateFunnelExclusions:
 
     def validate(self, context: QueryValidationContext[FunnelsQuery]) -> None:
         funnels_filter = context.query.funnelsFilter
-        exclusions = funnels_filter.exclusions if funnels_filter is not None else None
+        if funnels_filter is None:
+            return
+        exclusions = funnels_filter.exclusions
         if exclusions is None:
             return
 

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_validation_rules.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_validation_rules.py
@@ -139,24 +139,28 @@ class TestFunnelValidationRules(BaseTest):
         self.assertIn("Partial Exclusions not allowed in unordered funnels", str(context.exception))
         self.assertEqual(context.exception.get_codes(), ["funnel_exclusions_invalid"])
 
-    def test_allows_full_range_exclusion_in_unordered_funnels(self):
+    @parameterized.expand(
+        [
+            (
+                "full_range_in_unordered_funnel",
+                FunnelsFilter(
+                    funnelOrderType=StepOrderValue.UNORDERED,
+                    exclusions=[FunnelExclusionEventsNode(event="exclude", funnelFromStep=0, funnelToStep=2)],
+                ),
+            ),
+            (
+                "partial_range_in_ordered_funnel",
+                FunnelsFilter(
+                    funnelOrderType=StepOrderValue.ORDERED,
+                    exclusions=[FunnelExclusionEventsNode(event="exclude", funnelFromStep=0, funnelToStep=1)],
+                ),
+            ),
+        ]
+    )
+    def test_allows_valid_exclusion(self, _name, funnels_filter):
         query = FunnelsQuery(
             series=[EventsNode(event="step 1"), EventsNode(event="step 2"), EventsNode(event="step 3")],
-            funnelsFilter=FunnelsFilter(
-                funnelOrderType=StepOrderValue.UNORDERED,
-                exclusions=[FunnelExclusionEventsNode(event="exclude", funnelFromStep=0, funnelToStep=2)],
-            ),
-        )
-
-        ValidateFunnelExclusions().validate(self._context(query))
-
-    def test_allows_partial_exclusions_in_ordered_funnels(self):
-        query = FunnelsQuery(
-            series=[EventsNode(event="step 1"), EventsNode(event="step 2"), EventsNode(event="step 3")],
-            funnelsFilter=FunnelsFilter(
-                funnelOrderType=StepOrderValue.ORDERED,
-                exclusions=[FunnelExclusionEventsNode(event="exclude", funnelFromStep=0, funnelToStep=1)],
-            ),
+            funnelsFilter=funnels_filter,
         )
 
         ValidateFunnelExclusions().validate(self._context(query))

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_validation_rules.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_validation_rules.py
@@ -115,6 +115,55 @@ class TestFunnelValidationRules(BaseTest):
     @parameterized.expand(
         [
             (
+                "partial_from_step",
+                FunnelExclusionEventsNode(event="exclude", funnelFromStep=1, funnelToStep=2),
+            ),
+            (
+                "partial_to_step",
+                FunnelExclusionEventsNode(event="exclude", funnelFromStep=0, funnelToStep=1),
+            ),
+        ]
+    )
+    def test_disallows_partial_exclusions_in_unordered_funnels(self, _name, exclusion):
+        query = FunnelsQuery(
+            series=[EventsNode(event="step 1"), EventsNode(event="step 2"), EventsNode(event="step 3")],
+            funnelsFilter=FunnelsFilter(
+                funnelOrderType=StepOrderValue.UNORDERED,
+                exclusions=[exclusion],
+            ),
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            ValidateFunnelExclusions().validate(self._context(query))
+
+        self.assertIn("Partial Exclusions not allowed in unordered funnels", str(context.exception))
+        self.assertEqual(context.exception.get_codes(), ["funnel_exclusions_invalid"])
+
+    def test_allows_full_range_exclusion_in_unordered_funnels(self):
+        query = FunnelsQuery(
+            series=[EventsNode(event="step 1"), EventsNode(event="step 2"), EventsNode(event="step 3")],
+            funnelsFilter=FunnelsFilter(
+                funnelOrderType=StepOrderValue.UNORDERED,
+                exclusions=[FunnelExclusionEventsNode(event="exclude", funnelFromStep=0, funnelToStep=2)],
+            ),
+        )
+
+        ValidateFunnelExclusions().validate(self._context(query))
+
+    def test_allows_partial_exclusions_in_ordered_funnels(self):
+        query = FunnelsQuery(
+            series=[EventsNode(event="step 1"), EventsNode(event="step 2"), EventsNode(event="step 3")],
+            funnelsFilter=FunnelsFilter(
+                funnelOrderType=StepOrderValue.ORDERED,
+                exclusions=[FunnelExclusionEventsNode(event="exclude", funnelFromStep=0, funnelToStep=1)],
+            ),
+        )
+
+        ValidateFunnelExclusions().validate(self._context(query))
+
+    @parameterized.expand(
+        [
+            (
                 "unsupported_feature_combination",
                 FunnelsQuery(
                     series=[EventsNode(event="step 1"), EventsNode(event="step 2", optionalInFunnel=True)],


### PR DESCRIPTION
## Problem

The check that rejects partial exclusions in unordered funnels lived inside `FunnelUDF.get_query`, mixed in with query-building code. The other funnel exclusion rules (overlap with funnel steps, `funnelFromStep >= funnelToStep`, etc.) already live in `ValidateFunnelExclusions` and run as part of the standard validation pipeline. Splitting the rule across two places makes it easy to miss when adding new funnel paths and means the same error is raised from different layers depending on the code path.

## Changes

- Move the "Partial Exclusions not allowed in unordered funnels" check from `FunnelUDF.get_query` into `ValidateFunnelExclusions` so all funnel-exclusion validation lives in one place.
- The raised `ValidationError` now carries the `funnel_exclusions_invalid` code, matching the sibling exclusion validations.

## How did you test this code?

I'm an agent. I did not perform manual testing. Automated coverage added in `posthog/hogql_queries/insights/funnels/test/test_funnel_validation_rules.py`:

- partial `funnelFromStep` rejected in unordered funnels
- partial `funnelToStep` rejected in unordered funnels
- full-range exclusion (0 → last step) accepted in unordered funnels
- partial exclusions still accepted in ordered funnels

## Publish to changelog?

no

## Docs update

No docs change needed — this is an internal refactor with no behavior change visible to users (same error message, same rejection condition).

## 🤖 Agent context

Agent-authored via PostHog Code. The change is a straight relocation of an existing validation: the predicate (`funnelFromStep != 0 or funnelToStep != max_steps - 1` under `StepOrderValue.UNORDERED`) is preserved, only the call site moves. `max_steps - 1` becomes `len(series) - 1` in the new location because the validator works off the query's `series`, not the runtime `FunnelQueryContext`. Tests were added in the same style as the existing parameterized exclusion tests in the file.