### PR TITLE
chore(toolbox): scope pod selector with component label in per-app namespace

### DIFF
--- a/tools/infra-scripts/clitools/test_toolbox.py
+++ b/tools/infra-scripts/clitools/test_toolbox.py
@@ -1200,62 +1200,48 @@ class TestToolbox(unittest.TestCase):
         )
 
     def test_main_default_pool_dispatches_toolbox_django_kwargs(self):
-        """No --pool argument defaults to toolbox-django and threads its labels."""
-        patches = self._patch_main_collaborators()
+        """--pool toolbox-django (the default) threads the right kwargs per active namespace.
 
-        with (
-            patches["get_current_user"],
-            patches["get_toolbox_pod"] as m_get_pod,
-            patches["claim_pod"],
-            patches["connect_to_pod"],
-            patches["delete_pod"],
-            patches["select_context"],
-            patches["validate_context"],
-            patch.object(toolbox_script.sys, "argv", ["toolbox.py"]),
-            patch.dict(os.environ, {}, clear=False),
-        ):
-            self._clean_env()
-            with self.assertRaises(SystemExit):
-                toolbox_script.main()
-
-        m_get_pod.assert_called_once_with(
-            "user_at_posthog.com",
-            check_claimed=True,
-            app_label="posthog-toolbox-django",
-            claimed_label_key="toolbox-claimed",
-            namespace="posthog",
-            context="posthog-dev",
-            extra_selector=None,
-        )
-
-    def test_main_toolbox_django_in_per_app_namespace_adds_component_selector(self):
-        """Targeting the golden-chart namespace adds `component=app` to the kubectl selector.
-
-        Under the golden chart, the toolbox release also owns pgbouncer Deployments in the
-        per-app namespace, and they share `app.kubernetes.io/name=posthog-toolbox-django`
-        with the toolbox itself. Without the extra `component=app` filter, the wrapper
-        could pick up a pgbouncer pod.
+        The legacy `posthog` namespace gets no `extra_selector`. The golden-chart per-app
+        namespace `posthog-toolbox-django` adds `app.kubernetes.io/component=app` so the
+        wrapper can't claim a pgbouncer pod (the chart's pgbouncers share
+        `app.kubernetes.io/name=posthog-toolbox-django` with the toolbox itself).
         """
-        patches = self._patch_main_collaborators()
+        cases = [
+            ("posthog", None),  # legacy default — KUBE_NAMESPACE unset
+            ("posthog-toolbox-django", "app.kubernetes.io/component=app"),
+        ]
+        for namespace, expected_extra in cases:
+            with self.subTest(namespace=namespace):
+                patches = self._patch_main_collaborators()
+                env_override = {"KUBE_NAMESPACE": namespace} if namespace != "posthog" else {}
+                with (
+                    patches["get_current_user"],
+                    patches["get_toolbox_pod"] as m_get_pod,
+                    patches["claim_pod"],
+                    patches["connect_to_pod"],
+                    patches["delete_pod"],
+                    patches["select_context"],
+                    patches["validate_context"],
+                    patch.object(toolbox_script.sys, "argv", ["toolbox.py"]),
+                    patch.dict(os.environ, env_override, clear=False),
+                ):
+                    os.environ.pop("KUBE_CONTEXT", None)
+                    os.environ.pop("FLOX_ENV", None)
+                    if namespace == "posthog":
+                        os.environ.pop("KUBE_NAMESPACE", None)
+                    with self.assertRaises(SystemExit):
+                        toolbox_script.main()
 
-        with (
-            patches["get_current_user"],
-            patches["get_toolbox_pod"] as m_get_pod,
-            patches["claim_pod"],
-            patches["connect_to_pod"],
-            patches["delete_pod"],
-            patches["select_context"],
-            patches["validate_context"],
-            patch.object(toolbox_script.sys, "argv", ["toolbox.py"]),
-            patch.dict(os.environ, {"KUBE_NAMESPACE": "posthog-toolbox-django"}, clear=False),
-        ):
-            os.environ.pop("KUBE_CONTEXT", None)
-            os.environ.pop("FLOX_ENV", None)
-            with self.assertRaises(SystemExit):
-                toolbox_script.main()
-
-        self.assertEqual(m_get_pod.call_args.kwargs["namespace"], "posthog-toolbox-django")
-        self.assertEqual(m_get_pod.call_args.kwargs["extra_selector"], "app.kubernetes.io/component=app")
+                m_get_pod.assert_called_once_with(
+                    "user_at_posthog.com",
+                    check_claimed=True,
+                    app_label="posthog-toolbox-django",
+                    claimed_label_key="toolbox-claimed",
+                    namespace=namespace,
+                    context="posthog-dev",
+                    extra_selector=expected_extra,
+                )
 
     def test_main_kube_context_env_validates_without_switching(self):
         """When KUBE_CONTEXT is set, main() validates it and threads it as --context, never calling switch_context."""

--- a/tools/infra-scripts/clitools/test_toolbox.py
+++ b/tools/infra-scripts/clitools/test_toolbox.py
@@ -276,6 +276,54 @@ class TestToolbox(unittest.TestCase):
         )
 
     @patch("subprocess.run")
+    def test_get_toolbox_pod_extra_selector(self, mock_run):
+        """extra_selector= is ANDed onto the base name= selector passed to kubectl."""
+        mock_response = MagicMock()
+        mock_response.stdout = json.dumps(
+            {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "toolbox-pod-1",
+                            "resourceVersion": "12345",
+                            "labels": {
+                                "app.kubernetes.io/name": "posthog-toolbox-django",
+                                "app.kubernetes.io/component": "app",
+                            },
+                            "deletionTimestamp": None,
+                        },
+                        "status": {"phase": "Running"},
+                    }
+                ]
+            }
+        )
+        mock_run.return_value = mock_response
+
+        get_toolbox_pod(
+            "michael.k_at_posthog.com",
+            app_label="posthog-toolbox-django",
+            claimed_label_key="toolbox-claimed",
+            namespace="posthog-toolbox-django",
+            extra_selector="app.kubernetes.io/component=app",
+        )
+        mock_run.assert_called_once_with(
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                "posthog-toolbox-django",
+                "-l",
+                "app.kubernetes.io/name=posthog-toolbox-django,app.kubernetes.io/component=app",
+                "-o",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch("subprocess.run")
     def test_get_toolbox_pod_returns_existing_claim_with_rv(self, mock_run):
         """An already-claimed pod returns is_claimed=True and the observed resourceVersion."""
         mock_response = MagicMock()
@@ -807,7 +855,13 @@ class TestToolbox(unittest.TestCase):
         """POOLS contains both pools with the expected app and claim labels."""
         self.assertEqual(
             toolbox_script.POOLS["toolbox-django"],
-            {"app_label": "posthog-toolbox-django", "claimed_label_key": "toolbox-claimed"},
+            {
+                "app_label": "posthog-toolbox-django",
+                "claimed_label_key": "toolbox-claimed",
+                "extra_selectors_by_namespace": {
+                    "posthog-toolbox-django": "app.kubernetes.io/component=app",
+                },
+            },
         )
         self.assertEqual(
             toolbox_script.POOLS["flags-cache-jumphost"],
@@ -1137,6 +1191,7 @@ class TestToolbox(unittest.TestCase):
             claimed_label_key="flags-jumphost-claimed",
             namespace="posthog",
             context="posthog-dev",
+            extra_selector=None,
         )
         # claim_pod gets namespace, context, and resource_version from get_toolbox_pod's return.
         self.assertEqual(
@@ -1170,7 +1225,37 @@ class TestToolbox(unittest.TestCase):
             claimed_label_key="toolbox-claimed",
             namespace="posthog",
             context="posthog-dev",
+            extra_selector=None,
         )
+
+    def test_main_toolbox_django_in_per_app_namespace_adds_component_selector(self):
+        """Targeting the golden-chart namespace adds `component=app` to the kubectl selector.
+
+        Under the golden chart, the toolbox release also owns pgbouncer Deployments in the
+        per-app namespace, and they share `app.kubernetes.io/name=posthog-toolbox-django`
+        with the toolbox itself. Without the extra `component=app` filter, the wrapper
+        could pick up a pgbouncer pod.
+        """
+        patches = self._patch_main_collaborators()
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"] as m_get_pod,
+            patches["claim_pod"],
+            patches["connect_to_pod"],
+            patches["delete_pod"],
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py"]),
+            patch.dict(os.environ, {"KUBE_NAMESPACE": "posthog-toolbox-django"}, clear=False),
+        ):
+            os.environ.pop("KUBE_CONTEXT", None)
+            os.environ.pop("FLOX_ENV", None)
+            with self.assertRaises(SystemExit):
+                toolbox_script.main()
+
+        self.assertEqual(m_get_pod.call_args.kwargs["namespace"], "posthog-toolbox-django")
+        self.assertEqual(m_get_pod.call_args.kwargs["extra_selector"], "app.kubernetes.io/component=app")
 
     def test_main_kube_context_env_validates_without_switching(self):
         """When KUBE_CONTEXT is set, main() validates it and threads it as --context, never calling switch_context."""

--- a/tools/infra-scripts/clitools/toolbox.py
+++ b/tools/infra-scripts/clitools/toolbox.py
@@ -18,10 +18,20 @@ from toolbox.kubernetes import select_context, validate_context
 from toolbox.pod import ClaimRaceError, claim_pod, connect_to_pod, delete_pod, get_toolbox_pod
 from toolbox.user import get_current_user
 
+# Extra label selectors ANDed onto the base `app.kubernetes.io/name=<app_label>`
+# selector. Keyed by namespace because the legacy and golden-chart deployments
+# share the same `app_label` but live in different namespaces with different
+# co-tenants (pgbouncer pods in the golden chart's per-app namespace also carry
+# `app.kubernetes.io/name=posthog-toolbox-django`, so we need `component=app` to
+# pick out only the main pool). The legacy `posthog` namespace doesn't need a
+# discriminator because its pgbouncers have a different `name` label.
 POOLS = {
     "toolbox-django": {
         "app_label": "posthog-toolbox-django",
         "claimed_label_key": "toolbox-claimed",
+        "extra_selectors_by_namespace": {
+            "posthog-toolbox-django": "app.kubernetes.io/component=app",
+        },
     },
     "flags-cache-jumphost": {
         "app_label": "flags-cache-jumphost",
@@ -83,6 +93,12 @@ def main():
         app_label = pool["app_label"]
         claimed_label_key = pool["claimed_label_key"]
         namespace = os.environ.get("KUBE_NAMESPACE", "posthog")
+        # The base selector is `app.kubernetes.io/name=<app_label>`. Some
+        # namespaces also host other workloads that share that label (e.g. the
+        # golden chart deploys a per-app pgbouncer under the same name in the
+        # `posthog-toolbox-django` namespace), so we may need a further
+        # discriminator to pick only the main pool pods.
+        extra_selector = pool.get("extra_selectors_by_namespace", {}).get(namespace)
 
         print(f"🛠️  Connecting to {args.pool} pool in namespace {namespace}...")  # noqa: T201
 
@@ -110,6 +126,7 @@ def main():
             claimed_label_key=claimed_label_key,
             namespace=namespace,
             context=selected_context,
+            extra_selector=extra_selector,
         )
         print(f"🎯 Found pod: {pod_name}")  # noqa: T201
 
@@ -177,6 +194,7 @@ def main():
                         claimed_label_key=claimed_label_key,
                         namespace=namespace,
                         context=selected_context,
+                        extra_selector=extra_selector,
                     )
                     if is_already_claimed:
                         # Either we won an earlier race attempt (whose ack we missed) or

--- a/tools/infra-scripts/clitools/toolbox/pod.py
+++ b/tools/infra-scripts/clitools/toolbox/pod.py
@@ -33,6 +33,7 @@ def get_toolbox_pod(
     claimed_label_key: str,
     namespace: str,
     context: str | None = None,
+    extra_selector: str | None = None,
 ) -> tuple[str, bool, str]:
     """Get an available toolbox pod name and the resourceVersion observed.
 
@@ -43,12 +44,21 @@ def get_toolbox_pod(
         claimed_label_key: Label key the wrapper sets on a claimed pod.
         namespace: Kubernetes namespace the pool lives in.
         context: Optional kubernetes context to scope the kubectl call to.
+        extra_selector: Optional additional label selector ANDed onto
+            ``app.kubernetes.io/name=<app_label>``. Used when other resources
+            in the namespace share the same name label (e.g. the golden chart
+            puts the toolbox's own pgbouncer pods under the same name) so we
+            need a second key like ``app.kubernetes.io/component=app`` to
+            pick out only the main pool.
 
     Returns:
         Tuple of (pod_name, is_already_claimed, resource_version). The
         resource_version reflects the pod state at observation time and is
         used by ``claim_pod`` for optimistic concurrency control.
     """
+    label_selector = f"app.kubernetes.io/name={app_label}"
+    if extra_selector:
+        label_selector = f"{label_selector},{extra_selector}"
     wait_start = datetime.now()
     max_wait = timedelta(minutes=5)
     update_interval = timedelta(seconds=30)
@@ -63,7 +73,7 @@ def get_toolbox_pod(
                     "-n",
                     namespace,
                     "-l",
-                    f"app.kubernetes.io/name={app_label}",
+                    label_selector,
                     "-o",
                     "json",
                     context=context,


### PR DESCRIPTION
## Problem

The toolbox wrapper picks pods via `app.kubernetes.io/name=posthog-toolbox-django`. That selector is unique enough in the legacy `posthog` namespace, but the per-app namespace deployment (`posthog-toolbox-django`) bundles the toolbox release's own pgbouncer Deployments under the same `name` label. When run against that namespace, the wrapper can claim a pgbouncer pod by mistake.

## Changes

- New `extra_selectors_by_namespace` field on the `toolbox-django` pool config. For namespace `posthog-toolbox-django` it resolves to `app.kubernetes.io/component=app`; for any other namespace (the legacy one) it stays empty.
- `get_toolbox_pod` gains an optional `extra_selector` argument that ANDs onto the base `name=...` selector when set.
- `main()` resolves the extra selector from the active namespace at startup and threads it through both `get_toolbox_pod` call sites (initial fetch + race-retry).
- The `flags-cache-jumphost` pool is untouched.

Backwards-compat: pools that don't declare `extra_selectors_by_namespace` fall through to the same kubectl call as before, and namespaces not listed in the map fall back to no extras. Default invocation (`toolbox.py` against `posthog`) is byte-identical to today.

## How did you test this code?

I'm Claude (PostHog Code). Manual testing of the kubectl behaviour against a real cluster has NOT been done by me — leaving that for the human reviewer to validate end-to-end before merge.

Automated:
- `python3 -m unittest test_toolbox` — 68 tests, all green.
- New unit test (`test_get_toolbox_pod_extra_selector`) asserts the kubectl call shape when `extra_selector` is set.
- New integration test (`test_main_toolbox_django_in_per_app_namespace_adds_component_selector`) drives `main()` with `KUBE_NAMESPACE=posthog-toolbox-django` and asserts the resolved `extra_selector` reaches `get_toolbox_pod`.
- Existing `main()` integration tests updated to assert `extra_selector=None` for the legacy default path, locking in the no-op for unaffected callers.
- `test_pools_definition` updated to reflect the new POOLS shape.

## Publish to changelog?

no

## Docs update

Not applicable — this is internal tooling and the user-facing usage doesn't change.

## 🤖 Agent context

Authored by Claude (PostHog Code). Companion fix to PostHog/charts#11146, which narrows the chart-side cleanup CronJob's selector the same way; both are needed because the golden-chart layout co-locates pgbouncer pods with the toolbox under one Helm release.

Design notes worth flagging for the reviewer:

- I considered putting the discriminator on the pool entry directly (one constant for all namespaces) but kept it keyed by namespace so the legacy `posthog` deployment, which has no `component=app` label on its toolbox pod today, doesn't suddenly stop matching.
- Considered using set-based selectors like `component notin (pgbouncer-*)` so the wrapper logic could stay flat; rejected because the list of components leaks chart internals and grows over time.
- The extra selector is threaded through both `get_toolbox_pod` call sites in `main()` (initial fetch and the race-retry inside the claim loop). The race-retry was an easy thing to miss.