### PR TITLE
feat(user-interviews): add Max tool to create interview topics

### DIFF
--- a/ee/hogai/chat_agent/prompts/base.py
+++ b/ee/hogai/chat_agent/prompts/base.py
@@ -62,6 +62,7 @@ Created data is used by the user on the PostHog's website to perform business ac
 - Feature flags – feature flags that the user creates to control the feature rollout in their product.
 - Notebooks – notebooks that the user creates to perform business analysis.
 - Error tracking issues – issues that the user creates to track errors in their product.
+- User interview topics – topics that drive AI voice agent interviews with selected users, with questions you author.
 - Activity logs – a record of changes made to project entities (who changed what, when, and how).
 
 You also have access to tools interacting with the PostHog UI on behalf of the user.
@@ -197,6 +198,7 @@ PostHog products:
 - **Feature flags** – targeting rules, gradual rollouts, kill switches
 - **Experiments** – A/B testing and no-code A/B testing with statistical rigor
 - **Surveys** – in-app questionnaires, NPS, user feedback collection
+- **User interviews** – AI voice agent interviews with selected users, organized into topics with questions you author
 - **LLM observability** – monitor AI/LLM application costs, latency, and quality
 - **Data warehouse** – connect external data sources (Stripe, Hubspot, Postgres, etc.) for combined analysis
 - **Data pipelines (CDP)** – import data from 20+ sources, transform events in real-time, and export to external destinations

--- a/ee/hogai/research_agent/prompts/base.py
+++ b/ee/hogai/research_agent/prompts/base.py
@@ -26,6 +26,7 @@ Created data is used by the user on the PostHog's website to perform business ac
 - Feature flags – feature flags that the user creates to control the feature rollout in their product.
 - Notebooks – notebooks that the user creates to perform business analysis.
 - Error tracking issues – issues that the user creates to track errors in their product.
+- User interview topics – topics that drive AI voice agent interviews with selected users, with questions you author.
 
 Before using a tool, say what you're about to do, in one sentence.
 Do not generate any code like Python scripts. Users don't have the ability to run code.

--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -35,12 +35,13 @@ export function Navigation({
     sceneConfig: SceneConfig | null
 }): JSX.Element {
     useMountedLogic(maxGlobalLogic)
+    const userInterviewsEnabled = useFeatureFlag('USER_INTERVIEWS')
     // Register `create_user_interview_topic` globally so Max can create user interview
     // topics from any page (including the homepage), not only from the user-interviews
     // scene. The scene wires its own richer `useMaxTool` for the "New topic" button.
     useMaxTool({
         identifier: 'create_user_interview_topic',
-        active: useFeatureFlag('USER_INTERVIEWS'),
+        active: userInterviewsEnabled,
         context: {},
     })
     const { theme } = useValues(themeLogic)

--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -7,6 +7,7 @@ import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableSh
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
+import { useMaxTool } from 'scenes/max/useMaxTool'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { SceneConfig } from 'scenes/sceneTypes'
 
@@ -34,6 +35,14 @@ export function Navigation({
     sceneConfig: SceneConfig | null
 }): JSX.Element {
     useMountedLogic(maxGlobalLogic)
+    // Register `create_user_interview_topic` globally so Max can create user interview
+    // topics from any page (including the homepage), not only from the user-interviews
+    // scene. The scene wires its own richer `useMaxTool` for the "New topic" button.
+    useMaxTool({
+        identifier: 'create_user_interview_topic',
+        active: useFeatureFlag('USER_INTERVIEWS'),
+        context: {},
+    })
     const { theme } = useValues(themeLogic)
     const { mobileLayout } = useValues(navigationLogic)
     const { mode } = useValues(navigation3000Logic)

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3512,6 +3512,7 @@
                 "search_session_recordings",
                 "fix_hogql_query",
                 "analyze_user_interviews",
+                "create_user_interview_topic",
                 "create_hog_transformation_function",
                 "create_hog_function_filters",
                 "create_hog_function_inputs",

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -452,6 +452,7 @@ export type AssistantTool =
     | 'search_session_recordings'
     | 'fix_hogql_query'
     | 'analyze_user_interviews'
+    | 'create_user_interview_topic'
     | 'create_hog_transformation_function'
     | 'create_hog_function_filters'
     | 'create_hog_function_inputs'

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -542,6 +542,19 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
             return 'Analyzing user interviews...'
         },
     },
+    create_user_interview_topic: {
+        name: 'Set up user interviews',
+        description: 'Set up user interviews — plan a research topic, target participants, and draft questions',
+        product: Scene.UserInterviews,
+        flag: FEATURE_FLAGS.USER_INTERVIEWS,
+        icon: iconForType('user_interview'),
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Created interview topic'
+            }
+            return 'Setting up interview topic...'
+        },
+    },
     create_hog_function_filters: {
         name: 'Set up function filters',
         description: 'Set up function filters for quick pipeline configuration',

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -687,6 +687,7 @@ class AssistantTool(StrEnum):
     SEARCH_SESSION_RECORDINGS = "search_session_recordings"
     FIX_HOGQL_QUERY = "fix_hogql_query"
     ANALYZE_USER_INTERVIEWS = "analyze_user_interviews"
+    CREATE_USER_INTERVIEW_TOPIC = "create_user_interview_topic"
     CREATE_HOG_TRANSFORMATION_FUNCTION = "create_hog_transformation_function"
     CREATE_HOG_FUNCTION_FILTERS = "create_hog_function_filters"
     CREATE_HOG_FUNCTION_INPUTS = "create_hog_function_inputs"

--- a/products/user_interviews/backend/max_tools.py
+++ b/products/user_interviews/backend/max_tools.py
@@ -1,13 +1,23 @@
+from textwrap import dedent
 from typing import Any
 
 from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
 
 from openai import OpenAI
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+from posthog.exceptions_capture import capture_exception
+from posthog.rbac.user_access_control import AccessControlLevel
+from posthog.scopes import APIScopeObject
 
 from ee.hogai.tool import MaxTool
 
-from .models import UserInterview
+from .models import EmailWithDisplayNameValidator, UserInterview, UserInterviewTopic
+
+
+def _topic_url(topic_id: str) -> str:
+    return f"/user_research/{topic_id}"
 
 
 class AnalyzeUserInterviewsArgs(BaseModel):
@@ -68,3 +78,190 @@ Provide a structured analysis with clear sections and bullet points where approp
         )
 
         return analysis_response.output_text, None
+
+
+CREATE_USER_INTERVIEW_TOPIC_DESCRIPTION = dedent("""
+    Create a user research interview topic — a planned voice-AI interview campaign.
+
+    # When to use
+    - The user wants to set up or run user interviews, user research, customer research,
+      or "talk to users" about a feature, product area, or hypothesis.
+    - The user asks to plan, schedule, draft, or kick off user interviews.
+
+    # What this creates
+    A `UserInterviewTopic` containing who to talk to (`interviewee_emails` and/or
+    `interviewee_distinct_ids`), the research topic, optional context for the AI voice
+    agent, and the ordered list of questions it should work through. After creation, the
+    user can generate per-interviewee public links from the topic page and email invites
+    to participants. The voice agent handles the live call.
+
+    # Required information
+    - `topic`: short statement of what to learn (e.g. "the new dashboard onboarding flow").
+    - At least one of `interviewee_emails` OR `interviewee_distinct_ids` must be non-empty.
+      Emails are preferred when known — invites can be sent automatically. PostHog distinct
+      IDs work too but cannot receive email invites until an email is added.
+    - `questions`: 3-6 focused, open-ended questions in the order the agent should ask
+      them. Keep them conversational and avoid leading or yes/no phrasings.
+
+    # Optional
+    - `agent_context`: extra background for the voice agent — tone, what the product
+      does, what NOT to ask about, who the interviewer "is" representing. Becomes part
+      of the agent's system prompt for every call on this topic.
+
+    # Important
+    - This is NOT a survey. Do NOT use `create_survey` when the user asks for an
+      interview, research call, or "talk to users" — those are live AI voice
+      conversations, not in-app survey widgets.
+    - This is NOT a session recording filter. Do NOT redirect to session recordings
+      or replays when the user wants to interview people.
+    - Do not invent emails or distinct IDs. If the user has not provided participants
+      and you cannot derive them from the available cohort/persons tools, ask the user.
+    """).strip()
+
+
+class CreateUserInterviewTopicArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    topic: str = Field(
+        description=(
+            "Short statement of what you want to learn from the interviews — the product "
+            "area, feature, or hypothesis being researched."
+        ),
+    )
+    interviewee_emails: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Email addresses of people to interview. Accepts plain `email@host` or the "
+            "`Display Name <email@host>` form. May be combined with `interviewee_distinct_ids` "
+            "but at least one of the two lists must be non-empty."
+        ),
+    )
+    interviewee_distinct_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "PostHog distinct IDs of people to interview. May be combined with "
+            "`interviewee_emails`, but at least one of the two lists must be non-empty. "
+            "Distinct-ID-only interviewees cannot receive email invites until they are "
+            "given an email address."
+        ),
+    )
+    questions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Ordered list of questions the AI voice agent should work through during the "
+            "interview. Keep questions open-ended, conversational, and focused on the topic."
+        ),
+    )
+    agent_context: str = Field(
+        default="",
+        description=(
+            "Optional extra context for the voice agent — background on the product, "
+            "tone, or constraints. Becomes part of the agent's system prompt for every "
+            "call on this topic. Leave empty if no extra context is needed."
+        ),
+    )
+
+
+class CreateUserInterviewTopicTool(MaxTool):
+    name: str = "create_user_interview_topic"
+    description: str = CREATE_USER_INTERVIEW_TOPIC_DESCRIPTION
+    context_prompt_template: str = (
+        "When the user explicitly wants to interview users, talk to users live, or run "
+        "user research calls, prefer `create_user_interview_topic`. For passive, in-app "
+        "feedback (e.g. NPS, opinion polls, ratings), `create_survey` is still the right "
+        "choice."
+    )
+    args_schema: type[BaseModel] = CreateUserInterviewTopicArgs
+
+    def get_required_resource_access(self) -> list[tuple[APIScopeObject, AccessControlLevel]]:
+        return [("user_interview", "editor")]
+
+    async def _arun_impl(
+        self,
+        topic: str = "",
+        interviewee_emails: list[str] | None = None,
+        interviewee_distinct_ids: list[str] | None = None,
+        questions: list[str] | None = None,
+        agent_context: str = "",
+    ) -> tuple[str, dict[str, Any]]:
+        emails = [e.strip() for e in (interviewee_emails or []) if e and e.strip()]
+        distinct_ids = [d.strip() for d in (interviewee_distinct_ids or []) if d and d.strip()]
+        questions = [q.strip() for q in (questions or []) if q and q.strip()]
+        topic = (topic or "").strip()
+
+        if not topic:
+            return "Topic is required.", {
+                "error": "validation_failed",
+                "error_message": "Topic must be a non-empty string describing what you want to learn.",
+            }
+
+        if not emails and not distinct_ids:
+            return (
+                "At least one interviewee email or PostHog distinct ID must be provided.",
+                {
+                    "error": "validation_failed",
+                    "error_message": (
+                        "Provide at least one entry in `interviewee_emails` or "
+                        "`interviewee_distinct_ids` so we know who to interview."
+                    ),
+                },
+            )
+
+        validator = EmailWithDisplayNameValidator()
+        invalid_emails: list[str] = []
+        for email in emails:
+            try:
+                validator(email)
+            except DjangoValidationError:
+                invalid_emails.append(email)
+        if invalid_emails:
+            return (
+                f"Invalid email address(es): {', '.join(invalid_emails)}",
+                {
+                    "error": "validation_failed",
+                    "error_message": (
+                        "These values are not valid email addresses: "
+                        + ", ".join(invalid_emails)
+                        + ". Use plain `email@host` or `Display Name <email@host>`."
+                    ),
+                },
+            )
+
+        try:
+            created_topic = await UserInterviewTopic.objects.acreate(
+                team=self._team,
+                created_by=self._user,
+                topic=topic,
+                interviewee_emails=emails,
+                interviewee_distinct_ids=distinct_ids,
+                questions=questions,
+                agent_context=agent_context or "",
+            )
+        except Exception as e:
+            capture_exception(e, {"team_id": self._team.id, "user_id": self._user.id})
+            return f"Failed to create interview topic: {str(e)}", {
+                "error": "creation_failed",
+                "error_message": str(e),
+            }
+
+        topic_id = str(created_topic.id)
+        topic_url = _topic_url(topic_id)
+        targeting_summary_parts = []
+        if emails:
+            targeting_summary_parts.append(f"{len(emails)} email{'s' if len(emails) != 1 else ''}")
+        if distinct_ids:
+            targeting_summary_parts.append(f"{len(distinct_ids)} distinct ID{'s' if len(distinct_ids) != 1 else ''}")
+        targeting_summary = " + ".join(targeting_summary_parts) or "no interviewees"
+
+        message = (
+            f"Created interview topic '{topic}' targeting {targeting_summary} with "
+            f"{len(questions)} question{'s' if len(questions) != 1 else ''}. "
+            f"[Open topic]({topic_url}) to generate links or send invites."
+        )
+        return message, {
+            "topic_id": topic_id,
+            "topic": created_topic.topic,
+            "interviewee_email_count": len(emails),
+            "interviewee_distinct_id_count": len(distinct_ids),
+            "question_count": len(questions),
+        }

--- a/products/user_interviews/backend/max_tools.py
+++ b/products/user_interviews/backend/max_tools.py
@@ -207,6 +207,18 @@ class CreateUserInterviewTopicTool(MaxTool):
                 },
             )
 
+        if not questions:
+            return (
+                "At least one interview question is required.",
+                {
+                    "error": "validation_failed",
+                    "error_message": (
+                        "Provide at least one question in `questions`. "
+                        "The AI voice agent needs questions to ask during the interview."
+                    ),
+                },
+            )
+
         validator = EmailWithDisplayNameValidator()
         invalid_emails: list[str] = []
         for email in emails:

--- a/products/user_interviews/backend/test_max_tools.py
+++ b/products/user_interviews/backend/test_max_tools.py
@@ -45,7 +45,9 @@ class TestCreateUserInterviewTopicTool(BaseTest):
         assert artifact["question_count"] == 3
 
         topic = await sync_to_async(
-            lambda: UserInterviewTopic.objects.select_related("team", "created_by").get(id=artifact["topic_id"])
+            lambda: UserInterviewTopic.objects.select_related("team", "created_by").get(
+                team=self.team, id=artifact["topic_id"]
+            )
         )()
         assert topic.team == self.team
         assert topic.created_by == self.user
@@ -128,7 +130,7 @@ class TestCreateUserInterviewTopicTool(BaseTest):
         assert artifact["interviewee_distinct_id_count"] == 1
         assert artifact["question_count"] == 1
 
-        topic = await sync_to_async(UserInterviewTopic.objects.get)(id=artifact["topic_id"])
+        topic = await sync_to_async(lambda: UserInterviewTopic.objects.get(team=self.team, id=artifact["topic_id"]))()
         assert topic.interviewee_emails == ["alex@example.com"]
         assert topic.interviewee_distinct_ids == ["user_1"]
         assert topic.questions == ["A real question?"]

--- a/products/user_interviews/backend/test_max_tools.py
+++ b/products/user_interviews/backend/test_max_tools.py
@@ -1,0 +1,134 @@
+import pytest
+from posthog.test.base import BaseTest
+
+from asgiref.sync import sync_to_async
+from langchain_core.runnables import RunnableConfig
+
+from products.user_interviews.backend.models import UserInterviewTopic
+
+from .max_tools import CreateUserInterviewTopicTool
+
+
+class TestCreateUserInterviewTopicTool(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self._config: RunnableConfig = {
+            "configurable": {
+                "team": self.team,
+                "user": self.user,
+            },
+        }
+
+    def _tool(self) -> CreateUserInterviewTopicTool:
+        return CreateUserInterviewTopicTool(team=self.team, user=self.user, config=self._config)
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_arun_impl_success_with_emails(self):
+        tool = self._tool()
+
+        content, artifact = await tool._arun_impl(
+            topic="Onboarding experience",
+            interviewee_emails=["alex@example.com", "Sam <sam@example.com>"],
+            questions=[
+                "What were you hoping to achieve when you signed up?",
+                "Where did you get stuck during onboarding?",
+                "What would have made the first 5 minutes easier?",
+            ],
+            agent_context="Focus on emotional friction, not feature requests.",
+        )
+
+        assert "Created interview topic" in content
+        assert artifact["topic"] == "Onboarding experience"
+        assert artifact["interviewee_email_count"] == 2
+        assert artifact["interviewee_distinct_id_count"] == 0
+        assert artifact["question_count"] == 3
+
+        topic = await sync_to_async(
+            lambda: UserInterviewTopic.objects.select_related("team", "created_by").get(id=artifact["topic_id"])
+        )()
+        assert topic.team == self.team
+        assert topic.created_by == self.user
+        assert topic.interviewee_emails == ["alex@example.com", "Sam <sam@example.com>"]
+        assert topic.interviewee_distinct_ids == []
+        assert len(topic.questions) == 3
+        assert topic.agent_context == "Focus on emotional friction, not feature requests."
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_arun_impl_success_with_distinct_ids_only(self):
+        tool = self._tool()
+
+        content, artifact = await tool._arun_impl(
+            topic="Power user dashboard usage",
+            interviewee_distinct_ids=["user_123", "user_456"],
+            questions=["How do you currently use dashboards?"],
+        )
+
+        assert "Created interview topic" in content
+        assert artifact["interviewee_email_count"] == 0
+        assert artifact["interviewee_distinct_id_count"] == 2
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_arun_impl_rejects_empty_topic(self):
+        tool = self._tool()
+
+        content, artifact = await tool._arun_impl(
+            topic="   ",
+            interviewee_emails=["alex@example.com"],
+        )
+
+        assert "Topic is required" in content
+        assert artifact["error"] == "validation_failed"
+        assert not await sync_to_async(UserInterviewTopic.objects.filter(team=self.team).exists)()
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_arun_impl_rejects_no_interviewees(self):
+        tool = self._tool()
+
+        content, artifact = await tool._arun_impl(
+            topic="Some topic",
+            interviewee_emails=[],
+            interviewee_distinct_ids=[],
+        )
+
+        assert "interviewee" in content.lower()
+        assert artifact["error"] == "validation_failed"
+        assert not await sync_to_async(UserInterviewTopic.objects.filter(team=self.team).exists)()
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_arun_impl_rejects_invalid_emails(self):
+        tool = self._tool()
+
+        content, artifact = await tool._arun_impl(
+            topic="Some topic",
+            interviewee_emails=["not-an-email", "also bad"],
+        )
+
+        assert artifact["error"] == "validation_failed"
+        assert "not-an-email" in content
+        assert not await sync_to_async(UserInterviewTopic.objects.filter(team=self.team).exists)()
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_arun_impl_strips_blank_entries(self):
+        tool = self._tool()
+
+        content, artifact = await tool._arun_impl(
+            topic="Some topic",
+            interviewee_emails=["alex@example.com", "  ", ""],
+            interviewee_distinct_ids=["", "user_1"],
+            questions=["A real question?", "  ", ""],
+        )
+
+        assert artifact["interviewee_email_count"] == 1
+        assert artifact["interviewee_distinct_id_count"] == 1
+        assert artifact["question_count"] == 1
+
+        topic = await sync_to_async(UserInterviewTopic.objects.get)(id=artifact["topic_id"])
+        assert topic.interviewee_emails == ["alex@example.com"]
+        assert topic.interviewee_distinct_ids == ["user_1"]
+        assert topic.questions == ["A real question?"]

--- a/products/user_interviews/backend/test_max_tools.py
+++ b/products/user_interviews/backend/test_max_tools.py
@@ -88,8 +88,17 @@ class TestCreateUserInterviewTopicTool(BaseTest):
             ),
             (
                 "invalid_emails",
-                {"topic": "Some topic", "interviewee_emails": ["not-an-email", "also bad"]},
+                {
+                    "topic": "Some topic",
+                    "interviewee_emails": ["not-an-email", "also bad"],
+                    "questions": ["A question?"],
+                },
                 "not-an-email",
+            ),
+            (
+                "no_questions",
+                {"topic": "Some topic", "interviewee_emails": ["alex@example.com"], "questions": []},
+                "question",
             ),
         ]
     )

--- a/products/user_interviews/backend/test_max_tools.py
+++ b/products/user_interviews/backend/test_max_tools.py
@@ -3,6 +3,7 @@ from posthog.test.base import BaseTest
 
 from asgiref.sync import sync_to_async
 from langchain_core.runnables import RunnableConfig
+from parameterized import parameterized
 
 from products.user_interviews.backend.models import UserInterviewTopic
 
@@ -73,45 +74,32 @@ class TestCreateUserInterviewTopicTool(BaseTest):
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_arun_impl_rejects_empty_topic(self):
+    @parameterized.expand(
+        [
+            (
+                "empty_topic",
+                {"topic": "   ", "interviewee_emails": ["alex@example.com"]},
+                "topic is required",
+            ),
+            (
+                "no_interviewees",
+                {"topic": "Some topic", "interviewee_emails": [], "interviewee_distinct_ids": []},
+                "interviewee",
+            ),
+            (
+                "invalid_emails",
+                {"topic": "Some topic", "interviewee_emails": ["not-an-email", "also bad"]},
+                "not-an-email",
+            ),
+        ]
+    )
+    async def test_arun_impl_rejects_invalid_input(self, _name, kwargs, expected_content_fragment):
         tool = self._tool()
 
-        content, artifact = await tool._arun_impl(
-            topic="   ",
-            interviewee_emails=["alex@example.com"],
-        )
-
-        assert "Topic is required" in content
-        assert artifact["error"] == "validation_failed"
-        assert not await sync_to_async(UserInterviewTopic.objects.filter(team=self.team).exists)()
-
-    @pytest.mark.django_db
-    @pytest.mark.asyncio
-    async def test_arun_impl_rejects_no_interviewees(self):
-        tool = self._tool()
-
-        content, artifact = await tool._arun_impl(
-            topic="Some topic",
-            interviewee_emails=[],
-            interviewee_distinct_ids=[],
-        )
-
-        assert "interviewee" in content.lower()
-        assert artifact["error"] == "validation_failed"
-        assert not await sync_to_async(UserInterviewTopic.objects.filter(team=self.team).exists)()
-
-    @pytest.mark.django_db
-    @pytest.mark.asyncio
-    async def test_arun_impl_rejects_invalid_emails(self):
-        tool = self._tool()
-
-        content, artifact = await tool._arun_impl(
-            topic="Some topic",
-            interviewee_emails=["not-an-email", "also bad"],
-        )
+        content, artifact = await tool._arun_impl(**kwargs)
 
         assert artifact["error"] == "validation_failed"
-        assert "not-an-email" in content
+        assert expected_content_fragment in content.lower()
         assert not await sync_to_async(UserInterviewTopic.objects.filter(team=self.team).exists)()
 
     @pytest.mark.django_db

--- a/products/user_interviews/frontend/UserInterviews.tsx
+++ b/products/user_interviews/frontend/UserInterviews.tsx
@@ -1,17 +1,16 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 
 import { IconSparkles } from '@posthog/icons'
 import { LemonButton, LemonTable } from '@posthog/lemon-ui'
 
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { useMaxTool } from 'scenes/max/useMaxTool'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { SidePanelTab } from '~/types'
 
 import type { UserInterviewTopicApi } from './generated/api.schemas'
 import { userInterviewsLogic } from './userInterviewsLogic'
@@ -34,19 +33,28 @@ function targetingLabel(topic: UserInterviewTopicApi): string {
     return parts.length > 0 ? parts.join(' + ') : 'Not set'
 }
 
-const NEW_TOPIC_PROMPT = `!I want to set up a new user research topic. Help me through the process:
+const NEW_TOPIC_PROMPT = `!I want to set up a new user research topic. Help me work through:
+1. What I want to learn — the feature, behavior, or question to research.
+2. Who to interview — let me give you emails or distinct IDs, or help me pick from a cohort.
+3. The interview questions — 3-6 open-ended, conversational prompts in a sensible order.
+Then create the topic using the create_user_interview_topic tool. Don't try to send emails or generate links yourself — once the topic exists I'll do that from the topic page.`
 
-1. First, let's figure out what I want to learn — what feature, behavior, or question I want to research.
-2. Then, help me identify the right users to interview — pick a cohort, find users by behavior, or provide emails directly.
-3. Draft interview questions based on the topic.
-4. Set up the outreach workflow to email each user with their unique interview link.
-5. Once I confirm, trigger the emails — I'll track responses in User research.
-
-Let's start — ask me what I want to learn about.`
+const NEW_TOPIC_SUGGESTIONS = [
+    'Interview recent signups about their onboarding experience',
+    'Talk to power users about what they wish the product did better',
+    'Interview customers who churned in the last 30 days',
+    'Research how teams are using dashboards day-to-day',
+]
 
 export function UserInterviews(): JSX.Element {
     const { topics, topicsLoading } = useValues(userInterviewsLogic)
-    const { openSidePanel } = useActions(sidePanelStateLogic)
+
+    const { openMax } = useMaxTool({
+        identifier: 'create_user_interview_topic',
+        context: {},
+        initialMaxPrompt: NEW_TOPIC_PROMPT,
+        suggestions: NEW_TOPIC_SUGGESTIONS,
+    })
 
     return (
         <SceneContent>
@@ -61,7 +69,8 @@ export function UserInterviews(): JSX.Element {
                         type="primary"
                         icon={<IconSparkles />}
                         data-attr="new-topic"
-                        onClick={() => openSidePanel(SidePanelTab.Max, NEW_TOPIC_PROMPT)}
+                        onClick={() => openMax?.()}
+                        disabledReason={openMax ? undefined : 'PostHog AI is unavailable here'}
                     >
                         New topic
                     </LemonButton>


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## **Problem**

When a user asked PostHog AI ("Max") to "set up user interviews", "talk to users", or "do user research" — from the homepage or anywhere outside the user-interviews scene — Max either hallucinated alternatives (Calendly handoff, "outreach workflow", create a survey, point at session recordings) or flatly said "PostHog doesn't have a user interviews product."

Three underlying gaps:

1. No `create_user_interview_topic` MaxTool existed. The only user-interviews MaxTool was `analyze_user_interviews`, which reads existing interviews.
2. Every existing MaxTool registration was scene-scoped via `useMaxTool`, so even after the tool existed it would only be callable while the user was sitting on `/user_interviews`.
3. Neither `BASIC_FUNCTIONALITY_PROMPT` nor `PRODUCT_ADVOCACY_PROMPT` mentioned user interviews, so Max didn't know to recommend the product.

The MCP server already exposes the full topic lifecycle, so MCP users have a working flow — this PR closes the gap for the in-app Max experience.

**Changes**

- **New MaxTool**: `CreateUserInterviewTopicTool` in max_tools.py. Takes `topic`, `interviewee_emails`, `interviewee_distinct_ids`, `questions`, and optional `agent_context`. Validates non-empty topic, at least one targeting list, and email format (reusing `EmailWithDisplayNameValidator` from the model). Persists via `UserInterviewTopic.objects.acreate(...)`. Requires `user_interview:editor` access. Description explicitly steers the agent away from `create_survey` and session recordings to prevent the prior hallucinations.
- **Global tool registration**: Navigation.tsx now calls `useMaxTool({ identifier: 'create_user_interview_topic', active: useFeatureFlag('USER_INTERVIEWS') })`. This is the first globally-registered MaxTool — every other `useMaxTool` today is scene-scoped — and is what makes Max able to invoke the tool when the user is on the homepage. Behind the `USER_INTERVIEWS` feature flag.
- **Scene wiring**: UserInterviews.tsx now uses `useMaxTool` with an `initialMaxPrompt` (rewritten to drop the "outreach workflow" phrasing that produced Calendly hallucinations) and a `NEW_TOPIC_SUGGESTIONS` list. The "New topic" button calls `openMax()`.
- **Prompt-level awareness**: added "User interview topics" to the chat agent's `BASIC_FUNCTIONALITY_PROMPT` "Created data" list and `PRODUCT_ADVOCACY_PROMPT` product list, plus the research agent's `BASIC_FUNCTIONALITY_PROMPT`. Max now knows the product exists and can recommend it unprompted.
- **Schema**: `create_user_interview_topic` added to `AssistantTool` in schema-assistant-messages.ts, schema.json, and schema.py, plus a `TOOL_DEFINITIONS` entry (name: "Set up user interviews") in max-constants.tsx for Max's UI.
- **Test**: test_max_tools.py covers success (emails-only and distinct-ids-only), validation failures (empty topic, no interviewees, invalid emails), and whitespace stripping.

Link generation and invite sending are intentionally **not** added as MaxTools in this PR — they remain on the topic detail page so a human always confirms the final outreach step.

**How did you test**

Automated tests added in test_max_tools.py:

- success with emails (including `Display Name <email@host>` form) + questions + agent_context
- success with distinct IDs only
- rejects empty/whitespace topic
- rejects when both targeting lists are empty
- rejects invalid email entries
- strips blank/whitespace entries from emails, distinct IDs, and questions

All 6 pass locally via `hogli test products/user_interviews/backend/test_max_tools.py`. Ran `pnpm schema:build` and confirmed it produced zero diff against the hand-edited schema files. Ran `ruff check` and TypeScript check on the touched files — clean.

Manual verification still needed once in prod

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->