### PR TITLE
chore(mcp): bump `@posthog/mcp-analytics` to 0.0.7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3516,8 +3516,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@posthog/mcp-analytics':
-        specifier: npm:@posthog/mcp@0.0.6
-        version: '@posthog/mcp@0.0.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(rxjs@7.8.1)'
+        specifier: npm:@posthog/mcp@0.0.7
+        version: '@posthog/mcp@0.0.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(rxjs@7.8.1)'
       '@posthog/quill':
         specifier: workspace:*
         version: link:../../packages/quill/packages/quill
@@ -8970,8 +8970,8 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@posthog/mcp@0.0.6':
-    resolution: {integrity: sha512-emcvEZzyq8U4ct6a8ndPwlL+Gv5y33a/O8kt9oIJxp3oZ/pAa7v8lxUU04feOSZbI9SmWtH5N8EuZeuWV4z5/g==}
+  '@posthog/mcp@0.0.7':
+    resolution: {integrity: sha512-pB5oyt6WrhYJVauIwZbQSmsoVNAPxYRulKVfpRCNJNCN6tUycDYtdvox8jqqfwHoJHOmYUjRVJPCmyTVNQYlNg==}
     engines: {node: '>=22.22.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.29.0
@@ -32018,7 +32018,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@posthog/mcp@0.0.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(rxjs@7.8.1)':
+  '@posthog/mcp@0.0.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(rxjs@7.8.1)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       posthog-node: 5.33.3(rxjs@7.8.1)

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.0.6",
+        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.0.7",
         "@posthog/quill": "workspace:*",
         "@toon-format/toon": "^2.1.0",
         "agents": "0.10.2",


### PR DESCRIPTION
Bumps the `@posthog/mcp` package from `0.0.6` to `0.0.7`.

Need this to pass Codex's app store approval