### PR TITLE
feat(flags): restore v2 match-by UI

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -538,9 +538,9 @@ const ConditionContent = ({
                                                 size="small"
                                                 data-attr={`condition-set-${index}-aggregation`}
                                                 value={
-                                                    group.aggregation_group_type_index ??
-                                                    releaseFilters.aggregation_group_type_index ??
-                                                    PERSON
+                                                    group.aggregation_group_type_index !== undefined
+                                                        ? (group.aggregation_group_type_index ?? PERSON)
+                                                        : (releaseFilters.aggregation_group_type_index ?? PERSON)
                                                 }
                                                 onChange={(value) => {
                                                     setConditionAggregation(index, value === PERSON ? null : value)

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -16,7 +16,7 @@ import React, { useRef, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
-    IconBalance,
+    IconBrackets,
     IconCollapse,
     IconCopy,
     IconEllipsis,
@@ -91,6 +91,18 @@ interface FeatureFlagReleaseConditionsCollapsibleProps extends FeatureFlagReleas
     evaluationRuntime?: FeatureFlagEvaluationRuntime
     /** When true, hides the "Match by" User/Group selector. Use when the aggregation type is inherited from the parent flag. */
     hideMatchOptions?: boolean
+}
+
+const PERSON = 'person' as const
+type AggregationValue = number | typeof PERSON
+
+type MatchByOption = {
+    value: string
+    icon: JSX.Element
+    label: string
+    description: string
+    badge?: { type: 'warning' | 'highlight'; text: string }
+    learnMoreUrl?: string
 }
 
 function summarizeProperties(properties: AnyPropertyFilter[], aggregationTargetName: string): string {
@@ -302,8 +314,8 @@ interface ConditionProps {
     taxonomicGroupTypesForCondition: (conditionGroupTypeIndex: number | null | undefined) => TaxonomicFilterGroupType[]
     groupTypes: Map<GroupTypeIndex, GroupType>
     setConditionAggregation: (index: number, groupTypeIndex: number | null) => void
-    isMixedTargetingEnabled: boolean
-    mixedGroupTypeIndex: number
+    isTargetingV2Enabled: boolean
+    isDeviceTargeting: boolean
     onMoveUp: () => void
     onMoveDown: () => void
     onDuplicate: () => void
@@ -371,8 +383,8 @@ const ConditionContent = ({
     taxonomicGroupTypesForCondition,
     groupTypes,
     setConditionAggregation,
-    isMixedTargetingEnabled,
-    mixedGroupTypeIndex,
+    isTargetingV2Enabled,
+    isDeviceTargeting,
     onMoveUp,
     onMoveDown,
     onDuplicate,
@@ -519,39 +531,46 @@ const ConditionContent = ({
                                         />
                                     </div>
 
-                                    {isMixedTargetingEnabled && groupTypes.size > 0 && (
+                                    {isTargetingV2Enabled && groupTypes.size > 0 && !isDeviceTargeting && (
                                         <div>
-                                            <LemonLabel className="mb-1">Targeting criteria</LemonLabel>
-                                            <LemonSelect
+                                            <LemonLabel className="mb-1">Target by</LemonLabel>
+                                            <LemonSelect<AggregationValue>
                                                 size="small"
                                                 data-attr={`condition-set-${index}-aggregation`}
-                                                value={group.aggregation_group_type_index != null ? 'group' : 'person'}
+                                                value={
+                                                    group.aggregation_group_type_index ??
+                                                    releaseFilters.aggregation_group_type_index ??
+                                                    PERSON
+                                                }
                                                 onChange={(value) => {
-                                                    setConditionAggregation(
-                                                        index,
-                                                        value === 'person' ? null : mixedGroupTypeIndex
-                                                    )
+                                                    setConditionAggregation(index, value === PERSON ? null : value)
                                                 }}
-                                                options={(() => {
-                                                    const gt = groupTypes.get(mixedGroupTypeIndex as GroupTypeIndex)
-                                                    const groupLabel = gt
-                                                        ? gt.name_plural ||
-                                                          gt.group_type.charAt(0).toUpperCase() +
-                                                              gt.group_type.slice(1) +
-                                                              's'
-                                                        : 'Groups'
-                                                    return [
-                                                        { value: 'person' as const, label: 'Users' },
-                                                        {
-                                                            value: 'group' as const,
-                                                            label: groupLabel,
-                                                        },
-                                                    ]
-                                                })()}
+                                                options={[
+                                                    {
+                                                        options: [
+                                                            {
+                                                                value: PERSON,
+                                                                label: 'Users',
+                                                                icon: <IconPerson />,
+                                                            },
+                                                        ],
+                                                    },
+                                                    {
+                                                        title: 'Group types',
+                                                        options: Array.from(groupTypes.values()).map((gt) => ({
+                                                            value: gt.group_type_index as number,
+                                                            label:
+                                                                gt.name_plural ||
+                                                                gt.group_type.charAt(0).toUpperCase() +
+                                                                    gt.group_type.slice(1) +
+                                                                    's',
+                                                            icon: <IconPeople />,
+                                                        })),
+                                                    },
+                                                ]}
                                             />
                                         </div>
                                     )}
-
                                     <div>
                                         <LemonLabel className="mb-1">Match filters</LemonLabel>
                                         <PropertyFilters
@@ -787,14 +806,15 @@ export function FeatureFlagReleaseConditionsCollapsible({
         openConditions,
         properties,
         isMixedTargeting,
-        mixedGroupTypeIndex,
         isAnyItemDragging,
         draggedGroup,
     } = useValues(releaseConditionsLogic)
 
     const { featureFlags } = useValues(featureFlagLogic)
     const isDragDropEnabled = !!featureFlags[FEATURE_FLAGS.FEATURE_FLAG_DRAG_DROP_CONDITIONS]
-    const isMixedTargetingEnabled = !!featureFlags[FEATURE_FLAGS.FEATURE_FLAG_MIXED_TARGETING]
+    // The mixed-targeting flag now gates the unified v2 UI (Properties / Device with full per-condition group-type selector).
+    // The legacy 4-card path is reached only when the flag is off.
+    const isTargetingV2Enabled = !!featureFlags[FEATURE_FLAGS.FEATURE_FLAG_MIXED_TARGETING]
 
     // Ref map for focus management
     const optionRefs = useRef<Record<string, HTMLDivElement | null>>({})
@@ -814,7 +834,6 @@ export function FeatureFlagReleaseConditionsCollapsible({
         setOpenConditions,
         setIsMixedTargeting,
         switchToMixedTargeting,
-        setMixedGroupTypeIndex,
         setIsAnyItemDragging,
         setDraggedGroup,
     } = useActions(releaseConditionsLogic)
@@ -911,19 +930,88 @@ export function FeatureFlagReleaseConditionsCollapsible({
     }
 
     const showGroupsOptions = groupTypes.size > 0
+    const isDeviceTargeting = bucketingIdentifier === FeatureFlagBucketingIdentifier.DEVICE_ID
+
+    const v2MatchByOptions = [
+        {
+            value: 'properties',
+            icon: <IconBrackets className="text-base shrink-0" />,
+            label: 'Properties',
+            description: showGroupsOptions
+                ? 'Target by user or group property filters. Each condition picks its own targeting type.'
+                : 'Target by user property filters.',
+        },
+        ...(onBucketingIdentifierChange
+            ? [
+                  {
+                      value: 'device',
+                      icon: <IconLaptop className="text-base shrink-0" />,
+                      label: 'Device',
+                      description: 'Stable assignment per device. Good fit for experiments on anonymous users.',
+                      badge: { type: 'warning' as const, text: 'BETA' },
+                      learnMoreUrl: 'https://posthog.com/docs/feature-flags/device-bucketing',
+                  },
+              ]
+            : []),
+    ] satisfies MatchByOption[]
+
+    const legacyMatchByOptions = [
+        {
+            value: 'user',
+            icon: <IconPerson className="text-base shrink-0" />,
+            label: 'User',
+            description: 'Stable assignment for logged-in users based on their distinct ID.',
+        },
+        ...(onBucketingIdentifierChange
+            ? [
+                  {
+                      value: 'device',
+                      icon: <IconLaptop className="text-base shrink-0" />,
+                      label: 'Device',
+                      description: 'Stable assignment per device. Good fit for experiments on anonymous users.',
+                      badge: { type: 'warning' as const, text: 'BETA' },
+                      learnMoreUrl: 'https://posthog.com/docs/feature-flags/device-bucketing',
+                  },
+              ]
+            : []),
+        ...(showGroupsOptions
+            ? [
+                  {
+                      value: 'group',
+                      icon: <IconPeople className="text-base shrink-0" />,
+                      label: 'Group',
+                      description:
+                          'Stable assignment for everyone in an organization, company, or other custom group type.',
+                  },
+              ]
+            : []),
+    ] satisfies MatchByOption[]
+
+    const matchByOptions: MatchByOption[] = isTargetingV2Enabled ? v2MatchByOptions : legacyMatchByOptions
 
     // Compute current selected option (shared between keyboard navigation and selection rendering)
-    const currentSelected = isMixedTargeting
-        ? 'mixed'
+    const currentSelected = isTargetingV2Enabled
+        ? isDeviceTargeting && onBucketingIdentifierChange
+            ? 'device'
+            : 'properties'
         : releaseFilters.aggregation_group_type_index != null
           ? 'group'
-          : bucketingIdentifier === FeatureFlagBucketingIdentifier.DEVICE_ID
+          : isDeviceTargeting
             ? 'device'
             : 'user'
 
     // Handler for option selection logic (shared by click and keyboard events)
     const selectMatchByOption = (value: string): void => {
         const applyChange = (targetValue: string): void => {
+            if (isTargetingV2Enabled) {
+                if (targetValue === 'properties') {
+                    onBucketingIdentifierChange?.(FeatureFlagBucketingIdentifier.DISTINCT_ID)
+                } else if (targetValue === 'device') {
+                    setAggregationGroupTypeIndex(null)
+                    onBucketingIdentifierChange?.(FeatureFlagBucketingIdentifier.DEVICE_ID)
+                }
+                return
+            }
             if (targetValue === 'user') {
                 setIsMixedTargeting(false)
                 setAggregationGroupTypeIndex(null)
@@ -1008,12 +1096,13 @@ export function FeatureFlagReleaseConditionsCollapsible({
                             // Handle arrow key navigation for radio group
                             if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
                                 e.preventDefault()
-                                const options = [
-                                    'user',
-                                    ...(onBucketingIdentifierChange ? ['device'] : []),
-                                    ...(showGroupsOptions ? ['group'] : []),
-                                    ...(showGroupsOptions && isMixedTargetingEnabled ? ['mixed'] : []),
-                                ]
+                                const options = isTargetingV2Enabled
+                                    ? ['properties', ...(onBucketingIdentifierChange ? ['device'] : [])]
+                                    : [
+                                          'user',
+                                          ...(onBucketingIdentifierChange ? ['device'] : []),
+                                          ...(showGroupsOptions ? ['group'] : []),
+                                      ]
 
                                 const currentIndex = options.indexOf(currentSelected)
                                 let nextIndex = currentIndex
@@ -1031,49 +1120,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                             }
                         }}
                     >
-                        {[
-                            {
-                                value: 'user',
-                                icon: <IconPerson className="text-base shrink-0" />,
-                                label: 'User',
-                                description: 'Stable assignment for logged-in users based on their distinct ID.',
-                            },
-                            ...(onBucketingIdentifierChange
-                                ? [
-                                      {
-                                          value: 'device',
-                                          icon: <IconLaptop className="text-base shrink-0" />,
-                                          label: 'Device',
-                                          description:
-                                              'Stable assignment per device. Good fit for experiments on anonymous users.',
-                                          learnMoreUrl: 'https://posthog.com/docs/feature-flags/device-bucketing',
-                                      },
-                                  ]
-                                : []),
-                            ...(showGroupsOptions
-                                ? [
-                                      {
-                                          value: 'group',
-                                          icon: <IconPeople className="text-base shrink-0" />,
-                                          label: 'Group',
-                                          description:
-                                              'Stable assignment for everyone in an organization, company, or other custom group type.',
-                                      },
-                                  ]
-                                : []),
-                            ...(showGroupsOptions && isMixedTargetingEnabled
-                                ? [
-                                      {
-                                          value: 'mixed',
-                                          icon: <IconBalance className="text-base shrink-0" />,
-                                          label: 'User & Group',
-                                          description:
-                                              'Mix user and group targeting across condition sets. Each condition set picks its own targeting type.',
-                                          badge: { type: 'highlight' as const, text: 'NEW' },
-                                      },
-                                  ]
-                                : []),
-                        ].map((option) => {
+                        {matchByOptions.map((option) => {
                             const isSelected = option.value === currentSelected
 
                             return (
@@ -1155,29 +1202,6 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                                     {groupTypeValues[0]?.group_type}
                                                 </span>
                                             ))}
-                                        {/* Mixed group type selector */}
-                                        {option.value === 'mixed' &&
-                                            isSelected &&
-                                            isMixedTargeting &&
-                                            groupTypeValues.length > 1 && (
-                                                <div onClick={(e) => e.stopPropagation()}>
-                                                    <LemonSelect
-                                                        size="xsmall"
-                                                        dropdownMatchSelectWidth={false}
-                                                        data-attr="feature-flag-mixed-group-type-select"
-                                                        value={mixedGroupTypeIndex}
-                                                        onChange={(value) => {
-                                                            if (value != null) {
-                                                                setMixedGroupTypeIndex(value)
-                                                            }
-                                                        }}
-                                                        options={groupTypeValues.map((groupType) => ({
-                                                            value: groupType.group_type_index,
-                                                            label: groupType.group_type,
-                                                        }))}
-                                                    />
-                                                </div>
-                                            )}
                                     </div>
                                 </div>
                             )
@@ -1256,8 +1280,8 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                                 taxonomicGroupTypesForCondition={taxonomicGroupTypesForCondition}
                                                 groupTypes={groupTypes}
                                                 setConditionAggregation={setConditionAggregation}
-                                                isMixedTargetingEnabled={isMixedTargeting}
-                                                mixedGroupTypeIndex={mixedGroupTypeIndex}
+                                                isTargetingV2Enabled={isTargetingV2Enabled}
+                                                isDeviceTargeting={isDeviceTargeting}
                                                 onMoveUp={() => moveConditionSetUp(index)}
                                                 onMoveDown={() => moveConditionSetDown(index)}
                                                 onDuplicate={() => duplicateConditionSet(index)}
@@ -1330,8 +1354,8 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                         taxonomicGroupTypesForCondition={taxonomicGroupTypesForCondition}
                                         groupTypes={groupTypes}
                                         setConditionAggregation={setConditionAggregation}
-                                        isMixedTargetingEnabled={isMixedTargeting}
-                                        mixedGroupTypeIndex={mixedGroupTypeIndex}
+                                        isTargetingV2Enabled={isTargetingV2Enabled}
+                                        isDeviceTargeting={isDeviceTargeting}
                                         onMoveUp={() => moveConditionSetUp(index)}
                                         onMoveDown={() => moveConditionSetDown(index)}
                                         onDuplicate={() => duplicateConditionSet(index)}
@@ -1380,8 +1404,8 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                         taxonomicGroupTypesForCondition={taxonomicGroupTypesForCondition}
                                         groupTypes={groupTypes}
                                         setConditionAggregation={setConditionAggregation}
-                                        isMixedTargetingEnabled={isMixedTargeting}
-                                        mixedGroupTypeIndex={mixedGroupTypeIndex}
+                                        isTargetingV2Enabled={isTargetingV2Enabled}
+                                        isDeviceTargeting={isDeviceTargeting}
                                         onMoveUp={() => moveConditionSetUp(index)}
                                         onMoveDown={() => moveConditionSetDown(index)}
                                         onDuplicate={() => duplicateConditionSet(index)}
@@ -1412,8 +1436,8 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                 taxonomicGroupTypesForCondition={taxonomicGroupTypesForCondition}
                                 groupTypes={groupTypes}
                                 setConditionAggregation={setConditionAggregation}
-                                isMixedTargetingEnabled={isMixedTargeting}
-                                mixedGroupTypeIndex={mixedGroupTypeIndex}
+                                isTargetingV2Enabled={isTargetingV2Enabled}
+                                isDeviceTargeting={isDeviceTargeting}
                                 onMoveUp={() => moveConditionSetUp(index)}
                                 onMoveDown={() => moveConditionSetDown(index)}
                                 onDuplicate={() => duplicateConditionSet(index)}


### PR DESCRIPTION
## Problem

#57007 shipped the v2 release-conditions UI (collapses Match-by from four tiles to two — Properties / Device — when the `feature-flag-mixed-targeting` flag is enabled). It was silently reverted the next day by #57560, whose merge-conflict resolution dropped every `isTargetingV2Enabled` / `v2MatchByOptions` / `legacyMatchByOptions` reference in `FeatureFlagReleaseConditionsCollapsible.tsx`. The companion test file was spared, so CI stayed green and nobody noticed until the gating flag was rolled out and the new UI didn't appear.

## Changes

Cherry-pick of 2ac18e995b7 (the original commit from #57007) onto current master. One conflict in `selectMatchByOption` because #57338 wrapped the function body in a `LemonDialog.open` confirmation via an `applyChange` callback after #57007 landed. Resolved by placing the v2 short-circuit inside `applyChange`, so the confirmation dialog still wraps the bucketing change for existing flags.

The Jest coverage from #57007 (`drops group-scoped condition properties when v2 switches to Device mode`) is already on master — only the `.tsx` was damaged by the bad merge.

## How did you test this code?

Agent-authored. No manual browser testing performed in this session — relying on CI for typecheck and the existing Jest suite that already covers the v2 switch behavior.

## Publish to changelog?

no — this is a re-land of an already-changelogged feature.

## 🤖 Agent context

Authored by Claude Code at the user's direction. Investigation traced the missing UI to a silent revert: bisected recent commits to `FeatureFlagReleaseConditionsCollapsible.tsx`, found #57560's merge-conflict resolution had stripped the v2 code without touching the test file. Considered hand-rewriting the v2 hunks vs. cherry-picking the original — went with cherry-pick to preserve fidelity to #57007 and keep the diff reviewable against the original PR. The one conflict was in `selectMatchByOption` (LemonDialog wrapper added by #57338 post-#57007); resolved by nesting the v2 short-circuit inside the existing `applyChange` callback so the confirmation flow still triggers.