### PR TITLE
fix(mcp): disable conversation id in mcp analytics

### DIFF
--- a/services/mcp/src/lib/posthog/analytics.ts
+++ b/services/mcp/src/lib/posthog/analytics.ts
@@ -227,7 +227,7 @@ export async function initMcpAnalytics(
             posthogClient: getPostHogClient(),
             context: options.contextEnabled,
             enableAITracing: true,
-            enableConversationId: true,
+            enableConversationId: false,
             enableTracing: true,
             identify: { userId: distinctId },
             reportMissing: options.reportMissingEnabled,


### PR DESCRIPTION
## Problem

Claude models treat conversation_id as prompt injection.

## Changes

Set `enableConversationId` to `false` in the MCP analytics initialization (`services/mcp/src/lib/posthog/analytics.ts`).

## How did you test this code?

Single-line config change verified locally; existing MCP analytics behavior is unaffected aside from conversation ID no longer being set.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no
