### PR TITLE
feat(subscriptions): support Slack DM delivery + handle messages_tab_disabled

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -35,7 +35,7 @@ from posthog.event_usage import groups
 from posthog.exceptions import QuotaLimitExceeded
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Insight
-from posthog.models.integration import Integration
+from posthog.models.integration import SLACK_DM_SCOPES, Integration
 from posthog.models.subscription import Subscription, SubscriptionDelivery, unsubscribe_using_token
 from posthog.permissions import PremiumFeaturePermission
 from posthog.rate_limit import SubscriptionTestDeliveryThrottle
@@ -81,6 +81,15 @@ def _count_active_summaries(organization) -> int:
 
 def _invalidate_summary_quota_cache(organization_id) -> None:
     cache.delete(_summary_quota_cache_key(organization_id))
+
+
+def _is_slack_user_target(target_value: str) -> bool:
+    """Slack target_value is `<id>|<display>`; user IDs start with `U` (regular)
+    or `W` (enterprise / shared) — channels are `C` (public), `G` (private).
+    Empty or whitespace-only first segment falls through as non-user so the rest
+    of the validation chain catches it."""
+    first = target_value.split("|", 1)[0].strip()
+    return first[:1] in ("U", "W")
 
 
 @extend_schema_field({"type": "array", "items": {"type": "integer"}})
@@ -166,7 +175,15 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             "insight": {"help_text": "Insight ID to subscribe to (mutually exclusive with dashboard on create)."},
             "target_type": {"help_text": "Delivery channel: email, slack, or webhook."},
             "target_value": {
-                "help_text": "Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook."
+                "help_text": (
+                    "Recipient(s) for the subscription. "
+                    "Email: comma-separated email addresses. "
+                    "Slack: either a channel ID (e.g. `C0123ABC`) / name (`#alerts`), or a user ID "
+                    "(e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the "
+                    "workspace's Slack integration to have been authorized with the `im:write` "
+                    "scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. "
+                    "Webhook: a full URL."
+                )
             },
             "frequency": {
                 "help_text": (
@@ -264,6 +281,22 @@ class SubscriptionSerializer(serializers.ModelSerializer):
                 )
             if integration.kind != "slack":
                 raise ValidationError({"integration_id": ["Slack subscriptions require a Slack integration."]})
+
+            # Gate user-DM targets on the Slack install actually having the scopes
+            # required to deliver direct messages. Channels stay unconditional —
+            # the original install pre-dates `im:write` and we don't want to break
+            # channel-target creates for the long tail of older workspaces.
+            slack_target = attrs.get("target_value") or (self.instance.target_value if self.instance else None)
+            if slack_target and _is_slack_user_target(slack_target) and not integration.has_scopes(SLACK_DM_SCOPES):
+                raise ValidationError(
+                    {
+                        "target_value": [
+                            "PostHog needs to be re-authorized in your Slack workspace to deliver direct "
+                            "messages. Reconnect Slack from your integration settings and try again."
+                        ]
+                    },
+                    code="slack_dm_needs_reauth",
+                )
 
         # SSRF protection for webhook subscriptions
         target_value = attrs.get("target_value") or (self.instance.target_value if self.instance else None)

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -422,6 +422,62 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "require a Slack integration" in response.json()["detail"]
 
+    _DM_REQUIRED_SCOPES = "im:write,users:read,chat:write"
+    _CHANNEL_ONLY_SCOPES = "chat:write,channels:read,groups:read"
+
+    @parameterized.expand(
+        [
+            # User-DM targets succeed only when the integration has the DM scopes granted.
+            ("user_id_with_im_write_scope", "U0AC72QNTJ9|alice", _DM_REQUIRED_SCOPES, status.HTTP_201_CREATED, None),
+            ("user_id_bare_with_im_write_scope", "U0AC72QNTJ9", _DM_REQUIRED_SCOPES, status.HTTP_201_CREATED, None),
+            (
+                "user_id_without_im_write_scope",
+                "U0AC72QNTJ9|alice",
+                _CHANNEL_ONLY_SCOPES,
+                status.HTTP_400_BAD_REQUEST,
+                "slack_dm_needs_reauth",
+            ),
+            (
+                "workspace_user_id_without_scope",
+                "W0123ABC|alice",
+                _CHANNEL_ONLY_SCOPES,
+                status.HTTP_400_BAD_REQUEST,
+                "slack_dm_needs_reauth",
+            ),
+            # Channel targets must keep working regardless — don't break creates for the
+            # long tail of older installs whose scope grant pre-dates `im:write`.
+            ("public_channel_with_dm_scopes", "C0123ABC|#general", _DM_REQUIRED_SCOPES, status.HTTP_201_CREATED, None),
+            (
+                "public_channel_without_dm_scopes",
+                "C0123ABC|#general",
+                _CHANNEL_ONLY_SCOPES,
+                status.HTTP_201_CREATED,
+                None,
+            ),
+            (
+                "private_channel_without_dm_scopes",
+                "G0123ABC|#secret",
+                _CHANNEL_ONLY_SCOPES,
+                status.HTTP_201_CREATED,
+                None,
+            ),
+        ]
+    )
+    def test_slack_subscription_dm_target_capability_gating(
+        self, _name, target_value, granted_scopes, expected_status, expected_code
+    ):
+        integration = Integration.objects.create(team=self.team, kind="slack", config={"scope": granted_scopes})
+        response = self._create_subscription(
+            target_type="slack",
+            target_value=target_value,
+            integration_id=integration.id,
+        )
+        assert response.status_code == expected_status, response.json()
+        if expected_code is not None:
+            assert response.json()["code"] == expected_code
+            assert response.json()["attr"] == "target_value"
+            assert "re-authorized" in response.json()["detail"]
+
     def test_patch_enabled_true_rejected_when_slack_integration_missing(self):
         """Re-enabling a disabled Slack subscription whose integration is gone must be
         rejected up front — otherwise the next delivery would auto-disable it again

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -7,12 +7,6 @@ from posthog.models.subscription import Subscription
 
 logger = structlog.get_logger(__name__)
 
-# Slack errors that won't self-heal without user action — skip Temporal retries
-# and auto-disable the subscription so it stops re-firing every cycle.
-SLACK_USER_CONFIG_ERRORS = frozenset(
-    {"not_in_channel", "account_inactive", "is_archived", "channel_not_found", "invalid_auth", "token_revoked"}
-)
-
 
 # Temporal metrics for temporal workers
 def get_metric_meter() -> MetricMeter:

--- a/ee/tasks/subscriptions/auto_disable.py
+++ b/ee/tasks/subscriptions/auto_disable.py
@@ -34,6 +34,30 @@ SLACK_PERMISSION_REVOKED_DISABLE_REASON = DisableReason(
     description="PostHog can no longer post to this Slack channel",
     user_message="Cannot re-enable {target_type} subscription: PostHog can't post to this Slack channel. Reconnect Slack or re-add the bot to the channel, then try again.",
 )
+# Surfaced when Slack returns `messages_tab_disabled` on a DM-target subscription.
+# Most often the workspace's Slack install pre-dates the `im:write` scope and needs
+# to re-authorize via the standard "Add to Slack" flow. The serializer gates new
+# DM-target creates on this scope, so this disable reason mainly catches installs
+# that lose the scope between create and delivery, or workspace-side restrictions.
+SLACK_DM_NEEDS_REAUTH_DISABLE_REASON = DisableReason(
+    key="slack_dm_needs_reauth",
+    description="PostHog needs to be re-authorized in Slack to send direct messages",
+    user_message="Cannot re-enable {target_type} subscription: PostHog needs to be re-authorized in your Slack workspace to send direct messages. Reconnect Slack and try again.",
+)
+
+# Slack `chat.postMessage` error codes that won't self-heal without user action.
+# Membership IS the auto-disable classification — Temporal short-circuits retries
+# for any code in this map. The value is the remediation message routed to the
+# customer; codes that share a remediation path share a DisableReason.
+SLACK_USER_CONFIG_DISABLE_REASONS: dict[str, DisableReason] = {
+    "not_in_channel": SLACK_PERMISSION_REVOKED_DISABLE_REASON,
+    "account_inactive": SLACK_PERMISSION_REVOKED_DISABLE_REASON,
+    "is_archived": SLACK_PERMISSION_REVOKED_DISABLE_REASON,
+    "channel_not_found": SLACK_PERMISSION_REVOKED_DISABLE_REASON,
+    "invalid_auth": SLACK_PERMISSION_REVOKED_DISABLE_REASON,
+    "token_revoked": SLACK_PERMISSION_REVOKED_DISABLE_REASON,
+    "messages_tab_disabled": SLACK_DM_NEEDS_REAUTH_DISABLE_REASON,
+}
 
 logger = structlog.get_logger(__name__)
 

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -2612,7 +2612,7 @@ export interface SubscriptionApi {
   * `slack` - Slack
   * `webhook` - Webhook */
     target_type: TargetTypeEnumApi
-    /** Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook. */
+    /** Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) / name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL. */
     target_value: string
     /** How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.
 
@@ -2743,7 +2743,7 @@ export interface PatchedSubscriptionApi {
   * `slack` - Slack
   * `webhook` - Webhook */
     target_type?: TargetTypeEnumApi
-    /** Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook. */
+    /** Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) / name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL. */
     target_value?: string
     /** How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.
 

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -2591,7 +2591,7 @@ export const SubscriptionsCreateBody = /* @__PURE__ */ zod
         target_value: zod
             .string()
             .describe(
-                'Recipient(s): comma-separated email addresses for email, Slack channel name\/ID for slack, or full URL for webhook.'
+                "Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) \/ name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL."
             ),
         frequency: zod
             .enum(['hourly', 'daily', 'weekly', 'monthly', 'yearly'])
@@ -2699,7 +2699,7 @@ export const SubscriptionsUpdateBody = /* @__PURE__ */ zod
         target_value: zod
             .string()
             .describe(
-                'Recipient(s): comma-separated email addresses for email, Slack channel name\/ID for slack, or full URL for webhook.'
+                "Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) \/ name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL."
             ),
         frequency: zod
             .enum(['hourly', 'daily', 'weekly', 'monthly', 'yearly'])
@@ -2809,7 +2809,7 @@ export const SubscriptionsPartialUpdateBody = /* @__PURE__ */ zod
             .string()
             .optional()
             .describe(
-                'Recipient(s): comma-separated email addresses for email, Slack channel name\/ID for slack, or full URL for webhook.'
+                "Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) \/ name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL."
             ),
         frequency: zod
             .enum(['hourly', 'daily', 'weekly', 'monthly', 'yearly'])

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -200,6 +200,7 @@ import {
     SessionSummaryResponse,
     SharingConfigurationType,
     SlackChannelType,
+    SlackUserType,
     SubscriptionType,
     Survey,
     SurveyStatsResponse,
@@ -1524,6 +1525,17 @@ export class ApiRequest {
             .addPathComponent(id)
             .addPathComponent('channels')
             .withQueryString({ channel_id: channelId })
+    }
+
+    public integrationSlackUsers(
+        id: IntegrationType['id'],
+        forceRefresh: boolean,
+        teamId?: TeamType['id']
+    ): ApiRequest {
+        return this.integrations(teamId)
+            .addPathComponent(id)
+            .addPathComponent('users')
+            .withQueryString({ force_refresh: forceRefresh })
     }
 
     public integrationTwilioPhoneNumbers(
@@ -5807,6 +5819,12 @@ const api = {
             channelId: string
         ): Promise<{ channels: SlackChannelType[] }> {
             return await new ApiRequest().integrationSlackChannelsById(id, channelId).get()
+        },
+        async slackUsers(
+            id: IntegrationType['id'],
+            forceRefresh: boolean
+        ): Promise<{ users: SlackUserType[]; lastRefreshedAt: string }> {
+            return await new ApiRequest().integrationSlackUsers(id, forceRefresh).get()
         },
         async twilioPhoneNumbers(
             id: IntegrationType['id'],

--- a/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
@@ -14,7 +14,7 @@ import api from 'lib/api'
 import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
 import { IconSlackExternal } from 'lib/lemon-ui/icons'
 
-import { IntegrationType, SlackChannelType } from '~/types'
+import { IntegrationType, SlackChannelType, SlackUserType } from '~/types'
 
 import { slackIntegrationLogic } from './slackIntegrationLogic'
 
@@ -64,6 +64,20 @@ const getSlackChannelOptions = (slackChannels?: SlackChannelType[] | null): Lemo
         : null
 }
 
+const getSlackUserOptions = (slackUsers?: SlackUserType[] | null): LemonInputSelectOption[] => {
+    // Match the channel key format so consumers (subscriptions, alerts) see a uniform
+    // `<id>|<display>` shape regardless of whether the target is a channel or a DM.
+    return slackUsers
+        ? slackUsers.map((u) => {
+              const displayLabel = `@${u.name} (${u.id})`
+              return {
+                  key: `${u.id}|@${u.name}`,
+                  label: displayLabel,
+              }
+          })
+        : []
+}
+
 export type SlackChannelPickerProps = {
     integration: IntegrationType
     value?: string
@@ -76,11 +90,21 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
         slackChannels,
         allSlackChannelsLoading,
         slackChannelByIdLoading,
+        slackUsers,
+        allSlackUsersLoading,
         isMemberOfSlackChannel,
         isPrivateChannelWithoutAccess,
         getChannelRefreshButtonDisabledReason,
     } = useValues(slackIntegrationLogic({ id: integration.id }))
-    const { loadAllSlackChannels, loadSlackChannelById } = useActions(slackIntegrationLogic({ id: integration.id }))
+    const { loadAllSlackChannels, loadSlackChannelById, loadAllSlackUsers } = useActions(
+        slackIntegrationLogic({ id: integration.id })
+    )
+
+    // Only load (and offer) people if the install has been authorized with the DM scopes.
+    // Older installs grant only channel scopes; surfacing people in the picker would
+    // create a "looks pickable, fails on save" trap. The serializer's create-time 400
+    // (code=slack_dm_needs_reauth) is the backstop for any caller that tries anyway.
+    const supportsDms = (integration.config?.scope ?? '').split(',').includes('im:write')
     const [localValue, setLocalValue] = useState<string | null>(null)
 
     const channelRefreshButtonDisabledReason = getChannelRefreshButtonDisabledReason()
@@ -89,15 +113,19 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
 
     // If slackChannels aren't loaded, make sure we display only the channel name and not the actual underlying value
     const rawSlackChannelOptions = useMemo(() => getSlackChannelOptions(slackChannels), [slackChannels])
+    const rawSlackUserOptions = useMemo(() => getSlackUserOptions(slackUsers), [slackUsers])
 
     const slackChannelOptions = (): LemonInputSelectOption[] | null => {
-        return rawSlackChannelOptions
+        const channels = rawSlackChannelOptions
             ? rawSlackChannelOptions.filter((x) => {
                   const [id] = x.key.split('|#')
                   // Only show a private channel if searching for the exact channelId or it's currently selected
                   return !isPrivateChannelWithoutAccess(id) || id === value || id === localValue
               })
             : []
+        // Append users below channels when the install supports DMs. Sorting per-section
+        // keeps channel grouping intact while letting the People list stay alphabetical.
+        return supportsDms ? [...channels, ...rawSlackUserOptions] : channels
     }
     const showSlackMembershipWarning = value && isMemberOfSlackChannel(value) === false
 
@@ -117,8 +145,11 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
     useEffect(() => {
         if (!disabled) {
             loadAllSlackChannels()
+            if (supportsDms) {
+                loadAllSlackUsers()
+            }
         }
-    }, [loadAllSlackChannels, disabled])
+    }, [loadAllSlackChannels, loadAllSlackUsers, disabled, supportsDms])
 
     return (
         <>
@@ -160,7 +191,7 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
                           ]
                         : [])
                 }
-                loading={allSlackChannelsLoading || slackChannelByIdLoading}
+                loading={allSlackChannelsLoading || slackChannelByIdLoading || allSlackUsersLoading}
             />
 
             {showSlackMembershipWarning ? (

--- a/frontend/src/lib/integrations/slackIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.ts
@@ -5,7 +5,7 @@ import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
-import { SlackChannelType } from '~/types'
+import { SlackChannelType, SlackUserType } from '~/types'
 
 import type { slackIntegrationLogicType } from './slackIntegrationLogicType'
 
@@ -21,6 +21,7 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
     actions({
         loadAllSlackChannels: (forceRefresh: boolean = false) => ({ forceRefresh }),
         loadSlackChannelById: (channelId: string) => ({ channelId }),
+        loadAllSlackUsers: (forceRefresh: boolean = false) => ({ forceRefresh }),
     }),
 
     loaders(({ props }) => ({
@@ -42,6 +43,14 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
                 },
             },
         ],
+        allSlackUsers: [
+            null as { users: SlackUserType[]; lastRefreshedAt: string } | null,
+            {
+                loadAllSlackUsers: async ({ forceRefresh }) => {
+                    return await api.integrations.slackUsers(props.id, forceRefresh)
+                },
+            },
+        ],
     })),
 
     reducers({
@@ -55,6 +64,12 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
             null as SlackChannelType | null,
             {
                 loadSlackChannelByIdSuccess: (_, { slackChannelById }) => slackChannelById,
+            },
+        ],
+        slackUsers: [
+            [] as SlackUserType[],
+            {
+                loadAllSlackUsersSuccess: (_, { allSlackUsers }) => allSlackUsers.users ?? [],
             },
         ],
     }),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5142,6 +5142,13 @@ export interface SlackChannelType {
     is_private_without_access?: boolean
 }
 
+export interface SlackUserType {
+    id: string
+    name: string
+    real_name: string
+    is_admin: boolean
+}
+
 export interface TwilioPhoneNumberType {
     sid: string
     phone_number: string

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -251,6 +251,29 @@ class SlackChannelsResponseSerializer(serializers.Serializer):
     )
 
 
+class SlackUserSerializer(serializers.Serializer):
+    id = serializers.CharField(
+        help_text="Slack user ID (e.g. `U0123ABC`). Use as the channel arg to chat.postMessage to deliver a DM."
+    )
+    name = serializers.CharField(
+        help_text="Display name (`profile.display_name_normalized` if set, else `real_name`, else `name`, else id)."
+    )
+    real_name = serializers.CharField(allow_blank=True, help_text="Slack `real_name` field, may be empty.")
+    is_admin = serializers.BooleanField(help_text="True if the user is a workspace admin or owner.")
+
+
+class SlackUsersResponseSerializer(serializers.Serializer):
+    users = SlackUserSerializer(
+        many=True,
+        help_text="Workspace members the PostHog Slack app can see (excludes bots and deactivated accounts).",
+    )
+    lastRefreshedAt = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="ISO 8601 timestamp of the last full Slack API refresh.",
+    )
+
+
 @extend_schema_serializer(component_name="IntegrationConfig")
 class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerializerMixin):
     """Standard Integration serializer."""
@@ -750,6 +773,38 @@ class IntegrationViewSet(
             "lastRefreshedAt": timezone.now().isoformat(),
         }
 
+        cache.set(key, response, 60 * 60)  # one hour
+        return Response(response)
+
+    @extend_schema(responses={200: SlackUsersResponseSerializer})
+    @action(methods=["GET"], detail=True, url_path="users")
+    def users(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Workspace members the PostHog Slack app can see — drives the DM picker."""
+        instance = self.get_object()
+        if instance.kind not in SLACK_INTEGRATION_KINDS:
+            raise ValidationError("users endpoint is only supported for Slack integrations")
+        # Listing users requires the `users:read` scope. Older installs grant it
+        # implicitly because POSTHOG_SLACK_SCOPE has carried it for years; if a
+        # caller hits this with a stripped-down install we'd rather return a
+        # clean 400 than an opaque Slack 403.
+        if not instance.has_scopes({"users:read"}):
+            raise ValidationError(
+                "This Slack integration is missing the `users:read` scope. Reconnect Slack to refresh.",
+                code="slack_users_read_missing",
+            )
+        slack = SlackIntegration(instance)
+        is_session_auth = isinstance(request.successful_authenticator, SessionAuthentication)
+        force_refresh: bool = is_session_auth and request.query_params.get("force_refresh", "false").lower() == "true"
+
+        key = f"slack/{instance.id}/users"
+        data = cache.get(key)
+        if data is not None and not force_refresh:
+            return Response(data)
+
+        response = {
+            "users": slack.list_users(),
+            "lastRefreshedAt": timezone.now().isoformat(),
+        }
         cache.set(key, response, 60 * 60)  # one hour
         return Response(response)
 

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1279,7 +1279,7 @@ class SlackIntegration:
                         "is_admin": bool(member.get("is_admin")),
                     }
                 )
-            cursor = res.get("response_metadata", {}).get("next_cursor")
+            cursor = res["response_metadata"]["next_cursor"]
             if not cursor:
                 break
 

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -4,6 +4,7 @@ import time
 import base64
 import socket
 import hashlib
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NoReturn, Optional
@@ -214,6 +215,25 @@ class Integration(models.Model):
         ]
 
     @property
+    def granted_scopes(self) -> frozenset[str]:
+        """OAuth scopes Slack actually granted on this install.
+
+        The OAuth callback persists the response payload's `scope` field into
+        `config["scope"]` as a comma-separated string (see
+        `OauthIntegration.integration_from_oauth_response`). PostHog's requested
+        scope list (`POSTHOG_SLACK_SCOPE`) has grown over time, so older installs
+        carry a strict subset and need to re-authorize to pick up the new scopes.
+        Empty set when the config has no scope field (non-OAuth integrations
+        or pre-OAuth rows).
+        """
+        scope_str = self.config.get("scope") or ""
+        return frozenset(s.strip() for s in scope_str.split(",") if s.strip())
+
+    def has_scopes(self, required: Iterable[str]) -> bool:
+        """True iff every scope in `required` was granted on this integration."""
+        return set(required).issubset(self.granted_scopes)
+
+    @property
     def display_name(self) -> str:
         if self.kind in OauthIntegration.supported_kinds:
             oauth_config = OauthIntegration.oauth_config_for_kind(self.kind)
@@ -275,6 +295,11 @@ POSTHOG_SLACK_SCOPE = ",".join(
         "app_mentions:read",
         "channels:history",
         "groups:history",
+        # Open and write to direct-message conversations — required for subscriptions
+        # whose target_value is a Slack user ID (rather than a channel). Workspaces
+        # that installed before this scope was added need to re-authorize before
+        # DM-target deliveries work; the subscription API gates on this.
+        "im:write",
         "links:read",
         "links:write",
         "reactions:read",
@@ -284,6 +309,10 @@ POSTHOG_SLACK_SCOPE = ",".join(
         "users:read.email",
     ]
 )
+# Scopes required for delivering a subscription to a Slack user DM. Subscription
+# create / update returns 400 with `error_code=slack_dm_needs_reauth` if the
+# integration's granted scopes don't include all of these.
+SLACK_DM_SCOPES: frozenset[str] = frozenset({"im:write", "users:read"})
 
 
 class OauthIntegration:
@@ -1217,6 +1246,44 @@ class SlackIntegration:
                 break
 
         return channels
+
+    def list_users(self) -> list[dict]:
+        """Workspace members the bot can see, paged through `users.list`.
+
+        Filters out bots, deactivated accounts, and the `USLACKBOT` system user —
+        those are never valid DM-subscription targets. Names follow Slack's
+        precedence: real_name → name → id.
+        """
+        max_page = SLACK_CHANNELS_MAX_PAGES
+        users: list[dict] = []
+        cursor: str | None = None
+
+        while max_page > 0:
+            max_page -= 1
+            res = self.client.users_list(limit=SLACK_CHANNELS_PAGE_SIZE, cursor=cursor)
+            for member in res["members"]:
+                if member.get("is_bot") or member.get("deleted") or member.get("id") == "USLACKBOT":
+                    continue
+                profile = member.get("profile") or {}
+                display_name = (
+                    profile.get("display_name_normalized")
+                    or member.get("real_name")
+                    or member.get("name")
+                    or member["id"]
+                )
+                users.append(
+                    {
+                        "id": member["id"],
+                        "name": display_name,
+                        "real_name": member.get("real_name") or "",
+                        "is_admin": bool(member.get("is_admin")),
+                    }
+                )
+            cursor = res.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+
+        return sorted(users, key=lambda u: u["name"].lower())
 
     @classmethod
     def validate_request(cls, request: HttpRequest | Request):

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -35,10 +35,10 @@ from posthog.temporal.subscriptions.types import (
 
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 
-from ee.tasks.subscriptions import SLACK_USER_CONFIG_ERRORS, _capture_delivery_failed_event
+from ee.tasks.subscriptions import _capture_delivery_failed_event
 from ee.tasks.subscriptions.auto_disable import (
     SLACK_DISCONNECTED_DISABLE_REASON,
-    SLACK_PERMISSION_REVOKED_DISABLE_REASON,
+    SLACK_USER_CONFIG_DISABLE_REASONS,
     UNSUPPORTED_TARGET_DISABLE_REASON,
     DisableReason,
     disable_invalid_subscription,
@@ -553,22 +553,22 @@ async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> DeliverSubs
             raise
         except Exception as e:
             slack_error_code = e.response.get("error") if isinstance(e, SlackApiError) else None
-            is_user_config_error = slack_error_code in SLACK_USER_CONFIG_ERRORS
+            disable_reason = SLACK_USER_CONFIG_DISABLE_REASONS.get(slack_error_code) if slack_error_code else None
             _capture_delivery_failed_event(subscription, e)
             LOGGER.error(
                 "deliver_subscription.slack_failed",
                 subscription_id=subscription.id,
                 next_delivery_date=subscription.next_delivery_date,
                 destination=subscription.target_type,
+                slack_error_code=slack_error_code,
+                disable_reason_key=disable_reason.key if disable_reason else None,
                 exc_info=True,
             )
             capture_exception(e)
-            if is_user_config_error:
+            if disable_reason is not None:
                 # Won't self-heal without user action — auto-disable so the subscription
                 # stops re-firing every cycle.
-                return await _auto_disable_and_return(
-                    subscription, SLACK_PERMISSION_REVOKED_DISABLE_REASON, recipient_results
-                )
+                return await _auto_disable_and_return(subscription, disable_reason, recipient_results)
             raise  # Transient Slack errors — let Temporal retry
 
     await LOGGER.ainfo(

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -314,6 +314,27 @@ export interface GitHubReposRefreshResponseApi {
     repositories: GitHubRepoApi[]
 }
 
+export interface SlackUserApi {
+    /** Slack user ID (e.g. `U0123ABC`). Use as the channel arg to chat.postMessage to deliver a DM. */
+    id: string
+    /** Display name (`profile.display_name_normalized` if set, else `real_name`, else `name`, else id). */
+    name: string
+    /** Slack `real_name` field, may be empty. */
+    real_name: string
+    /** True if the user is a workspace admin or owner. */
+    is_admin: boolean
+}
+
+export interface SlackUsersResponseApi {
+    /** Workspace members the PostHog Slack app can see (excludes bots and deactivated accounts). */
+    users: SlackUserApi[]
+    /**
+     * ISO 8601 timestamp of the last full Slack API refresh.
+     * @nullable
+     */
+    lastRefreshedAt?: string | null
+}
+
 export interface UserGitHubAccountApi {
     /**
      * GitHub account type for the installation (e.g. User or Organization).

--- a/products/integrations/frontend/generated/api.ts
+++ b/products/integrations/frontend/generated/api.ts
@@ -27,6 +27,7 @@ import type {
     RoleExternalReferencesLookupRetrieveParams,
     RoleLookupResponseApi,
     SlackChannelsResponseApi,
+    SlackUsersResponseApi,
     UserGitHubLinkStartRequestApi,
     UserGitHubLinkStartResponseApi,
     UsersIntegrationsGithubBranchesRetrieveParams,
@@ -561,6 +562,24 @@ export const integrationsTwilioPhoneNumbersRetrieve = async (
     options?: RequestInit
 ): Promise<void> => {
     return apiMutator<void>(getIntegrationsTwilioPhoneNumbersRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getIntegrationsUsersRetrieveUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/integrations/${id}/users/`
+}
+
+/**
+ * Workspace members the PostHog Slack app can see — drives the DM picker.
+ */
+export const integrationsUsersRetrieve = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<SlackUsersResponseApi> => {
+    return apiMutator<SlackUsersResponseApi>(getIntegrationsUsersRetrieveUrl(projectId, id), {
         ...options,
         method: 'GET',
     })

--- a/products/integrations/mcp/tools.yaml
+++ b/products/integrations/mcp/tools.yaml
@@ -159,6 +159,9 @@ tools:
     integrations-twilio-phone-numbers-retrieve:
         operation: integrations_twilio_phone_numbers_retrieve
         enabled: false
+    integrations-users-retrieve:
+        operation: integrations_users_retrieve
+        enabled: false
     role-external-references-create:
         operation: role_external_references_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -23580,7 +23580,7 @@ export namespace Schemas {
       * `slack` - Slack
       * `webhook` - Webhook */
       target_type: TargetTypeEnum;
-      /** Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook. */
+      /** Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) / name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL. */
       target_value: string;
       /** How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.
 
@@ -29181,7 +29181,7 @@ export namespace Schemas {
       * `slack` - Slack
       * `webhook` - Webhook */
       target_type?: TargetTypeEnum;
-      /** Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook. */
+      /** Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) / name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL. */
       target_value?: string;
       /** How often to deliver: hourly, daily, weekly, monthly, or yearly. Hourly is feature-flagged and limited to one active subscription per organization.
 
@@ -34069,6 +34069,27 @@ export namespace Schemas {
       channels: SlackChannel[];
       /**
          * ISO 8601 timestamp of the last full Slack API refresh (only set on full lists, not single-channel lookups).
+         * @nullable
+         */
+      lastRefreshedAt?: string | null;
+    }
+
+    export interface SlackUser {
+      /** Slack user ID (e.g. `U0123ABC`). Use as the channel arg to chat.postMessage to deliver a DM. */
+      id: string;
+      /** Display name (`profile.display_name_normalized` if set, else `real_name`, else `name`, else id). */
+      name: string;
+      /** Slack `real_name` field, may be empty. */
+      real_name: string;
+      /** True if the user is a workspace admin or owner. */
+      is_admin: boolean;
+    }
+
+    export interface SlackUsersResponse {
+      /** Workspace members the PostHog Slack app can see (excludes bots and deactivated accounts). */
+      users: SlackUser[];
+      /**
+         * ISO 8601 timestamp of the last full Slack API refresh.
          * @nullable
          */
       lastRefreshedAt?: string | null;

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -341,7 +341,7 @@ export const SubscriptionsCreateBody = /* @__PURE__ */ zod
         target_value: zod
             .string()
             .describe(
-                'Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook.'
+                "Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) / name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL."
             ),
         frequency: zod
             .enum(['hourly', 'daily', 'weekly', 'monthly', 'yearly'])
@@ -469,7 +469,7 @@ export const SubscriptionsPartialUpdateBody = /* @__PURE__ */ zod
             .string()
             .optional()
             .describe(
-                'Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook.'
+                "Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) / name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL."
             ),
         frequency: zod
             .enum(['hourly', 'daily', 'weekly', 'monthly', 'yearly'])

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-create.json
@@ -133,7 +133,7 @@
             "type": "string"
         },
         "target_value": {
-            "description": "Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook.",
+            "description": "Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) / name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL.",
             "type": "string"
         },
         "title": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-partial-update.json
@@ -136,7 +136,7 @@
             "type": "string"
         },
         "target_value": {
-            "description": "Recipient(s): comma-separated email addresses for email, Slack channel name/ID for slack, or full URL for webhook.",
+            "description": "Recipient(s) for the subscription. Email: comma-separated email addresses. Slack: either a channel ID (e.g. `C0123ABC`) / name (`#alerts`), or a user ID (e.g. `U0123ABC`) to deliver as a direct message. DM delivery requires the workspace's Slack integration to have been authorized with the `im:write` scope; if it hasn't, the create returns 400 with `code=slack_dm_needs_reauth`. Webhook: a full URL.",
             "type": "string"
         },
         "title": {


### PR DESCRIPTION
## Problem

Slack subscriptions targeted at a user DM (e.g. `target_value="U0AC72QNTJ9|alice"`) cannot succeed today. The PostHog Slack app installation grants only channel scopes (`chat:write`, `channels:read`, …) — no `im:write`, no enabled Messages tab — so `chat.postMessage` to a user channel returns `messages_tab_disabled` on every send. Over 90 days, 3 distinct subscriptions across 3 teams attempted user-DM delivery; none succeeded.

The MCP `subscriptions-create` tool let agents create these traps without warning — "Slack channel name/ID" in the help text didn't prohibit user IDs.

## What this PR ships

End-to-end DM support, behind a capability gate keyed on the install's actual granted scopes (not the constant the code currently asks for — older installs lag).

### Backend
- `im:write` added to `POSTHOG_SLACK_SCOPE`; new installs grant it automatically.
- `Integration.granted_scopes` / `has_scopes()` helpers read the actual granted-scope string from `config["scope"]`. Older installs (e.g. the Manual.co integration from Feb 12) hold a strict subset and need reauthorization to upgrade.
- `SubscriptionSerializer.validate` now allows user-ID `target_value` when the integration has the DM scopes (`im:write`, `users:read`). Otherwise returns 400 with `code="slack_dm_needs_reauth"` and a re-authorize message. Channel targets unaffected.
- `target_value` `help_text` now describes the user-ID path and the capability gate. Propagates to MCP `subscriptions-create` description, generated TS types, and Zod via `hogli build:openapi`.
- Collapsed the old dual sources of truth (`SLACK_USER_CONFIG_ERRORS` frozenset + per-code override map) into a single `SLACK_USER_CONFIG_DISABLE_REASONS: dict[str, DisableReason]` in `auto_disable.py`. Membership IS the auto-disable classification, value IS the remediation. New `SLACK_DM_NEEDS_REAUTH_DISABLE_REASON` handles `messages_tab_disabled` with reauth-themed wording rather than the channel-revoked wording.
- Delivery activity log now includes `slack_error_code` and `disable_reason_key` for triage.

### Slack helpers
- `SlackIntegration.list_users` — paged `users.list` call, filters bots and deactivated accounts. Returns id / display name / real_name / is_admin.
- `/api/projects/<id>/integrations/<id>/users` viewset action, mirrors `/channels` shape, 1h cache, requires `users:read` scope.

### Frontend
- `SlackChannelPicker` renders channels + people in one list when the integration has `im:write` (gated client-side to avoid surfacing a section that would 400 on save). User selections map to `target_value="U.../@name"` so backend and delivery code see a uniform shape.
- Older channel-only installs see the picker unchanged.

### Tests
- Parametrized capability gate: user ID + DM scopes → 201, user ID without scopes → 400 with `code=slack_dm_needs_reauth`, channel target → 201 regardless of scope state.

## Operational notes

Before merging this PR, the Slack app config at `api.slack.com/apps/A03M3FN0RSQ` needs:
1. App Home → Show Tabs → Messages: **on**
2. Add `im:write` to bot token scopes
3. Save & republish

Existing channel-target subscriptions stay working with old tokens (no scope change required). User-target subscriptions on older installs stay broken until that workspace's admin re-authorizes via the standard "Add to Slack" flow — the auto-disable safety net catches future failures cleanly with the reauth-themed remediation message.

## How tested

I'm an agent. I ran:
- `ruff check` across all touched Python — clean.
- `hogli build:openapi` — regenerated TS / Zod / MCP tool definitions; confirmed the new help_text propagated.
- `python -c '...'` smoke checks importing the new constants and helpers.
- Did NOT run `pytest` locally (ClickHouse / Redis fixtures down in this worktree) — CI will. Did NOT run `pnpm typescript:check` to completion (tsc OOMed on the dev machine); the actual diff is small surface so I'm comfortable letting CI verify.
- Did NOT run `/review-swarm` on this final state due to context budget; happy to do a follow-up pass if you want one.

## 🤖 Agent context

Authored by Claude Code (agent). The investigation came out of `/slo-failures-daily` triage and went through several pivots:

1. Started as "auto-disable on `messages_tab_disabled`" — minimal fix to stop the Manual.co subscription's 5×/day failure loop.
2. Added a targeted remediation message via a new `DisableReason`.
3. Refactored to a single source of truth dict after review-swarm flagged drift risk.
4. Slack docs research revealed the original "ask the user to enable the Messages tab" framing was wrong — recipients can't fix this, it's app-developer controlled.
5. DB inspection on prod-eu confirmed the actual cause: PostHog's Slack app install doesn't carry the `im:write` scope, so DMs fail uniformly across all workspaces that try.
6. User decision: rather than ship a "channels-only" PR that we'd partially undo when adding DM support, ship DM support end-to-end in a single coherent PR.

This is that single coherent PR. The earlier 5-commit evolution on this branch has been force-pushed away in favor of the one commit.

Agent-authored — requires human review before merging.
