### PR TITLE
chore: add managing-github-actions-secrets skill

### DIFF
--- a/.agents/skills/managing-github-actions-secrets/SKILL.md
+++ b/.agents/skills/managing-github-actions-secrets/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: managing-github-actions-secrets
+description: >
+  Creates and updates GitHub Actions secrets for PostHog workflows. Use when
+  adding a new CI secret, rotating an existing secret, wiring a workflow to an
+  API token, package registry credential, deploy key, or any value referenced
+  via `${{ secrets.* }}` in `.github/workflows/`.
+---
+
+# Managing GitHub Actions secrets for PostHog
+
+PostHog centralizes all GitHub Actions secrets at the **organization** level
+and grants individual repositories access to them. Do not add secrets to a
+single repo, even if the secret is only consumed by one workflow today.
+
+## The rule
+
+- **Always** create secrets on the `posthog` org, not on a repo.
+- Grant the secret to specific repos via the org-level access control
+  (selected repositories). Do not make it available to all repos by default
+  unless the secret is genuinely meant to be shared org-wide.
+- Never paste secret values into chat, PR descriptions, commit messages, or
+  files. Pipe them in, or paste them only into the GitHub UI's secret field.
+
+## Creating or updating a secret via `gh` CLI
+
+Pipe the secret value into `gh secret set` with `--org posthog`. The example
+below reads the value from stdin so it never appears in shell history:
+
+```sh
+# Read from clipboard / a pipe / a file — never inline as an argument
+<secret-value> | gh secret set POSTHOGOS_PACKAGER_KEY --org posthog
+```
+
+Common variants:
+
+```sh
+# From a file
+gh secret set POSTHOGOS_PACKAGER_KEY --org posthog < secret.txt
+
+# Restrict to selected repositories at creation time
+gh secret set POSTHOGOS_PACKAGER_KEY --org posthog \
+  --visibility selected --repos PostHog/posthog,PostHog/posthog-foss
+
+# Update which repos can access an existing org secret
+gh secret set POSTHOGOS_PACKAGER_KEY --org posthog \
+  --visibility selected --repos PostHog/posthog
+```
+
+Verify:
+
+```sh
+gh secret list --org posthog | grep POSTHOGOS_PACKAGER_KEY
+```
+
+## Creating or updating a secret via the GitHub UI
+
+1. Open <https://github.com/organizations/PostHog/settings/secrets/actions>.
+2. Click **New organization secret** (or the existing secret to update it).
+3. Set the **Name** (SCREAMING_SNAKE_CASE, descriptive, like `POSTHOGOS_PACKAGER_KEY`).
+4. Paste the **Value**.
+5. Under **Repository access**, choose **Selected repositories** and pick the
+   exact repos that need it. Avoid **All repositories** unless the secret is
+   safe to expose to every repo in the org.
+6. Click **Add secret** / **Update secret**.
+
+## What not to do
+
+- Do not run `gh secret set NAME` without `--org posthog` — that creates a
+  repo-level secret on whatever repo `gh` is currently pointed at.
+- Do not navigate to `Settings → Secrets and variables → Actions` on an
+  individual repo to add a secret. If a repo-level secret already exists for
+  something that should be org-level, migrate it (create at org, grant to the
+  repo, then delete the repo-level copy).
+- Do not echo secret values in commands, logs, or files. If a value was
+  accidentally exposed, rotate it immediately.
+
+## When the user asks "where do I add this secret?"
+
+Default answer: at the org level via `gh secret set --org posthog`, granted
+to the specific repos that need it. Only deviate if the user explicitly
+overrides this (e.g. for an environment-scoped secret on a deployment
+environment, which is a different mechanism).

--- a/.agents/skills/managing-github-actions-secrets/SKILL.md
+++ b/.agents/skills/managing-github-actions-secrets/SKILL.md
@@ -29,7 +29,7 @@ below reads the value from stdin so it never appears in shell history:
 
 ```sh
 # Read from clipboard / a pipe / a file — never inline as an argument
-<secret-value> | gh secret set POSTHOGOS_PACKAGER_KEY --org posthog
+pbpaste | gh secret set POSTHOGOS_PACKAGER_KEY --org posthog
 ```
 
 Common variants:


### PR DESCRIPTION
## Problem

Agents working on PostHog CI need a consistent answer to "where do I add this secret?" GitHub Actions secrets here are centralized on the `posthog` org and granted to selected repos, but that convention isn't documented in the repo. Without it, agents (and humans) default to repo-level secrets, which fragments ownership and access control.

## Changes

Adds a new skill at `.agents/skills/managing-github-actions-secrets/SKILL.md` covering:

- The org-level rule and why repo-level secrets are discouraged.
- `gh secret set --org posthog` usage with selected-repository visibility.
- The equivalent GitHub UI flow.
- Common pitfalls (missing `--org posthog`, echoing values, repo-level secrets that should be migrated).

No code or workflow changes — documentation only.

## How did you test this code?

I'm an agent. No automated tests cover skill markdown content; lint-staged ran `bin/hogli format:markdown` on commit and passed. I did not execute any `gh secret` commands.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). The user asked to create a skill capturing the org-level GitHub Actions secrets convention, then to branch/commit/push/open this PR. No alternatives were rejected — the skill follows the existing `.agents/skills/` SKILL.md layout used elsewhere in the repo. Human review required before merge.