### PR TITLE
fix(web-analytics): tag external clicks queries with distinct query_type

### DIFF
--- a/posthog/hogql_queries/web_analytics/external_clicks.py
+++ b/posthog/hogql_queries/web_analytics/external_clicks.py
@@ -38,7 +38,7 @@ class WebExternalClicksTableQueryRunner(WebAnalyticsQueryRunner[WebExternalClick
         else:
             url_expr = ast.Field(chain=["properties", "$external_click_url"])
 
-        with self.timings.measure("stats_table_query"):
+        with self.timings.measure("external_clicks_query"):
             query = parse_select(
                 """
 SELECT
@@ -113,7 +113,7 @@ GROUP BY "context.columns.url"
     def _calculate(self):
         query = self.to_query()
         response = self.paginator.execute_hogql_query(
-            query_type="stats_table_query",
+            query_type="external_clicks_query",
             query=query,
             team=self.team,
             timings=self.timings,

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -82,7 +82,8 @@ def queries_to_keep_fresh(
                     'web_goals_query',
                     'web_overview_preaggregated_query',
                     'web_overview_query',
-                    'web_vitals_path_breakdown_query'
+                    'web_vitals_path_breakdown_query',
+                    'external_clicks_query'
                 )
                 )
                 AND query_json_raw != ''


### PR DESCRIPTION
## Problem

`WebExternalClicksTableQueryRunner` was tagging its ClickHouse queries with `query_type='stats_table_query'` — the same hardcoded string that `WebStatsTableQueryRunner` used before #58177 split stats table queries by strategy.

After #58177 shipped, the new `stats_table_*_query` tags surfaced the strategy breakdown for the stats table runner, but external clicks queries kept emitting the legacy `stats_table_query` tag — making it look (in `system.query_log` and the cache warmer) like the unmigrated remainder of stats table traffic.

## Changes

- renamed the external clicks `query_type` (and matching `timings.measure` label) to `external_clicks_query` so traffic from this runner is observable on its own
- added `external_clicks_query` to the web analytics cache warmer's explicit allowlist so warming behavior is preserved (previously it was matched by the broader `stats_table_*` prefix)

## How did you test this code?

Agent-authored change. No manual testing.

Automated checks run:
- `hogli test posthog/hogql_queries/web_analytics/test/test_external_clicks_table.py` (9 passed)
- `ruff check` and `ruff format` on both changed files

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

- Tooling used: Claude Code in the local repo
- Spotted while verifying PR #58177's tag rollout in `system.query_log` — the lingering `stats_table_query` hits in prod-us turned out to come from this runner, not from an unmigrated `WebStatsTableQueryRunner` code path
- The new tag drops the `stats_table_` prefix entirely because this is a separate runner with a different result shape; sharing the prefix would re-create the same observability collision that #58177 just resolved
- Cache warmer change was deliberate: previously these queries were warmed by the `startsWith(query_type, 'stats_table_')` rule, so the new tag is added to the explicit OR list to preserve that