### PR TITLE
feat(sharing): log activity when dashboard sharing is toggled

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardActivityDescriber.tsx
+++ b/frontend/src/scenes/dashboard/dashboardActivityDescriber.tsx
@@ -226,6 +226,39 @@ export function dashboardActivityDescriber(logItem: ActivityLogItem, asNotificat
         }
     }
 
+    if (logItem.activity === 'sharing enabled') {
+        return {
+            description: (
+                <>
+                    <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> shared{' '}
+                    {asNotification ? 'your' : 'the'} dashboard {nameAndLink(logItem)}
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity === 'sharing disabled') {
+        return {
+            description: (
+                <>
+                    <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> deleted shared link for{' '}
+                    {asNotification ? 'your' : 'the'} dashboard {nameAndLink(logItem)}
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity === 'access token refreshed') {
+        return {
+            description: (
+                <>
+                    <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> refreshed the shared link
+                    for {asNotification ? 'your' : 'the'} dashboard {nameAndLink(logItem)}
+                </>
+            ),
+        }
+    }
+
     if (logItem.activity === 'share_login_success') {
         const afterData = logItem.detail.changes?.[0]?.after as any
         const clientIp = afterData?.client_ip || 'unknown IP'

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -422,6 +422,28 @@ class SharingConfigurationViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin,
                 ),
             )
 
+        if context.get("dashboard") and "enabled" in request.data:
+            log_activity(
+                organization_id=None,
+                team_id=self.team_id,
+                user=cast(User, self.request.user),
+                was_impersonated=is_impersonated_session(self.request),
+                item_id=instance.dashboard.pk,
+                scope="Dashboard",
+                activity="sharing " + ("enabled" if serializer.data.get("enabled") else "disabled"),
+                detail=Detail(
+                    name=instance.dashboard.name,
+                    changes=[
+                        Change(
+                            type="Dashboard",
+                            action="changed",
+                            field="sharing",
+                            after=serializer.data.get("enabled"),
+                        )
+                    ],
+                ),
+            )
+
         if context.get("notebook"):
             log_activity(
                 organization_id=None,
@@ -480,6 +502,18 @@ class SharingConfigurationViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin,
                     name=str(name) if name else None,
                     short_id=str(new_instance.insight.short_id),
                 ),
+            )
+
+        if context.get("dashboard"):
+            log_activity(
+                organization_id=None,
+                team_id=self.team_id,
+                user=cast(User, self.request.user),
+                was_impersonated=is_impersonated_session(self.request),
+                item_id=new_instance.dashboard.pk,
+                scope="Dashboard",
+                activity="access token refreshed",
+                detail=Detail(name=new_instance.dashboard.name),
             )
 
         if context.get("notebook"):

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -202,25 +202,6 @@ class TestSharing(APIBaseTest):
         ]
 
     @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
-    def test_refreshing_dashboard_share_token_is_logged(self, patched_exporter_task: Mock):
-        self.client.patch(
-            f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing",
-            {"enabled": True},
-        )
-
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing/refresh"
-        )
-        assert response.status_code == status.HTTP_200_OK
-
-        assert (
-            ActivityLog.objects.filter(
-                scope="Dashboard", activity="access token refreshed", user_id=self.user.id
-            ).count()
-            == 1
-        )
-
-    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_edit_enabled_state_for_insight(self, patched_exporter_task: Mock):
         assert ActivityLog.objects.filter(scope="SharingConfiguration").count() == 0
 
@@ -486,6 +467,13 @@ class TestSharing(APIBaseTest):
         # Verify the token persists
         response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing")
         assert response.json()["access_token"] == refreshed_data["access_token"]
+
+        # Verify activity log was created
+        activity_logs = ActivityLog.objects.filter(scope="Dashboard", activity="access token refreshed")
+        assert activity_logs.count() == 1
+        first = activity_logs.first()
+        assert first is not None
+        assert first.item_id == str(self.dashboard.id)
 
     @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_refresh_sharing_access_token_for_insight(self, patched_exporter_task: Mock):

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -173,6 +173,8 @@ class TestSharing(APIBaseTest):
 
     @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_edit_enabled_state(self, patched_exporter_task: Mock):
+        assert ActivityLog.objects.filter(scope="Dashboard").count() == 0
+
         response = self.client.patch(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing",
             {"enabled": True},
@@ -185,6 +187,38 @@ class TestSharing(APIBaseTest):
 
         assert response.json()["is_shared"]
         assert ActivityLog.objects.filter(scope="SharingConfiguration").count() == 0
+
+        self.client.patch(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing",
+            {"enabled": False},
+        )
+
+        dashboard_sharing_logs = ActivityLog.objects.filter(
+            scope="Dashboard", activity__in=["sharing enabled", "sharing disabled"]
+        ).order_by("created_at")
+        assert [(x.activity, x.user_id) for x in dashboard_sharing_logs] == [
+            ("sharing enabled", self.user.id),
+            ("sharing disabled", self.user.id),
+        ]
+
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
+    def test_refreshing_dashboard_share_token_is_logged(self, patched_exporter_task: Mock):
+        self.client.patch(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing",
+            {"enabled": True},
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing/refresh"
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        assert (
+            ActivityLog.objects.filter(
+                scope="Dashboard", activity="access token refreshed", user_id=self.user.id
+            ).count()
+            == 1
+        )
 
     @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_edit_enabled_state_for_insight(self, patched_exporter_task: Mock):

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -173,8 +173,6 @@ class TestSharing(APIBaseTest):
 
     @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_edit_enabled_state(self, patched_exporter_task: Mock):
-        assert ActivityLog.objects.filter(scope="Dashboard").count() == 0
-
         response = self.client.patch(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing",
             {"enabled": True},


### PR DESCRIPTION
## Problem

Today there is no audit trail for who turned a dashboard's public sharing link on or off. Insight sharing toggles already write to the activity log (scope=`Insight`) and notebook sharing was added recently, but dashboards were the one resource type still missing the equivalent entry.

That makes it hard to answer questions like _"who shared this dashboard publicly?"_ when the only signal the audit logs surface for dashboards today is `share_login_success` / `share_login_failed` (i.e. password-auth attempts on an already-shared dashboard).

## Changes

- `posthog/api/sharing.py`: mirror the existing insight branches in `patch()` and `refresh()` so a `Dashboard`-scoped activity log entry is written when a dashboard's sharing is enabled / disabled and when its access token is refreshed. The `patch()` branch is gated on `"enabled" in request.data` so that other partial updates to a dashboard's sharing config (e.g. only `password_required` or `settings`) don't generate spurious sharing-toggle events.
- `frontend/src/scenes/dashboard/dashboardActivityDescriber.tsx`: add describer handlers for `sharing enabled`, `sharing disabled`, and `access token refreshed` so the new entries render with the same shape as the existing insight entries when viewed in the advanced audit logs page.

After this, filtering the audit logs by scope=`Dashboard` will surface the user who toggled public sharing, alongside the existing password-auth events.

## How did you test this code?

I'm an agent and have not done manual testing. Automated coverage I added:

- `test_can_edit_enabled_state` (existing dashboard test) now asserts that toggling sharing on then off writes a pair of `Dashboard`-scoped `sharing enabled` / `sharing disabled` log entries attributed to the acting user.
- New `test_refreshing_dashboard_share_token_is_logged` asserts that hitting `/sharing/refresh` writes a `Dashboard`-scoped `access token refreshed` entry.

I did not run the local test suite (no flox/uv env available locally) — relying on CI to confirm.

## Publish to changelog?

no

## 🤖 Agent context

PostHog Code session: Dana asked how to see who shared a dashboard publicly. Investigation showed the activity log already captured insight (and now notebook) sharing toggles but never dashboard sharing toggles. This PR closes that gap by adding the symmetric dashboard branch in the same two methods. The describer changes are cosmetic — needed so the new entries don't fall through to the default "updated" describer in the audit logs UI.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*