### PR TITLE
fix(settings): use surface-tertiary bg and quill button hover for nav

### DIFF
--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -359,7 +359,7 @@ export function Settings({
                 <div
                     data-quill
                     className={clsx(
-                        'bg-muted border rounded w-[var(--settings-nav-width)] flex flex-col',
+                        'bg-surface-tertiary border rounded w-[var(--settings-nav-width)] flex flex-col',
                         isFullScene
                             ? 'fixed top-[calc(var(--scene-layout-header-height)+var(--scene-padding))] bottom-[var(--scene-padding)]'
                             : 'sticky top-[var(--scene-layout-header-height)] self-start max-h-[calc(100dvh-var(--scene-layout-header-height)-var(--scene-padding))]'
@@ -522,13 +522,7 @@ const OptionButton = ({
             {...(to && !isDisabled
                 ? {
                       render: (
-                          <Link
-                              to={to}
-                              className={cn(
-                                  'no-underline hover:underline px-1',
-                                  active && 'bg-fill-button-tertiary-active font-bold'
-                              )}
-                          />
+                          <Link to={to} className={cn('no-underline px-1', active && 'bg-fill-selected font-bold')} />
                       ),
                   }
                 : {})}

--- a/frontend/src/styles/quill-bridge.scss
+++ b/frontend/src/styles/quill-bridge.scss
@@ -73,8 +73,6 @@
      */
     --color-bg-primary: var(--primary);
     --color-bg-surface-primary: var(--background);
-    --color-bg-surface-secondary: var(--card);
-    --color-bg-surface-tertiary: var(--muted);
     --color-text-primary: var(--foreground);
     --color-text-secondary: var(--muted-foreground);
     --color-border-primary: var(--border);
@@ -220,8 +218,6 @@
     --muted-3000: var(--muted-3000-light);
     --color-bg-primary: var(--color-posthog-3000-50);
     --color-bg-surface-primary: var(--color-white);
-    --color-bg-surface-secondary: var(--color-posthog-3000-100);
-    --color-bg-surface-tertiary: var(--color-posthog-3000-150);
     --color-text-primary: var(--color-neutral-950);
     --color-text-secondary: var(--color-neutral-750);
     --color-border-primary: var(--color-posthog-3000-200);
@@ -247,8 +243,6 @@
     --muted-3000: var(--muted-3000-dark);
     --color-bg-primary: var(--color-neutral-cool-950);
     --color-bg-surface-primary: var(--color-neutral-cool-850);
-    --color-bg-surface-secondary: var(--color-neutral-cool-900);
-    --color-bg-surface-tertiary: var(--color-neutral-cool-950);
     --color-text-primary: var(--color-neutral-100);
     --color-text-secondary: var(--color-neutral-350);
     --color-border-primary: var(--color-neutral-cool-800);


### PR DESCRIPTION
## Problem

New settings nav had two visual issues:

1. Background used quill's `bg-muted` token, which reads too orange against the rest of the app. The `[data-quill]` bridge was rebinding PostHog's `--color-bg-surface-tertiary` / `--color-bg-surface-secondary` to quill values, leaking the orange tint anywhere a quill subtree used those PostHog tokens.
2. Link-style section buttons underlined on hover and used `bg-fill-button-tertiary-active` for the active state, which didn't match the normal quill button hover/selected behaviour used elsewhere in the nav.

## Changes

- `Settings.tsx`: nav background now uses `bg-surface-tertiary` (resolves to `var(--color-bg-surface-tertiary)`).
- `Settings.tsx`: `OptionButton` link render drops `hover:underline`; active state switched to `bg-fill-selected` + `font-bold` so links match the surrounding quill button selected style.
- `quill-bridge.scss`: removed the `[data-quill]` overrides for `--color-bg-surface-tertiary` and `--color-bg-surface-secondary`, plus the corresponding restorations in the `[data-not-quill]` escape hatch (light + dark).

## How did you test this code?

Agent-authored. No manual UI testing performed. Verified:

- `bg-surface-tertiary` is defined in `common/tailwind/tailwind.config.js`.
- `bg-fill-selected` is registered for `[data-quill]` subtrees in `quill-bridge.scss`.
- `OptionButton` already passes `aria-selected={active || undefined}` so the non-link branch picks up quill's default selected styling automatically.

Reviewer should sanity-check the nav visually in light + dark themes, and confirm no other consumer of `[data-quill]` relied on the removed surface-tertiary/secondary rebindings.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Two-part task: pick the right PostHog surface token for the nav background and align link-rendered option buttons with quill button selected styling. Considered keeping the active class as `bg-fill-button-tertiary-active` but switched to `bg-fill-selected` to match the rest of the quill nav (consistent with `quill-button--variant-default[aria-selected='true']`). Kept `no-underline` on the Link render to suppress lemon-ui's global `.Link` underline.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*