### PR TITLE
fix(insights): lower hogql big number font cap to match trends

### DIFF
--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -278,7 +278,7 @@ export function HogQLBoldNumber(): JSX.Element {
         return (
             <div className="BoldNumber LemonTable HogQL">
                 <div className="BoldNumber__value">
-                    <Textfit min={32} max={120}>
+                    <Textfit min={32} max={64}>
                         Loading...
                     </Textfit>
                 </div>
@@ -305,7 +305,7 @@ export function HogQLBoldNumber(): JSX.Element {
     return (
         <div className="BoldNumber LemonTable HogQL ph-no-capture">
             <div className="BoldNumber__value">
-                <Textfit min={32} max={120}>
+                <Textfit min={32} max={64}>
                     {String(value ?? 'Error')}
                 </Textfit>
             </div>


### PR DESCRIPTION
## Problem

HogQL big number insights cap font size at 120px, while trends big numbers cap at 64px. On dashboards with several HogQL big number cards, this produces numbers that fill nearly the entire card and run edge-to-edge — too large to look pleasant or scan quickly.

## Changes

Lower the HogQL big number `Textfit` `max` from 120 to 64, matching the trends path.

### History

- April 2024 (#21918) — HogQL big number added with `max={120}`. At that time the trends cap was also 120.
- January 2025 (#27510) — Trends cap lowered from 120 → 64 to make big numbers more pleasant to look at. HogQL path was missed.

This change just brings HogQL in line with the trends cap that has been in place for over a year.

## How did you test this code?

I am an agent (PostHog Code). No manual testing performed. The change is a two-line literal swap of `max={120}` → `max={64}` in `BoldNumber.tsx`. The behavior under test was already validated for the trends path in #27510.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code on behalf of @danazou.

Decision path: investigated why a customer's HogQL big numbers looked "horrendously big" on their dashboard. Located the `Textfit` `max={120}` cap in `HogQLBoldNumber`, compared against the `max={64}` cap in the trends `BoldNumber`, and traced both back through git history. Found that the trends cap had been deliberately lowered from 120 → 64 in #27510 as a "make this less ugly" change, but the HogQL path was missed. Considered also bumping card padding and making the cap container-relative; rejected both as additional scope given the simpler change is exactly the same fix already validated on the trends path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*