### PR TITLE
fix(surveys): skip appearance CSS validation for API surveys

### DIFF
--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -38,6 +38,7 @@ import {
     sanitizeSurveyDisplayConditions,
     splitChoicesOnPaste,
     validateCSSProperty,
+    validateSurveyAppearance,
 } from './utils'
 
 jest.mock('lib/utils/getAppContext', () => ({
@@ -156,6 +157,28 @@ describe('survey utils', () => {
             expect(sanitizeColor('#ff0000')).toBe('#ff0000')
             expect(sanitizeColor('rgb(255, 0, 0)')).toBe('rgb(255, 0, 0)')
             expect(sanitizeColor('red')).toBe('red')
+        })
+    })
+
+    describe('validateSurveyAppearance', () => {
+        const invalidAppearance: SurveyAppearance = {
+            backgroundColor: 'not-a-color',
+            borderColor: 'also-not-a-color',
+            maxWidth: 'definitely-not-a-width',
+        }
+
+        it('skips all appearance validation for API surveys', () => {
+            // API surveys are rendered by the customer, so PostHog's appearance CSS is not applied
+            // and the Customization section is hidden in the editor — flagging errors here would
+            // route submitSurveyFailure to a non-existent section and silently block saves.
+            expect(validateSurveyAppearance(invalidAppearance, false, SurveyType.API)).toEqual({})
+        })
+
+        it('validates appearance CSS for Popover surveys', () => {
+            const result = validateSurveyAppearance(invalidAppearance, false, SurveyType.Popover)
+            expect(result.backgroundColor).toBe('not-a-color is not a valid property for background-color.')
+            expect(result.borderColor).toBe('also-not-a-color is not a valid property for border-color.')
+            expect(result.maxWidth).toBe('definitely-not-a-width is not a valid property for width.')
         })
     })
 

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -65,6 +65,13 @@ export function validateSurveyAppearance(
     hasRatingQuestions: boolean,
     surveyType: SurveyType
 ): DeepPartialMap<SurveyAppearance, ValidationErrorType> {
+    // API surveys are rendered by the customer, so PostHog's appearance CSS is not applied.
+    // The Customization section is also hidden in the editor for API surveys (SurveyEdit.tsx),
+    // so flagging appearance errors would route submitSurveyFailure to a non-existent section
+    // and silently block saves.
+    if (surveyType === SurveyType.API) {
+        return {}
+    }
     return {
         backgroundColor: validateCSSProperty('background-color', appearance.backgroundColor),
         borderColor: validateCSSProperty('border-color', appearance.borderColor),


### PR DESCRIPTION
## Problem

When editing an API survey whose appearance contains any invalid CSS value (color, dimension, etc.), saving silently fails:

1. `validateSurveyAppearance` validates every appearance CSS property regardless of `surveyType` (`frontend/src/scenes/surveys/utils.ts:62`).
2. The Customization section is hidden in the editor for API surveys (`frontend/src/scenes/surveys/SurveyEdit.tsx:1307`) since the customer renders the survey themselves.
3. On validation failure, `submitSurveyFailure` (`frontend/src/scenes/surveys/surveyLogic.tsx:1393-1394`) routes appearance errors to `SurveyEditSection.Customization` — a section that doesn't exist for API surveys. The editor never refocuses anywhere visible, and the save just stops.

Symptom: rage clicks and dead clicks on the **Save** button with no error indication.

## Changes

`validateSurveyAppearance` returns an empty error map for `SurveyType.API`. Appearance CSS never applies to API surveys (the customer renders them), so validating it is dead weight and the section it would point to isn't rendered anyway.

## How did you test this code?

- Authored by an agent (PostHog Code). No manual UI verification.
- Added two automated tests in `frontend/src/scenes/surveys/utils.test.ts` covering the API skip path and a Popover control case.
- `flox activate -- bash -c "hogli test frontend/src/scenes/surveys/utils.test.ts"` — 90/90 tests pass.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). The reporter pointed at a session showing rage clicks on Save; the agent traced the failure to `submitSurveyFailure` routing to a hidden section. The fix narrowly skips appearance validation for `SurveyType.API` rather than touching the editor's section routing — appearance validation never has any reason to run for API surveys, so the early return is the smallest change that closes the silent-save path. No telemetry or feature flag added; the change is a pure no-op for non-API surveys.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*