### PR TITLE
chore(insights): remove beta tag from chart color themes setting

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -785,14 +785,7 @@ export const SETTINGS_MAP: SettingSection[] = [
             },
             {
                 id: 'data-theme',
-                title: (
-                    <>
-                        Chart color themes
-                        <LemonTag type="warning" className="ml-1 uppercase">
-                            Beta
-                        </LemonTag>
-                    </>
-                ),
+                title: 'Chart color themes',
                 description: 'Customize the color palette used in charts and visualizations.',
                 component: <DataColorThemes />,
                 keywords: ['color', 'palette', 'chart', 'visualization'],


### PR DESCRIPTION
## Problem

The "Chart color themes" entry in environment settings still renders a "Beta" pill next to its title, even though the feature is no longer in beta.

## Changes

Replaced the JSX `title` fragment for the `data-theme` setting in `frontend/src/scenes/settings/SettingsMap.tsx` with the plain string `'Chart color themes'`, dropping the trailing `<LemonTag type="warning">Beta</LemonTag>`. The shared `LemonTag` import is kept because other settings (e.g. Group analytics) still use it.

## How did you test this code?

I'm an agent. No manual UI verification was performed and no automated tests were run for this PR — the change is a single string-literal swap in a settings registration, with no runtime logic affected. A human reviewer should confirm the setting renders without the Beta pill in the Settings UI.

## Publish to changelog?

no

## Docs update

No docs change required.

## 🤖 Agent context

- Authored by PostHog Code (Claude Code, Opus 4.7).
- Located the Beta tag via a single Explore subagent scoped to `frontend/src/scenes/settings/`; confirmed the marker exists only in `SettingsMap.tsx` and that `DataColorThemes.tsx` does not render it.
- Considered also removing the `LemonTag` import but kept it because lines 226 and 1039 of the same file still use it for other Beta/New markers.