### PR TITLE
fix(slack): format upstream provider failures

### DIFF
--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -9,6 +10,21 @@ from posthog.models.integration import Integration, SlackIntegration
 logger = structlog.get_logger(__name__)
 
 PROGRESS_MESSAGE_MARKER = "Working on task..."
+UPSTREAM_PROVIDER_FAILURE_MESSAGE = (
+    "The upstream AI provider failed to process the request. Please retry the task in a few minutes."
+)
+UPSTREAM_PROVIDER_ERROR_STATUS_PATTERN = re.compile(r"\bapi error:\s*(?:429|5\d\d)\b", re.IGNORECASE)
+
+
+def _format_task_error(error: str) -> str:
+    error = error.strip()
+    if not error:
+        return "Unknown error"
+
+    if UPSTREAM_PROVIDER_ERROR_STATUS_PATTERN.search(error):
+        return UPSTREAM_PROVIDER_FAILURE_MESSAGE
+
+    return error
 
 
 @dataclass
@@ -289,6 +305,7 @@ class SlackThreadHandler:
     def post_error(self, error: str, task_url: str) -> None:
         """Post error message with link to PostHog for details."""
         header = "*Task Failed* :x:"
+        error = _format_task_error(error)
         truncated_error = error[:200] if len(error) > 200 else error
 
         blocks: list[dict[str, Any]] = [

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -2,10 +2,31 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
-from products.slack_app.backend.slack_thread import SlackThreadContext, SlackThreadHandler
+from parameterized import parameterized
+
+from products.slack_app.backend.slack_thread import (
+    UPSTREAM_PROVIDER_FAILURE_MESSAGE,
+    SlackThreadContext,
+    SlackThreadHandler,
+    _format_task_error,
+)
 
 
 class TestSlackThreadHandler(TestCase):
+    @parameterized.expand(
+        [
+            ("empty", "", "Unknown error"),
+            ("whitespace", "   ", "Unknown error"),
+            ("passthrough", "Internal error: something else", "Internal error: something else"),
+            ("stripped_passthrough", "  Internal error: something else  ", "Internal error: something else"),
+            ("rate_limit", "Internal error: API Error: 429 rate_limit_error", UPSTREAM_PROVIDER_FAILURE_MESSAGE),
+            ("overloaded", "Internal error: API Error: 529 overloaded_error", UPSTREAM_PROVIDER_FAILURE_MESSAGE),
+            ("server_error", "Internal error: API Error: 500 internal_error", UPSTREAM_PROVIDER_FAILURE_MESSAGE),
+        ]
+    )
+    def test_format_task_error(self, _name: str, error: str, expected: str) -> None:
+        assert _format_task_error(error) == expected
+
     @patch.object(SlackThreadHandler, "_find_progress_message_ts", return_value=None)
     @patch.object(SlackThreadHandler, "_get_client")
     def test_progress_message_has_no_terminate_button(self, mock_get_client, _mock_find_progress):
@@ -105,3 +126,26 @@ class TestSlackThreadHandler(TestCase):
         actions = kwargs["blocks"][1]["elements"]
         assert actions[0]["text"]["text"] == "View PR"
         assert actions[1]["text"]["text"] == "Open in PostHog"
+
+    @patch.object(SlackThreadHandler, "_find_progress_message_ts", return_value=None)
+    @patch.object(SlackThreadHandler, "_get_client")
+    def test_post_error_formats_upstream_provider_failure(self, mock_get_client, _mock_find_progress):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        context = SlackThreadContext(
+            integration_id=1,
+            channel="C001",
+            thread_ts="1234.5678",
+        )
+        handler = SlackThreadHandler(context)
+
+        handler.post_error(
+            'Internal error: API Error: 529 {"error":{"message":"{\\"type\\":\\"error\\",\\"error\\":{\\"type\\":\\"overloaded_error\\"}}"}}',
+            "https://posthog.com/task/1",
+        )
+
+        mock_client.chat_postMessage.assert_called_once()
+        kwargs = mock_client.chat_postMessage.call_args.kwargs
+        assert kwargs["text"] == f"*Task Failed* :x:\n{UPSTREAM_PROVIDER_FAILURE_MESSAGE}"
+        assert kwargs["blocks"][1]["text"]["text"] == UPSTREAM_PROVIDER_FAILURE_MESSAGE


### PR DESCRIPTION
## Problem

Task failure notifications can show raw upstream provider error payloads when an agent run fails because the provider returned a retryable API failure. The Slack message becomes noisy and hides the useful user action: retry later
