### PR TITLE
fix(feature-flags): handle invalid timestamps in cookieless salt cache

### DIFF
--- a/rust/common/cookieless/src/manager.rs
+++ b/rust/common/cookieless/src/manager.rs
@@ -14,7 +14,9 @@ use crate::constants::{
     SALT_TTL_SECONDS, TIMEZONE_FALLBACK,
 };
 use crate::hash::{do_hash, HashError};
+use crate::metrics::metrics_consts::COOKIELESS_SALT_FALLBACK_COUNTER;
 use crate::salt_cache::{SaltCache, SaltCacheError};
+use common_metrics::inc;
 use common_redis::Client as RedisClient;
 
 #[derive(Debug, Error)]
@@ -270,6 +272,11 @@ impl CookielessManager {
                     original_date = %yyyymmdd,
                     original_timestamp_ms = params.timestamp_ms,
                     "Date out of range for salt cache, falling back to current date"
+                );
+                inc(
+                    COOKIELESS_SALT_FALLBACK_COUNTER,
+                    &[("reason".to_string(), "date_out_of_range".to_string())],
+                    1,
                 );
                 let now_ms = Utc::now().timestamp_millis() as u64;
                 let fallback_date = to_yyyy_mm_dd_in_timezone_safe(

--- a/rust/common/cookieless/src/manager.rs
+++ b/rust/common/cookieless/src/manager.rs
@@ -259,7 +259,28 @@ impl CookielessManager {
             params.event_time_zone,
             params.team_time_zone,
         )?;
-        let salt = self.get_salt_for_day(&yyyymmdd).await?;
+
+        // Try to get salt for the computed date, falling back to current date if it's out of range.
+        // This handles cases where the client sends timestamps in seconds instead of milliseconds,
+        // or sends otherwise invalid timestamps that produce dates like 1970.
+        let salt = match self.get_salt_for_day(&yyyymmdd).await {
+            Ok(salt) => salt,
+            Err(CookielessManagerError::SaltCacheError(SaltCacheError::DateOutOfRange)) => {
+                tracing::warn!(
+                    original_date = %yyyymmdd,
+                    original_timestamp_ms = params.timestamp_ms,
+                    "Date out of range for salt cache, falling back to current date"
+                );
+                let now_ms = Utc::now().timestamp_millis() as u64;
+                let fallback_date = to_yyyy_mm_dd_in_timezone_safe(
+                    now_ms,
+                    params.event_time_zone,
+                    params.team_time_zone,
+                )?;
+                self.get_salt_for_day(&fallback_date).await?
+            }
+            Err(e) => return Err(e),
+        };
 
         // Extract the root domain from the host
         let root_domain = extract_root_domain(params.host)?;
@@ -1118,5 +1139,89 @@ mod tests {
         let error_str = result.to_string();
         assert!(error_str.contains(&redis_key));
         assert!(error_str.contains("Some Redis error"));
+    }
+
+    #[tokio::test]
+    async fn test_do_hash_for_day_falls_back_on_invalid_timestamp() {
+        // Create a mock Redis client that only has a salt for today
+        let mut mock_redis = MockRedisClient::new();
+        let salt_base64 = "AAAAAAAAAAAAAAAAAAAAAA=="; // 16 bytes of zeros
+        let today = Utc::now().format("%Y-%m-%d").to_string();
+        let redis_key = format!("cookieless_salt:{today}");
+        mock_redis = mock_redis.get_ret(&redis_key, Ok(salt_base64.to_string()));
+        let redis_client = Arc::new(mock_redis);
+
+        // Create a CookielessManager
+        let config = CookielessConfig::default();
+        let manager = CookielessManager::new(config, redis_client);
+
+        // Use a timestamp in seconds (not milliseconds) which would produce 1970
+        // This simulates a client bug where timestamp is sent as seconds
+        let timestamp_in_seconds: u64 = 1779190409; // ~2026-05-19 in seconds
+
+        let hash_params = HashParams {
+            timestamp_ms: timestamp_in_seconds, // Bug: seconds instead of ms
+            event_time_zone: None,
+            team_time_zone: Some("UTC"),
+            team_id: 1,
+            ip: "127.0.0.1",
+            host: "example.com",
+            user_agent: "Mozilla/5.0",
+            n: 0,
+            hash_extra: "",
+        };
+
+        // This should succeed by falling back to today's date
+        let result = manager.do_hash_for_day(hash_params).await;
+        assert!(
+            result.is_ok(),
+            "Should fall back to current date when timestamp produces invalid date"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compute_cookieless_distinct_id_with_timestamp_in_seconds() {
+        // Create a mock Redis client that only has a salt for today
+        let mut mock_redis = MockRedisClient::new();
+        let salt_base64 = "AAAAAAAAAAAAAAAAAAAAAA=="; // 16 bytes of zeros
+        let today = Utc::now().format("%Y-%m-%d").to_string();
+        let redis_key = format!("cookieless_salt:{today}");
+        mock_redis = mock_redis.get_ret(&redis_key, Ok(salt_base64.to_string()));
+        let redis_client = Arc::new(mock_redis);
+
+        // Create a CookielessManager
+        let config = CookielessConfig::default();
+        let manager = CookielessManager::new(config, redis_client);
+
+        // Simulate a client sending timestamp in seconds instead of milliseconds
+        let timestamp_in_seconds: u64 = 1779190409; // ~2026-05-19 in seconds
+
+        let event_data = EventData {
+            ip: "127.0.0.1",
+            timestamp_ms: timestamp_in_seconds, // Bug: seconds instead of ms
+            host: "example.com",
+            user_agent: "Mozilla/5.0",
+            event_time_zone: None,
+            hash_extra: None,
+            distinct_id: COOKIELESS_SENTINEL_VALUE,
+        };
+
+        // This should succeed by falling back to today's date
+        let result = manager
+            .compute_cookieless_distinct_id(
+                event_data,
+                TeamData {
+                    team_id: 1,
+                    timezone: "UTC".to_string(),
+                    cookieless_server_hash_mode: CookielessServerHashMode::Stateless,
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "Should succeed with fallback when timestamp produces invalid date"
+        );
+        assert!(result.unwrap().starts_with(COOKIELESS_DISTINCT_ID_PREFIX));
     }
 }

--- a/rust/common/cookieless/src/metrics/metrics_consts.rs
+++ b/rust/common/cookieless/src/metrics/metrics_consts.rs
@@ -2,3 +2,4 @@
 pub const COOKIELESS_CACHE_HIT_COUNTER: &str = "cookieless_salt_cache_hit_total";
 pub const COOKIELESS_CACHE_MISS_COUNTER: &str = "cookieless_salt_cache_miss_total";
 pub const COOKIELESS_REDIS_ERROR_COUNTER: &str = "cookieless_redis_error_total";
+pub const COOKIELESS_SALT_FALLBACK_COUNTER: &str = "cookieless_salt_fallback_total";


### PR DESCRIPTION

> this is all Claude coded - @PostHog/team-flags-platform should take it or leave it

When clients send timestamps in seconds instead of milliseconds (or otherwise invalid timestamps), the cookieless salt cache would return a "Date is out of range" error that bubbled up as a 500 Internal Server Error.

This fix adds a fallback mechanism: when the computed date from a timestamp fails validation, we fall back to using the current date instead. This ensures the cookieless feature continues to work even when clients have timestamp bugs, while still logging a warning for debugging purposes.

Root cause: timestamps in seconds (e.g., 1779190409) divided by 1000 produced dates like 1970-01-21, which failed the date range validation.

https://claude.ai/code/session_01W7vZhzfkCRbjNuUeg3BPR2

<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
