### PR TITLE
chore(ci): prune stale entries from .test_durations

### DIFF
--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -29,6 +29,26 @@ logger = logging.getLogger(__name__)
 DEFAULT_CEILING = 60.0
 
 
+def drop_missing_files(durations: dict[str, float], repo_root: Path) -> dict[str, float]:
+    """Drop entries whose source file no longer exists in the checkout.
+
+    Each pytest nodeid is `<file>::<class>::<method>`; if `<file>` is missing,
+    the test cannot run and its timing is dead weight that biases pytest-split's
+    `duration_based_chunks` toward never-executed slots.
+    """
+    seen_files: dict[str, bool] = {}
+    kept: dict[str, float] = {}
+    for nodeid, duration in durations.items():
+        file_part = nodeid.split("::", 1)[0]
+        exists = seen_files.get(file_part)
+        if exists is None:
+            exists = (repo_root / file_part).exists()
+            seen_files[file_part] = exists
+        if exists:
+            kept[nodeid] = duration
+    return kept
+
+
 def load_timing_artifacts(artifacts_dir: Path, segment: str | None = None) -> dict[str, float]:
     """Load and merge timing data from shard artifacts.
 
@@ -150,6 +170,12 @@ def main():
         logger.info("  Filtering to segment: %s", args.segment)
     real_durations = load_timing_artifacts(args.artifacts_dir, segment=args.segment)
     logger.info("  Loaded %d tests from artifacts", len(real_durations))
+
+    before_prune = len(real_durations)
+    real_durations = drop_missing_files(real_durations, Path.cwd())
+    pruned = before_prune - len(real_durations)
+    if pruned:
+        logger.info("  Pruned %d entries whose source files no longer exist", pruned)
 
     # Filter to only existing tests if requested
     if args.filter_existing:


### PR DESCRIPTION
## Problem

`.test_durations` is used by `pytest-split` to balance backend CI shards.
The CI updater workflow (`.github/workflows/ci-backend-update-test-timing.yml`)
merges per-shard timing artifacts that pytest-split itself produces, but those
artifacts carry forward old entries — when tests get moved or deleted, the
old `nodeid → seconds` entry is never dropped.

The file had drifted to 48,258 entries spanning 2,026 files, of which **247
files no longer exist** (~5,019 s of phantom test time across 5,785 entries).
These phantom entries inflate `duration_based_chunks` slot allocations for
slots that will never run, leading to less-balanced sharding.

Largest stale contributors (by phantom seconds):

- `posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py` — 818 s (moved to `products/batch_exports/...`)
- `posthog/hogql_queries/insights/test/test_paths_query_runner_ee.py` — 504 s (also moved/renamed)
- `products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py` — 453 s

## Changes

Two commits:

1. **One-shot prune of `.test_durations`** — drops every entry whose file
   does not exist in the current checkout (6.9 MB → 6.0 MB, 48,258 → 42,473
   entries).
2. **Self-healing in the CI updater script** — adds an unconditional
   `drop_missing_files` step to `.github/scripts/optimize_test_durations.py`
   so future weekly refreshes can't drift back into the same state. Stat-only
   (`Path.exists` per nodeid file part) — no pytest collection, no imports,
   negligible cost. Verified locally that the script produces an identical
   42,473-entry set when run against the pre-prune file.

The existing opt-in `--filter-existing` flag (which calls `pytest --collect-only`)
is unchanged; the new `drop_missing_files` is the cheap, always-on companion.

## How did you test this code?

Agent-authored. Verified by:

- Running `drop_missing_files` against the pre-prune snapshot — produces the
  exact same 42,473-entry set that was committed manually.
- Spot-checking 10 dropped paths with `git log -- <path>` to confirm they were
  removed or renamed in earlier commits, not present-but-missed.
- Confirming the remaining 42,473 entries all reference files that exist on
  disk in this checkout.

No tests were run; this PR only touches the timings data file and the CI
updater script. The script change is exercised by the `ci-backend-update-test-timing.yml`
workflow on its weekly schedule.

## Publish to changelog?

no

## 🤖 Agent context

PostHog Code session. Investigated the timings file to identify the slowest
backend tests; the prune surfaced as the safest standalone first step. Initially
only landed the data-file change, then added the self-healing script change so
the next workflow run won't undo it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*