### PR TITLE
feat(error-tracking): add skip-on-conflict for symbol uploads

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # posthog-cli
 
+# 0.7.12
+
+- feat: add `--skip-on-conflict` to symbol upload commands for keeping existing symbol sets when content differs
+- feat: add `--force` to sourcemap, Hermes, and ProGuard uploads for explicit content overwrites
+
 # 0.7.11
 
 - fix: resolve release once in `process` command to avoid race condition when multiple workers run in parallel

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-cli"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.7.11"
+version = "0.7.12"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/api/client.rs
+++ b/cli/src/api/client.rs
@@ -24,6 +24,36 @@ pub struct PHClient {
     throttler: Arc<Mutex<Throttler>>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn api_error(body: &str) -> ClientError {
+        ClientError::ApiError(
+            400,
+            Box::new(Url::parse("https://example.com/api/test").unwrap()),
+            body.to_string(),
+        )
+    }
+
+    #[test]
+    fn matches_structured_api_error_code() {
+        let error = api_error(
+            r#"{"type":"validation_error","code":"content_hash_mismatch","detail":"Different content","attr":null}"#,
+        );
+
+        assert!(error.has_api_error_code("content_hash_mismatch"));
+        assert!(!error.has_api_error_code("release_id_mismatch"));
+    }
+
+    #[test]
+    fn falls_back_to_body_match_for_legacy_errors() {
+        let error = api_error("legacy release_id_mismatch response");
+
+        assert!(error.has_api_error_code("release_id_mismatch"));
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum ClientError {
     RequestError(reqwest::Error),
@@ -59,6 +89,28 @@ impl From<reqwest::Error> for ClientError {
     fn from(error: reqwest::Error) -> Self {
         ClientError::RequestError(error)
     }
+}
+
+impl ClientError {
+    pub fn has_api_error_code(&self, expected_code: &str) -> bool {
+        let ClientError::ApiError(_, _, body) = self else {
+            return false;
+        };
+
+        api_error_code(body).is_some_and(|code| code == expected_code)
+            || body.contains(expected_code)
+    }
+}
+
+#[derive(Deserialize)]
+struct ApiErrorCodeResponse {
+    code: Option<String>,
+}
+
+fn api_error_code(body: &str) -> Option<String> {
+    serde_json::from_str::<ApiErrorCodeResponse>(body)
+        .ok()
+        .and_then(|api_error| api_error.code)
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -7,7 +7,6 @@ use thiserror::Error;
 use tracing::{debug, info, warn};
 
 use crate::{
-    api::client::ClientError,
     invocation_context::context,
     utils::{files::content_hash, raise_for_err},
 };
@@ -18,6 +17,8 @@ const MAX_FILE_SIZE: usize = 100 * 1024 * 1024; // 100 MB
 pub enum UploadError {
     #[error("Release ID mismatch: symbol sets already exist with different release IDs")]
     ReleaseIdMismatch,
+    #[error("Content mismatch: use --skip-on-conflict or --force")]
+    ContentHashMismatch,
     #[error("{0}")]
     Other(#[from] anyhow::Error),
 }
@@ -46,9 +47,11 @@ pub struct PresignedUrl {
 struct BulkUploadStartRequest {
     symbol_sets: Vec<CreateSymbolSetRequest>,
     /// When true, allow overwriting symbol sets whose content has changed.
-    /// When false (default), changed-content re-uploads are skipped server-side.
     #[serde(default)]
     force: bool,
+    /// When true, skip symbol sets whose content changed instead of failing.
+    #[serde(default)]
+    skip_on_conflict: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,13 +68,15 @@ struct BulkUploadFinishRequest {
 /// If `skip_release_on_fail` is true and the server returns a release_id_mismatch error,
 /// the upload will be retried without release IDs.
 /// If `force` is true, symbol sets whose content has changed are overwritten rather than skipped.
+/// If `skip_on_conflict` is true, symbol sets whose content has changed are skipped rather than failing.
 pub fn upload_with_retry(
     input_sets: Vec<SymbolSetUpload>,
     batch_size: usize,
     skip_release_on_fail: bool,
     force: bool,
+    skip_on_conflict: bool,
 ) -> Result<()> {
-    let res = upload_inner(&input_sets, batch_size, force);
+    let res = upload_inner(&input_sets, batch_size, force, skip_on_conflict);
     match res {
         Ok(()) => Ok(()),
         Err(UploadError::ReleaseIdMismatch) if skip_release_on_fail => {
@@ -84,7 +89,8 @@ pub fn upload_with_retry(
                     data: s.data,
                 })
                 .collect();
-            upload_inner(&sets_without_release, batch_size, force).map_err(|e| e.into())
+            upload_inner(&sets_without_release, batch_size, force, skip_on_conflict)
+                .map_err(|e| e.into())
         }
         Err(e) => Err(e.into()),
     }
@@ -94,6 +100,7 @@ fn upload_inner(
     input_sets: &[SymbolSetUpload],
     batch_size: usize,
     force: bool,
+    skip_on_conflict: bool,
 ) -> Result<(), UploadError> {
     let upload_requests: Vec<_> = input_sets
         .iter()
@@ -110,7 +117,7 @@ fn upload_inner(
 
     for (i, batch) in upload_requests.chunks(batch_size).enumerate() {
         info!("Starting upload of batch {i}, {} symbol sets", batch.len());
-        let start_response = start_upload(batch, force)?;
+        let start_response = start_upload(batch, force, skip_on_conflict)?;
 
         let id_map: HashMap<_, _> = batch.iter().map(|u| (u.chunk_id.as_str(), u)).collect();
 
@@ -146,6 +153,7 @@ fn upload_inner(
 fn start_upload(
     symbol_sets: &[&SymbolSetUpload],
     force: bool,
+    skip_on_conflict: bool,
 ) -> Result<BulkUploadStartResponse, UploadError> {
     let client = &context().client;
 
@@ -155,6 +163,7 @@ fn start_upload(
             .map(|s| CreateSymbolSetRequest::new(s))
             .collect(),
         force,
+        skip_on_conflict,
     };
 
     let res = retry(retry_policy(500, 2, 3), |_| {
@@ -168,8 +177,11 @@ fn start_upload(
         Ok(response) => Ok(response
             .json()
             .context("Failed to parse start upload response")?),
-        Err(ClientError::ApiError(_, _, body)) if body.contains("release_id_mismatch") => {
+        Err(e) if e.has_api_error_code("release_id_mismatch") => {
             Err(UploadError::ReleaseIdMismatch)
+        }
+        Err(e) if e.has_api_error_code("content_hash_mismatch") => {
+            Err(UploadError::ContentHashMismatch)
         }
         Err(e) => Err(UploadError::Other(
             anyhow::anyhow!(e).context("Failed to start upload"),

--- a/cli/src/dsym/upload.rs
+++ b/cli/src/dsym/upload.rs
@@ -6,7 +6,7 @@ use tracing::info;
 use crate::{
     api::{self, releases::ReleaseBuilder, symbol_sets::SymbolSetUpload},
     dsym::{find_dsym_bundles, DsymFile, PlistInfo},
-    sourcemaps::args::{pack_version, ReleaseArgs},
+    sourcemaps::args::{pack_version, ReleaseArgs, UploadConflictArgs},
     utils::git::get_git_info,
 };
 
@@ -20,6 +20,9 @@ pub struct Args {
     #[clap(flatten)]
     pub release: ReleaseArgs,
 
+    #[clap(flatten)]
+    pub conflict: UploadConflictArgs,
+
     /// The main dSYM file name (e.g., MyApp.app.dSYM).
     /// Used to extract version info from the correct dSYM when multiple are present.
     /// This is typically $DWARF_DSYM_FILE_NAME in Xcode build phases.
@@ -29,29 +32,18 @@ pub struct Args {
     /// Include source code files in the dSYM upload.
     /// When enabled, source files referenced by DWARF debug info are bundled into the upload,
     /// allowing PostHog to display source code context around crash locations.
+    /// Implies --force unless --skip-on-conflict is set.
     #[arg(long, default_value_t = false)]
     pub include_source: bool,
-
-    /// Allow overwriting an existing symbol set that has already been uploaded.
-    ///
-    /// By default, if a symbol set with the same UUID already exists on the server
-    /// its content is left unchanged. Use this flag to replace it — for example
-    /// after adding source files to a previously source-less upload.
-    ///
-    /// Without this flag a re-upload whose content differs from the stored copy is
-    /// silently skipped, preventing accidental overwrites of production symbol sets
-    /// from a local development machine.
-    #[arg(long, default_value_t = false)]
-    pub force: bool,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
     let Args {
         directory,
         release,
+        conflict,
         main_dsym,
         include_source,
-        force,
     } = args;
     let release_args = release;
 
@@ -206,14 +198,15 @@ pub fn upload(args: &Args) -> Result<()> {
     }
 
     info!("Uploading {} dSYM(s)...", uploads.len());
-    // --include-source implies force: uploading with source replaces an existing
-    // source-less upload, so we always want the new content to win.
-    let effective_force = *force || *include_source;
+    // --include-source implies force unless the user explicitly asked to keep
+    // existing symbol sets with --skip-on-conflict.
+    let effective_force = conflict.force || (*include_source && !conflict.skip_on_conflict);
     api::symbol_sets::upload_with_retry(
         uploads,
         10,
         release_args.skip_release_on_fail,
         effective_force,
+        conflict.skip_on_conflict,
     )?;
     info!("dSYM upload complete");
 

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use crate::{
     api::{self, releases::ReleaseBuilder, symbol_sets::SymbolSetUpload},
     proguard::ProguardFile,
-    sourcemaps::args::{pack_version, ReleaseArgs},
+    sourcemaps::args::{pack_version, ReleaseArgs, UploadConflictArgs},
     utils::git::get_git_info,
 };
 
@@ -26,6 +26,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub release: ReleaseArgs,
+
+    #[clap(flatten)]
+    pub conflict: UploadConflictArgs,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -34,6 +37,7 @@ pub fn upload(args: &Args) -> Result<()> {
         map_id,
         batch_size,
         release,
+        conflict,
     } = args;
 
     let ReleaseArgs {
@@ -77,7 +81,8 @@ pub fn upload(args: &Args) -> Result<()> {
         vec![to_upload],
         *batch_size,
         *skip_release_on_fail,
-        false,
+        conflict.force,
+        conflict.skip_on_conflict,
     )?;
 
     Ok(())

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -103,6 +103,18 @@ pub struct ReleaseArgs {
     pub skip_release_on_fail: bool,
 }
 
+#[derive(clap::Args, Clone, Default)]
+pub struct UploadConflictArgs {
+    /// Allow overwriting an existing symbol set whose content has changed.
+    #[arg(long, default_value_t = false, conflicts_with = "skip_on_conflict")]
+    pub force: bool,
+
+    /// Skip symbol sets that already exist with different content instead of failing.
+    /// Existing symbol sets are left unchanged.
+    #[arg(long, default_value_t = false, conflicts_with = "force")]
+    pub skip_on_conflict: bool,
+}
+
 /// Pack version and build into a single string for release uniqueness.
 /// Releases are keyed on (name, version), so "1.0+42" and "1.0+43" are
 /// distinct releases. The UI splits on "+" to display them separately.

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -7,7 +7,7 @@ use walkdir::WalkDir;
 
 use crate::api::symbol_sets::{self, SymbolSetUpload};
 use crate::invocation_context::context;
-use crate::sourcemaps::args::ReleaseArgs;
+use crate::sourcemaps::args::{ReleaseArgs, UploadConflictArgs};
 use crate::sourcemaps::content::SourceMapFile;
 use crate::sourcemaps::inject::get_release_for_maps;
 
@@ -23,6 +23,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub release: ReleaseArgs,
+
+    #[clap(flatten)]
+    pub conflict: UploadConflictArgs,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -31,6 +34,7 @@ pub fn upload(args: &Args) -> Result<()> {
         directory,
         release,
         batch_size,
+        conflict,
     } = args;
 
     let directory = directory.canonicalize().map_err(|e| {
@@ -87,8 +91,13 @@ pub fn upload(args: &Args) -> Result<()> {
     );
 
     let started_at = Instant::now();
-    let upload_result =
-        symbol_sets::upload_with_retry(uploads, *batch_size, release.skip_release_on_fail, false);
+    let upload_result = symbol_sets::upload_with_retry(
+        uploads,
+        *batch_size,
+        release.skip_release_on_fail,
+        conflict.force,
+        conflict.skip_on_conflict,
+    );
     let duration_ms = started_at.elapsed().as_millis();
 
     let mut props = vec![

--- a/cli/src/sourcemaps/plain/mod.rs
+++ b/cli/src/sourcemaps/plain/mod.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Subcommand;
 
 use crate::sourcemaps::{
-    args::{FileSelectionArgs, ReleaseArgs},
+    args::{FileSelectionArgs, ReleaseArgs, UploadConflictArgs},
     inject::InjectArgs,
 };
 
@@ -40,6 +40,9 @@ pub struct ProcessArgs {
     /// The maximum number of chunks to upload in a single batch
     #[arg(long, default_value = "50")]
     pub batch_size: usize,
+
+    #[clap(flatten)]
+    pub conflict: UploadConflictArgs,
 }
 
 impl ProcessArgs {
@@ -64,6 +67,7 @@ impl From<ProcessArgs> for (InjectArgs, upload::Args) {
             skip_ssl_verification: false,
             batch_size: args.batch_size,
             release: args.release,
+            conflict: args.conflict,
         };
 
         (inject_args, upload_args)

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     invocation_context::context,
     sourcemaps::{
-        args::{FileSelectionArgs, ReleaseArgs},
+        args::{FileSelectionArgs, ReleaseArgs, UploadConflictArgs},
         inject::get_release_for_maps,
         plain::inject::is_javascript_file,
         source_pairs::read_pairs,
@@ -40,6 +40,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub release: ReleaseArgs,
+
+    #[clap(flatten)]
+    pub conflict: UploadConflictArgs,
 
     /// DEPRECATED - use top-level `--skip-ssl-verification` instead
     #[arg(long, default_value = "false")]
@@ -120,7 +123,8 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
         uploads,
         args.batch_size,
         args.release.skip_release_on_fail,
-        false,
+        args.conflict.force,
+        args.conflict.skip_on_conflict,
     );
     let duration_ms = started_at.elapsed().as_millis();
 

--- a/products/error_tracking/backend/api/symbol_sets.py
+++ b/products/error_tracking/backend/api/symbol_sets.py
@@ -150,6 +150,19 @@ class ErrorTrackingSymbolSetBulkStartUploadSerializer(serializers.Serializer):
         default=False,
         help_text="Whether to overwrite uploaded symbol sets whose content hash changed.",
     )
+    skip_on_conflict = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Whether to skip uploaded symbol sets whose content hash changed instead of failing.",
+    )
+
+    def validate(self, attrs: dict[str, object]) -> dict[str, object]:
+        if attrs.get("force") and attrs.get("skip_on_conflict"):
+            raise ValidationError(
+                code="invalid_conflict_handling",
+                detail="Use either force or skip_on_conflict, not both.",
+            )
+        return attrs
 
 
 class ErrorTrackingSymbolSetBulkFinishUploadSerializer(serializers.Serializer):
@@ -414,31 +427,34 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
     def bulk_start_upload(self, request, **kwargs):
         if request.user.pk:
             posthoganalytics.identify_context(request.user.pk)
-        # Earlier ones send a list of chunk IDs, all associated with one release
-        # Extract a list of chunk IDs from the request json
-        chunk_ids: list[str] = request.data.get("chunk_ids") or []
-        # Grab the release ID from the request json
-        release_id: str | None = request.data.get("release_id", None)
+
+        upload_serializer = ErrorTrackingSymbolSetBulkStartUploadSerializer(data=request.data)
+        _ = upload_serializer.is_valid(raise_exception=True)
+        upload_data = upload_serializer.validated_data
+
+        # Earlier clients send chunk_ids, all associated with one release.
+        chunk_ids: list[str] = upload_data.get("chunk_ids") or []
+        release_id: str | None = upload_data.get("release_id", None)
+
+        # force=True allows overwriting an existing symbol set whose content has changed.
+        # skip_on_conflict=True leaves the existing symbol set unchanged and continues.
+        force: bool = upload_data["force"]
+        skip_on_conflict: bool = upload_data["skip_on_conflict"]
 
         _ = posthoganalytics.capture(
             "error_tracking_symbol_set_upload_started",
-            properties={"team_id": self.team.id, "endpoint": "bulk_start_upload"},
+            properties={
+                "team_id": self.team.id,
+                "endpoint": "bulk_start_upload",
+                "force": force,
+                "skip_on_conflict": skip_on_conflict,
+            },
             groups=groups(self.team.organization, self.team),
         )
 
-        # Validate symbol_sets using the serializer
-        symbol_sets: list[SymbolSetUpload] = []
-        if "symbol_sets" in request.data:
-            chunk_serializer = ErrorTrackingSymbolSetUploadSerializer(data=request.data["symbol_sets"], many=True)
-            _ = chunk_serializer.is_valid(raise_exception=True)
-            symbol_sets = [SymbolSetUpload(**data) for data in chunk_serializer.validated_data]
+        symbol_sets = [SymbolSetUpload(**data) for data in upload_data.get("symbol_sets", [])]
 
         symbol_sets.extend([SymbolSetUpload(x, release_id, None) for x in chunk_ids])
-
-        # force=True allows overwriting an existing symbol set whose content has changed.
-        # Without it, changed-content re-uploads are silently skipped to prevent
-        # accidental overwrites of production symbol sets from a local dev machine.
-        force: bool = bool(request.data.get("force", False))
 
         if not settings.OBJECT_STORAGE_ENABLED:
             raise ValidationError(
@@ -447,7 +463,11 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
             )
 
         chunk_id_url_map = bulk_create_symbol_sets(
-            symbol_sets, self.team, force=force, distinct_id=str(request.user.pk) if request.user.pk else None
+            symbol_sets,
+            self.team,
+            force=force,
+            skip_on_conflict=skip_on_conflict,
+            distinct_id=str(request.user.pk) if request.user.pk else None,
         )
         return Response({"id_map": chunk_id_url_map}, status=status.HTTP_201_CREATED)
 
@@ -584,6 +604,7 @@ def bulk_create_symbol_sets(
     new_symbol_sets: list[SymbolSetUpload],
     team: Team,
     force: bool = False,
+    skip_on_conflict: bool = False,
     distinct_id: str | None = None,
 ) -> dict[str, dict[str, str]]:
     accelerate = bool(
@@ -699,16 +720,7 @@ def bulk_create_symbol_sets(
                 # Content is identical — no upload needed.
                 # (We may still update the release below if it changed.)
                 pass
-            elif not force:
-                # Content has changed but the caller did not pass force=True.
-                # Silently skip to prevent accidental overwrites of production
-                # symbol sets from a local development machine.
-                logger.warning(
-                    "symbol_set_content_changed_skipped",
-                    ref=existing.ref,
-                    team_id=team.id,
-                )
-            else:
+            elif force:
                 # force=True: content has changed and the caller explicitly
                 # requested an overwrite. Issue a new presigned URL and clear
                 # the old content hash so bulk_finish_upload stores the new one.
@@ -721,6 +733,19 @@ def bulk_create_symbol_sets(
                 existing.storage_ptr = storage_ptr
                 existing.content_hash = None  # will be set by bulk_finish_upload
                 dirty = True
+            elif skip_on_conflict:
+                # Content has changed, but the caller explicitly asked to keep
+                # the already-uploaded symbol set.
+                logger.warning(
+                    "symbol_set_content_changed_skipped",
+                    ref=existing.ref,
+                    team_id=team.id,
+                )
+            else:
+                raise ValidationError(
+                    code="content_hash_mismatch",
+                    detail=f"Symbol set {existing.ref} already exists with different content.",
+                )
 
             if dirty:
                 to_update.append(existing)

--- a/products/error_tracking/backend/api/test/test_error_tracking_api.py
+++ b/products/error_tracking/backend/api/test/test_error_tracking_api.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, Mock, patch
 
 from boto3 import resource
 from botocore.config import Config
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import User
@@ -640,6 +641,64 @@ class TestErrorTracking(APIBaseTest):
         new_symbol_set = ErrorTrackingSymbolSet.objects.get(ref=new_chunk_id)
         assert new_symbol_set.release_id == release.id
         assert id_map[str(new_chunk_id)]["symbol_set_id"] == str(new_symbol_set.id)
+
+    @parameterized.expand(
+        [
+            ("default_rejects", {}, status.HTTP_400_BAD_REQUEST, "content_hash_mismatch", "unchanged"),
+            ("skip_on_conflict", {"skip_on_conflict": True}, status.HTTP_201_CREATED, None, "unchanged"),
+            ("force", {"force": True}, status.HTTP_201_CREATED, None, "overwritten"),
+            (
+                "force_and_skip_rejected",
+                {"force": True, "skip_on_conflict": True},
+                status.HTTP_400_BAD_REQUEST,
+                "invalid_conflict_handling",
+                "unchanged",
+            ),
+        ]
+    )
+    def test_bulk_start_upload_handles_content_mismatch(
+        self,
+        _name: str,
+        request_flags: dict[str, bool],
+        expected_status: int,
+        expected_code: str | None,
+        expected_outcome: str,
+    ) -> None:
+        chunk_id = str(uuid7())
+        symbol_set = ErrorTrackingSymbolSet.objects.create(
+            team=self.team,
+            ref=chunk_id,
+            storage_ptr="existing",
+            content_hash="already_uploaded",
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_start_upload",
+            data={
+                "symbol_sets": [
+                    {
+                        "chunk_id": chunk_id,
+                        "content_hash": "different_hash",
+                    }
+                ],
+                **request_flags,
+            },
+            format="json",
+        )
+
+        assert response.status_code == expected_status
+        if expected_code:
+            assert response.json()["code"] == expected_code
+        if expected_outcome == "overwritten":
+            assert response.json()["id_map"][chunk_id]["symbol_set_id"] == str(symbol_set.id)
+
+        symbol_set.refresh_from_db()
+        if expected_outcome == "unchanged":
+            assert symbol_set.storage_ptr == "existing"
+            assert symbol_set.content_hash == "already_uploaded"
+        else:
+            assert symbol_set.storage_ptr != "existing"
+            assert symbol_set.content_hash is None
 
     def test_bulk_start_upload_fail_restart_with_no_content_hash(self) -> None:
         existing_chunk_id = str(uuid7())

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -1541,6 +1541,8 @@ export interface ErrorTrackingSymbolSetBulkStartUploadApi {
     symbol_sets?: ErrorTrackingSymbolSetUploadApi[]
     /** Whether to overwrite uploaded symbol sets whose content hash changed. */
     force?: boolean
+    /** Whether to skip uploaded symbol sets whose content hash changed instead of failing. */
+    skip_on_conflict?: boolean
 }
 
 export type ErrorTrackingAssignmentRulesListParams = {

--- a/products/error_tracking/frontend/generated/api.zod.ts
+++ b/products/error_tracking/frontend/generated/api.zod.ts
@@ -960,6 +960,7 @@ export const ErrorTrackingSymbolSetsBulkFinishUploadCreateBody = /* @__PURE__ */
 })
 
 export const errorTrackingSymbolSetsBulkStartUploadCreateBodyForceDefault = false
+export const errorTrackingSymbolSetsBulkStartUploadCreateBodySkipOnConflictDefault = false
 
 export const ErrorTrackingSymbolSetsBulkStartUploadCreateBody = /* @__PURE__ */ zod.object({
     chunk_ids: zod
@@ -987,4 +988,8 @@ export const ErrorTrackingSymbolSetsBulkStartUploadCreateBody = /* @__PURE__ */ 
         .boolean()
         .default(errorTrackingSymbolSetsBulkStartUploadCreateBodyForceDefault)
         .describe('Whether to overwrite uploaded symbol sets whose content hash changed.'),
+    skip_on_conflict: zod
+        .boolean()
+        .default(errorTrackingSymbolSetsBulkStartUploadCreateBodySkipOnConflictDefault)
+        .describe('Whether to skip uploaded symbol sets whose content hash changed instead of failing.'),
 })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14691,6 +14691,8 @@ export namespace Schemas {
       symbol_sets?: ErrorTrackingSymbolSetUpload[];
       /** Whether to overwrite uploaded symbol sets whose content hash changed. */
       force?: boolean;
+      /** Whether to skip uploaded symbol sets whose content hash changed instead of failing. */
+      skip_on_conflict?: boolean;
     }
 
     export interface ErrorTrackingSymbolSetFinishUpload {


### PR DESCRIPTION
Closes: https://github.com/PostHog/posthog/issues/48179

## Problem

Symbol uploads can encounter existing symbol sets with the same reference but different content. Release automation needs an explicit way to either keep existing uploaded symbols or intentionally overwrite them, instead of relying on implicit behavior.

## Changes

- Adds `--skip-on-conflict` for sourcemap, Hermes, ProGuard, and dSYM uploads to leave conflicting existing symbol sets unchanged.
- Adds shared `--force` handling for sourcemap, Hermes, and ProGuard uploads, matching existing dSYM overwrite behavior.
- Changes content-hash mismatches to fail by default unless `skip_on_conflict` or `force` is set.
- Adds structured CLI handling for API error codes while preserving legacy substring matching.
- Tracks `force` and `skip_on_conflict` on the existing symbol upload analytics event.
- Regenerates API and MCP types for the new `skip_on_conflict` request field.
- Bumps the CLI version and changelog to `0.7.12`.

## How did you test this code?

Agent-authored PR. Tested with:

- `cd cli && cargo test --no-default-features`
- `cd cli && cargo check --no-default-features`
- `bin/hogli test products/error_tracking/backend/api/test/test_error_tracking_api.py::TestErrorTracking::test_bulk_start_upload_rejects_content_mismatch_by_default products/error_tracking/backend/api/test/test_error_tracking_api.py::TestErrorTracking::test_bulk_start_upload_skips_content_mismatch_when_requested products/error_tracking/backend/api/test/test_error_tracking_api.py::TestErrorTracking::test_bulk_start_upload_overwrites_content_mismatch_with_force`
- `bin/hogli test products/error_tracking/backend/api/test/test_error_tracking_api.py::TestErrorTracking::test_bulk_start_upload_skips_uploaded_symbol_sets products/error_tracking/backend/api/test/test_error_tracking_api.py::TestErrorTracking::test_bulk_start_upload_updates_release_for_uploaded_symbol_set products/error_tracking/backend/api/test/test_error_tracking_api.py::TestErrorTracking::test_bulk_start_upload_rejects_release_change`
- `ruff check products/error_tracking/backend/api/symbol_sets.py products/error_tracking/backend/api/test/test_error_tracking_api.py`
- `ruff format --check products/error_tracking/backend/api/symbol_sets.py products/error_tracking/backend/api/test/test_error_tracking_api.py`
- `bin/hogli build:openapi`
- `git diff --check`

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

Implemented with Pi. The main design choice was to keep API errors client-neutral while surfacing CLI guidance in the CLI error. The CLI now parses structured API error codes first and falls back to body substring matching for compatibility with older API responses. The backend tracks the new options on the existing upload-start analytics event rather than adding a new event.