### PR TITLE
fix(ingestion): auto-create output topics on dev startup

### DIFF
--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -115,6 +115,7 @@ export type CommonConfig = BaseServerConfig & {
     CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: boolean
     CONSUMER_REBALANCE_TIMEOUT_MS: number
     CONSUMER_AUTO_CREATE_TOPICS: boolean
+    KAFKA_PRODUCER_AUTO_CREATE_TOPICS: boolean
     /**
      * When true, every Kafka consumer in this service uses KafkaConsumerV2; otherwise the
      * legacy KafkaConsumer (v1) is used. Used by `createKafkaConsumer()` in
@@ -281,6 +282,8 @@ export function getDefaultCommonConfig(): CommonConfig {
         CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: false,
         CONSUMER_REBALANCE_TIMEOUT_MS: 20_000,
         CONSUMER_AUTO_CREATE_TOPICS: true,
+        // Dev-only default — broker auto-create only fires on produce, not on metadata reads.
+        KAFKA_PRODUCER_AUTO_CREATE_TOPICS: isDevEnv(),
         CONSUMER_USE_V2: false,
 
         // Kafka

--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -1576,4 +1576,54 @@ describe('IngestionConsumer', () => {
             resetSpy.mockRestore()
         })
     })
+
+    describe('startup topic management', () => {
+        const buildIngester = (configOverrides: Partial<typeof hub>): IngestionConsumer => {
+            const config = { ...hub, ...configOverrides }
+            const outputs = createTestIngestionOutputs(mockProducer)
+            const i = new IngestionConsumer(config as typeof hub, {
+                ...hub,
+                outputs,
+                clickhouseGroupRepository: new ClickhouseGroupRepository(outputs),
+                hogTransformer: createHogTransformerService(hub, {
+                    ...hub,
+                    monitoringOutputs: createTestMonitoringOutputs(mockProducer),
+                }),
+            })
+            i['kafkaConsumer'] = {
+                connect: jest.fn(),
+                disconnect: jest.fn(),
+                isHealthy: jest.fn(),
+            } as any
+            return i
+        }
+
+        it('calls ensureTopicExists during startup when the flag is on (dev path)', async () => {
+            const ensureSpy = jest.spyOn(mockProducer, 'ensureTopicExists').mockResolvedValue(undefined)
+            const i = buildIngester({ KAFKA_PRODUCER_AUTO_CREATE_TOPICS: true } as any)
+            try {
+                await expect(i.start()).resolves.toBeUndefined()
+                expect(ensureSpy).toHaveBeenCalled()
+            } finally {
+                await i.stop()
+                ensureSpy.mockRestore()
+            }
+        })
+
+        it('skips ensureTopicExists and throws on missing topics when the flag is off (prod path)', async () => {
+            const ensureSpy = jest.spyOn(mockProducer, 'ensureTopicExists').mockResolvedValue(undefined)
+            const checkSpy = jest
+                .spyOn(mockProducer, 'checkTopicExists')
+                .mockRejectedValue(new Error('Topic not found'))
+            const i = buildIngester({ KAFKA_PRODUCER_AUTO_CREATE_TOPICS: false } as any)
+            try {
+                await expect(i.start()).rejects.toThrow(/Output topic verification failed/)
+                expect(ensureSpy).not.toHaveBeenCalled()
+            } finally {
+                ensureSpy.mockRestore()
+                checkSpy.mockRestore()
+                // start() threw before kafkaConsumer.connect ran; nothing extra to stop.
+            }
+        })
+    })
 })

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -53,7 +53,7 @@ import {
 import { IngestionConsumerConfig } from './config'
 import { CookielessManager } from './cookieless/cookieless-manager'
 import { parseSplitAiEventsConfig } from './event-processing/split-ai-events-step'
-import { IngestionOutputs } from './outputs/ingestion-outputs'
+import { IngestionOutputs, ensureAndVerifyOutputTopics } from './outputs/ingestion-outputs'
 import { createOkContext } from './pipelines/helpers'
 import { TopHog } from './tophog'
 import { MainLaneOverflowRedirect } from './utils/overflow-redirect/main-lane-overflow-redirect'
@@ -62,7 +62,7 @@ import { OverflowRedirectService } from './utils/overflow-redirect/overflow-redi
 import { RedisOverflowRepository } from './utils/overflow-redirect/overflow-redis-repository'
 
 export type IngestionConsumerFullConfig = IngestionConsumerConfig &
-    Pick<CommonConfig, 'KAFKA_CLIENT_RACK' | 'CDP_HOG_WATCHER_SAMPLE_RATE'>
+    Pick<CommonConfig, 'KAFKA_CLIENT_RACK' | 'CDP_HOG_WATCHER_SAMPLE_RATE' | 'KAFKA_PRODUCER_AUTO_CREATE_TOPICS'>
 
 export interface IngestionConsumerDeps {
     postgres: PostgresRouter
@@ -241,14 +241,7 @@ export class IngestionConsumer {
         this.topHog.start()
 
         const outputs = this.deps.outputs
-
-        // Verify all output topics exist. When auto_create_topics_enabled=true
-        // (hobby/dev), this ensures topics are created before first produce.
-        // When auto-create is off (production), this catches misconfigurations early.
-        const topicFailures = await outputs.checkTopics()
-        if (topicFailures.length > 0) {
-            throw new Error(`Output topic verification failed for: ${topicFailures.join(', ')}`)
-        }
+        await ensureAndVerifyOutputTopics(outputs, this.config.KAFKA_PRODUCER_AUTO_CREATE_TOPICS)
 
         const joinedPipelineConfig: JoinedIngestionPipelineConfig = {
             eventSchemaEnforcementEnabled: this.config.EVENT_SCHEMA_ENFORCEMENT_ENABLED,

--- a/nodejs/src/ingestion/outputs/dual-write-ingestion-output.ts
+++ b/nodejs/src/ingestion/outputs/dual-write-ingestion-output.ts
@@ -87,6 +87,10 @@ export class DualWriteIngestionOutput implements IngestionOutput {
         await Promise.all([this.primary.checkTopicExists(timeoutMs), this.secondary.checkTopicExists(timeoutMs)])
     }
 
+    async ensureTopicExists(): Promise<void> {
+        await Promise.all([this.primary.ensureTopicExists(), this.secondary.ensureTopicExists()])
+    }
+
     private isCopyMode(): boolean {
         return this.mode === 'copy' || this.mode === 'copy_team_denylist'
     }

--- a/nodejs/src/ingestion/outputs/ingestion-output.ts
+++ b/nodejs/src/ingestion/outputs/ingestion-output.ts
@@ -7,4 +7,9 @@ export interface IngestionOutput {
     queueMessages(messages: IngestionOutputMessage[]): Promise<void>
     checkHealth(timeoutMs: number): Promise<void>
     checkTopicExists(timeoutMs: number): Promise<void>
+    /**
+     * Idempotently create the underlying topic on the broker. Should only be
+     * called during dev/local startup — see `KafkaProducerWrapper.ensureTopicExists`.
+     */
+    ensureTopicExists(): Promise<void>
 }

--- a/nodejs/src/ingestion/outputs/ingestion-outputs.test.ts
+++ b/nodejs/src/ingestion/outputs/ingestion-outputs.test.ts
@@ -7,6 +7,7 @@ function createMockProducer(): jest.Mocked<KafkaProducerWrapper> {
     return {
         checkConnection: jest.fn().mockResolvedValue(undefined),
         checkTopicExists: jest.fn().mockResolvedValue(undefined),
+        ensureTopicExists: jest.fn().mockResolvedValue(undefined),
         produce: jest.fn().mockResolvedValue(undefined),
         queueMessages: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<KafkaProducerWrapper>
@@ -179,6 +180,71 @@ describe('IngestionOutputs', () => {
             expect(failures).toEqual([])
             expect(primary.checkTopicExists).toHaveBeenCalledWith('events_v1', 10000)
             expect(secondary.checkTopicExists).toHaveBeenCalledWith('events_v2', 10000)
+        })
+    })
+
+    describe('ensureTopics', () => {
+        it('calls ensureTopicExists for each non-empty topic', async () => {
+            const producer = createMockProducer()
+            const outputs = new IngestionOutputs({
+                events: new SingleIngestionOutput('events', 'events', producer, 'test'),
+                ai_events: new SingleIngestionOutput('ai_events', 'ai_events', producer, 'test'),
+            })
+
+            const failures = await outputs.ensureTopics()
+
+            expect(failures).toEqual([])
+            expect(producer.ensureTopicExists).toHaveBeenCalledWith('events')
+            expect(producer.ensureTopicExists).toHaveBeenCalledWith('ai_events')
+        })
+
+        it('skips outputs with empty topic names', async () => {
+            const producer = createMockProducer()
+            const outputs = new IngestionOutputs({
+                events: new SingleIngestionOutput('events', 'events', producer, 'test'),
+                redirect: new SingleIngestionOutput('redirect', '', producer, 'test'),
+            })
+
+            const failures = await outputs.ensureTopics()
+
+            expect(failures).toEqual([])
+            expect(producer.ensureTopicExists).toHaveBeenCalledTimes(1)
+            expect(producer.ensureTopicExists).toHaveBeenCalledWith('events')
+        })
+
+        it('collects failures per output and keeps going', async () => {
+            const producer = createMockProducer()
+            producer.ensureTopicExists
+                .mockResolvedValueOnce(undefined)
+                .mockRejectedValueOnce(new Error('admin call failed'))
+            const outputs = new IngestionOutputs({
+                events: new SingleIngestionOutput('events', 'events', producer, 'test'),
+                ai_events: new SingleIngestionOutput('ai_events', 'ai_events', producer, 'test'),
+            })
+
+            const failures = await outputs.ensureTopics()
+
+            expect(failures).toEqual(['ai_events'])
+            expect(producer.ensureTopicExists).toHaveBeenCalledTimes(2)
+        })
+
+        it('creates both topics in a dual-write output', async () => {
+            const primary = createMockProducer()
+            const secondary = createMockProducer()
+            const outputs = new IngestionOutputs({
+                events: new DualWriteIngestionOutput(
+                    new SingleIngestionOutput('events', 'events_v1', primary, 'test'),
+                    new SingleIngestionOutput('events', 'events_v2', secondary, 'test'),
+                    'copy',
+                    100
+                ),
+            })
+
+            const failures = await outputs.ensureTopics()
+
+            expect(failures).toEqual([])
+            expect(primary.ensureTopicExists).toHaveBeenCalledWith('events_v1')
+            expect(secondary.ensureTopicExists).toHaveBeenCalledWith('events_v2')
         })
     })
 

--- a/nodejs/src/ingestion/outputs/ingestion-outputs.ts
+++ b/nodejs/src/ingestion/outputs/ingestion-outputs.ts
@@ -45,6 +45,27 @@ export class IngestionOutputs<O extends string> {
     }
 
     /**
+     * Idempotently create all non-empty topics via the admin API. Each output's
+     * admin call has its own 30s timeout in dev — run them in parallel so one
+     * slow broker doesn't serialize startup across 10+ outputs. Failures are
+     * logged, not thrown; callers re-run `checkTopics()` as the source of truth.
+     */
+    async ensureTopics(): Promise<string[]> {
+        const results = await Promise.all(
+            Object.keys(this.outputs).map(async (outputName) => {
+                try {
+                    await this.outputs[outputName as O].ensureTopicExists()
+                    return null
+                } catch (error) {
+                    logger.error('🔴', `Topic creation failed for output "${outputName}"`, { error })
+                    return outputName
+                }
+            })
+        )
+        return results.filter((name): name is string => name !== null)
+    }
+
+    /**
      * Check that all non-empty topics exist on their brokers.
      *
      * @param timeoutMs - Timeout for each topic metadata check.
@@ -63,5 +84,26 @@ export class IngestionOutputs<O extends string> {
             logger.error('🔴', `Topic check failed for outputs: ${failures.join(', ')}`)
         }
         return failures
+    }
+}
+
+/**
+ * Startup gate shared by every server that owns an `IngestionOutputs`. When
+ * auto-create is on (dev default), tries to create missing topics via the
+ * admin API — broker metadata reads don't trigger broker-side auto-create, so
+ * a fresh cluster would otherwise fail the verification step below. Then
+ * verifies all topics exist and throws if any are still missing (the prod
+ * safety net for misconfigured topic names).
+ */
+export async function ensureAndVerifyOutputTopics(
+    outputs: IngestionOutputs<string>,
+    autoCreateEnabled: boolean
+): Promise<void> {
+    if (autoCreateEnabled) {
+        await outputs.ensureTopics()
+    }
+    const topicFailures = await outputs.checkTopics()
+    if (topicFailures.length > 0) {
+        throw new Error(`Output topic verification failed for: ${topicFailures.join(', ')}`)
     }
 }

--- a/nodejs/src/ingestion/outputs/single-ingestion-output.ts
+++ b/nodejs/src/ingestion/outputs/single-ingestion-output.ts
@@ -60,6 +60,13 @@ export class SingleIngestionOutput implements IngestionOutput {
             throw error
         }
     }
+
+    async ensureTopicExists(): Promise<void> {
+        if (!this.topic) {
+            return
+        }
+        await this.producer.ensureTopicExists(this.topic)
+    }
 }
 
 async function withMetrics<T>(

--- a/nodejs/src/kafka/producer.ts
+++ b/nodejs/src/kafka/producer.ts
@@ -15,6 +15,7 @@ import { Counter, Histogram, Summary } from 'prom-client'
 import { instrumentFn } from '../common/tracing/tracing-utils'
 import { DependencyUnavailableError, MessageSizeTooLarge } from '../utils/db/error'
 import { logger } from '../utils/logger'
+import { ensureTopicExists } from './admin'
 import { KafkaConfigTarget, getKafkaConfigFromEnv } from './config'
 import { ProducerStatsTracker } from './kafka-producer-metrics'
 
@@ -109,14 +110,17 @@ export class KafkaProducerWrapper {
             })
         )
 
-        return new KafkaProducerWrapper(producer, name)
+        return new KafkaProducerWrapper(producer, producerConfig, name)
     }
 
     /** Optional human-readable name (e.g. 'DEFAULT', 'WARPSTREAM') used in metrics labels. */
     public readonly name?: string
 
-    constructor(producer: HighLevelProducer, name?: string) {
+    private readonly connectionConfig: ProducerGlobalConfig
+
+    constructor(producer: HighLevelProducer, connectionConfig: ProducerGlobalConfig, name?: string) {
         this.producer = producer
+        this.connectionConfig = connectionConfig
         this.name = name
 
         if (name) {
@@ -275,6 +279,11 @@ export class KafkaProducerWrapper {
                 }
             })
         )
+    }
+
+    /** Idempotently create a topic on the broker, reusing this producer's connection settings. */
+    public async ensureTopicExists(topic: string): Promise<void> {
+        await ensureTopicExists(this.connectionConfig, topic)
     }
 
     /** Check that a topic exists on the broker. */

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -47,6 +47,7 @@ import {
 } from '../ingestion/config'
 import { CookielessManager } from '../ingestion/cookieless/cookieless-manager'
 import { parseSplitAiEventsConfig } from '../ingestion/event-processing/split-ai-events-step'
+import { ensureAndVerifyOutputTopics } from '../ingestion/outputs/ingestion-outputs'
 import { KafkaProducerRegistry } from '../ingestion/outputs/kafka-producer-registry'
 import { buildGroupRepository, buildPersonRepository, createPersonHogClient } from '../ingestion/personhog'
 import { createOkContext } from '../ingestion/pipelines/helpers'
@@ -100,6 +101,7 @@ export type IngestionApiServerConfig = BaseServerConfig &
         | 'POSTHOG_HOST_URL'
         | 'HEALTHCHECK_MAX_STALE_SECONDS'
         | 'KAFKA_HEALTHCHECK_SECONDS'
+        | 'KAFKA_PRODUCER_AUTO_CREATE_TOPICS'
     >
 
 const batchesProcessed = new Counter({
@@ -243,10 +245,7 @@ export class IngestionApiServer implements NodeServer {
         const ingestionOutputs = createOutputsRegistry().build(this.ingestionProducerRegistry, this.config)
         const clickhouseGroupRepository = new ClickhouseGroupRepository(ingestionOutputs)
 
-        const topicFailures = await ingestionOutputs.checkTopics()
-        if (topicFailures.length > 0) {
-            throw new Error(`Output topic verification failed for: ${topicFailures.join(', ')}`)
-        }
+        await ensureAndVerifyOutputTopics(ingestionOutputs, this.config.KAFKA_PRODUCER_AUTO_CREATE_TOPICS)
 
         // 5. HogTransformer
         const hogTransformerDeps: HogTransformerServiceDeps = {

--- a/nodejs/src/servers/ingestion-general-server.ts
+++ b/nodejs/src/servers/ingestion-general-server.ts
@@ -94,6 +94,7 @@ export type IngestionGeneralServerConfig = BaseServerConfig &
         | 'POSTHOG_HOST_URL'
         | 'HEALTHCHECK_MAX_STALE_SECONDS'
         | 'KAFKA_HEALTHCHECK_SECONDS'
+        | 'KAFKA_PRODUCER_AUTO_CREATE_TOPICS'
     >
 
 export class IngestionGeneralServer implements NodeServer {

--- a/nodejs/tests/helpers/mocks/producer.mock.ts
+++ b/nodejs/tests/helpers/mocks/producer.mock.ts
@@ -32,7 +32,7 @@ jest.mock('../../../src/kafka/producer', () => {
     } as any
 
     // Rather than calling create we just create a new instance with the underlying node-rdkafka producer mocked.
-    const kafkaProducer = new ActualKafkaProducerWrapper(mockHighLevelProducer)
+    const kafkaProducer = new ActualKafkaProducerWrapper(mockHighLevelProducer, { 'metadata.broker.list': 'mock:9092' })
 
     class MockKafkaProducer {
         static create = jest.fn(() => Promise.resolve(kafkaProducer))


### PR DESCRIPTION
`checkTopics()` only reads broker metadata, which never triggers Kafka's auto-create — that fires on produce. On a fresh Redpanda/Kafka cluster this caused ingestion-v2-combined to fail startup before any produce could happen.

Add `KAFKA_PRODUCER_AUTO_CREATE_TOPICS` (default `isDevEnv()`) that runs the admin-API `ensureTopicExists` per output before the verify pass, so dev/AMI bakes start cleanly. Prod default stays `false` and keeps the fail-fast safety net for misconfigured topic names.
