### PR TITLE
fix: scrollbar click event pop-up close

### DIFF
--- a/frontend/src/lib/hooks/useOutsideClickHandler.ts
+++ b/frontend/src/lib/hooks/useOutsideClickHandler.ts
@@ -24,34 +24,54 @@ export function useOutsideClickHandler(
     const exceptTagNamesRef = useRef(exceptTagNames)
     exceptTagNamesRef.current = exceptTagNames
 
+    // Tracks whether the pointer/touch gesture started inside any of the tracked refs.
+    const gestureStartedInsideRef = useRef(false)
+
     useEffect(() => {
+        function isInsideRefs(event: Event): boolean {
+            return refsRef.current.some((maybeRef) => {
+                if (typeof maybeRef === 'string') {
+                    return !!event.composedPath?.()?.find((e) => (e as HTMLElement)?.matches?.(maybeRef))
+                }
+                const ref = maybeRef.current
+
+                if (!event.target || !ref) {
+                    return false
+                }
+
+                const hasShadowRoot = !!(event.target as HTMLElement).shadowRoot
+                return hasShadowRoot
+                    ? !!event.composedPath?.()?.find((el) => el === ref)
+                    : `contains` in ref && ref.contains(event.target as Element)
+            })
+        }
+
+        function handleGestureStart(event: Event): void {
+            if (event instanceof MouseEvent && event.button !== 0) {
+                return
+            }
+            gestureStartedInsideRef.current = isInsideRefs(event)
+        }
+
         function handleClick(event: Event): void {
+            const startedInside = gestureStartedInsideRef.current
+            gestureStartedInsideRef.current = false
+
             // Ignore non-primary clicks (right-click, middle-click).
             // Radix context menus (BrowserLikeMenuItems) fire `contextmenu` before `mouseup`,
             // causing the browser to retarget `mouseup` to <html> which falsely triggers outside-click dismissal.
             if (event instanceof MouseEvent && event.button !== 0) {
                 return
             }
+            // If the gesture started inside a tracked ref (e.g. scrollbar drag, text selection
+            // that ends outside the popover), don't treat the release as an outside click.
+            if (startedInside) {
+                return
+            }
             if (exceptions.some((exception) => (event.target as Element)?.matches?.(exception))) {
                 return
             }
-            if (
-                refsRef.current.some((maybeRef) => {
-                    if (typeof maybeRef === 'string') {
-                        return event.composedPath?.()?.find((e) => (e as HTMLElement)?.matches?.(maybeRef))
-                    }
-                    const ref = maybeRef.current
-
-                    if (!event.target || !ref) {
-                        return false
-                    }
-
-                    const hasShadowRoot = !!(event.target as HTMLElement).shadowRoot
-                    return hasShadowRoot
-                        ? event.composedPath?.()?.find((el) => el === ref)
-                        : `contains` in ref && ref.contains(event.target as Element)
-                })
-            ) {
+            if (isInsideRefs(event)) {
                 return
             }
             const target = (event.composedPath?.()?.[0] || event.target) as HTMLElement
@@ -63,9 +83,13 @@ export function useOutsideClickHandler(
 
         // Only attach event listeners if there's something to track
         if (refsRef.current.length > 0) {
+            document.addEventListener('mousedown', handleGestureStart, true)
+            document.addEventListener('touchstart', handleGestureStart, true)
             document.addEventListener('mouseup', handleClick)
             document.addEventListener('touchend', handleClick)
             return () => {
+                document.removeEventListener('mousedown', handleGestureStart, true)
+                document.removeEventListener('touchstart', handleGestureStart, true)
                 document.removeEventListener('mouseup', handleClick)
                 document.removeEventListener('touchend', handleClick)
             }

--- a/frontend/src/lib/hooks/useOutsideClickHandler.ts
+++ b/frontend/src/lib/hooks/useOutsideClickHandler.ts
@@ -24,8 +24,11 @@ export function useOutsideClickHandler(
     const exceptTagNamesRef = useRef(exceptTagNames)
     exceptTagNamesRef.current = exceptTagNames
 
-    // Tracks whether the pointer/touch gesture started inside any of the tracked refs.
-    const gestureStartedInsideRef = useRef(false)
+    // Tracks per-gesture whether the down event landed inside any tracked ref. Keyed by
+    // touch identifier for `TouchEvent`s, and a separate sentinel for the mouse — touch
+    // identifiers are integers starting at 0, so we can't share a key space with mouse.
+    const MOUSE_GESTURE_KEY = 'mouse' as const
+    const gestureStartedInsideMap = useRef<Map<number | typeof MOUSE_GESTURE_KEY, boolean>>(new Map())
 
     useEffect(() => {
         function isInsideRefs(event: Event): boolean {
@@ -50,12 +53,35 @@ export function useOutsideClickHandler(
             if (event instanceof MouseEvent && event.button !== 0) {
                 return
             }
-            gestureStartedInsideRef.current = isInsideRefs(event)
+            const inside = isInsideRefs(event)
+            if (typeof TouchEvent !== 'undefined' && event instanceof TouchEvent) {
+                // Track each newly-started touch independently so a concurrent touch
+                // outside the popover doesn't overwrite an earlier touch that started inside.
+                for (let i = 0; i < event.changedTouches.length; i++) {
+                    gestureStartedInsideMap.current.set(event.changedTouches[i].identifier, inside)
+                }
+            } else {
+                gestureStartedInsideMap.current.set(MOUSE_GESTURE_KEY, inside)
+            }
         }
 
         function handleClick(event: Event): void {
-            const startedInside = gestureStartedInsideRef.current
-            gestureStartedInsideRef.current = false
+            // Pull and clear the entries for the gesture(s) ending in this event.
+            // For touchend with multiple ended touches, treat the release as "started inside"
+            // if *any* ended touch began inside — matches the single-touch semantics.
+            let startedInside = false
+            if (typeof TouchEvent !== 'undefined' && event instanceof TouchEvent) {
+                for (let i = 0; i < event.changedTouches.length; i++) {
+                    const id = event.changedTouches[i].identifier
+                    if (gestureStartedInsideMap.current.get(id)) {
+                        startedInside = true
+                    }
+                    gestureStartedInsideMap.current.delete(id)
+                }
+            } else {
+                startedInside = gestureStartedInsideMap.current.get(MOUSE_GESTURE_KEY) ?? false
+                gestureStartedInsideMap.current.delete(MOUSE_GESTURE_KEY)
+            }
 
             // Ignore non-primary clicks (right-click, middle-click).
             // Radix context menus (BrowserLikeMenuItems) fire `contextmenu` before `mouseup`,

--- a/frontend/src/lib/hooks/useOutsideClickHandler.ts
+++ b/frontend/src/lib/hooks/useOutsideClickHandler.ts
@@ -24,11 +24,11 @@ export function useOutsideClickHandler(
     const exceptTagNamesRef = useRef(exceptTagNames)
     exceptTagNamesRef.current = exceptTagNames
 
-    // Tracks per-gesture whether the down event landed inside any tracked ref. Keyed by
-    // touch identifier for `TouchEvent`s, and a separate sentinel for the mouse — touch
-    // identifiers are integers starting at 0, so we can't share a key space with mouse.
-    const MOUSE_GESTURE_KEY = 'mouse' as const
-    const gestureStartedInsideMap = useRef<Map<number | typeof MOUSE_GESTURE_KEY, boolean>>(new Map())
+    // Tracks whether the most recent down event landed inside any tracked ref, so a release
+    // outside (e.g. a scrollbar drag) isn't mistaken for an outside click. A single flag is
+    // enough: gestures are processed one at a time, and the rare overlapping multi-touch case
+    // degrades gracefully (the last touch's start position wins).
+    const gestureStartedInsideRef = useRef(false)
 
     useEffect(() => {
         function isInsideRefs(event: Event): boolean {
@@ -53,35 +53,12 @@ export function useOutsideClickHandler(
             if (event instanceof MouseEvent && event.button !== 0) {
                 return
             }
-            const inside = isInsideRefs(event)
-            if (typeof TouchEvent !== 'undefined' && event instanceof TouchEvent) {
-                // Track each newly-started touch independently so a concurrent touch
-                // outside the popover doesn't overwrite an earlier touch that started inside.
-                for (let i = 0; i < event.changedTouches.length; i++) {
-                    gestureStartedInsideMap.current.set(event.changedTouches[i].identifier, inside)
-                }
-            } else {
-                gestureStartedInsideMap.current.set(MOUSE_GESTURE_KEY, inside)
-            }
+            gestureStartedInsideRef.current = isInsideRefs(event)
         }
 
         function handleClick(event: Event): void {
-            // Pull and clear the entries for the gesture(s) ending in this event.
-            // For touchend with multiple ended touches, treat the release as "started inside"
-            // if *any* ended touch began inside — matches the single-touch semantics.
-            let startedInside = false
-            if (typeof TouchEvent !== 'undefined' && event instanceof TouchEvent) {
-                for (let i = 0; i < event.changedTouches.length; i++) {
-                    const id = event.changedTouches[i].identifier
-                    if (gestureStartedInsideMap.current.get(id)) {
-                        startedInside = true
-                    }
-                    gestureStartedInsideMap.current.delete(id)
-                }
-            } else {
-                startedInside = gestureStartedInsideMap.current.get(MOUSE_GESTURE_KEY) ?? false
-                gestureStartedInsideMap.current.delete(MOUSE_GESTURE_KEY)
-            }
+            const startedInside = gestureStartedInsideRef.current
+            gestureStartedInsideRef.current = false
 
             // Ignore non-primary clicks (right-click, middle-click).
             // Radix context menus (BrowserLikeMenuItems) fire `contextmenu` before `mouseup`,

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -819,6 +819,9 @@ export function LemonInputSelect<T = string>({
                 popoverFocusRef.current = true
                 e.stopPropagation()
             }}
+            onMouseDownInside={() => {
+                popoverFocusRef.current = true
+            }}
             className={popoverClassName}
             placement="bottom-start"
             fallbackPlacements={['bottom-end', 'top-start', 'top-end']}

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -37,6 +37,7 @@ export interface PopoverProps {
     visible: boolean
     onClickOutside?: (event: Event) => void
     onClickInside?: MouseEventHandler<HTMLDivElement>
+    onMouseDownInside?: MouseEventHandler<HTMLDivElement>
     onMouseEnterInside?: MouseEventHandler<HTMLDivElement>
     onMouseLeaveInside?: MouseEventHandler<HTMLDivElement>
     /** Popover trigger element. If you pass one <Component/> child, it will get the `ref` prop automatically. */
@@ -101,6 +102,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
         visible,
         onClickOutside,
         onClickInside,
+        onMouseDownInside,
         onMouseEnterInside,
         onMouseLeaveInside,
         placement = 'bottom-start',
@@ -318,6 +320,24 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
         }
     }
 
+    const _onMouseDownInside: MouseEventHandler<HTMLDivElement> = (e): void => {
+        if (e.target instanceof HTMLElement && e.target.closest(`.${CLICK_OUTSIDE_BLOCK_CLASS}`)) {
+            return
+        }
+        onMouseDownInside?.(e)
+        if (parentPopoverLevel > -1 && !closeParentPopoverOnClickInside) {
+            nestedPopoverReceivedClick = true
+            const onUp = (): void => {
+                document.removeEventListener('mouseup', onUp, true)
+                // Hold the flag past the parent's outside-click setTimeout(1) check.
+                setTimeout(() => {
+                    nestedPopoverReceivedClick = false
+                }, 10)
+            }
+            document.addEventListener('mouseup', onUp, true)
+        }
+    }
+
     const clonedChildren = children ? React.cloneElement(children as ReactElement, { ref: mergedReferenceRef }) : null
 
     const floatingCallbackRef = useCallback(
@@ -373,6 +393,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
                                     ...style,
                                 }}
                                 onClick={_onClickInside}
+                                onMouseDown={_onMouseDownInside}
                                 onMouseEnter={onMouseEnterInside}
                                 onMouseLeave={onMouseLeaveInside}
                                 aria-level={currentPopoverLevel}

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -89,6 +89,10 @@ export const PopoverReferenceContext = React.createContext<[boolean, Placement] 
 
 let nestedPopoverReceivedClick = false
 
+// Must outlast the `setTimeout(..., 1)` that parent popovers use in their outside-click
+// callback to check `nestedPopoverReceivedClick`. 10ms gives comfortable headroom.
+const NESTED_CLICK_FLAG_HOLD_MS = 10
+
 /** This is a custom popover control that uses `floating-ui` to position DOM nodes.
  *
  * Often used with buttons for various menu. If this is your intention, use `LemonButtonWithDropdown`.
@@ -320,6 +324,36 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
         }
     }
 
+    // For nested popovers, holding `nestedPopoverReceivedClick` true across a drag (mousedown
+    // until just after mouseup) requires a document-level mouseup listener. We manage its
+    // lifecycle here so it can't leak past unmount or visibility change — see PR #59028.
+    const pendingMouseDownResetRef = useRef(false)
+    useEffect(() => {
+        if (parentPopoverLevel <= -1 || closeParentPopoverOnClickInside || !visible) {
+            return
+        }
+        const onUp = (): void => {
+            if (!pendingMouseDownResetRef.current) {
+                return
+            }
+            pendingMouseDownResetRef.current = false
+            setTimeout(() => {
+                nestedPopoverReceivedClick = false
+            }, NESTED_CLICK_FLAG_HOLD_MS)
+        }
+        document.addEventListener('mouseup', onUp, true)
+        return () => {
+            document.removeEventListener('mouseup', onUp, true)
+            // If we unmount or hide mid-drag, clear the global flag so a never-arriving
+            // mouseup doesn't leave it stuck — that would suppress legitimate
+            // outside-click dismissals on sibling popovers opened shortly after.
+            if (pendingMouseDownResetRef.current) {
+                pendingMouseDownResetRef.current = false
+                nestedPopoverReceivedClick = false
+            }
+        }
+    }, [visible, parentPopoverLevel, closeParentPopoverOnClickInside])
+
     const _onMouseDownInside: MouseEventHandler<HTMLDivElement> = (e): void => {
         if (e.target instanceof HTMLElement && e.target.closest(`.${CLICK_OUTSIDE_BLOCK_CLASS}`)) {
             return
@@ -327,14 +361,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
         onMouseDownInside?.(e)
         if (parentPopoverLevel > -1 && !closeParentPopoverOnClickInside) {
             nestedPopoverReceivedClick = true
-            const onUp = (): void => {
-                document.removeEventListener('mouseup', onUp, true)
-                // Hold the flag past the parent's outside-click setTimeout(1) check.
-                setTimeout(() => {
-                    nestedPopoverReceivedClick = false
-                }, 10)
-            }
-            document.addEventListener('mouseup', onUp, true)
+            pendingMouseDownResetRef.current = true
         }
     }
 


### PR DESCRIPTION
## Problem

on the data tabs, when adding filters the pop-up closes when clicking and releasing the scroll bar. 
raised here: https://posthoghelp.zendesk.com/agent/tickets/58367 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/60130)

## Changes

Added mousedown-aware dismiss logic so popovers stay open during scrollbar drags: useOutsideClickHandler ignores mouseup when the gesture started inside; Popover trips nestedPopoverReceivedClick on mousedown so parent popovers don't close while a nested popover is being dragged; LemonInputSelect keeps popoverFocusRef set on mousedown so its input's _onBlur doesn't dismiss either.

## How did you test this code?

ran it and verified locally

## Publish to changelog?
no
