### PR TITLE
fix(llm-gateway): correct Bedrock model id for claude-opus-4-7

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -94,7 +94,7 @@ async def _send_bedrock_messages(
     data = dict(request_data)
     bedrock_model = map_to_bedrock_model(data["model"], region_name=bedrock_region_name)
     # litellm can't infer the bedrock provider from regional inference profile
-    # ids like "us.anthropic.claude-opus-4-7-v1", so prefix explicitly.
+    # ids like "us.anthropic.claude-opus-4-7", so prefix explicitly.
     data["model"] = f"bedrock/{bedrock_model}"
 
     anthropic_beta = request.headers.get("anthropic-beta")

--- a/services/llm-gateway/src/llm_gateway/bedrock.py
+++ b/services/llm-gateway/src/llm_gateway/bedrock.py
@@ -41,8 +41,8 @@ ANTHROPIC_TO_BEDROCK_MODEL_MAP: Final[dict[str, dict[str, str]]] = {
         "eu": "eu.anthropic.claude-opus-4-6-v1",
     },
     "claude-opus-4-7": {
-        "us": "us.anthropic.claude-opus-4-7-v1",
-        "eu": "eu.anthropic.claude-opus-4-7-v1",
+        "us": "us.anthropic.claude-opus-4-7",
+        "eu": "eu.anthropic.claude-opus-4-7",
     },
     "claude-sonnet-4-5": {
         "us": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",

--- a/services/llm-gateway/tests/test_bedrock.py
+++ b/services/llm-gateway/tests/test_bedrock.py
@@ -115,7 +115,7 @@ class TestBedrockSpecific:
         "model,expected_litellm_model",
         [
             pytest.param("claude-sonnet-4-6", "bedrock/us.anthropic.claude-sonnet-4-6", id="anthropic_name_mapped"),
-            pytest.param("claude-opus-4-7", "bedrock/us.anthropic.claude-opus-4-7-v1", id="opus_4_7_inference_profile"),
+            pytest.param("claude-opus-4-7", "bedrock/us.anthropic.claude-opus-4-7", id="opus_4_7_inference_profile"),
             pytest.param(
                 "us.anthropic.claude-sonnet-4-6", "bedrock/us.anthropic.claude-sonnet-4-6", id="already_bedrock_id"
             ),
@@ -133,7 +133,7 @@ class TestBedrockSpecific:
         expected_litellm_model: str,
     ) -> None:
         # Regression: litellm needs the "bedrock/" prefix to route requests; without
-        # it, regional inference profile ids (e.g. "us.anthropic.claude-opus-4-7-v1")
+        # it, regional inference profile ids (e.g. "us.anthropic.claude-opus-4-7")
         # don't match litellm's pattern matchers and the request 400s with
         # "LLM Provider NOT provided" before leaving the gateway.
         mock_response = MagicMock()


### PR DESCRIPTION
## Problem

The Bedrock fallback for `claude-opus-4-7` is failing 100% of the time. Bedrock returns
`400 The provided model identifier is invalid` for the id we configure
(`us.anthropic.claude-opus-4-7-v1`), so the entire Anthropic → Bedrock failover path is
broken for Opus 4.7. This surfaced as an LLM Gateway 5xx error-rate alert when upstream
Anthropic was returning `529 Overloaded` and the fallback could not absorb traffic.

## Changes

Update `ANTHROPIC_TO_BEDROCK_MODEL_MAP` for `claude-opus-4-7` to use the actual AWS
Bedrock cross-region inference profile ids documented in the model card:

- US geo: `us.anthropic.claude-opus-4-7`
- EU geo: `eu.anthropic.claude-opus-4-7`

The earlier values had a stray `-v1` suffix that does not exist on this model
(other Opus / Sonnet versions use `-vN` or dated `-YYYYMMDD-v1:0` ids, so it's an easy
miss). The reference comment in `api/anthropic.py` and the regression-test param in
`tests/test_bedrock.py` are updated accordingly.

Reference: [Claude Opus 4.7 — Bedrock model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html).

## How did you test this code?

I'm an agent — no manual smoke testing performed. Automated coverage:

- Existing `tests/test_bedrock.py::TestBedrockSpecific::test_bedrock_model_passed_to_litellm_with_bedrock_prefix[opus_4_7_inference_profile]` updated to assert the new id; remaining bedrock tests cover the prefix and mapping logic that's unchanged.

A human should validate end-to-end by issuing a `claude-opus-4-7` request through the gateway with the `X-PostHog-Provider: bedrock` header (or by forcing the fallback path) and confirming the request reaches Bedrock and returns 200.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Authored by PostHog Code (Opus 4.7) responding to an LLM Gateway 5xx alert.
- Investigation path: pulled error logs for service `llm-gateway` filtered to `claude-opus-4-7` and saw `Bedrock fallback also failed` paired with `llm_request_failed` carrying `error_message: "The provided model identifier is invalid"` for model `us.anthropic.claude-opus-4-7-v1`. Cross-checked the AWS Bedrock model card for Claude Opus 4.7 to find the correct cross-region inference profile ids (`us.anthropic.claude-opus-4-7` / `eu.anthropic.claude-opus-4-7`).
- Considered: leaving the `-v1` suffix and adding a date (matching the Opus 4.5 / Sonnet 4.5 dated ids) — rejected because the published Bedrock model card explicitly lists the unsuffixed `us.anthropic.claude-opus-4-7` form as the geo inference id, with no dated variant.
- Scope kept tight: only the broken model ids and the references that name them. Did not touch other models (4.6 / 4.5 / sonnet / haiku) since they aren't reported failing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*