### PR TITLE
fix(llma): json-stringify structured outputs in eval judge prompt

### DIFF
--- a/posthog/temporal/llm_analytics/message_utils.py
+++ b/posthog/temporal/llm_analytics/message_utils.py
@@ -72,6 +72,12 @@ def _render_message(msg: dict) -> str | None:
         # Preserve the conversation slot when a message has a role
         # but no body (e.g. a tool that returned nothing).
         return f"{role_label}:"
+    # Dict carries data but doesn't match the chat-message shape — most often
+    # a manually-captured structured-output payload like `{"entities": [...]}`.
+    # JSON-stringify so the judge sees the actual response instead of an empty
+    # `Output:`. Truly-empty dicts still return None so the caller can skip them.
+    if msg:
+        return json.dumps(msg, default=str)
     return None
 
 

--- a/posthog/temporal/llm_analytics/test_message_utils.py
+++ b/posthog/temporal/llm_analytics/test_message_utils.py
@@ -297,6 +297,43 @@ class TestExtractTextFromMessages:
         result = extract_text_from_messages(message)
         assert "send_email" in result
 
+    def test_structured_output_bare_dict_is_json_stringified(self):
+        # A manually-captured `$ai_output_choices` set to a bare structured-output
+        # payload (no `role`/`content`) used to render as an empty string, which
+        # caused the LLM judge to grade against `Output:` with nothing after it.
+        # The fallback JSON-stringifies the payload so the judge sees the actual
+        # model response.
+        message = {"entities": [{"name": "Google Ads", "type": "product"}]}
+        result = extract_text_from_messages(message)
+        assert '"entities"' in result
+        assert "Google Ads" in result
+
+    def test_structured_output_list_of_bare_dicts_is_json_stringified(self):
+        messages = [
+            {"entities": [{"name": "Google Ads"}]},
+            {"entities": [{"name": "Meta Ads"}]},
+        ]
+        result = extract_text_from_messages(messages)
+        assert "Google Ads" in result
+        assert "Meta Ads" in result
+        assert result.count("\n") == 1
+
+    def test_structured_output_inside_list_alongside_messages(self):
+        messages = [
+            {"role": "user", "content": "Extract brands."},
+            {"some_structured_payload": {"brands": ["Google Ads"]}},
+        ]
+        result = extract_text_from_messages(messages)
+        assert "user: Extract brands." in result
+        assert "Google Ads" in result
+
+    def test_empty_dict_is_still_skipped(self):
+        # The JSON-stringify fallback must not regress the empty-dict skip path
+        # used by `test_completely_empty_message_is_skipped` — `{}` carries no
+        # information and should not produce a `"{}"` line in the rendered output.
+        assert extract_text_from_messages({}) == ""
+        assert extract_text_from_messages([{}, {}]) == ""
+
 
 class TestFormatToolDefinitions:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Manually captured events not in a message array format were skipped from evals.

## Changes

If we can't parse the data, we fall back to a full JSON representation of it

## Publish to changelog?

no
