### PR TITLE
fix(replay): cap shared-link snapshot fetches per token, not per IP

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -687,20 +687,12 @@ class ListingSustainedRateThrottle(_TierAwareReplayThrottle):
 
 
 class SharingTokenReplayThrottle(SimpleRateThrottle):
-    """Per-sharing-token throttle for replay endpoints accessed via SharingAccessToken.
-
-    Replaces the per-IP / per-team throttles for sharing-token requests: those punish
-    legitimate corporate-NAT viewers and embed users while doing little to bound a leaked
-    token (which can be replayed from arbitrary IPs anyway). Capping per token instead
-    isolates abuse to the specific shared resource, and the owning team can revoke a
-    misused token via SharingConfiguration.rotate_access_token().
-    """
+    """Per-token cap for replay endpoints reached via SharingAccessToken."""
 
     scope = "replay_sharing_token"
 
     def __init__(self) -> None:
-        # Read at instantiation so override_settings in tests (and runtime env changes
-        # after import) take effect — class-attribute capture would freeze the default.
+        # Read at instantiation so override_settings takes effect.
         self.rate = settings.REPLAY_SHARING_TOKEN_RATE
         super().__init__()
 
@@ -775,11 +767,7 @@ class SessionRecordingViewSet(
 
     def get_throttles(self):
         if isinstance(self.request.successful_authenticator, SharingAccessTokenAuthentication):
-            # Sharing-token requests are per-resource authorizations. The default
-            # tier-aware / per-IP throttles don't fit: tier rates only apply to
-            # personal API key requests (so a paid/enterprise team's embed gets free
-            # rates), and the per-IP key collides corporate-NAT viewers. Replace with
-            # a per-token cap — see SharingTokenReplayThrottle.
+            # Sharing-token requests get a per-token cap instead of per-IP / per-team.
             return [SharingTokenReplayThrottle()]
         if self.action == "list":
             return [*super().get_throttles(), ListingBurstRateThrottle(), ListingSustainedRateThrottle()]

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import json
+import time
 import struct
 import asyncio
 import builtins
@@ -65,6 +66,7 @@ from posthog.auth import (
     OAuthAccessTokenAuthentication,
     PersonalAPIKeyAuthentication,
     SharingAccessTokenAuthentication,
+    SharingPasswordProtectedAuthentication,
 )
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.cloud_utils import is_cloud
@@ -76,7 +78,14 @@ from posthog.models.activity_logging.activity_log import Detail, log_activity
 from posthog.models.comment import Comment
 from posthog.models.person.util import get_persons_mapped_by_distinct_id
 from posthog.models.team.extensions import get_or_create_team_extension
-from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle, PersonalApiKeyRateThrottle
+from posthog.models.utils import hash_key_value
+from posthog.rate_limit import (
+    ClickHouseBurstRateThrottle,
+    ClickHouseSustainedRateThrottle,
+    PersonalApiKeyRateThrottle,
+    is_rate_limit_enabled,
+    team_is_allowed_to_bypass_throttle,
+)
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 from posthog.renderers import ServerSentEventRenderer
@@ -687,7 +696,7 @@ class ListingSustainedRateThrottle(_TierAwareReplayThrottle):
 
 
 class SharingTokenReplayThrottle(SimpleRateThrottle):
-    """Per-token cap for replay endpoints reached via SharingAccessToken."""
+    """Per-token cap for replay endpoints reached via a sharing-token authenticator."""
 
     scope = "replay_sharing_token"
 
@@ -701,7 +710,19 @@ class SharingTokenReplayThrottle(SimpleRateThrottle):
         token = getattr(getattr(auth, "sharing_configuration", None), "access_token", None)
         if not token:
             return None
-        return self.cache_format % {"scope": self.scope, "ident": token}
+        # Hash the bearer token before composing the key — mirrors PersonalApiKeyRateThrottle.
+        return self.cache_format % {"scope": self.scope, "ident": hash_key_value(token)}
+
+    def allow_request(self, request, view) -> bool:
+        if not is_rate_limit_enabled(round(time.time() / 60)):
+            return True
+        team_id = PersonalApiKeyRateThrottle.safely_get_team_id_from_view(view)
+        if team_id is not None and team_is_allowed_to_bypass_throttle(team_id):
+            return True
+        if super().allow_request(request, view):
+            return True
+        SESSION_RECORDING_THROTTLED.labels(location=self.scope, auth_type="sharing_token").inc()
+        return False
 
 
 def _length_prefix_blocks(blocks: list[bytes]) -> bytes:
@@ -766,7 +787,10 @@ class SessionRecordingViewSet(
         return SessionRecording.get_or_build(session_id=self.kwargs["pk"], team=self.team)
 
     def get_throttles(self):
-        if isinstance(self.request.successful_authenticator, SharingAccessTokenAuthentication):
+        if isinstance(
+            self.request.successful_authenticator,
+            SharingAccessTokenAuthentication | SharingPasswordProtectedAuthentication,
+        ):
             # Sharing-token requests get a per-token cap instead of per-IP / per-team.
             return [SharingTokenReplayThrottle()]
         if self.action == "list":

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -39,6 +39,7 @@ from rest_framework.mixins import UpdateModelMixin
 from rest_framework.renderers import JSONRenderer
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.throttling import SimpleRateThrottle
 from rest_framework.utils.encoders import JSONEncoder
 from temporalio.service import RPCError, RPCStatusCode
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
@@ -685,6 +686,32 @@ class ListingSustainedRateThrottle(_TierAwareReplayThrottle):
         return listing_rates()
 
 
+class SharingTokenReplayThrottle(SimpleRateThrottle):
+    """Per-sharing-token throttle for replay endpoints accessed via SharingAccessToken.
+
+    Replaces the per-IP / per-team throttles for sharing-token requests: those punish
+    legitimate corporate-NAT viewers and embed users while doing little to bound a leaked
+    token (which can be replayed from arbitrary IPs anyway). Capping per token instead
+    isolates abuse to the specific shared resource, and the owning team can revoke a
+    misused token via SharingConfiguration.rotate_access_token().
+    """
+
+    scope = "replay_sharing_token"
+
+    def __init__(self) -> None:
+        # Read at instantiation so override_settings in tests (and runtime env changes
+        # after import) take effect — class-attribute capture would freeze the default.
+        self.rate = settings.REPLAY_SHARING_TOKEN_RATE
+        super().__init__()
+
+    def get_cache_key(self, request, view) -> str | None:
+        auth = request.successful_authenticator
+        token = getattr(getattr(auth, "sharing_configuration", None), "access_token", None)
+        if not token:
+            return None
+        return self.cache_format % {"scope": self.scope, "ident": token}
+
+
 def _length_prefix_blocks(blocks: list[bytes]) -> bytes:
     chunks = []
     for block in blocks:
@@ -747,6 +774,13 @@ class SessionRecordingViewSet(
         return SessionRecording.get_or_build(session_id=self.kwargs["pk"], team=self.team)
 
     def get_throttles(self):
+        if isinstance(self.request.successful_authenticator, SharingAccessTokenAuthentication):
+            # Sharing-token requests are per-resource authorizations. The default
+            # tier-aware / per-IP throttles don't fit: tier rates only apply to
+            # personal API key requests (so a paid/enterprise team's embed gets free
+            # rates), and the per-IP key collides corporate-NAT viewers. Replace with
+            # a per-token cap — see SharingTokenReplayThrottle.
+            return [SharingTokenReplayThrottle()]
         if self.action == "list":
             return [*super().get_throttles(), ListingBurstRateThrottle(), ListingSustainedRateThrottle()]
         return super().get_throttles()

--- a/posthog/session_recordings/test/test_session_recording_throttle.py
+++ b/posthog/session_recordings/test/test_session_recording_throttle.py
@@ -5,14 +5,19 @@ from django.core.cache import cache
 from django.test import override_settings
 
 from parameterized import parameterized
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 
-from posthog.auth import PersonalAPIKeyAuthentication
+from posthog.auth import PersonalAPIKeyAuthentication, SharingAccessTokenAuthentication
+from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.session_recordings.session_recording_api import (
     LISTING_RATES,
     REPLAY_TIER_CACHE_TTL_SECONDS,
     SNAPSHOT_DEFAULT_TIER,
     SNAPSHOT_RATES,
     ListingBurstRateThrottle,
+    SessionRecordingViewSet,
+    SharingTokenReplayThrottle,
     SnapshotsBurstRateThrottle,
     SnapshotsSustainedRateThrottle,
     get_cached_org_tier,
@@ -295,3 +300,105 @@ class TestSnapshotAndListingThrottlesUseIndependentRates(BaseTest):
         assert listing_throttle._get_rates() == listing_rates()
         assert snapshot_throttle._get_rates() == snapshot_rates()
         assert listing_throttle._get_rates() == listing_rates()
+
+
+def _fake_sharing_token_request(token: str):
+    auth = SharingAccessTokenAuthentication()
+    auth.sharing_configuration = SharingConfiguration(access_token=token, enabled=True)
+    return type("FakeRequest", (), {"META": {}, "auth": None, "successful_authenticator": auth})()
+
+
+class TestSharingTokenReplayThrottle(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        cache.clear()
+
+    def test_cache_key_uses_token_not_ip(self) -> None:
+        throttle = SharingTokenReplayThrottle()
+
+        key = throttle.get_cache_key(_fake_sharing_token_request("token-abc"), view=None)
+
+        assert key is not None
+        assert "token-abc" in key
+        assert throttle.scope in key
+
+    def test_different_tokens_have_different_cache_keys(self) -> None:
+        throttle = SharingTokenReplayThrottle()
+
+        key_a = throttle.get_cache_key(_fake_sharing_token_request("token-a"), view=None)
+        key_b = throttle.get_cache_key(_fake_sharing_token_request("token-b"), view=None)
+
+        assert key_a != key_b
+
+    def test_same_token_from_different_requests_shares_one_bucket(self) -> None:
+        throttle = SharingTokenReplayThrottle()
+
+        key_first = throttle.get_cache_key(_fake_sharing_token_request("token-shared"), view=None)
+        key_second = throttle.get_cache_key(_fake_sharing_token_request("token-shared"), view=None)
+
+        assert key_first == key_second
+
+    def test_returns_none_cache_key_when_no_sharing_configuration(self) -> None:
+        # Defensive guard — the viewset only routes sharing-token requests here, but if
+        # something else slips through we should not throttle on a NoneType token.
+        throttle = SharingTokenReplayThrottle()
+        request = type("FakeRequest", (), {"META": {}, "auth": None, "successful_authenticator": None})()
+
+        assert throttle.get_cache_key(request, view=None) is None
+
+    def test_rate_reads_from_settings_default(self) -> None:
+        throttle = SharingTokenReplayThrottle()
+
+        # The default exposed through django settings; this guards against silently
+        # changing the default in a way that drops the cap.
+        assert throttle.rate == "600/minute"
+
+    @override_settings(REPLAY_SHARING_TOKEN_RATE="42/minute")
+    def test_rate_is_configurable_via_settings(self) -> None:
+        throttle = SharingTokenReplayThrottle()
+
+        assert throttle.rate == "42/minute"
+
+
+class TestSessionRecordingViewSetThrottleSelection(BaseTest):
+    def _viewset(self, action: str, authenticator) -> SessionRecordingViewSet:
+        viewset = SessionRecordingViewSet()
+        viewset.action = action
+        request = Request(APIRequestFactory().get("/"))
+        request._authenticator = authenticator  # read-only @property in DRF
+        viewset.request = request  # ty: ignore[invalid-assignment]
+        return viewset
+
+    def test_sharing_token_requests_only_use_per_token_throttle(self) -> None:
+        auth = SharingAccessTokenAuthentication()
+        auth.sharing_configuration = SharingConfiguration(access_token="tok", enabled=True)
+        viewset = self._viewset(action="snapshots", authenticator=auth)
+
+        throttles = viewset.get_throttles()
+
+        assert len(throttles) == 1
+        assert isinstance(throttles[0], SharingTokenReplayThrottle)
+
+    def test_sharing_token_on_list_does_not_include_listing_throttles(self) -> None:
+        # `list` is not in sharing_enabled_actions but defence-in-depth: even if a
+        # sharing-token request reaches here, the per-IP listing throttles shouldn't
+        # apply — the sharing-token throttle is the single source of truth.
+        auth = SharingAccessTokenAuthentication()
+        auth.sharing_configuration = SharingConfiguration(access_token="tok", enabled=True)
+        viewset = self._viewset(action="list", authenticator=auth)
+
+        throttles = viewset.get_throttles()
+
+        assert all(not isinstance(t, ListingBurstRateThrottle) for t in throttles)
+        assert any(isinstance(t, SharingTokenReplayThrottle) for t in throttles)
+
+    def test_non_sharing_requests_keep_default_throttles(self) -> None:
+        viewset = self._viewset(action="retrieve", authenticator=PersonalAPIKeyAuthentication())
+
+        throttles = viewset.get_throttles()
+
+        assert not any(isinstance(t, SharingTokenReplayThrottle) for t in throttles)

--- a/posthog/session_recordings/test/test_session_recording_throttle.py
+++ b/posthog/session_recordings/test/test_session_recording_throttle.py
@@ -395,8 +395,10 @@ class TestSharingTokenReplayThrottle(BaseTest):
         for _ in range(10_000):
             assert throttle.allow_request(_fake_sharing_token_request("token"), view=view) is True
 
+    @patch("posthog.session_recordings.session_recording_api.is_rate_limit_enabled", return_value=True)
     @patch("posthog.session_recordings.session_recording_api.team_is_allowed_to_bypass_throttle", return_value=True)
-    def test_allow_request_short_circuits_for_bypass_listed_team(self, _mock) -> None:
+    def test_allow_request_short_circuits_for_bypass_listed_team(self, _mock_bypass, _mock_enabled) -> None:
+        # Without enabling the kill switch, the test would short-circuit on it and never exercise bypass.
         throttle = SharingTokenReplayThrottle()
         view = type("FakeView", (), {"team_id": 7})()
 

--- a/posthog/session_recordings/test/test_session_recording_throttle.py
+++ b/posthog/session_recordings/test/test_session_recording_throttle.py
@@ -343,8 +343,7 @@ class TestSharingTokenReplayThrottle(BaseTest):
         assert key_first == key_second
 
     def test_returns_none_cache_key_when_no_sharing_configuration(self) -> None:
-        # Defensive guard — the viewset only routes sharing-token requests here, but if
-        # something else slips through we should not throttle on a NoneType token.
+        # Defensive guard against misrouted requests.
         throttle = SharingTokenReplayThrottle()
         request = type("FakeRequest", (), {"META": {}, "auth": None, "successful_authenticator": None})()
 
@@ -353,8 +352,6 @@ class TestSharingTokenReplayThrottle(BaseTest):
     def test_rate_reads_from_settings_default(self) -> None:
         throttle = SharingTokenReplayThrottle()
 
-        # The default exposed through django settings; this guards against silently
-        # changing the default in a way that drops the cap.
         assert throttle.rate == "600/minute"
 
     @override_settings(REPLAY_SHARING_TOKEN_RATE="42/minute")
@@ -369,7 +366,7 @@ class TestSessionRecordingViewSetThrottleSelection(BaseTest):
         viewset = SessionRecordingViewSet()
         viewset.action = action
         request = Request(APIRequestFactory().get("/"))
-        request._authenticator = authenticator  # read-only @property in DRF
+        request._authenticator = authenticator  # type: ignore[attr-defined]  # backs read-only @property
         viewset.request = request  # ty: ignore[invalid-assignment]
         return viewset
 
@@ -384,9 +381,7 @@ class TestSessionRecordingViewSetThrottleSelection(BaseTest):
         assert isinstance(throttles[0], SharingTokenReplayThrottle)
 
     def test_sharing_token_on_list_does_not_include_listing_throttles(self) -> None:
-        # `list` is not in sharing_enabled_actions but defence-in-depth: even if a
-        # sharing-token request reaches here, the per-IP listing throttles shouldn't
-        # apply — the sharing-token throttle is the single source of truth.
+        # Defence in depth: `list` isn't sharing-enabled, but if it ever is, the per-token cap must be the only throttle.
         auth = SharingAccessTokenAuthentication()
         auth.sharing_configuration = SharingConfiguration(access_token="tok", enabled=True)
         viewset = self._viewset(action="list", authenticator=auth)

--- a/posthog/session_recordings/test/test_session_recording_throttle.py
+++ b/posthog/session_recordings/test/test_session_recording_throttle.py
@@ -8,8 +8,13 @@ from parameterized import parameterized
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
-from posthog.auth import PersonalAPIKeyAuthentication, SharingAccessTokenAuthentication
+from posthog.auth import (
+    PersonalAPIKeyAuthentication,
+    SharingAccessTokenAuthentication,
+    SharingPasswordProtectedAuthentication,
+)
 from posthog.models.sharing_configuration import SharingConfiguration
+from posthog.models.utils import hash_key_value
 from posthog.session_recordings.session_recording_api import (
     LISTING_RATES,
     REPLAY_TIER_CACHE_TTL_SECONDS,
@@ -302,8 +307,15 @@ class TestSnapshotAndListingThrottlesUseIndependentRates(BaseTest):
         assert listing_throttle._get_rates() == listing_rates()
 
 
-def _fake_sharing_token_request(token: str):
-    auth = SharingAccessTokenAuthentication()
+def _counter_value(location: str, auth_type: str) -> float:
+    from posthog.session_recordings.session_recording_api import SESSION_RECORDING_THROTTLED
+
+    sample = SESSION_RECORDING_THROTTLED.labels(location=location, auth_type=auth_type)
+    return sample._value.get()  # prometheus_client's internal counter accessor
+
+
+def _fake_sharing_token_request(token: str, auth_cls: type = SharingAccessTokenAuthentication):
+    auth = auth_cls()
     auth.sharing_configuration = SharingConfiguration(access_token=token, enabled=True)
     return type("FakeRequest", (), {"META": {}, "auth": None, "successful_authenticator": auth})()
 
@@ -317,13 +329,15 @@ class TestSharingTokenReplayThrottle(BaseTest):
         super().tearDown()
         cache.clear()
 
-    def test_cache_key_uses_token_not_ip(self) -> None:
+    def test_cache_key_uses_hashed_token_not_raw(self) -> None:
+        # Raw bearer tokens must never appear in cache keys (Redis MONITOR / log leakage).
         throttle = SharingTokenReplayThrottle()
 
         key = throttle.get_cache_key(_fake_sharing_token_request("token-abc"), view=None)
 
         assert key is not None
-        assert "token-abc" in key
+        assert "token-abc" not in key
+        assert hash_key_value("token-abc") in key
         assert throttle.scope in key
 
     def test_different_tokens_have_different_cache_keys(self) -> None:
@@ -341,6 +355,19 @@ class TestSharingTokenReplayThrottle(BaseTest):
         key_second = throttle.get_cache_key(_fake_sharing_token_request("token-shared"), view=None)
 
         assert key_first == key_second
+
+    def test_password_protected_auth_shares_bucket_with_access_token_auth(self) -> None:
+        # Both authenticators expose `sharing_configuration.access_token` — same recording, same bucket.
+        throttle = SharingTokenReplayThrottle()
+
+        key_access = throttle.get_cache_key(
+            _fake_sharing_token_request("token-x", SharingAccessTokenAuthentication), view=None
+        )
+        key_password = throttle.get_cache_key(
+            _fake_sharing_token_request("token-x", SharingPasswordProtectedAuthentication), view=None
+        )
+
+        assert key_access == key_password
 
     def test_returns_none_cache_key_when_no_sharing_configuration(self) -> None:
         # Defensive guard against misrouted requests.
@@ -360,6 +387,37 @@ class TestSharingTokenReplayThrottle(BaseTest):
 
         assert throttle.rate == "42/minute"
 
+    @patch("posthog.session_recordings.session_recording_api.is_rate_limit_enabled", return_value=False)
+    def test_allow_request_short_circuits_when_kill_switch_off(self, _mock) -> None:
+        throttle = SharingTokenReplayThrottle()
+        view = type("FakeView", (), {"team_id": 1})()
+
+        for _ in range(10_000):
+            assert throttle.allow_request(_fake_sharing_token_request("token"), view=view) is True
+
+    @patch("posthog.session_recordings.session_recording_api.team_is_allowed_to_bypass_throttle", return_value=True)
+    def test_allow_request_short_circuits_for_bypass_listed_team(self, _mock) -> None:
+        throttle = SharingTokenReplayThrottle()
+        view = type("FakeView", (), {"team_id": 7})()
+
+        for _ in range(10_000):
+            assert throttle.allow_request(_fake_sharing_token_request("token"), view=view) is True
+
+    @patch("posthog.session_recordings.session_recording_api.is_rate_limit_enabled", return_value=True)
+    @override_settings(REPLAY_SHARING_TOKEN_RATE="2/minute")
+    def test_allow_request_emits_throttled_counter_on_rejection(self, _mock) -> None:
+        throttle = SharingTokenReplayThrottle()
+        view = type("FakeView", (), {"team_id": 1})()
+        before = _counter_value("replay_sharing_token", "sharing_token")
+
+        # Burn the bucket then attempt one more — only the rejected one bumps the counter.
+        for _ in range(2):
+            throttle.allow_request(_fake_sharing_token_request("token-counted"), view=view)
+        throttle.allow_request(_fake_sharing_token_request("token-counted"), view=view)
+
+        after = _counter_value("replay_sharing_token", "sharing_token")
+        assert after - before == 1
+
 
 class TestSessionRecordingViewSetThrottleSelection(BaseTest):
     def _viewset(self, action: str, authenticator) -> SessionRecordingViewSet:
@@ -370,8 +428,14 @@ class TestSessionRecordingViewSetThrottleSelection(BaseTest):
         viewset.request = request  # ty: ignore[invalid-assignment]
         return viewset
 
-    def test_sharing_token_requests_only_use_per_token_throttle(self) -> None:
-        auth = SharingAccessTokenAuthentication()
+    @parameterized.expand(
+        [
+            ("access_token", SharingAccessTokenAuthentication),
+            ("password_protected", SharingPasswordProtectedAuthentication),
+        ]
+    )
+    def test_sharing_token_requests_only_use_per_token_throttle(self, _name: str, auth_cls: type) -> None:
+        auth = auth_cls()
         auth.sharing_configuration = SharingConfiguration(access_token="tok", enabled=True)
         viewset = self._viewset(action="snapshots", authenticator=auth)
 

--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -37,9 +37,5 @@ LISTING_RATE_PAID_SUSTAINED = get_from_env("LISTING_RATE_PAID_SUSTAINED", "300/h
 LISTING_RATE_ENTERPRISE_BURST = get_from_env("LISTING_RATE_ENTERPRISE_BURST", "100/minute")
 LISTING_RATE_ENTERPRISE_SUSTAINED = get_from_env("LISTING_RATE_ENTERPRISE_SUSTAINED", "400/hour")
 
-# Per-token throttle for replay endpoints accessed via a SharingAccessToken.
-# Sharing tokens are per-resource authorizations, so the cap is keyed by token
-# rather than IP — corporate-NAT viewers and embed users sharing one IP don't
-# collide on the same bucket, but a leaked token still has a defined runaway
-# cap. The owning team can revoke a misused token via rotate_access_token().
+# Per-token cap for replay endpoints reached via a SharingAccessToken.
 REPLAY_SHARING_TOKEN_RATE = get_from_env("REPLAY_SHARING_TOKEN_RATE", "600/minute")

--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -36,3 +36,10 @@ LISTING_RATE_PAID_BURST = get_from_env("LISTING_RATE_PAID_BURST", "60/minute")
 LISTING_RATE_PAID_SUSTAINED = get_from_env("LISTING_RATE_PAID_SUSTAINED", "300/hour")
 LISTING_RATE_ENTERPRISE_BURST = get_from_env("LISTING_RATE_ENTERPRISE_BURST", "100/minute")
 LISTING_RATE_ENTERPRISE_SUSTAINED = get_from_env("LISTING_RATE_ENTERPRISE_SUSTAINED", "400/hour")
+
+# Per-token throttle for replay endpoints accessed via a SharingAccessToken.
+# Sharing tokens are per-resource authorizations, so the cap is keyed by token
+# rather than IP — corporate-NAT viewers and embed users sharing one IP don't
+# collide on the same bucket, but a leaked token still has a defined runaway
+# cap. The owning team can revoke a misused token via rotate_access_token().
+REPLAY_SHARING_TOKEN_RATE = get_from_env("REPLAY_SHARING_TOKEN_RATE", "600/minute")


### PR DESCRIPTION
## Problem

Replay endpoints reached via a sharing-token authenticator get rate-limited at free-tier rates per IP, regardless of the team's plan.

- `_TierAwareReplayThrottle` only applies tier rates for personal-API-key requests; sharing-token requests stay on `SNAPSHOT_RATES["free"]` (12/min, 60/hour).
- The cache key falls through to the client IP, so corporate-NAT and embed viewers collide. A single recording's player fires one request per block, so any session with more than ~12 blocks 429s on its own.

## Changes

- New `SharingTokenReplayThrottle`, default `600/minute` (configurable via `REPLAY_SHARING_TOKEN_RATE`). The cap is **per token, cluster-wide** (shared Redis cache).
- Cache key is the SHA-256 of the access token (`hash_key_value`), mirroring `PersonalApiKeyRateThrottle` — the raw bearer never lands in cache keys.
- Honors `is_rate_limit_enabled` (global kill switch) and `team_is_allowed_to_bypass_throttle` (allow-list), and emits the existing `SESSION_RECORDING_THROTTLED` Prometheus counter on rejection.
- `SessionRecordingViewSet.get_throttles` swaps in `[SharingTokenReplayThrottle()]` for both `SharingAccessTokenAuthentication` and `SharingPasswordProtectedAuthentication` (the router wires both for sharing-enabled actions).

`SharingConfiguration.rotate_access_token()` remains the break-glass for a leaked link.

## How did you test this code?

Agent-authored — automated tests only.

`hogli test posthog/session_recordings/test/test_session_recording_throttle.py`: all 55 tests pass, including new coverage for the hashed cache key, both auth classes sharing one bucket, the kill switch, the bypass-allowlist, and the counter increment on rejection.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Authored via Claude Code. Investigation traced a customer's 429s on the embed path to `/snapshots/` under `snapshots_burst`, with per-IP + free-tier-default behavior independent of the team's tier. Considered (and rejected) bumping `SNAPSHOT_RATE_FREE_BURST` env-wide (wrong blast radius) and adding the team to `RATE_LIMITING_ALLOW_LIST_TEAMS` (works as hotfix, doesn't fix the underlying mismatch). The first push of this branch missed the `SharingPasswordProtectedAuthentication` branch and used the raw token in the cache key — both addressed in the second commit after a Claude+Codex dual review.