### PR TITLE
chore(replay): remove unused REPLAY_WAIT_FOR_IFRAME_READY flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -447,7 +447,6 @@ export const FEATURE_FLAGS = {
     REPLAY_UI_REDESIGN_2026: 'replay-ui-redesign-2026', // owner: #team-replay, New UI layout for replay
     REPLAY_VIDEO_BASED_SUMMARIZATION: 'replay-video-based-summarization', // owner: #team-replay
     REPLAY_VISION: 'replay-vision', // owner: #team-replay
-    REPLAY_WAIT_FOR_IFRAME_READY: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
     REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW: 'replay-x-llm-analytics-conversation-view', // owner: @pauldambra #team-replay
     REVENUE_ANALYTICS: 'revenue-analytics', // owner: @rafaeelaudibert #team-customer-analytics
     REVENUE_FIELDS_IN_POWER_USERS_TABLE: 'revenue-fields-in-power-users-table', // owner: @arthurdedeus #team-customer-analytics

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -31,9 +31,7 @@ import { EventType, IncrementalSource, eventWithTime } from '@posthog/rrweb-type
 
 import api from 'lib/api'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs, now } from 'lib/dayjs'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { clamp, downloadFile, findLastIndex, objectsEqual, uuid } from 'lib/utils'
 import { openBillingPopupModal } from 'scenes/billing/BillingPopup'
 import { ReplayIframeData } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
@@ -494,8 +492,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             ['user', 'hasAvailableFeature'],
             preflightLogic,
             ['preflight'],
-            featureFlagLogic,
-            ['featureFlags'],
             exportsLogic,
             ['hasReachedExportFullVideoLimit'],
         ],
@@ -1338,82 +1334,36 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
                     replayer.on('fullsnapshot-rebuilded', () => {
                         const iframeContentWindow = replayer.iframe.contentWindow
-                        const iframeDocument = iframeContentWindow?.document
                         const iframeFetch = iframeContentWindow?.fetch
 
-                        const setupErrorHandlers = (): void => {
-                            if (
-                                iframeFetch &&
-                                !(iframeFetch as any).__isWrappedForErrorReporting &&
-                                iframeContentWindow
-                            ) {
-                                const originalFetch = iframeFetch
-                                const windowRef = new WeakRef(iframeContentWindow)
+                        if (iframeFetch && !(iframeFetch as any).__isWrappedForErrorReporting && iframeContentWindow) {
+                            const originalFetch = iframeFetch
+                            const windowRef = new WeakRef(iframeContentWindow)
 
-                                iframeContentWindow.fetch = wrapFetchAndReport({
-                                    fetch: iframeFetch,
-                                    onError: (errorDetails: ResourceErrorDetails) => {
-                                        actions.caughtAssetErrorFromIframe(errorDetails)
-                                    },
-                                })
-                                ;(iframeContentWindow.fetch as any).__isWrappedForErrorReporting = true
-
-                                iframeCleanups.push(() => {
-                                    const window = windowRef.deref()
-                                    if (window && window.fetch) {
-                                        window.fetch = originalFetch
-                                        delete (window.fetch as any).__isWrappedForErrorReporting
-                                    }
-                                })
-                            }
-
-                            if (iframeContentWindow) {
-                                iframeCleanups.push(
-                                    registerErrorListeners({
-                                        iframeWindow: iframeContentWindow,
-                                        onError: (error) => actions.caughtAssetErrorFromIframe(error),
-                                    })
-                                )
-                            }
-                        }
-
-                        if (
-                            values.featureFlags[FEATURE_FLAGS.REPLAY_WAIT_FOR_IFRAME_READY] &&
-                            iframeDocument &&
-                            iframeDocument.readyState === 'loading'
-                        ) {
-                            let pauseTimeoutId: ReturnType<typeof setTimeout> | null = null
-
-                            const onReady = (): void => {
-                                setupErrorHandlers()
-
-                                if (
-                                    replayer &&
-                                    values.currentTimestamp !== undefined &&
-                                    values.sessionPlayerData.start
-                                ) {
-                                    const currentTime =
-                                        values.currentTimestamp - values.sessionPlayerData.start.valueOf()
-                                    replayer.pause(currentTime)
-                                    pauseTimeoutId = setTimeout(() => {
-                                        if (replayer) {
-                                            replayer.pause(currentTime)
-                                        }
-                                    }, 0)
-                                }
-
-                                iframeDocument.removeEventListener('DOMContentLoaded', onReady)
-                            }
-                            iframeDocument.addEventListener('DOMContentLoaded', onReady)
+                            iframeContentWindow.fetch = wrapFetchAndReport({
+                                fetch: iframeFetch,
+                                onError: (errorDetails: ResourceErrorDetails) => {
+                                    actions.caughtAssetErrorFromIframe(errorDetails)
+                                },
+                            })
+                            ;(iframeContentWindow.fetch as any).__isWrappedForErrorReporting = true
 
                             iframeCleanups.push(() => {
-                                iframeDocument.removeEventListener('DOMContentLoaded', onReady)
-                                if (pauseTimeoutId !== null) {
-                                    clearTimeout(pauseTimeoutId)
+                                const window = windowRef.deref()
+                                if (window && window.fetch) {
+                                    window.fetch = originalFetch
+                                    delete (window.fetch as any).__isWrappedForErrorReporting
                                 }
                             })
-                        } else {
-                            setupErrorHandlers()
+                        }
+
+                        if (iframeContentWindow) {
+                            iframeCleanups.push(
+                                registerErrorListeners({
+                                    iframeWindow: iframeContentWindow,
+                                    onError: (error) => actions.caughtAssetErrorFromIframe(error),
+                                })
+                            )
                         }
                     })
 


### PR DESCRIPTION
## Problem

The `replay-wait-for-full-snapshot-playback` feature flag (`FEATURE_FLAGS.REPLAY_WAIT_FOR_IFRAME_READY`) is at 0% rollout and the conditional branch it gates in `sessionRecordingPlayerLogic.ts` is unreachable in production. Keeping the flag around carries a few risks even though it never fires today:

- The gated branch attaches a `DOMContentLoaded` listener plus a `setTimeout(..., 0)` that call `replayer.pause()` *after* iframe load. If the player is torn down between `fullsnapshot-rebuilded` and `DOMContentLoaded` (a window-id change, a tab-visibility flip, or navigation to another recording) those callbacks fire on a `Replayer` whose iframe `body`/`head` have already been wiped by the disposable cleanup — which can leave the iframe in a half-detached state. That race widens at higher playback speeds, where `fullsnapshot-rebuilded` arrives sooner relative to iframe load. If the flag were ever re-enabled at higher rollout, this would be a real bug.
- The deferred `pause()` was meant to fix a missing-first-frame issue under specific conditions but never reached general availability.

Removing the dead code shrinks the player surface area and eliminates a class of races the team would otherwise need to guard against if the flag came back.

## Changes

- Drop `REPLAY_WAIT_FOR_IFRAME_READY` from `frontend/src/lib/constants.tsx`.
- In `sessionRecordingPlayerLogic.ts`:
  - Inline the (formerly conditional) `setupErrorHandlers` body so `fullsnapshot-rebuilded` always wires up the iframe `fetch` wrap and `window` error listeners directly.
  - Remove the unused `iframeDocument` local and the `DOMContentLoaded` / `setTimeout` deferred-pause path.
  - Remove the now-unused `FEATURE_FLAGS` and `featureFlagLogic` imports plus the `featureFlagLogic, ['featureFlags']` connect entry (no other consumers in this logic).

No behavior change for users not on the flag (which is everyone — rollout is 0%).

## How did you test this code?

I'm an agent. Manual end-to-end verification was not performed in this environment. Automated checks I ran:

- `pnpm exec tsc --noEmit` (after running `kea-typegen write`) — no errors introduced in `sessionRecordingPlayerLogic.ts` or `constants.tsx`. Remaining errors elsewhere are pre-existing module-resolution issues unrelated to this PR.
- `oxlint` + `oxfmt` on both touched files — clean.
- I attempted to run `sessionRecordingPlayerLogic.test.ts` but the local test runner failed on a pre-existing unrelated module resolution (`@posthog/quill`) before reaching this file. CI will exercise the suite properly.

The flag's removal is a pure deletion of an unreachable branch — the only runtime path that exists today is the `else` branch, which is what remains.

## Publish to changelog?

no

## Docs update

No docs reference this flag.

## 🤖 Agent context

This PR is the follow-up to a support investigation where a user reported that watching replays at 1.5x/2x repeatedly eventually caused all subsequent replays to render as a blank white iframe (1x playback unaffected). I (PostHog Code, agent) walked through the replay player code paths with the support engineer and identified the `REPLAY_WAIT_FOR_IFRAME_READY` branch as a structural race-condition concern that becomes more dangerous at high speed. The flag is at 0% rollout, making removal a safe cleanup independent of whether it explains the reported bug (it likely does not for this specific user, since the branch never executes for them).

Decisions:
- Considered just guarding the deferred `pause()` calls with a destroyed-replayer check rather than removing the branch. Rejected because the branch is dead code in production — removing it is simpler and there's no signal that the flag will be re-enabled.
- Removed the `FEATURE_FLAGS` import and `featureFlagLogic` connect since the flag was the only consumer; leaving them in would be lint noise.

Note: this PR does not address the original support bug. That remains under investigation — the white-screen symptom must be coming from a different code path (decompression worker singleton, visibility-change tear-down + insufficient-snapshot bail in `tryInitReplayer`, or the speed-based `insertStyleRules` snapshot drift), since the flag-gated branch never ran for the affected user.

Tool used: Claude Code (PostHog Code agent).