### PR TITLE
fix(replay-vision): rename duplicate temporal activity names

### DIFF
--- a/products/replay_vision/backend/temporal/activities/cleanup_gemini_file.py
+++ b/products/replay_vision/backend/temporal/activities/cleanup_gemini_file.py
@@ -14,7 +14,7 @@ from products.replay_vision.backend.temporal.types import CleanupGeminiFileInput
 logger = structlog.get_logger(__name__)
 
 
-@activity.defn
+@activity.defn(name="replay_vision_cleanup_gemini_file_activity")
 async def cleanup_gemini_file_activity(inputs: CleanupGeminiFileInputs) -> None:
     """Best-effort delete of the uploaded Gemini file; the cleanup sweep retries on failure via the tracking key."""
     try:

--- a/products/replay_vision/backend/temporal/activities/upload_video_to_gemini.py
+++ b/products/replay_vision/backend/temporal/activities/upload_video_to_gemini.py
@@ -27,7 +27,7 @@ logger = structlog.get_logger(__name__)
 _MAX_PROCESSING_WAIT_SECONDS = 300
 
 
-@activity.defn
+@activity.defn(name="replay_vision_upload_video_to_gemini_activity")
 async def upload_video_to_gemini_activity(inputs: UploadVideoToGeminiInputs) -> UploadedVideo:
     """Read the asset's MP4 bytes, upload to Gemini, poll until ACTIVE, return the file reference."""
     workflow_id = activity.info().workflow_id

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -174,6 +174,37 @@ export const ObservationStatusEnumApi = {
 } as const
 
 /**
+ * Mirrors `temporal.types.LensSnapshot` for OpenAPI generation.
+ */
+export interface LensSnapshotApi {
+    /** Lens name at run time. */
+    name: string
+    /** Lens type (monitor, classifier, scorer, summarizer, indexer) at run time.
+
+  * `monitor` - Monitor
+  * `classifier` - Classifier
+  * `scorer` - Scorer
+  * `summarizer` - Summarizer
+  * `indexer` - Indexer */
+    lens_type: LensTypeEnumApi
+    /** The `ReplayLens.lens_version` value at the moment the workflow ran. */
+    lens_version: number
+    /** Concrete model that ran the observation.
+
+  * `gemini-3-flash` - Gemini 3 Flash
+  * `gemini-3-flash-lite` - Gemini 3 Flash Lite */
+    model: LensModelEnumApi
+    /** Concrete provider that ran the observation.
+
+  * `google` - Google */
+    provider: LensProviderEnumApi
+    /** Whether the observation was run with Signal emission enabled. */
+    emits_signals: boolean
+    /** Lens-type-specific configuration at run time (prompt, tags, scale, etc.). */
+    lens_config: unknown
+}
+
+/**
  * * `schedule` - Schedule
  * `on_demand` - On demand
  */
@@ -197,24 +228,18 @@ export interface ReplayObservationApi {
   * `succeeded` - Succeeded
   * `failed` - Failed */
     readonly status: ObservationStatusEnumApi
-    /** Populated on failure. Includes the malformed model response when validation fails. */
+    /** Populated on failure; includes the malformed model response when validation fails. */
     readonly error_reason: string
     /** Temporal workflow id for progress queries and debugging. Empty until the workflow starts. */
     readonly workflow_id: string
-    /** The `ReplayLens.lens_version` value at the moment the workflow ran. */
-    readonly lens_version: number
-    /** Snapshot of `ReplayLens.lens_config` at run time. Lens edits do not retroactively mutate observations. */
-    readonly lens_config_snapshot: unknown
-    /** Concrete model that ran the observation. */
-    readonly model_used: string
-    /** Concrete provider that ran the observation. */
-    readonly provider_used: string
+    /** Frozen view of the lens at run time; lens edits do not retroactively mutate this observation. */
+    readonly lens_snapshot: LensSnapshotApi
     /** Whether this observation came from the schedule or an on-demand request.
 
   * `schedule` - Schedule
   * `on_demand` - On demand */
     readonly triggered_by: ObservationTriggerEnumApi
-    /** User who triggered an on-demand observation. Null for scheduled observations. */
+    /** User who triggered an on-demand observation; null for scheduled observations. */
     readonly triggered_by_user: UserBasicApi | null
     /** @nullable */
     started_at?: string | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19733,6 +19733,37 @@ export namespace Schemas {
       Indexer: 'indexer',
     } as const;
 
+    /**
+     * Mirrors `temporal.types.LensSnapshot` for OpenAPI generation.
+     */
+    export interface LensSnapshot {
+      /** Lens name at run time. */
+      name: string;
+      /** Lens type (monitor, classifier, scorer, summarizer, indexer) at run time.
+
+      * `monitor` - Monitor
+      * `classifier` - Classifier
+      * `scorer` - Scorer
+      * `summarizer` - Summarizer
+      * `indexer` - Indexer */
+      lens_type: LensTypeEnum;
+      /** The `ReplayLens.lens_version` value at the moment the workflow ran. */
+      lens_version: number;
+      /** Concrete model that ran the observation.
+
+      * `gemini-3-flash` - Gemini 3 Flash
+      * `gemini-3-flash-lite` - Gemini 3 Flash Lite */
+      model: LensModelEnum;
+      /** Concrete provider that ran the observation.
+
+      * `google` - Google */
+      provider: LensProviderEnum;
+      /** Whether the observation was run with Signal emission enabled. */
+      emits_signals: boolean;
+      /** Lens-type-specific configuration at run time (prompt, tags, scale, etc.). */
+      lens_config: unknown;
+    }
+
     export type LimitContext = typeof LimitContext[keyof typeof LimitContext];
 
 
@@ -22707,24 +22738,18 @@ export namespace Schemas {
       * `succeeded` - Succeeded
       * `failed` - Failed */
       readonly status: ObservationStatusEnum;
-      /** Populated on failure. Includes the malformed model response when validation fails. */
+      /** Populated on failure; includes the malformed model response when validation fails. */
       readonly error_reason: string;
       /** Temporal workflow id for progress queries and debugging. Empty until the workflow starts. */
       readonly workflow_id: string;
-      /** The `ReplayLens.lens_version` value at the moment the workflow ran. */
-      readonly lens_version: number;
-      /** Snapshot of `ReplayLens.lens_config` at run time. Lens edits do not retroactively mutate observations. */
-      readonly lens_config_snapshot: unknown;
-      /** Concrete model that ran the observation. */
-      readonly model_used: string;
-      /** Concrete provider that ran the observation. */
-      readonly provider_used: string;
+      /** Frozen view of the lens at run time; lens edits do not retroactively mutate this observation. */
+      readonly lens_snapshot: LensSnapshot;
       /** Whether this observation came from the schedule or an on-demand request.
 
       * `schedule` - Schedule
       * `on_demand` - On demand */
       readonly triggered_by: ObservationTriggerEnum;
-      /** User who triggered an on-demand observation. Null for scheduled observations. */
+      /** User who triggered an on-demand observation; null for scheduled observations. */
       readonly triggered_by_user: UserBasic | null;
       /** @nullable */
       started_at?: string | null;


### PR DESCRIPTION
## Problem

Local temporal workers collapse all task queues into `development-task-queue` when `DEBUG=True`. Replay vision added activities named `cleanup_gemini_file_activity` and `upload_video_to_gemini_activity`, which already exist on the session replay worker. That made `start_temporal_worker` fail with `ValueError: More than one activity named cleanup_gemini_file_activity`.

## Changes

Give replay vision Gemini activities explicit Temporal names (`replay_vision_cleanup_gemini_file_activity`, `replay_vision_upload_video_to_gemini_activity`) so they do not collide with session summary activities on the shared dev queue. Python function names and workflow call sites stay unchanged.

## How did you test this code?

Agent-authored PR. I did not manually restart the temporal worker locally. Automated tests ran:
44 passed in ~2 min:

- products/replay_vision/backend/tests/test_temporal.py (29) — workflow mocks use the Python function refs, not Temporal name=, so cleanup/upload behavior is covered
- posthog/temporal/tests/session_replay/session_summary/test_a5_cleanup_gemini_file.py (2)
- posthog/temporal/tests/ai/test_module_integrity.py (13) — session-summary activity list unchanged

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

N/A

## 🤖 Agent context

Cursor agent helped debug a local `start_temporal_worker` failure caused by duplicate Temporal activity registration on `development-task-queue`. We considered reusing the session-summary cleanup activity but chose explicit `name=` on the replay-vision decorators as the minimal fix that keeps product boundaries intact.

Made with [Cursor](https://cursor.com)