### PR TITLE
fix(dashboards): prevent cross-tab url overwrite

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.tsx
@@ -18,6 +18,18 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
         setSidePanelOptions: (options: string | null) => ({ options }),
         setSidePanelAvailable: (available: boolean) => ({ available }),
         onSceneTabChanged: (previousTabId: string | null, newTabId: string) => ({ previousTabId, newTabId }),
+        // Restores side panel state for a scene tab without touching the URL. Unlike openSidePanel/
+        // closeSidePanel this has no actionToUrl, so it can't navigate the active tab to a stale
+        // location mid-tab-switch. The tab's own stored URL hash already carries `#panel=…`.
+        restoreSidePanelStateForTab: (
+            open: boolean,
+            selectedTab: SidePanelTab | null,
+            selectedTabOptions: string | null
+        ) => ({
+            open,
+            selectedTab,
+            selectedTabOptions,
+        }),
     }),
 
     reducers(() => ({
@@ -32,6 +44,7 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
             { persist: true },
             {
                 openSidePanel: (_, { tab }) => tab,
+                restoreSidePanelStateForTab: (state, { open, selectedTab }) => (open ? selectedTab : state),
             },
         ],
 
@@ -41,6 +54,7 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
                 openSidePanel: (_, { options }) => options ?? null,
                 setSidePanelOptions: (_, { options }) => options ?? null,
                 closeSidePanel: () => null,
+                restoreSidePanelStateForTab: (_, { open, selectedTabOptions }) => (open ? selectedTabOptions : null),
             },
         ],
         sidePanelOpen: [
@@ -48,6 +62,7 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
             { persist: true },
             {
                 setSidePanelOpen: (_, { open }) => open,
+                restoreSidePanelStateForTab: (_, { open }) => open,
             },
         ],
     })),
@@ -93,14 +108,17 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
             }
 
             // Restore state for the new tab (preserve current state for never-visited tabs
-            // so the URL hash handler can set it if needed)
+            // so the URL hash handler can set it if needed). Use restoreSidePanelStateForTab
+            // rather than openSidePanel/closeSidePanel: those carry an actionToUrl that would
+            // replace() the active tab's URL using the stale (pre-switch) router location,
+            // overwriting the just-activated tab with the previous tab's pathname.
             const savedState = cache.sidePanelStateByTab[newTabId]
             if (savedState) {
-                if (savedState.open && savedState.selectedTab) {
-                    actions.openSidePanel(savedState.selectedTab, savedState.selectedTabOptions ?? undefined)
-                } else {
-                    actions.closeSidePanel()
-                }
+                actions.restoreSidePanelStateForTab(
+                    !!(savedState.open && savedState.selectedTab),
+                    savedState.selectedTab,
+                    savedState.selectedTabOptions
+                )
             }
         },
     })),


### PR DESCRIPTION
## Problem

Switching between two dashboard scene tabs (same window) overwrote the newly activated tab's URL with the previous tab's. A tab on `/dashboard/1#panel=Max`, after switching away to a second dashboard tab and back, would show `/dashboard/2#panel=Max`.

`onSceneTabChanged` restored the side panel via `openSidePanel`/`closeSidePanel`, whose `actionToUrl` issues `router.replace()` against the *stale* (pre-switch) router location. That replace landed on the just-activated tab, corrupting its URL.

## Changes

Restore per-tab side panel state through a new `restoreSidePanelStateForTab` action that updates reducers only and has **no** `actionToUrl` — so it can't navigate the active tab to a stale location mid-switch. The tab's own stored URL hash already carries `#panel=…`, so the panel is reflected correctly without a redundant, racy navigation.

## How did you test this code?

Agent-authored change. Verified manually: switching between two dashboard tabs with `#panel=Max` no longer corrupts the first tab's URL.

- `pnpm --filter=@posthog/frontend exec jest frontend/src/scenes/sceneLogic.test.tsx --runInBand`

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

The investigation started in the dashboard scene. The behavior traced to `sidePanelStateLogic`'s `actionToUrl` reading the global `router.values.location` while a tab switch was still in flight. Fixed independently of dashboard rendering or `dashboardLogic`. An earlier cross-window `mergePinnedTabs` change was dropped — it addressed a different, unverified scenario and did not fix the reported bug.
