### PR TITLE
feat(experiments): declutter metric header with ellipsis menu

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4115,17 +4115,17 @@ snapshots:
     scenes-app-experiments--draft-experiment--light:
         hash: v1.k794b7964.70dc18be765207610c6040e3f2c831c2c5ebaa1726a330e293fa8c00d49a5cd9.rPoZm0K5sQEKk_6Br3PLSxWDdh9BKzhs7EHtpqP54KM
     scenes-app-experiments--experiment-asymmetric-intervals--dark:
-        hash: v1.k794b7964.1dd58adf303e4a00d3f8fb6c479ecf9390794dc114802d9928a4281095fbccaf.ZJLgIsceVDD5miInK-C7tFnQX2OUa05xm_byQnOqHg0
+        hash: v1.k794b7964.cba7d55aa1a7d4b310d210118cb9a9d644c97a522cd855e08014cb8ea20de373.DRZgKpNgQ9kDl9NwVIrDfa29EUAo8hkhgNMR3PWX204
     scenes-app-experiments--experiment-asymmetric-intervals--light:
-        hash: v1.k794b7964.098e8d7f7435b5ce4c01d0c6f224fb433c6bc4c54cc35b9bd849ba14c19ff765.mAqmiUY5_BUgBQ2N31Cm0jxA30CGP3yDFEjddMWOo8s
+        hash: v1.k794b7964.10a29cbd091d468255f6f9daaea63c562fbe79b6898a4036d1ef6aa84447f5d5.bDwdfY2wuzA1aTOs3L2icCegZbZu9fiTVbIxXJSGCl8
     scenes-app-experiments--experiment-frequentist-five-variants--dark:
-        hash: v1.k794b7964.bb7669eca3f0f9026dfef6a5e5f7b6b7cf2d53ce1279c8a4ba4ebe333d53d527.jOoWwE3-HRtf8w8xYn60kte9UPJcK0qn_IsJzKz0NOM
+        hash: v1.k794b7964.09d23fd44208249b4fd1555fcbdb941118bc2825dc7142bd6ba96335c9cb8f32.AipSypBKnQguXtQO9tkCsdO9IVj-_0bHqjCnFe0BE-U
     scenes-app-experiments--experiment-frequentist-five-variants--light:
         hash: v1.k794b7964.3c0bbbedd69ecc4c499dd0639d1f0a6943c4fb8edb471d9c792affe1f2859fae.Q0RJJMyRpPWhrkDJyEmGuWREjFzxDUscM-NRNgh4Gyc
     scenes-app-experiments--experiment-frequentist-two-variants--dark:
-        hash: v1.k794b7964.6dfe0080ac5f69bea9410456ff7f9bb219ed86e892185d75dae425a72b2c8030.GqlFGcvmuVTbPTX7u1XpuZiWdkL5PUZIpjD4Zx9RJMM
+        hash: v1.k794b7964.e09386503a4afe1b35afea46561b001c53fe4a0b33462b38411cf946062964d9.Wt1HdAZFHB1UJRhWLISfuBT-PnBvc6KPpc3VT1D4kF4
     scenes-app-experiments--experiment-frequentist-two-variants--light:
-        hash: v1.k794b7964.ab005706e454437028947967ceea50b815755356414a4c9ce7db4bab243e8e6b.K4P8Zu8ZQvPldTsJZZ2-fiY0BCBjyh7UJJaPq4lbFGg
+        hash: v1.k794b7964.8ee2590f5129b8a545e1f0029bacad4b43b58d943c207424f7cff0908b42bab5.Cax-2Fdq70E_grVVDy_Sa5OSmss7McsfaIVRFV4Vmfk
     scenes-app-experiments--experiment-with-funnel-metric--dark:
         hash: v1.k794b7964.6317a572fc1697c9b77b79c593478834b68f83d21ddd8fb8713ec858af2042b1._rk-6L1TCi63xSzlU3MdORcD7t0MvVeVmQE9M116Gi4
     scenes-app-experiments--experiment-with-funnel-metric--light:
@@ -4143,13 +4143,13 @@ snapshots:
     scenes-app-experiments--experiment-with-mean-metric--light:
         hash: v1.k794b7964.d36342fca8103ad432d47ece5b57e448c5e1986e14b2ba4254b24ae3d668c3d7.cuV6yg9spCNMj3jEAnGOqs1NP9T_94QNl8TvKp9yW04
     scenes-app-experiments--experiment-with-multiple-metrics--dark:
-        hash: v1.k794b7964.064066681e33e6c84552a86cf11e823b5cd09949b48aa5b6fb86b4a9f108bc60._fYo6xkW_Dsxlu8OTjPSNpLDNRAskksQSJVit6Tmt84
+        hash: v1.k794b7964.95fd3aff7460e851d88e3dd8d9dfa5c6023b715f7cda2c849cefb5c361ec9559.ZIwd8rMpnJ1bmP1Cd2ahFz2rJbmSmbLB5z5DJF3vWuA
     scenes-app-experiments--experiment-with-multiple-metrics--light:
-        hash: v1.k794b7964.262e1639d22e818a7bb59937c4c477c98af1bef589552ff4d9e4a24825970e32.tC2wcNKr8WY9EZ3Sew8s2kzP6eztY4V9GJTMyIFT7hs
+        hash: v1.k794b7964.606b4610f2e035fe660f6b8cb89b88d6f9757c5abe6117a0e7cfa84432fab17e.dNHaFfFq68PedICOmTDCzx6rCMc-MbG694Xc_YYAGbw
     scenes-app-experiments--experiment-with-multiple-metrics-reordered--dark:
-        hash: v1.k794b7964.9f53015606373d5dc92d5b0546a4c598e5200ff067524cf1100695bff63a5c05.CNhBkDhynuFNyiZEe198GLL-ecCbdgazoIINiiIppoY
+        hash: v1.k794b7964.e18320b97b008a57060912dd3717b22426cc24000aac9503e8e3a007fe5806c0.8qbDFm5IEyL-a3Vh7W9EkSfWDqOplQHIAFHuX9x3elU
     scenes-app-experiments--experiment-with-multiple-metrics-reordered--light:
-        hash: v1.k794b7964.8d70390de3abc305407a96f356f95bc5eb080376100461ef56499767c4669ef5.7hJ5OIMfWgb-1ZVW6sPuDnmZXnT7AFCzHLngxZYNE-4
+        hash: v1.k794b7964.5e3fb29456b6d37dd4940ed634289719e528a383c73d1da2105107de24897ef4.dTifbyJDGSHo6uJNXII3aE6j3QLfDvDHHhNrOmdUlzQ
     scenes-app-experiments--experiment-with-ratio-metric--dark:
         hash: v1.k794b7964.d608a86d70061c4e1b5f9681c35d2c095b8dd467b8748cbf0b1a5b9eea15aa87.OdZx92WCi32HUJ7LEQu7rLm2TfnL2PFMgjQQIM6264U
     scenes-app-experiments--experiment-with-ratio-metric--light:

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -477,6 +477,7 @@ interface MetricRowGroupProps {
     isLastMetric: boolean
     isAlternatingRow: boolean
     onDuplicateMetric?: () => void
+    onDeleteMetric?: () => void
     onBreakdownChange: (breakdown: Breakdown) => void
     onRemoveBreakdown: (index: number) => void
     error?: any
@@ -497,6 +498,7 @@ export function MetricRowGroup({
     isLastMetric,
     isAlternatingRow,
     onDuplicateMetric,
+    onDeleteMetric,
     onBreakdownChange,
     onRemoveBreakdown,
     error,
@@ -701,6 +703,7 @@ export function MetricRowGroup({
                             isPrimaryMetric={!isSecondary}
                             experiment={experiment}
                             onDuplicateMetricClick={() => onDuplicateMetric?.()}
+                            onDeleteMetricClick={onDeleteMetric ? () => onDeleteMetric() : undefined}
                             onBreakdownChange={onBreakdownChange}
                         />
                     </td>
@@ -809,6 +812,7 @@ export function MetricRowGroup({
                         isPrimaryMetric={!isSecondary}
                         experiment={experiment}
                         onDuplicateMetricClick={() => onDuplicateMetric?.()}
+                        onDeleteMetricClick={onDeleteMetric ? () => onDeleteMetric() : undefined}
                         onBreakdownChange={onBreakdownChange}
                     />
                 </td>

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -35,8 +35,14 @@ export function MetricsTable({
     showDetailsModal = true,
 }: MetricsTableProps): JSX.Element {
     const { experiment, exposuresLoading } = useValues(experimentLogic)
-    const { duplicateMetric, updateExperimentMetrics, updateMetricBreakdown, removeMetricBreakdown } =
-        useActions(experimentLogic)
+    const {
+        duplicateMetric,
+        updateExperimentMetrics,
+        updateMetricBreakdown,
+        removeMetricBreakdown,
+        removeMetric,
+        removeSharedMetricFromExperiment,
+    } = useActions(experimentLogic)
 
     // Calculate shared axisRange across all metrics
     let hasBreakdowns = false
@@ -123,6 +129,16 @@ export function MetricsTable({
                                     const newUuid = crypto.randomUUID()
                                     duplicateMetric({ uuid: metric.uuid, isSecondary, newUuid })
                                     updateExperimentMetrics()
+                                }}
+                                onDeleteMetric={() => {
+                                    if (metric.isSharedMetric && metric.sharedMetricId) {
+                                        removeSharedMetricFromExperiment(metric.sharedMetricId)
+                                        return
+                                    }
+                                    if (!metric.uuid) {
+                                        return
+                                    }
+                                    removeMetric(metric.uuid, isSecondary ? 'secondary' : 'primary')
                                 }}
                                 onBreakdownChange={(breakdown) => {
                                     if (!metric.uuid) {

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -1,8 +1,8 @@
 import { useActions } from 'kea'
 import { useState } from 'react'
 
-import { IconCopy, IconPencil, IconStack } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonDropdown, LemonTag } from '@posthog/lemon-ui'
+import { IconCopy, IconEllipsis, IconStack, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonDialog, LemonDropdown, LemonMenu, LemonTag } from '@posthog/lemon-ui'
 
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -19,6 +19,8 @@ import type { Experiment } from '~/types'
 import { MetricTitle } from './MetricTitle'
 import { getMetricTag } from './utils'
 
+const MAX_BREAKDOWNS = 3
+
 // Helper function to get the exposure event from experiment
 const getExposureEvent = (experiment: Experiment): string => {
     const exposureConfig = experiment.exposure_criteria?.exposure_config
@@ -32,37 +34,25 @@ const getExposureEvent = (experiment: Experiment): string => {
     return '$feature_flag_called'
 }
 
-// AddBreakdownButton component for event and person property breakdowns
-const AddBreakdownButton = ({
+const AddBreakdownMenuItem = ({
     experiment,
     onChange,
 }: {
     experiment: Experiment
     onChange: (breakdown: Breakdown) => void
-}): JSX.Element | null => {
+}): JSX.Element => {
     const [dropdownOpen, setDropdownOpen] = useState(false)
 
-    /**
-     * bail if we don't have an experiment
-     * this could happen if the experiment has not been loaded yet
-     * or if we are in the legacy experiment view
-     */
-    if (!experiment) {
-        return null
-    }
-
-    // Create metadata source for the exposure event to filter properties
     const exposureEvent = getExposureEvent(experiment)
     const metadataSource: EventsNode = {
         kind: NodeKind.EventsNode,
         event: exposureEvent,
     }
-
-    // Allow both event and person properties for all metric types
     const taxonomicGroupTypes = [TaxonomicFilterGroupType.EventProperties, TaxonomicFilterGroupType.PersonProperties]
 
     return (
         <LemonDropdown
+            placement="left-start"
             overlay={
                 <TaxonomicFilter
                     onChange={(group, value) => {
@@ -78,13 +68,8 @@ const AddBreakdownButton = ({
             visible={dropdownOpen}
             onClickOutside={() => setDropdownOpen(false)}
         >
-            <LemonButton
-                tooltip="Add breakdown"
-                type="secondary"
-                size="xsmall"
-                onClick={() => setDropdownOpen(!dropdownOpen)}
-            >
-                <IconStack />
+            <LemonButton size="small" fullWidth icon={<IconStack />} onClick={() => setDropdownOpen(!dropdownOpen)}>
+                Add breakdown
             </LemonButton>
         </LemonDropdown>
     )
@@ -98,6 +83,7 @@ export const MetricHeader = ({
     experiment,
     onDuplicateMetricClick,
     onBreakdownChange,
+    onDeleteMetricClick,
     readOnly,
 }: {
     displayOrder?: number
@@ -107,6 +93,7 @@ export const MetricHeader = ({
     experiment: Experiment
     onDuplicateMetricClick: (metric: ExperimentMetric) => void
     onBreakdownChange: (breakdown: Breakdown) => void
+    onDeleteMetricClick?: (metric: ExperimentMetric) => void
     readOnly?: boolean
 }): JSX.Element => {
     /**
@@ -122,6 +109,98 @@ export const MetricHeader = ({
     const { openExperimentMetricModal } = useActions(experimentMetricModalLogic)
     const { openSharedMetricDetailModal } = useActions(sharedMetricDetailsModalLogic)
 
+    const [menuVisible, setMenuVisible] = useState(false)
+    const closeMenu = (): void => setMenuVisible(false)
+
+    const isSharedMetric = !!metric.isSharedMetric && !!metric.sharedMetricId
+
+    const openEditModal = (): void => {
+        if (isSharedMetric) {
+            /**
+             * this is for legacy experiments support
+             */
+            const openSharedModal = isPrimaryMetric ? openPrimarySharedMetricModal : openSecondarySharedMetricModal
+            openSharedModal(metric.sharedMetricId!)
+
+            openSharedMetricDetailModal(metric, METRIC_CONTEXTS[isPrimaryMetric ? 'primary' : 'secondary'])
+            return
+        }
+
+        /**
+         * this is for legacy experiments support
+         */
+        const openMetricModal = isPrimaryMetric ? openPrimaryMetricModal : openSecondaryMetricModal
+        if (metric.uuid) {
+            openMetricModal(metric.uuid)
+        }
+        openExperimentMetricModal(METRIC_CONTEXTS[isPrimaryMetric ? 'primary' : 'secondary'], metric)
+    }
+
+    const handleDuplicate = (): void => {
+        /**
+         * For shared metrics we open the duplicate form
+         * after a confirmation.
+         */
+        if (isSharedMetric) {
+            LemonDialog.open({
+                title: 'Duplicate this shared metric?',
+                content: (
+                    <div className="text-sm text-secondary max-w-lg">
+                        <p>
+                            We'll take you to the form to customize and save this metric. Your new version will appear
+                            in your shared metrics, ready to be added to your experiment.
+                        </p>
+                    </div>
+                ),
+                primaryButton: {
+                    children: 'Duplicate metric',
+                    to: urls.experimentsSharedMetric(metric.sharedMetricId!, 'duplicate'),
+                    type: 'primary',
+                    size: 'small',
+                },
+                secondaryButton: {
+                    children: 'Cancel',
+                    type: 'tertiary',
+                    size: 'small',
+                },
+            })
+            return
+        }
+
+        // regular metrics just get duplicated
+        onDuplicateMetricClick(metric)
+    }
+
+    const handleDelete = (): void => {
+        if (!onDeleteMetricClick) {
+            return
+        }
+
+        const deleteLabel = isSharedMetric ? 'Remove from experiment' : 'Delete metric'
+        const description = isSharedMetric
+            ? 'This will remove the shared metric from this experiment. The shared metric itself will not be deleted.'
+            : 'This will permanently remove this metric from the experiment. This action cannot be undone.'
+
+        LemonDialog.open({
+            title: isSharedMetric ? 'Remove this metric from the experiment?' : 'Delete this metric?',
+            content: <div className="text-sm text-secondary max-w-lg">{description}</div>,
+            primaryButton: {
+                children: deleteLabel,
+                status: 'danger',
+                type: 'primary',
+                size: 'small',
+                onClick: () => onDeleteMetricClick(metric),
+            },
+            secondaryButton: {
+                children: 'Cancel',
+                type: 'tertiary',
+                size: 'small',
+            },
+        })
+    }
+
+    const canAddBreakdown = !isSharedMetric && (metric.breakdownFilter?.breakdowns || []).length < MAX_BREAKDOWNS
+
     return (
         <div className="text-xs font-semibold flex flex-col justify-between h-full">
             <div className="deprecated-space-y-1">
@@ -129,98 +208,77 @@ export const MetricHeader = ({
                     <div className="text-xs font-semibold flex items-start min-w-0 flex-1">
                         {displayOrder !== undefined && <span className="mr-1 flex-shrink-0">{displayOrder + 1}.</span>}
                         <div className="min-w-0 flex-1">
-                            <MetricTitle metric={metric} metricType={metricType} />
+                            {readOnly ? (
+                                <MetricTitle metric={metric} metricType={metricType} />
+                            ) : (
+                                <button
+                                    type="button"
+                                    onClick={openEditModal}
+                                    className="text-left w-full min-w-0 hover:underline cursor-pointer bg-transparent border-0 p-0 font-semibold text-xs"
+                                    title="Edit metric"
+                                >
+                                    <MetricTitle metric={metric} metricType={metricType} />
+                                </button>
+                            )}
                         </div>
                     </div>
                     {!readOnly && (
-                        <div className="flex flex-col gap-1 flex-shrink-0 items-end">
-                            <div className="flex gap-1">
-                                <LemonButton
-                                    className="flex-shrink-0"
-                                    type="secondary"
-                                    size="xsmall"
-                                    icon={<IconPencil fontSize="12" />}
-                                    tooltip="Edit"
-                                    onClick={() => {
-                                        if (metric.isSharedMetric && metric.sharedMetricId) {
-                                            /**
-                                             * this is for legacy experiments support
-                                             */
-                                            const openSharedModal = isPrimaryMetric
-                                                ? openPrimarySharedMetricModal
-                                                : openSecondarySharedMetricModal
-                                            openSharedModal(metric.sharedMetricId)
-
-                                            openSharedMetricDetailModal(
-                                                metric,
-                                                METRIC_CONTEXTS[isPrimaryMetric ? 'primary' : 'secondary']
-                                            )
-                                        } else {
-                                            /**
-                                             * this is for legacy experiments support
-                                             */
-                                            const openMetricModal = isPrimaryMetric
-                                                ? openPrimaryMetricModal
-                                                : openSecondaryMetricModal
-                                            if (metric.uuid) {
-                                                openMetricModal(metric.uuid)
-                                            }
-
-                                            openExperimentMetricModal(
-                                                METRIC_CONTEXTS[isPrimaryMetric ? 'primary' : 'secondary'],
-                                                metric
-                                            )
-                                        }
-                                    }}
-                                />
-                                <LemonButton
-                                    className="flex-shrink-0"
-                                    type="secondary"
-                                    size="xsmall"
-                                    icon={<IconCopy fontSize="12" />}
-                                    tooltip="Duplicate"
-                                    onClick={() => {
-                                        /**
-                                         * For shared metrics we open the duplicate form
-                                         * after a confirmation.
-                                         */
-                                        if (metric.isSharedMetric && metric.sharedMetricId) {
-                                            LemonDialog.open({
-                                                title: 'Duplicate this shared metric?',
-                                                content: (
-                                                    <div className="text-sm text-secondary max-w-lg">
-                                                        <p>
-                                                            We'll take you to the form to customize and save this
-                                                            metric. Your new version will appear in your shared metrics,
-                                                            ready to be added to your experiment.
-                                                        </p>
-                                                    </div>
+                        <LemonMenu
+                            placement="bottom-end"
+                            visible={menuVisible}
+                            onVisibilityChange={setMenuVisible}
+                            closeOnClickInside={false}
+                            items={
+                                [
+                                    {
+                                        items: [
+                                            canAddBreakdown && {
+                                                label: () => (
+                                                    <AddBreakdownMenuItem
+                                                        experiment={experiment}
+                                                        onChange={(breakdown) => {
+                                                            onBreakdownChange(breakdown)
+                                                            closeMenu()
+                                                        }}
+                                                    />
                                                 ),
-                                                primaryButton: {
-                                                    children: 'Duplicate metric',
-                                                    to: urls.experimentsSharedMetric(
-                                                        metric.sharedMetricId,
-                                                        'duplicate'
-                                                    ),
-                                                    type: 'primary',
-                                                    size: 'small',
+                                                custom: true,
+                                            },
+                                            {
+                                                label: 'Duplicate',
+                                                icon: <IconCopy />,
+                                                onClick: () => {
+                                                    closeMenu()
+                                                    handleDuplicate()
                                                 },
-                                                secondaryButton: {
-                                                    children: 'Cancel',
-                                                    type: 'tertiary',
-                                                    size: 'small',
+                                            },
+                                        ].filter(Boolean) as any,
+                                    },
+                                    onDeleteMetricClick && {
+                                        items: [
+                                            {
+                                                label: isSharedMetric ? 'Remove from experiment' : 'Delete',
+                                                icon: <IconTrash />,
+                                                status: 'danger',
+                                                onClick: () => {
+                                                    closeMenu()
+                                                    handleDelete()
                                                 },
-                                            })
-
-                                            return
-                                        }
-
-                                        // regular metrics just get duplicated
-                                        onDuplicateMetricClick(metric)
-                                    }}
-                                />
-                            </div>
-                        </div>
+                                            },
+                                        ],
+                                    },
+                                ].filter(Boolean) as any
+                            }
+                        >
+                            <LemonButton
+                                className="flex-shrink-0"
+                                type="tertiary"
+                                size="xsmall"
+                                icon={<IconEllipsis />}
+                                tooltip="More actions"
+                                aria-label="More actions"
+                            />
+                        </LemonMenu>
                     )}
                 </div>
                 <div className="deprecated-space-x-1">
@@ -239,11 +297,6 @@ export const MetricHeader = ({
                     )}
                 </div>
             </div>
-            {!readOnly && (metric.breakdownFilter?.breakdowns || []).length < 3 && (
-                <div className="flex justify-end items-end">
-                    <AddBreakdownButton experiment={experiment} onChange={onBreakdownChange} />
-                </div>
-            )}
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -1,7 +1,7 @@
 import { useActions } from 'kea'
 import { useState } from 'react'
 
-import { IconCopy, IconEllipsis, IconStack, IconTrash } from '@posthog/icons'
+import { IconCopy, IconEllipsis, IconPencil, IconStack, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDialog, LemonDropdown, LemonMenu, LemonTag } from '@posthog/lemon-ui'
 
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
@@ -208,77 +208,75 @@ export const MetricHeader = ({
                     <div className="text-xs font-semibold flex items-start min-w-0 flex-1">
                         {displayOrder !== undefined && <span className="mr-1 flex-shrink-0">{displayOrder + 1}.</span>}
                         <div className="min-w-0 flex-1">
-                            {readOnly ? (
-                                <MetricTitle metric={metric} metricType={metricType} />
-                            ) : (
-                                <button
-                                    type="button"
-                                    onClick={openEditModal}
-                                    className="text-left w-full min-w-0 hover:underline cursor-pointer bg-transparent border-0 p-0 font-semibold text-xs"
-                                    title="Edit metric"
-                                >
-                                    <MetricTitle metric={metric} metricType={metricType} />
-                                </button>
-                            )}
+                            <MetricTitle metric={metric} metricType={metricType} />
                         </div>
                     </div>
                     {!readOnly && (
-                        <LemonMenu
-                            placement="bottom-end"
-                            visible={menuVisible}
-                            onVisibilityChange={setMenuVisible}
-                            closeOnClickInside={false}
-                            items={
-                                [
-                                    {
-                                        items: [
-                                            canAddBreakdown && {
-                                                label: () => (
-                                                    <AddBreakdownMenuItem
-                                                        experiment={experiment}
-                                                        onChange={(breakdown) => {
-                                                            onBreakdownChange(breakdown)
-                                                            closeMenu()
-                                                        }}
-                                                    />
-                                                ),
-                                                custom: true,
-                                            },
-                                            {
-                                                label: 'Duplicate',
-                                                icon: <IconCopy />,
-                                                onClick: () => {
-                                                    closeMenu()
-                                                    handleDuplicate()
-                                                },
-                                            },
-                                        ].filter(Boolean) as any,
-                                    },
-                                    onDeleteMetricClick && {
-                                        items: [
-                                            {
-                                                label: isSharedMetric ? 'Remove from experiment' : 'Delete',
-                                                icon: <IconTrash />,
-                                                status: 'danger',
-                                                onClick: () => {
-                                                    closeMenu()
-                                                    handleDelete()
-                                                },
-                                            },
-                                        ],
-                                    },
-                                ].filter(Boolean) as any
-                            }
-                        >
+                        <div className="flex flex-shrink-0 gap-1">
                             <LemonButton
-                                className="flex-shrink-0"
                                 type="tertiary"
                                 size="xsmall"
-                                icon={<IconEllipsis />}
-                                tooltip="More actions"
-                                aria-label="More actions"
+                                icon={<IconPencil />}
+                                tooltip="Edit"
+                                aria-label="Edit metric"
+                                onClick={openEditModal}
                             />
-                        </LemonMenu>
+                            <LemonMenu
+                                placement="bottom-end"
+                                visible={menuVisible}
+                                onVisibilityChange={setMenuVisible}
+                                closeOnClickInside={false}
+                                items={
+                                    [
+                                        {
+                                            items: [
+                                                canAddBreakdown && {
+                                                    label: () => (
+                                                        <AddBreakdownMenuItem
+                                                            experiment={experiment}
+                                                            onChange={(breakdown) => {
+                                                                onBreakdownChange(breakdown)
+                                                                closeMenu()
+                                                            }}
+                                                        />
+                                                    ),
+                                                    custom: true,
+                                                },
+                                                {
+                                                    label: 'Duplicate',
+                                                    icon: <IconCopy />,
+                                                    onClick: () => {
+                                                        closeMenu()
+                                                        handleDuplicate()
+                                                    },
+                                                },
+                                            ].filter(Boolean) as any,
+                                        },
+                                        onDeleteMetricClick && {
+                                            items: [
+                                                {
+                                                    label: isSharedMetric ? 'Remove from experiment' : 'Delete',
+                                                    icon: <IconTrash />,
+                                                    status: 'danger',
+                                                    onClick: () => {
+                                                        closeMenu()
+                                                        handleDelete()
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    ].filter(Boolean) as any
+                                }
+                            >
+                                <LemonButton
+                                    type="tertiary"
+                                    size="xsmall"
+                                    icon={<IconEllipsis />}
+                                    tooltip="More actions"
+                                    aria-label="More actions"
+                                />
+                            </LemonMenu>
+                        </div>
                     )}
                 </div>
                 <div className="deprecated-space-x-1">

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -199,7 +199,7 @@ export const MetricHeader = ({
         })
     }
 
-    const canAddBreakdown = !isSharedMetric && (metric.breakdownFilter?.breakdowns || []).length < MAX_BREAKDOWNS
+    const canAddBreakdown = (metric.breakdownFilter?.breakdowns || []).length < MAX_BREAKDOWNS
 
     return (
         <div className="text-xs font-semibold flex flex-col justify-between h-full">


### PR DESCRIPTION
## Problem

The metric header has three buttons crammed in (edit, duplicate, add breakdown). It looks busy and the actions aren't grouped in any meaningful way. There's also no way to delete a metric directly from the list, you have to open the edit modal first.

## Changes

1. Made the metric name clickable. Clicking it opens the edit form, so the pencil button is gone.
2. Replaced the remaining buttons with a single `...` menu that contains Add breakdown, Duplicate, and Delete (in red, with a divider above it).

Delete asks for confirmation before removing the metric. For shared metrics it says "Remove from experiment" and explains the shared metric itself remains.

## How did you test this code?
|Before|After|
|----|----|
|<img width="258" height="353" alt="image" src="https://github.com/user-attachments/assets/d6be515a-ebad-46f8-91a9-474113c463df" />|<img width="257" height="354" alt="image" src="https://github.com/user-attachments/assets/1114cb3d-f578-4348-b085-9972005b8118" />|

<img width="258" height="251" alt="image" src="https://github.com/user-attachments/assets/d4486982-5ff2-4737-9de0-8af8f164debc" />