### PR TITLE
refactor(surveys): tidy legacy Display conditions section

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5563,9 +5563,9 @@ snapshots:
     scenes-app-surveys--new-survey-customisation-section--light:
         hash: v1.k794b7964.288fec0f91326deccbaf9910189134f14be62162013df6c8364e438e90e095cc.IuLmX5ajln3b3KtOTFFdHZMGlJk9iaCRitsBWvb2bzU
     scenes-app-surveys--new-survey-targeting-section--dark:
-        hash: v1.k794b7964.3bfc8b6bf633d952b40bb28397b317a7d0c7ce937aa00c1c36fb8296c8fdc5ca.Y00qyQ4JDGcqi4wwbMhuyofDZc_5xZWP42_JrLZ0lLE
+        hash: v1.k794b7964.291b22007c1e8f4fd06d46e9c7d1f87ae70ebd3ec766328340ad89ea3f2ab16b.xS2De9yYBV2JVrvQlzbqMjD2i3HpALi7iVI7TczcfdI
     scenes-app-surveys--new-survey-targeting-section--light:
-        hash: v1.k794b7964.8a3821d75dfea493f5a9e3586d5057e5da30dc9e6a9c37cf40c4b80e78792988.fX3miFzzpV66ZEeVZJQjO-UUmvlQggLHZRAwAkCsuMg
+        hash: v1.k794b7964.428c3041d4d8a23ad1faa0c885f06cb34a166c344f7b74c39450107279a68b69.SYss9mta5gXUBO6hDBww3B8CJc0HtI-8EoCgtobBtO0
     scenes-app-surveys--new-survey-with-html-question-description--dark:
         hash: v1.k794b7964.70d82e0de54aa3a0982efc2faed7b69936d09f4d24571e270fc6291130ac7af4.SK36SUGAETwqhQUwRQp_oZ8E4AgSWRrZSN5pt-H9xKU
     scenes-app-surveys--new-survey-with-html-question-description--light:

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -1367,11 +1367,11 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                               <LemonField
                                                                   name="linked_flag_id"
                                                                   label="Feature flag targeting"
-                                                                  info="Optionally limit this survey to users who have a specific feature flag enabled. Connecting a flag enables the survey for everyone the flag is on for."
+                                                                  help="Optionally limit this survey to users who have a specific feature flag enabled. Connecting a flag enables the survey for everyone the flag is on for."
                                                               >
                                                                   {({ value, onChange }) => (
                                                                       <div
-                                                                          className="flex"
+                                                                          className="flex items-center gap-2"
                                                                           data-attr="survey-display-conditions-linked-flag"
                                                                       >
                                                                           <FlagSelector
@@ -1428,7 +1428,6 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                           />
                                                                           {value && (
                                                                               <LemonButton
-                                                                                  className="ml-2"
                                                                                   type="tertiary"
                                                                                   size="small"
                                                                                   icon={<IconTrash />}
@@ -1498,10 +1497,11 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                           <LemonField.Pure
                                                                               label="URL targeting"
                                                                               error={urlMatchTypeValidationError}
-                                                                              info="Targeting by regex or exact match requires at least version 1.82 of posthog-js"
+                                                                              help="Match the current URL against the pattern you provide. Regex and exact match require posthog-js 1.82 or later."
                                                                           >
                                                                               <div className="flex flex-row gap-2 items-center">
                                                                                   <LemonSelect
+                                                                                      className="w-40 shrink-0"
                                                                                       value={
                                                                                           value?.urlMatchType ||
                                                                                           SurveyMatchType.Contains
@@ -1547,22 +1547,22 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                               error={
                                                                                   deviceTypesMatchTypeValidationError
                                                                               }
-                                                                              info={
+                                                                              help={
                                                                                   <>
-                                                                                      Add the device types to show the
-                                                                                      survey on. Possible values:
-                                                                                      'Desktop', 'Mobile', 'Tablet'. For
-                                                                                      the full list and caveats,{' '}
+                                                                                      Restrict the survey to specific
+                                                                                      devices. Common values: Desktop,
+                                                                                      Mobile, Tablet — see the{' '}
                                                                                       <Link to="https://posthog.com/docs/surveys/creating-surveys#display-conditions">
-                                                                                          check the documentation here
+                                                                                          full list and caveats
                                                                                       </Link>
-                                                                                      . Requires at least version 1.214
-                                                                                      of posthog-js
+                                                                                      . Requires posthog-js 1.214 or
+                                                                                      later.
                                                                                   </>
                                                                               }
                                                                           >
                                                                               <div className="flex flex-row gap-2 items-center">
                                                                                   <LemonSelect
+                                                                                      className="w-40 shrink-0"
                                                                                       value={
                                                                                           value?.deviceTypesMatchType ||
                                                                                           SurveyMatchType.Contains
@@ -1614,37 +1614,39 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                           placeholder="ex: Desktop|Mobile"
                                                                                       />
                                                                                   ) : (
-                                                                                      <PropertyValue
-                                                                                          propertyKey={getPropertyKey(
-                                                                                              'Device Type',
-                                                                                              TaxonomicFilterGroupType.EventProperties
-                                                                                          )}
-                                                                                          type={
-                                                                                              PropertyFilterType.Event
-                                                                                          }
-                                                                                          onSet={(
-                                                                                              deviceTypes:
-                                                                                                  | string
-                                                                                                  | string[]
-                                                                                          ) => {
-                                                                                              onChange({
-                                                                                                  ...value,
+                                                                                      <div className="flex-1 min-w-0">
+                                                                                          <PropertyValue
+                                                                                              propertyKey={getPropertyKey(
+                                                                                                  'Device Type',
+                                                                                                  TaxonomicFilterGroupType.EventProperties
+                                                                                              )}
+                                                                                              type={
+                                                                                                  PropertyFilterType.Event
+                                                                                              }
+                                                                                              onSet={(
                                                                                                   deviceTypes:
-                                                                                                      Array.isArray(
-                                                                                                          deviceTypes
-                                                                                                      )
-                                                                                                          ? deviceTypes
-                                                                                                          : [
-                                                                                                                deviceTypes,
-                                                                                                            ],
-                                                                                              })
-                                                                                          }}
-                                                                                          operator={
-                                                                                              PropertyOperator.Exact
-                                                                                          }
-                                                                                          value={value?.deviceTypes}
-                                                                                          inputClassName="flex-1"
-                                                                                      />
+                                                                                                      | string
+                                                                                                      | string[]
+                                                                                              ) => {
+                                                                                                  onChange({
+                                                                                                      ...value,
+                                                                                                      deviceTypes:
+                                                                                                          Array.isArray(
+                                                                                                              deviceTypes
+                                                                                                          )
+                                                                                                              ? deviceTypes
+                                                                                                              : [
+                                                                                                                    deviceTypes,
+                                                                                                                ],
+                                                                                                  })
+                                                                                              }}
+                                                                                              operator={
+                                                                                                  PropertyOperator.Exact
+                                                                                              }
+                                                                                              value={value?.deviceTypes}
+                                                                                              inputClassName="w-full"
+                                                                                          />
+                                                                                      </div>
                                                                                   )}
                                                                               </div>
                                                                           </LemonField.Pure>
@@ -1662,7 +1664,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                           </LemonField.Pure>
                                                                           <LemonField.Pure
                                                                               label="Survey wait period"
-                                                                              info="Only reliable for identified users within a single browser session. Anonymous users, browser switches, incognito sessions, or log out / log back in flows may still see the survey again. Responses submitted while anonymous may be associated with the account if the user logs in during the same session."
+                                                                              help="Only reliable for identified users in a single browser session. Anonymous users, browser switches, incognito sessions, or log out / log back in flows may still see the survey again. Responses submitted while anonymous may be linked to the account if the user logs in during the same session."
                                                                           >
                                                                               <div className="flex flex-wrap gap-2 items-center text-sm">
                                                                                   <LemonCheckbox
@@ -1713,7 +1715,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                               </LemonField>
                                                               <LemonField.Pure
                                                                   label="Audience filters"
-                                                                  info="Limit this survey to users (or groups) whose properties match the conditions below."
+                                                                  help="Limit this survey to users (or groups) whose properties match the conditions below."
                                                               >
                                                                   <BindLogic
                                                                       logic={featureFlagLogic}

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -1333,33 +1333,34 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                               dataAttr: 'survey-display-conditions',
                                               content: (
                                                   <LemonField.Pure>
-                                                      <LemonSelect
+                                                      <LemonRadio
+                                                          value={hasTargetingSet ? 'matching' : 'all'}
                                                           onChange={(value) => {
-                                                              if (value) {
+                                                              if (value === 'all') {
                                                                   resetTargeting()
                                                               } else {
-                                                                  // TRICKY: When attempting to set user match conditions
-                                                                  // we want a proxy value to be set so that the user
-                                                                  // can then edit these, or decide to go back to all user targeting
+                                                                  // Proxy value so the conditions block renders and the
+                                                                  // user can start editing or return to "all users".
                                                                   setSurveyValue('conditions', { url: '' })
                                                               }
                                                           }}
-                                                          value={!hasTargetingSet}
                                                           options={[
-                                                              { label: 'All users', value: true },
                                                               {
-                                                                  label: 'Users who match all of the following...',
-                                                                  value: false,
+                                                                  value: 'all',
+                                                                  label: 'All users',
+                                                                  description: 'Show this survey to everyone',
+                                                              },
+                                                              {
+                                                                  value: 'matching',
+                                                                  label: 'Only users who match conditions',
+                                                                  description:
+                                                                      'Show this survey only when every condition below is met',
                                                                   'data-attr': 'survey-display-conditions-select-users',
                                                               },
                                                           ]}
                                                           data-attr="survey-display-conditions-select"
                                                       />
-                                                      {!hasTargetingSet ? (
-                                                          <span className="text-secondary">
-                                                              Survey <b>will be released to everyone</b>
-                                                          </span>
-                                                      ) : (
+                                                      {hasTargetingSet && (
                                                           <>
                                                               <LemonField
                                                                   name="linked_flag_id"
@@ -1502,7 +1503,6 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                               info="Targeting by regex or exact match requires at least version 1.82 of posthog-js"
                                                                           >
                                                                               <div className="flex flex-row gap-2 items-center">
-                                                                                  URL
                                                                                   <LemonSelect
                                                                                       value={
                                                                                           value?.urlMatchType ||
@@ -1545,7 +1545,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                               </div>
                                                                           </LemonField.Pure>
                                                                           <LemonField.Pure
-                                                                              label="Device Types"
+                                                                              label="Device types"
                                                                               error={
                                                                                   deviceTypesMatchTypeValidationError
                                                                               }
@@ -1564,7 +1564,6 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                               }
                                                                           >
                                                                               <div className="flex flex-row gap-2 items-center">
-                                                                                  Device Types
                                                                                   <LemonSelect
                                                                                       value={
                                                                                           value?.deviceTypesMatchType ||
@@ -1651,7 +1650,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                   )}
                                                                               </div>
                                                                           </LemonField.Pure>
-                                                                          <LemonField.Pure label="CSS selector matches:">
+                                                                          <LemonField.Pure label="CSS selector matches">
                                                                               <LemonInput
                                                                                   value={value?.selector}
                                                                                   onChange={(selectorVal) =>
@@ -1665,67 +1664,48 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                           </LemonField.Pure>
                                                                           <LemonField.Pure
                                                                               label="Survey wait period"
-                                                                              info="Note that this condition will only apply reliably for identified users within a single browser session. Anonymous users or users who switch browsers, use incognito sessions, or log out and log back in may see the survey again. Additionally, responses submitted while a user is anonymous may be associated with their account if they log in during the same session."
+                                                                              info="Only reliable for identified users within a single browser session. Anonymous users, browser switches, incognito sessions, or log out / log back in flows may still see the survey again. Responses submitted while anonymous may be associated with the account if the user logs in during the same session."
                                                                           >
-                                                                              <div className="flex flex-row gap-2 items-center">
+                                                                              <div className="flex flex-wrap gap-2 items-center text-sm">
                                                                                   <LemonCheckbox
                                                                                       checked={
                                                                                           !!value?.seenSurveyWaitPeriodInDays
                                                                                       }
                                                                                       onChange={(checked) => {
-                                                                                          if (checked) {
-                                                                                              onChange({
-                                                                                                  ...value,
-                                                                                                  seenSurveyWaitPeriodInDays:
-                                                                                                      value?.seenSurveyWaitPeriodInDays ||
-                                                                                                      30,
-                                                                                              })
-                                                                                          } else {
-                                                                                              const {
-                                                                                                  seenSurveyWaitPeriodInDays,
-                                                                                                  ...rest
-                                                                                              } = value || {}
-                                                                                              onChange(rest)
-                                                                                          }
+                                                                                          onChange({
+                                                                                              ...value,
+                                                                                              seenSurveyWaitPeriodInDays:
+                                                                                                  checked
+                                                                                                      ? value?.seenSurveyWaitPeriodInDays ||
+                                                                                                        30
+                                                                                                      : null,
+                                                                                          })
                                                                                       }}
+                                                                                      label="Don't show this survey if another one was shown to the user in the last"
                                                                                   />
-                                                                                  Don't show to users who saw any survey
-                                                                                  in the last
                                                                                   <LemonInput
                                                                                       type="number"
                                                                                       size="xsmall"
-                                                                                      min={0}
+                                                                                      min={1}
                                                                                       value={
-                                                                                          value?.seenSurveyWaitPeriodInDays ||
-                                                                                          NaN
+                                                                                          value?.seenSurveyWaitPeriodInDays ??
+                                                                                          undefined
                                                                                       }
-                                                                                      onChange={(val) => {
-                                                                                          if (
-                                                                                              val !== undefined &&
-                                                                                              val > 0
-                                                                                          ) {
-                                                                                              onChange({
-                                                                                                  ...value,
-                                                                                                  seenSurveyWaitPeriodInDays:
-                                                                                                      val,
-                                                                                              })
-                                                                                          } else {
-                                                                                              onChange({
-                                                                                                  ...value,
-                                                                                                  seenSurveyWaitPeriodInDays:
-                                                                                                      null,
-                                                                                              })
-                                                                                          }
-                                                                                      }}
-                                                                                      className="w-12"
+                                                                                      onChange={(val) =>
+                                                                                          onChange({
+                                                                                              ...value,
+                                                                                              seenSurveyWaitPeriodInDays:
+                                                                                                  val && val > 0
+                                                                                                      ? val
+                                                                                                      : null,
+                                                                                          })
+                                                                                      }
+                                                                                      className="w-16 tabular-nums"
                                                                                       id="survey-wait-period-input"
-                                                                                  />{' '}
-                                                                                  {value?.seenSurveyWaitPeriodInDays ===
-                                                                                  1 ? (
-                                                                                      <span>day.</span>
-                                                                                  ) : (
-                                                                                      <span>days.</span>
-                                                                                  )}
+                                                                                  />
+                                                                                  <span className="text-secondary">
+                                                                                      days.
+                                                                                  </span>
                                                                               </div>
                                                                           </LemonField.Pure>
                                                                       </>

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -1793,9 +1793,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                               {featureFlags[FEATURE_FLAGS.SURVEYS_ACTIONS] ? (
                                                                   <LemonField.Pure
                                                                       label="Activation triggers"
-                                                                      info="Survey will activate when any of these conditions are met"
+                                                                      help="The survey activates when any of these conditions are met."
                                                                   >
-                                                                      <div className="border rounded p-3 space-y-3">
+                                                                      <div className="space-y-4">
                                                                           <SurveyEventTrigger />
                                                                           <div className="flex items-center gap-2">
                                                                               <div className="flex-1 border-t border-dashed" />

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -1362,6 +1362,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                       />
                                                       {hasTargetingSet && (
                                                           <>
+                                                              <h3 className="text-xs font-semibold text-secondary uppercase tracking-wider mt-3 mb-0">
+                                                                  Targeting
+                                                              </h3>
                                                               <LemonField
                                                                   name="linked_flag_id"
                                                                   label="Link feature flag (optional)"
@@ -1683,29 +1686,31 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                       }}
                                                                                       label="Don't show this survey if another one was shown to the user in the last"
                                                                                   />
-                                                                                  <LemonInput
-                                                                                      type="number"
-                                                                                      size="xsmall"
-                                                                                      min={1}
-                                                                                      value={
-                                                                                          value?.seenSurveyWaitPeriodInDays ??
-                                                                                          undefined
-                                                                                      }
-                                                                                      onChange={(val) =>
-                                                                                          onChange({
-                                                                                              ...value,
-                                                                                              seenSurveyWaitPeriodInDays:
-                                                                                                  val && val > 0
-                                                                                                      ? val
-                                                                                                      : null,
-                                                                                          })
-                                                                                      }
-                                                                                      className="w-16 tabular-nums"
-                                                                                      id="survey-wait-period-input"
-                                                                                  />
-                                                                                  <span className="text-secondary">
-                                                                                      days.
-                                                                                  </span>
+                                                                                  <div className="flex items-center gap-2">
+                                                                                      <LemonInput
+                                                                                          type="number"
+                                                                                          size="xsmall"
+                                                                                          min={1}
+                                                                                          value={
+                                                                                              value?.seenSurveyWaitPeriodInDays ??
+                                                                                              undefined
+                                                                                          }
+                                                                                          onChange={(val) =>
+                                                                                              onChange({
+                                                                                                  ...value,
+                                                                                                  seenSurveyWaitPeriodInDays:
+                                                                                                      val && val > 0
+                                                                                                          ? val
+                                                                                                          : null,
+                                                                                              })
+                                                                                          }
+                                                                                          className="w-16 tabular-nums"
+                                                                                          id="survey-wait-period-input"
+                                                                                      />
+                                                                                      <span className="text-secondary">
+                                                                                          days.
+                                                                                      </span>
+                                                                                  </div>
                                                                               </div>
                                                                           </LemonField.Pure>
                                                                       </>
@@ -1782,6 +1787,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                       )}
                                                                   </BindLogic>
                                                               </LemonField.Pure>
+                                                              <h3 className="text-xs font-semibold text-secondary uppercase tracking-wider mt-4 mb-0">
+                                                                  Triggers
+                                                              </h3>
                                                               {featureFlags[FEATURE_FLAGS.SURVEYS_ACTIONS] ? (
                                                                   <LemonField.Pure
                                                                       label="Activation triggers"

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -29,7 +29,6 @@ import { PropertyValue } from 'lib/components/PropertyFilters/components/Propert
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
-import { IconCancel } from 'lib/lemon-ui/icons'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonRadio, LemonRadioOption } from 'lib/lemon-ui/LemonRadio'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -1367,14 +1366,8 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                               </h3>
                                                               <LemonField
                                                                   name="linked_flag_id"
-                                                                  label="Link feature flag (optional)"
-                                                                  info={
-                                                                      <>
-                                                                          Connecting to a feature flag will
-                                                                          automatically enable this survey for everyone
-                                                                          in the feature flag.
-                                                                      </>
-                                                                  }
+                                                                  label="Feature flag targeting"
+                                                                  info="Optionally limit this survey to users who have a specific feature flag enabled. Connecting a flag enables the survey for everyone the flag is on for."
                                                               >
                                                                   {({ value, onChange }) => (
                                                                       <div
@@ -1436,8 +1429,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                           {value && (
                                                                               <LemonButton
                                                                                   className="ml-2"
-                                                                                  icon={<IconCancel />}
+                                                                                  type="tertiary"
                                                                                   size="small"
+                                                                                  icon={<IconTrash />}
                                                                                   onClick={() => {
                                                                                       onChange(null)
                                                                                       setSurveyValue(
@@ -1452,8 +1446,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                           ...conditions,
                                                                                       })
                                                                                   }}
-                                                                                  aria-label="close"
-                                                                              />
+                                                                              >
+                                                                                  Clear
+                                                                              </LemonButton>
                                                                           )}
                                                                       </div>
                                                                   )}
@@ -1716,7 +1711,10 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                       </>
                                                                   )}
                                                               </LemonField>
-                                                              <LemonField.Pure label="Properties">
+                                                              <LemonField.Pure
+                                                                  label="Audience filters"
+                                                                  info="Limit this survey to users (or groups) whose properties match the conditions below."
+                                                              >
                                                                   <BindLogic
                                                                       logic={featureFlagLogic}
                                                                       props={{

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -1367,7 +1367,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                               <LemonField
                                                                   name="linked_flag_id"
                                                                   label="Feature flag targeting"
-                                                                  help="Optionally limit this survey to users who have a specific feature flag enabled. Connecting a flag enables the survey for everyone the flag is on for."
+                                                                  help="Linking a flag also enables the survey for everyone the flag is on for."
                                                               >
                                                                   {({ value, onChange }) => (
                                                                       <div
@@ -1497,7 +1497,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                           <LemonField.Pure
                                                                               label="URL targeting"
                                                                               error={urlMatchTypeValidationError}
-                                                                              help="Match the current URL against the pattern you provide. Regex and exact match require posthog-js 1.82 or later."
+                                                                              help="Regex and exact match need posthog-js 1.82+."
                                                                           >
                                                                               <div className="flex flex-row gap-2 items-center">
                                                                                   <LemonSelect
@@ -1549,14 +1549,10 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                               }
                                                                               help={
                                                                                   <>
-                                                                                      Restrict the survey to specific
-                                                                                      devices. Common values: Desktop,
-                                                                                      Mobile, Tablet — see the{' '}
                                                                                       <Link to="https://posthog.com/docs/surveys/creating-surveys#display-conditions">
-                                                                                          full list and caveats
+                                                                                          See accepted values
                                                                                       </Link>
-                                                                                      . Requires posthog-js 1.214 or
-                                                                                      later.
+                                                                                      . Needs posthog-js 1.214+.
                                                                                   </>
                                                                               }
                                                                           >
@@ -1664,7 +1660,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                           </LemonField.Pure>
                                                                           <LemonField.Pure
                                                                               label="Survey wait period"
-                                                                              help="Only reliable for identified users in a single browser session. Anonymous users, browser switches, incognito sessions, or log out / log back in flows may still see the survey again. Responses submitted while anonymous may be linked to the account if the user logs in during the same session."
+                                                                              help="Reliable only for identified users in the same browser session — incognito, browser switches, and logout/login may still see the survey again."
                                                                           >
                                                                               <div className="flex flex-wrap gap-2 items-center text-sm">
                                                                                   <LemonCheckbox
@@ -1713,10 +1709,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                       </>
                                                                   )}
                                                               </LemonField>
-                                                              <LemonField.Pure
-                                                                  label="Audience filters"
-                                                                  help="Limit this survey to users (or groups) whose properties match the conditions below."
-                                                              >
+                                                              <LemonField.Pure label="Audience filters">
                                                                   <BindLogic
                                                                       logic={featureFlagLogic}
                                                                       props={{
@@ -1791,10 +1784,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                   Triggers
                                                               </h3>
                                                               {featureFlags[FEATURE_FLAGS.SURVEYS_ACTIONS] ? (
-                                                                  <LemonField.Pure
-                                                                      label="Activation triggers"
-                                                                      help="The survey activates when any of these conditions are met."
-                                                                  >
+                                                                  <LemonField.Pure label="Activation triggers">
                                                                       <div className="space-y-4">
                                                                           <SurveyEventTrigger />
                                                                           <div className="flex items-center gap-2">

--- a/frontend/src/scenes/surveys/SurveyEventTrigger.test.tsx
+++ b/frontend/src/scenes/surveys/SurveyEventTrigger.test.tsx
@@ -78,8 +78,7 @@ describe('Survey event trigger property filters', () => {
             </Provider>
         )
 
-        expect(await screen.findByText('Narrow this trigger to matching events only.')).toBeInTheDocument()
-        expect(screen.getByText('No filters yet')).toBeInTheDocument()
+        expect(await screen.findByText('No filters')).toBeInTheDocument()
         expect(screen.getByText('Property filters for signed_up')).toBeInTheDocument()
     })
 

--- a/frontend/src/scenes/surveys/SurveyEventTrigger.tsx
+++ b/frontend/src/scenes/surveys/SurveyEventTrigger.tsx
@@ -177,18 +177,13 @@ function SurveyEventSelector({
                                                     <span className="text-xs text-muted bg-border px-1.5 py-0.5 rounded">
                                                         {hasPropertyFilters
                                                             ? `${propertyFilterCount} filter${propertyFilterCount !== 1 ? 's' : ''}`
-                                                            : 'No filters yet'}
-                                                    </span>
-                                                    <span className="text-xs text-muted-alt">
-                                                        {hasPropertyFilters
-                                                            ? 'Refine this trigger'
-                                                            : 'Optional: add property filters'}
+                                                            : 'No filters'}
                                                     </span>
                                                 </div>
                                             ),
                                             content: (
-                                                <div>
-                                                    <div className="flex justify-end mb-2">
+                                                <div className="space-y-2">
+                                                    <div className="flex justify-end">
                                                         <LemonButton
                                                             size="xsmall"
                                                             icon={<IconX />}
@@ -196,14 +191,8 @@ function SurveyEventSelector({
                                                             type="tertiary"
                                                             status="alt"
                                                         >
-                                                            Remove event
+                                                            Remove
                                                         </LemonButton>
-                                                    </div>
-                                                    <div className="text-xs font-medium text-muted-alt mb-2 uppercase tracking-wide">
-                                                        Event property filters
-                                                    </div>
-                                                    <div className="text-xs text-muted mb-3">
-                                                        Narrow this trigger to matching events only.
                                                     </div>
                                                     <PropertyFilters
                                                         propertyFilters={convertPropertyFiltersToArray(
@@ -224,11 +213,9 @@ function SurveyEventSelector({
                                                         buttonSize="small"
                                                         operatorAllowlist={SUPPORTED_OPERATORS}
                                                     />
-                                                    <span className="text-xs text-muted">
-                                                        Only primitive types (strings, numbers, booleans) are supported
-                                                        for property filters. Array and object properties are not
-                                                        supported and will not be shown.
-                                                    </span>
+                                                    <p className="text-xs text-muted m-0">
+                                                        Array and object properties aren't supported here.
+                                                    </p>
                                                 </div>
                                             ),
                                         },
@@ -241,7 +228,7 @@ function SurveyEventSelector({
 
                 {showRepeatedActivation && surveyRepeatedActivationAvailable && (
                     <LemonCheckbox
-                        label="Display the survey every time events occur, instead of only once per user"
+                        label="Show every time these events fire (otherwise: once per user)"
                         checked={survey.conditions?.events?.repeatedActivation || false}
                         onChange={(checked) => {
                             setSurveyValue('conditions', {
@@ -270,9 +257,9 @@ export function SurveyEventTrigger(): JSX.Element {
         <SurveyEventSelector
             conditionField="events"
             label="User sends events"
-            info="It only triggers when the event is captured in the current user session and using the PostHog SDK. Filtering by event properties requires posthog-js >= v1.268.0 or posthog-react-native >= v4.15.0. Not supported for other SDKs."
+            info="Triggers fire when the event is captured in the current user session via a PostHog SDK. Property filtering requires posthog-js 1.268+ or posthog-react-native 4.15+."
             emptyTitle="No events selected"
-            emptyDescription="Add events to trigger this survey when those events are captured in the current user session"
+            emptyDescription="Pick events that should trigger this survey."
             showRepeatedActivation
         />
     )
@@ -286,9 +273,9 @@ export function SurveyCancelEventTrigger(): JSX.Element {
         <SurveyEventSelector
             conditionField="cancelEvents"
             label="Cancel survey on events"
-            info="It only triggers when the event is captured in the current user session and using the PostHog SDK. Requires posthog-js SDK at least v1.299.0, and it's supported only for web surveys."
+            info="Triggers fire when the event is captured in the current user session via a PostHog SDK. Requires posthog-js 1.299+. Web surveys only."
             emptyTitle={`During your ${delaySeconds} second delay...`}
-            emptyDescription="If any of these events fire, the survey will be cancelled. Useful for not interrupting users who complete an action successfully."
+            emptyDescription="If any of these events fire, the survey is cancelled — useful when the user has already completed the action."
             addButtonText="Add cancel event"
         />
     )

--- a/frontend/src/scenes/surveys/SurveyEventTrigger.tsx
+++ b/frontend/src/scenes/surveys/SurveyEventTrigger.tsx
@@ -172,28 +172,32 @@ function SurveyEventSelector({
                                         {
                                             key: panelKey,
                                             header: (
-                                                <div className="flex items-center gap-2 flex-1">
-                                                    <span className="font-semibold text-sm">{event.name}</span>
-                                                    <span className="text-xs text-muted bg-border px-1.5 py-0.5 rounded">
-                                                        {hasPropertyFilters
-                                                            ? `${propertyFilterCount} filter${propertyFilterCount !== 1 ? 's' : ''}`
-                                                            : 'No filters'}
-                                                    </span>
+                                                <div className="flex items-center gap-2 flex-1 justify-between">
+                                                    <div className="flex items-center gap-2 min-w-0">
+                                                        <span className="font-semibold text-sm truncate">
+                                                            {event.name}
+                                                        </span>
+                                                        <span className="text-xs text-muted bg-border px-1.5 py-0.5 rounded shrink-0">
+                                                            {hasPropertyFilters
+                                                                ? `${propertyFilterCount} filter${propertyFilterCount !== 1 ? 's' : ''}`
+                                                                : 'No filters'}
+                                                        </span>
+                                                    </div>
+                                                    <LemonButton
+                                                        size="xsmall"
+                                                        icon={<IconX />}
+                                                        onClick={(e) => {
+                                                            e.stopPropagation()
+                                                            removeEventAtIndex(index)
+                                                        }}
+                                                        type="tertiary"
+                                                        status="alt"
+                                                        tooltip="Remove event"
+                                                    />
                                                 </div>
                                             ),
                                             content: (
                                                 <div className="space-y-2">
-                                                    <div className="flex justify-end">
-                                                        <LemonButton
-                                                            size="xsmall"
-                                                            icon={<IconX />}
-                                                            onClick={() => removeEventAtIndex(index)}
-                                                            type="tertiary"
-                                                            status="alt"
-                                                        >
-                                                            Remove
-                                                        </LemonButton>
-                                                    </div>
                                                     <PropertyFilters
                                                         propertyFilters={convertPropertyFiltersToArray(
                                                             event.propertyFilters

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -228,7 +228,6 @@ export function SurveyTranslations(): JSX.Element {
                     placeholder="Add a language (e.g., 'fr', 'French', 'fr-CA')"
                     className="grow"
                     allowCustomValues
-                    autoFocus={addedLanguages.length === 0}
                     value={[]}
                 />
                 <LemonButton

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -28,6 +28,7 @@ import {
     SurveyQuestion,
     SurveyQuestionType,
     SurveyRates,
+    SurveySchedule,
     SurveyStats,
     SurveyType,
 } from '~/types'
@@ -507,6 +508,12 @@ export function isSurveyRunning(survey: Pick<Survey, 'start_date' | 'end_date'>)
 // list in sync with what the wizard's steps actually expose.
 export function canUseSurveyWizard(survey: Survey | NewSurvey): boolean {
     if (survey.type !== SurveyType.Popover) {
+        return false
+    }
+    // SurveySchedule.Always — the wizard offers Once + recurring frequencies, but not "every time
+    // the display conditions are met". Keep Always surveys in the legacy editor where the option
+    // is actually visible, so the wizard never silently misrepresents the cadence.
+    if (survey.schedule === SurveySchedule.Always) {
         return false
     }
     // Adaptive sampling — WhenStep exposes a simple responses_limit but not


### PR DESCRIPTION
## Problem

The legacy survey editor's **Display conditions** section had drifted from the guided wizard's equivalent screens — different copy, different control choices, inconsistent field widths, redundant inline labels, tooltips hiding load-bearing helper text, and an outer panel border around the Activation triggers group that nested inside another border per event. Separately, the new-survey screen autofocused the "Add a language" input on every load.

This PR is a pass of contained polish that pulls the legacy editor closer to the wizard without restructuring the panel layout itself. Field IDs and `data-attr` selectors are preserved so e2e selectors keep working.

## Changes

Grouped by intent:

### Controls and visual structure
- Replace the two-option "All users / Users who match all..." `LemonSelect` with a `LemonRadio` that mirrors the wizard's trigger-mode control, with per-option descriptions instead of a separate status line.
- Add two understated sub-headers — **Targeting** and **Triggers** — inside the Display conditions panel. Names and order mirror the wizard's step names so future unification can promote them to actual panels.
- Drop the outer `border rounded p-3` wrapper around Activation triggers. The per-event collapse keeps its border; the OR divider separates events from actions.
- Move the per-event Remove control into the `LemonCollapse` header (icon-only with tooltip, stops propagation), saving a row and keeping the action reachable when the panel is collapsed.
- Match the wizard's tertiary "Clear" + IconTrash for the linked-flag clear button (was a bare IconCancel "X").

### Width / layout
- URL targeting and Device types match-type selects get a fixed `w-40 shrink-0` width so they line up vertically.
- Device types' value picker wraps `PropertyValue` in `flex-1 min-w-0` so it fills the row to the same edge as the URL field.
- Fix the survey-wait-period row: the trailing "days." was wrapping onto its own line when the long checkbox label pushed the input below.

### Copy
- Remove duplicated inline text nodes "URL" and "Device Types" that restated the section labels above them.
- Sentence-case "Device Types" → "Device types"; drop the trailing colon on "CSS selector matches".
- Rename "Link feature flag (optional)" → "Feature flag targeting" and "Properties" → "Audience filters" to match the wizard.
- Sync the survey-wait-period copy to the wizard's wording.
- Tighten the per-event card: drop the "Optional: add property filters / Refine this trigger" caption, the "EVENT PROPERTY FILTERS" divider, and the "Narrow this trigger to matching events only" helper — the count tag already says it. The "Only primitive types..." paragraph becomes "Array and object properties aren't supported here."
- Tighten the SurveyEventTrigger / SurveyCancelEventTrigger info tooltips and empty-state copy. Shorten "Display the survey every time events occur, instead of only once per user" → "Show every time these events fire (otherwise: once per user)".
- Audit helper text: keep helpers only where they say something the label and control don't (version requirements, side effects, gotchas). Drop or shorten the rest.

### Behaviour fixes
- Replace the `value || NaN` anti-pattern in the survey-wait-period input with `value ?? undefined`.
- Add a guard in `canUseSurveyWizard` so `SurveySchedule.Always` surveys stay in the legacy editor — the wizard never exposed Always, so without the guard, an Always survey opens in the wizard with "Once ever" silently selected.
- Drop the autofocus on the translations "Add a language" input — it stole focus on every new-survey load.

## How did you test this code?

I'm an agent. I did not run the dev server. The changes are mostly label / control swaps against existing component props; behaviour-altering changes (`Always`-surveys guard, autofocus removal, `value ?? undefined` fix) are local and have no test impact. Recommend a quick visual pass over Display conditions and the new-survey landing before merging.

## Publish to changelog?

do not publish to changelog

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.7) over an iterative review with the user, following an earlier guided-wizard cleanup (#58744).

Decisions worth flagging for review:
- The wait period stays in its current structural position (inside the "Targeting" sub-group, alongside URL / Device / CSS) even though conceptually it's more of a cadence concern that the wizard puts under "How often should this survey show?". Moving it requires either duplicating the `LemonField name="conditions"` wrapper or a structural refactor — deferred.
- Sub-headers are added inside the existing "Display conditions" panel rather than promoting them to two separate `LemonCollapse` panels named "Targeting" and "Triggers". Splitting the panel would touch the `SurveyEditSection` enum, the section-routing logic in `surveyLogic.tsx`, and any URL state; that's a natural follow-up.
- I chose `LemonRadio` over `LemonSegmentedButton` for the All users / Match conditions toggle so the descriptions can spell out the difference between the two modes — same pattern the wizard's trigger-mode control uses.
- Sub-headers use a small uppercase secondary style so they read as *category markers* and don't compete visually with the bold field labels below.
- The Remove button in the per-event collapse header is a nested button inside the `LemonCollapse`'s own `LemonButton` wrapper. That's technically invalid HTML, but it's an existing pattern in the codebase and `stopPropagation` keeps the collapse from toggling on click.

Planned follow-ups (not in this PR):
- Promote the sub-headers to top-level `LemonCollapse` panels named "Targeting" and "Triggers" and align panel order with the wizard step order.
- Extract the ~460-line Display conditions JSX block out of `SurveyEdit.tsx` into its own component — the current 14-deep nesting is the real obstacle to further design work.
- Port the wizard's URL targeting (3 modes, `LemonInputSelect` autocomplete, live audience estimate, regex validation) into a shared component used by both editors.
- Replace the legacy device-types match-type select with the wizard's three toggle buttons.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*