### PR TITLE
feat(web-analytics): tag clickhouse queries with breakdown for query_log segmentation

### DIFF
--- a/posthog/hogql_queries/web_analytics/test/test_web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_analytics_query_runner.py
@@ -8,6 +8,7 @@ from posthog.test.base import (
     _create_person,
     snapshot_clickhouse_queries,
 )
+from unittest import mock
 
 from parameterized import parameterized
 
@@ -23,6 +24,7 @@ from posthog.schema import (
     WebStatsTableQuery,
 )
 
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.hogql_queries.web_analytics.stats_table import WebStatsTableQueryRunner
 from posthog.hogql_queries.web_analytics.web_analytics_query_runner import _sample_rate_from_count
 from posthog.hogql_queries.web_analytics.web_overview import WebOverviewQueryRunner
@@ -194,3 +196,52 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
             self.team.web_analytics_pre_aggregated_tables_version = "v2"
 
         self.assertEqual(runner.clickhouse_query_type(), expected_query_type)
+
+
+class TestWebAnalyticsBreakdownTagging(ClickhouseTestMixin, APIBaseTest):
+    @parameterized.expand(
+        [
+            ("page", WebStatsBreakdown.PAGE, ["Page"]),
+            ("browser", WebStatsBreakdown.BROWSER, ["Browser"]),
+            ("initial_channel_type", WebStatsBreakdown.INITIAL_CHANNEL_TYPE, ["InitialChannelType"]),
+            ("country", WebStatsBreakdown.COUNTRY, ["Country"]),
+        ]
+    )
+    def test_calculate_tags_breakdown_by_for_stats_table_query(
+        self,
+        _name: str,
+        breakdown_by: WebStatsBreakdown,
+        expected_breakdown_by: list[str],
+    ) -> None:
+        query = WebStatsTableQuery(
+            dateRange=DateRange(date_from="2023-12-08", date_to="2023-12-15"),
+            properties=[],
+            breakdownBy=breakdown_by,
+        )
+        runner = WebStatsTableQueryRunner(team=self.team, query=query)
+
+        with mock.patch(
+            "posthog.hogql_queries.web_analytics.web_analytics_query_runner.tag_queries",
+            wraps=tag_queries,
+        ) as spy:
+            runner.calculate()
+
+        breakdown_calls = [c for c in spy.call_args_list if "breakdown_by" in c.kwargs]
+        self.assertEqual(len(breakdown_calls), 1, f"expected one breakdown_by tag, got: {spy.call_args_list}")
+        self.assertEqual(breakdown_calls[0].kwargs["breakdown_by"], expected_breakdown_by)
+
+    def test_calculate_does_not_tag_breakdown_by_when_query_has_no_breakdown(self) -> None:
+        query = WebOverviewQuery(
+            dateRange=DateRange(date_from="2023-12-08", date_to="2023-12-15"),
+            properties=[],
+        )
+        runner = WebOverviewQueryRunner(team=self.team, query=query)
+
+        with mock.patch(
+            "posthog.hogql_queries.web_analytics.web_analytics_query_runner.tag_queries",
+            wraps=tag_queries,
+        ) as spy:
+            runner.calculate()
+
+        breakdown_calls = [c for c in spy.call_args_list if "breakdown_by" in c.kwargs]
+        self.assertEqual(breakdown_calls, [], f"did not expect any breakdown_by tag, got: {spy.call_args_list}")

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -35,7 +35,7 @@ from posthog.hogql.property import action_to_expr, apply_path_cleaning, property
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.caching.insights_api import BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL, REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL
-from posthog.clickhouse.query_tagging import get_query_tag_value
+from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
 from posthog.hogql_queries.query_runner import AnalyticsQueryResponseProtocol, AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -92,6 +92,9 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
             team_id=self.team.pk,
             query_kind=query_kind,
         )
+
+        if breakdown_value is not None:
+            tag_queries(breakdown_by=[breakdown_value.value])
 
         start = perf_counter()
         response: Optional[WAR] = None


### PR DESCRIPTION
## Problem

After #58177 split web stats table queries by strategy, `stats_table_main_query` still covers all the non-specialized breakdowns (DeviceType, Browser, Country, Channel, all UTM_*, etc.). Slicing performance by breakdown in `system.query_log` currently requires nested-JSON extraction:

```sql
JSONExtractString(JSONExtractRaw(log_comment, 'query'), 'breakdownBy')
```

`QueryTags.breakdown_by` is already a defined field in `posthog/clickhouse/query_tagging.py` but no code sets it, so it never shows up as a top-level `log_comment` key.

## Changes

- call `tag_queries(breakdown_by=[<breakdownBy>.value])` from `WebAnalyticsQueryRunner.calculate` before super dispatch, so the tag is in scope for any downstream ClickHouse query the runner fires
- tag is only set when the query has a `breakdownBy` (runners without a breakdown — overview, external-clicks, etc. — don't emit it)
- added parameterized tests covering several breakdowns plus a negative test for a runner without `breakdownBy`

After this lands, breakdown segmentation in `system.query_log` becomes:

```sql
JSONExtractString(log_comment, 'breakdown_by')
```

## How did you test this code?

Agent-authored change. No manual testing.

Automated checks run:
- `hogli test posthog/hogql_queries/web_analytics/test/test_web_analytics_query_runner.py` (17 passed)
- `ruff check` + `ruff format` on changed files
- pre-commit hooks (ruff, ty, format)

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

- Tooling used: Claude Code in the local repo
- Identified while verifying #58177's rollout: a follow-up `system.query_log` analysis showed `stats_table_main_query` was a catch-all across ~20 different breakdowns (DeviceType ~1.4k/4h, InitialChannelType ~1k/4h, etc.) with no top-level tag to segment on
- Considered adding `breakdown` as a Prometheus label, but #58177 already added it — the actual gap was the ClickHouse query_log side
- Hooked into the central `WebAnalyticsQueryRunner.calculate` rather than per-runner so all web analytics runners with a breakdown automatically benefit (currently `WebStatsTableQueryRunner`; the central spot is future-proof if more runners gain a breakdown dimension)