### PR TITLE
fix(mcp): align read-only header name with sandbox

### DIFF
--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -376,7 +376,7 @@ const handleRequest = async (
 
     const version = Number(request.headers.get('x-posthog-mcp-version') || url.searchParams.get('v')) || 1
 
-    const readOnlyRaw = request.headers.get('x-posthog-readonly') || url.searchParams.get('readonly')
+    const readOnlyRaw = request.headers.get('x-posthog-read-only') || url.searchParams.get('readonly')
     const readOnly = readOnlyRaw === 'true' || readOnlyRaw === '1' || undefined
 
     // Explicit selection between tool-based and CLI-based MCP. Falls back to the

--- a/services/mcp/src/lib/request-properties.ts
+++ b/services/mcp/src/lib/request-properties.ts
@@ -56,7 +56,7 @@ export function parseRequestProperties(
     const params = url.searchParams
 
     const token = request.headers.get('Authorization')?.split(' ')[1] ?? ''
-    const readOnlyRaw = header(request, 'x-posthog-readonly') || params.get('readonly')
+    const readOnlyRaw = header(request, 'x-posthog-read-only') || params.get('readonly')
 
     return {
         apiToken: token,


### PR DESCRIPTION
## Problem

There was a mismatch of readonly and read-only in headers.

## Changes

- Read the read-only flag from `x-posthog-read-only` in
  `services/mcp/src/index.ts` and
  `services/mcp/src/lib/request-properties.ts` so the MCP service
  matches what the sandbox actually sends.

The query-string fallback (`?readonly=`) is unchanged.

## How did you test this code?

I'm an agent. No automated tests were added or run for this change —
it's a one-character header rename. Reviewers should confirm there are
no other call sites still sending the old `x-posthog-readonly` header.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude).
- Grepped for both spellings across the repo to confirm the sandbox
  side (`products/tasks/backend/temporal/process_task/utils.py`)
  already uses `x-posthog-read-only`, so aligning the MCP side was the
  smaller and less risky change than touching the sandbox.
- No remaining references to `x-posthog-readonly` after the edit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*