### PR TITLE
fix: Imprve personless distinct id query performance

### DIFF
--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -1,4 +1,13 @@
 # serializer version: 1
+# name: TestTeamAPI.test_delete_bulky_postgres_data
+  '''
+  DELETE
+  FROM "posthog_persondistinctid"
+  WHERE ("team_id",
+         "id") IN ((1,
+                    2)/* ... */)
+  '''
+# ---
 # name: TestTeamAPI.test_delete_bulky_postgres_data.1
   '''
   DELETE

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -1,13 +1,4 @@
 # serializer version: 1
-# name: TestTeamAPI.test_delete_bulky_postgres_data
-  '''
-  DELETE
-  FROM "posthog_persondistinctid"
-  WHERE ("team_id",
-         "id") IN ((1,
-                    2)/* ... */)
-  '''
-# ---
 # name: TestTeamAPI.test_delete_bulky_postgres_data.1
   '''
   DELETE

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -78,18 +78,19 @@ def _raw_delete_personless_distinct_ids_for_team(team_id: int, batch_size: int =
 
     db_alias = router.db_for_write(PersonlessDistinctId)
     db_connection = connections[db_alias]
+    table_name = PersonlessDistinctId._meta.db_table
 
     while True:
         with db_connection.cursor() as cursor:
             cursor.execute(
-                """
+                f"""
                 WITH deletion_candidates AS (
                     SELECT ctid
-                    FROM posthog_personlessdistinctid
+                    FROM {table_name}
                     WHERE team_id = %s
                     LIMIT %s
                 )
-                DELETE FROM posthog_personlessdistinctid p
+                DELETE FROM {table_name} p
                 USING deletion_candidates d
                 WHERE p.ctid = d.ctid
                 """,  # nosemgrep: no-direct-persons-db-orm

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -29,7 +29,6 @@ def delete_bulky_postgres_data(team_ids: list[int]):
     from posthog.models.feature_flag.feature_flag import FeatureFlagHashKeyOverride
     from posthog.models.file_system.file_system_view_log import FileSystemViewLog
     from posthog.models.insight_caching_state import InsightCachingState
-    from posthog.models.person import PersonlessDistinctId
 
     from products.data_modeling.backend.models import Edge, Node
     from products.early_access_features.backend.models import EarlyAccessFeature
@@ -43,7 +42,8 @@ def delete_bulky_postgres_data(team_ids: list[int]):
     _raw_delete(FileSystemViewLog.objects.filter(team_id__in=team_ids))
 
     _raw_delete(EarlyAccessFeature.objects.filter(team_id__in=team_ids))
-    _raw_delete_batch(PersonlessDistinctId.objects.filter(team_id__in=team_ids))  # nosemgrep: no-direct-persons-db-orm
+    for team_id in team_ids:
+        _raw_delete_personless_distinct_ids_for_team(team_id)
     _raw_delete(ErrorTrackingIssueFingerprintV2.objects.filter(team_id__in=team_ids))
 
     # Get cohort_ids from the default database first to avoid cross-database join
@@ -61,6 +61,46 @@ def delete_bulky_postgres_data(team_ids: list[int]):
     _delete_persons_for_teams(team_ids)
 
     _raw_delete(InsightCachingState.objects.filter(team_id__in=team_ids))
+
+
+def _raw_delete_personless_distinct_ids_for_team(team_id: int, batch_size: int = 10000) -> None:
+    """Delete posthog_personlessdistinctid rows for a single team in batches.
+
+    Uses a CTE + ctid pattern so each batch is one statement: the inner SELECT
+    streams ctids from the (team_id, distinct_id) unique index and the outer
+    DELETE targets heap tuples directly, avoiding a per-row primary key lookup.
+    Each batch runs in its own autocommit statement so row locks release between
+    batches and autovacuum can keep up.
+    """
+    from django.db import connections, router
+
+    from posthog.models.person import PersonlessDistinctId
+
+    db_alias = router.db_for_write(PersonlessDistinctId)
+    db_connection = connections[db_alias]
+
+    while True:
+        with db_connection.cursor() as cursor:
+            cursor.execute(
+                """
+                WITH deletion_candidates AS (
+                    SELECT ctid
+                    FROM posthog_personlessdistinctid
+                    WHERE team_id = %s
+                    LIMIT %s
+                )
+                DELETE FROM posthog_personlessdistinctid p
+                USING deletion_candidates d
+                WHERE p.ctid = d.ctid
+                """,  # nosemgrep: no-direct-persons-db-orm
+                [team_id, batch_size],
+            )
+            deleted = cursor.rowcount
+
+        if deleted < batch_size:
+            break
+
+        time.sleep(0.1)
 
 
 def _delete_persons_for_teams(team_ids: list[int]) -> None:


### PR DESCRIPTION
## Problem

`delete_bulky_postgres_data` deletes `posthog_personlessdistinctid` rows in batches via the shared `_raw_delete_batch` helper, which does two roundtrips per batch (a `values_list` SELECT then a composite-tuple `DELETE … WHERE ("team_id", "id") IN ((…))`). On large teams this is slow: the planner picks a sequential or bitmap scan, and the outer DELETE pays a per-row primary-key lookup on top of the index maintenance work. Measured throughput on a real team was ~400 rows/sec.

## Changes

Add a dedicated `_raw_delete_personless_distinct_ids_for_team` helper that deletes via a single statement per batch:

```sql
WITH deletion_candidates AS (
    SELECT ctid
    FROM posthog_personlessdistinctid
    WHERE team_id = %s
    LIMIT %s
)
DELETE FROM posthog_personlessdistinctid p
USING deletion_candidates d
WHERE p.ctid = d.ctid
```

- The CTE streams `ctid`s from the `(team_id, distinct_id)` unique index and the outer DELETE targets heap tuples directly, skipping the PK lookup.
- `delete_bulky_postgres_data` now loops per `team_id` using this helper instead of going through `_raw_delete_batch`.
- The shared `_raw_delete_batch` is left untouched so the partitioned `Person` / `PersonDistinctId` ORM fallback path is unaffected.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
