### PR TITLE
fix(ph-ai): resolve $group_N index per region for /usage credits

### DIFF
--- a/ee/hogai/chat_agent/slash_commands/commands/usage/queries.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/usage/queries.py
@@ -7,6 +7,7 @@ import posthoganalytics
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.models.group_type_mapping import get_group_types_for_team
 from posthog.tasks.usage_report import (
     AI_BILLING_EXCLUDED_TOOLS,
     AI_COST_MARKUP_PERCENT,
@@ -29,7 +30,23 @@ CH_BILLING_SETTINGS = {
     "max_execution_time": 60,  # 1 minute
 }
 
-POSTHOG_AI_EVENTS_PRIMARY_REGION = "US"
+# Name of the group type whose value is the customer cloud URL (e.g. https://eu.posthog.com).
+# Sent via `event_usage.groups(...)` when capturing $ai_trace / $ai_generation events.
+INSTANCE_GROUP_TYPE = "instance"
+
+
+def _get_instance_group_type_index(team_id: int) -> int | None:
+    """Resolve the $group_N index that holds the cloud URL for the given internal AI events team.
+
+    group_type_index is assigned in the order group types were registered per project,
+    so the same `instance` group lives at different indexes between the EU (team 1)
+    and US (team 2) internal projects.
+    """
+    for mapping in get_group_types_for_team(team_id):
+        if mapping.get("group_type") == INSTANCE_GROUP_TYPE:
+            index = mapping.get("group_type_index")
+            return int(index) if index is not None else None
+    return None
 
 
 def _get_billing_config_payload() -> dict | None:
@@ -128,16 +145,22 @@ def get_ai_credits(
     """
     Calculate AI credits used for a specific team (and optionally a specific conversation) in the given time period.
     """
+    # Depending on the region, events are stored in different teams
+    # Default to EU (team_id 1) for local dev or unknown regions
     region = get_instance_region()
     region_value = region if region in CLOUD_REGION_TO_TEAM_ID else "EU"
+    team_to_query = CLOUD_REGION_TO_TEAM_ID[region_value]
+
+    # Only filter by region in production (EU/US) - local dev events don't have region set.
+    # The $group_N index for the `instance` group differs across internal projects,
+    # so resolve it from the destination team rather than hard-coding $group_1.
     is_production = region in ["EU", "US"]
-
-    # PostHog AI trace events are captured into the primary internal analytics project.
-    # The customer cloud is still isolated by $group_1, so EU traffic is filtered by the EU URL.
-    ai_events_region = POSTHOG_AI_EVENTS_PRIMARY_REGION if is_production else region_value
-    team_to_query = CLOUD_REGION_TO_TEAM_ID[ai_events_region]
-
-    region_filter = "AND JSONExtractString(properties, '$group_1') = %(region_url)s" if is_production else ""
+    instance_group_index = _get_instance_group_type_index(team_to_query) if is_production else None
+    region_filter = (
+        f"AND JSONExtractString(properties, '$group_{instance_group_index}') = %(region_url)s"
+        if instance_group_index is not None
+        else ""
+    )
 
     # Session filter expression for PREWHERE (must NOT use alias)
     session_filter_prewhere = (
@@ -256,7 +279,7 @@ def get_ai_credits(
             "excluded_tools": AI_BILLING_EXCLUDED_TOOLS,
         }
 
-        if is_production:
+        if instance_group_index is not None:
             params["region_url"] = CLOUD_REGION_TO_URL[region_value]
 
         if conversation_id:

--- a/ee/hogai/chat_agent/slash_commands/commands/usage/test/test_usage.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/usage/test/test_usage.py
@@ -12,7 +12,6 @@ from ee.hogai.chat_agent.slash_commands.commands.usage.queries import (
     CLOUD_REGION_TO_URL,
     DEFAULT_FREE_TIER_CREDITS,
     DEFAULT_GA_LAUNCH_DATE,
-    POSTHOG_AI_EVENTS_PRIMARY_REGION,
     format_usage_message,
     get_ai_credits,
     get_ai_free_tier_credits,
@@ -80,9 +79,9 @@ class TestUsage(BaseTest):
 
     @parameterized.expand(
         [
-            ("eu_cloud", "EU", CLOUD_REGION_TO_TEAM_ID[POSTHOG_AI_EVENTS_PRIMARY_REGION], CLOUD_REGION_TO_URL["EU"]),
-            ("us_cloud", "US", CLOUD_REGION_TO_TEAM_ID[POSTHOG_AI_EVENTS_PRIMARY_REGION], CLOUD_REGION_TO_URL["US"]),
-            ("local_dev", None, CLOUD_REGION_TO_TEAM_ID["EU"], None),
+            ("eu_cloud", "EU", CLOUD_REGION_TO_TEAM_ID["EU"], CLOUD_REGION_TO_URL["EU"], 2),
+            ("us_cloud", "US", CLOUD_REGION_TO_TEAM_ID["US"], CLOUD_REGION_TO_URL["US"], 1),
+            ("local_dev", None, CLOUD_REGION_TO_TEAM_ID["EU"], None, None),
         ]
     )
     def test_get_ai_credits_scopes_ai_events_query(
@@ -91,17 +90,31 @@ class TestUsage(BaseTest):
         region,
         expected_team_to_query,
         expected_region_url,
+        instance_group_index,
     ):
         begin = datetime(2026, 5, 1, tzinfo=UTC)
         end = datetime(2026, 5, 2, tzinfo=UTC)
         conversation_id = uuid4()
 
+        group_mappings = (
+            [
+                {"group_type": "organization", "group_type_index": 0},
+                {"group_type": "instance", "group_type_index": instance_group_index},
+            ]
+            if instance_group_index is not None
+            else []
+        )
+
         with (
             patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_instance_region") as mock_region,
             patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.sync_execute") as mock_sync_execute,
+            patch(
+                "ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_group_types_for_team"
+            ) as mock_group_types,
         ):
             mock_region.return_value = region
             mock_sync_execute.return_value = [(42,)]
+            mock_group_types.return_value = group_mappings
 
             credits = get_ai_credits(team_id=133393, begin=begin, end=end, conversation_id=conversation_id)
 
@@ -111,10 +124,38 @@ class TestUsage(BaseTest):
             self.assertEqual(params["session_id"], str(conversation_id))
             if expected_region_url is None:
                 self.assertNotIn("region_url", params)
-                self.assertNotIn("JSONExtractString(properties, '$group_1') = %(region_url)s", query)
+                self.assertNotIn("%(region_url)s", query)
+                mock_group_types.assert_not_called()
             else:
                 self.assertEqual(params["region_url"], expected_region_url)
-                self.assertIn("JSONExtractString(properties, '$group_1') = %(region_url)s", query)
+                mock_group_types.assert_called_once_with(expected_team_to_query)
+                self.assertIn(
+                    f"AND JSONExtractString(properties, '$group_{instance_group_index}') = %(region_url)s",
+                    query,
+                )
+
+    def test_get_ai_credits_skips_region_filter_when_instance_group_missing(self):
+        """If the destination team has no `instance` group registered, skip the region filter rather than match nothing."""
+        begin = datetime(2026, 5, 1, tzinfo=UTC)
+        end = datetime(2026, 5, 2, tzinfo=UTC)
+        conversation_id = uuid4()
+
+        with (
+            patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_instance_region") as mock_region,
+            patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.sync_execute") as mock_sync_execute,
+            patch(
+                "ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_group_types_for_team",
+                return_value=[{"group_type": "organization", "group_type_index": 0}],
+            ),
+        ):
+            mock_region.return_value = "EU"
+            mock_sync_execute.return_value = [(0,)]
+
+            get_ai_credits(team_id=133393, begin=begin, end=end, conversation_id=conversation_id)
+
+            query, params = mock_sync_execute.call_args[0][:2]
+            self.assertNotIn("region_url", params)
+            self.assertNotIn("%(region_url)s", query)
 
     def test_get_conversation_start_time_exists(self):
         """Test retrieving conversation start time for existing conversation."""


### PR DESCRIPTION
## Problem

Stacks on top of #58862. That PR routed all `/usage` AI-credit queries to the US internal project and kept the existing `$group_1` filter, on the assumption that EU events were mirrored into the US project. The EU report was still returning zero credits because the underlying mismatch is in the group index, not the destination team:

- `group_type_index` is assigned per project in the order group types are registered.
- The `instance` group (whose value is the customer cloud URL like `https://eu.posthog.com`) sits at a different index in the EU internal project (team 1) than in the US one (team 2).
- Hard-coding `$group_1` therefore matched nothing for EU traffic, regardless of which team we queried.

## Changes

- Revert the `queries.py` rerouting from #58862 — query the region-local internal project again (EU → team 1, US → team 2).
- Resolve the `instance` group's `group_type_index` for the destination team via `get_group_types_for_team` and substitute it into the `$group_N` filter at query build time.
- If the destination team has no `instance` group, drop the region filter rather than match nothing.
- Keep the prompt / slash-commands changes from #58862 untouched (separate fix).

## How did you test this code?

I'm an agent. I ran:

- `ruff check` and `ruff format` on the changed files (both clean).
- An inline behavioural script that exercises `get_ai_credits` for EU (`instance` at index 2), US (`instance` at index 1), local dev (no region), and a missing-`instance`-group fallback, asserting on the rendered query / params.

Did not run the full `pytest` suite locally (Postgres unavailable in this environment). The added unit tests use `unittest.mock.patch` and parameterized cases for the three regions plus the missing-group fallback; the existing scoping test was rewritten to cover the new behaviour.

## Publish to changelog?

no

## 🤖 Agent context

PostHog Code agent picked this up from a Slack thread between Alessandro Pogliaghi (PR #58862 author), Christiaan Brand, Josh Snyder, and Georgiy Tarasov. Georgiy's diagnosis ("groups don't match across regions — for instance, group1 in the US and group2 in the EU") pointed at the root cause: the same `instance` group lives at different `group_type_index` values per project. The instruction was to revert the routing change in `queries.py` and fix the group handle resolution instead.

Decisions worth flagging:

- Dynamic lookup via `get_group_types_for_team` (which routes through personhog with ORM fallback) rather than a hard-coded `CLOUD_REGION_TO_INSTANCE_GROUP_INDEX = {"EU": 2, "US": 1}`. The map would be terser, but stale entries silently revert this exact bug; resolving from the source is the safer default.
- `usage_report.py:1167`/`:1191` likely has the same `$group_1` bug for the EU billing aggregation. Left out of this PR per the stacking scope (revert + fix `queries.py` only) — worth a follow-up.
- Interpolation safety: the resolved index is cast to `int` before being inlined into the SQL string. Direct DB integer; not user-controlled.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*