### PR TITLE
feat(surveys): add hosted-only templates and mode-aware filtering

### DIFF
--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -253,7 +253,11 @@ export enum SurveyTemplateType {
     OnboardingFeedback = 'Onboarding feedback',
     BetaFeedback = 'Beta feedback',
     Announcement = 'Announcement',
+    UserResearchIntake = 'User research intake',
+    ProductResearch = 'Product research',
 }
+
+export type SurveyTemplateMode = 'in_app' | 'hosted'
 
 export interface QuickSurveyFromTemplate {
     context: QuickSurveyContext
@@ -268,6 +272,8 @@ export type SurveyTemplate = Partial<Survey> & {
     badge?: string
     featured?: boolean
     quickSurvey?: QuickSurveyFromTemplate
+    // Which template modes this template should appear in. Omitted = available in all modes.
+    modes?: SurveyTemplateMode[]
 }
 
 export const defaultSurveyTemplates: SurveyTemplate[] = [
@@ -310,6 +316,7 @@ export const defaultSurveyTemplates: SurveyTemplate[] = [
         category: 'Business',
         badge: 'New!',
         featured: true,
+        modes: ['in_app'],
         quickSurvey: {
             context: { type: QuickSurveyType.ANNOUNCEMENT },
             modalTitle: 'New announcement',
@@ -511,6 +518,7 @@ export const defaultSurveyTemplates: SurveyTemplate[] = [
         description: 'Get user context when errors occur to debug faster.',
         tagType: 'default',
         category: 'General',
+        modes: ['in_app'],
         appearance: {
             ...defaultSurveyAppearance,
             surveyPopupDelaySeconds: 2,
@@ -576,6 +584,7 @@ export const defaultSurveyTemplates: SurveyTemplate[] = [
         description: "Capture first impressions while they're fresh.",
         tagType: 'primary',
         category: 'Product',
+        modes: ['in_app'],
         appearance: defaultSurveyAppearance,
     },
     {
@@ -616,6 +625,103 @@ export const defaultSurveyTemplates: SurveyTemplate[] = [
         tagType: 'primary',
         category: 'Product',
         appearance: defaultSurveyAppearance,
+    },
+    {
+        type: SurveyType.ExternalSurvey,
+        templateType: SurveyTemplateType.UserResearchIntake,
+        questions: [
+            {
+                type: SurveyQuestionType.SingleChoice,
+                question: 'Would you be open to a 30-minute conversation with our team?',
+                description: 'We are exploring how customers use our product and would love to hear from you.',
+                descriptionContentType: 'text' as SurveyQuestionDescriptionContentType,
+                choices: ['Yes, I am interested', 'Maybe later', 'No thanks'],
+                skipSubmitButton: true,
+            },
+            {
+                type: SurveyQuestionType.Open,
+                question: 'What is the best email to reach you at?',
+                description: 'We will send a calendar invite within one business day.',
+                descriptionContentType: 'text' as SurveyQuestionDescriptionContentType,
+                buttonText: 'Submit',
+            },
+            {
+                type: SurveyQuestionType.Open,
+                question: 'Anything specific you would like to talk about?',
+                description: 'Optional. Helps us prepare for the call.',
+                descriptionContentType: 'text' as SurveyQuestionDescriptionContentType,
+                optional: true,
+                buttonText: 'Send',
+            },
+        ],
+        appearance: {
+            ...defaultSurveyAppearance,
+            displayThankYouMessage: true,
+            thankYouMessageHeader: 'Thanks — we will be in touch shortly!',
+        },
+        description: 'Recruit research participants via a shareable link.',
+        tagType: 'completion',
+        category: 'Business',
+        modes: ['hosted'],
+    },
+    {
+        type: SurveyType.ExternalSurvey,
+        templateType: SurveyTemplateType.ProductResearch,
+        questions: [
+            {
+                type: SurveyQuestionType.SingleChoice,
+                question: 'How would you describe your role?',
+                choices: ['Founder / leadership', 'Product manager', 'Engineer', 'Designer', 'Marketing', 'Other'],
+                hasOpenChoice: true,
+                skipSubmitButton: true,
+            },
+            {
+                type: SurveyQuestionType.SingleChoice,
+                question: 'How often do you use the product?',
+                choices: ['Daily', 'A few times a week', 'A few times a month', 'Rarely', 'Never'],
+                skipSubmitButton: true,
+            },
+            {
+                type: SurveyQuestionType.Rating,
+                question: 'How likely are you to recommend us to a colleague?',
+                description: '',
+                descriptionContentType: 'text' as SurveyQuestionDescriptionContentType,
+                display: 'number',
+                scale: SURVEY_RATING_SCALE.NPS_10_POINT,
+                lowerBoundLabel: 'Not at all likely',
+                upperBoundLabel: 'Extremely likely',
+                isNpsQuestion: true,
+                skipSubmitButton: true,
+            },
+            {
+                type: SurveyQuestionType.Open,
+                question: 'What is the single biggest benefit you get from our product?',
+                description: '',
+                descriptionContentType: 'text' as SurveyQuestionDescriptionContentType,
+            },
+            {
+                type: SurveyQuestionType.Open,
+                question: 'What would you like us to improve next?',
+                description: '',
+                descriptionContentType: 'text' as SurveyQuestionDescriptionContentType,
+            },
+            {
+                type: SurveyQuestionType.Open,
+                question: 'What would you use instead if our product did not exist?',
+                description: '',
+                descriptionContentType: 'text' as SurveyQuestionDescriptionContentType,
+                optional: true,
+            },
+        ],
+        appearance: {
+            ...defaultSurveyAppearance,
+            displayThankYouMessage: true,
+            thankYouMessageHeader: 'Thanks for sharing your perspective!',
+        },
+        description: 'Go deep on segmentation, satisfaction, and roadmap signal.',
+        tagType: 'primary',
+        category: 'Product',
+        modes: ['hosted'],
     },
 ]
 

--- a/frontend/src/scenes/surveys/wizard/steps/TemplateStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/TemplateStep.tsx
@@ -11,7 +11,9 @@ import {
     IconGraph,
     IconHandwave,
     IconMegaphone,
+    IconNotebook,
     IconPeople,
+    IconPhone,
     IconPulse,
     IconSparkles,
     IconTarget,
@@ -26,9 +28,9 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 
-import { SURVEY_CREATED_SOURCE, SurveyTemplate, SurveyTemplateType } from '../../constants'
+import { SURVEY_CREATED_SOURCE, SurveyTemplate, SurveyTemplateMode, SurveyTemplateType } from '../../constants'
 import { surveysLogic } from '../../surveysLogic'
-import { SurveyTemplateMode, surveyWizardLogic } from '../surveyWizardLogic'
+import { surveyWizardLogic } from '../surveyWizardLogic'
 
 const TEMPLATE_ICONS: Partial<Record<SurveyTemplateType, React.ComponentType<{ className?: string }>>> = {
     [SurveyTemplateType.NPS]: IconGraph,
@@ -44,6 +46,8 @@ const TEMPLATE_ICONS: Partial<Record<SurveyTemplateType, React.ComponentType<{ c
     [SurveyTemplateType.OnboardingFeedback]: IconHandwave,
     [SurveyTemplateType.BetaFeedback]: IconFlask,
     [SurveyTemplateType.Announcement]: IconMegaphone,
+    [SurveyTemplateType.UserResearchIntake]: IconPhone,
+    [SurveyTemplateType.ProductResearch]: IconNotebook,
 }
 
 interface TemplateCardProps {

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts
@@ -363,36 +363,44 @@ describe('surveyWizardLogic', () => {
             })
         })
 
-        it('exposes mode-specific core templates and hides in-app-only templates in hosted mode', () => {
+        it.each([
+            {
+                mode: 'in_app' as const,
+                expectedCore: [
+                    SurveyTemplateType.NPS,
+                    SurveyTemplateType.CSAT,
+                    SurveyTemplateType.PMF,
+                    SurveyTemplateType.OpenFeedback,
+                ],
+                otherContains: [SurveyTemplateType.Announcement, SurveyTemplateType.ErrorTracking],
+                otherExcludes: [SurveyTemplateType.UserResearchIntake, SurveyTemplateType.ProductResearch],
+            },
+            {
+                mode: 'hosted' as const,
+                expectedCore: [
+                    SurveyTemplateType.UserResearchIntake,
+                    SurveyTemplateType.ProductResearch,
+                    SurveyTemplateType.NPS,
+                    SurveyTemplateType.CCR,
+                ],
+                otherContains: [SurveyTemplateType.FeatureRequest],
+                otherExcludes: [
+                    SurveyTemplateType.Announcement,
+                    SurveyTemplateType.ErrorTracking,
+                    SurveyTemplateType.OnboardingFeedback,
+                ],
+            },
+        ])('exposes mode-specific templates for $mode mode', ({ mode, expectedCore, otherContains, otherExcludes }) => {
             const logic = surveyWizardLogic({ id: 'new' })
             logic.mount()
+            logic.actions.setTemplateMode(mode)
 
-            const inAppCore = logic.values.coreTemplates.map((t) => t.templateType)
-            expect(inAppCore).toEqual([
-                SurveyTemplateType.NPS,
-                SurveyTemplateType.CSAT,
-                SurveyTemplateType.PMF,
-                SurveyTemplateType.OpenFeedback,
-            ])
+            const coreTypes = logic.values.coreTemplates.map((t) => t.templateType)
+            expect(coreTypes).toEqual(expectedCore)
 
-            const inAppOther = logic.values.otherTemplates.map((t) => t.templateType)
-            expect(inAppOther).toContain(SurveyTemplateType.Announcement)
-            expect(inAppOther).not.toContain(SurveyTemplateType.UserResearchIntake)
-
-            logic.actions.setTemplateMode('hosted')
-
-            const hostedCore = logic.values.coreTemplates.map((t) => t.templateType)
-            expect(hostedCore).toEqual([
-                SurveyTemplateType.UserResearchIntake,
-                SurveyTemplateType.ProductResearch,
-                SurveyTemplateType.NPS,
-                SurveyTemplateType.CCR,
-            ])
-
-            const hostedOther = logic.values.otherTemplates.map((t) => t.templateType)
-            expect(hostedOther).not.toContain(SurveyTemplateType.Announcement)
-            expect(hostedOther).not.toContain(SurveyTemplateType.ErrorTracking)
-            expect(hostedOther).not.toContain(SurveyTemplateType.OnboardingFeedback)
+            const otherTypes = logic.values.otherTemplates.map((t) => t.templateType)
+            otherContains.forEach((type) => expect(otherTypes).toContain(type))
+            otherExcludes.forEach((type) => expect(otherTypes).not.toContain(type))
         })
     })
 })

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts
@@ -362,5 +362,37 @@ describe('surveyWizardLogic', () => {
                 }),
             })
         })
+
+        it('exposes mode-specific core templates and hides in-app-only templates in hosted mode', () => {
+            const logic = surveyWizardLogic({ id: 'new' })
+            logic.mount()
+
+            const inAppCore = logic.values.coreTemplates.map((t) => t.templateType)
+            expect(inAppCore).toEqual([
+                SurveyTemplateType.NPS,
+                SurveyTemplateType.CSAT,
+                SurveyTemplateType.PMF,
+                SurveyTemplateType.OpenFeedback,
+            ])
+
+            const inAppOther = logic.values.otherTemplates.map((t) => t.templateType)
+            expect(inAppOther).toContain(SurveyTemplateType.Announcement)
+            expect(inAppOther).not.toContain(SurveyTemplateType.UserResearchIntake)
+
+            logic.actions.setTemplateMode('hosted')
+
+            const hostedCore = logic.values.coreTemplates.map((t) => t.templateType)
+            expect(hostedCore).toEqual([
+                SurveyTemplateType.UserResearchIntake,
+                SurveyTemplateType.ProductResearch,
+                SurveyTemplateType.NPS,
+                SurveyTemplateType.CCR,
+            ])
+
+            const hostedOther = logic.values.otherTemplates.map((t) => t.templateType)
+            expect(hostedOther).not.toContain(SurveyTemplateType.Announcement)
+            expect(hostedOther).not.toContain(SurveyTemplateType.ErrorTracking)
+            expect(hostedOther).not.toContain(SurveyTemplateType.OnboardingFeedback)
+        })
     })
 })

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -16,6 +16,8 @@ import { Breadcrumb, LinkSurveyQuestion, Survey, SurveyQuestionType, SurveySched
 import {
     SURVEY_CREATED_SOURCE,
     SurveyTemplate,
+    SurveyTemplateMode,
+    SurveyTemplateType,
     defaultSurveyAppearance,
     defaultSurveyTemplates,
     surveyThemes,
@@ -26,18 +28,26 @@ import type { surveyWizardLogicType } from './surveyWizardLogicType'
 
 export type WizardStep = 'template' | 'questions' | 'where' | 'when' | 'appearance' | 'success'
 
-export type SurveyTemplateMode = 'in_app' | 'hosted'
+// Re-exported for convenience — the canonical definition lives in ../constants.
+export type { SurveyTemplateMode } from '../constants'
 
 // Main flow steps (appearance is optional, branched from 'when')
 const WIZARD_STEPS: WizardStep[] = ['template', 'questions', 'where', 'when']
 
-// Core templates to show prominently
-const CORE_TEMPLATE_TYPES = [
-    'Net promoter score (NPS)',
-    'Customer satisfaction score (CSAT)',
-    'Product-market fit (PMF)',
-    'Open feedback',
-]
+// Core templates to show prominently, per template mode.
+const CORE_TEMPLATE_TYPES: Record<SurveyTemplateMode, SurveyTemplateType[]> = {
+    in_app: [SurveyTemplateType.NPS, SurveyTemplateType.CSAT, SurveyTemplateType.PMF, SurveyTemplateType.OpenFeedback],
+    hosted: [
+        SurveyTemplateType.UserResearchIntake,
+        SurveyTemplateType.ProductResearch,
+        SurveyTemplateType.NPS,
+        SurveyTemplateType.CCR,
+    ],
+}
+
+function templateMatchesMode(template: SurveyTemplate, mode: SurveyTemplateMode): boolean {
+    return !template.modes || template.modes.includes(mode)
+}
 
 export interface SurveyWizardLogicProps {
     id: string // 'new' for new surveys, or a UUID for editing
@@ -151,15 +161,22 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
 
     selectors({
         coreTemplates: [
-            () => [],
-            (): SurveyTemplate[] => {
-                return defaultSurveyTemplates.filter((t) => CORE_TEMPLATE_TYPES.includes(t.templateType))
+            (s) => [s.templateMode],
+            (mode: SurveyTemplateMode): SurveyTemplate[] => {
+                const coreTypes = CORE_TEMPLATE_TYPES[mode]
+                // Preserve the order declared in CORE_TEMPLATE_TYPES so featured cards stay positioned.
+                return coreTypes
+                    .map((type) => defaultSurveyTemplates.find((t) => t.templateType === type))
+                    .filter((t): t is SurveyTemplate => !!t && templateMatchesMode(t, mode))
             },
         ],
         otherTemplates: [
-            () => [],
-            (): SurveyTemplate[] => {
-                return defaultSurveyTemplates.filter((t) => !CORE_TEMPLATE_TYPES.includes(t.templateType))
+            (s) => [s.templateMode],
+            (mode: SurveyTemplateMode): SurveyTemplate[] => {
+                const coreTypes = new Set<SurveyTemplateType>(CORE_TEMPLATE_TYPES[mode])
+                return defaultSurveyTemplates.filter(
+                    (t) => !coreTypes.has(t.templateType) && templateMatchesMode(t, mode)
+                )
             },
         ],
         stepNumber: [(s) => [s.currentStep], (currentStep: WizardStep): number => WIZARD_STEPS.indexOf(currentStep)],


### PR DESCRIPTION
## Problem

Hosted and in-app surveys are different products in a meaningful way. In-app templates lean on SDK triggers (page events, exceptions, onboarding completion) and short cognitive load (one question in a popover). Hosted surveys are accessed by clicking a link, so they tolerate longer flows and need different framing — a recruitment intake, a long-form research survey, a post-call NPS.

Today the wizard's template grid shows the same templates regardless of mode. Picking "Announcement" or "Error feedback" in hosted mode is misleading — those need SDK triggers that hosted surveys can't use. And the list is missing the patterns that hosted is actually best at.

## Changes

- **Two new hosted-only templates:**
  - **User research intake** — 3 questions, ends with email opt-in. Turns a shareable link into a research recruitment pipeline.
  - **Product research** — 6 questions: role, frequency, NPS, biggest benefit, top improvement, alternative product. Based on the Superhuman PMF pattern, but bigger because hosted surveys can carry it.
- **`modes` field on `SurveyTemplate`** — opt-in declaration of which template modes a template is offered for. Omitted = both. New hosted templates set `modes: ['hosted']`. Announcement / Error feedback / Onboarding feedback are now `modes: ['in_app']` because they require SDK-driven triggers.
- **Mode-aware `coreTemplates` / `otherTemplates` selectors** in `surveyWizardLogic` — the featured row at the top of the template step now differs per mode. Hosted core: User research intake → Product research → NPS → Exit survey.
- Test covering both core / other lists for each mode.

## How did you test this code?

I'm an agent (PostHog Code). What I ran:

- `pnpm typescript:check` — clean (after deleting an unrelated orphan kea-type file `insightAIAnalysisLogicType.ts` that wasn't part of this PR).
- `hogli test frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts` — 12 passed, including a new test for mode-aware template filtering.
- `hogli test frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx` — passes.
- `pnpm oxlint` on 4 touched files — 0 warnings.
- `kea-typegen write` — regenerated types.

I did **not** click through this in a browser. Reviewer can verify with `surveys-hosted-editor` enabled:

1. `/surveys/guided/new`, "In-app survey" — featured row shows NPS / CSAT / PMF / Open feedback (unchanged). The 14 templates listed under "More templates" include Announcement, Error feedback, and Onboarding feedback.
2. Toggle to "Hosted link" — featured row swaps to User research intake / Product research / NPS / Exit survey. "More templates" shows only hosted-compatible templates; Announcement / Error feedback / Onboarding feedback are hidden.

## Publish to changelog?

no

## Docs update

No docs touched.

## 🤖 Agent context

This builds on #58912 (which introduced the in-app/hosted mode toggle in the wizard template step). Now that the toggle exists, this PR makes the template list actually reflect the chosen mode.

Design call worth flagging: rather than splitting *every* template into two versions (one in-app, one hosted), the `modes` field defaults to "available in both" — so NPS, CSAT, PMF, Open feedback, exit survey, CES, traffic attribution, feature request, beta feedback, and existing User interview all stay in both lists. Only the templates whose *trigger* requires SDK behavior are restricted to in-app.

Hosted core list ordering (User research intake → Product research → NPS → Exit survey) reflects what hosted does best: cold/shareable, longer-form, research-oriented.

Tools used: Claude Code (PostHog Code), Opus 4.7.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*