### PR TITLE
chore(tests): speed up two slow django backend tests

### DIFF
--- a/posthog/clickhouse/client/test/test_limit.py
+++ b/posthog/clickhouse/client/test/test_limit.py
@@ -388,8 +388,10 @@ class TestMaterializedEndpointsRateLimiter(BaseTest):
                 slot = rate_limiter.use(team_id=self.team.id, task_id=f"test-slot-{i}", is_materialized_endpoint=True)
                 acquired_slots.append(slot)
 
-            # 11th request should fail
-            with self.assertRaises(ConcurrencyLimitExceeded):
+            # 11th request should fail. The production rate limiter has a 30s retry_timeout;
+            # we explicitly disable retries here so the test doesn't burn 30s waiting for a
+            # slot we know will never free up.
+            with patch.object(rate_limiter, "retry", None), self.assertRaises(ConcurrencyLimitExceeded):
                 rate_limiter.use(team_id=self.team.id, task_id="test-slot-overflow", is_materialized_endpoint=True)
         finally:
             # Clean up all acquired slots

--- a/posthog/hogql_queries/ai/test/test_team_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_team_taxonomy_query_runner.py
@@ -124,7 +124,11 @@ class TestTeamTaxonomyQueryRunner(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
         )
 
-        for i in range(501):
+        # Use an explicit small limit so we only have to create limit+1 events
+        # to exercise the hasMore path. The default-limit branch is covered by
+        # `test_taxonomy_query_runner` above (asserts `limit == 500`).
+        limit = 5
+        for i in range(limit + 1):
             _create_event(
                 event=f"event{i}",
                 distinct_id="person1",
@@ -134,12 +138,12 @@ class TestTeamTaxonomyQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         flush_persons_and_events()
 
-        runner = TeamTaxonomyQueryRunner(team=self.team, query=TeamTaxonomyQuery())
+        runner = TeamTaxonomyQueryRunner(team=self.team, query=TeamTaxonomyQuery(limit=limit))
         response = runner.run()
 
         assert isinstance(response, CachedTeamTaxonomyQueryResponse)
         # hasMore=True, so no well-known events appended
-        self.assertEqual(len(response.results), 500)
+        self.assertEqual(len(response.results), limit)
         self.assertTrue(response.hasMore)
 
     def test_pagination_with_limit_and_offset(self):


### PR DESCRIPTION
## Problem

Two backend tests in CI are burning ~70s combined to verify behavior that can
be exercised in seconds, slowing down whichever shard they land in.

Found by analyzing `.test_durations` for tests that exceed 30s of real
measured time (entries below the file's 60s cap). Companion PR #59012 cleans
up the timings data itself; this PR fixes the underlying slowness in two
clear cases.

| Test | Old | Why slow |
|------|-----|----------|
| `TestTeamTaxonomyQueryRunner::test_limit` | 41s | Creates 501 events to exercise a 500-row paginator limit |
| `test_rate_limiter_enforces_concurrency_limit` | 31s | Waits the production rate limiter's full 30s `retry_timeout` for a slot that intentionally never frees |

## Changes

**`test_limit`** (`posthog/hogql_queries/ai/test/test_team_taxonomy_query_runner.py`):
Pass `limit=5` explicitly on the query and create 6 events instead of 501.
The test's purpose is to verify enforcement of the limit + the `hasMore`
flag, not the literal `500` default — that's already covered by
`test_taxonomy_query_runner` immediately above, which asserts
`results.limit == 500`.

**`test_rate_limiter_enforces_concurrency_limit`** (`posthog/clickhouse/client/test/test_limit.py`):
The materialized-endpoints rate limiter is configured with `retry=0.134,
retry_timeout=30.0` (see `get_materialized_endpoints_rate_limiter` in
`posthog/clickhouse/client/limit.py`). The test acquires all 10 slots and
then deliberately tries to use an 11th — the production retry path waits
the full 30s of exponential backoff before raising
`ConcurrencyLimitExceeded`. Patch `retry=None` on the rate limiter for that
one failing call so it raises immediately. All 10 happy-path acquires keep
their normal config.

## How did you test this code?

Agent-authored. Verified by:

- `pytest --collect-only` on the modified test files (both collect cleanly).
- Static reading of `RateLimit.use()` (`posthog/clickhouse/client/limit.py`):
  the retry loop guard is `if self.retry and self.get_time() < wait_deadline`,
  so setting `retry=None` skips the loop entirely and the next iteration's
  `raise ConcurrencyLimitExceeded` fires immediately.
- The pre-commit linter (`ruff check`, `ruff format`, `ty check`) passed
  cleanly on both files.

I did not run the tests against a live ClickHouse / Redis. The behavior
they assert (paginator limit + `hasMore`; `ConcurrencyLimitExceeded` on
slot overflow) is unchanged — only the input scale and one retry knob
move.

## Publish to changelog?

no

## 🤖 Agent context

PostHog Code session. After landing the timings prune (#59012) I looked
at the remaining genuinely-slow (sub-60s-cap) tests in `.test_durations`.
Most candidates in the top of the list turned out to be either renamed/
moved (so the timing entry is stale and #59012 already drops them) or
heavy ClickHouse-integration tests that aren't easily sped up without
deeper refactors. These two were the clearest standalone wins.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*