### PR TITLE
fix(error-tracking): stretch insights to fill container height

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightViz.scss
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.scss
@@ -252,6 +252,7 @@
 .ErrorTracking__breakdowns,
 .ErrorTracking__insights {
     .InsightViz {
+        align-items: stretch;
         height: 100%;
     }
 


### PR DESCRIPTION
## Changes

| Before | After |
|--------|--------|
| <img width="922" height="1488" alt="CleanShot 2026-05-19 at 17 29 42@2x" src="https://github.com/user-attachments/assets/4e67fdf3-4d81-48a4-8f3a-7cda99f18de5" /> | <img width="922" height="1488" alt="CleanShot 2026-05-19 at 17 35 09@2x" src="https://github.com/user-attachments/assets/739abe53-17b7-4933-8862-e1b04b1118b2" /> | 

| Before | After |
|--------|--------|
| <img width="2588" height="1488" alt="CleanShot 2026-05-19 at 17 35 55@2x" src="https://github.com/user-attachments/assets/2a89a209-cf36-4805-95e8-7b36476ef21c" /> | <img width="2588" height="1488" alt="CleanShot 2026-05-19 at 17 35 45@2x" src="https://github.com/user-attachments/assets/067a7fca-f434-453a-85a1-4e4404b90a9d" /> | 

## 🤖 Agent context

Authored with Claude Code. Regression introduced by #54188 (always-on horizontal layout). Fix is a 1-line SCSS override scoped to `.ErrorTracking__breakdowns` / `.ErrorTracking__insights`. No automated tests added; manual verification by the author.