### PR TITLE
feat(user-interviews): bulk create endpoint for interviewee context rows

### DIFF
--- a/products/user_interviews/backend/api.py
+++ b/products/user_interviews/backend/api.py
@@ -1081,11 +1081,13 @@ class IntervieweeContextViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         topic_id = self.parents_query_dict["topic_id"]
         team_id = self.parents_query_dict["team_id"]
 
-        if not UserInterviewTopic.objects.filter(id=topic_id, team_id=team_id).exists():
+        topic = UserInterviewTopic.objects.filter(id=topic_id, team_id=team_id).first()
+        if topic is None:
             return response.Response(
                 {"error": "Topic not found in this project."},
                 status=status.HTTP_404_NOT_FOUND,
             )
+        self.check_object_permissions(request, topic)
 
         payload = BulkIntervieweeContextRequestSerializer(data=request.data)
         payload.is_valid(raise_exception=True)

--- a/products/user_interviews/backend/api.py
+++ b/products/user_interviews/backend/api.py
@@ -32,10 +32,10 @@ from posthog.api.embedding_worker import generate_embedding
 from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
-from posthog.models.user import User
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.email import EmailMessage, is_email_available
 from posthog.models.sharing_configuration import SharingConfiguration
+from posthog.models.user import User
 from posthog.permissions import PostHogFeatureFlagPermission
 from posthog.utils import absolute_uri
 

--- a/products/user_interviews/backend/api.py
+++ b/products/user_interviews/backend/api.py
@@ -1049,7 +1049,6 @@ class IntervieweeContextViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         "create",
         "update",
         "partial_update",
-        "patch",
         "destroy",
         "bulk_create",
     ]
@@ -1112,11 +1111,11 @@ class IntervieweeContextViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             if item["interviewee_identifier"] not in existing
         ]
 
-        IntervieweeContext.objects.bulk_create(new_rows, ignore_conflicts=True)
+        inserted = IntervieweeContext.objects.bulk_create(new_rows, ignore_conflicts=True)
 
         response_payload = {
-            "inserted_count": len(new_rows),
-            "skipped_count": len(existing),
+            "inserted_count": len(inserted),
+            "skipped_count": len(existing) + (len(new_rows) - len(inserted)),
             "skipped_identifiers": sorted(existing),
         }
         return response.Response(BulkIntervieweeContextResponseSerializer(response_payload).data)

--- a/products/user_interviews/backend/api.py
+++ b/products/user_interviews/backend/api.py
@@ -989,11 +989,69 @@ class IntervieweeContextSerializer(serializers.ModelSerializer):
         )
 
 
+BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS = 500
+
+
+class BulkIntervieweeContextItemSerializer(serializers.Serializer):
+    interviewee_identifier = serializers.CharField(
+        max_length=400,
+        help_text="Identifier for the interviewee — typically an email address or PostHog distinct ID. Must match a value in the parent topic's interviewee_emails or interviewee_distinct_ids.",
+    )
+    agent_context = serializers.CharField(
+        max_length=10000,
+        help_text="Extra context the voice agent should know about this specific interviewee — e.g. 'uses the replay product but has never used summarization'.",
+    )
+
+
+class BulkIntervieweeContextRequestSerializer(serializers.Serializer):
+    items = BulkIntervieweeContextItemSerializer(
+        many=True,
+        allow_empty=False,
+        help_text=(
+            "List of interviewee context rows to create. Each item has an `interviewee_identifier` and an "
+            f"`agent_context`. At most {BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS} items per request."
+        ),
+    )
+
+    def validate_items(self, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if len(value) > BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS:
+            raise serializers.ValidationError(
+                f"Cannot create more than {BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS} interviewee contexts in one request."
+            )
+        identifiers = [item["interviewee_identifier"] for item in value]
+        if len(set(identifiers)) != len(identifiers):
+            raise serializers.ValidationError("Duplicate interviewee_identifier values within items.")
+        return value
+
+
+class BulkIntervieweeContextResponseSerializer(serializers.Serializer):
+    inserted_count = serializers.IntegerField(help_text="Number of rows inserted by this request.")
+    skipped_count = serializers.IntegerField(
+        help_text="Number of items skipped because a row for that (topic, interviewee_identifier) already existed."
+    )
+    skipped_identifiers = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Identifiers from the request whose rows were skipped because a row for that (topic, interviewee_identifier) already existed.",
+    )
+
+
 @extend_schema(tags=[ProductKey.USER_INTERVIEWS])
 class IntervieweeContextViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     """Per-interviewee extra context for a user interview topic. At most one row per (topic, interviewee_identifier)."""
 
     scope_object = "user_interview"
+    # Treat the custom @action endpoints as writes so personal API keys with
+    # `user_interview:write` can hit them. Without this override, APIScopePermission
+    # can't map a custom action name to a scope and rejects the request with
+    # "This action does not support personal API key access".
+    scope_object_write_actions = [
+        "create",
+        "update",
+        "partial_update",
+        "patch",
+        "destroy",
+        "bulk_create",
+    ]
     serializer_class = IntervieweeContextSerializer
     queryset = IntervieweeContext.objects.select_related("created_by").all()
     posthog_feature_flag = "user-interviews"
@@ -1007,3 +1065,57 @@ class IntervieweeContextViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def get_serializer_context(self) -> dict[str, Any]:
         return {**super().get_serializer_context(), "topic_id": self.parents_query_dict["topic_id"]}
+
+    @extend_schema(
+        request=BulkIntervieweeContextRequestSerializer,
+        responses={200: OpenApiResponse(response=BulkIntervieweeContextResponseSerializer)},
+        description=(
+            f"Create up to {BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS} interviewee context rows for a topic in a single "
+            "request. Rows whose (topic, interviewee_identifier) already exists are skipped — the response surfaces "
+            "an `inserted_count`, a `skipped_count`, and the `skipped_identifiers` so the caller can reconcile. "
+            "Items must have unique `interviewee_identifier` values within the batch."
+        ),
+    )
+    @action(detail=False, methods=["post"], url_path="bulk", pagination_class=None)
+    def bulk_create(self, request: Request, *args: Any, **kwargs: Any) -> response.Response:
+        topic_id = self.parents_query_dict["topic_id"]
+        team_id = self.parents_query_dict["team_id"]
+
+        if not UserInterviewTopic.objects.filter(id=topic_id, team_id=team_id).exists():
+            return response.Response(
+                {"error": "Topic not found in this project."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        payload = BulkIntervieweeContextRequestSerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+        items: list[dict[str, Any]] = payload.validated_data["items"]
+
+        identifiers = [item["interviewee_identifier"] for item in items]
+        existing = set(
+            IntervieweeContext.objects.filter(
+                topic_id=topic_id,
+                interviewee_identifier__in=identifiers,
+            ).values_list("interviewee_identifier", flat=True)
+        )
+
+        new_rows = [
+            IntervieweeContext(
+                team_id=team_id,
+                topic_id=topic_id,
+                created_by=request.user,
+                interviewee_identifier=item["interviewee_identifier"],
+                agent_context=item["agent_context"],
+            )
+            for item in items
+            if item["interviewee_identifier"] not in existing
+        ]
+
+        IntervieweeContext.objects.bulk_create(new_rows, ignore_conflicts=True)
+
+        response_payload = {
+            "inserted_count": len(new_rows),
+            "skipped_count": len(existing),
+            "skipped_identifiers": sorted(existing),
+        }
+        return response.Response(BulkIntervieweeContextResponseSerializer(response_payload).data)

--- a/products/user_interviews/backend/api.py
+++ b/products/user_interviews/backend/api.py
@@ -1,7 +1,7 @@
 import re
 import json
 from functools import cached_property
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 from django.conf import settings
@@ -32,6 +32,7 @@ from posthog.api.embedding_worker import generate_embedding
 from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.models.user import User
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.email import EmailMessage, is_email_available
 from posthog.models.sharing_configuration import SharingConfiguration
@@ -1103,7 +1104,7 @@ class IntervieweeContextViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             IntervieweeContext(
                 team_id=team_id,
                 topic_id=topic_id,
-                created_by=request.user,
+                created_by=cast(User, request.user),
                 interviewee_identifier=item["interviewee_identifier"],
                 agent_context=item["agent_context"],
             )

--- a/products/user_interviews/backend/test_interviewee_context_bulk_create.py
+++ b/products/user_interviews/backend/test_interviewee_context_bulk_create.py
@@ -82,6 +82,23 @@ class TestIntervieweeContextBulkCreate(_FeatureFlagEnabledMixin):
 
         assert response.status_code == status.HTTP_404_NOT_FOUND, response.content
 
+    def test_bulk_create_rejects_topic_belonging_to_another_team(self):
+        other_team = self.organization.teams.create(name="other-team")
+        other_topic = UserInterviewTopic.objects.create(
+            team=other_team,
+            created_by=self.user,
+            topic="other team topic",
+        )
+
+        response = self.client.post(
+            self._bulk_url(str(other_topic.id)),
+            {"items": [self._item("a@b.com")]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.content
+        assert IntervieweeContext.objects.filter(topic=other_topic).count() == 0
+
     @parameterized.expand(
         [
             ("empty_items", {"items": []}),

--- a/products/user_interviews/backend/test_interviewee_context_bulk_create.py
+++ b/products/user_interviews/backend/test_interviewee_context_bulk_create.py
@@ -1,0 +1,132 @@
+from typing import Any
+from uuid import uuid4
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from parameterized import parameterized
+from rest_framework import status
+
+from products.user_interviews.backend.api import BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS
+from products.user_interviews.backend.models import IntervieweeContext, UserInterviewTopic
+
+
+class _FeatureFlagEnabledMixin(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        patcher = patch("posthoganalytics.feature_enabled", return_value=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class TestIntervieweeContextBulkCreate(_FeatureFlagEnabledMixin):
+    def _create_topic(self, **overrides: Any) -> UserInterviewTopic:
+        defaults: dict = {
+            "team": self.team,
+            "created_by": self.user,
+            "interviewee_emails": [],
+            "interviewee_distinct_ids": [],
+            "topic": "MCP-only insight creators",
+        }
+        defaults.update(overrides)
+        return UserInterviewTopic.objects.create(**defaults)
+
+    def _bulk_url(self, topic_id: str) -> str:
+        return f"/api/environments/{self.team.id}/user_interview_topics/{topic_id}/interviewees/bulk/"
+
+    def _item(self, identifier: str, context: str = "ctx") -> dict[str, str]:
+        return {"interviewee_identifier": identifier, "agent_context": context}
+
+    def test_bulk_create_inserts_all_new_rows(self):
+        topic = self._create_topic()
+        items = [self._item(f"user{i}@example.com", f"context {i}") for i in range(3)]
+
+        response = self.client.post(self._bulk_url(str(topic.id)), {"items": items}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json() == {
+            "inserted_count": 3,
+            "skipped_count": 0,
+            "skipped_identifiers": [],
+        }
+        assert IntervieweeContext.objects.filter(topic=topic).count() == 3
+
+    def test_bulk_create_skips_existing_rows(self):
+        topic = self._create_topic()
+        IntervieweeContext.objects.create(
+            team=self.team,
+            topic=topic,
+            interviewee_identifier="existing@example.com",
+            agent_context="existing context",
+            created_by=self.user,
+        )
+        items = [
+            self._item("existing@example.com", "would-be-overwritten"),
+            self._item("new@example.com", "new context"),
+        ]
+
+        response = self.client.post(self._bulk_url(str(topic.id)), {"items": items}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json() == {
+            "inserted_count": 1,
+            "skipped_count": 1,
+            "skipped_identifiers": ["existing@example.com"],
+        }
+        existing = IntervieweeContext.objects.get(topic=topic, interviewee_identifier="existing@example.com")
+        assert existing.agent_context == "existing context"
+        assert IntervieweeContext.objects.filter(topic=topic).count() == 2
+
+    def test_bulk_create_rejects_unknown_topic(self):
+        response = self.client.post(self._bulk_url(str(uuid4())), {"items": [self._item("a@b.com")]}, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.content
+
+    @parameterized.expand(
+        [
+            ("empty_items", {"items": []}),
+            ("missing_items", {}),
+            ("missing_identifier", {"items": [{"agent_context": "x"}]}),
+            ("missing_context", {"items": [{"interviewee_identifier": "a@b.com"}]}),
+            (
+                "duplicate_identifiers_in_batch",
+                {"items": [{"interviewee_identifier": "a@b.com", "agent_context": "x"}] * 2},
+            ),
+            (
+                "identifier_too_long",
+                {"items": [{"interviewee_identifier": "a" * 401, "agent_context": "x"}]},
+            ),
+            (
+                "context_too_long",
+                {"items": [{"interviewee_identifier": "a@b.com", "agent_context": "x" * 10_001}]},
+            ),
+        ]
+    )
+    def test_bulk_create_validation_errors(self, _name: str, body: dict[str, Any]):
+        topic = self._create_topic()
+
+        response = self.client.post(self._bulk_url(str(topic.id)), body, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert IntervieweeContext.objects.filter(topic=topic).count() == 0
+
+    def test_bulk_create_rejects_oversized_batch(self):
+        topic = self._create_topic()
+        items = [self._item(f"u{i}@example.com") for i in range(BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS + 1)]
+
+        response = self.client.post(self._bulk_url(str(topic.id)), {"items": items}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert IntervieweeContext.objects.filter(topic=topic).count() == 0
+
+    def test_bulk_create_accepts_max_size_batch(self):
+        topic = self._create_topic()
+        items = [self._item(f"u{i}@example.com") for i in range(BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS)]
+
+        response = self.client.post(self._bulk_url(str(topic.id)), {"items": items}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        body = response.json()
+        assert body["inserted_count"] == BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS
+        assert body["skipped_count"] == 0
+        assert IntervieweeContext.objects.filter(topic=topic).count() == BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS

--- a/products/user_interviews/frontend/generated/api.schemas.ts
+++ b/products/user_interviews/frontend/generated/api.schemas.ts
@@ -212,6 +212,33 @@ export interface PatchedIntervieweeContextApi {
     agent_context?: string
 }
 
+export interface BulkIntervieweeContextItemApi {
+    /**
+     * Identifier for the interviewee — typically an email address or PostHog distinct ID. Must match a value in the parent topic's interviewee_emails or interviewee_distinct_ids.
+     * @maxLength 400
+     */
+    interviewee_identifier: string
+    /**
+     * Extra context the voice agent should know about this specific interviewee — e.g. 'uses the replay product but has never used summarization'.
+     * @maxLength 10000
+     */
+    agent_context: string
+}
+
+export interface BulkIntervieweeContextRequestApi {
+    /** List of interviewee context rows to create. Each item has an `interviewee_identifier` and an `agent_context`. At most 500 items per request. */
+    items: BulkIntervieweeContextItemApi[]
+}
+
+export interface BulkIntervieweeContextResponseApi {
+    /** Number of rows inserted by this request. */
+    inserted_count: number
+    /** Number of items skipped because a row for that (topic, interviewee_identifier) already existed. */
+    skipped_count: number
+    /** Identifiers from the request whose rows were skipped because a row for that (topic, interviewee_identifier) already existed. */
+    skipped_identifiers: string[]
+}
+
 export interface UserInterviewApi {
     readonly id: string
     readonly created_by: UserBasicApi

--- a/products/user_interviews/frontend/generated/api.ts
+++ b/products/user_interviews/frontend/generated/api.ts
@@ -9,6 +9,8 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    BulkIntervieweeContextRequestApi,
+    BulkIntervieweeContextResponseApi,
     IntervieweeContextApi,
     IntervieweeIdentifierRequestApi,
     PaginatedInterviewInviteResultListApi,
@@ -400,6 +402,30 @@ export const userInterviewTopicsIntervieweesDestroy = async (
         ...options,
         method: 'DELETE',
     })
+}
+
+export const getUserInterviewTopicsIntervieweesBulkCreateUrl = (projectId: string, topicId: string) => {
+    return `/api/environments/${projectId}/user_interview_topics/${topicId}/interviewees/bulk/`
+}
+
+/**
+ * Create up to 500 interviewee context rows for a topic in a single request. Rows whose (topic, interviewee_identifier) already exists are skipped — the response surfaces an `inserted_count`, a `skipped_count`, and the `skipped_identifiers` so the caller can reconcile. Items must have unique `interviewee_identifier` values within the batch.
+ */
+export const userInterviewTopicsIntervieweesBulkCreate = async (
+    projectId: string,
+    topicId: string,
+    bulkIntervieweeContextRequestApi: BulkIntervieweeContextRequestApi,
+    options?: RequestInit
+): Promise<BulkIntervieweeContextResponseApi> => {
+    return apiMutator<BulkIntervieweeContextResponseApi>(
+        getUserInterviewTopicsIntervieweesBulkCreateUrl(projectId, topicId),
+        {
+            ...options,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(bulkIntervieweeContextRequestApi),
+        }
+    )
 }
 
 export const getUserInterviewsListUrl = (projectId: string, params?: UserInterviewsListParams) => {

--- a/products/user_interviews/frontend/generated/api.zod.ts
+++ b/products/user_interviews/frontend/generated/api.zod.ts
@@ -211,6 +211,36 @@ export const UserInterviewTopicsIntervieweesPartialUpdateBody = /* @__PURE__ */ 
         ),
 })
 
+/**
+ * Create up to 500 interviewee context rows for a topic in a single request. Rows whose (topic, interviewee_identifier) already exists are skipped — the response surfaces an `inserted_count`, a `skipped_count`, and the `skipped_identifiers` so the caller can reconcile. Items must have unique `interviewee_identifier` values within the batch.
+ */
+export const userInterviewTopicsIntervieweesBulkCreateBodyItemsItemIntervieweeIdentifierMax = 400
+
+export const userInterviewTopicsIntervieweesBulkCreateBodyItemsItemAgentContextMax = 10000
+
+export const UserInterviewTopicsIntervieweesBulkCreateBody = /* @__PURE__ */ zod.object({
+    items: zod
+        .array(
+            zod.object({
+                interviewee_identifier: zod
+                    .string()
+                    .max(userInterviewTopicsIntervieweesBulkCreateBodyItemsItemIntervieweeIdentifierMax)
+                    .describe(
+                        "Identifier for the interviewee — typically an email address or PostHog distinct ID. Must match a value in the parent topic's interviewee_emails or interviewee_distinct_ids."
+                    ),
+                agent_context: zod
+                    .string()
+                    .max(userInterviewTopicsIntervieweesBulkCreateBodyItemsItemAgentContextMax)
+                    .describe(
+                        "Extra context the voice agent should know about this specific interviewee — e.g. 'uses the replay product but has never used summarization'."
+                    ),
+            })
+        )
+        .describe(
+            'List of interviewee context rows to create. Each item has an `interviewee_identifier` and an `agent_context`. At most 500 items per request.'
+        ),
+})
+
 export const userInterviewsCreateBodyIntervieweeEmailsItemMax = 254
 
 export const UserInterviewsCreateBody = /* @__PURE__ */ zod.object({

--- a/products/user_interviews/mcp/tools.yaml
+++ b/products/user_interviews/mcp/tools.yaml
@@ -73,6 +73,25 @@ tools:
             alongside the URL the interviewee should open. The URL hosts the call publicly — no PostHog login required.
             Calling this multiple times is safe: existing share links are reused.
         feature_flag: user-interviews
+    user-interview-topics-interviewees-bulk-create:
+        operation: user_interview_topics_interviewees_bulk_create
+        enabled: true
+        scopes:
+            - user_interview:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create many per-interviewee context rows at once
+        description: >
+            Create up to 500 per-interviewee context rows for a topic in a single request. Each item is
+            (interviewee_identifier, agent_context). Rows whose (topic, interviewee_identifier) already exists are
+            skipped — the response surfaces `inserted_count`, `skipped_count`, and `skipped_identifiers` so the caller
+            can reconcile. Items must have unique `interviewee_identifier` values within the batch. Prefer this over
+            `user-interview-topics-interviewees-create` when adding many rows.
+        include_params:
+            - items
+        feature_flag: user-interviews
     user-interview-topics-interviewees-create:
         operation: user_interview_topics_interviewees_create
         enabled: true
@@ -93,25 +112,6 @@ tools:
         include_params:
             - interviewee_identifier
             - agent_context
-        feature_flag: user-interviews
-    user-interview-topics-interviewees-bulk-create:
-        operation: user_interview_topics_interviewees_bulk_create
-        enabled: true
-        scopes:
-            - user_interview:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: false
-        title: Create many per-interviewee context rows at once
-        description: >
-            Create up to 500 per-interviewee context rows for a topic in a single request. Each item is
-            (interviewee_identifier, agent_context). Rows whose (topic, interviewee_identifier) already exists are
-            skipped — the response surfaces `inserted_count`, `skipped_count`, and `skipped_identifiers` so the caller
-            can reconcile. Items must have unique `interviewee_identifier` values within the batch. Prefer this over
-            `user-interview-topics-interviewees-create` when adding many rows.
-        include_params:
-            - items
         feature_flag: user-interviews
     user-interview-topics-interviewees-destroy:
         operation: user_interview_topics_interviewees_destroy

--- a/products/user_interviews/mcp/tools.yaml
+++ b/products/user_interviews/mcp/tools.yaml
@@ -88,10 +88,30 @@ tools:
             background it should know about this specific person — e.g. "uses the replay product but has never used
             summarization". `interviewee_identifier` is the email or PostHog distinct ID matching one of the entries in
             the parent topic's targeting fields. `agent_context` is free text. At most one row per (topic,
-            interviewee_identifier) — calling create twice for the same pair will conflict.
+            interviewee_identifier) — calling create twice for the same pair will conflict. Prefer
+            `user-interview-topics-interviewees-bulk-create` when adding many rows at once.
         include_params:
             - interviewee_identifier
             - agent_context
+        feature_flag: user-interviews
+    user-interview-topics-interviewees-bulk-create:
+        operation: user_interview_topics_interviewees_bulk_create
+        enabled: true
+        scopes:
+            - user_interview:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create many per-interviewee context rows at once
+        description: >
+            Create up to 500 per-interviewee context rows for a topic in a single request. Each item is
+            (interviewee_identifier, agent_context). Rows whose (topic, interviewee_identifier) already exists are
+            skipped — the response surfaces `inserted_count`, `skipped_count`, and `skipped_identifiers` so the caller
+            can reconcile. Items must have unique `interviewee_identifier` values within the batch. Prefer this over
+            `user-interview-topics-interviewees-create` when adding many rows.
+        include_params:
+            - items
         feature_flag: user-interviews
     user-interview-topics-interviewees-destroy:
         operation: user_interview_topics_interviewees_destroy

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4960,8 +4960,24 @@
         },
         "feature_flag": "user-interviews"
     },
+    "user-interview-topics-interviewees-bulk-create": {
+        "description": "Create up to 500 per-interviewee context rows for a topic in a single request. Each item is (interviewee_identifier, agent_context). Rows whose (topic, interviewee_identifier) already exists are skipped — the response surfaces `inserted_count`, `skipped_count`, and `skipped_identifiers` so the caller can reconcile. Items must have unique `interviewee_identifier` values within the batch. Prefer this over `user-interview-topics-interviewees-create` when adding many rows.",
+        "category": "User interview topics",
+        "feature": "user_interviews",
+        "summary": "Create many per-interviewee context rows at once",
+        "title": "Create many per-interviewee context rows at once",
+        "required_scopes": ["user_interview:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "user-interviews"
+    },
     "user-interview-topics-interviewees-create": {
-        "description": "Attach extra context for a single interviewee on a user interview topic. Use this to give the voice agent background it should know about this specific person — e.g. \"uses the replay product but has never used summarization\". `interviewee_identifier` is the email or PostHog distinct ID matching one of the entries in the parent topic's targeting fields. `agent_context` is free text. At most one row per (topic, interviewee_identifier) — calling create twice for the same pair will conflict.",
+        "description": "Attach extra context for a single interviewee on a user interview topic. Use this to give the voice agent background it should know about this specific person — e.g. \"uses the replay product but has never used summarization\". `interviewee_identifier` is the email or PostHog distinct ID matching one of the entries in the parent topic's targeting fields. `agent_context` is free text. At most one row per (topic, interviewee_identifier) — calling create twice for the same pair will conflict. Prefer `user-interview-topics-interviewees-bulk-create` when adding many rows at once.",
         "category": "User interview topics",
         "feature": "user_interviews",
         "summary": "Add per-interviewee context to a topic",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5441,8 +5441,24 @@
         },
         "feature_flag": "user-interviews"
     },
+    "user-interview-topics-interviewees-bulk-create": {
+        "description": "Create up to 500 per-interviewee context rows for a topic in a single request. Each item is (interviewee_identifier, agent_context). Rows whose (topic, interviewee_identifier) already exists are skipped — the response surfaces `inserted_count`, `skipped_count`, and `skipped_identifiers` so the caller can reconcile. Items must have unique `interviewee_identifier` values within the batch. Prefer this over `user-interview-topics-interviewees-create` when adding many rows.",
+        "category": "User interview topics",
+        "feature": "user_interviews",
+        "summary": "Create many per-interviewee context rows at once",
+        "title": "Create many per-interviewee context rows at once",
+        "required_scopes": ["user_interview:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "user-interviews"
+    },
     "user-interview-topics-interviewees-create": {
-        "description": "Attach extra context for a single interviewee on a user interview topic. Use this to give the voice agent background it should know about this specific person — e.g. \"uses the replay product but has never used summarization\". `interviewee_identifier` is the email or PostHog distinct ID matching one of the entries in the parent topic's targeting fields. `agent_context` is free text. At most one row per (topic, interviewee_identifier) — calling create twice for the same pair will conflict.",
+        "description": "Attach extra context for a single interviewee on a user interview topic. Use this to give the voice agent background it should know about this specific person — e.g. \"uses the replay product but has never used summarization\". `interviewee_identifier` is the email or PostHog distinct ID matching one of the entries in the parent topic's targeting fields. `agent_context` is free text. At most one row per (topic, interviewee_identifier) — calling create twice for the same pair will conflict. Prefer `user-interview-topics-interviewees-bulk-create` when adding many rows at once.",
         "category": "User interview topics",
         "feature": "user_interviews",
         "summary": "Add per-interviewee context to a topic",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6422,6 +6422,33 @@ export namespace Schemas {
       DeviceId: 'device_id',
     } as const;
 
+    export interface BulkIntervieweeContextItem {
+      /**
+         * Identifier for the interviewee — typically an email address or PostHog distinct ID. Must match a value in the parent topic's interviewee_emails or interviewee_distinct_ids.
+         * @maxLength 400
+         */
+      interviewee_identifier: string;
+      /**
+         * Extra context the voice agent should know about this specific interviewee — e.g. 'uses the replay product but has never used summarization'.
+         * @maxLength 10000
+         */
+      agent_context: string;
+    }
+
+    export interface BulkIntervieweeContextRequest {
+      /** List of interviewee context rows to create. Each item has an `interviewee_identifier` and an `agent_context`. At most 500 items per request. */
+      items: BulkIntervieweeContextItem[];
+    }
+
+    export interface BulkIntervieweeContextResponse {
+      /** Number of rows inserted by this request. */
+      inserted_count: number;
+      /** Number of items skipped because a row for that (topic, interviewee_identifier) already existed. */
+      skipped_count: number;
+      /** Identifiers from the request whose rows were skipped because a row for that (topic, interviewee_identifier) already existed. */
+      skipped_identifiers: string[];
+    }
+
     export interface BulkNotificationIdsRequest {
       /**
          * UUIDs of notification events to mark in bulk (max 500). Events the user is not a recipient of are silently skipped.

--- a/services/mcp/src/generated/user_interviews/api.ts
+++ b/services/mcp/src/generated/user_interviews/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 15 enabled ops
+ * PostHog API - MCP 16 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -293,6 +293,45 @@ export const UserInterviewTopicsIntervieweesDestroyParams = /* @__PURE__ */ zod.
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
     topic_id: zod.string(),
+})
+
+/**
+ * Create up to 500 interviewee context rows for a topic in a single request. Rows whose (topic, interviewee_identifier) already exists are skipped — the response surfaces an `inserted_count`, a `skipped_count`, and the `skipped_identifiers` so the caller can reconcile. Items must have unique `interviewee_identifier` values within the batch.
+ */
+export const UserInterviewTopicsIntervieweesBulkCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    topic_id: zod.string(),
+})
+
+export const userInterviewTopicsIntervieweesBulkCreateBodyItemsItemIntervieweeIdentifierMax = 400
+
+export const userInterviewTopicsIntervieweesBulkCreateBodyItemsItemAgentContextMax = 10000
+
+export const UserInterviewTopicsIntervieweesBulkCreateBody = /* @__PURE__ */ zod.object({
+    items: zod
+        .array(
+            zod.object({
+                interviewee_identifier: zod
+                    .string()
+                    .max(userInterviewTopicsIntervieweesBulkCreateBodyItemsItemIntervieweeIdentifierMax)
+                    .describe(
+                        "Identifier for the interviewee — typically an email address or PostHog distinct ID. Must match a value in the parent topic's interviewee_emails or interviewee_distinct_ids."
+                    ),
+                agent_context: zod
+                    .string()
+                    .max(userInterviewTopicsIntervieweesBulkCreateBodyItemsItemAgentContextMax)
+                    .describe(
+                        "Extra context the voice agent should know about this specific interviewee — e.g. 'uses the replay product but has never used summarization'."
+                    ),
+            })
+        )
+        .describe(
+            'List of interviewee context rows to create. Each item has an `interviewee_identifier` and an `agent_context`. At most 500 items per request.'
+        ),
 })
 
 export const UserInterviewsListParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/user_interviews.ts
+++ b/services/mcp/src/tools/generated/user_interviews.ts
@@ -7,6 +7,8 @@ import {
     UserInterviewTopicsAddIntervieweeCreateParams,
     UserInterviewTopicsCreateBody,
     UserInterviewTopicsGenerateLinksCreateParams,
+    UserInterviewTopicsIntervieweesBulkCreateBody,
+    UserInterviewTopicsIntervieweesBulkCreateParams,
     UserInterviewTopicsIntervieweesCreateBody,
     UserInterviewTopicsIntervieweesCreateParams,
     UserInterviewTopicsIntervieweesDestroyParams,
@@ -126,6 +128,31 @@ const userInterviewTopicsIntervieweesCreate = (): ToolBase<
         const result = await context.api.request<Schemas.IntervieweeContext>({
             method: 'POST',
             path: `/api/environments/${encodeURIComponent(String(projectId))}/user_interview_topics/${encodeURIComponent(String(params.topic_id))}/interviewees/`,
+            body,
+        })
+        return result
+    },
+})
+
+const UserInterviewTopicsIntervieweesBulkCreateSchema = UserInterviewTopicsIntervieweesBulkCreateParams.omit({
+    project_id: true,
+}).extend(UserInterviewTopicsIntervieweesBulkCreateBody.shape)
+
+const userInterviewTopicsIntervieweesBulkCreate = (): ToolBase<
+    typeof UserInterviewTopicsIntervieweesBulkCreateSchema,
+    Schemas.BulkIntervieweeContextResponse
+> => ({
+    name: 'user-interview-topics-interviewees-bulk-create',
+    schema: UserInterviewTopicsIntervieweesBulkCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof UserInterviewTopicsIntervieweesBulkCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.items !== undefined) {
+            body['items'] = params.items
+        }
+        const result = await context.api.request<Schemas.BulkIntervieweeContextResponse>({
+            method: 'POST',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/user_interview_topics/${encodeURIComponent(String(params.topic_id))}/interviewees/bulk/`,
             body,
         })
         return result
@@ -407,6 +434,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'user-interview-topics-create': userInterviewTopicsCreate,
     'user-interview-topics-generate-links': userInterviewTopicsGenerateLinks,
     'user-interview-topics-interviewees-create': userInterviewTopicsIntervieweesCreate,
+    'user-interview-topics-interviewees-bulk-create': userInterviewTopicsIntervieweesBulkCreate,
     'user-interview-topics-interviewees-destroy': userInterviewTopicsIntervieweesDestroy,
     'user-interview-topics-interviewees-list': userInterviewTopicsIntervieweesList,
     'user-interview-topics-interviewees-partial-update': userInterviewTopicsIntervieweesPartialUpdate,

--- a/services/mcp/src/tools/generated/user_interviews.ts
+++ b/services/mcp/src/tools/generated/user_interviews.ts
@@ -106,6 +106,31 @@ const userInterviewTopicsGenerateLinks = (): ToolBase<
     },
 })
 
+const UserInterviewTopicsIntervieweesBulkCreateSchema = UserInterviewTopicsIntervieweesBulkCreateParams.omit({
+    project_id: true,
+}).extend(UserInterviewTopicsIntervieweesBulkCreateBody.shape)
+
+const userInterviewTopicsIntervieweesBulkCreate = (): ToolBase<
+    typeof UserInterviewTopicsIntervieweesBulkCreateSchema,
+    Schemas.BulkIntervieweeContextResponse
+> => ({
+    name: 'user-interview-topics-interviewees-bulk-create',
+    schema: UserInterviewTopicsIntervieweesBulkCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof UserInterviewTopicsIntervieweesBulkCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.items !== undefined) {
+            body['items'] = params.items
+        }
+        const result = await context.api.request<Schemas.BulkIntervieweeContextResponse>({
+            method: 'POST',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/user_interview_topics/${encodeURIComponent(String(params.topic_id))}/interviewees/bulk/`,
+            body,
+        })
+        return result
+    },
+})
+
 const UserInterviewTopicsIntervieweesCreateSchema = UserInterviewTopicsIntervieweesCreateParams.omit({
     project_id: true,
 }).extend(UserInterviewTopicsIntervieweesCreateBody.shape)
@@ -128,31 +153,6 @@ const userInterviewTopicsIntervieweesCreate = (): ToolBase<
         const result = await context.api.request<Schemas.IntervieweeContext>({
             method: 'POST',
             path: `/api/environments/${encodeURIComponent(String(projectId))}/user_interview_topics/${encodeURIComponent(String(params.topic_id))}/interviewees/`,
-            body,
-        })
-        return result
-    },
-})
-
-const UserInterviewTopicsIntervieweesBulkCreateSchema = UserInterviewTopicsIntervieweesBulkCreateParams.omit({
-    project_id: true,
-}).extend(UserInterviewTopicsIntervieweesBulkCreateBody.shape)
-
-const userInterviewTopicsIntervieweesBulkCreate = (): ToolBase<
-    typeof UserInterviewTopicsIntervieweesBulkCreateSchema,
-    Schemas.BulkIntervieweeContextResponse
-> => ({
-    name: 'user-interview-topics-interviewees-bulk-create',
-    schema: UserInterviewTopicsIntervieweesBulkCreateSchema,
-    handler: async (context: Context, params: z.infer<typeof UserInterviewTopicsIntervieweesBulkCreateSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.items !== undefined) {
-            body['items'] = params.items
-        }
-        const result = await context.api.request<Schemas.BulkIntervieweeContextResponse>({
-            method: 'POST',
-            path: `/api/environments/${encodeURIComponent(String(projectId))}/user_interview_topics/${encodeURIComponent(String(params.topic_id))}/interviewees/bulk/`,
             body,
         })
         return result
@@ -433,8 +433,8 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'user-interview-topics-add-interviewee': userInterviewTopicsAddInterviewee,
     'user-interview-topics-create': userInterviewTopicsCreate,
     'user-interview-topics-generate-links': userInterviewTopicsGenerateLinks,
-    'user-interview-topics-interviewees-create': userInterviewTopicsIntervieweesCreate,
     'user-interview-topics-interviewees-bulk-create': userInterviewTopicsIntervieweesBulkCreate,
+    'user-interview-topics-interviewees-create': userInterviewTopicsIntervieweesCreate,
     'user-interview-topics-interviewees-destroy': userInterviewTopicsIntervieweesDestroy,
     'user-interview-topics-interviewees-list': userInterviewTopicsIntervieweesList,
     'user-interview-topics-interviewees-partial-update': userInterviewTopicsIntervieweesPartialUpdate,


### PR DESCRIPTION
## Problem

The MCP-driven flow for attaching per-interviewee context to a topic was one HTTP call per row. When I planned a research topic for 100 MCP-only insight creators yesterday the wall-clock cost was several minutes — almost entirely network round-trips, with each call doing a single trivial INSERT. Per-row writes don't scale and aren't a fit for what's effectively a batched ingest from an agent that's already resolved the audience.

## Changes

Adds `POST /api/environments/:team/user_interview_topics/:topic/interviewees/bulk/` accepting up to 500 `(interviewee_identifier, agent_context)` items per request.

Validation and safety:

- `BulkIntervieweeContextRequestSerializer` caps `items` at 500 and rejects in-batch duplicate identifiers eagerly.
- Per-row: `interviewee_identifier` capped at 400 chars, `agent_context` capped at 10,000 chars (same as the single-row endpoint).
- Worst-case payload ~5 MB — well under PostHog's 20 MB `DATA_UPLOAD_MAX_MEMORY_SIZE`.
- One pre-fetch query to find existing `(topic, interviewee_identifier)` pairs, then a single `bulk_create(..., ignore_conflicts=True)`. Race-safe via the existing unique constraint.

Conflict behavior:

- Rows whose `(topic, interviewee_identifier)` already exists are skipped silently.
- Response shape: `{ inserted_count, skipped_count, skipped_identifiers }` so the caller can reconcile.

MCP tool wired through as `user-interview-topics-interviewees-bulk-create`. The single-row tool description now steers agents to prefer the bulk tool when adding many rows.

## How did you test this code?

I'm an agent. Automated tests only — 12 parameterised pytest cases in `test_interviewee_context_bulk_create.py` covering: happy path, skip-on-conflict, unknown topic, max-size batch, oversized batch, and seven validation-failure cases (empty/missing `items`, missing fields, in-batch duplicates, oversized identifier/context). All pass locally via `hogli test`.

I also ran `hogli build:openapi` and verified the new operation flows through to the generated TypeScript types, Zod schemas, and MCP tool definitions.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) on behalf of @pauldambra.

Context: the bulk endpoint exists because we hit the slow per-row path live yesterday while planning a topic for 100 MCP-only insight creators. The agent surfaced the issue to the human, the human asked for a batch endpoint with a 500-row cap, and approved skipping genuinely-identical rows rather than 409-ing the whole batch.

Considered and rejected:

- **CSV body**: the MCP tools are codegened from DRF serializers via OpenAPI. CSV would break the codegen, require an extra parser, and the agent would still JSON-encode it on the way out — no win.
- **Adding `MaxLengthValidator(10000)` to the model field**: `bulk_create` skips `full_clean()`, so model-level validators wouldn't help. Kept the cap at the serializer where it actually runs.
- **Failing the whole batch on dupe**: the user explicitly wanted skip-and-report so agents can re-run idempotently after a partial failure.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
