### PR TITLE
fix(posthog-code): use :loading-2: reaction for in-progress agent

### DIFF
--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -101,7 +101,7 @@ class SlackThreadHandler:
         target_ts = self.context.user_message_ts or self.context.thread_ts
         try:
             client = self._get_client()
-            for stale in ("seedling", "eyes"):
+            for stale in ("seedling", "eyes", "loading-2"):
                 try:
                     client.reactions_remove(channel=self.context.channel, timestamp=target_ts, name=stale)
                 except Exception:

--- a/products/slack_app/backend/tests/test_post_slack_update.py
+++ b/products/slack_app/backend/tests/test_post_slack_update.py
@@ -126,7 +126,7 @@ class TestPostSlackUpdate(TestCase):
         post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
 
         mock_post_progress.assert_not_called()
-        mock_update_reaction.assert_called_once_with("hedgehog")
+        mock_update_reaction.assert_called_once_with("loading-2")
         mock_delete_progress.assert_called_once()
 
     @patch.object(SlackThreadHandler, "delete_progress")
@@ -166,7 +166,7 @@ class TestPostSlackUpdate(TestCase):
             "https://github.com/org/repo/pull/1",
             "http://localhost:8000/project/1/tasks/10?runId=run-1",
         )
-        mock_update_reaction.assert_called_once_with("hedgehog")
+        mock_update_reaction.assert_called_once_with("loading-2")
         mock_delete_progress.assert_called_once()
         mock_post_progress.assert_not_called()
         mock_task_run_class.update_state_atomic.assert_called_once_with(

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -63,7 +63,7 @@ class TestSlackThreadHandler(TestCase):
         mock_client.chat_delete.assert_not_called()
 
     @patch.object(SlackThreadHandler, "_get_client")
-    def test_update_reaction_removes_seedling_and_eyes(self, mock_get_client):
+    def test_update_reaction_removes_stale_reactions(self, mock_get_client):
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
 
@@ -77,9 +77,7 @@ class TestSlackThreadHandler(TestCase):
         handler.update_reaction("hedgehog")
 
         remove_calls = mock_client.reactions_remove.call_args_list
-        assert len(remove_calls) == 2
-        assert remove_calls[0].kwargs["name"] == "seedling"
-        assert remove_calls[1].kwargs["name"] == "eyes"
+        assert [c.kwargs["name"] for c in remove_calls] == ["seedling", "eyes", "loading-2"]
         mock_client.reactions_add.assert_called_once_with(channel="C001", timestamp="1234.5678", name="hedgehog")
 
     @patch.object(SlackThreadHandler, "_get_client")

--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -272,7 +272,7 @@ def execute_posthog_code_agent_relay_workflow(
     relay_id: str | None = None,
     user_message_ts: str | None = None,
     delete_progress: bool = True,
-    reaction_emoji: str = "hedgehog",
+    reaction_emoji: str = "loading-2",
 ) -> str:
     relay_id = relay_id or str(uuid.uuid4())
     workflow_id = f"posthog-code-agent-relay-{run_id}-{relay_id}"

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -69,7 +69,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
         else:
             if pr_url:
                 _post_pr_opened_notification_once(task_run, handler, pr_url, task_url)
-                handler.update_reaction("hedgehog")
+                handler.update_reaction("loading-2")
                 handler.delete_progress()
                 return
             stage = _get_stage_from_status(task_run.status, task_run.stage)

--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -106,7 +106,7 @@ class RelaySlackMessageInput:
     text: str
     user_message_ts: str | None = None
     delete_progress: bool = True
-    reaction_emoji: str = "hedgehog"
+    reaction_emoji: str = "loading-2"
 
 
 @activity.defn

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -81,7 +81,7 @@ class TestRelaySlackMessage(TestCase):
         mock_delete_progress.assert_called_once()
         mock_post.assert_called_once()
         assert "Which license should I use?" in mock_post.call_args.args[0]
-        mock_update.assert_called_once_with("hedgehog")
+        mock_update.assert_called_once_with("loading-2")
         self.task_run.refresh_from_db()
         assert "relay-1" in self.task_run.state.get("slack_sent_relay_ids", [])
 


### PR DESCRIPTION
## Summary

When the PostHog Code agent is working in a Slack thread, the bot swaps the `:eyes:` reaction on the user's mention for `:hedgehog:` while it's still processing. That's confusing because `:hedgehog:` is also the *completion* reaction — you can't tell from Slack whether the agent is still thinking or done.

This switches the in-progress reaction to `:loading-2:` and keeps `:hedgehog:` for terminal success states.

Changes:
- `update_reaction` in `slack_thread.py` now also strips a stale `loading-2` reaction so the eventual hedgehog/x replaces it cleanly.
- `post_slack_update.py`: the in-progress (`status not in {COMPLETED, CANCELLED, FAILED}` + `pr_url`) branch now reacts with `loading-2` instead of `hedgehog`.
- Default `reaction_emoji` in `execute_posthog_code_agent_relay_workflow` / `RelaySlackMessageInput` is now `loading-2` — relays happen while the agent is still working, so this is the right default.
- Terminal reactions (COMPLETED, CANCELLED, sandbox cleaned + PR opened) stay as `hedgehog`. Failures stay as `x`. Explicit override callers like `forward_pending_message.py` (already passes `"x"`) are unaffected.

## Test plan

- [ ] `pytest products/slack_app/backend/tests/test_slack_thread.py`
- [ ] `pytest products/slack_app/backend/tests/test_post_slack_update.py`
- [ ] `pytest products/tasks/backend/temporal/slack_relay/tests/test_activities.py`
- [ ] Verify `:loading-2:` exists in the PostHog Slack workspace before merging — Slack will silently drop a `reactions.add` call for an unknown emoji.
- [ ] Manual: kick off a Slack-triggered task and watch the reaction transition `eyes → loading-2 → hedgehog`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*