### PR TITLE
feat(cdp): add hog invocation replay with paginated ClickHouse-backed re-execution

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -356,6 +356,7 @@
       attempts UInt8,
       is_retry UInt8,
       scheduled_at DateTime64(6, 'UTC'),
+      first_scheduled_at DateTime64(6, 'UTC'),
       started_at Nullable(DateTime64(6, 'UTC')),
       finished_at Nullable(DateTime64(6, 'UTC')),
       duration_ms Nullable(UInt32),
@@ -1836,6 +1837,7 @@
       attempts UInt8,
       is_retry UInt8,
       scheduled_at DateTime64(6, 'UTC'),
+      first_scheduled_at DateTime64(6, 'UTC'),
       started_at Nullable(DateTime64(6, 'UTC')),
       finished_at Nullable(DateTime64(6, 'UTC')),
       duration_ms Nullable(UInt32),
@@ -1871,6 +1873,7 @@
       attempts UInt8,
       is_retry UInt8,
       scheduled_at DateTime64(6, 'UTC'),
+      first_scheduled_at DateTime64(6, 'UTC') DEFAULT scheduled_at,
       started_at Nullable(DateTime64(6, 'UTC')),
       finished_at Nullable(DateTime64(6, 'UTC')),
       duration_ms Nullable(UInt32),
@@ -1915,6 +1918,12 @@
       attempts,
       is_retry,
       scheduled_at,
+      -- Defensive fallback: if the producer omits the field (e.g. an older build
+      -- still in rollout), the Kafka JSONEachRow parser populates the column
+      -- with epoch 0. Substitute `scheduled_at` in that case so the column reads
+      -- sensibly. Once every producer carries the field, this resolves to a
+      -- straight passthrough.
+      if(first_scheduled_at = toDateTime64('1970-01-01 00:00:00', 6, 'UTC'), scheduled_at, first_scheduled_at) AS first_scheduled_at,
       started_at,
       finished_at,
       duration_ms,
@@ -2250,6 +2259,7 @@
       attempts UInt8,
       is_retry UInt8,
       scheduled_at DateTime64(6, 'UTC'),
+      first_scheduled_at DateTime64(6, 'UTC'),
       started_at Nullable(DateTime64(6, 'UTC')),
       finished_at Nullable(DateTime64(6, 'UTC')),
       duration_ms Nullable(UInt32),
@@ -5603,49 +5613,6 @@
   
   '''
 # ---
-# name: test_create_table_query[sharded_hog_invocation_results]
-  '''
-  
-  CREATE TABLE IF NOT EXISTS sharded_hog_invocation_results
-  (
-      team_id Int64,
-      function_kind LowCardinality(String),
-      function_id String,
-      invocation_id String,
-      parent_run_id String,
-      status LowCardinality(String),
-      attempts UInt8,
-      is_retry UInt8,
-      scheduled_at DateTime64(6, 'UTC'),
-      started_at Nullable(DateTime64(6, 'UTC')),
-      finished_at Nullable(DateTime64(6, 'UTC')),
-      duration_ms Nullable(UInt32),
-      error_kind LowCardinality(String),
-      error_message String CODEC(ZSTD(3)),
-      event_uuid String,
-      distinct_id String,
-      person_id String,
-      invocation_globals String CODEC(ZSTD(3)),
-      version UInt64,
-      is_deleted UInt8 DEFAULT 0,
-      INDEX status_idx     status      TYPE set(8)             GRANULARITY 4,
-      INDEX function_idx   function_id TYPE bloom_filter(0.01) GRANULARITY 4,
-      INDEX event_uuid_idx event_uuid  TYPE bloom_filter(0.01) GRANULARITY 4,
-      INDEX is_retry_idx   is_retry    TYPE set(2)             GRANULARITY 4
-      
-  , _timestamp DateTime
-  , _offset UInt64
-  , _partition UInt64
-  
-  )
-  ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.sharded_hog_invocation_results', '{replica}', version)
-  PARTITION BY toYYYYMMDD(scheduled_at)
-  ORDER BY (team_id, function_kind, function_id, invocation_id)
-  
-  SETTINGS index_granularity = 1024, ttl_only_drop_parts = 1
-  
-  '''
-# ---
 # name: test_create_table_query[sharded_ingestion_warnings]
   '''
   
@@ -6830,41 +6797,6 @@
   
   '''
 # ---
-# name: test_create_table_query[writable_hog_invocation_results]
-  '''
-  
-  CREATE TABLE IF NOT EXISTS writable_hog_invocation_results
-  (
-      team_id Int64,
-      function_kind LowCardinality(String),
-      function_id String,
-      invocation_id String,
-      parent_run_id String,
-      status LowCardinality(String),
-      attempts UInt8,
-      is_retry UInt8,
-      scheduled_at DateTime64(6, 'UTC'),
-      started_at Nullable(DateTime64(6, 'UTC')),
-      finished_at Nullable(DateTime64(6, 'UTC')),
-      duration_ms Nullable(UInt32),
-      error_kind LowCardinality(String),
-      error_message String,
-      event_uuid String,
-      distinct_id String,
-      person_id String,
-      invocation_globals String,
-      version UInt64,
-      is_deleted UInt8
-      
-  , _timestamp DateTime
-  , _offset UInt64
-  , _partition UInt64
-  
-  )
-  ENGINE = Distributed('posthog', 'posthog_test', 'sharded_hog_invocation_results', cityHash64(invocation_id))
-  
-  '''
-# ---
 # name: test_create_table_query[writable_ingestion_warnings]
   '''
   
@@ -7704,6 +7636,7 @@
       attempts UInt8,
       is_retry UInt8,
       scheduled_at DateTime64(6, 'UTC'),
+      first_scheduled_at DateTime64(6, 'UTC') DEFAULT scheduled_at,
       started_at Nullable(DateTime64(6, 'UTC')),
       finished_at Nullable(DateTime64(6, 'UTC')),
       duration_ms Nullable(UInt32),
@@ -8938,49 +8871,6 @@
   -- the default is 8192, and we will be loading a lot of data
   -- per query, we tend to copy this 512 around the place but
   -- i don't think it applies here
-  
-  '''
-# ---
-# name: test_create_table_query_replicated_and_storage[sharded_hog_invocation_results]
-  '''
-  
-  CREATE TABLE IF NOT EXISTS sharded_hog_invocation_results
-  (
-      team_id Int64,
-      function_kind LowCardinality(String),
-      function_id String,
-      invocation_id String,
-      parent_run_id String,
-      status LowCardinality(String),
-      attempts UInt8,
-      is_retry UInt8,
-      scheduled_at DateTime64(6, 'UTC'),
-      started_at Nullable(DateTime64(6, 'UTC')),
-      finished_at Nullable(DateTime64(6, 'UTC')),
-      duration_ms Nullable(UInt32),
-      error_kind LowCardinality(String),
-      error_message String CODEC(ZSTD(3)),
-      event_uuid String,
-      distinct_id String,
-      person_id String,
-      invocation_globals String CODEC(ZSTD(3)),
-      version UInt64,
-      is_deleted UInt8 DEFAULT 0,
-      INDEX status_idx     status      TYPE set(8)             GRANULARITY 4,
-      INDEX function_idx   function_id TYPE bloom_filter(0.01) GRANULARITY 4,
-      INDEX event_uuid_idx event_uuid  TYPE bloom_filter(0.01) GRANULARITY 4,
-      INDEX is_retry_idx   is_retry    TYPE set(2)             GRANULARITY 4
-      
-  , _timestamp DateTime
-  , _offset UInt64
-  , _partition UInt64
-  
-  )
-  ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.sharded_hog_invocation_results', '{replica}', version)
-  PARTITION BY toYYYYMMDD(scheduled_at)
-  ORDER BY (team_id, function_kind, function_id, invocation_id)
-  
-  SETTINGS index_granularity = 1024, ttl_only_drop_parts = 1
   
   '''
 # ---


### PR DESCRIPTION
## Problem

Users need the ability to replay past hog function and hog flow invocations from their stored execution payloads. This is critical for debugging failed invocations, testing fixes, and recovering from transient errors without re-triggering the original events.

## Changes

This PR implements a complete replay system for hog invocations:

**Backend (Node.js CDP):**
- `ReplayPaginatorService`: Paginated replay engine that reads matching invocation rows from ClickHouse, rehydrates execution globals, and re-enqueues onto cyclotron with `is_retry=1`
- `CdpReplayWorkerConsumer`: New consumer mode that dequeues replay jobs, manages pagination state, and handles heartbeats during long-running pages
- `ReplayJobManager`: Manages replay job lifecycle in PostgreSQL, supporting both explicit invocation IDs and filter-based queries
- `HogInvocationResultsService`: Produces lifecycle rows (running/succeeded/failed) to ClickHouse via Kafka for invocation tracking
- Cyclotron V2 `overwriteExisting` flag: Prevents clobbering in-flight jobs during replay re-enqueue

**Backend (Django):**
- `HogInvocationReplayRequestSerializer` / `HogInvocationReplayResponseSerializer`: Request/response shapes for replay endpoints
- `/replay` endpoints on both `HogFunctionViewSet` and `HogFlowViewSet`: Accept filter (date range, status, error kind) or explicit invocation IDs, proxy to Node worker
- ClickHouse schema: `hog_invocation_results` table (ReplacingMergeTree) with Kafka MV for lifecycle row ingestion
- HogQL schema: `HogInvocationResultsTable` for querying invocation history

**Frontend:**
- `HogInvocations` component: Full-featured invocations table with filtering (date, status, error kind), search, sorting, and bulk replay
- `InvocationsSparkline`: Sparkline chart showing invocation success/failure distribution over time
- Date filter with minute-level precision (5m, 30m, 1h, 4h, 24h, 7d, 30d presets)
- Replay action with confirmation dialog and progress tracking
- Integrated into both hog function and workflow scenes

**Testing:**
- Integration test (`replay-paginator.service.test.ts`): Seeds real lifecycle rows through Kafka → ClickHouse, verifies paginator query and re-enqueue
- E2E test (`replay-e2e.test.ts`): Full pipeline from invocation → lifecycle row → replay → re-execution
- Unit tests for `HogInvocationResultsService` and replay job manager

## How did you test this code?

- Automated integration tests verify the ClickHouse lifecycle row pipeline and paginator query collapse
- E2E tests confirm end-to-end replay flow: invocation execution → lifecycle row production → replay job creation → re-enqueue
- Unit tests cover `HogInvocationResultsService` row production and replay job state transitions
- Existing cyclotron V2 tests extended to cover `overwriteExisting` conflict detection

## Publish to changelog?

Yes — this is a user-facing feature enabling replay of past invocations.

## 🤖 Agent context

Agent-authored. This PR implements the complete replay infrastructure for hog invocations, spanning Node.js CDP services, Django API endpoints, ClickHouse schema, and React frontend components. Key decisions:

- **Paginated replay via cyclotron**: Replay jobs are first-class cyclotron jobs with pagination state, allowing long-running replays to survive worker restarts and provide progress tracking
- **ClickHouse lifecycle rows**: Invocation execution state (running/succeeded/failed) is persisted to ClickHouse via Kafka, enabling the paginator to query matching rows and the frontend to display invocation history
- **ReplacingMergeTree with version**: Replay re-enqueues bump `attempts` and set `is_retry=1`; the ReplacingMergeTree collapses prior versions at merge time so the frontend sees the latest state

https://claude.ai/code/session_01B2ujnJL7E24TvpBC9Hg11s