### PR TITLE
feat(cymbal): support pgbouncer connections

### DIFF
--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -2,7 +2,10 @@ use common_kafka::kafka_producer::{create_kafka_producer, KafkaContext};
 use common_redis::{Client as RedisClientTrait, RedisClient};
 use health::HealthRegistry;
 use rdkafka::producer::FutureProducer;
-use sqlx::{postgres::PgPoolOptions, PgPool};
+use sqlx::{
+    postgres::{PgConnectOptions, PgPoolOptions},
+    PgPool,
+};
 use std::{sync::Arc, time::Duration};
 use tokio::sync::{Mutex, Semaphore};
 use tracing::info;
@@ -47,7 +50,13 @@ pub struct AppContext {
 impl AppContext {
     pub async fn from_config(config: &Config) -> Result<Self, UnhandledError> {
         let options = PgPoolOptions::new().max_connections(config.max_pg_connections);
-        let posthog_pool = options.connect(&config.database_url).await?;
+        let connect_options: PgConnectOptions = config.database_url.parse()?;
+        let connect_options = connect_options
+            // PgBouncer in transaction-pooling mode cannot safely reuse SQLx's
+            // named prepared statements across backend connections.
+            .statement_cache_capacity(0)
+            .application_name("cymbal");
+        let posthog_pool = options.connect_with(connect_options).await?;
 
         let s3_client = aws_sdk_s3::Client::from_conf(get_aws_config(config).await);
         let s3_client = S3Client::new(s3_client);

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -54,8 +54,8 @@ pub struct Config {
     #[envconfig(default = "postgres://posthog:posthog@localhost:5432/posthog")]
     pub database_url: String,
 
-    // Rust service connect directly to postgres, not via pgbouncer, so we keep this low
-    #[envconfig(default = "4")]
+    // Maximum number of client connections from Cymbal to PgBouncer.
+    #[envconfig(default = "50")]
     pub max_pg_connections: u32,
 
     // cymbal makes HTTP get requests to auto-resolve sourcemaps - and follows redirects. To protect against SSRF, we only allow requests to public URLs by default


### PR DESCRIPTION
## Problem

Cymbal is being routed through PgBouncer, but SQLx's default prepared statement cache is not compatible with PgBouncer transaction pooling. Cymbal also needs its local database pool limit to represent app-to-PgBouncer concurrency rather than direct Postgres connections.

## Changes

- Build the Cymbal Postgres pool from `PgConnectOptions`.
- Disable SQLx statement caching for PgBouncer transaction-pooling compatibility.
- Set the Postgres `application_name` to `cymbal`.
- Raise the default `MAX_PG_CONNECTIONS` to `50` now that PgBouncer controls upstream Postgres fan-out.

## How did you test this code?

As an agent, I ran:

```bash
cd rust && cargo fmt --package cymbal
cd rust && cargo check -p cymbal
```

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

This PR was authored with pi. The key decision was to keep a bounded SQLx pool in Cymbal as local app-side backpressure while moving upstream Postgres connection fan-out to PgBouncer. SQLx statement caching is disabled because PgBouncer transaction pooling can reuse backend connections across client sessions.
