### PR TITLE
fix(subscriptions): heartbeat create_export_assets and deliver_subscription

### DIFF
--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -16,6 +16,7 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
 from posthog.models.subscription import Subscription, SubscriptionDelivery
 from posthog.sync import database_sync_to_async
+from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.subscriptions.insight_snapshot import (
     build_initial_content_snapshot,
     build_insight_delivery_snapshot,
@@ -205,138 +206,141 @@ async def validate_subscription_for_delivery(subscription_id: int) -> Subscripti
 
 @temporalio.activity.defn
 async def create_export_assets(inputs: CreateExportAssetsInputs) -> CreateExportAssetsResult:
-    await LOGGER.ainfo(
-        "create_export_assets.starting",
-        subscription_id=inputs.subscription_id,
-    )
-
-    subscription = await database_sync_to_async(
-        Subscription.objects.select_related("created_by", "insight", "dashboard", "team").get,
-        thread_sensitive=False,
-    )(pk=inputs.subscription_id)
-
-    team = subscription.team
-    dashboard = subscription.dashboard
-
-    await LOGGER.ainfo(
-        "create_export_assets.loaded",
-        subscription_id=inputs.subscription_id,
-        has_dashboard=bool(dashboard),
-        has_insight=bool(subscription.insight_id),
-        target_type=subscription.target_type,
-    )
-
-    # Early exit if target value hasn't changed — avoids creating orphaned assets
-    if inputs.previous_value is not None and subscription.target_value == inputs.previous_value:
+    async with Heartbeater():
         await LOGGER.ainfo(
-            "create_export_assets.no_change_skipping",
+            "create_export_assets.starting",
             subscription_id=inputs.subscription_id,
+        )
+
+        subscription = await database_sync_to_async(
+            Subscription.objects.select_related("created_by", "insight", "dashboard", "team").get,
+            thread_sensitive=False,
+        )(pk=inputs.subscription_id)
+
+        team = subscription.team
+        dashboard = subscription.dashboard
+
+        await LOGGER.ainfo(
+            "create_export_assets.loaded",
+            subscription_id=inputs.subscription_id,
+            has_dashboard=bool(dashboard),
+            has_insight=bool(subscription.insight_id),
+            target_type=subscription.target_type,
+        )
+
+        # Early exit if target value hasn't changed — avoids creating orphaned assets
+        if inputs.previous_value is not None and subscription.target_value == inputs.previous_value:
+            await LOGGER.ainfo(
+                "create_export_assets.no_change_skipping",
+                subscription_id=inputs.subscription_id,
+            )
+            return CreateExportAssetsResult(
+                exported_asset_ids=[],
+                total_insight_count=0,
+                team_id=team.id,
+            )
+
+        if dashboard:
+            tiles = await database_sync_to_async(
+                lambda: list(
+                    dashboard.tiles.select_related("insight")
+                    .filter(insight__isnull=False, insight__deleted=False)
+                    .all()
+                ),
+                thread_sensitive=False,
+            )()
+            tiles.sort(
+                key=lambda x: (
+                    (x.layouts or {}).get("sm", {}).get("y", 100),
+                    (x.layouts or {}).get("sm", {}).get("x", 100),
+                )
+            )
+            tile_insight_pairs: list[tuple[DashboardTile | None, Insight]] = [
+                (tile, tile.insight) for tile in tiles if tile.insight
+            ]
+
+            selected_ids = await database_sync_to_async(
+                lambda: (
+                    set(subscription.dashboard_export_insights.values_list("id", flat=True))
+                    if subscription.dashboard_export_insights.exists()
+                    else None
+                ),
+                thread_sensitive=False,
+            )()
+            if selected_ids:
+                tile_insight_pairs = [(t, i) for t, i in tile_insight_pairs if i.id in selected_ids]
+        elif subscription.insight:
+            tile_insight_pairs = [(None, subscription.insight)]
+        else:
+            raise Exception("There are no insights to be sent for this Subscription")
+
+        total_insight_count = len(tile_insight_pairs)
+        export_pairs = tile_insight_pairs[: inputs.max_asset_count]
+
+        expiry = ExportedAsset.compute_expires_after(ExportedAsset.ExportFormat.PNG)
+        assets = [
+            ExportedAsset(
+                team=team,
+                export_format=ExportedAsset.ExportFormat.PNG,
+                insight=insight,
+                dashboard=dashboard,
+                expires_after=expiry,
+            )
+            for _tile, insight in export_pairs
+        ]
+        await database_sync_to_async(ExportedAsset.objects.bulk_create, thread_sensitive=False)(assets)
+
+        @database_sync_to_async(thread_sensitive=False)
+        def build_insight_snapshots() -> list[dict[str, typing.Any]]:
+            return [
+                build_insight_delivery_snapshot(
+                    insight=insight,
+                    team=team,
+                    dashboard=dashboard,
+                    tile=tile,
+                    user=subscription.created_by,
+                )
+                for tile, insight in export_pairs
+            ]
+
+        insight_snapshots = await build_insight_snapshots()
+
+        # Persist insight snapshots directly on SubscriptionDelivery.content_snapshot
+        # instead of returning them across the Temporal activity boundary — per-insight
+        # query_results can reach multi-MB and will trip Temporal's ~2 MiB payload cap.
+        #
+        # Resolve the target row. In the steady state the workflow passes delivery_id
+        # directly. For pre-rollout workflow retries replaying the old input shape
+        # (no delivery_id) and standalone callers, fall back to locating the row via
+        # the activity's workflow_id so we don't silently drop the snapshot.
+        target_delivery_id = await _resolve_target_delivery_id(inputs)
+        if target_delivery_id is not None:
+            snapshot_bytes = await _persist_content_snapshot(
+                delivery_id=target_delivery_id,
+                total_insight_count=total_insight_count,
+                insight_snapshots=insight_snapshots,
+            )
+            await LOGGER.ainfo(
+                "create_export_assets.content_snapshot_persisted",
+                subscription_id=inputs.subscription_id,
+                delivery_id=str(target_delivery_id),
+                insight_count=len(insight_snapshots),
+                snapshot_bytes=snapshot_bytes,
+            )
+
+        await LOGGER.ainfo(
+            "create_export_assets.assets_created",
+            subscription_id=inputs.subscription_id,
+            asset_count=len(assets),
+            total_insights=total_insight_count,
         )
         return CreateExportAssetsResult(
-            exported_asset_ids=[],
-            total_insight_count=0,
-            team_id=team.id,
-        )
-
-    if dashboard:
-        tiles = await database_sync_to_async(
-            lambda: list(
-                dashboard.tiles.select_related("insight").filter(insight__isnull=False, insight__deleted=False).all()
-            ),
-            thread_sensitive=False,
-        )()
-        tiles.sort(
-            key=lambda x: (
-                (x.layouts or {}).get("sm", {}).get("y", 100),
-                (x.layouts or {}).get("sm", {}).get("x", 100),
-            )
-        )
-        tile_insight_pairs: list[tuple[DashboardTile | None, Insight]] = [
-            (tile, tile.insight) for tile in tiles if tile.insight
-        ]
-
-        selected_ids = await database_sync_to_async(
-            lambda: (
-                set(subscription.dashboard_export_insights.values_list("id", flat=True))
-                if subscription.dashboard_export_insights.exists()
-                else None
-            ),
-            thread_sensitive=False,
-        )()
-        if selected_ids:
-            tile_insight_pairs = [(t, i) for t, i in tile_insight_pairs if i.id in selected_ids]
-    elif subscription.insight:
-        tile_insight_pairs = [(None, subscription.insight)]
-    else:
-        raise Exception("There are no insights to be sent for this Subscription")
-
-    total_insight_count = len(tile_insight_pairs)
-    export_pairs = tile_insight_pairs[: inputs.max_asset_count]
-
-    expiry = ExportedAsset.compute_expires_after(ExportedAsset.ExportFormat.PNG)
-    assets = [
-        ExportedAsset(
-            team=team,
-            export_format=ExportedAsset.ExportFormat.PNG,
-            insight=insight,
-            dashboard=dashboard,
-            expires_after=expiry,
-        )
-        for _tile, insight in export_pairs
-    ]
-    await database_sync_to_async(ExportedAsset.objects.bulk_create, thread_sensitive=False)(assets)
-
-    @database_sync_to_async(thread_sensitive=False)
-    def build_insight_snapshots() -> list[dict[str, typing.Any]]:
-        return [
-            build_insight_delivery_snapshot(
-                insight=insight,
-                team=team,
-                dashboard=dashboard,
-                tile=tile,
-                user=subscription.created_by,
-            )
-            for tile, insight in export_pairs
-        ]
-
-    insight_snapshots = await build_insight_snapshots()
-
-    # Persist insight snapshots directly on SubscriptionDelivery.content_snapshot
-    # instead of returning them across the Temporal activity boundary — per-insight
-    # query_results can reach multi-MB and will trip Temporal's ~2 MiB payload cap.
-    #
-    # Resolve the target row. In the steady state the workflow passes delivery_id
-    # directly. For pre-rollout workflow retries replaying the old input shape
-    # (no delivery_id) and standalone callers, fall back to locating the row via
-    # the activity's workflow_id so we don't silently drop the snapshot.
-    target_delivery_id = await _resolve_target_delivery_id(inputs)
-    if target_delivery_id is not None:
-        snapshot_bytes = await _persist_content_snapshot(
-            delivery_id=target_delivery_id,
+            exported_asset_ids=[a.id for a in assets],
             total_insight_count=total_insight_count,
-            insight_snapshots=insight_snapshots,
+            team_id=team.id,
+            distinct_id=str(subscription.created_by.distinct_id) if subscription.created_by else str(team.id),
+            target_type=subscription.target_type,
         )
-        await LOGGER.ainfo(
-            "create_export_assets.content_snapshot_persisted",
-            subscription_id=inputs.subscription_id,
-            delivery_id=str(target_delivery_id),
-            insight_count=len(insight_snapshots),
-            snapshot_bytes=snapshot_bytes,
-        )
-
-    await LOGGER.ainfo(
-        "create_export_assets.assets_created",
-        subscription_id=inputs.subscription_id,
-        asset_count=len(assets),
-        total_insights=total_insight_count,
-    )
-    return CreateExportAssetsResult(
-        exported_asset_ids=[a.id for a in assets],
-        total_insight_count=total_insight_count,
-        team_id=team.id,
-        distinct_id=str(subscription.created_by.distinct_id) if subscription.created_by else str(team.id),
-        target_type=subscription.target_type,
-    )
 
 
 async def _auto_disable_and_return(
@@ -362,221 +366,222 @@ async def _auto_disable_and_return(
 
 @temporalio.activity.defn
 async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> DeliverSubscriptionResult:
-    recipient_results: list[RecipientResult] = []
+    async with Heartbeater():
+        recipient_results: list[RecipientResult] = []
 
-    subscription = await database_sync_to_async(
-        Subscription.objects.select_related("created_by", "insight", "dashboard", "team", "integration").get,
-        thread_sensitive=False,
-    )(pk=inputs.subscription_id)
+        subscription = await database_sync_to_async(
+            Subscription.objects.select_related("created_by", "insight", "dashboard", "team", "integration").get,
+            thread_sensitive=False,
+        )(pk=inputs.subscription_id)
 
-    # Activity-retry idempotency: if a previous attempt already auto-disabled this
-    # subscription (UPDATE committed) and Temporal redispatched the activity (e.g.
-    # worker crash mid-acknowledge), don't re-fire the disable side effects — UUID4
-    # campaign keys mean MessagingRecord wouldn't dedup the duplicate email.
-    if not subscription.enabled:
-        LOGGER.info("deliver_subscription.skipped_disabled", subscription_id=inputs.subscription_id)
-        return DeliverSubscriptionResult(recipient_results=[])
+        # Activity-retry idempotency: if a previous attempt already auto-disabled this
+        # subscription (UPDATE committed) and Temporal redispatched the activity (e.g.
+        # worker crash mid-acknowledge), don't re-fire the disable side effects — UUID4
+        # campaign keys mean MessagingRecord wouldn't dedup the duplicate email.
+        if not subscription.enabled:
+            LOGGER.info("deliver_subscription.skipped_disabled", subscription_id=inputs.subscription_id)
+            return DeliverSubscriptionResult(recipient_results=[])
 
-    await LOGGER.ainfo(
-        "deliver_subscription.starting",
-        subscription_id=inputs.subscription_id,
-        target_type=subscription.target_type,
-        asset_count=len(inputs.exported_asset_ids),
-        is_new=inputs.is_new_subscription_target,
-    )
-
-    if (
-        get_subscription_disable_reason(subscription.target_type, subscription.integration_id)
-        == UNSUPPORTED_TARGET_DISABLE_REASON
-    ):
-        LOGGER.warning(
-            "deliver_subscription.unsupported_target",
+        await LOGGER.ainfo(
+            "deliver_subscription.starting",
             subscription_id=inputs.subscription_id,
             target_type=subscription.target_type,
+            asset_count=len(inputs.exported_asset_ids),
+            is_new=inputs.is_new_subscription_target,
         )
-        return await _auto_disable_and_return(subscription, UNSUPPORTED_TARGET_DISABLE_REASON, recipient_results)
 
-    assets_by_id = await database_sync_to_async(
-        lambda: {
-            a.id: a
-            for a in ExportedAsset.objects_including_ttl_deleted.select_related("insight", "dashboard").filter(
-                pk__in=inputs.exported_asset_ids
+        if (
+            get_subscription_disable_reason(subscription.target_type, subscription.integration_id)
+            == UNSUPPORTED_TARGET_DISABLE_REASON
+        ):
+            LOGGER.warning(
+                "deliver_subscription.unsupported_target",
+                subscription_id=inputs.subscription_id,
+                target_type=subscription.target_type,
             )
-        },
-        thread_sensitive=False,
-    )()
-    # Preserve the order from create_export_assets (sorted by dashboard tile layout)
-    assets = [assets_by_id[aid] for aid in inputs.exported_asset_ids if aid in assets_by_id]
+            return await _auto_disable_and_return(subscription, UNSUPPORTED_TARGET_DISABLE_REASON, recipient_results)
 
-    if not assets:
-        # Empty here means non-empty exported_asset_ids didn't resolve from DB — a
-        # transient condition (TTL sweep, prior export crash, S3 race). Genuine
-        # deletion is filtered upstream in create_export_assets and the workflow
-        # short-circuits to SKIPPED before this activity runs. Don't auto-disable;
-        # the failure is observable via the `subscription_delivery_failed` analytics
-        # event and the next scheduled delivery retries.
-        LOGGER.warning("deliver_subscription.no_assets", subscription_id=inputs.subscription_id)
-        recipient_results.append(
-            RecipientResult(
-                recipient=subscription.target_value,
-                status="failed",
-                error={"message": NO_ASSETS_REASON, "type": "no_assets"},
+        assets_by_id = await database_sync_to_async(
+            lambda: {
+                a.id: a
+                for a in ExportedAsset.objects_including_ttl_deleted.select_related("insight", "dashboard").filter(
+                    pk__in=inputs.exported_asset_ids
+                )
+            },
+            thread_sensitive=False,
+        )()
+        # Preserve the order from create_export_assets (sorted by dashboard tile layout)
+        assets = [assets_by_id[aid] for aid in inputs.exported_asset_ids if aid in assets_by_id]
+
+        if not assets:
+            # Empty here means non-empty exported_asset_ids didn't resolve from DB — a
+            # transient condition (TTL sweep, prior export crash, S3 race). Genuine
+            # deletion is filtered upstream in create_export_assets and the workflow
+            # short-circuits to SKIPPED before this activity runs. Don't auto-disable;
+            # the failure is observable via the `subscription_delivery_failed` analytics
+            # event and the next scheduled delivery retries.
+            LOGGER.warning("deliver_subscription.no_assets", subscription_id=inputs.subscription_id)
+            recipient_results.append(
+                RecipientResult(
+                    recipient=subscription.target_value,
+                    status="failed",
+                    error={"message": NO_ASSETS_REASON, "type": "no_assets"},
+                )
             )
-        )
-        # Plain Exception — `_capture_delivery_failed_event` only reads `str(e)` and
-        # `type(e).__name__`, and the activity returns cleanly so retry semantics on
-        # ApplicationError would be misleading (matches `_auto_disable_and_return`).
-        _capture_delivery_failed_event(subscription, Exception(NO_ASSETS_REASON))
-        return DeliverSubscriptionResult(recipient_results=recipient_results)
+            # Plain Exception — `_capture_delivery_failed_event` only reads `str(e)` and
+            # `type(e).__name__`, and the activity returns cleanly so retry semantics on
+            # ApplicationError would be misleading (matches `_auto_disable_and_return`).
+            _capture_delivery_failed_event(subscription, Exception(NO_ASSETS_REASON))
+            return DeliverSubscriptionResult(recipient_results=recipient_results)
 
-    if subscription.target_type == "email":
-        emails = subscription.target_value.split(",")
-        await LOGGER.ainfo(
-            "deliver_subscription.sending_email",
-            subscription_id=inputs.subscription_id,
-            recipient_count=len(emails),
-        )
-        if inputs.is_new_subscription_target:
-            previous_emails = inputs.previous_value.split(",") if inputs.previous_value else []
-            emails = list(set(emails) - set(previous_emails))
+        if subscription.target_type == "email":
+            emails = subscription.target_value.split(",")
+            await LOGGER.ainfo(
+                "deliver_subscription.sending_email",
+                subscription_id=inputs.subscription_id,
+                recipient_count=len(emails),
+            )
+            if inputs.is_new_subscription_target:
+                previous_emails = inputs.previous_value.split(",") if inputs.previous_value else []
+                emails = list(set(emails) - set(previous_emails))
 
-        last_error: Exception | None = None
-        success_count = 0
-        for email in emails:
+            last_error: Exception | None = None
+            success_count = 0
+            for email in emails:
+                try:
+                    await database_sync_to_async(send_email_subscription_report, thread_sensitive=False)(
+                        email,
+                        subscription,
+                        assets,
+                        invite_message=inputs.invite_message or "" if inputs.is_new_subscription_target else None,
+                        total_asset_count=inputs.total_insight_count,
+                        send_async=False,
+                        change_summary=inputs.change_summary,
+                    )
+                    success_count += 1
+                    recipient_results.append(RecipientResult(recipient=email, status="success"))
+                except Exception as e:
+                    _capture_delivery_failed_event(subscription, e)
+                    LOGGER.error(
+                        "deliver_subscription.email_failed",
+                        subscription_id=subscription.id,
+                        email=email,
+                        next_delivery_date=subscription.next_delivery_date,
+                        destination=subscription.target_type,
+                        exc_info=True,
+                    )
+                    capture_exception(e)
+                    last_error = e
+                    recipient_results.append(
+                        RecipientResult(
+                            recipient=email,
+                            status="failed",
+                            error={"message": str(e), "type": type(e).__name__},
+                        )
+                    )
+
+            await LOGGER.ainfo(
+                "deliver_subscription.email_complete",
+                subscription_id=inputs.subscription_id,
+                success_count=success_count,
+                total_count=len(emails),
+            )
+
+            # Only retry if ALL recipients failed — partial success is acceptable
+            # to avoid duplicate sends to already-delivered recipients
+            if last_error is not None and success_count == 0:
+                raise last_error
+
+        elif subscription.target_type == "slack":
             try:
-                await database_sync_to_async(send_email_subscription_report, thread_sensitive=False)(
-                    email,
+                integration = subscription.integration
+                if integration is None:
+                    integration = await database_sync_to_async(get_slack_integration_for_team, thread_sensitive=False)(
+                        subscription.team_id
+                    )
+                elif integration.kind != "slack":
+                    LOGGER.warn(
+                        "deliver_subscription.invalid_integration_kind",
+                        subscription_id=subscription.id,
+                        integration_id=integration.id,
+                        kind=integration.kind,
+                    )
+                    integration = await database_sync_to_async(get_slack_integration_for_team, thread_sensitive=False)(
+                        subscription.team_id
+                    )
+
+                if not integration:
+                    LOGGER.warning(
+                        "deliver_subscription.no_slack_integration",
+                        subscription_id=inputs.subscription_id,
+                    )
+                    # Slack integration disconnected — auto-disable, mirrors the alert pattern.
+                    return await _auto_disable_and_return(
+                        subscription, SLACK_DISCONNECTED_DISABLE_REASON, recipient_results
+                    )
+
+                LOGGER.info("deliver_subscription.sending_slack_message", subscription_id=subscription.id)
+                delivery_result = await send_slack_message_with_integration_async(
+                    integration,
                     subscription,
                     assets,
-                    invite_message=inputs.invite_message or "" if inputs.is_new_subscription_target else None,
                     total_asset_count=inputs.total_insight_count,
-                    send_async=False,
+                    is_new_subscription=inputs.is_new_subscription_target,
                     change_summary=inputs.change_summary,
                 )
-                success_count += 1
-                recipient_results.append(RecipientResult(recipient=email, status="success"))
+
+                if delivery_result.is_complete_success:
+                    await LOGGER.ainfo(
+                        "deliver_subscription.slack_sent",
+                        subscription_id=inputs.subscription_id,
+                    )
+                    recipient_results.append(RecipientResult(recipient=subscription.target_value, status="success"))
+                elif delivery_result.is_partial_failure:
+                    await LOGGER.awarning(
+                        "deliver_subscription.slack_partial_failure",
+                        subscription_id=inputs.subscription_id,
+                        failed_thread_count=len(delivery_result.failed_thread_message_indices),
+                        total_thread_count=delivery_result.total_thread_messages,
+                    )
+                    recipient_results.append(
+                        RecipientResult(
+                            recipient=subscription.target_value,
+                            status="partial",
+                            error={
+                                "message": f"{len(delivery_result.failed_thread_message_indices)} thread message(s) failed",
+                                "type": "partial_thread_failure",
+                            },
+                        )
+                    )
+
+            except ApplicationError:
+                raise
             except Exception as e:
+                slack_error_code = e.response.get("error") if isinstance(e, SlackApiError) else None
+                is_user_config_error = slack_error_code in SLACK_USER_CONFIG_ERRORS
                 _capture_delivery_failed_event(subscription, e)
                 LOGGER.error(
-                    "deliver_subscription.email_failed",
+                    "deliver_subscription.slack_failed",
                     subscription_id=subscription.id,
-                    email=email,
                     next_delivery_date=subscription.next_delivery_date,
                     destination=subscription.target_type,
                     exc_info=True,
                 )
                 capture_exception(e)
-                last_error = e
-                recipient_results.append(
-                    RecipientResult(
-                        recipient=email,
-                        status="failed",
-                        error={"message": str(e), "type": type(e).__name__},
+                if is_user_config_error:
+                    # Won't self-heal without user action — auto-disable so the subscription
+                    # stops re-firing every cycle.
+                    return await _auto_disable_and_return(
+                        subscription, SLACK_PERMISSION_REVOKED_DISABLE_REASON, recipient_results
                     )
-                )
+                raise  # Transient Slack errors — let Temporal retry
 
         await LOGGER.ainfo(
-            "deliver_subscription.email_complete",
+            "deliver_subscription.completed",
             subscription_id=inputs.subscription_id,
-            success_count=success_count,
-            total_count=len(emails),
+            target_type=subscription.target_type,
         )
-
-        # Only retry if ALL recipients failed — partial success is acceptable
-        # to avoid duplicate sends to already-delivered recipients
-        if last_error is not None and success_count == 0:
-            raise last_error
-
-    elif subscription.target_type == "slack":
-        try:
-            integration = subscription.integration
-            if integration is None:
-                integration = await database_sync_to_async(get_slack_integration_for_team, thread_sensitive=False)(
-                    subscription.team_id
-                )
-            elif integration.kind != "slack":
-                LOGGER.warn(
-                    "deliver_subscription.invalid_integration_kind",
-                    subscription_id=subscription.id,
-                    integration_id=integration.id,
-                    kind=integration.kind,
-                )
-                integration = await database_sync_to_async(get_slack_integration_for_team, thread_sensitive=False)(
-                    subscription.team_id
-                )
-
-            if not integration:
-                LOGGER.warning(
-                    "deliver_subscription.no_slack_integration",
-                    subscription_id=inputs.subscription_id,
-                )
-                # Slack integration disconnected — auto-disable, mirrors the alert pattern.
-                return await _auto_disable_and_return(
-                    subscription, SLACK_DISCONNECTED_DISABLE_REASON, recipient_results
-                )
-
-            LOGGER.info("deliver_subscription.sending_slack_message", subscription_id=subscription.id)
-            delivery_result = await send_slack_message_with_integration_async(
-                integration,
-                subscription,
-                assets,
-                total_asset_count=inputs.total_insight_count,
-                is_new_subscription=inputs.is_new_subscription_target,
-                change_summary=inputs.change_summary,
-            )
-
-            if delivery_result.is_complete_success:
-                await LOGGER.ainfo(
-                    "deliver_subscription.slack_sent",
-                    subscription_id=inputs.subscription_id,
-                )
-                recipient_results.append(RecipientResult(recipient=subscription.target_value, status="success"))
-            elif delivery_result.is_partial_failure:
-                await LOGGER.awarning(
-                    "deliver_subscription.slack_partial_failure",
-                    subscription_id=inputs.subscription_id,
-                    failed_thread_count=len(delivery_result.failed_thread_message_indices),
-                    total_thread_count=delivery_result.total_thread_messages,
-                )
-                recipient_results.append(
-                    RecipientResult(
-                        recipient=subscription.target_value,
-                        status="partial",
-                        error={
-                            "message": f"{len(delivery_result.failed_thread_message_indices)} thread message(s) failed",
-                            "type": "partial_thread_failure",
-                        },
-                    )
-                )
-
-        except ApplicationError:
-            raise
-        except Exception as e:
-            slack_error_code = e.response.get("error") if isinstance(e, SlackApiError) else None
-            is_user_config_error = slack_error_code in SLACK_USER_CONFIG_ERRORS
-            _capture_delivery_failed_event(subscription, e)
-            LOGGER.error(
-                "deliver_subscription.slack_failed",
-                subscription_id=subscription.id,
-                next_delivery_date=subscription.next_delivery_date,
-                destination=subscription.target_type,
-                exc_info=True,
-            )
-            capture_exception(e)
-            if is_user_config_error:
-                # Won't self-heal without user action — auto-disable so the subscription
-                # stops re-firing every cycle.
-                return await _auto_disable_and_return(
-                    subscription, SLACK_PERMISSION_REVOKED_DISABLE_REASON, recipient_results
-                )
-            raise  # Transient Slack errors — let Temporal retry
-
-    await LOGGER.ainfo(
-        "deliver_subscription.completed",
-        subscription_id=inputs.subscription_id,
-        target_type=subscription.target_type,
-    )
-    return DeliverSubscriptionResult(recipient_results=recipient_results)
+        return DeliverSubscriptionResult(recipient_results=recipient_results)
 
 
 @temporalio.activity.defn

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -268,7 +268,12 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                     previous_value=inputs.previous_value,
                     delivery_id=delivery_id,
                 ),
-                start_to_close_timeout=dt.timedelta(minutes=5),
+                # 15 min ceiling absorbs per-insight snapshot serialization on large
+                # dashboards; the inner Heartbeater keeps Temporal informed so a hung
+                # activity surfaces as heartbeat-timeout rather than burning the full
+                # 15 min × 3 attempts = ~45 min ActivityError before Temporal gives up.
+                start_to_close_timeout=dt.timedelta(minutes=15),
+                heartbeat_timeout=dt.timedelta(minutes=2),
                 retry_policy=temporalio.common.RetryPolicy(
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(minutes=2),
@@ -372,6 +377,10 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                     change_summary=change_summary,
                 ),
                 start_to_close_timeout=dt.timedelta(minutes=5),
+                # Heartbeater inside the activity body keeps Temporal informed during
+                # slow SMTP/Slack calls; without this timeout, a stalled third-party
+                # client burns the full start_to_close on every retry.
+                heartbeat_timeout=dt.timedelta(minutes=2),
                 retry_policy=temporalio.common.RetryPolicy(
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(minutes=5),


### PR DESCRIPTION
## Problem

The `subscription_delivery` SLO surfaced a recurring `ActivityError` "Activity task timed out" — 22 failures across 4 teams over the last 7 days, with an average failure duration of ~940 seconds. That maps cleanly to three full 5-minute retries on `create_export_assets`, which has **no heartbeat**: Temporal can't tell a stalled activity from a slow one, so both die at the start_to_close ceiling. The same gap exists on `deliver_subscription`, whose SMTP / Slack calls can stall similarly.

The fix mirrors the established pattern in `posthog/temporal/exports/activities.py:21` (`export_asset_activity`), which already wraps its body in `Heartbeater` paired with `heartbeat_timeout=2 min` on the workflow side.

## Changes

`posthog/temporal/subscriptions/activities.py`:
- Import `Heartbeater` from `posthog.temporal.common.heartbeat`.
- Wrap the bodies of `create_export_assets` and `deliver_subscription` in `async with Heartbeater():`. No other logic change — the indentation accounts for almost all of the diff size.

`posthog/temporal/subscriptions/workflows.py`:
- `create_export_assets` invocation: bump `start_to_close_timeout` from 5 → 15 minutes (per-insight snapshot serialization on large dashboards needs headroom; the heartbeat keeps a genuinely hung activity from running the full ceiling), and add `heartbeat_timeout=2 minutes`.
- `deliver_subscription` invocation: keep `start_to_close_timeout=5 minutes`, add `heartbeat_timeout=2 minutes`.

The 2 hour workflow `execution_timeout` still bounds the worst case (45 min create + 25 min deliver + per-insight fan-out fits comfortably).

## How did you test this code?

I'm an agent. I ran:
- `ruff check posthog/temporal/subscriptions/` — clean.
- `python -c '... inspect.getsource(create_export_assets) ...'` — confirmed `async with Heartbeater():` is present in both activity bodies.
- Did NOT run the activity tests locally (the test fixtures need ClickHouse, which is not running in this worktree). CI will run them.

## Publish to changelog?

no

## Docs update

(no docs changes needed)

## 🤖 Agent context

Authored by Claude Code (agent). The investigation came out of `/slo-failures-daily` triage: the `slo_operation_completed` event with `outcome=failure`, `area=analytic-platform`, `operation=subscription_delivery`, `error_type=ActivityError` had 22 occurrences over 7 days with avg `duration_ms=940858` — three retries × 5-minute `start_to_close` ceiling on `create_export_assets`.

Reviewed via `/review-swarm` (vasco + sre + xp + superpowers:code-reviewer):

- **Overall A** — no HIGH/CRITICAL findings. Several LOWs and NITs about comment density, worst-case slot occupation (15min × 3 retries = 45min on a poison-pill subscription), and `deliver_subscription`'s 5-min ceiling being tight for very large email recipient lists. None are blockers; the slot-occupation point is worth post-deploy observation (p99 duration on `create_export_assets`).
- One round of polish: trimmed verbose activity-side comments to match the sibling `export_asset_activity` pattern (zero comments — workflow-side comments carry the rationale).

Two follow-ups flagged for separate consideration, intentionally not in this PR:
1. If post-deploy data shows `create_export_assets` still routinely hitting the 15min ceiling, consider dropping `maximum_attempts` from 3 to 2 to cap worst-case slot occupation at 30min.
2. If large email subscription recipient lists start showing the same timeout pattern on `deliver_subscription`, that activity also needs a higher `start_to_close_timeout`.

Agent-authored — requires human review before merging.
