### PR TITLE
fix(annotations): hide annotations on soft-deleted insights and dashboards

### DIFF
--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -148,6 +148,15 @@ class AnnotationsViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.Mo
             # We never want deleted items to be included in the queryset… except when we want to restore an annotation
             # That's because annotations are restored with a PATCH request setting `deleted` to `False`
             queryset = queryset.filter(deleted=False)
+        # Annotations attached to a soft-deleted insight or dashboard are hidden
+        # across all actions — including `partial_update`, so they cannot be
+        # individually edited or restored while their parent is soft-deleted.
+        # They reappear automatically when the parent is restored. Mirrors how
+        # alerts behave (see posthog/tasks/alerts/checks.py).
+        queryset = queryset.filter(
+            Q(dashboard_item__isnull=True) | Q(dashboard_item__deleted=False),
+            Q(dashboard__isnull=True) | Q(dashboard__deleted=False),
+        )
 
         scope = self.request.query_params.get("scope")
         if scope:

--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -363,7 +363,13 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT "posthog_annotation"."deleted"
+         AND ("posthog_annotation"."dashboard_item_id" IS NULL
+              OR NOT "posthog_dashboarditem"."deleted")
+         AND ("posthog_annotation"."dashboard_id" IS NULL
+              OR NOT "posthog_dashboard"."deleted")
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 99999))
@@ -453,8 +459,13 @@
          "posthog_user"."email_opt_in"
   FROM "posthog_annotation"
   LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
   WHERE (NOT "posthog_annotation"."deleted"
+         AND ("posthog_annotation"."dashboard_item_id" IS NULL
+              OR NOT "posthog_dashboarditem"."deleted")
+         AND ("posthog_annotation"."dashboard_id" IS NULL
+              OR NOT "posthog_dashboard"."deleted")
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 99999))
@@ -955,7 +966,13 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT "posthog_annotation"."deleted"
+         AND ("posthog_annotation"."dashboard_item_id" IS NULL
+              OR NOT "posthog_dashboarditem"."deleted")
+         AND ("posthog_annotation"."dashboard_id" IS NULL
+              OR NOT "posthog_dashboard"."deleted")
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 99999))
@@ -1045,8 +1062,13 @@
          "posthog_user"."email_opt_in"
   FROM "posthog_annotation"
   LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
   WHERE (NOT "posthog_annotation"."deleted"
+         AND ("posthog_annotation"."dashboard_item_id" IS NULL
+              OR NOT "posthog_dashboarditem"."deleted")
+         AND ("posthog_annotation"."dashboard_id" IS NULL
+              OR NOT "posthog_dashboard"."deleted")
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 99999))
@@ -1208,7 +1230,13 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT "posthog_annotation"."deleted"
+         AND ("posthog_annotation"."dashboard_item_id" IS NULL
+              OR NOT "posthog_dashboarditem"."deleted")
+         AND ("posthog_annotation"."dashboard_id" IS NULL
+              OR NOT "posthog_dashboard"."deleted")
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 99999))

--- a/posthog/api/test/test_annotation.py
+++ b/posthog/api/test/test_annotation.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
 from posthog.test.base import APIBaseTest, FuzzyInt, QueryMatchingTest, snapshot_postgres_queries_context
@@ -476,6 +477,66 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["attr"] == "dashboard_item"
         assert response.json()["code"] == "does_not_exist"
+
+    @parameterized.expand(
+        [
+            (
+                "insight",
+                lambda tc: (
+                    insight := Insight.objects.create(team=tc.team, name="My Insight"),
+                    Annotation.objects.create(
+                        organization=tc.organization,
+                        team=tc.team,
+                        created_by=tc.user,
+                        content="Insight annotation",
+                        dashboard_item=insight,
+                    ),
+                ),
+            ),
+            (
+                "dashboard",
+                lambda tc: (
+                    dashboard := Dashboard.objects.create(team=tc.team, name="My Dashboard"),
+                    Annotation.objects.create(
+                        organization=tc.organization,
+                        team=tc.team,
+                        created_by=tc.user,
+                        content="Dashboard annotation",
+                        scope=Annotation.Scope.DASHBOARD,
+                        dashboard=dashboard,
+                    ),
+                ),
+            ),
+        ]
+    )
+    def test_annotations_attached_to_soft_deleted_parent_are_hidden(
+        self, _kind: str, create_annotation: Callable[[Any], tuple[Insight | Dashboard, Annotation]]
+    ) -> None:
+        parent, annotation = create_annotation(self)
+
+        list_response = self.client.get(f"/api/projects/{self.team.id}/annotations/")
+        assert annotation.id in {a["id"] for a in list_response.json()["results"]}
+
+        parent.deleted = True
+        parent.save()
+
+        list_response = self.client.get(f"/api/projects/{self.team.id}/annotations/")
+        assert annotation.id not in {a["id"] for a in list_response.json()["results"]}
+
+        retrieve_response = self.client.get(f"/api/projects/{self.team.id}/annotations/{annotation.id}/")
+        assert retrieve_response.status_code == status.HTTP_404_NOT_FOUND
+
+        patch_response = self.client.patch(
+            f"/api/projects/{self.team.id}/annotations/{annotation.id}/",
+            {"content": "edited"},
+        )
+        assert patch_response.status_code == status.HTTP_404_NOT_FOUND
+
+        parent.deleted = False
+        parent.save()
+
+        list_response = self.client.get(f"/api/projects/{self.team.id}/annotations/")
+        assert annotation.id in {a["id"] for a in list_response.json()["results"]}
 
     def test_creating_annotation_with_nonexistent_insight_returns_400(self) -> None:
         response = self.client.post(


### PR DESCRIPTION
## Problem

A user reported being unable to delete an annotation in EU prod. The API returned `Invalid pk "<id>" - object does not exist` on PATCH, where the offending id was an internal `dashboard_item` (Insight) FK — not the annotation itself.

Root cause: `AnnotationSerializer.dashboard_item` declares `queryset=Insight.objects.all()`. `Insight.objects` is an override manager (`InsightManager`) that filters out soft-deleted insights. The frontend echoes the existing `dashboard_item` id back on every PATCH (including the soft-delete payload), so DRF's `PrimaryKeyRelatedField` re-validation fails to find the (still-existent, now-`deleted=True`) insight and rejects the request — even when the caller isn't trying to *change* the FK.

`on_delete=SET_NULL` does not save us here because soft-delete is an `UPDATE`, not a `DELETE`, so Postgres-level FK cascades never fire. The annotation's FK keeps pointing at the flagged-but-existing insight row.

The same trap exists for the parallel `Annotation.dashboard` FK — `Dashboard.objects` (via `DashboardManager`) excludes soft-deleted dashboards in the same way.

## Changes

The fix follows the pattern PostHog already uses for alerts: annotations attached to a soft-deleted parent (insight or dashboard) are hidden from all API surfaces (list, retrieve, update, delete), and they reappear automatically when the parent is restored. No data change, no cascade, no special restoration path.

- `posthog/api/annotation.py` — in `AnnotationsViewSet.safely_get_queryset`, apply a Q-filter for both parents: `Q(dashboard_item__isnull=True) | Q(dashboard_item__deleted=False)` AND `Q(dashboard__isnull=True) | Q(dashboard__deleted=False)`. Mirrors `posthog/tasks/alerts/checks.py:85, 96, 138, 169` (which gate alerts on `insight__deleted=False`).
- The filter is **unconditional** — including during `partial_update` — so orphan annotations cannot be edited or restored while their parent is soft-deleted. Restore the parent and the annotation comes back. Same lifecycle contract alerts have. Comment alongside the filter documents this intentionally.
- `posthog/api/test/test_annotation.py` — `test_annotations_attached_to_soft_deleted_parent_are_hidden`, parameterized over insight and dashboard, asserts the full contract: visible by default → soft-delete parent → hidden from list, retrieve 404s, PATCH 404s → restore parent → visible again.
- `posthog/api/test/__snapshots__/test_annotation.ambr` — query snapshot updated for the new WHERE clauses.

## How did you test this code?

I'm an agent.

- New parameterized regression test (`test_annotations_attached_to_soft_deleted_parent_are_hidden`) — covers the full lifecycle for both insight and dashboard parents.
- `hogli test posthog/api/test/test_annotation.py` — all 36 tests pass.
- Confirmed the alerts precedent: `posthog/tasks/alerts/checks.py:85,96,138,169,244` and `posthog/tasks/alerts/test/test_alert_checks.py:697 test_alert_is_not_triggered_when_insight_deleted`.

I did not exercise the change in a browser.

## Publish to changelog?

no

## Docs update

No docs change required.

## 🤖 Agent context

- Authored with Claude Code (Opus 4.7, 1M context).
- Initial direction was to fix the validation pitfall in the serializer by widening the queryset to `Insight.objects_including_soft_deleted` plus a `validate_dashboard_item` guard. Pivoted after the human pointed out that the cleaner, more PostHog-idiomatic pattern is exactly what the alerts code does — read-time filter on the parent's `deleted` field. That makes orphan annotations vanish from the UI naturally, restoration is automatic, no special handling.
- Final scope was expanded to cover the parallel `dashboard` FK after a reviewer pointed out the same trap exists for dashboard-scoped annotations.
- Considered and rejected:
  - **Serializer-only fix** (widen queryset + per-action validation): unblocks the API symptom but leaves orphan annotations cluttering the UI; doesn't align with how PostHog handles soft-delete elsewhere.
  - **Cascade soft-delete from parent to Annotation**: changes data lifecycle; requires backfill of existing rows; restoration must also cascade; activity-log noise. Heavy and asymmetric with how alerts work.
- Agent-authored; human review required, not self-merging.