### PR TITLE
fix(flags): reclassify salt cache date out of range

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -723,34 +723,25 @@ mod tests {
         assert!(!FlagError::TokenValidationError.is_5xx());
 
         // Cookieless: DateOutOfRange is client-data (4xx); other SaltCache errors are server faults (5xx).
-        assert!(
-            !FlagError::CookielessError(CookielessManagerError::SaltCacheError(
-                SaltCacheError::DateOutOfRange
-            ))
-            .is_5xx()
-        );
-        assert!(
-            FlagError::CookielessError(CookielessManagerError::SaltCacheError(
-                SaltCacheError::SaltRetrievalFailed
-            ))
-            .is_5xx()
-        );
-        assert!(
-            FlagError::CookielessError(CookielessManagerError::SaltCacheError(
-                SaltCacheError::RedisError("boom".to_string())
-            ))
-            .is_5xx()
-        );
+        let salt_cache_cases = [
+            (SaltCacheError::DateOutOfRange, false),
+            (SaltCacheError::SaltRetrievalFailed, true),
+            (SaltCacheError::RedisError("boom".to_string()), true),
+        ];
+        for (variant, expected_5xx) in salt_cache_cases {
+            let err = FlagError::CookielessError(CookielessManagerError::SaltCacheError(variant));
+            assert_eq!(err.is_5xx(), expected_5xx, "is_5xx() mismatch for {err:?}");
+        }
     }
 
     #[test]
     fn test_date_out_of_range_is_400() {
+        // is_5xx() for this variant is covered by the SaltCacheError table in test_is_5xx.
         let err = FlagError::CookielessError(CookielessManagerError::SaltCacheError(
             SaltCacheError::DateOutOfRange,
         ));
         assert_eq!(err.status_code(), 400);
         assert_eq!(err.error_code(), "cookieless_error");
-        assert!(!err.is_5xx());
     }
 
     #[test]

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -1,6 +1,6 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
-use common_cookieless::CookielessManagerError;
+use common_cookieless::{CookielessManagerError, SaltCacheError};
 use common_database::{extract_timeout_type, is_timeout_error, CustomDatabaseError};
 use common_hypercache::HyperCacheError;
 use common_redis::CustomRedisError;
@@ -206,7 +206,10 @@ impl FlagError {
             FlagError::CookielessError(err) => match err {
                 CookielessManagerError::MissingProperty(_)
                 | CookielessManagerError::UrlParseError(_)
-                | CookielessManagerError::InvalidTimestamp(_) => ("cookieless_error", 400),
+                | CookielessManagerError::InvalidTimestamp(_)
+                | CookielessManagerError::SaltCacheError(SaltCacheError::DateOutOfRange) => {
+                    ("cookieless_error", 400)
+                }
                 _ => ("cookieless_error", 500),
             },
         }
@@ -346,7 +349,9 @@ impl FlagError {
                 CookielessManagerError::HashError(_)
                 | CookielessManagerError::ChronoError(_)
                 | CookielessManagerError::RedisError(_, _)
-                | CookielessManagerError::SaltCacheError(_)
+                | CookielessManagerError::SaltCacheError(
+                    SaltCacheError::RedisError(_) | SaltCacheError::SaltRetrievalFailed,
+                )
                 | CookielessManagerError::InvalidIdentifyCount(_),
             ) => StatusCode::INTERNAL_SERVER_ERROR,
             FlagError::CookielessError(_) => return false, // Other CookielessErrors are 4XX
@@ -579,6 +584,15 @@ impl IntoResponse for FlagError {
                         tracing::warn!("Cookieless invalid timestamp: {}", msg);
                         (StatusCode::BAD_REQUEST, format!("Invalid timestamp: {msg}"))
                     },
+                    // sent_at resolved to a date outside the salt-cache validity window
+                    // (e.g. crawlers with frozen Date.now()) — bad input, not a server fault.
+                    CookielessManagerError::SaltCacheError(SaltCacheError::DateOutOfRange) => {
+                        tracing::warn!("Cookieless date out of range - sent_at outside salt-cache validity window");
+                        (
+                            StatusCode::BAD_REQUEST,
+                            "Invalid sent_at: timestamp resolves to a date outside the accepted ingestion window".to_string(),
+                        )
+                    },
 
                     // 500 Internal Server Error - server-side issues
                     err @ (CookielessManagerError::HashError(_) |
@@ -707,6 +721,56 @@ mod tests {
         assert!(!FlagError::MissingDistinctId.is_5xx());
         assert!(!FlagError::NoTokenError.is_5xx());
         assert!(!FlagError::TokenValidationError.is_5xx());
+
+        // Cookieless: DateOutOfRange is client-data (4xx); other SaltCache errors are server faults (5xx).
+        assert!(
+            !FlagError::CookielessError(CookielessManagerError::SaltCacheError(
+                SaltCacheError::DateOutOfRange
+            ))
+            .is_5xx()
+        );
+        assert!(
+            FlagError::CookielessError(CookielessManagerError::SaltCacheError(
+                SaltCacheError::SaltRetrievalFailed
+            ))
+            .is_5xx()
+        );
+        assert!(
+            FlagError::CookielessError(CookielessManagerError::SaltCacheError(
+                SaltCacheError::RedisError("boom".to_string())
+            ))
+            .is_5xx()
+        );
+    }
+
+    #[test]
+    fn test_date_out_of_range_is_400() {
+        let err = FlagError::CookielessError(CookielessManagerError::SaltCacheError(
+            SaltCacheError::DateOutOfRange,
+        ));
+        assert_eq!(err.status_code(), 400);
+        assert_eq!(err.error_code(), "cookieless_error");
+        assert!(!err.is_5xx());
+    }
+
+    #[test]
+    fn test_date_out_of_range_response_body() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = FlagError::CookielessError(CookielessManagerError::SaltCacheError(
+            SaltCacheError::DateOutOfRange,
+        ));
+
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body_bytes = rt
+            .block_on(axum::body::to_bytes(response.into_body(), usize::MAX))
+            .unwrap();
+        let body = String::from_utf8(body_bytes.to_vec()).unwrap();
+        assert!(
+            body.contains("Invalid sent_at"),
+            "body should describe the bad sent_at, got: {body}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The feature flags service shows a sustained 5xx spike driven entirely by `cookieless_error` / `SaltCacheError::DateOutOfRange`, almost all of it from a bot crawling a specific team. The bot's rendering service uses a synthetic frozen `Date.now()`, so the `sent_at` query param resolves to a date outside the salt cache validity window (`[now-12h, now+86h]`). That is deterministically a client data error, but `FlagError::error_metadata()` maps it to HTTP 500, inflating the service fault rate and waking on call.

## Changes

`rust/feature-flags/src/api/errors.rs` reclassifies `CookielessManagerError::SaltCacheError(SaltCacheError::DateOutOfRange)` as 400 across all three classification surfaces. `error_metadata()` now returns `("cookieless_error", 400)` for this variant, keeping the existing error code for dashboard continuity. `is_5xx()` was changed from a catch all `SaltCacheError(_)` to an explicit `RedisError(_) | SaltRetrievalFailed` match, so `DateOutOfRange` falls through to the 4xx tail and `FLAG_REQUEST_FAULTS_COUNTER` stops incrementing for these requests. `IntoResponse::into_response()` gets a dedicated arm that emits 400 with the body `"Invalid sent_at: timestamp resolves to a date outside the accepted ingestion window"` and a `tracing::warn!` instead of the generic 500 plus `tracing::error!`. Other `SaltCacheError` variants (`RedisError`, `SaltRetrievalFailed`) stay 5xx because they are genuine server faults.

No change to the shared `common-cookieless` library. It stays strict and keeps mirroring the TS ingestion path at `nodejs/src/ingestion/cookieless/cookieless-manager.ts:436-451`, which drops events on `date_out_of_range`. Both services now refuse polluted input symmetrically, neither silently synthesizes identities.

## How did you test this code?

Extended `test_is_5xx` with three assertions covering `DateOutOfRange` (4xx), `SaltRetrievalFailed` (5xx), and `RedisError` (5xx). Added `test_date_out_of_range_is_400` asserting `status_code() == 400`, `error_code() == "cookieless_error"`, and `!is_5xx()`. Added `test_date_out_of_range_response_body` that calls `into_response()` and verifies the body contains `"Invalid sent_at"`. `cargo test -p feature-flags --lib api::errors::tests` passes 16/16, `cargo test -p common-cookieless --lib` still passes 20/20, `cargo clippy -p feature-flags --lib --tests -- -D warnings` clean.
## Publish to changelog?

no
