### PR TITLE
chore(insights): rip out persons-on-events feature flag eval

### DIFF
--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -14,7 +14,6 @@ from django.db.models.signals import post_delete, post_save
 
 import pytz
 import pydantic
-import posthoganalytics
 
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries, tags_context
 from posthog.cloud_utils import is_cloud
@@ -739,6 +738,14 @@ class Team(UUIDTClassicModel):
         if self._person_on_events_person_id_no_override_properties_on_events:
             return PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
 
+        # Cloud teams are backfilled into `team.modifiers["personsOnEventsMode"]`
+        # (see posthog/dags/backfill_persons_on_events_mode.py), so this branch
+        # is reached on cloud only for brand-new teams created after the backfill.
+        # v2 has been at 100% rollout for orgs created after 2024-06-14, so it is
+        # the canonical modern default. Self-hosted with neither instance setting
+        # enabled keeps the historical JOINED behavior.
+        if is_cloud():
+            return PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
         return PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED
 
     # KLUDGE: DO NOT REFERENCE IN THE BACKEND!
@@ -756,24 +763,6 @@ class Team(UUIDTClassicModel):
         if person_on_events_override is not None:
             return person_on_events_override
 
-        # on PostHog Cloud, use the feature flag
-        if is_cloud():
-            return posthoganalytics.feature_enabled(
-                "persons-on-events-person-id-no-override-properties-on-events",
-                str(self.uuid),
-                groups={"project": str(self.id)},
-                group_properties={
-                    "project": {
-                        "id": str(self.id),
-                        "created_at": self.created_at.isoformat() if self.created_at else None,
-                        "uuid": self.uuid,
-                    }
-                },
-                only_evaluate_locally=True,
-                send_feature_flag_events=False,
-            )
-
-        # on self-hosted, use the instance setting
         return get_instance_setting("PERSON_ON_EVENTS_ENABLED")
 
     @property
@@ -781,24 +770,6 @@ class Team(UUIDTClassicModel):
         person_on_events_v2_override = getattr(settings, "PERSON_ON_EVENTS_V2_OVERRIDE", None)
         if person_on_events_v2_override is not None:
             return person_on_events_v2_override
-
-        # on PostHog Cloud, use the feature flag
-        if is_cloud():
-            return posthoganalytics.feature_enabled(
-                "persons-on-events-v2-reads-enabled",
-                str(self.uuid),
-                groups={"organization": str(self.organization_id)},
-                group_properties={
-                    "organization": {
-                        "id": str(self.organization_id),
-                        "created_at": self.organization.created_at.isoformat()
-                        if self.organization.created_at
-                        else None,
-                    }
-                },
-                only_evaluate_locally=True,
-                send_feature_flag_events=False,
-            )
 
         return get_instance_setting("PERSON_ON_EVENTS_V2_ENABLED")
 

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -738,12 +738,7 @@ class Team(UUIDTClassicModel):
         if self._person_on_events_person_id_no_override_properties_on_events:
             return PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
 
-        # Cloud teams are backfilled into `team.modifiers["personsOnEventsMode"]`
-        # (see posthog/dags/backfill_persons_on_events_mode.py), so this branch
-        # is reached on cloud only for brand-new teams created after the backfill.
-        # v2 has been at 100% rollout for orgs created after 2024-06-14, so it is
-        # the canonical modern default. Self-hosted with neither instance setting
-        # enabled keeps the historical JOINED behavior.
+        # Cloud teams are backfilled via backfill_persons_on_events_mode_job; this branch is hit only for new teams.
         if is_cloud():
             return PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
         return PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -1867,27 +1867,3 @@ async def test_hogql_table_applies_custom_modifier_to_sessions_query(ateam):
     assert str(custom_bounce_rate_duration) in captured_sql, (
         f"Expected bounce rate duration {custom_bounce_rate_duration} in SQL, got: {captured_sql}"
     )
-
-
-async def test_create_default_modifiers_for_team_in_async_context(ateam):
-    """Test that create_default_modifiers_for_team must be wrapped with database_sync_to_async in async context.
-
-    The function accesses team.organization.created_at via person_on_events_mode_flag_based_default,
-    which triggers a lazy load of the organization foreign key. Without database_sync_to_async,
-    this raises SynchronousOnlyOperation in an async context.
-
-    This is a regression test for the fix that wrapped the call in hogql_table and get_query_row_count.
-    """
-    from django.core.exceptions import SynchronousOnlyOperation
-
-    from posthog.hogql.modifiers import create_default_modifiers_for_team
-
-    # fetch team without select_related to ensure organization needs lazy loading
-    team = await database_sync_to_async(Team.objects.get)(id=ateam.pk)
-    # mock is_cloud() to return true so that the code path accessing team.organization.created_at is triggered
-    with unittest.mock.patch("posthog.models.team.team.is_cloud", return_value=True):
-        # calling directly raises
-        with pytest.raises(SynchronousOnlyOperation):
-            create_default_modifiers_for_team(team)
-        # wrapped doesn't raise
-        await database_sync_to_async(create_default_modifiers_for_team)(team)

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -169,10 +169,6 @@ class TestTeam(BaseTest):
         self.assertEqual(DashboardTile.objects.filter(dashboard=team.primary_dashboard).count(), 6)
 
     def test_team_on_cloud_defaults_to_v2_when_modifier_unset(self):
-        # Cloud teams are backfilled into team.modifiers["personsOnEventsMode"]
-        # (see posthog/dags/backfill_persons_on_events_mode.py). Brand-new cloud
-        # teams created after the backfill have a null modifier and should adopt
-        # v2 as the canonical modern default.
         with self.is_cloud(True):
             with override_instance_config("PERSON_ON_EVENTS_ENABLED", False):
                 team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -168,47 +168,29 @@ class TestTeam(BaseTest):
         # Ensure insights are created and linked
         self.assertEqual(DashboardTile.objects.filter(dashboard=team.primary_dashboard).count(), 6)
 
-    @mock.patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_team_on_cloud_uses_feature_flag_to_determine_person_on_events(self, mock_feature_enabled):
+    def test_team_on_cloud_defaults_to_v2_when_modifier_unset(self):
+        # Cloud teams are backfilled into team.modifiers["personsOnEventsMode"]
+        # (see posthog/dags/backfill_persons_on_events_mode.py). Brand-new cloud
+        # teams created after the backfill have a null modifier and should adopt
+        # v2 as the canonical modern default.
         with self.is_cloud(True):
             with override_instance_config("PERSON_ON_EVENTS_ENABLED", False):
                 team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
                 self.assertEqual(
                     team.person_on_events_mode, PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
                 )
-                # called more than once when evaluating hogql
-                mock_feature_enabled.assert_called_with(
-                    "persons-on-events-v2-reads-enabled",
-                    str(team.uuid),
-                    groups={"organization": str(self.organization.id)},
-                    group_properties={
-                        "organization": {
-                            "id": str(self.organization.id),
-                            "created_at": self.organization.created_at.isoformat(),
-                        }
-                    },
-                    only_evaluate_locally=True,
-                    send_feature_flag_events=False,
-                )
 
-    @mock.patch("posthoganalytics.feature_enabled", return_value=False)
-    def test_team_on_self_hosted_uses_instance_setting_to_determine_person_on_events(self, mock_feature_enabled):
+    def test_team_on_self_hosted_uses_instance_setting_to_determine_person_on_events(self):
         with self.is_cloud(False):
             with override_instance_config("PERSON_ON_EVENTS_V2_ENABLED", True):
                 team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
                 self.assertEqual(
                     team.person_on_events_mode, PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
                 )
-                for args_list in mock_feature_enabled.call_args_list:
-                    # It is ok if we check other feature flags, just not `persons-on-events-v2-reads-enabled`
-                    assert args_list[0][0] != "persons-on-events-v2-reads-enabled"
 
             with override_instance_config("PERSON_ON_EVENTS_V2_ENABLED", False):
                 team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
                 self.assertEqual(team.person_on_events_mode, PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED)
-                for args_list in mock_feature_enabled.call_args_list:
-                    # It is ok if we check other feature flags, just not `persons-on-events-v2-reads-enabled`
-                    assert args_list[0][0] != "persons-on-events-v2-reads-enabled"
 
     def test_each_team_gets_project_with_default_name_and_same_id(self):
         # Can be removed once environments are fully rolled out

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -174,6 +174,37 @@ export const ObservationStatusEnumApi = {
 } as const
 
 /**
+ * Mirrors `temporal.types.LensSnapshot` for OpenAPI generation.
+ */
+export interface LensSnapshotApi {
+    /** Lens name at run time. */
+    name: string
+    /** Lens type (monitor, classifier, scorer, summarizer, indexer) at run time.
+
+  * `monitor` - Monitor
+  * `classifier` - Classifier
+  * `scorer` - Scorer
+  * `summarizer` - Summarizer
+  * `indexer` - Indexer */
+    lens_type: LensTypeEnumApi
+    /** The `ReplayLens.lens_version` value at the moment the workflow ran. */
+    lens_version: number
+    /** Concrete model that ran the observation.
+
+  * `gemini-3-flash` - Gemini 3 Flash
+  * `gemini-3-flash-lite` - Gemini 3 Flash Lite */
+    model: LensModelEnumApi
+    /** Concrete provider that ran the observation.
+
+  * `google` - Google */
+    provider: LensProviderEnumApi
+    /** Whether the observation was run with Signal emission enabled. */
+    emits_signals: boolean
+    /** Lens-type-specific configuration at run time (prompt, tags, scale, etc.). */
+    lens_config: unknown
+}
+
+/**
  * * `schedule` - Schedule
  * `on_demand` - On demand
  */
@@ -197,24 +228,18 @@ export interface ReplayObservationApi {
   * `succeeded` - Succeeded
   * `failed` - Failed */
     readonly status: ObservationStatusEnumApi
-    /** Populated on failure. Includes the malformed model response when validation fails. */
+    /** Populated on failure; includes the malformed model response when validation fails. */
     readonly error_reason: string
     /** Temporal workflow id for progress queries and debugging. Empty until the workflow starts. */
     readonly workflow_id: string
-    /** The `ReplayLens.lens_version` value at the moment the workflow ran. */
-    readonly lens_version: number
-    /** Snapshot of `ReplayLens.lens_config` at run time. Lens edits do not retroactively mutate observations. */
-    readonly lens_config_snapshot: unknown
-    /** Concrete model that ran the observation. */
-    readonly model_used: string
-    /** Concrete provider that ran the observation. */
-    readonly provider_used: string
+    /** Frozen view of the lens at run time; lens edits do not retroactively mutate this observation. */
+    readonly lens_snapshot: LensSnapshotApi
     /** Whether this observation came from the schedule or an on-demand request.
 
   * `schedule` - Schedule
   * `on_demand` - On demand */
     readonly triggered_by: ObservationTriggerEnumApi
-    /** User who triggered an on-demand observation. Null for scheduled observations. */
+    /** User who triggered an on-demand observation; null for scheduled observations. */
     readonly triggered_by_user: UserBasicApi | null
     /** @nullable */
     started_at?: string | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19725,6 +19725,37 @@ export namespace Schemas {
       Indexer: 'indexer',
     } as const;
 
+    /**
+     * Mirrors `temporal.types.LensSnapshot` for OpenAPI generation.
+     */
+    export interface LensSnapshot {
+      /** Lens name at run time. */
+      name: string;
+      /** Lens type (monitor, classifier, scorer, summarizer, indexer) at run time.
+
+      * `monitor` - Monitor
+      * `classifier` - Classifier
+      * `scorer` - Scorer
+      * `summarizer` - Summarizer
+      * `indexer` - Indexer */
+      lens_type: LensTypeEnum;
+      /** The `ReplayLens.lens_version` value at the moment the workflow ran. */
+      lens_version: number;
+      /** Concrete model that ran the observation.
+
+      * `gemini-3-flash` - Gemini 3 Flash
+      * `gemini-3-flash-lite` - Gemini 3 Flash Lite */
+      model: LensModelEnum;
+      /** Concrete provider that ran the observation.
+
+      * `google` - Google */
+      provider: LensProviderEnum;
+      /** Whether the observation was run with Signal emission enabled. */
+      emits_signals: boolean;
+      /** Lens-type-specific configuration at run time (prompt, tags, scale, etc.). */
+      lens_config: unknown;
+    }
+
     export type LimitContext = typeof LimitContext[keyof typeof LimitContext];
 
 
@@ -22697,24 +22728,18 @@ export namespace Schemas {
       * `succeeded` - Succeeded
       * `failed` - Failed */
       readonly status: ObservationStatusEnum;
-      /** Populated on failure. Includes the malformed model response when validation fails. */
+      /** Populated on failure; includes the malformed model response when validation fails. */
       readonly error_reason: string;
       /** Temporal workflow id for progress queries and debugging. Empty until the workflow starts. */
       readonly workflow_id: string;
-      /** The `ReplayLens.lens_version` value at the moment the workflow ran. */
-      readonly lens_version: number;
-      /** Snapshot of `ReplayLens.lens_config` at run time. Lens edits do not retroactively mutate observations. */
-      readonly lens_config_snapshot: unknown;
-      /** Concrete model that ran the observation. */
-      readonly model_used: string;
-      /** Concrete provider that ran the observation. */
-      readonly provider_used: string;
+      /** Frozen view of the lens at run time; lens edits do not retroactively mutate this observation. */
+      readonly lens_snapshot: LensSnapshot;
       /** Whether this observation came from the schedule or an on-demand request.
 
       * `schedule` - Schedule
       * `on_demand` - On demand */
       readonly triggered_by: ObservationTriggerEnum;
-      /** User who triggered an on-demand observation. Null for scheduled observations. */
+      /** User who triggered an on-demand observation; null for scheduled observations. */
       readonly triggered_by_user: UserBasic | null;
       /** @nullable */
       started_at?: string | null;


### PR DESCRIPTION
## Problem

`set_default_modifier_values` fills `personsOnEventsMode` by evaluating the `persons-on-events-v2-reads-enabled` (and v1) feature flag locally at request time via `team.person_on_events_mode_flag_based_default`. The local SDK flag-cache state varies across web pods (cold-start, polling lag, regional hypercache mis-pointing), so the same team can resolve to different values across pods. That value flows into `get_cache_payload`, fragmenting the query `cache_key` per-pod and breaking dashboard cache coherence.

#58035 introduced a Dagster job that persists each team's canonical mode into `team.modifiers["personsOnEventsMode"]`. That job has been run against US and EU production. This PR is the follow-up that the previous PR called out as "out of scope": removing the request-path flag eval so the modifier is the single source of truth.

## Changes

- **`posthog/models/team/team.py`**:
  - Drop the `if is_cloud(): return posthoganalytics.feature_enabled(...)` branches from `_person_on_events_person_id_no_override_properties_on_events` and `_person_on_events_person_id_override_properties_on_events`. Env-var overrides (test/runtime knob) and self-hosted instance settings continue to work unchanged.
  - Switch the cloud fallback in `person_on_events_mode_flag_based_default` from `PERSON_ID_OVERRIDE_PROPERTIES_JOINED` to `PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS` (v2). Backfilled cloud teams keep using their persisted modifier; only brand-new cloud teams created after the backfill hit this branch, and v2 has been at 100% rollout for orgs created after 2024-06-14 anyway. Self-hosted retains the historical JOINED default.
  - Drop the now-unused `import posthoganalytics`.
- **`posthog/test/test_team.py`**: Replace `test_team_on_cloud_uses_feature_flag_to_determine_person_on_events` with `test_team_on_cloud_defaults_to_v2_when_modifier_unset` (the feature flag is gone, so the assertion changes from "FF was called" to "v2 is the new cloud default"). Drop the FF mock from `test_team_on_self_hosted_uses_instance_setting_to_determine_person_on_events` — it no longer needs to assert the flag isn't called because there is no eval anywhere.
- **`posthog/temporal/tests/data_modeling/test_run_workflow.py`**: Remove `test_create_default_modifiers_for_team_in_async_context`. The test was a regression test for `team.organization.created_at` being lazy-loaded inside `create_default_modifiers_for_team` via the FF eval. With the eval gone, the function no longer touches the organization FK, so the test premise (raises `SynchronousOnlyOperation`) is no longer true. The `database_sync_to_async` wrap at the two callsites in `run_workflow.py` is left in place as defense-in-depth.

## How did you test this code?

I'm an agent. I did not run the Python test suite (no dev env available in this sandbox). Locally I ran:

- `ruff check` and `ruff format --check` on the four touched files → clean.

End-to-end verification before merging:
- Run `posthog/test/test_team.py::TestTeam` to confirm the two updated cloud/self-hosted tests pass.
- Run `posthog/hogql/test/test_modifiers.py` — `test_modifiers_persons_on_events_default_is_based_on_team_property` still patches `_person_on_events_person_id_override_properties_on_events` and should continue to pass; `test_create_default_modifiers_for_team_init` and `test_team_modifiers_override` run in self-hosted mode and expect the JOINED default, which this PR preserves.
- Run `posthog/temporal/tests/data_modeling/test_run_workflow.py` to confirm the file still parses after the deletion.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7).

Tools used: read/grep/edit/bash. No web fetches were used to pull external context beyond the public GitHub PR description for #58035.

Decisions made along the way:

- **Why move the cloud null-modifier default to v2 (instead of leaving JOINED)?** #58035's description explicitly anticipated this PR doing it ("v2 as the post-deploy default for null modifiers"). Without it, brand-new cloud teams would silently downgrade from v2 (what the FF gave them) to JOINED (the old fallback), which is a behavior regression for new customers. Self-hosted defaults are not touched because self-hosted instances are not part of the backfill — their `team.modifiers` will remain null and existing JOINED + instance-setting behavior is the right answer.
- **Why keep env-var overrides and instance-setting fallback?** The previous PR explicitly described env vars as "runtime knobs the request-path code consults each request" — they are intentionally not encoded into `team.modifiers`. Removing them would also force ~30+ test files that use `@override_settings(PERSON_ON_EVENTS_OVERRIDE=...)` to be rewritten. Keeping them is a no-op for production (the vars are unset) and preserves the test pattern.
- **Why keep `_person_on_events_person_id_*` as separate inner properties instead of inlining?** `test_modifiers.py::test_modifiers_persons_on_events_default_is_based_on_team_property` patches one of these properties directly, so the patch target needs to keep existing. Inlining would have required updating that test for no real win.
- **Why delete (rather than rewrite) `test_create_default_modifiers_for_team_in_async_context`?** The test specifically asserted that `create_default_modifiers_for_team` raises `SynchronousOnlyOperation` because the FF eval touched `team.organization.created_at`. With the FF eval removed, that codepath no longer exists. There is no equivalent invariant to test for the new code (it just reads in-memory settings).

Out of scope (could be follow-ups if anyone wants to clean further):

- Removing the `PERSON_ON_EVENTS_OVERRIDE` / `PERSON_ON_EVENTS_V2_OVERRIDE` env vars and `PERSON_ON_EVENTS_ENABLED` / `PERSON_ON_EVENTS_V2_ENABLED` instance settings entirely, and converting the ~30+ tests that rely on them to set `team.modifiers["personsOnEventsMode"]` directly.
- Renaming `person_on_events_mode_flag_based_default` now that it no longer evaluates a flag. Left alone here to keep the diff focused; many call sites and tests reference the name.
- Auditing other `posthoganalytics.feature_enabled` call sites for similar cache-identity leaks (also called out in #58035).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*