### PR TITLE
fix(replay): skip too-fresh recordings in kiosk mode

### DIFF
--- a/frontend/src/scenes/session-recordings/kiosk/sessionRecordingsKioskLogic.ts
+++ b/frontend/src/scenes/session-recordings/kiosk/sessionRecordingsKioskLogic.ts
@@ -15,6 +15,10 @@ const SOFT_REFRESH_AFTER_RECORDINGS = 10
 const HARD_REFRESH_AFTER_RECORDINGS = 50
 const MAX_RECORDING_PLAY_TIME_MS = 5 * 60 * 1000 // 5 minutes
 const RETRY_DELAY_MS = 5000
+// Skip recordings still inside the player's "still working on it" window
+// (sessionRecordingDataCoordinatorLogic.isRecentAndInvalid: start < 5 min ago).
+// 10 min gives a buffer for ingestion to settle.
+const INGESTION_GRACE_DATE_TO = '-600s'
 
 let stuckRecordingTimeout: ReturnType<typeof setTimeout> | null = null
 
@@ -148,7 +152,7 @@ export const sessionRecordingsKioskLogic = kea<sessionRecordingsKioskLogicType>(
                         order: 'start_time',
                         order_direction: 'DESC',
                         date_from: dateFrom || '-30d',
-                        date_to: null,
+                        date_to: INGESTION_GRACE_DATE_TO,
                         limit: 100,
                         filter_test_accounts: true,
                         properties,


### PR DESCRIPTION
## Problem

Customer report: kiosk gets stuck on the "We're still working on it" hedgehog screen. Root cause: kiosk orders recordings by `start_time DESC` and the freshest recordings are the ones most likely to still be ingesting — the player shows that empty state when `isRecentAndInvalid` (`snapshots invalid && start < 5 min ago`). The 5-min stuck-timeout eventually advances kiosk to the next recording, which on a busy site is also too fresh, so the loop never finds a playable one.

## Changes

Anchor the kiosk recordings query's `date_to` 10 min back (`-600s`) so we never land on a recording inside the player's 5-min not-ready window. Tradeoff: the freshest 10 min of recordings won't appear in kiosk — fine for a TV-display use case.

## How did you test this code?

Agent-authored. `oxlint` and `tsc` clean for the touched file. No manual browser testing — worth confirming locally that kiosk no longer hits the empty state for sessions that just started.

## Publish to changelog?

no

## 🤖 Agent context

Claude Code (Opus 4.7). Considered reacting to `isRecentAndInvalid` from inside `KioskPlayer` to auto-advance immediately, but a query-level filter is simpler and avoids coupling kiosk to player-internal selectors. The relative-date parser doesn't support a "minute" unit (`m` = months) so seconds (`-600s`) is used.