### PR TITLE
chore(flags): apply tabular-nums to changing numbers

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -17,9 +17,9 @@ snapshots:
     components-activitylog--data-management-activity--light:
         hash: v1.k794b7964.d75d8b866f0fe5f85862a03ce6bb381aa7c1d63438cc4dab1cc6ca532da0deb5.JRuWE_224b0bosdFVzY3MN6PA9vd2ijrIeNHrVFoeGg
     components-activitylog--feature-flag-activity--dark:
-        hash: v1.k794b7964.683f5d74e5c0b1e6783366a71eda4a59d3d2614d9a76c867885e77fd1c281cca.fGJ5Wh1ylnoCarPX9u9e25gkadbVNqAFEhgeS9VWS9c
+        hash: v1.k794b7964.b3248585f6c16d40587e398e0501b3aad84bb079401d62299f11e684a429e4c5.oXLGlf705o3U9vY15F_7HWSMMbeb58T4h-Bzf_SlLwE
     components-activitylog--feature-flag-activity--light:
-        hash: v1.k794b7964.11328aa76bf16ded46d446c49a05e3b1da3bf9b264bc461b9ea9d1ea3058fc28.ybbXr3hMUT58STjuwFa5He3m8skKUpFjgxdmmgjePRM
+        hash: v1.k794b7964.6922cf1bce62b2362d807fa8cd927f75be1132065c50c5a4062d6d0327048e64.buNCHmr90BfI2GMxUEo9dS06VjbS0aR92PvgayfkgbM
     components-activitylog--insight-activity--dark:
         hash: v1.k794b7964.96cfee7cc2654e3db1d04a41296681ac8d20e8375f7773e33013ec278c6ffbba.yqqiJ60o5xAHxzRnBqrIpb3eRvFeiCPg9pt6_4_bXVY
     components-activitylog--insight-activity--light:
@@ -33,9 +33,9 @@ snapshots:
     components-activitylog--team-activity--light:
         hash: v1.k794b7964.145bc3addbd3e76e9af0e2c9e8825671cf846a36e38a29d817284a7f470ea8d3.3Q-ovMws2k1teYNIklhq4H431uungkrwXIfHZEE9aiw
     components-activitylog--with-caption--dark:
-        hash: v1.k794b7964.5318de007bb5091f0694646989526b7a899a24163ee237d94bbf4665a5376095.YM-zIsnUYs-3eVv4NfQScQr0N-UC1Okt4tBHKwnexZs
+        hash: v1.k794b7964.f889835eb6b1a40515525306d8ec6e2479074f1668e4ce33d6caab1cd48099ac.vfSXz25zq_l72HTaHc6Mk6QaXL93lqAblXgqvVyTIYw
     components-activitylog--with-caption--light:
-        hash: v1.k794b7964.43fad4af52d72f7e633d87b5da32c98b788c985d7637c6626f3fff4d2cc426d5.wO0hWe4-9LGC9XPxLKleCTUsiLX0cvSvPouZrDNpGdI
+        hash: v1.k794b7964.2b1508a0cf4bfe1ff500f48b61bd25c7502cca5dce5c960bb49585b2a540be1e.AOhNcyFrYfWZomEwTfU0DhSbLonqpqb5epSgrIX4j1g
     components-activitylog--with-no-data--dark:
         hash: v1.k794b7964.c71b0cad91ef46cfb758d80a1a366a5fcbedf6c4ad37949c631fd3e6534a26e7.zwlJDb-H68xn0j_2lpOMIRl7vFW8iO_x7F7Mem2hKRs
     components-activitylog--with-no-data--light:
@@ -4179,9 +4179,9 @@ snapshots:
     scenes-app-feature-flags--feature-flag-not-found--light:
         hash: v1.k794b7964.484080c338426577cb9da75ff8bec71dd03bca1927dadfaf3b917d8f5cdc53d1.2Ifp1jtIRJ3OtTM1zSbdFi59x103xiikEmsdi26GTcw
     scenes-app-feature-flags--feature-flags-list--dark:
-        hash: v1.k794b7964.909e4c7bd20e65b83a467a6fd7415e6ebc758a4f2c9f0467a07da751cbcad40e.o8RxQiqXKXiVZOiJvMZHlzLscO3d1C5R-eosdWk21y0
+        hash: v1.k794b7964.c3a17177fde3d99920a77cffffa67c2bd026ffaf54e0d0590a46bbe1e2aaafc4.-uE2rDJgTJxVwiwLeEMuZ5Hfz_64Sw-rLst4mRdaSoY
     scenes-app-feature-flags--feature-flags-list--light:
-        hash: v1.k794b7964.a8c1deec58292c1eae5fa7714297cb8133dd7482e8e63cab08007812474e43a6.H5jVyUOvofKoe_JlVT3FWZPgIPkhNdPZkUS3e9cwYL4
+        hash: v1.k794b7964.87731849b4f4b2888755f9ee331b846a5c4c905dacb8d9008ac6d79f35381726.nYqNyfzpXQwPE-PkP9uhPuOKXBRVwdHC14Z9tFElg7U
     scenes-app-feature-flags--new-feature-flag--dark:
         hash: v1.k794b7964.4fde6fb028b96110a7ba260785fdb7739d57285129b1a5d2a78bbf6de0124ee5.9ZHWl5hLcjIh4iaVlBLPZwjFdMT8ih4esVB86IP5gKE
     scenes-app-feature-flags--new-feature-flag--light:

--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -104,7 +104,7 @@ function SortableVariantHeader({
             <div className="flex gap-2 items-center">
                 <Lettermark name={alphabet[index] ?? String(index + 1)} color={LettermarkColor.Gray} size="small" />
                 <span className="text-sm font-medium">{variant.key || `Variant ${index + 1}`}</span>
-                <span className="text-xs text-muted">({variant.rollout_percentage || 0}%)</span>
+                <span className="text-xs text-muted tabular-nums">({variant.rollout_percentage || 0}%)</span>
             </div>
             <div className="flex gap-1 items-center ml-auto">
                 <LemonButton
@@ -942,7 +942,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                                             <span className="text-sm font-medium">
                                                                 {getActiveVariant()?.key || 'Variant'}
                                                             </span>
-                                                            <span className="text-xs text-muted">
+                                                            <span className="text-xs text-muted tabular-nums">
                                                                 ({getActiveVariant()?.rollout_percentage || 0}%)
                                                             </span>
                                                         </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -413,7 +413,11 @@ export function FeatureFlagReleaseConditions({
                         >
                             <div className="text-sm ">
                                 Rolled out to{' '}
-                                {group.rollout_percentage != null ? <b>{group.rollout_percentage}</b> : <b>100</b>}
+                                {group.rollout_percentage != null ? (
+                                    <b className="tabular-nums">{group.rollout_percentage}</b>
+                                ) : (
+                                    <b className="tabular-nums">100</b>
+                                )}
                                 <b>%</b>
                                 <span> of </span>
                                 <b>{aggregationTargetName(group.aggregation_group_type_index)}</b>{' '}
@@ -450,7 +454,7 @@ export function FeatureFlagReleaseConditions({
                                 of <b>{aggregationTargetName(group.aggregation_group_type_index)}</b> in this set. Will
                                 match approximately{' '}
                                 {group.sort_key && affectedCounts[group.sort_key] !== undefined ? (
-                                    <b>
+                                    <b className="tabular-nums">
                                         {`${
                                             Math.max(
                                                 computeBlastRadiusPercentage(
@@ -475,9 +479,13 @@ export function FeatureFlagReleaseConditions({
                                         const rolloutPct = Number.isNaN(group.rollout_percentage)
                                             ? 0
                                             : (group.rollout_percentage ?? 100)
-                                        return `(${humanFriendlyNumber(
-                                            Math.floor((affected * clamp(rolloutPct, 0, 100)) / 100)
-                                        )} / ${humanFriendlyNumber(total)})`
+                                        return (
+                                            <span className="tabular-nums">
+                                                {`(${humanFriendlyNumber(
+                                                    Math.floor((affected * clamp(rolloutPct, 0, 100)) / 100)
+                                                )} / ${humanFriendlyNumber(total)})`}
+                                            </span>
+                                        )
                                     }
                                     return ''
                                 })()}{' '}

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -179,7 +179,7 @@ function ConditionHeader({
                 <span className="text-sm break-all">{summary}</span>
             </div>
             <div className="flex items-center gap-2 shrink-0">
-                <span className="text-sm text-muted mr-2">
+                <span className="text-sm text-muted mr-2 tabular-nums">
                     ({rollout}%{group.variant && ` · ${group.variant}`}
                     {countSummary !== null && ` · ${countSummary}`})
                 </span>
@@ -631,18 +631,33 @@ const ConditionContent = ({
                                                     if (rolloutPct === 100) {
                                                         return (
                                                             <>
-                                                                <b>{humanFriendlyNumber(affected)}</b> of{' '}
-                                                                {humanFriendlyNumber(total)} {resolvedTargetName} match
-                                                                these filters
+                                                                <b className="tabular-nums">
+                                                                    {humanFriendlyNumber(affected)}
+                                                                </b>{' '}
+                                                                of{' '}
+                                                                <span className="tabular-nums">
+                                                                    {humanFriendlyNumber(total)}
+                                                                </span>{' '}
+                                                                {resolvedTargetName} match these filters
                                                             </>
                                                         )
                                                     }
                                                     return (
                                                         <>
-                                                            Will match ~<b>{humanFriendlyNumber(receivingFlag)}</b> of{' '}
-                                                            {humanFriendlyNumber(total)} {resolvedTargetName} (
-                                                            {rolloutPct}% of {humanFriendlyNumber(affected)} matching
-                                                            the filters)
+                                                            Will match ~
+                                                            <b className="tabular-nums">
+                                                                {humanFriendlyNumber(receivingFlag)}
+                                                            </b>{' '}
+                                                            of{' '}
+                                                            <span className="tabular-nums">
+                                                                {humanFriendlyNumber(total)}
+                                                            </span>{' '}
+                                                            {resolvedTargetName} (
+                                                            <span className="tabular-nums">{rolloutPct}%</span> of{' '}
+                                                            <span className="tabular-nums">
+                                                                {humanFriendlyNumber(affected)}
+                                                            </span>{' '}
+                                                            matching the filters)
                                                         </>
                                                     )
                                                 })()}
@@ -898,7 +913,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                         </span>
                                         <span>{summary}</span>
                                     </div>
-                                    <span className="text-muted">
+                                    <span className="text-muted tabular-nums">
                                         ({rollout}%{group.variant && ` · ${group.variant}`})
                                     </span>
                                 </div>
@@ -1300,7 +1315,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                                     </span>
                                                 </div>
                                                 <div className="flex items-center gap-2 shrink-0">
-                                                    <span className="text-sm text-muted mr-2">
+                                                    <span className="text-sm text-muted mr-2 tabular-nums">
                                                         ({draggedGroup.rollout_percentage ?? 100}%
                                                         {draggedGroup.variant && ` · ${draggedGroup.variant}`})
                                                     </span>

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
@@ -196,7 +196,8 @@ function ConditionSetCard({ group, index, aggregationTargetName }: ConditionSetC
             <div className="mt-3">
                 <LemonTag type={rollout === 100 ? 'highlight' : rollout === 0 ? 'caution' : 'none'}>
                     <span className="text-sm">
-                        Rolled out to <b>{rollout}%</b> of <b>{aggregationTargetName}</b> in this set.
+                        Rolled out to <b className="tabular-nums">{rollout}%</b> of <b>{aggregationTargetName}</b> in
+                        this set.
                     </span>
                 </LemonTag>
             </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
@@ -150,7 +150,7 @@ export function FeatureFlagVariantsForm({
                                     <span className="text-secondary">No payload associated with this variant</span>
                                 )}
                             </div>
-                            <div>{variant.rollout_percentage}%</div>
+                            <div className="tabular-nums">{variant.rollout_percentage}%</div>
                             {(flagKey || onGetFeedback) && (
                                 <div className="col-span-2 flex gap-2 items-start">
                                     {flagKey && (

--- a/frontend/src/scenes/feature-flags/FeatureFlagVariantsSection.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagVariantsSection.tsx
@@ -48,7 +48,9 @@ export function FeatureFlagVariantsSection({ featureFlag, variants }: FeatureFla
                                 ) : (
                                     <span className="text-sm font-medium font-mono">{`Variant ${index + 1}`}</span>
                                 )}
-                                <span className="text-xs text-muted">{variant.rollout_percentage || 0}%</span>
+                                <span className="text-xs text-muted tabular-nums">
+                                    {variant.rollout_percentage || 0}%
+                                </span>
                             </div>
                         ),
                         content: hasExpandableContent ? (

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -416,7 +416,8 @@ export function OverviewTab({
                                 {variants.map((variant) => (
                                     <span key={variant.key}>
                                         <LemonTag type="muted" size="small">
-                                            {variant.key}: {variant.rollout_percentage}%
+                                            {variant.key}:{' '}
+                                            <span className="tabular-nums">{variant.rollout_percentage}%</span>
                                         </LemonTag>
                                     </span>
                                 ))}
@@ -784,7 +785,7 @@ export function groupFilters(
                 `${rollout_percentage ?? 100}% of one group`
             ) : (
                 <div className="flex items-center">
-                    <span className="shrink-0 mr-2">{rollout_percentage ?? 100}% of</span>
+                    <span className="shrink-0 mr-2 tabular-nums">{rollout_percentage ?? 100}% of</span>
                     <PropertyFiltersDisplay filters={properties as AnyPropertyFilter[]} compact />
                 </div>
             )

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -117,7 +117,10 @@ const featureFlagActionsMapping: Record<
                                             {' '}
                                             {idx === 0 && (
                                                 <span>
-                                                    <strong>{rollout_percentage ?? 100}%</strong> of{' '}
+                                                    <strong className="tabular-nums">
+                                                        {rollout_percentage ?? 100}%
+                                                    </strong>{' '}
+                                                    of{' '}
                                                 </span>
                                             )}
                                             <PropertyFilterButton item={property} />
@@ -127,7 +130,7 @@ const featureFlagActionsMapping: Record<
                             newButtons[0] = (
                                 <Fragment key={nonEmptyProperties[0].key ?? 0}>
                                     <span>
-                                        <strong>{rollout_percentage ?? 100}%</strong> of{' '}
+                                        <strong className="tabular-nums">{rollout_percentage ?? 100}%</strong> of{' '}
                                     </span>
                                     <PropertyFilterButton
                                         key={nonEmptyProperties[0].key}
@@ -139,7 +142,8 @@ const featureFlagActionsMapping: Record<
                         } else {
                             groupAdditions.push(
                                 <>
-                                    <strong>{rollout_percentage ?? 100}%</strong> of <strong>all users</strong>
+                                    <strong className="tabular-nums">{rollout_percentage ?? 100}%</strong> of{' '}
+                                    <strong>all users</strong>
                                 </>
                             )
                         }
@@ -220,7 +224,7 @@ const featureFlagActionsMapping: Record<
                     <SentenceList
                         listParts={changedVariants.map((v) => (
                             <div key={v.key} className="highlighted-activity">
-                                {v.key}: <strong>{v.rollout_percentage}%</strong>
+                                {v.key}: <strong className="tabular-nums">{v.rollout_percentage}%</strong>
                             </div>
                         ))}
                         prefix="changed the rollout percentage for the variants to"


### PR DESCRIPTION
## Problem

In the feature flags UI, rollout percentages and counts are rendered with a proportional font, so digits shift horizontally as values change (e.g. dragging the rollout slider). This causes layout jitter and makes the numbers harder to scan.

## Changes

Add the `tabular-nums` Tailwind utility to spans, `<b>`, and `<strong>` tags that host dynamic numeric content (rollout percentages, blast radius, affected/total counts, variant percentages) across the feature flag scene:

- `FeatureFlagReleaseConditionsCollapsible.tsx` — condition header summary, static condition summary, drag overlay, blast radius affected/total/rollout
- `FeatureFlagReleaseConditions.tsx` — rollout percentage, blast radius percentage, `(affected / total)` count
- `FeatureFlagReleaseConditionsReadonly.tsx` — readonly rollout percentage
- `FeatureFlagVariantsForm.tsx`, `FeatureFlagVariantsSection.tsx`, `FeatureFlagForm.tsx` — variant percentage displays
- `FeatureFlags.tsx` — variant tag percentages, single-group release summary
- `activityDescriptions.tsx` — rollout/variant percentages in activity log entries

## How did you test this code?

I'm an agent (PostHog Code). No manual UI verification was performed. No automated tests were added — the change is a single Tailwind utility applied to existing markup and does not affect behavior.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code. User asked to find the `text-sm text-muted mr-2` span in feature flags hosting a rollout percentage, add `tabular-nums`, and extend the class to `<b>` tags and anywhere else numbers change in the feature flag area. I grepped for the className, then expanded to `<b>` / `<strong>` tags and other percentage/count displays across the feature-flags scene. An earlier iteration also touched unrelated `frontend/src/lib/hog-charts/core/` files; those were reverted before committing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*