### PR TITLE
fix(endpoints): handle tz-aware datetime objects in materialized read

### DIFF
--- a/products/endpoints/backend/insight_transformers.py
+++ b/products/endpoints/backend/insight_transformers.py
@@ -115,34 +115,36 @@ def _extract_type_str(entry: Any) -> str | None:
 
 
 def _to_team_tz(value: Any, team_tz: "ZoneInfo | None") -> Any:
-    """Re-anchor a temporal value to team_tz so downstream strftime renders the local day.
+    """Coerce a temporal value into something downstream ``strftime`` can render.
 
-    Parquet-backed reads return DateTime columns as tz-aware UTC datetimes (or, in some
-    code paths, as ISO strings). In both cases the wall-clock is UTC, not team-tz, which
-    shifts the rendered day by the team's UTC offset. Naive values are treated as UTC;
-    aware values are converted directly. Non-temporal values pass through.
+    ISO strings are always parsed to ``datetime`` so ``.strftime()`` calls don't blow up.
+    When ``team_tz`` is given (DateTime columns), naive values are treated as UTC and
+    converted to team_tz; aware values are converted directly. When ``team_tz`` is None
+    (Date columns), the parsed value passes through unchanged. Non-temporal values pass
+    through untouched.
     """
-    if team_tz is None:
-        return value
     if isinstance(value, str):
         parsed = datetime.fromisoformat(value)
     elif isinstance(value, datetime):
         parsed = value
     else:
         return value
+    if team_tz is None:
+        return parsed
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
     return parsed.astimezone(team_tz)
 
 
 def _coerce_temporal_columns(rows: list, types: list | None, team: Team | None = None) -> None:
-    """Parse ISO strings into ``datetime`` objects for every Date/DateTime column.
+    """Parse/coerce temporal values for every Date/DateTime column.
 
-    HogQL's response pipeline stringifies all Date/DateTime values regardless of name,
-    but the insight runners call .strftime() on them. We use the ``types`` metadata to
-    find temporal columns so this works for any column name (``date``, ``timestamp``,
-    custom aliases), not just ``date``. Rows can be tuples, so we replace the row in
-    the outer list.
+    For DateTime columns, ISO strings and tz-aware UTC datetimes are re-anchored to the
+    team timezone so downstream strftime renders the correct local day. For Date columns
+    (no tz conversion needed), string values are parsed to naive ``datetime`` objects so
+    that downstream ``.strftime()`` calls succeed. We use the ``types`` metadata to find
+    temporal columns so this works for any column name (``date``, ``timestamp``, custom
+    aliases). Rows can be tuples, so we replace the row in the outer list.
     """
     if not types:
         return

--- a/products/endpoints/backend/insight_transformers.py
+++ b/products/endpoints/backend/insight_transformers.py
@@ -114,16 +114,25 @@ def _extract_type_str(entry: Any) -> str | None:
     return None
 
 
-def _parse_temporal_value(value: str, team_tz: "ZoneInfo | None") -> datetime:
-    """Parquet drops the timezone metadata from ClickHouse `DateTime('Europe/...')` columns,
-    so naive parsed values are treated as UTC and converted to team_tz before strftime.
-    Already-aware values are converted directly so the function is correct either way."""
-    parsed = datetime.fromisoformat(value)
-    if team_tz is not None:
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=UTC)
-        parsed = parsed.astimezone(team_tz)
-    return parsed
+def _to_team_tz(value: Any, team_tz: "ZoneInfo | None") -> Any:
+    """Re-anchor a temporal value to team_tz so downstream strftime renders the local day.
+
+    Parquet-backed reads return DateTime columns as tz-aware UTC datetimes (or, in some
+    code paths, as ISO strings). In both cases the wall-clock is UTC, not team-tz, which
+    shifts the rendered day by the team's UTC offset. Naive values are treated as UTC;
+    aware values are converted directly. Non-temporal values pass through.
+    """
+    if team_tz is None:
+        return value
+    if isinstance(value, str):
+        parsed = datetime.fromisoformat(value)
+    elif isinstance(value, datetime):
+        parsed = value
+    else:
+        return value
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(team_tz)
 
 
 def _coerce_temporal_columns(rows: list, types: list | None, team: Team | None = None) -> None:
@@ -154,11 +163,9 @@ def _coerce_temporal_columns(rows: list, types: list | None, team: Team | None =
             value = row[col_idx]
             convert_tz = team_tz if is_datetime else None
             if isinstance(value, list):
-                coerced: Any = [
-                    _parse_temporal_value(item, convert_tz) if isinstance(item, str) else item for item in value
-                ]
-            elif isinstance(value, str):
-                coerced = _parse_temporal_value(value, convert_tz)
+                coerced: Any = [_to_team_tz(item, convert_tz) for item in value]
+            elif isinstance(value, str | datetime):
+                coerced = _to_team_tz(value, convert_tz)
             else:
                 continue
             if new_row is None:

--- a/products/endpoints/backend/tests/test_insight_response_parity.py
+++ b/products/endpoints/backend/tests/test_insight_response_parity.py
@@ -292,6 +292,30 @@ class TestInsightResponseParity(ClickhouseTestMixin, APIBaseTest):
         assert series["days"] == ["2026-05-04", "2026-05-05", "2026-05-06"]
         assert series["labels"] == ["4-May-2026", "5-May-2026", "6-May-2026"]
 
+    def test_transform_trends_parses_date_column_strings_so_strftime_succeeds(self):
+        """Date columns (no tz conversion) must still have ISO strings parsed to datetime
+        objects — otherwise downstream strftime() raises AttributeError on the string."""
+        original_query = TrendsQuery(
+            series=[EventsNode(event="$pageview")],
+            dateRange={"date_from": "2026-05-04", "date_to": "2026-05-06"},
+        ).model_dump()
+
+        result: dict[str, Any] = {
+            "results": [(0, ["2026-05-04", "2026-05-05", "2026-05-06"], [1, 0, 2])],
+            "columns": ["__series_index", "date", "total"],
+            "types": [
+                ["__series_index", "Int64"],
+                ["date", "Array(Nullable(Date32))"],
+                ["total", "Array(Nullable(UInt64))"],
+            ],
+        }
+
+        _transform_trends(result, original_query, self.team)
+
+        series = result["results"][0]
+        assert series["days"] == ["2026-05-04", "2026-05-05", "2026-05-06"]
+        assert series["labels"] == ["4-May-2026", "5-May-2026", "6-May-2026"]
+
     # =========================================================================
     # LIFECYCLE
     # =========================================================================

--- a/products/endpoints/backend/tests/test_insight_response_parity.py
+++ b/products/endpoints/backend/tests/test_insight_response_parity.py
@@ -4,7 +4,7 @@ These tests are written TDD-style: they define the expected contract and initial
 materialized path currently returns flat HogQL data instead of rich insight-specific responses.
 """
 
-from datetime import date
+from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
@@ -227,25 +227,43 @@ class TestInsightResponseParity(ClickhouseTestMixin, APIBaseTest):
         )
         assert len(first["data"]) == 10, f"Expected 10 data points, got {len(first['data'])}"
 
-    # Each case picks parquet wall-clock UTC values that map to May 4/5/6 midnight in the
-    # team timezone — covers both UTC-ahead (Bucharest, prior day 21:00) and UTC-behind
-    # (New York, same day 04:00) offsets so the conversion direction is exercised both ways.
+    # Cases cover both timezone-offset directions (UTC-ahead, UTC-behind) and both shapes
+    # the materialized read can hand us (the CH Python client returns tz-aware UTC datetime
+    # objects; ISO strings appear when results round-trip through JSON serialization).
     @parameterized.expand(
         [
             (
-                "europe_bucharest",
+                "europe_bucharest_str",
                 "Europe/Bucharest",
                 ["2026-05-03 21:00:00.000", "2026-05-04 21:00:00.000", "2026-05-05 21:00:00.000"],
             ),
             (
-                "america_new_york",
+                "europe_bucharest_aware_dt",
+                "Europe/Bucharest",
+                [
+                    datetime(2026, 5, 3, 21, 0, tzinfo=UTC),
+                    datetime(2026, 5, 4, 21, 0, tzinfo=UTC),
+                    datetime(2026, 5, 5, 21, 0, tzinfo=UTC),
+                ],
+            ),
+            (
+                "america_new_york_str",
                 "America/New_York",
                 ["2026-05-04 04:00:00.000", "2026-05-05 04:00:00.000", "2026-05-06 04:00:00.000"],
+            ),
+            (
+                "america_new_york_aware_dt",
+                "America/New_York",
+                [
+                    datetime(2026, 5, 4, 4, 0, tzinfo=UTC),
+                    datetime(2026, 5, 5, 4, 0, tzinfo=UTC),
+                    datetime(2026, 5, 6, 4, 0, tzinfo=UTC),
+                ],
             ),
         ]
     )
     def test_transform_trends_formats_dates_in_team_timezone_at_day_boundary(
-        self, _name: str, team_timezone: str, parquet_date_strings: list[str]
+        self, _name: str, team_timezone: str, date_values: list
     ) -> None:
         self.team.timezone = team_timezone
         self.team.save()
@@ -255,10 +273,10 @@ class TestInsightResponseParity(ClickhouseTestMixin, APIBaseTest):
             dateRange={"date_from": "2026-05-04", "date_to": "2026-05-06"},
         ).model_dump()
 
-        # Shape matches what S3/parquet returns after round-trip: tz-stripped DateTime64
-        # values with millisecond precision.
+        # Shape matches what the materialized read returns: a date column whose values
+        # are either tz-aware UTC datetimes (CH Python client) or ISO strings (JSON path).
         result: dict[str, Any] = {
-            "results": [(0, parquet_date_strings, [1, 0, 2])],
+            "results": [(0, date_values, [1, 0, 2])],
             "columns": ["__series_index", "date", "total"],
             "types": [
                 ["__series_index", "Int64"],


### PR DESCRIPTION
## Problem

Follow-up to #58891. The customer-reported off-by-one day in materialized insight labels for non-UTC teams was **not** actually fixed — only the string-parsing branch of \`_coerce_temporal_columns\` was updated, but the ClickHouse Python client returns DateTime columns as tz-aware UTC \`datetime\` objects, not ISO strings. Those went through the \`else\` branch and reached \`strftime\` unchanged, still rendering the UTC day.

## Changes

Generalized the tz re-anchoring (\`_to_team_tz\`) to accept both \`str\` and \`datetime\` values. Naive values are treated as UTC; aware values are converted directly. Parameterized test now covers both shapes (string + tz-aware datetime) across both timezone-offset directions (Europe/Bucharest UTC+3, America/New_York UTC-4) — 4 cases total.

## How did you test this code?

Verified the actual shape returned by the parquet read path against a local ClickHouse parquet file (\`datetime.datetime(2026, 5, 3, 21, 0, tzinfo=<UTC>)\`), then expanded the parameterized test to cover that shape. Full \`test_insight_response_parity.py\` (15 tests) passes.

I'm an agent — no manual UI testing.

## Publish to changelog?

no

## 🤖 Agent context

The previous PR's test fed strings to the transformer and passed — but production never sees that shape. The actual return shape was verified by running a parquet round-trip experiment in local ClickHouse and inspecting what \`sync_execute\` returned, before extending the test. Lesson: when the bug surface is at a shape boundary, the test fixture has to be sampled from the real shape, not the documented/expected one.