### PR TITLE
feat(logs): redesign drop rules form with filter bar and sections

### DIFF
--- a/products/logs/frontend/components/LogsSampling/DropRuleFilterEditor.tsx
+++ b/products/logs/frontend/components/LogsSampling/DropRuleFilterEditor.tsx
@@ -1,0 +1,149 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { memo, useCallback, useMemo, useRef, useState } from 'react'
+
+import { LemonDropdown } from '@posthog/lemon-ui'
+
+import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
+import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
+import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
+import { TaxonomicFilterGroupType, TaxonomicFilterLogicProps } from 'lib/components/TaxonomicFilter/types'
+import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
+import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
+import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
+
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator, UniversalFiltersGroup } from '~/types'
+
+const ROOT_KEY = 'logs-drop-rule'
+const TAXONOMIC_GROUP_TYPES = [
+    TaxonomicFilterGroupType.Logs,
+    TaxonomicFilterGroupType.LogResourceAttributes,
+    TaxonomicFilterGroupType.LogAttributes,
+]
+
+export const DropRuleFilterEditor = memo(function DropRuleFilterEditor({
+    filterGroup,
+    onChange,
+}: {
+    filterGroup: UniversalFiltersGroup
+    onChange: (group: UniversalFiltersGroup) => void
+}): JSX.Element {
+    return (
+        <UniversalFilters
+            rootKey={ROOT_KEY}
+            group={filterGroup}
+            taxonomicGroupTypes={TAXONOMIC_GROUP_TYPES}
+            onChange={onChange}
+        >
+            <div className="space-y-2">
+                <DropRuleFilterSearch />
+                <DropRuleAppliedFilters />
+            </div>
+        </UniversalFilters>
+    )
+})
+
+function DropRuleFilterSearch(): JSX.Element {
+    const [visible, setVisible] = useState<boolean>(false)
+    const { addGroupFilter, setGroupValues } = useActions(universalFiltersLogic)
+    const { filterGroup } = useValues(universalFiltersLogic)
+
+    const searchInputRef = useRef<HTMLInputElement | null>(null)
+    const floatingRef = useRef<HTMLDivElement | null>(null)
+    const filterGroupRef = useRef(filterGroup)
+    filterGroupRef.current = filterGroup
+
+    const onClose = useCallback((): void => {
+        searchInputRef.current?.blur()
+        setVisible(false)
+    }, [])
+
+    const taxonomicFilterLogicProps: TaxonomicFilterLogicProps = useMemo(
+        () => ({
+            taxonomicFilterLogicKey: ROOT_KEY,
+            taxonomicGroupTypes: TAXONOMIC_GROUP_TYPES,
+            onChange: (taxonomicGroup, value, item) => {
+                if (item.value === undefined) {
+                    addGroupFilter(taxonomicGroup, value, item)
+                    setVisible(false)
+                    return
+                }
+
+                const newValues = [...filterGroupRef.current.values]
+                const newPropertyFilter = {
+                    key: item.key,
+                    value: item.value,
+                    operator: PropertyOperator.IContains,
+                    type: item.propertyFilterType,
+                } as AnyPropertyFilter
+                newValues.push(newPropertyFilter)
+                setGroupValues(newValues)
+                setVisible(false)
+            },
+            onEnter: () => {
+                searchInputRef.current?.blur()
+                setVisible(false)
+            },
+            autoSelectItem: true,
+        }),
+        [addGroupFilter, setGroupValues]
+    )
+
+    const showDropdown = useCallback(() => setVisible(true), [])
+
+    return (
+        <BindLogic logic={taxonomicFilterLogic} props={taxonomicFilterLogicProps}>
+            <LemonDropdown
+                overlay={
+                    <div className="w-[400px]">
+                        <InfiniteSelectResults
+                            focusInput={() => searchInputRef.current?.focus()}
+                            taxonomicFilterLogicProps={taxonomicFilterLogicProps}
+                            popupAnchorElement={floatingRef.current}
+                        />
+                    </div>
+                }
+                visible={visible}
+                closeOnClickInside={false}
+                floatingRef={floatingRef}
+                onClickOutside={onClose}
+            >
+                <TaxonomicFilterSearchInput
+                    onClick={showDropdown}
+                    searchInputRef={searchInputRef}
+                    onClose={onClose}
+                    onChange={showDropdown}
+                />
+            </LemonDropdown>
+        </BindLogic>
+    )
+}
+
+function DropRuleAppliedFilters(): JSX.Element | null {
+    const { filterGroup } = useValues(universalFiltersLogic)
+    const { replaceGroupValue, removeGroupValue } = useActions(universalFiltersLogic)
+
+    if (filterGroup.values.length === 0) {
+        return null
+    }
+
+    return (
+        <div className="flex gap-1 items-center flex-wrap">
+            {filterGroup.values.map((filterOrGroup, index) => {
+                return isUniversalGroupFilterLike(filterOrGroup) ? (
+                    <UniversalFilters.Group index={index} key={index} group={filterOrGroup}>
+                        <DropRuleAppliedFilters />
+                    </UniversalFilters.Group>
+                ) : (
+                    <UniversalFilters.Value
+                        key={index}
+                        index={index}
+                        filter={filterOrGroup}
+                        onRemove={() => removeGroupValue(index)}
+                        onChange={(value) => replaceGroupValue(index, value)}
+                        initiallyOpen={filterOrGroup.type !== PropertyFilterType.HogQL}
+                    />
+                )
+            })}
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsSampling/DropRuleFilterEditor.tsx
+++ b/products/logs/frontend/components/LogsSampling/DropRuleFilterEditor.tsx
@@ -1,5 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { memo, useCallback, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useId, useMemo, useRef, useState } from 'react'
 
 import { LemonDropdown } from '@posthog/lemon-ui'
 
@@ -13,7 +13,10 @@ import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/util
 
 import { AnyPropertyFilter, PropertyFilterType, PropertyOperator, UniversalFiltersGroup } from '~/types'
 
-const ROOT_KEY = 'logs-drop-rule'
+// Namespace prefix only — the real per-mount key is appended below so that two
+// editors mounted simultaneously (e.g. during fast scene navigation) don't share
+// universalFiltersLogic / taxonomicFilterLogic instances.
+const ROOT_KEY_PREFIX = 'logs-drop-rule'
 const TAXONOMIC_GROUP_TYPES = [
     TaxonomicFilterGroupType.Logs,
     TaxonomicFilterGroupType.LogResourceAttributes,
@@ -23,26 +26,31 @@ const TAXONOMIC_GROUP_TYPES = [
 export const DropRuleFilterEditor = memo(function DropRuleFilterEditor({
     filterGroup,
     onChange,
+    logicKey,
 }: {
     filterGroup: UniversalFiltersGroup
     onChange: (group: UniversalFiltersGroup) => void
+    /** Optional explicit key (e.g. `rule-${id}`); defaults to a per-mount React id. */
+    logicKey?: string
 }): JSX.Element {
+    const fallback = useId()
+    const rootKey = logicKey ?? `${ROOT_KEY_PREFIX}:${fallback}`
     return (
         <UniversalFilters
-            rootKey={ROOT_KEY}
+            rootKey={rootKey}
             group={filterGroup}
             taxonomicGroupTypes={TAXONOMIC_GROUP_TYPES}
             onChange={onChange}
         >
             <div className="space-y-2">
-                <DropRuleFilterSearch />
+                <DropRuleFilterSearch logicKey={rootKey} />
                 <DropRuleAppliedFilters />
             </div>
         </UniversalFilters>
     )
 })
 
-function DropRuleFilterSearch(): JSX.Element {
+function DropRuleFilterSearch({ logicKey }: { logicKey: string }): JSX.Element {
     const [visible, setVisible] = useState<boolean>(false)
     const { addGroupFilter, setGroupValues } = useActions(universalFiltersLogic)
     const { filterGroup } = useValues(universalFiltersLogic)
@@ -59,7 +67,7 @@ function DropRuleFilterSearch(): JSX.Element {
 
     const taxonomicFilterLogicProps: TaxonomicFilterLogicProps = useMemo(
         () => ({
-            taxonomicFilterLogicKey: ROOT_KEY,
+            taxonomicFilterLogicKey: logicKey,
             taxonomicGroupTypes: TAXONOMIC_GROUP_TYPES,
             onChange: (taxonomicGroup, value, item) => {
                 if (item.value === undefined) {
@@ -85,7 +93,7 @@ function DropRuleFilterSearch(): JSX.Element {
             },
             autoSelectItem: true,
         }),
-        [addGroupFilter, setGroupValues]
+        [addGroupFilter, setGroupValues, logicKey]
     )
 
     const showDropdown = useCallback(() => setVisible(true), [])

--- a/products/logs/frontend/components/LogsSampling/LogsSamplingForm.tsx
+++ b/products/logs/frontend/components/LogsSampling/LogsSamplingForm.tsx
@@ -4,7 +4,6 @@ import { LemonInput, LemonSegmentedButton, LemonSwitch } from '@posthog/lemon-ui
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
-import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 
 import { ServiceFilter } from 'products/logs/frontend/components/LogsViewer/Filters/ServiceFilter'
@@ -39,8 +38,6 @@ export function LogsSamplingForm(): JSX.Element {
                 </LemonField.Pure>
             </div>
 
-            <SceneDivider />
-
             <SceneSection
                 title="Match"
                 titleSize="sm"
@@ -57,8 +54,6 @@ export function LogsSamplingForm(): JSX.Element {
                     />
                 )}
             </SceneSection>
-
-            <SceneDivider />
 
             <SceneSection title="Action" titleSize="sm">
                 <LemonField.Pure label="What to do when a log matches">
@@ -84,8 +79,6 @@ export function LogsSamplingForm(): JSX.Element {
                     </LemonField.Pure>
                 )}
             </SceneSection>
-
-            <SceneDivider />
 
             <SceneSection
                 title="Scope"

--- a/products/logs/frontend/components/LogsSampling/LogsSamplingForm.tsx
+++ b/products/logs/frontend/components/LogsSampling/LogsSamplingForm.tsx
@@ -1,365 +1,122 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonBanner, LemonInput, LemonSelect, LemonSwitch, LemonTag, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonInput, LemonSegmentedButton, LemonSwitch } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneSection } from '~/layout/scenes/components/SceneSection'
 
 import { ServiceFilter } from 'products/logs/frontend/components/LogsViewer/Filters/ServiceFilter'
 import { RuleTypeEnumApi } from 'products/logs/frontend/generated/api.schemas'
 
-import { LogsSamplingFormType, PathDropMatchTarget, SeverityActionChoice } from './logsSamplingFormLogic'
+import { DropRuleFilterEditor } from './DropRuleFilterEditor'
 import { logsSamplingFormLogic } from './logsSamplingFormLogic'
-import { ruleTypeLabel } from './ruleTypeLabel'
 
-const RULE_TYPE_OPTIONS_CREATE: { value: RuleTypeEnumApi; label: string }[] = [
-    {
-        value: RuleTypeEnumApi.PathDrop,
-        label: 'Drop when matched (regex on path or attribute)',
-    },
-    {
-        value: RuleTypeEnumApi.SeveritySampling,
-        label: 'Drop by severity',
-    },
-    {
-        value: RuleTypeEnumApi.RateLimit,
-        label: 'Rate limit by service (logs/sec)',
-    },
+const ACTION_OPTIONS: { value: RuleTypeEnumApi; label: string }[] = [
+    { value: RuleTypeEnumApi.PathDrop, label: 'Drop' },
+    { value: RuleTypeEnumApi.RateLimit, label: 'Rate limit' },
 ]
-
-const PATH_DROP_MATCH_TARGET_OPTIONS: { value: PathDropMatchTarget; label: string }[] = [
-    { value: 'auto_path', label: 'Automatic path (http.route, url.path, …)' },
-    { value: 'custom_attribute', label: 'One log attribute' },
-]
-
-const SEVERITY_ACTION_OPTIONS: { value: SeverityActionChoice; label: string }[] = [
-    { value: 'keep', label: 'Keep' },
-    { value: 'drop', label: 'Drop (not stored)' },
-]
-
-function SeverityRow({ label, actionKey }: { label: string; actionKey: keyof LogsSamplingFormType }): JSX.Element {
-    const { samplingForm } = useValues(logsSamplingFormLogic)
-    const { setSamplingFormValue } = useActions(logsSamplingFormLogic)
-    const action = samplingForm[actionKey] as SeverityActionChoice
-
-    return (
-        <div className="grid grid-cols-[5.5rem_minmax(11rem,16rem)] items-center gap-x-3 gap-y-1">
-            <span className="text-muted text-sm">{label}</span>
-            <LemonSelect
-                options={SEVERITY_ACTION_OPTIONS}
-                value={action === 'sample' ? 'keep' : action}
-                onChange={(v) => v && setSamplingFormValue(actionKey, v)}
-            />
-        </div>
-    )
-}
 
 export function LogsSamplingForm(): JSX.Element {
-    const {
-        samplingForm,
-        samplingFormErrors,
-        simulation,
-        simulationLoading,
-        canSimulate,
-        isNewRule,
-        serviceTraffic,
-        serviceTrafficLoading,
-    } = useValues(logsSamplingFormLogic)
+    const { samplingForm, samplingFormErrors, serviceTraffic, serviceTrafficLoading } = useValues(logsSamplingFormLogic)
     const { setSamplingFormValue } = useActions(logsSamplingFormLogic)
 
-    const isPathDrop = samplingForm.rule_type === RuleTypeEnumApi.PathDrop
-    const isSeverity = samplingForm.rule_type === RuleTypeEnumApi.SeveritySampling
     const isRateLimit = samplingForm.rule_type === RuleTypeEnumApi.RateLimit
 
     return (
         <div className="flex flex-col gap-4 max-w-3xl">
-            <LemonBanner type="warning">
-                When this rule is <strong>enabled</strong> and matches a log line, that line is{' '}
-                <strong>not stored</strong>. Dropped logs do not appear in the UI, exports, or alerts. Disabling the
-                rule or editing patterns only affects <em>new</em> ingestion—already dropped data cannot be recovered.
-            </LemonBanner>
-            {canSimulate && (
-                <LemonBanner type="info">
-                    {simulationLoading
-                        ? 'Estimating impact…'
-                        : simulation
-                          ? `Rough drop estimate: ~${simulation.estimated_reduction_pct.toFixed(1)}%. ${simulation.notes}`
-                          : 'Impact estimate will appear after you save or change the rule.'}
-                </LemonBanner>
-            )}
-            <LemonField.Pure label="Name" error={samplingFormErrors.name}>
-                <LemonInput
-                    value={samplingForm.name}
-                    onChange={(v) => setSamplingFormValue('name', v)}
-                    placeholder="e.g. Drop noisy health checks"
-                />
-            </LemonField.Pure>
-            <LemonField.Pure label="Enabled">
-                <LemonSwitch checked={samplingForm.enabled} onChange={(v) => setSamplingFormValue('enabled', v)} />
-            </LemonField.Pure>
-            {isNewRule ? (
-                <LemonField.Pure
-                    label="What should this rule do?"
-                    info="You can create multiple rules; lower priority number runs first. The first rule that matches wins for each log line."
-                    help={
-                        <>
-                            “Drop by severity” is for whole severity levels (debug, info, warn, error). “Drop when
-                            matched” is for regex on a path string or one attribute you pick. “Rate limit by service”
-                            caps how many log lines per second from one service are stored (extras are dropped at
-                            ingestion).
-                        </>
-                    }
-                >
-                    <LemonSelect
-                        options={RULE_TYPE_OPTIONS_CREATE}
+            <div className="flex flex-col gap-3">
+                <LemonField.Pure label="Name" error={samplingFormErrors.name}>
+                    <LemonInput
+                        value={samplingForm.name}
+                        onChange={(v) => setSamplingFormValue('name', v)}
+                        placeholder="e.g. Drop noisy health checks"
+                    />
+                </LemonField.Pure>
+                <LemonField.Pure label="Enabled">
+                    <LemonSwitch checked={samplingForm.enabled} onChange={(v) => setSamplingFormValue('enabled', v)} />
+                </LemonField.Pure>
+            </div>
+
+            <SceneDivider />
+
+            <SceneSection
+                title="Match"
+                titleSize="sm"
+                description="Drop logs matching these filters. Dropped lines are not stored — they will not appear in the UI, exports, or alerts. Already-dropped data cannot be recovered."
+            >
+                {isRateLimit ? (
+                    <p className="text-sm text-secondary m-0">
+                        Rate limit applies to every log line from the selected service — no per-line matcher.
+                    </p>
+                ) : (
+                    <DropRuleFilterEditor
+                        filterGroup={samplingForm.filter_group}
+                        onChange={(group) => setSamplingFormValue('filter_group', group)}
+                    />
+                )}
+            </SceneSection>
+
+            <SceneDivider />
+
+            <SceneSection title="Action" titleSize="sm">
+                <LemonField.Pure label="What to do when a log matches">
+                    <LemonSegmentedButton
                         value={samplingForm.rule_type}
                         onChange={(v) => v && setSamplingFormValue('rule_type', v)}
+                        options={ACTION_OPTIONS}
+                        size="small"
                     />
                 </LemonField.Pure>
-            ) : (
-                <LemonField.Pure label="Rule type">
-                    <LemonTag>{ruleTypeLabel(samplingForm.rule_type)}</LemonTag>
-                </LemonField.Pure>
-            )}
-            {isRateLimit ? (
-                <>
-                    <LemonBanner type="info">
-                        <div className="text-sm">
-                            <strong>Which service?</strong> This must match the log&apos;s OpenTelemetry{' '}
-                            <code className="text-xs font-mono bg-bg-mid rounded px-1 py-0.5">service.name</code>{' '}
-                            exactly (same string as the Service column or log details—no wildcards, case-sensitive).
-                            Example:{' '}
-                            <code className="text-xs font-mono bg-bg-mid rounded px-1 py-0.5">payment-api</code>.
-                        </div>
-                    </LemonBanner>
+                {isRateLimit && (
                     <LemonField.Pure
-                        label="Service"
-                        help="Pick from names seen in the last 24h, or type the full name in the field below if it does not appear in the list."
-                        error={samplingFormErrors.scope_service}
-                    >
-                        <div className="flex flex-col gap-2">
-                            <ServiceFilter
-                                selectionMode="single"
-                                emptyButtonLabel="Pick from last 24h…"
-                                value={samplingForm.scope_service ? [samplingForm.scope_service] : []}
-                                onChange={(names) => setSamplingFormValue('scope_service', names[0] ?? '')}
-                                dateRange={{ date_from: '-24h', date_to: null }}
-                            />
-                            <LemonInput
-                                value={samplingForm.scope_service}
-                                onChange={(v) => setSamplingFormValue('scope_service', v)}
-                                placeholder="Type exact service.name (required)"
-                            />
-                            {serviceTrafficLoading ? (
-                                <span className="text-muted text-sm">Loading recent volume…</span>
-                            ) : serviceTraffic && samplingForm.scope_service.trim() ? (
-                                <span className="text-muted text-sm">
-                                    ~{serviceTraffic.avg_logs_per_sec.toFixed(2)} logs/sec average over the last 24h (
-                                    {serviceTraffic.log_count.toLocaleString()} lines).
-                                </span>
-                            ) : null}
-                        </div>
-                    </LemonField.Pure>
-                </>
-            ) : (
-                <LemonField.Pure
-                    label="Scope: service name (optional)"
-                    info="If set, the rule only runs for logs from this service.name. Leave empty to apply to all services."
-                >
-                    <LemonInput
-                        value={samplingForm.scope_service}
-                        onChange={(v) => setSamplingFormValue('scope_service', v)}
-                        placeholder="Empty = all services"
-                    />
-                </LemonField.Pure>
-            )}
-            {!isRateLimit ? (
-                <LemonField.Pure
-                    label="Limit rule to matching path (optional)"
-                    info="If set, this rule only runs for log lines where this regex matches the automatic path string (first non-empty among url.path, http.path, http.route, path). Separate from “what your drop patterns match” below. Applies to severity rules too."
-                >
-                    <LemonInput
-                        value={samplingForm.scope_path_pattern}
-                        onChange={(v) => setSamplingFormValue('scope_path_pattern', v)}
-                        placeholder="e.g. ^/api/internal/"
-                    />
-                </LemonField.Pure>
-            ) : null}
-            {isPathDrop ? (
-                <>
-                    <LemonField.Pure
-                        label="Drop patterns match on"
-                        help="Choose what each regex line is compared to. Switching to automatic path clears the attribute key."
-                        info="Automatic path uses the same path-like fields as the limit-to-path filter above. One log attribute tests only that field’s string (missing counts as empty)."
-                    >
-                        <LemonSelect<PathDropMatchTarget>
-                            options={PATH_DROP_MATCH_TARGET_OPTIONS}
-                            value={samplingForm.path_drop_match_target}
-                            onChange={(v) => {
-                                if (!v) {
-                                    return
-                                }
-                                setSamplingFormValue('path_drop_match_target', v)
-                                if (v === 'auto_path') {
-                                    setSamplingFormValue('path_drop_match_attribute_key', '')
-                                }
-                            }}
-                        />
-                    </LemonField.Pure>
-                    {samplingForm.path_drop_match_target === 'auto_path' ? (
-                        <LemonBanner type="info">
-                            <div className="text-sm">
-                                <strong>Example:</strong> add lines{' '}
-                                <code className="text-xs font-mono bg-bg-mid rounded px-1 py-0.5">/healthz</code> and{' '}
-                                <code className="text-xs font-mono bg-bg-mid rounded px-1 py-0.5">/ready</code> — if{' '}
-                                <em>any</em> pattern matches the log’s automatic path value, the line is dropped. Add a
-                                limit above if you only want this under e.g.{' '}
-                                <code className="text-xs font-mono bg-bg-mid rounded px-1 py-0.5">^/api/</code>.
-                            </div>
-                        </LemonBanner>
-                    ) : (
-                        <>
-                            <LemonBanner type="info">
-                                <div className="text-sm">
-                                    <strong>Example:</strong> key{' '}
-                                    <code className="text-xs font-mono bg-bg-mid rounded px-1 py-0.5">
-                                        deployment.environment
-                                    </code>
-                                    , pattern line{' '}
-                                    <code className="text-xs font-mono bg-bg-mid rounded px-1 py-0.5">^staging$</code> —
-                                    only that attribute is tested (not the URL path).
-                                </div>
-                            </LemonBanner>
-                            <LemonField.Pure
-                                label="Log attribute key"
-                                info="Exact OpenTelemetry attribute name as it appears on the log (copy from the log detail inspector)."
-                                help="Not a property picker — type the key string."
-                                error={samplingFormErrors.path_drop_match_attribute_key}
-                            >
-                                <LemonInput
-                                    value={samplingForm.path_drop_match_attribute_key}
-                                    onChange={(v) => setSamplingFormValue('path_drop_match_attribute_key', v)}
-                                    placeholder="e.g. deployment.environment"
-                                />
-                            </LemonField.Pure>
-                        </>
-                    )}
-                    <LemonField.Pure
-                        label="Patterns to drop (regex, one per line)"
-                        info={
-                            samplingForm.path_drop_match_target === 'auto_path' ? (
-                                <>
-                                    Each line is a JavaScript-style regex tested against the automatic path string. If{' '}
-                                    <strong>any</strong> line matches, the log is dropped. Invalid regex lines are
-                                    skipped at ingestion.
-                                </>
-                            ) : (
-                                <>
-                                    Each line is a regex tested against the attribute value only. If{' '}
-                                    <strong>any</strong> line matches, the log is dropped.
-                                </>
-                            )
-                        }
-                        help={
-                            samplingForm.path_drop_match_target === 'auto_path'
-                                ? 'Examples: /internal/ (substring), ^/api/v1/debug/ (prefix). Multiple lines are OR’d.'
-                                : 'Examples: ^prod$, staging|dev. Multiple lines are OR’d.'
-                        }
-                    >
-                        <LemonTextArea
-                            value={samplingForm.path_drop_patterns}
-                            onChange={(v) => setSamplingFormValue('path_drop_patterns', v)}
-                            placeholder={'/healthz\n/metrics'}
-                            rows={4}
-                        />
-                    </LemonField.Pure>
-                </>
-            ) : null}
-            {isRateLimit ? (
-                <>
-                    <LemonBanner type="info">
-                        <div className="text-sm">
-                            <strong>How limits work:</strong> lines above your sustained cap are dropped at ingestion.
-                            Optional <strong>burst</strong> is how many lines can be stored in a short spike before the
-                            limiter pulls you back toward the sustained rate. Example: sustained{' '}
-                            <code className="text-xs font-mono bg-bg-mid rounded px-1 py-0.5">100</code>, burst{' '}
-                            <code className="text-xs font-mono bg-bg-mid rounded px-1 py-0.5">300</code> — you can admit
-                            up to 300 lines quickly, then stored volume trends toward ~100/sec for this service.
-                        </div>
-                    </LemonBanner>
-                    <LemonField.Pure
-                        label="Sustained limit (lines per second)"
-                        help="Whole number from 1 to 1,000,000. Average stored lines/sec for this service while this rule is the first match."
+                        label="Sustained limit (logs per second)"
+                        help="Whole number from 1 to 1,000,000. Burst capacity is set automatically (10× sustained)."
                         error={samplingFormErrors.rate_limit_logs_per_second}
                     >
                         <LemonInput
                             value={samplingForm.rate_limit_logs_per_second}
                             onChange={(v) => setSamplingFormValue('rate_limit_logs_per_second', v)}
                             placeholder="e.g. 5000"
+                            className="max-w-xs"
                         />
                     </LemonField.Pure>
-                    <LemonField.Pure
-                        label="Burst capacity (optional)"
-                        help="Whole number at least equal to sustained, up to 60,000,000, or leave empty for 3× sustained. Larger burst allows a bigger one-off spike before extra lines drop."
-                        error={samplingFormErrors.rate_limit_burst_logs}
-                    >
-                        <LemonInput
-                            value={samplingForm.rate_limit_burst_logs}
-                            onChange={(v) => setSamplingFormValue('rate_limit_burst_logs', v)}
-                            placeholder="Empty = 3× sustained"
+                )}
+            </SceneSection>
+
+            <SceneDivider />
+
+            <SceneSection
+                title="Scope"
+                titleSize="sm"
+                description="Limit this rule to one service, or apply it across the whole project."
+            >
+                <LemonField.Pure
+                    label={isRateLimit ? 'Service (required)' : 'Service (optional)'}
+                    error={samplingFormErrors.scope_service}
+                    help={isRateLimit ? 'Pick a service from the last 24h.' : 'Leave empty to apply to every service.'}
+                >
+                    <div className="flex flex-col gap-2">
+                        <ServiceFilter
+                            selectionMode="single"
+                            emptyButtonLabel={isRateLimit ? 'Pick from last 24h…' : 'All services'}
+                            value={samplingForm.scope_service ? [samplingForm.scope_service] : []}
+                            onChange={(names) => setSamplingFormValue('scope_service', names[0] ?? '')}
+                            dateRange={{ date_from: '-24h', date_to: null }}
                         />
-                    </LemonField.Pure>
-                </>
-            ) : null}
-            {isSeverity ? (
-                <>
-                    <LemonBanner type="info">
-                        <div className="text-sm">
-                            <strong>Example — drop only noisy info logs:</strong> set <strong>Info</strong> to{' '}
-                            <strong>Drop (not stored)</strong>, leave Debug / Warn / Error on <strong>Keep</strong>.
-                            Every matching INFO line in scope is removed at ingestion; other levels pass through unless
-                            another rule matches first.
-                        </div>
-                    </LemonBanner>
-                    <LemonBanner type="warning">
-                        <strong>Drop (not stored)</strong> removes data for affected lines; only <strong>Keep</strong>{' '}
-                        leaves that severity unchanged for this rule.
-                    </LemonBanner>
-                    <LemonField.Pure
-                        label="Per severity level"
-                        info="Evaluated after scope (service + path filter above). Ordinals follow OpenTelemetry severity on the log line (debug, info, warn, error)."
-                    >
-                        <div className="flex flex-col gap-2">
-                            <SeverityRow label="Debug" actionKey="severity_debug" />
-                            <SeverityRow label="Info" actionKey="severity_info" />
-                            <SeverityRow label="Warn" actionKey="severity_warn" />
-                            <SeverityRow label="Error" actionKey="severity_error" />
-                        </div>
-                    </LemonField.Pure>
-                    <div className="font-semibold mt-2">Always keep (optional)</div>
-                    <LemonField.Pure
-                        label="HTTP status >="
-                        className="max-w-xs"
-                        info="Logs with this HTTP status or higher are never dropped by this rule, when the status attribute is present."
-                    >
-                        <LemonInput
-                            value={samplingForm.always_keep_status_gte}
-                            onChange={(v) => setSamplingFormValue('always_keep_status_gte', v)}
-                            placeholder="e.g. 500"
-                        />
-                    </LemonField.Pure>
-                    <LemonField.Pure
-                        label="Latency greater than (ms)"
-                        className="max-w-xs"
-                        info="Logs slower than this threshold are always kept when duration attributes are present."
-                    >
-                        <LemonInput
-                            value={samplingForm.always_keep_latency_ms_gt}
-                            onChange={(v) => setSamplingFormValue('always_keep_latency_ms_gt', v)}
-                            placeholder="e.g. 2000"
-                        />
-                    </LemonField.Pure>
-                </>
-            ) : null}
+                        {isRateLimit &&
+                            (serviceTrafficLoading ? (
+                                <span className="text-muted text-sm">Loading recent volume…</span>
+                            ) : serviceTraffic && samplingForm.scope_service.trim() ? (
+                                <span className="text-muted text-sm">
+                                    ~{serviceTraffic.avg_logs_per_sec.toFixed(2)} logs/sec average over the last 24h (
+                                    {serviceTraffic.log_count.toLocaleString()} lines).
+                                </span>
+                            ) : null)}
+                    </div>
+                </LemonField.Pure>
+            </SceneSection>
         </div>
     )
 }

--- a/products/logs/frontend/components/LogsSampling/LogsSamplingSection.tsx
+++ b/products/logs/frontend/components/LogsSampling/LogsSamplingSection.tsx
@@ -17,8 +17,8 @@ export function LogsSamplingSection(): JSX.Element | null {
             <div className="space-y-3">
                 <p className="text-muted m-0">
                     Exclude noisy or sensitive lines before they are stored. Rules run top to bottom during ingestion —
-                    drag the handle on each row to change that order. Use pattern drops (regex on a path or one
-                    attribute) or drop by severity.
+                    drag the handle on each row to change that order. Use Drop to remove matching lines, or Rate limit
+                    to cap a service's volume.
                 </p>
                 <LogsSamplingRulesSortableTable />
             </div>

--- a/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.ts
+++ b/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
@@ -7,10 +7,11 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import { teamLogic } from 'scenes/teamLogic'
 
+import { FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
+
 import {
     logsSamplingRulesCreate,
     logsSamplingRulesPartialUpdate,
-    logsSamplingRulesSimulateCreate,
     logsServicesCreate,
 } from 'products/logs/frontend/generated/api'
 import {
@@ -22,33 +23,22 @@ import { logsDropRulesSettingsUrl } from 'products/logs/frontend/logsDropRulesSe
 
 import type { logsSamplingFormLogicType } from './logsSamplingFormLogicType'
 
-export type SeverityActionChoice = 'keep' | 'drop' | 'sample'
+const EMPTY_FILTER_GROUP: UniversalFiltersGroup = {
+    type: FilterLogicalOperator.And,
+    values: [],
+}
 
-/** What `path_drop` regex lines are evaluated against (maps to config.match_attribute_key). */
-export type PathDropMatchTarget = 'auto_path' | 'custom_attribute'
+// Burst capacity is no longer user-configurable — hardcoded to 10× sustained.
+// Backend follow-up will revisit this alongside the kB/s unit change.
+const BURST_MULTIPLIER = 10
 
 export interface LogsSamplingFormType {
     name: string
     enabled: boolean
     rule_type: RuleTypeEnumApi
     scope_service: string
-    scope_path_pattern: string
-    path_drop_match_target: PathDropMatchTarget
-    /** When path_drop_match_target is custom_attribute, patterns match only this attribute. */
-    path_drop_match_attribute_key: string
-    path_drop_patterns: string
-    severity_debug: SeverityActionChoice
-    severity_debug_rate: number
-    severity_info: SeverityActionChoice
-    severity_info_rate: number
-    severity_warn: SeverityActionChoice
-    severity_warn_rate: number
-    severity_error: SeverityActionChoice
-    severity_error_rate: number
-    always_keep_status_gte: string
-    always_keep_latency_ms_gt: string
+    filter_group: UniversalFiltersGroup
     rate_limit_logs_per_second: string
-    rate_limit_burst_logs: string
 }
 
 const DEFAULT_FORM: LogsSamplingFormType = {
@@ -56,158 +46,74 @@ const DEFAULT_FORM: LogsSamplingFormType = {
     enabled: true,
     rule_type: RuleTypeEnumApi.PathDrop,
     scope_service: '',
-    scope_path_pattern: '',
-    path_drop_match_target: 'auto_path',
-    path_drop_match_attribute_key: '',
-    path_drop_patterns: '',
-    severity_debug: 'keep',
-    severity_debug_rate: 0.5,
-    severity_info: 'keep',
-    severity_info_rate: 0.5,
-    severity_warn: 'keep',
-    severity_warn_rate: 0.5,
-    severity_error: 'keep',
-    severity_error_rate: 0.5,
-    always_keep_status_gte: '',
-    always_keep_latency_ms_gt: '',
+    filter_group: EMPTY_FILTER_GROUP,
     rate_limit_logs_per_second: '',
-    rate_limit_burst_logs: '',
 }
 
-function parseSeverityPart(
-    key: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR',
-    actionsObj: Record<string, unknown> | undefined,
-    form: LogsSamplingFormType
-): void {
-    const raw = actionsObj?.[key] as Record<string, unknown> | undefined
-    const prefix =
-        key === 'DEBUG'
-            ? 'severity_debug'
-            : key === 'INFO'
-              ? 'severity_info'
-              : key === 'WARN'
-                ? 'severity_warn'
-                : 'severity_error'
-    if (!raw || typeof raw.type !== 'string') {
-        return
+/** Read either the wrapped `{type, values: [innerGroup]}` (logs-viewer/alerts shape) or the bare inner group. */
+function extractFilterGroup(stored: unknown): UniversalFiltersGroup {
+    if (!stored || typeof stored !== 'object') {
+        return EMPTY_FILTER_GROUP
     }
-    const patch = form as unknown as Record<string, unknown>
-    if (raw.type === 'drop') {
-        patch[prefix] = 'drop'
-    } else if (raw.type === 'sample') {
-        // Sampling is not exposed in the UI; coerce legacy configs to keep on load.
-        patch[prefix] = 'keep'
-    } else {
-        patch[prefix] = 'keep'
+    const candidate = stored as { type?: unknown; values?: unknown[] }
+    if (!Array.isArray(candidate.values)) {
+        return EMPTY_FILTER_GROUP
     }
+    const first = candidate.values[0] as { type?: unknown; values?: unknown[] } | undefined
+    if (first && Array.isArray(first.values) && typeof first.type === 'string') {
+        return first as UniversalFiltersGroup
+    }
+    return candidate as UniversalFiltersGroup
+}
+
+/** Wrap inner group as the alerts / logs-viewer wire format expects. */
+function wrapFilterGroup(inner: UniversalFiltersGroup): UniversalFiltersGroup {
+    return { type: FilterLogicalOperator.And, values: [inner] as never }
 }
 
 export function buildSamplingFormDefaults(rule: LogsSamplingRuleApi | null): LogsSamplingFormType {
     if (!rule) {
         return { ...DEFAULT_FORM }
     }
-    const form: LogsSamplingFormType = { ...DEFAULT_FORM, name: rule.name, enabled: rule.enabled ?? false }
-    form.rule_type = rule.rule_type
-    form.scope_service = rule.scope_service ?? ''
-    form.scope_path_pattern = rule.scope_path_pattern ?? ''
+    // Legacy SEVERITY_SAMPLING rules collapse into PathDrop — the new form unifies
+    // severity into the filter group, so the dedicated severity rule type is no longer surfaced.
+    const rule_type = rule.rule_type === RuleTypeEnumApi.SeveritySampling ? RuleTypeEnumApi.PathDrop : rule.rule_type
     const cfg = (rule.config ?? {}) as Record<string, unknown>
-    if (rule.rule_type === RuleTypeEnumApi.PathDrop) {
-        const patterns = (cfg.patterns as string[]) || []
-        form.path_drop_patterns = patterns.join('\n')
-        const mak = cfg.match_attribute_key
-        const makStr = typeof mak === 'string' ? mak : ''
-        form.path_drop_match_attribute_key = makStr
-        form.path_drop_match_target = makStr.trim() !== '' ? 'custom_attribute' : 'auto_path'
+    const form: LogsSamplingFormType = {
+        ...DEFAULT_FORM,
+        name: rule.name,
+        enabled: rule.enabled ?? false,
+        rule_type,
+        scope_service: rule.scope_service ?? '',
     }
-    if (rule.rule_type === RuleTypeEnumApi.SeveritySampling) {
-        const actionsObj = cfg.actions as Record<string, unknown> | undefined
-        parseSeverityPart('DEBUG', actionsObj, form)
-        parseSeverityPart('INFO', actionsObj, form)
-        parseSeverityPart('WARN', actionsObj, form)
-        parseSeverityPart('ERROR', actionsObj, form)
-        const ak = cfg.always_keep as Record<string, unknown> | undefined
-        if (ak && typeof ak === 'object') {
-            if (typeof ak.status_gte === 'number') {
-                form.always_keep_status_gte = String(ak.status_gte)
-            }
-            if (typeof ak.latency_ms_gt === 'number') {
-                form.always_keep_latency_ms_gt = String(ak.latency_ms_gt)
-            }
-        }
+    if (rule_type === RuleTypeEnumApi.PathDrop) {
+        form.filter_group = extractFilterGroup(cfg.filter_group)
     }
-    if (rule.rule_type === RuleTypeEnumApi.RateLimit) {
+    if (rule_type === RuleTypeEnumApi.RateLimit) {
         form.rate_limit_logs_per_second =
             typeof cfg.logs_per_second === 'number' && !Number.isNaN(cfg.logs_per_second)
                 ? String(cfg.logs_per_second)
                 : ''
-        form.rate_limit_burst_logs =
-            typeof cfg.burst_logs === 'number' && !Number.isNaN(cfg.burst_logs) ? String(cfg.burst_logs) : ''
     }
     return form
 }
 
-function severityActionPayload(choice: SeverityActionChoice, rate: number): Record<string, unknown> {
-    if (choice === 'drop') {
-        return { type: 'drop' }
-    }
-    if (choice === 'sample') {
-        return { type: 'sample', rate: Math.max(0, Math.min(1, rate)) }
-    }
-    return { type: 'keep' }
-}
-
 export function buildSamplingConfigPayload(form: LogsSamplingFormType): Record<string, unknown> {
-    if (form.rule_type === RuleTypeEnumApi.PathDrop) {
-        const patterns = form.path_drop_patterns
-            .split('\n')
-            .map((s) => s.trim())
-            .filter(Boolean)
-        const key = form.path_drop_match_target === 'custom_attribute' ? form.path_drop_match_attribute_key.trim() : ''
-        const out: Record<string, unknown> = { patterns }
-        if (key !== '') {
-            out.match_attribute_key = key
-        }
-        return out
-    }
     if (form.rule_type === RuleTypeEnumApi.RateLimit) {
         const lps = parseInt(form.rate_limit_logs_per_second.trim(), 10)
-        const out: Record<string, unknown> = { logs_per_second: lps }
-        const burst = form.rate_limit_burst_logs.trim()
-        if (burst !== '') {
-            const b = parseInt(burst, 10)
-            if (!Number.isNaN(b)) {
-                out.burst_logs = b
-            }
-        }
-        return out
-    }
-    const always: Record<string, unknown> = {}
-    const sg = form.always_keep_status_gte.trim()
-    if (sg !== '') {
-        const n = parseInt(sg, 10)
-        if (!Number.isNaN(n)) {
-            always.status_gte = n
+        return {
+            logs_per_second: lps,
+            burst_logs: lps * BURST_MULTIPLIER,
         }
     }
-    const lat = form.always_keep_latency_ms_gt.trim()
-    if (lat !== '') {
-        const n = parseFloat(lat)
-        if (!Number.isNaN(n)) {
-            always.latency_ms_gt = n
-        }
+    // `patterns: []` keeps the existing path_drop config validator happy.
+    // Backend filter_group evaluation is wired in the follow-up PR; today the
+    // worker reads `patterns` only, so rules saved through the new UI are
+    // no-ops on the ingestion path until that lands.
+    return {
+        patterns: [],
+        filter_group: wrapFilterGroup(form.filter_group),
     }
-    const out: Record<string, unknown> = {
-        actions: {
-            DEBUG: severityActionPayload(form.severity_debug, form.severity_debug_rate),
-            INFO: severityActionPayload(form.severity_info, form.severity_info_rate),
-            WARN: severityActionPayload(form.severity_warn, form.severity_warn_rate),
-            ERROR: severityActionPayload(form.severity_error, form.severity_error_rate),
-        },
-    }
-    if (Object.keys(always).length > 0) {
-        out.always_keep = always
-    }
-    return out
 }
 
 export interface LogsSamplingFormLogicProps {
@@ -224,27 +130,10 @@ export const logsSamplingFormLogic = kea<logsSamplingFormLogicType>([
     })),
 
     actions({
-        scheduleSimulate: true,
         refreshServiceTraffic: true,
     }),
 
-    loaders(({ values, props }) => ({
-        simulation: [
-            null as { estimated_reduction_pct: number; notes: string } | null,
-            {
-                runSimulateNow: async () => {
-                    if (
-                        !props.rule?.id ||
-                        props.rule.rule_type === RuleTypeEnumApi.SeveritySampling ||
-                        props.rule.rule_type === RuleTypeEnumApi.RateLimit
-                    ) {
-                        return null
-                    }
-                    const projectId = String(values.currentTeamId)
-                    return await logsSamplingRulesSimulateCreate(projectId, props.rule.id)
-                },
-            },
-        ],
+    loaders(({ values }) => ({
         serviceTraffic: [
             null as { log_count: number; avg_logs_per_sec: number } | null,
             {
@@ -270,76 +159,32 @@ export const logsSamplingFormLogic = kea<logsSamplingFormLogicType>([
                         return { log_count: 0, avg_logs_per_sec: 0 }
                     }
                     const logCount = row.log_count
-                    const avg = logCount / (24 * 3600)
-                    return { log_count: logCount, avg_logs_per_sec: avg }
+                    return { log_count: logCount, avg_logs_per_sec: logCount / (24 * 3600) }
                 },
             },
         ],
     })),
 
-    listeners(({ actions, props, cache }) => ({
+    listeners(({ actions }) => ({
         refreshServiceTraffic: () => {
             actions.loadServiceTraffic(null)
         },
-        scheduleSimulate: () => {
-            if (!props.rule?.id) {
-                return
-            }
-            const w = cache as { simulateTimer?: ReturnType<typeof setTimeout> }
-            if (w.simulateTimer) {
-                clearTimeout(w.simulateTimer)
-            }
-            w.simulateTimer = setTimeout(() => {
-                actions.runSimulateNow()
-            }, 500)
-        },
         setSamplingFormValue: () => {
-            actions.scheduleSimulate()
             actions.refreshServiceTraffic()
-        },
-        submitSamplingFormSuccess: () => {
-            actions.scheduleSimulate()
         },
     })),
 
-    selectors({
-        canSimulate: [
-            () => [(_, props) => props.rule],
-            (rule: LogsSamplingRuleApi | null) =>
-                Boolean(rule?.id) &&
-                rule?.rule_type !== RuleTypeEnumApi.SeveritySampling &&
-                rule?.rule_type !== RuleTypeEnumApi.RateLimit,
-        ],
-        isNewRule: [() => [(_, props) => props.rule], (rule: LogsSamplingRuleApi | null) => !rule],
-    }),
-
-    afterMount(({ actions, props }) => {
-        actions.resetSamplingForm(buildSamplingFormDefaults(props.rule))
-        if (
-            props.rule?.id &&
-            props.rule.rule_type !== RuleTypeEnumApi.SeveritySampling &&
-            props.rule.rule_type !== RuleTypeEnumApi.RateLimit
-        ) {
-            actions.scheduleSimulate()
-        }
+    afterMount(({ actions }) => {
         actions.refreshServiceTraffic()
     }),
 
     forms(({ props, values }) => ({
         samplingForm: {
             defaults: buildSamplingFormDefaults(props.rule),
-            errors: (form) => {
+            errors: (form: LogsSamplingFormType) => {
                 const lps = parseInt(form.rate_limit_logs_per_second.trim(), 10)
-                const burstRaw = form.rate_limit_burst_logs.trim()
-                const burst = burstRaw === '' ? null : parseInt(burstRaw, 10)
                 return {
                     name: !form.name?.trim() ? 'Name is required' : undefined,
-                    path_drop_match_attribute_key:
-                        form.rule_type === RuleTypeEnumApi.PathDrop &&
-                        form.path_drop_match_target === 'custom_attribute' &&
-                        !form.path_drop_match_attribute_key?.trim()
-                            ? 'Enter the log attribute key (e.g. http.route)'
-                            : undefined,
                     scope_service:
                         form.rule_type === RuleTypeEnumApi.RateLimit && !form.scope_service?.trim()
                             ? 'Select or enter a service name'
@@ -349,20 +194,16 @@ export const logsSamplingFormLogic = kea<logsSamplingFormLogicType>([
                         (form.rate_limit_logs_per_second.trim() === '' || Number.isNaN(lps) || lps < 1)
                             ? 'Enter logs per second (integer ≥ 1)'
                             : undefined,
-                    rate_limit_burst_logs:
-                        form.rule_type === RuleTypeEnumApi.RateLimit &&
-                        burstRaw !== '' &&
-                        (burst === null || Number.isNaN(burst) || burst < lps)
-                            ? 'Burst must be an integer ≥ sustained rate, or leave empty for default'
-                            : undefined,
                 }
             },
-            submit: async (form) => {
+            submit: async (form: LogsSamplingFormType) => {
+                if (form.rule_type === RuleTypeEnumApi.PathDrop && form.filter_group.values.length === 0) {
+                    lemonToast.error('Add at least one filter to drop logs')
+                    return
+                }
                 const projectId = String(values.currentTeamId)
                 try {
                     const scope_service = form.scope_service.trim() || null
-                    const scope_path_pattern =
-                        form.rule_type === RuleTypeEnumApi.RateLimit ? null : form.scope_path_pattern.trim() || null
                     const scope_attribute_filters = (props.rule?.scope_attribute_filters ??
                         []) as PatchedLogsSamplingRuleApi['scope_attribute_filters']
                     const payload = {
@@ -370,7 +211,8 @@ export const logsSamplingFormLogic = kea<logsSamplingFormLogicType>([
                         enabled: form.enabled,
                         rule_type: form.rule_type,
                         scope_service,
-                        scope_path_pattern,
+                        // scope_path_pattern is folded into the filter group; the backend column will be retired in PR 2.
+                        scope_path_pattern: null,
                         scope_attribute_filters,
                         config: buildSamplingConfigPayload(form),
                     }

--- a/products/logs/frontend/components/LogsSampling/ruleTypeLabel.ts
+++ b/products/logs/frontend/components/LogsSampling/ruleTypeLabel.ts
@@ -4,11 +4,11 @@ import { RuleTypeEnumApi } from 'products/logs/frontend/generated/api.schemas'
 export function ruleTypeLabel(ruleType: RuleTypeEnumApi): string {
     switch (ruleType) {
         case RuleTypeEnumApi.PathDrop:
-            return 'Drop when matched'
+            return 'Drop'
         case RuleTypeEnumApi.SeveritySampling:
             return 'Drop by severity'
         case RuleTypeEnumApi.RateLimit:
-            return 'Rate limit by service'
+            return 'Rate limit'
         default: {
             return String(ruleType)
         }

--- a/products/logs/frontend/components/LogsSampling/samplingFormSaveDisabledReason.ts
+++ b/products/logs/frontend/components/LogsSampling/samplingFormSaveDisabledReason.ts
@@ -1,0 +1,17 @@
+import { RuleTypeEnumApi } from 'products/logs/frontend/generated/api.schemas'
+
+import type { LogsSamplingFormType } from './logsSamplingFormLogic'
+
+/**
+ * Returns the reason the Save button should be disabled, or null when save is allowed.
+ *
+ * kea-forms can't express scalar errors on object-shaped fields (the filter group),
+ * so the "filter group must be non-empty" check is surfaced via this pure function
+ * and consumed directly by the scene's submit button.
+ */
+export function samplingFormSaveDisabledReason(form: LogsSamplingFormType): string | null {
+    if (form.rule_type === RuleTypeEnumApi.PathDrop && form.filter_group.values.length === 0) {
+        return 'Add at least one filter to drop logs'
+    }
+    return null
+}

--- a/products/logs/frontend/scenes/LogsSamplingDetailScene/LogsSamplingDetailScene.tsx
+++ b/products/logs/frontend/scenes/LogsSamplingDetailScene/LogsSamplingDetailScene.tsx
@@ -9,10 +9,12 @@ import { compactNumber } from 'lib/utils'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneStickyBar } from '~/layout/scenes/components/SceneStickyBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { LogsSamplingForm } from 'products/logs/frontend/components/LogsSampling/LogsSamplingForm'
 import { logsSamplingFormLogic } from 'products/logs/frontend/components/LogsSampling/logsSamplingFormLogic'
+import { samplingFormSaveDisabledReason } from 'products/logs/frontend/components/LogsSampling/samplingFormSaveDisabledReason'
 import { LogsSamplingRuleApi } from 'products/logs/frontend/generated/api.schemas'
 
 import { LogsSamplingDetailSceneLogicProps, logsSamplingDetailSceneLogic } from './logsSamplingDetailSceneLogic'
@@ -57,6 +59,7 @@ function LogsSamplingDetailFormBody({ rule }: { rule: LogsSamplingRuleApi }): JS
     const { setSamplingFormValue } = useActions(logsSamplingFormLogic(formProps))
     const { samplingForm, isSamplingFormSubmitting } = useValues(logsSamplingFormLogic(formProps))
     const { ruleDropImpact24h, ruleDropImpact24hLoading } = useValues(logsSamplingDetailSceneLogic)
+    const saveDisabledReason = samplingFormSaveDisabledReason(samplingForm)
 
     const confirmDelete = (): void => {
         LemonDialog.open({
@@ -74,51 +77,61 @@ function LogsSamplingDetailFormBody({ rule }: { rule: LogsSamplingRuleApi }): JS
 
     return (
         <SceneContent>
-            <SceneTitleSection
-                name={samplingForm.name || rule.name}
-                resourceType={{ type: 'logs' }}
-                canEdit
-                onNameChange={(name) => setSamplingFormValue('name', name)}
-                renameDebounceMs={0}
-                actions={
-                    <LemonButton type="secondary" status="danger" onClick={confirmDelete}>
-                        Delete
-                    </LemonButton>
-                }
-            />
-            <div className="px-4 pt-2 pb-0 text-secondary text-sm flex items-center gap-1.5">
-                {ruleDropImpact24hLoading ? (
-                    <span className="text-muted">Loading drop impact…</span>
-                ) : ruleDropImpact24h === null ? (
-                    <span className="text-muted" title="Drop impact for the last 24 hours is not available">
-                        —
-                    </span>
-                ) : (
-                    <>
-                        <span>
-                            ~{compactNumber(ruleDropImpact24h)} log lines dropped in the last 24 hours (ingestion).
-                        </span>
-                        <Tooltip
-                            title={
+            <Form logic={logsSamplingFormLogic} props={formProps} formKey="samplingForm" enableFormOnSubmit>
+                <SceneTitleSection
+                    name={samplingForm.name || rule.name}
+                    resourceType={{ type: 'logs' }}
+                    canEdit
+                    onNameChange={(name) => setSamplingFormValue('name', name)}
+                    renameDebounceMs={0}
+                    actions={
+                        <LemonButton type="secondary" status="danger" onClick={confirmDelete}>
+                            Delete
+                        </LemonButton>
+                    }
+                />
+                <SceneStickyBar>
+                    <div className="flex items-center justify-between gap-2">
+                        <div className="text-secondary text-sm flex items-center gap-1.5">
+                            {ruleDropImpact24hLoading ? (
+                                <span className="text-muted">Loading drop impact…</span>
+                            ) : ruleDropImpact24h === null ? (
+                                <span className="text-muted" title="Drop impact for the last 24 hours is not available">
+                                    —
+                                </span>
+                            ) : (
                                 <>
-                                    From app metrics keyed by this rule. Service-scoped rules only affect that service;
-                                    others are counted across the project.
+                                    <span>
+                                        ~{compactNumber(ruleDropImpact24h)} log lines dropped in the last 24 hours
+                                        (ingestion).
+                                    </span>
+                                    <Tooltip
+                                        title={
+                                            <>
+                                                From app metrics keyed by this rule. Service-scoped rules only affect
+                                                that service; others are counted across the project.
+                                            </>
+                                        }
+                                    >
+                                        <IconInfo className="text-muted-alt text-base shrink-0" />
+                                    </Tooltip>
                                 </>
-                            }
+                            )}
+                        </div>
+                        <LemonButton
+                            type="primary"
+                            htmlType="submit"
+                            loading={isSamplingFormSubmitting}
+                            disabledReason={saveDisabledReason ?? undefined}
                         >
-                            <IconInfo className="text-muted-alt text-base shrink-0" />
-                        </Tooltip>
-                    </>
-                )}
-            </div>
-            <div className="flex flex-col gap-6 p-4">
-                <Form logic={logsSamplingFormLogic} props={formProps} formKey="samplingForm" enableFormOnSubmit>
+                            Save changes
+                        </LemonButton>
+                    </div>
+                </SceneStickyBar>
+                <div className="flex flex-col gap-6 p-4">
                     <LogsSamplingForm />
-                    <LemonButton className="mt-4" type="primary" htmlType="submit" loading={isSamplingFormSubmitting}>
-                        Save changes
-                    </LemonButton>
-                </Form>
-            </div>
+                </div>
+            </Form>
         </SceneContent>
     )
 }

--- a/products/logs/frontend/scenes/LogsSamplingNewScene/LogsSamplingNewScene.tsx
+++ b/products/logs/frontend/scenes/LogsSamplingNewScene/LogsSamplingNewScene.tsx
@@ -6,10 +6,12 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneStickyBar } from '~/layout/scenes/components/SceneStickyBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { LogsSamplingForm } from 'products/logs/frontend/components/LogsSampling/LogsSamplingForm'
 import { logsSamplingFormLogic } from 'products/logs/frontend/components/LogsSampling/logsSamplingFormLogic'
+import { samplingFormSaveDisabledReason } from 'products/logs/frontend/components/LogsSampling/samplingFormSaveDisabledReason'
 
 import { logsSamplingNewSceneLogic } from './logsSamplingNewSceneLogic'
 
@@ -23,30 +25,35 @@ export const scene: SceneExport = {
 export function LogsSamplingNewScene(): JSX.Element {
     const { samplingForm, isSamplingFormSubmitting } = useValues(logsSamplingFormLogic(FORM_PROPS))
     const { setSamplingFormValue } = useActions(logsSamplingFormLogic(FORM_PROPS))
+    const saveDisabledReason = samplingFormSaveDisabledReason(samplingForm)
 
     return (
         <BindLogic logic={logsSamplingFormLogic} props={FORM_PROPS}>
             <SceneContent>
-                <SceneTitleSection
-                    name={samplingForm.name || 'New drop rule'}
-                    resourceType={{ type: 'logs' }}
-                    canEdit
-                    onNameChange={(name) => setSamplingFormValue('name', name)}
-                    renameDebounceMs={0}
-                />
-                <div className="flex flex-col gap-6 p-4">
-                    <Form logic={logsSamplingFormLogic} props={FORM_PROPS} formKey="samplingForm" enableFormOnSubmit>
+                <Form logic={logsSamplingFormLogic} props={FORM_PROPS} formKey="samplingForm" enableFormOnSubmit>
+                    <SceneTitleSection
+                        name={samplingForm.name || 'New drop rule'}
+                        resourceType={{ type: 'logs' }}
+                        canEdit
+                        onNameChange={(name) => setSamplingFormValue('name', name)}
+                        renameDebounceMs={0}
+                    />
+                    <SceneStickyBar>
+                        <div className="flex justify-end gap-2">
+                            <LemonButton
+                                type="primary"
+                                htmlType="submit"
+                                loading={isSamplingFormSubmitting}
+                                disabledReason={saveDisabledReason ?? undefined}
+                            >
+                                Save drop rule
+                            </LemonButton>
+                        </div>
+                    </SceneStickyBar>
+                    <div className="flex flex-col gap-6 p-4">
                         <LogsSamplingForm />
-                        <LemonButton
-                            className="mt-4"
-                            type="primary"
-                            htmlType="submit"
-                            loading={isSamplingFormSubmitting}
-                        >
-                            Save drop rule
-                        </LemonButton>
-                    </Form>
-                </div>
+                    </div>
+                </Form>
             </SceneContent>
         </BindLogic>
     )


### PR DESCRIPTION
## Problem

The drop rules form was a flat list of fields with three rule types (`path_drop` / `severity_sampling` / `rate_limit`) that each surfaced a different combination of inputs. The matcher, the action, and the scope were interleaved, and the same concept — "drop a service's logs by an attribute predicate" — had two unrelated UIs depending on which rule type the user picked first. The bespoke `path_drop_match_target` / `match_attribute_key` / regex-textarea trio was the worst offender: AI agents and engineers alike had to guess what shape went where.

## Changes
After:
<img width="1305" height="596" alt="image" src="https://github.com/user-attachments/assets/7ffd88f1-0323-433a-a526-e24ec9f2552d" />

- Collapse the matching surface to one `UniversalFilters` group — the same primitive the logs viewer and alerts already use.
- Reorder the form to **Match → Action → Scope** and render each as a `SceneSection` with `SceneDivider` between, save action in a `SceneStickyBar` at the top of the scene.
- Merge severity-based rules into PathDrop in the UI; the `SEVERITY_SAMPLING` rule type is hidden from new rules but still loaded for legacy ones (coerced to PathDrop on form load).
- Remove the burst-capacity input; submit hardcodes `burst_logs = sustained * 10`.
- Rate-limit and drop both use the same single-select `ServiceFilter` for scope — drop empty = all services, rate-limit requires a pick.

Functional UI end-to-end (rules create / edit / save / list / delete). Ingestion still reads `config.patterns` rather than `config.filter_group`, so drop rules created through this UI are no-ops on the ingestion path until the stacked backend PR lands.

## Decisions

- **Follow the filter-bar mockup direction, not a conservative reorder.** A more conservative reshuffle (keep all rule-type-specific fields, just add headers) was on the table. Rejected because the bespoke matcher fields were the actual usability problem — not field order. The filter-bar primitive subsumes severity + service-name + arbitrary-attribute matching in one place.
- **Use scene-layout primitives, not the alerts form's raw `<h3>` + `<LemonDivider>`.** Alerts uses raw markup because `LogsAlertForm` lives inside a `LemonModal`. Drop rules lives in `<SceneContent>`, so the right reference is `SceneSection` / `SceneDivider` / `SceneStickyBar` (used by `ExperimentMetricForm.tsx`, feature flags, etc.). The alerts form is still the design influence for *what* the matcher section contains (the filter editor) — but not *how* the sections are framed.
- **Merge `SEVERITY_SAMPLING` into PathDrop in the UI, leave the backend enum alone.** Severity becomes just another filter in the universal group. The backend keeps the enum for now so existing rules continue to load; deprecation is a backend-PR decision.
- **Hardcode burst at 10× sustained instead of exposing it.** It was a confusing input that nobody had real intuition for. The follow-up backend PR will revisit alongside the rate-limit unit change.
- **Keep `DropRuleFilterEditor` as a near-copy of `AlertFilterGroup`, don't extract a shared component.** Extraction touches `LogsAlertForm` for no functional gain in this PR. Filed for a follow-up chore.
- **Defer multi-service scope to the backend PR (Path A).** Both modes are single-select today. Supporting "one / some / all" needs a model + serializer change (`scope_service: char` → list) and a worker change for rate-limit bucket keying. Bundling that with the UI refactor blurs the review boundary; splitting keeps PR concerns clean.
- **Don't ship a pre-save sparkline preview yet.** The previous form had a "rough drop estimate" simulation backed by legacy `patterns` evaluation — meaningless under the new shape. The saved-rule list already shows "Impact (24h)"; a truthful pre-save preview lands in the backend PR alongside filter-group evaluation.
- **Same `ServiceFilter` picker for both Drop and Rate limit** — only the empty-state label differs (`All services` vs `Pick from last 24h…`). Visual symmetry without backend changes.

## How did you test this code?

I'm an agent — manual testing claims are limited.

- `tsc --noEmit` (full repo, with `NODE_OPTIONS=--max-old-space-size=12288`): clean.
- `oxlint` on the 8 touched files: 0 warnings, 0 errors.
- Vite HMR picked up changes without compile errors in the frontend dev server logs.
- Human smoke test: confirmed the new scene renders, sections appear in the right order, the filter editor opens, the segmented action button switches between Drop and Rate limit, and saving redirects to the rule list. Rate-limit ingestion smoke test (sustained traffic + low limit + verify drops) **not yet run** — recommended before merge.

## Publish to changelog?

no

## Docs update

No docs change needed in this PR. Once the backend PR lands and rate-limit moves to kB/s, the docs page for logs drop rules will need an update to reflect the new matcher UI and the unit change.

## 🤖 Agent context

Authored via Claude Code (Claude Opus 4.7, 1M context). Reviewer-facing notes:

- Direction came from a frontend-only mockup posted by Frank Hamand in `#team-logs` on 2026-05-08 (`frank/drop-rules-ux-wip`, sha `32ba3a361d`). His branch was a data-shape reference but referenced two components (`DropRuleFilterEditor`, `DropRuleSparklinePreview`) that were never created, didn't use scene primitives, and was self-described as "vibe coded with no thought to backend implementation". Reimplemented from scratch on top of master per his suggestion ("probs easier to reimplement").
- The kea selector for `saveDisabledReason` was initially written as a kea `selectors()` block but failed at build time — kea-forms registers `samplingForm` later in the builder chain, so the selector input was undefined. Refactored to a pure `samplingFormSaveDisabledReason()` helper called directly from the scenes.
- This is PR 1 of a planned 2-PR stack. PR 2 (branch `daniel/drop-rules/backend-filter-eval`, not yet open) owns: wiring `config.filter_group` evaluation in the ingestion worker, retiring the `patterns: []` no-op write, rate-limit unit change to kB/s, removing the `scope_path_pattern` column, multi-service scope, and deciding the `SEVERITY_SAMPLING` deprecation strategy.

Agent-authored — requires human review; do not self-merge.