### PR TITLE
fix(experiments): description-modal draft no longer clobbered by refresh

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -45,9 +45,15 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
 
     const [tempDescription, setTempDescription] = useState(experiment.description || '')
 
+    // Snapshot the description when the modal opens, not on every external change to
+    // experiment.description — otherwise an auto-refresh (or another tab's save) mid-edit
+    // would clobber the user's draft.
     useEffect(() => {
-        setTempDescription(experiment.description || '')
-    }, [experiment.description])
+        if (isDescriptionModalOpen) {
+            setTempDescription(experiment.description || '')
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isDescriptionModalOpen])
 
     const { created_by } = experiment
 


### PR DESCRIPTION
## Problem

In `ExperimentView/Info.tsx`, the hypothesis modal keeps a local `tempDescription` state and mirrors `experiment.description` into it via `useEffect(..., [experiment.description])`. Any external update to `experiment.description` while the modal is open — auto-refresh, another tab saving, a websocket push — fires the effect and overwrites whatever the user is currently typing.

The bug is silent (no error, just lost characters) and probably hits anyone editing a hypothesis on an experiment that auto-refreshes frequently.

## Changes

Snapshot the description **when the modal opens** instead of mirroring on every external change. The effect now depends on `isDescriptionModalOpen` from `modalsLogic`:

- Open transition (`false` → `true`): read the latest `experiment.description` into `tempDescription`
- While open: external description changes are ignored — the user's draft is untouched
- Close transition (`true` → `false`): no-op
- Re-open: fresh snapshot

`react-hooks/exhaustive-deps` is suppressed on this effect with a comment explaining why we deliberately don't depend on `experiment.description`.

8-line diff to one file. No behavior change for the happy path (open → edit → save).

## How did you test this code?

I'm an agent. Automated checks I actually ran:

- `pnpm exec tsc --noEmit` under bumped heap — 0 errors.

No manual UI testing performed. The fix can be validated locally by: opening an experiment's hypothesis modal, starting to type, triggering an auto-refresh (or editing `description` from another tab / via the API), and confirming the local draft is no longer overwritten.

## Publish to changelog?

no — small bug fix with niche surface area.

## Docs update

n/a.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) acting on the highest-priority remaining item from an XP-style review of `ExperimentView/`. The other PRs in this small series are #59002, #59007, #59010.

Decisions worth surfacing:

- **`react-hooks/exhaustive-deps` suppression is intentional here.** The whole point of the fix is to ignore `experiment.description` in the dep array. The comment above the effect documents why, so future readers don't "fix" the lint by re-adding the dep and re-introducing the bug.
- **Same pattern exists elsewhere in this directory.** `DistributionTable.tsx`'s `useEffect` that mirrors `experiment.feature_flag.filters` into `variants`/`rolloutPercentage` has the same shape: gates with `if (isDistributionModalOpen)` but includes the experiment data in deps, so refresh-while-open clobbers edits. Same gating issue, less common in practice (variant rollout editing is rarer than hypothesis editing). Worth a follow-up. `FinishExperimentModal`'s `useEffect` that initializes `selectedVariantKey` from `experiment.parameters?.feature_flag_variants` has a softer version of the same issue, but the modal is only open briefly. Intentionally not bundled here — single-bug PR is easier to review and revert if anything regresses.