### PR TITLE
perf(tasks): cache github repo list in localStorage

### DIFF
--- a/frontend/src/lib/integrations/githubIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/githubIntegrationLogic.ts
@@ -16,9 +16,10 @@ export const githubIntegrationLogic = kea<githubIntegrationLogicType>([
     actions({
         loadRepositories: true,
         loadRepositoriesPage: (offset: number) => ({ offset }),
-        loadRepositoriesPageSuccess: (repositories: GitHubRepoApi[], hasMore: boolean) => ({
+        loadRepositoriesPageSuccess: (repositories: GitHubRepoApi[], hasMore: boolean, offset: number) => ({
             repositories,
             hasMore,
+            offset,
         }),
         loadRepositoriesPageFailure: true,
     }),
@@ -26,9 +27,13 @@ export const githubIntegrationLogic = kea<githubIntegrationLogicType>([
     reducers({
         repositories: [
             [] as GitHubRepoApi[],
+            { persist: true },
             {
-                loadRepositories: () => [],
-                loadRepositoriesPageSuccess: (state, { repositories }) => {
+                loadRepositoriesPageSuccess: (state, { repositories, offset }) => {
+                    // First page of a fresh fetch replaces the cached list so removed repos disappear.
+                    if (offset === 0) {
+                        return repositories
+                    }
                     const seenIds = new Set(state.map((r) => r.id))
                     const newRepos = repositories.filter((r) => !seenIds.has(r.id))
                     return [...state, ...newRepos]
@@ -68,7 +73,7 @@ export const githubIntegrationLogic = kea<githubIntegrationLogicType>([
                     offset,
                 })
                 await breakpoint()
-                actions.loadRepositoriesPageSuccess(response.repositories, response.has_more)
+                actions.loadRepositoriesPageSuccess(response.repositories, response.has_more, offset)
             } catch (e: any) {
                 if (isBreakpoint(e)) {
                     throw e


### PR DESCRIPTION
## Problem

When opening the 'New task' modal next to a GitHub-connected project, the repository picker shows a spinner and re-fetches the full repo list from the backend every single time — even though the user almost always picks the same repo they used before. On accounts with many repos this is a noticeable wait for what should be an instant interaction.

## Changes

`githubIntegrationLogic.repositories` is now persisted to `localStorage` (`persist: true`), keyed by integration ID via the existing `key((props) => props.id)`. The picker now renders the previous session's repo list immediately while a fresh fetch runs in the background — classic stale-while-revalidate.

To keep the cache honest, the first page of every fresh fetch (`offset === 0`) **replaces** the persisted list rather than appending to it, so repos that have been removed on GitHub disappear from the picker after the next sync. Subsequent pages still append with de-dup as before.

No backend change — the server-side 1-hour `Integration.repository_cache` continues to back the API.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual testing.

Verified by reading the code:

- The `LemonInputSelect` consumed by `GitHubRepositoryPicker` renders `options` independently of `loading`, so the cached list is visible immediately on mount.
- `loadRepositories` no longer resets the list to `[]`, but `currentOffset` is still reset to `0`, and the first-page success replaces the list — so pagination state and freshness are preserved.
- The logic is keyed by integration id, so per-integration caches are namespaced via the existing kea path.

No automated tests exist for `githubIntegrationLogic`; none added.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7), one session.
- Considered three approaches:
  1. Pure `persist: true` with no further changes — rejected because the existing `loadRepositories: () => []` action immediately clears the cache on mount, defeating the persistence.
  2. Persist + drop the reset, accumulate forever with de-dup — rejected because removed repos would linger in the cache indefinitely.
  3. Persist + drop the reset + replace on `offset === 0` — chosen. Gives instant first paint from cache and self-heals when repos are removed on GitHub.
- Decided not to introduce a separate "snapshot" reducer that only updates on full-sync completion. It would avoid a brief mid-fetch flash for users with >500 repos, but added complexity that isn't worth it for an edge case.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*