### PR TITLE
chore(flags): is_5xx cleanup

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -316,48 +316,7 @@ impl FlagError {
     }
 
     pub fn is_5xx(&self) -> bool {
-        let status = match self {
-            FlagError::ClientFacing(ClientFacingError::ServiceUnavailable) => {
-                StatusCode::SERVICE_UNAVAILABLE
-            }
-            FlagError::ClientFacing(_) => return false, // All other ClientFacing are 4XX
-            FlagError::Internal(_)
-            | FlagError::DeserializeFiltersError
-            | FlagError::DatabaseError(_, _)
-            | FlagError::NoGroupTypeMappings
-            | FlagError::GroupTypeMappingFetchFailed
-            | FlagError::RowNotFound
-            | FlagError::DependencyNotFound(_, _)
-            | FlagError::CohortFiltersParsingError
-            | FlagError::DependencyCycle(_, _)
-            | FlagError::DataParsingError
-            | FlagError::BatchEvaluationPanicked
-            | FlagError::DataParsingErrorWithContext(_)
-            | FlagError::HashKeyOverrideError => StatusCode::INTERNAL_SERVER_ERROR,
-
-            FlagError::RayonSemaphoreTimeout(_) => StatusCode::GATEWAY_TIMEOUT,
-
-            FlagError::RedisUnavailable
-            | FlagError::DatabaseUnavailable
-            | FlagError::TimeoutError(_)
-            | FlagError::CacheMiss
-            | FlagError::PersonNotFound
-            | FlagError::PropertiesNotInCache
-            | FlagError::StaticCohortMatchesNotCached => StatusCode::SERVICE_UNAVAILABLE,
-
-            FlagError::CookielessError(
-                CookielessManagerError::HashError(_)
-                | CookielessManagerError::ChronoError(_)
-                | CookielessManagerError::RedisError(_, _)
-                | CookielessManagerError::SaltCacheError(
-                    SaltCacheError::RedisError(_) | SaltCacheError::SaltRetrievalFailed,
-                )
-                | CookielessManagerError::InvalidIdentifyCount(_),
-            ) => StatusCode::INTERNAL_SERVER_ERROR,
-            FlagError::CookielessError(_) => return false, // Other CookielessErrors are 4XX
-            _ => return false,                             // Everything else is 4XX
-        };
-        status.is_server_error()
+        self.status_code() >= 500
     }
 }
 


### PR DESCRIPTION
## Problem

`FlagError::is_5xx()` in `rust/feature-flags/src/api/errors.rs` duplicated the per-variant classification already done by `error_metadata()` / `status_code()`. The two match statements had to stay in sync, and adding a new error variant required updating both, with only `test_error_code_consistency_with_is_5xx` catching drift.

## Changes

Replaced the 45-line match in `is_5xx()` with `self.status_code() >= 500`. Behavior is unchanged; classification now lives in one place.

## How did you test this code?

`cargo build`, `cargo clippy --no-deps`, and `cargo test --lib` all pass (1265 passed, 1 ignored, 0 failed). The existing `test_is_5xx` and `test_error_code_consistency_with_is_5xx` cases continue to pass and now verify the derivation directly.

## Publish to changelog?

No
