### PR TITLE
fix(replay): respect autoplay off in playlist player

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -209,7 +209,7 @@ describe('sessionRecordingsPlaylistLogic', () => {
         })
 
         describe('nextSessionRecording', () => {
-            it('returns next older recording when autoplay direction is null (autoplay off)', async () => {
+            it('returns undefined when autoplay direction is null (autoplay off)', async () => {
                 playerSettingsLogic.mount()
                 playerSettingsLogic.actions.setAutoplayDirection(null)
 
@@ -217,7 +217,7 @@ describe('sessionRecordingsPlaylistLogic', () => {
                     .toDispatchActions(['loadSessionRecordingsSuccess'])
                     .toMatchValues({
                         activeSessionRecording: listOfSessionRecordings[0],
-                        nextSessionRecording: listOfSessionRecordings[1],
+                        nextSessionRecording: undefined,
                     })
             })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -1369,7 +1369,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         nextSessionRecording: [
             (s) => [s.activeSessionRecording, s.recordings, s.autoplayDirection],
             (activeSessionRecording, recordings, autoplayDirection): Partial<SessionRecordingType> | undefined => {
-                if (!activeSessionRecording) {
+                if (!activeSessionRecording || autoplayDirection === null) {
                     return
                 }
                 const activeSessionRecordingIndex = recordings.findIndex((x) => x.id === activeSessionRecording.id)


### PR DESCRIPTION
## Problem

In the session replay playlist player, the Autoplay setting menu offers three values: **Off**, **Newer recordings**, **Older recordings**. A user reported that selecting **Off** has no effect — recordings still auto-advance to the next one at the end.

Root cause: the `nextSessionRecording` selector in `sessionRecordingsPlaylistLogic.ts` treated `autoplayDirection === null` (the value the menu's "Off" option sets) the same as `'older'`, returning the next-older recording. Downstream, `SessionRecordingsPlaylist.tsx` wires `playNextRecording` on the player whenever `nextSessionRecording` is defined, and `PlayerController.tsx` starts a 3-second end-of-recording auto-advance whenever `playNextRecording` is defined. So "Off" was effectively "Older".

A unit test enshrined the broken behavior under the name *"returns next older recording when autoplay direction is null (autoplay off)"*.

## Changes

- `nextSessionRecording` selector now returns `undefined` when `autoplayDirection === null`. This drops both the 3-second end-of-recording auto-advance and the manual skip-to-next surfaces (button + `n` shortcut) when the user explicitly turns autoplay off.
- Fixed the unit test to assert the intended behavior.

Kiosk mode is unaffected: it never reads `nextSessionRecording` and passes its own `playNextRecording` directly into `SessionRecordingPlayer`.

## How did you test this code?

Agent-authored. I'm an agent and ran:

- `hogli test frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts` — 53/53 tests pass, including the corrected "autoplay off" case and the existing cases for `'older'`, `'newer'`, and end-of-list behavior.

No manual UI verification.

## Publish to changelog?

no

## 🤖 Agent context

Investigated a customer support ticket reporting that disabling Autoplay had no effect on the player. Tracing the data flow `playerSettingsLogic → sessionRecordingsPlaylistLogic.nextSessionRecording → SessionRecordingsPlaylist.playNextRecording → PlayerController` made the bug obvious: the selector did not handle the `null` case.

Considered keeping the manual skip-to-next button active when autoplay is off (decouple manual nav from auto-advance), but rejected it for this PR — the setting is named *Autoplay* and the user's expectation is that Off means no automatic advancement. Honoring that intent end-to-end is simpler, smaller, and matches the menu label literally. If we later want a separate "manual next button" preference, that can be added without revisiting this fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*