### PR TITLE
feat(surveys): add in-app/hosted distribution toggle and converter

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -297,6 +297,30 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
     const { setPreferredEditor } = useActions(surveysLogic)
     const { featureFlags } = useValues(enabledFeaturesLogic)
     const surveyTranslationsEnabled = !!featureFlags[FEATURE_FLAGS.SURVEYS_TRANSLATIONS]
+    const hostedEditorEnabled = !!featureFlags[FEATURE_FLAGS.SURVEYS_HOSTED_EDITOR]
+    const canConvertToHosted = hostedEditorEnabled && survey.type !== SurveyType.ExternalSurvey
+
+    const convertToHostedSurvey = (): void => {
+        LemonDialog.open({
+            title: 'Convert to hosted survey?',
+            description: (
+                <p className="py-2">
+                    This keeps the questions and style, then switches the editor to the hosted-survey setup. Display
+                    conditions and in-app placement settings won't apply.
+                </p>
+            ),
+            primaryButton: {
+                children: 'Convert',
+                onClick: () => {
+                    setSurveyValue('type', SurveyType.ExternalSurvey)
+                    setSelectedPageIndex(0)
+                },
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    }
     const activeEditingLanguage = surveyTranslationsEnabled ? editingLanguage : null
     const surveyTranslations = survey.translations ?? {}
     const hasActualTranslations = !!(
@@ -440,6 +464,16 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                     onClick={() => setPreferredEditor('guided')}
                                 >
                                     Guided editor
+                                </LemonButton>
+                            )}
+                            {canConvertToHosted && (
+                                <LemonButton
+                                    data-attr="convert-to-hosted-survey"
+                                    type="tertiary"
+                                    size="small"
+                                    onClick={convertToHostedSurvey}
+                                >
+                                    Convert to hosted
                                 </LemonButton>
                             )}
                             <LemonButton

--- a/frontend/src/scenes/surveys/wizard/steps/TemplateStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/TemplateStep.tsx
@@ -19,14 +19,16 @@ import {
     IconTrending,
     IconWarning,
 } from '@posthog/icons'
-import { LemonButton, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonButton, LemonSegmentedButton, LemonTag, LemonTextArea } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 
 import { SURVEY_CREATED_SOURCE, SurveyTemplate, SurveyTemplateType } from '../../constants'
 import { surveysLogic } from '../../surveysLogic'
-import { surveyWizardLogic } from '../surveyWizardLogic'
+import { SurveyTemplateMode, surveyWizardLogic } from '../surveyWizardLogic'
 
 const TEMPLATE_ICONS: Partial<Record<SurveyTemplateType, React.ComponentType<{ className?: string }>>> = {
     [SurveyTemplateType.NPS]: IconGraph,
@@ -88,10 +90,12 @@ function TemplateCard({ template, onClick, featured }: TemplateCardProps): JSX.E
 }
 
 export function TemplateStep({ handleCustomizeMore }: { handleCustomizeMore: () => void }): JSX.Element {
-    const { coreTemplates, otherTemplates } = useValues(surveyWizardLogic)
-    const { selectTemplate } = useActions(surveyWizardLogic)
+    const { coreTemplates, otherTemplates, templateMode } = useValues(surveyWizardLogic)
+    const { selectTemplate, setTemplateMode } = useActions(surveyWizardLogic)
     const { reportSurveyAiPromptSubmitted } = useActions(eventUsageLogic)
     const { handleMaxSurveyCreated } = useActions(surveysLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const hostedEditorEnabled = !!featureFlags[FEATURE_FLAGS.SURVEYS_HOSTED_EDITOR]
     const [showOthers, setShowOthers] = useState(false)
     const [prompt, setPrompt] = useState('')
     const textAreaRef = useRef<HTMLTextAreaElement>(null)
@@ -109,12 +113,40 @@ export function TemplateStep({ handleCustomizeMore }: { handleCustomizeMore: () 
         }
     }
 
+    const isHostedMode = templateMode === 'hosted'
+    const modeDescription = isHostedMode
+        ? "Pick a template — you'll get a shareable link, no SDK needed."
+        : 'Start with a proven template, then customize it to your needs.'
+
     return (
         <div className="space-y-6">
             <div className="text-center space-y-2">
                 <h1 className="text-2xl font-semibold">Choose a survey template</h1>
-                <p className="text-secondary">Start with a proven template, then customize it to your needs</p>
+                <p className="text-secondary">{modeDescription}</p>
             </div>
+
+            {hostedEditorEnabled && (
+                <div className="flex justify-center">
+                    <LemonSegmentedButton
+                        value={templateMode}
+                        onChange={(value) => setTemplateMode(value as SurveyTemplateMode)}
+                        options={[
+                            { value: 'in_app', label: 'In-app survey' },
+                            {
+                                value: 'hosted',
+                                label: (
+                                    <span className="flex items-center gap-1.5">
+                                        Hosted link
+                                        <LemonTag type="warning" size="small">
+                                            Beta
+                                        </LemonTag>
+                                    </span>
+                                ),
+                            },
+                        ]}
+                    />
+                </div>
+            )}
 
             {/* Core templates - 2x2 grid */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -26,6 +26,8 @@ import type { surveyWizardLogicType } from './surveyWizardLogicType'
 
 export type WizardStep = 'template' | 'questions' | 'where' | 'when' | 'appearance' | 'success'
 
+export type SurveyTemplateMode = 'in_app' | 'hosted'
+
 // Main flow steps (appearance is optional, branched from 'when')
 const WIZARD_STEPS: WizardStep[] = ['template', 'questions', 'where', 'when']
 
@@ -73,6 +75,7 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
         prevStep: true,
         resetWizard: true,
         selectTemplate: (template: SurveyTemplate) => ({ template }),
+        setTemplateMode: (mode: SurveyTemplateMode) => ({ mode }),
         restoreDefaultQuestions: true,
         launchSurvey: true,
         launchSurveySuccess: (survey: Survey) => ({ survey }),
@@ -108,6 +111,13 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
             {
                 selectTemplate: (_, { template }) => template,
                 resetWizard: () => null,
+            },
+        ],
+        templateMode: [
+            'in_app' as SurveyTemplateMode,
+            {
+                setTemplateMode: (_, { mode }) => mode,
+                resetWizard: () => 'in_app' as SurveyTemplateMode,
             },
         ],
         createdSurvey: [
@@ -237,10 +247,14 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
 
     listeners(({ actions, values, props }) => ({
         selectTemplate: ({ template }) => {
+            const isHostedMode = values.templateMode === 'hosted'
             const timestamp = dayjs().format('YYYY-MM-DD HH:mm')
             actions.setSurveyValue('name', `${template.templateType} (${timestamp})`)
             actions.setSurveyValue('description', template.description || '')
-            actions.setSurveyValue('type', template.type || SurveyType.Popover)
+            actions.setSurveyValue(
+                'type',
+                isHostedMode ? SurveyType.ExternalSurvey : template.type || SurveyType.Popover
+            )
             actions.setSurveyValue('questions', template.questions)
 
             // Apply Clean theme by default (works well on most sites, and users without
@@ -285,6 +299,11 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
             actions.setSurveyValue('conditions', template.conditions ?? null)
 
             actions.reportSurveyTemplateClicked(template.templateType, SURVEY_CREATED_SOURCE.SURVEY_WIZARD)
+
+            // Hosted surveys don't have a guided wizard — route to the dedicated editor.
+            if (isHostedMode) {
+                router.actions.push(props.id === 'new' ? urls.survey('new') : `${urls.survey(props.id)}?edit=true`)
+            }
         },
         restoreDefaultQuestions: () => {
             const template = values.selectedTemplate


### PR DESCRIPTION
## Problem

Switching between an in-app survey and a hosted survey has been painful because the type lives inside the "Presentation" collapse, mixed with placement options (Popover / Widget / API). And from the guided wizard there's no way to pick a hosted survey at all — users had to bail out to the full editor, scroll to Presentation, and pick the ExternalSurvey card.

But "hosted vs in-app" isn't really a placement decision — it's a distribution one. This PR promotes it to a first-class top-level choice in the two highest-leverage spots while we continue rolling out the new hosted editor.

## Changes

- **Template step (guided wizard):** new `In-app survey / Hosted link` segmented control above the template grid. Picking Hosted overrides `survey.type` to `ExternalSurvey` and routes straight to the dedicated `HostedSurveyEdit` page once a template is chosen.
- **Full editor header:** new "Convert to hosted" tertiary button, mirroring the existing "Convert to in-app" button in `HostedSurveyEdit`. Symmetric affordance in both directions, with a `LemonDialog` confirmation.
- **Wizard logic:** new `templateMode` reducer + `setTemplateMode` action on `surveyWizardLogic`. Reset back to `in_app` on `resetWizard`.

All entry points are gated on the existing `SURVEYS_HOSTED_EDITOR` feature flag — users without the flag see the editor exactly as it is today.

## How did you test this code?

I'm an agent (PostHog Code). What I actually ran:

- `pnpm typescript:check` — clean.
- `hogli test frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx` — passes.
- `hogli test frontend/src/scenes/surveys/surveyLogic.test.ts` — passes.
- `pnpm oxlint` on the three touched files — 0 warnings, 0 errors.
- `kea-typegen write` — regenerated, no other logic types changed.

I did **not** click through this in a browser. Manual verification suggestions for the human reviewer:

1. With `SURVEYS_HOSTED_EDITOR` enabled: visit `/surveys/new` (or `/surveys/new/edit`) → the template step shows the segmented control. Toggling to "Hosted link" then picking a template should land you directly in the hosted editor with the chosen template's questions.
2. With the flag enabled, open an existing in-app survey → the header has a "Convert to hosted" button → clicking it shows a confirmation dialog → confirming switches the page to the hosted editor without losing questions or style.
3. With the flag disabled: nothing visible changes anywhere.

## Publish to changelog?

no

## Docs update

No docs touched.

## 🤖 Agent context

This is step 1 of a larger plan for survey-type ergonomics. The remaining steps (not in this PR):

1. Lift the In-app/Hosted control out of the Presentation collapse in the full editor, and keep Popover / Widget / API as sub-cards under In-app only.
2. Add a hosted-mode escape hatch in the wizard header (next to "Full editor") for mid-flow conversion.

We chose step 1 first because it's the smallest change with the biggest UX payoff and is fully gated by the existing flag. The framing decision worth flagging: lumping `ExternalSurvey` into the four-card Presentation grid treats hosted as a placement option, but it's really a distribution channel — own URL, no SDK, no display conditions. That's the rationale for surfacing the choice earlier.

Tools used: Claude Code (PostHog Code), Opus 4.7.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*