### PR TITLE
fix(rbac): scope User.teams feature gates per team's own organization

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -493,17 +493,10 @@ class AccessControlViewSetMixin(_GenericViewSet):
                 else:
                     role_resource_overrides[(str(role_id), resource_type)] = level
 
-        # Resource-level role overrides only take effect if the organization has the
-        # ROLE_BASED_ACCESS feature; otherwise role rows in the DB are inert for
-        # resource access and we must not surface them as the effective access level.
-        # NOTE: project-level role overrides are intentionally NOT gated here because
-        # UserTeamPermissions.effective_membership_level_for_parent_membership honors
-        # role-backed project AccessControl rows whenever ACCESS_CONTROL is
-        # enabled (no ROLE_BASED_ACCESS check), so gating the preview here would lie
-        # about a user's actual project access.
-        role_based_resource_access_supported = team.organization.is_feature_available(
-            AvailableFeature.ROLE_BASED_ACCESS
-        )
+        # Role overrides (project- and resource-level) only take effect if the
+        # organization has the ROLE_BASED_ACCESS feature; otherwise role rows in the
+        # DB are inert and we must not surface them as the effective access level.
+        role_based_access_supported = team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
 
         # Build results for each role
         roles = Role.objects.filter(organization=team.organization)
@@ -512,7 +505,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
         for role in roles:
             rid = str(role.id)
 
-            project_role_level = role_project_overrides.get(rid)
+            project_role_level = role_project_overrides.get(rid) if role_based_access_supported else None
             project_result = get_effective_access_level_for_role(
                 resource="project",
                 default_level=project_default_level,
@@ -522,7 +515,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
             resource_entries: dict[str, dict] = {}
             for resource in ACCESS_CONTROL_RESOURCES:
                 resource_role_level = (
-                    role_resource_overrides.get((rid, resource)) if role_based_resource_access_supported else None
+                    role_resource_overrides.get((rid, resource)) if role_based_access_supported else None
                 )
                 resource_default = resource_default_levels.get(resource)
                 resource_result = get_effective_access_level_for_role(
@@ -605,17 +598,10 @@ class AccessControlViewSetMixin(_GenericViewSet):
                 else:
                     member_resource_overrides[(str(member_id), resource_type)] = level
 
-        # Resource-level role overrides only take effect if the organization has the
-        # ROLE_BASED_ACCESS feature; otherwise role rows in the DB are inert for
-        # resource access and we must not let them influence members' effective
-        # resource access level. NOTE: project-level role overrides are intentionally
-        # NOT gated here because UserTeamPermissions.effective_membership_level_for_
-        # parent_membership honors role-backed project AccessControl rows whenever
-        # ACCESS_CONTROL is enabled (no ROLE_BASED_ACCESS check), so gating the
-        # preview here would lie about a user's actual project access.
-        role_based_resource_access_supported = team.organization.is_feature_available(
-            AvailableFeature.ROLE_BASED_ACCESS
-        )
+        # Role overrides (project- and resource-level) only take effect if the
+        # organization has the ROLE_BASED_ACCESS feature; otherwise role rows in the
+        # DB are inert and we must not let them influence members' effective access.
+        role_based_access_supported = team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
 
         # Build results for each member
         memberships = (
@@ -631,9 +617,11 @@ class AccessControlViewSetMixin(_GenericViewSet):
             member_role_ids = [str(rm.role_id) for rm in membership.role_memberships.all()]
 
             project_member_level = member_project_overrides.get(mid)
-            project_role_levels: list[AccessControlLevel] = [
-                role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides
-            ]
+            project_role_levels: list[AccessControlLevel] = (
+                [role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides]
+                if role_based_access_supported
+                else []
+            )
             project_result = get_effective_access_level_for_member(
                 resource="project",
                 default_level=project_default_level,
@@ -652,7 +640,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
                         for rid in member_role_ids
                         if (rid, resource) in role_resource_overrides
                     ]
-                    if role_based_resource_access_supported
+                    if role_based_access_supported
                     else []
                 )
                 resource_result = get_effective_access_level_for_member(

--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -619,14 +619,15 @@ class AccessControlViewSetMixin(_GenericViewSet):
         for membership in memberships:
             mid = str(membership.id)
             is_org_admin = membership.level >= OrganizationMembership.Level.ADMIN
-            member_role_ids = [str(rm.role_id) for rm in membership.role_memberships.all()]
+            # Role memberships only contribute when ROLE_BASED_ACCESS is enabled.
+            member_role_ids = (
+                [str(rm.role_id) for rm in membership.role_memberships.all()] if role_based_access_supported else []
+            )
 
             project_member_level = member_project_overrides.get(mid)
-            project_role_levels: list[AccessControlLevel] = (
-                [role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides]
-                if role_based_access_supported
-                else []
-            )
+            project_role_levels: list[AccessControlLevel] = [
+                role_project_overrides[rid] for rid in member_role_ids if rid in role_project_overrides
+            ]
             project_result = get_effective_access_level_for_member(
                 resource="project",
                 default_level=project_default_level,
@@ -639,15 +640,11 @@ class AccessControlViewSetMixin(_GenericViewSet):
             for resource in ACCESS_CONTROL_RESOURCES:
                 resource_member_level = member_resource_overrides.get((mid, resource))
                 resource_default = resource_default_levels.get(resource)
-                resource_role_levels: list[AccessControlLevel] = (
-                    [
-                        role_resource_overrides[(rid, resource)]
-                        for rid in member_role_ids
-                        if (rid, resource) in role_resource_overrides
-                    ]
-                    if role_based_access_supported
-                    else []
-                )
+                resource_role_levels: list[AccessControlLevel] = [
+                    role_resource_overrides[(rid, resource)]
+                    for rid in member_role_ids
+                    if (rid, resource) in role_resource_overrides
+                ]
                 resource_result = get_effective_access_level_for_member(
                     resource=resource,
                     default_level=resource_default,

--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -134,6 +134,11 @@ class AccessControlSerializer(serializers.ModelSerializer):
         team = context["view"].team
         the_object = context["view"].get_object()
 
+        # Role-backed access controls require the ROLE_BASED_ACCESS feature — same gate
+        # as the UI's "Roles" blocks and the runtime enforcement in UserTeamPermissions.
+        if data.get("role") and not team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS):
+            raise exceptions.PermissionDenied("Role-based access controls require the Role-based access feature.")
+
         if resource_id:
             if str(the_object.pk) != str(resource_id):
                 raise exceptions.PermissionDenied(

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -125,6 +125,26 @@ class TestAccessControlProjectLevelAPI(BaseAccessControlTest):
         assert "organization member id" in res.json()["detail"]
         assert "/api/organizations/" in res.json()["detail"]
 
+    def test_role_based_access_control_rejected_without_role_based_access_feature(self):
+        # Drop ROLE_BASED_ACCESS, keep ACCESS_CONTROL — same shape as the UI gate
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+        ]
+        self.organization.save()
+
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+        role = Role.objects.create(name="Engineering", organization=self.organization)
+
+        res = self._put_project_access_control({"role": str(role.id), "access_level": "admin"})
+        assert res.status_code == status.HTTP_403_FORBIDDEN, res.json()
+        assert "Role-based access" in res.json()["detail"]
+
+        # Member-level writes still work — only the role-backed write is blocked
+        res = self._put_project_access_control(
+            {"organization_member": str(self.organization_membership.id), "access_level": "admin"}
+        )
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
 
 class TestAccessControlMinimumLevelValidation(BaseAccessControlTest):
     def test_action_access_level_cannot_be_below_viewer(self):

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -1677,11 +1677,10 @@ class TestAccessControlRolesEndpoint(BaseAccessControlTest):
         role_data = self._find_role(res.json()["results"], self.role.id)
         assert role_data["project"]["access_level"] == "member"
 
-    def test_resource_role_overrides_ignored_when_role_based_access_not_available(self):
-        """Without ROLE_BASED_ACCESS, role-based resource overrides are inert at runtime,
-        so the per-role preview must show the resource default as the effective level.
-        Project-level role overrides remain effective (runtime still honors them via
-        UserTeamPermissions when ACCESS_CONTROL is enabled)."""
+    def test_role_overrides_ignored_when_role_based_access_not_available(self):
+        """Without ROLE_BASED_ACCESS, role-based overrides (project- and resource-level)
+        are inert at runtime, so the per-role preview must show the resource/project
+        default as the effective level."""
         self.organization.available_product_features = [
             {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
         ]
@@ -1703,10 +1702,10 @@ class TestAccessControlRolesEndpoint(BaseAccessControlTest):
         assert dashboard["inherited_access_level"] == "viewer"
         assert dashboard["inherited_access_level_reason"] == "project_default"
 
-        # Project-level role override is still effective (mirrors runtime)
+        # Project-level role override must also be ignored — falls back to project default
         project = role_data["project"]
-        assert project["access_level"] == "admin"
-        assert project["effective_access_level"] == "admin"
+        assert project["access_level"] is None
+        assert project["effective_access_level"] == "member"
 
 
 class TestAccessControlMembersEndpoint(BaseAccessControlTest):
@@ -1847,16 +1846,10 @@ class TestAccessControlMembersEndpoint(BaseAccessControlTest):
         assert ff["effective_access_level"] is None
         assert ff["inherited_access_level"] is None
 
-    def test_resource_role_overrides_ignored_when_role_based_access_not_available(self):
+    def test_role_overrides_ignored_when_role_based_access_not_available(self):
         """When the organization does not have the ROLE_BASED_ACCESS feature, role-based
-        *resource* overrides must not influence a member's effective resource access level.
-        The member should fall back to the resource default.
-
-        Project-level role overrides are deliberately NOT gated by this feature, because
-        UserTeamPermissions.effective_membership_level_for_parent_membership honors
-        role-backed project AccessControl rows whenever ACCESS_CONTROL is enabled
-        (no ROLE_BASED_ACCESS check). The preview must match that runtime behaviour.
-        """
+        overrides (project- and resource-level) must not influence a member's effective
+        access. The member should fall back to the default at each level."""
         # Remove the ROLE_BASED_ACCESS feature, keep ACCESS_CONTROL
         self.organization.available_product_features = [
             {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
@@ -1886,11 +1879,11 @@ class TestAccessControlMembersEndpoint(BaseAccessControlTest):
         assert dashboard["inherited_access_level"] == "viewer"
         assert dashboard["inherited_access_level_reason"] == "project_default"
 
-        # Project-level: role override IS still honored at runtime, so the preview must reflect it
+        # Project-level: role override must also be ignored, fall back to project default
         project = member_data["project"]
-        assert project["effective_access_level"] == "admin"
-        assert project["inherited_access_level"] == "admin"
-        assert project["inherited_access_level_reason"] == "role_override"
+        assert project["effective_access_level"] == "member"
+        assert project["inherited_access_level"] == "member"
+        assert project["inherited_access_level_reason"] == "project_default"
 
     def test_only_returns_current_team_member_overrides(self):
         """Member overrides from other teams are not included."""

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -1061,7 +1061,6 @@ class Team(UUIDTClassicModel):
 
             # Role-backed access only contributes when the org has ROLE_BASED_ACCESS —
             # same gate as the UI's "Roles" block on the project access settings page.
-            role_user_ids: QuerySet[Any] | list[Any] = []
             if self.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS):
                 roles_with_access = AccessControl.objects.filter(
                     team_id=self.id,
@@ -1076,6 +1075,9 @@ class Team(UUIDTClassicModel):
                     .values_list("organization_member__user_id", flat=True)
                     .distinct()
                 )
+            else:
+                # Empty queryset (not a list) so `.union()` keeps working.
+                role_user_ids = RoleMembership.objects.none().values_list("organization_member__user_id", flat=True)
 
             # Union all sets of user IDs
             user_ids_queryset = cast(Any, admin_user_ids).union(member_access_user_ids, role_user_ids)

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -1005,11 +1005,20 @@ class Team(UUIDTClassicModel):
         create_data_for_demo_team.delay(self.id, initiating_user.id, cache_key)
 
     def all_users_with_access(self) -> QuerySet["User"]:
+        from posthog.constants import AvailableFeature
         from posthog.models.organization import OrganizationMembership
         from posthog.models.user import User
 
         from ee.models.rbac.access_control import AccessControl
         from ee.models.rbac.role import RoleMembership
+
+        # Without ACCESS_CONTROL there is no notion of private teams — all org members have access.
+        # Mirrors User.teams and UserTeamPermissions.effective_membership_level_for_parent_membership.
+        if not self.organization.is_feature_available(AvailableFeature.ACCESS_CONTROL):
+            user_ids_queryset = OrganizationMembership.objects.filter(organization_id=self.organization_id).values_list(
+                "user_id", flat=True
+            )
+            return User.objects.filter(is_active=True, id__in=user_ids_queryset)
 
         # First, check if the team is private
         team_is_private = AccessControl.objects.filter(
@@ -1050,21 +1059,23 @@ class Team(UUIDTClassicModel):
                 id__in=org_memberships_with_access
             ).values_list("user_id", flat=True)
 
-            # Get roles with access to this team
-            roles_with_access = AccessControl.objects.filter(
-                team_id=self.id,
-                resource="project",
-                resource_id=str(self.id),
-                role__isnull=False,
-                access_level__in=["member", "admin"],
-            ).values_list("role", flat=True)
+            # Role-backed access only contributes when the org has ROLE_BASED_ACCESS —
+            # same gate as the UI's "Roles" block on the project access settings page.
+            role_user_ids: QuerySet[Any] | list[Any] = []
+            if self.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS):
+                roles_with_access = AccessControl.objects.filter(
+                    team_id=self.id,
+                    resource="project",
+                    resource_id=str(self.id),
+                    role__isnull=False,
+                    access_level__in=["member", "admin"],
+                ).values_list("role", flat=True)
 
-            # Get users who have these roles
-            role_user_ids = (
-                RoleMembership.objects.filter(role_id__in=roles_with_access)
-                .values_list("organization_member__user_id", flat=True)
-                .distinct()
-            )
+                role_user_ids = (
+                    RoleMembership.objects.filter(role_id__in=roles_with_access)
+                    .values_list("organization_member__user_id", flat=True)
+                    .distinct()
+                )
 
             # Union all sets of user IDs
             user_ids_queryset = cast(Any, admin_user_ids).union(member_access_user_ids, role_user_ids)

--- a/posthog/models/test/test_team_model.py
+++ b/posthog/models/test/test_team_model.py
@@ -280,3 +280,61 @@ class TestTeam(BaseTest):
 
         # Both users should have access
         assert sorted(all_user_with_access_ids) == sorted([self.user.id, member_user.id])
+
+    def test_all_users_with_access_returns_all_org_members_without_access_control_feature(self):
+        """Without ACCESS_CONTROL there are no private teams — every org member has access,
+        even if AccessControl rows exist in the DB."""
+        # No features enabled
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="none",
+        )
+        member_user = User.objects.create_and_join(
+            self.organization,
+            email="member-no-feature@posthog.com",
+            first_name="first_name",
+            password=None,
+            level=OrganizationMembership.Level.MEMBER,
+        )
+
+        all_user_with_access_ids = list(self.team.all_users_with_access().values_list("id", flat=True))
+        # Both users in, despite the private AccessControl row
+        assert sorted(all_user_with_access_ids) == sorted([self.user.id, member_user.id])
+
+    def test_all_users_with_access_role_access_inert_without_role_based_access_feature(self):
+        """With ACCESS_CONTROL but no ROLE_BASED_ACCESS, role-backed AccessControl rows
+        must not grant access — mirrors the UI gate and User.teams behaviour."""
+        self._enable_access_control()  # ACCESS_CONTROL only
+
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="none",
+        )
+        member_user = User.objects.create_and_join(
+            self.organization,
+            email="member-no-rbac@posthog.com",
+            first_name="first_name",
+            password=None,
+            level=OrganizationMembership.Level.MEMBER,
+        )
+        member_org_membership = OrganizationMembership.objects.get(organization=self.organization, user=member_user)
+        role = Role.objects.create(name="Test Role", organization=self.organization)
+        RoleMembership.objects.create(role=role, user=member_user, organization_member=member_org_membership)
+        AccessControl.objects.create(
+            team=self.team, resource="project", resource_id=str(self.team.id), role=role, access_level="member"
+        )
+
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        all_user_with_access_ids = list(self.team.all_users_with_access().values_list("id", flat=True))
+        # Only the org admin gets access — the role-backed member does not
+        assert all_user_with_access_ids == [self.user.id]

--- a/posthog/models/test/test_team_model.py
+++ b/posthog/models/test/test_team_model.py
@@ -112,6 +112,15 @@ class TestCoreEvent(BaseTest):
 
 
 class TestTeam(BaseTest):
+    def _enable_access_control(self, role_based: bool = False) -> None:
+        from posthog.constants import AvailableFeature
+
+        features = [{"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}]
+        if role_based:
+            features.append({"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS})
+        self.organization.available_product_features = features
+        self.organization.save()
+
     def test_all_users_with_access_simple_org_membership(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
@@ -153,6 +162,7 @@ class TestTeam(BaseTest):
 
     def test_all_users_with_access_new_access_control_private_team(self):
         """Test that only users with specific access have access to a private team with the new access control system"""
+        self._enable_access_control()
 
         # Make the team private
         AccessControl.objects.create(
@@ -185,6 +195,7 @@ class TestTeam(BaseTest):
 
     def test_all_users_with_access_new_access_control_private_team_with_member_access(self):
         """Test that users with specific member access have access to a private team with the new access control system"""
+        self._enable_access_control()
 
         # Make the team private
         AccessControl.objects.create(
@@ -227,6 +238,7 @@ class TestTeam(BaseTest):
 
     def test_all_users_with_access_new_access_control_private_team_with_role_access(self):
         """Test that users with role-based access have access to a private team with the new access control system"""
+        self._enable_access_control(role_based=True)
 
         # Make the team private
         AccessControl.objects.create(

--- a/posthog/models/test/test_user_teams_access_control.py
+++ b/posthog/models/test/test_user_teams_access_control.py
@@ -18,9 +18,10 @@ class TestUserTeamsAccessControl(BaseTest):
 
     def setUp(self):
         super().setUp()
-        # Enable access control for the organization
+        # Enable access control and role-based access for the organization
         self.organization.available_product_features = [
-            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
         ]
         self.organization.save()
 
@@ -138,6 +139,45 @@ class TestUserTeamsAccessControl(BaseTest):
         self.assertEqual(user_teams.count(), 2)
         self.assertIn(self.team, user_teams)
         self.assertIn(private_team, user_teams)
+
+    def test_user_teams_role_based_access_inert_without_role_based_access_feature(self):
+        """Role-backed project AccessControl rows must NOT grant team visibility when the
+        org lacks ROLE_BASED_ACCESS — mirrors the UI gate."""
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}
+        ]
+        self.organization.save()
+
+        private_team = Team.objects.create(organization=self.organization, name="Private Team")
+        AccessControl.objects.create(
+            team=private_team,
+            resource="project",
+            resource_id=str(private_team.id),
+            access_level="none",
+            organization_member=None,
+            role=None,
+        )
+
+        role = Role.objects.create(name="Developer", organization=self.organization)
+        RoleMembership.objects.create(
+            role=role,
+            user=self.user,
+            organization_member=self.organization_membership,
+        )
+        AccessControl.objects.create(
+            team=private_team,
+            resource="project",
+            resource_id=str(private_team.id),
+            access_level="admin",
+            organization_member=None,
+            role=role,
+        )
+
+        self.user.__dict__.pop("teams", None)  # bust cached_property if it was set
+        user_teams = self.user.teams.all()
+        self.assertEqual(user_teams.count(), 1)
+        self.assertIn(self.team, user_teams)
+        self.assertNotIn(private_team, user_teams)
 
     def test_organization_admin_sees_all_teams(self):
         """Test that organization admins can see all teams, including private ones."""

--- a/posthog/models/test/test_user_teams_access_control.py
+++ b/posthog/models/test/test_user_teams_access_control.py
@@ -243,6 +243,53 @@ class TestUserTeamsAccessControl(BaseTest):
         self.assertIn(self.team, user_teams)
         self.assertNotIn(other_team, user_teams)
 
+    def test_user_teams_feature_gates_scoped_per_organization(self):
+        """Feature entitlements must be evaluated per-org. A user who has ROLE_BASED_ACCESS in
+        Org A must not get role-backed access to a private team in Org B that has only
+        ACCESS_CONTROL — Org B's own entitlement decides Org B's enforcement."""
+        from posthog.models.user import User
+
+        # Org A keeps the setUp defaults: ACCESS_CONTROL + ROLE_BASED_ACCESS.
+        # Org B gets ACCESS_CONTROL only.
+        org_b = Organization.objects.create(name="Org B")
+        org_b.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}
+        ]
+        org_b.save()
+
+        self.user.join(organization=org_b, level=OrganizationMembership.Level.MEMBER)
+        membership_in_b = OrganizationMembership.objects.get(user=self.user, organization=org_b)
+
+        # Org B has a private team, role-backed access for a role this user belongs to.
+        private_team_in_b = Team.objects.create(organization=org_b, name="B Private")
+        AccessControl.objects.create(
+            team=private_team_in_b,
+            resource="project",
+            resource_id=str(private_team_in_b.id),
+            access_level="none",
+            organization_member=None,
+            role=None,
+        )
+        role_in_b = Role.objects.create(name="B Engineers", organization=org_b)
+        RoleMembership.objects.create(role=role_in_b, user=self.user, organization_member=membership_in_b)
+        AccessControl.objects.create(
+            team=private_team_in_b,
+            resource="project",
+            resource_id=str(private_team_in_b.id),
+            access_level="admin",
+            organization_member=None,
+            role=role_in_b,
+        )
+
+        # Bust cached_property so the queries actually run.
+        self.user = User.objects.get(pk=self.user.pk)
+
+        # Org A team is visible (no private restriction). Org B's private team must NOT be
+        # visible — even though Org A has ROLE_BASED_ACCESS, Org B does not.
+        team_ids = set(self.user.teams.values_list("id", flat=True))
+        self.assertIn(self.team.id, team_ids)
+        self.assertNotIn(private_team_in_b.id, team_ids)
+
     def test_user_teams_complex_scenario(self):
         """Test a complex scenario with multiple teams, roles, and access controls."""
         # Create multiple teams

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -327,20 +327,28 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
                         ).values_list("team_id", flat=True)
                     )
 
-                    # Get teams where user has role-based access
-                    try:
-                        from ee.models.rbac.role import RoleMembership
+                    # Get teams where user has role-based access. Only honored when the
+                    # org has ROLE_BASED_ACCESS — same gate as the UI's "Roles" block on
+                    # the project access settings page (and as resource-level role overrides).
+                    role_based_access_supported = (
+                        AvailableFeature.ROLE_BASED_ACCESS in org_available_product_feature_keys
+                    )
+                    if role_based_access_supported:
+                        try:
+                            from ee.models.rbac.role import RoleMembership
 
-                        user_roles = RoleMembership.objects.filter(
-                            user=self, organization_member__in=[membership.id for membership in org_memberships]
-                        ).values_list("role_id", flat=True)
+                            user_roles = RoleMembership.objects.filter(
+                                user=self, organization_member__in=[membership.id for membership in org_memberships]
+                            ).values_list("role_id", flat=True)
 
-                        role_accessible_team_ids = set(
-                            AccessControl.objects.filter(
-                                resource="project", access_level__in=["member", "admin"], role__in=user_roles
-                            ).values_list("team_id", flat=True)
-                        )
-                    except ImportError:
+                            role_accessible_team_ids = set(
+                                AccessControl.objects.filter(
+                                    resource="project", access_level__in=["member", "admin"], role__in=user_roles
+                                ).values_list("team_id", flat=True)
+                            )
+                        except ImportError:
+                            role_accessible_team_ids = set()
+                    else:
                         role_accessible_team_ids = set()
 
                     # Get organizations where user is admin or owner (have implicit access to all teams)

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -294,99 +294,73 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
     @cached_property
     def teams(self):
         """
-        All teams the user has access to on any organization, taking into account project based permissioning
+        All teams the user has access to on any organization, taking into account project-based permissioning.
+
+        Feature entitlements (ACCESS_CONTROL, ROLE_BASED_ACCESS) are evaluated per-team via each
+        team's own organization, so entitlements in one org never bypass gates in another.
         """
-        teams = Team.objects.filter(organization__members=self)
-        org_available_product_features = (
-            Organization.objects.filter(members=self).values_list("available_product_features", flat=True).first()
-        )
-        if org_available_product_features and len(org_available_product_features) > 0:
-            org_available_product_feature_keys = [feature["key"] for feature in org_available_product_features]
-            if AvailableFeature.ACCESS_CONTROL in org_available_product_feature_keys:
-                try:
-                    from ee.models.rbac.access_control import AccessControl
-                except ImportError:
-                    pass
-                else:
-                    # Get organization memberships for this user to check access levels
-                    org_memberships = OrganizationMembership.objects.filter(user=self).select_related("organization")
+        teams = Team.objects.filter(organization__members=self).select_related("organization")
+        try:
+            from ee.models.rbac.access_control import AccessControl
+            from ee.models.rbac.role import RoleMembership
+        except ImportError:
+            return teams.order_by("id")
 
-                    # Get teams that are private (have access_level="none" restrictions)
-                    private_team_ids = set(
-                        AccessControl.objects.filter(
-                            resource="project", access_level="none", organization_member=None, role=None
-                        ).values_list("team_id", flat=True)
-                    )
+        team_list = list(teams)
+        if not team_list:
+            return teams.order_by("id")
 
-                    # Get teams where user has explicit access
-                    accessible_private_team_ids = set(
-                        AccessControl.objects.filter(
-                            resource="project",
-                            access_level__in=["member", "admin"],
-                            organization_member__in=[membership.id for membership in org_memberships],
-                        ).values_list("team_id", flat=True)
-                    )
+        # Single fetch for memberships, AccessControls and RoleMemberships — constant 4 queries
+        # total regardless of how many orgs/teams the user belongs to.
+        memberships_by_org = {m.organization_id: m for m in OrganizationMembership.objects.filter(user=self)}
+        acs_by_team: dict[int, list] = {}
+        for ac in AccessControl.objects.filter(team_id__in=[t.id for t in team_list], resource="project"):
+            acs_by_team.setdefault(ac.team_id, []).append(ac)
+        role_ids_by_membership: dict[int, set[int]] = {}
+        for rm in RoleMembership.objects.filter(user=self).values("organization_member_id", "role_id"):
+            role_ids_by_membership.setdefault(rm["organization_member_id"], set()).add(rm["role_id"])
 
-                    # Get teams where user has role-based access. Only honored when the
-                    # org has ROLE_BASED_ACCESS — same gate as the UI's "Roles" block on
-                    # the project access settings page (and as resource-level role overrides).
-                    role_based_access_supported = (
-                        AvailableFeature.ROLE_BASED_ACCESS in org_available_product_feature_keys
-                    )
-                    if role_based_access_supported:
-                        try:
-                            from ee.models.rbac.role import RoleMembership
+        accessible: set[int] = set()
+        for team in team_list:
+            membership = memberships_by_org.get(team.organization_id)
+            if membership is None:
+                continue
 
-                            user_roles = RoleMembership.objects.filter(
-                                user=self, organization_member__in=[membership.id for membership in org_memberships]
-                            ).values_list("role_id", flat=True)
+            feature_keys = {f["key"] for f in (team.organization.available_product_features or [])}
 
-                            role_accessible_team_ids = set(
-                                AccessControl.objects.filter(
-                                    resource="project", access_level__in=["member", "admin"], role__in=user_roles
-                                ).values_list("team_id", flat=True)
-                            )
-                        except ImportError:
-                            role_accessible_team_ids = set()
-                    else:
-                        role_accessible_team_ids = set()
+            # Without ACCESS_CONTROL there's no notion of private teams — every org member sees the team.
+            if AvailableFeature.ACCESS_CONTROL not in feature_keys:
+                accessible.add(team.id)
+                continue
+            # Org admins/owners always see every team in their org.
+            if membership.level >= OrganizationMembership.Level.ADMIN:
+                accessible.add(team.id)
+                continue
 
-                    # Get organizations where user is admin or owner (have implicit access to all teams)
-                    organizations_where_user_is_admin = OrganizationMembership.objects.filter(
-                        user=self, level__gte=OrganizationMembership.Level.ADMIN
-                    ).values_list("organization_id", flat=True)
+            team_acs = acs_by_team.get(team.id, [])
 
-                    # Filter teams to include:
-                    # - Teams that are not private (not in private_team_ids) OR
-                    # - Teams where user has explicit access OR
-                    # - Teams where user has role-based access OR
-                    # - Teams in organizations where user is admin/owner
-                    accessible_team_ids = accessible_private_team_ids | role_accessible_team_ids
+            is_private = any(
+                ac.access_level == "none" and ac.organization_member_id is None and ac.role_id is None
+                for ac in team_acs
+            )
+            if not is_private:
+                accessible.add(team.id)
+                continue
 
-                    # Build the list of all accessible team IDs
-                    all_accessible_team_ids: set[int] = set()
+            # Direct member grant on this team.
+            if any(
+                ac.organization_member_id == membership.id and ac.access_level in ("member", "admin") for ac in team_acs
+            ):
+                accessible.add(team.id)
+                continue
 
-                    # Add teams from organizations where user is admin
-                    admin_teams = Team.objects.filter(
-                        organization__pk__in=organizations_where_user_is_admin, organization__members=self
-                    ).values_list("pk", flat=True)
-                    all_accessible_team_ids.update(admin_teams)
+            # Role-backed grant — only honored if THIS team's org has ROLE_BASED_ACCESS.
+            if AvailableFeature.ROLE_BASED_ACCESS in feature_keys:
+                user_role_ids = role_ids_by_membership.get(membership.id, set())
+                if any(ac.role_id in user_role_ids and ac.access_level in ("member", "admin") for ac in team_acs):
+                    accessible.add(team.id)
 
-                    # Add teams that are not private
-                    non_private_teams = (
-                        Team.objects.filter(organization__members=self)
-                        .exclude(pk__in=private_team_ids)
-                        .values_list("pk", flat=True)
-                    )
-                    all_accessible_team_ids.update(non_private_teams)
-
-                    # Add teams with explicit access
-                    all_accessible_team_ids.update(accessible_team_ids)
-
-                    # Apply the final filter
-                    teams = teams.filter(pk__in=all_accessible_team_ids)
-
-        return teams.order_by("id")
+        return teams.filter(pk__in=accessible).order_by("id")
 
     @cached_property
     def organization(self) -> Optional[Organization]:

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -28,7 +28,11 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
             {
                 "name": AvailableFeature.ACCESS_CONTROL,
                 "key": AvailableFeature.ACCESS_CONTROL,
-            }
+            },
+            {
+                "name": AvailableFeature.ROLE_BASED_ACCESS,
+                "key": AvailableFeature.ROLE_BASED_ACCESS,
+            },
         ]
         self.organization.save()
 
@@ -309,6 +313,44 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
         # Check effective membership level
         with self.assertNumQueries(3):
             assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.ADMIN
+
+    def test_team_effective_membership_level_role_based_access_inert_without_role_based_access_feature(self):
+        """Role-backed project AccessControl rows must NOT take effect when the org lacks
+        ROLE_BASED_ACCESS — mirrors the UI gate on the project access settings page."""
+        from ee.models.rbac.access_control import AccessControl
+        from ee.models.rbac.role import Role, RoleMembership
+
+        # Drop ROLE_BASED_ACCESS, keep ACCESS_CONTROL
+        self.organization.available_product_features = [
+            {"name": AvailableFeature.ACCESS_CONTROL, "key": AvailableFeature.ACCESS_CONTROL}
+        ]
+        self.organization.save()
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        role = Role.objects.create(name="Test Role", organization=self.organization)
+        RoleMembership.objects.create(role=role, user=self.user, organization_member=self.organization_membership)
+
+        # Make the team private and grant the role admin via project-level role override
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="none",
+        )
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            role=role,
+            access_level="admin",
+        )
+
+        # Without ROLE_BASED_ACCESS the role override is inert, so the private-team default ("none") applies
+        assert self.permissions().current_team.effective_membership_level is None
 
     def test_team_effective_membership_level_lower_project_membership_than_org_membership(self):
         """Test that users with admin org access maintain their admin level even with lower member project access"""

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -225,10 +225,13 @@ class UserTeamPermissions:
             for ac in access_controls
         )
 
-        # Check role-based access before returning any member level
+        # Role-backed project AccessControl rows only take effect if the organization has
+        # the ROLE_BASED_ACCESS feature — same gate as the UI's "Roles" block on the
+        # project access settings page (and as resource-level role overrides).
+        role_based_access_supported = organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
         user_roles = self.p._prefetched_role_memberships.get(organization_membership.id, [])
 
-        if user_roles:
+        if user_roles and role_based_access_supported:
             role_has_admin_access = any(
                 ac["resource_id"] == str(self.team.id) and ac["role_id"] in user_roles and ac["access_level"] == "admin"
                 for ac in access_controls


### PR DESCRIPTION
## Problem

`User.teams` picked one arbitrary org's `available_product_features` (via `.first()`) and used it as the gate for every team across every org the user belonged to. A user in Org A (with `ROLE_BASED_ACCESS`) and Org B (without) could get role-backed access in Org B because Org A's flag decided the policy. Mirror issue for the `ACCESS_CONTROL` gate.

## Changes

Rewrite `User.teams` to evaluate gates per-team, using each team's own organization's features. Prefetch memberships, AccessControls, and RoleMemberships once → **4 queries total** regardless of how many orgs the user belongs to (down from `1 + 4·N_orgs`).

## How did you test this code?

I'm an agent — automated tests only.

- New `test_user_teams_feature_gates_scoped_per_organization` exercises the cross-org bypass (Org A has ROLE_BASED_ACCESS, Org B doesn't — confirms Org B's private team stays hidden)
- Existing `User.teams` tests still pass with the rewrite

## Publish to changelog?

No

## 🤖 Agent context

Co-authored with Claude Code. Stacked on top of #56977 (the role-based-access runtime gate fix). The bug was flagged by veria-ai review; the fix replaces the per-org loop with a constant-query prefetch + Python evaluation per team.
