### PR TITLE
fix(data-warehouse): enforce access control on update_schema when no …

### DIFF
--- a/products/data_warehouse/backend/api/table.py
+++ b/products/data_warehouse/backend/api/table.py
@@ -304,11 +304,12 @@ class TableViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.M
 
     @action(methods=["POST"], detail=True)
     def update_schema(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+        table: DataWarehouseTable = self.get_object()
+
         updates = request.data.get("updates", None)
         if updates is None:
             return response.Response(status=status.HTTP_200_OK)
 
-        table: DataWarehouseTable = self.get_object()
         if table.external_data_source is not None:
             return response.Response(
                 status=status.HTTP_400_BAD_REQUEST, data={"message": "The table must be a manually linked table"}


### PR DESCRIPTION
## Problem

`TableViewSet.update_schema` returned `200 OK` whenever the request body had no `updates` field, before calling `get_object()`. As `get_object()` runs object-level permission checks (via `AccessControlViewSetMixin`), a caller without access to the table could hit this endpoint and receive a success response, bypassing access control.

While this is not a vulnerability (we were just returning 200 with no data for an empty request - no impact), this endpoint was flagged by a security test we're implementing. 

## Changes

Move `self.get_object()` above the `updates is None` early return in `products/data_warehouse/backend/api/table.py` so access control is enforced regardless of payload contents.

## How did you test this code?

No new tests were added.

## Publish to changelog?

no