### PR TITLE
fix(experiments): update activity descriptor to support shared metrics activities.

### DIFF
--- a/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
@@ -1,0 +1,131 @@
+import { render } from '@testing-library/react'
+
+import { ActivityLogItem, HumanizedChange } from 'lib/components/ActivityLog/humanizeActivity'
+
+import { ActivityScope } from '~/types'
+
+import { experimentActivityDescriber } from './experimentActivityDescriber'
+
+const textOf = (result: HumanizedChange): string => {
+    const { container } = render(<>{result.description}</>)
+    return container.textContent ?? ''
+}
+
+const baseLogItem = (overrides: Partial<ActivityLogItem>): ActivityLogItem => ({
+    activity: 'updated',
+    created_at: '2026-05-21T00:00:00Z',
+    scope: 'Experiment',
+    item_id: '42',
+    user: { first_name: 'Alice', last_name: 'Adams', email: 'alice@example.com' },
+    detail: { name: 'Checkout funnel', changes: null, merge: null, trigger: null },
+    ...overrides,
+})
+
+describe('experimentActivityDescriber', () => {
+    describe('saved_metric_config rows', () => {
+        it.each([
+            {
+                name: 'created: "added shared metric X to experiment"',
+                activity: 'created',
+                expected: ['Alice Adams', 'added shared metric', 'Conversion rate', 'experiment'],
+                notExpected: ['created a new', 'deleted'],
+            },
+            {
+                name: 'updated: "updated configuration for shared metric X on experiment"',
+                activity: 'updated',
+                expected: ['Alice Adams', 'updated configuration for shared metric', 'Conversion rate', 'experiment'],
+                notExpected: ['created a new', 'deleted'],
+            },
+            {
+                name: 'deleted: "removed shared metric X from experiment"',
+                activity: 'deleted',
+                expected: ['Alice Adams', 'removed shared metric', 'Conversion rate', 'experiment'],
+                notExpected: ['deleted experiment:', 'created a new'],
+            },
+        ])('$name', ({ activity, expected, notExpected }) => {
+            const result = experimentActivityDescriber(
+                baseLogItem({
+                    activity,
+                    detail: {
+                        name: 'Conversion rate',
+                        type: 'saved_metric_config',
+                        changes: [],
+                        merge: null,
+                        trigger: null,
+                    },
+                })
+            )
+            const text = textOf(result)
+            for (const fragment of expected) {
+                expect(text).toContain(fragment)
+            }
+            for (const fragment of notExpected) {
+                expect(text).not.toContain(fragment)
+            }
+        })
+    })
+
+    describe('metric reorder rows on the experiment scope', () => {
+        it.each([
+            {
+                name: 'primary reorder',
+                field: 'primary_metrics_ordered_uuids',
+                expectedFragment: 'reordered the primary metrics',
+            },
+            {
+                name: 'secondary reorder',
+                field: 'secondary_metrics_ordered_uuids',
+                expectedFragment: 'reordered the secondary metrics',
+            },
+        ])('$name: "$expectedFragment for Checkout funnel"', ({ field, expectedFragment }) => {
+            const result = experimentActivityDescriber(
+                baseLogItem({
+                    activity: 'updated',
+                    detail: {
+                        name: 'Checkout funnel',
+                        changes: [
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'changed',
+                                field,
+                                before: ['uuid-a', 'uuid-b'],
+                                after: ['uuid-b', 'uuid-a'],
+                            },
+                        ],
+                        merge: null,
+                        trigger: null,
+                    },
+                })
+            )
+            const text = textOf(result)
+            expect(text).toContain('Alice Adams')
+            expect(text).toContain(expectedFragment)
+            expect(text).toContain('Checkout funnel')
+            // The reorder must not bleed into the saved_metric_config copy
+            expect(text).not.toContain('shared metric')
+        })
+
+        it('does not describe a reorder when the same UUIDs are passed as before/after', () => {
+            const result = experimentActivityDescriber(
+                baseLogItem({
+                    activity: 'updated',
+                    detail: {
+                        name: 'Checkout funnel',
+                        changes: [
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'changed',
+                                field: 'primary_metrics_ordered_uuids',
+                                before: ['uuid-a', 'uuid-b'],
+                                after: ['uuid-a', 'uuid-b'],
+                            },
+                        ],
+                        merge: null,
+                        trigger: null,
+                    },
+                })
+            )
+            expect(textOf(result)).not.toContain('reordered')
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -111,12 +111,43 @@ const appendPreposition = (item: string | JSX.Element): string | JSX.Element => 
 
 export const experimentActivityDescriber = (logItem: ActivityLogItem): HumanizedChange => {
     /**
-     * we only have two item types, `shared_metric` or the `null` default for
-     * experiments.
+     * Item types: `shared_metric`, `saved_metric_config`, `holdout`, or the `null` default for experiments.
      */
     const isSharedMetric = logItem.detail.type === 'shared_metric'
 
     return match(logItem)
+        .with({ activity: 'created', detail: { type: 'saved_metric_config' } }, () => {
+            return {
+                description: (
+                    <SentenceList
+                        prefix={<strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong>}
+                        listParts={['added shared metric']}
+                        suffix={
+                            <span>
+                                <strong>{logItem.detail.name}</strong> to{' '}
+                                {nameOrLinkToExperiment('experiment', logItem.item_id)}
+                            </span>
+                        }
+                    />
+                ),
+            }
+        })
+        .with({ activity: 'updated', detail: { type: 'saved_metric_config' } }, () => {
+            return {
+                description: (
+                    <SentenceList
+                        prefix={<strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong>}
+                        listParts={['updated configuration for shared metric']}
+                        suffix={
+                            <span>
+                                <strong>{logItem.detail.name}</strong> on{' '}
+                                {nameOrLinkToExperiment('experiment', logItem.item_id)}
+                            </span>
+                        }
+                    />
+                ),
+            }
+        })
         .with({ activity: 'created', detail: { type: 'holdout' } }, () => {
             return {
                 description: (
@@ -164,6 +195,22 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                         prefix={<strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong>}
                         listParts={['deleted experiment:']}
                         suffix={logItem.detail.name}
+                    />
+                ),
+            }
+        })
+        .with({ activity: 'deleted', detail: { type: 'saved_metric_config' } }, () => {
+            return {
+                description: (
+                    <SentenceList
+                        prefix={<strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong>}
+                        listParts={['removed shared metric']}
+                        suffix={
+                            <span>
+                                <strong>{logItem.detail.name}</strong> from{' '}
+                                {nameOrLinkToExperiment('experiment', logItem.item_id)}
+                            </span>
+                        }
                     />
                 ),
             }
@@ -224,7 +271,10 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
              */
             const changes = updateLogDetail.changes || []
 
-            const isExperiment = updateLogDetail.type !== 'shared_metric' && updateLogDetail.type !== 'holdout'
+            const isExperiment =
+                updateLogDetail.type !== 'shared_metric' &&
+                updateLogDetail.type !== 'holdout' &&
+                updateLogDetail.type !== 'saved_metric_config'
 
             let listParts: (string | JSX.Element)[]
             if (changes.length === 0) {


### PR DESCRIPTION
## Problem

The experiment activity log describer did not handle the new `saved_metric_config` activity type, causing shared metric relationship changes to display incorrectly (e.g., showing "deleted experiment" when a shared metric was removed from an experiment).

## Changes

**`frontend/src/scenes/experiments/experimentActivityDescriber.tsx`**

- Added handler for `created` with `type: 'saved_metric_config'`: displays "added shared metric [name] to experiment".
- Added handler for `updated` with `type: 'saved_metric_config'`: displays "updated configuration for shared metric [name] on experiment".
- Added handler for `deleted` with `type: 'saved_metric_config'`: displays "removed shared metric [name] from experiment".
- Updated `isExperiment` check to exclude `saved_metric_config` type from experiment-specific change formatting.
- Updated comment to document the four item types: `shared_metric`, `saved_metric_config`, `holdout`, and `null` (default for experiments).

## How did you test this code?

This is a frontend-only change. The backend changes that emit these activity types are in PR #58837.

![cat-type-small](https://github.com/user-attachments/assets/1674a4ef-8daa-4986-aa52-cedcf5c2fcde)