### PR TITLE
chore(hogli): accept numbers in devenv wizard exclude prompt

### DIFF
--- a/tools/hogli-commands/hogli_commands/devenv/wizard.py
+++ b/tools/hogli-commands/hogli_commands/devenv/wizard.py
@@ -195,17 +195,20 @@ def _configure_overrides(config: DevenvConfig, registry, resolver: IntentResolve
 
     click.echo("")
     click.echo(click.style("Processes that will start:", fg="cyan"))
-    for unit in units_list:
+    for i, unit in enumerate(units_list, 1):
         if unit in manual_start:
-            click.echo(f"  {unit} (manual start)")
+            click.echo(f"  {i:2}. {unit} (manual start)")
         else:
-            click.echo(f"  {unit}")
+            click.echo(f"  {i:2}. {unit}")
 
     click.echo("")
-    click.echo("Units to exclude (enter names from above, or blank to skip):")
+    click.echo("Units to exclude (enter numbers or names from above, or blank to skip):")
     exclude = click.prompt("Comma-separated", default="")
-    if exclude.strip():
-        config.exclude_units = [u.strip() for u in exclude.split(",") if u.strip()]
+    excluded, out_of_range = _parse_exclude_input(exclude, units_list)
+    for idx in out_of_range:
+        click.echo(f"  Ignoring out-of-range number: {idx}")
+    if excluded:
+        config.exclude_units = excluded
 
     # Ask about manual-start processes (those with ask_skip: true)
     ask_skip_processes = registry.get_ask_skip_processes()
@@ -215,3 +218,27 @@ def _configure_overrides(config: DevenvConfig, registry, resolver: IntentResolve
             config.enable_autostart.append(process_name)
 
     return config
+
+
+def _parse_exclude_input(raw: str, units: list[str]) -> tuple[list[str], list[int]]:
+    """Parse the 'Units to exclude' prompt input.
+
+    Returns (resolved unit names, out-of-range numbers seen). A token that
+    parses as a digit is treated as a 1-based index into `units`; anything
+    else is passed through as a name.
+    """
+    excluded: list[str] = []
+    out_of_range: list[int] = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if token.isdigit():
+            idx = int(token)
+            if 1 <= idx <= len(units):
+                excluded.append(units[idx - 1])
+            else:
+                out_of_range.append(idx)
+        else:
+            excluded.append(token)
+    return excluded, out_of_range

--- a/tools/hogli-commands/hogli_commands/devenv/wizard.py
+++ b/tools/hogli-commands/hogli_commands/devenv/wizard.py
@@ -233,7 +233,7 @@ def _parse_exclude_input(raw: str, units: list[str]) -> tuple[list[str], list[in
         token = token.strip()
         if not token:
             continue
-        if token.isdigit():
+        if token.isdecimal():
             idx = int(token)
             if 1 <= idx <= len(units):
                 excluded.append(units[idx - 1])

--- a/tools/hogli-commands/hogli_commands/tests/test_devenv.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devenv.py
@@ -12,6 +12,7 @@ import yaml
 from hogli_commands.devenv.generator import DevenvConfig, MprocsGenerator, load_devenv_config
 from hogli_commands.devenv.registry import ProcessRegistry, create_mprocs_registry
 from hogli_commands.devenv.resolver import Capability, Intent, IntentMap, IntentResolver, load_intent_map
+from hogli_commands.devenv.wizard import _parse_exclude_input
 from parameterized import parameterized
 
 
@@ -738,3 +739,28 @@ class TestPersonhogEnvInjection:
                     assert var in shell, f"{var} should be in {proc_name} shell"
                 else:
                     assert var not in shell, f"{var} should not be in {proc_name} shell"
+
+
+class TestParseExcludeInput:
+    """The 'Units to exclude' prompt accepts numbers and/or names."""
+
+    UNITS = ["backend", "docker-compose", "feature-flags", "frontend", "migrate-postgres"]
+
+    @parameterized.expand(
+        [
+            ("3", ["feature-flags"], []),
+            ("feature-flags", ["feature-flags"], []),
+            ("1,3", ["backend", "feature-flags"], []),
+            ("1, feature-flags", ["backend", "feature-flags"], []),
+            ("  3  ,  1  ", ["feature-flags", "backend"], []),
+            ("", [], []),
+            ("   ", [], []),
+            ("  ,  ,  ", [], []),
+            ("99", [], [99]),
+            ("99, feature-flags", ["feature-flags"], [99]),
+        ]
+    )
+    def test_parse(self, raw: str, expected_excluded: list[str], expected_out_of_range: list[int]) -> None:
+        excluded, out_of_range = _parse_exclude_input(raw, self.UNITS)
+        assert excluded == expected_excluded
+        assert out_of_range == expected_out_of_range

--- a/tools/hogli-commands/hogli_commands/tests/test_devenv.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devenv.py
@@ -758,6 +758,8 @@ class TestParseExcludeInput:
             ("  ,  ,  ", [], []),
             ("99", [], [99]),
             ("99, feature-flags", ["feature-flags"], [99]),
+            ("1, backend", ["backend", "backend"], []),
+            ("²", ["²"], []),
         ]
     )
     def test_parse(self, raw: str, expected_excluded: list[str], expected_out_of_range: list[int]) -> None:


### PR DESCRIPTION
## Problem

The `hogli` developer-environment setup wizard asks two questions back-to-back:

1. "Select products (comma-separated numbers, or 'all')" — accepts numbers.
2. "Units to exclude (enter names from above, or blank to skip)" — only accepted full names, even though the units were shown as a plain list.

Having to retype `migrate-behavioral-cohorts` or `personhog-replica` after just picking products by number is awkward.

## Changes

- The "Processes that will start" list is now numbered, just like the products step before it.
- The exclude prompt accepts numbers, names, or a mix (e.g. `1, feature-flags, 5`).
- Out-of-range numbers are reported and skipped rather than silently mapped to nothing.
- Parsing is extracted into `_parse_exclude_input(raw, units)` so it can be unit-tested without driving Click.

## How did you test this code?

I'm an agent — no manual testing performed.

Automated coverage added in `TestParseExcludeInput` (`tools/hogli-commands/hogli_commands/tests/test_devenv.py`) covers: single number, single name, multiple numbers, mixed numbers and names, whitespace tolerance, blank/whitespace-only input, separator-only input, out-of-range numbers, and out-of-range mixed with valid input.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7).

Implementation notes:

- First pass kept the parsing inline in `_configure_overrides` and tested it by monkeypatching `click.prompt` / `click.confirm`. The first test version hardcoded indices (`"1,3"`) which would break if the resolved unit list ever reordered.
- Second pass derived indices from `sorted(resolver.resolve(...).units)` at runtime via an `@N` template — survived reordering but became hard to read.
- Final pass: extracted the parsing into a pure `_parse_exclude_input` helper and tested it directly against a fixed `UNITS` list owned by the test. No mocking, no templates — the test owns its inputs and asserts the contract.