### PR TITLE
chore(replay): remove dead replay-wait-for-full-snapshot-playback flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -447,7 +447,6 @@ export const FEATURE_FLAGS = {
     REPLAY_UI_REDESIGN_2026: 'replay-ui-redesign-2026', // owner: #team-replay, New UI layout for replay
     REPLAY_VIDEO_BASED_SUMMARIZATION: 'replay-video-based-summarization', // owner: #team-replay
     REPLAY_VISION: 'replay-vision', // owner: #team-replay
-    REPLAY_WAIT_FOR_IFRAME_READY: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
     REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW: 'replay-x-llm-analytics-conversation-view', // owner: @pauldambra #team-replay
     REVENUE_ANALYTICS: 'revenue-analytics', // owner: @rafaeelaudibert #team-customer-analytics
     REVENUE_FIELDS_IN_POWER_USERS_TABLE: 'revenue-fields-in-power-users-table', // owner: @arthurdedeus #team-customer-analytics

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -31,7 +31,6 @@ import { EventType, IncrementalSource, eventWithTime } from '@posthog/rrweb-type
 
 import api from 'lib/api'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs, now } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { clamp, downloadFile, findLastIndex, objectsEqual, uuid } from 'lib/utils'
@@ -1338,7 +1337,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
                     replayer.on('fullsnapshot-rebuilded', () => {
                         const iframeContentWindow = replayer.iframe.contentWindow
-                        const iframeDocument = iframeContentWindow?.document
                         const iframeFetch = iframeContentWindow?.fetch
 
                         const setupErrorHandlers = (): void => {
@@ -1377,44 +1375,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                             }
                         }
 
-                        if (
-                            values.featureFlags[FEATURE_FLAGS.REPLAY_WAIT_FOR_IFRAME_READY] &&
-                            iframeDocument &&
-                            iframeDocument.readyState === 'loading'
-                        ) {
-                            let pauseTimeoutId: ReturnType<typeof setTimeout> | null = null
-
-                            const onReady = (): void => {
-                                setupErrorHandlers()
-
-                                if (
-                                    replayer &&
-                                    values.currentTimestamp !== undefined &&
-                                    values.sessionPlayerData.start
-                                ) {
-                                    const currentTime =
-                                        values.currentTimestamp - values.sessionPlayerData.start.valueOf()
-                                    replayer.pause(currentTime)
-                                    pauseTimeoutId = setTimeout(() => {
-                                        if (replayer) {
-                                            replayer.pause(currentTime)
-                                        }
-                                    }, 0)
-                                }
-
-                                iframeDocument.removeEventListener('DOMContentLoaded', onReady)
-                            }
-                            iframeDocument.addEventListener('DOMContentLoaded', onReady)
-
-                            iframeCleanups.push(() => {
-                                iframeDocument.removeEventListener('DOMContentLoaded', onReady)
-                                if (pauseTimeoutId !== null) {
-                                    clearTimeout(pauseTimeoutId)
-                                }
-                            })
-                        } else {
-                            setupErrorHandlers()
-                        }
+                        setupErrorHandlers()
                     })
 
                     actions.setPlayer({ replayer, windowId })


### PR DESCRIPTION
## Problem

The feature flag `replay-wait-for-full-snapshot-playback` (FE constant `REPLAY_WAIT_FOR_IFRAME_READY`) is at 0% rollout. The branch it guards in `sessionRecordingPlayerLogic` — waiting for `DOMContentLoaded` and re-pausing the replayer at the current timestamp on `fullsnapshot-rebuilded` — is dead in production.

## Changes

- Removed the `if (flag && document.readyState === 'loading') { … } else { setupErrorHandlers() }` block in `sessionRecordingPlayerLogic.ts`. Only the unconditional `setupErrorHandlers()` path remains.
- Removed the now-unused `iframeDocument` local and `FEATURE_FLAGS` import in that file.
- Removed the `REPLAY_WAIT_FOR_IFRAME_READY` entry from `frontend/src/lib/constants.tsx`.

No tests referenced the flag and there are no other call sites.

## How did you test this code?

- `tsc --noEmit` is clean for both touched files (remaining errors are pre-existing on master in `products/user_interviews/` and `products/workflows/`).
- Grep for `REPLAY_WAIT_FOR_IFRAME_READY` and `replay-wait-for-full-snapshot-playback` returns no matches.
- Error capture inside the iframe still flows through the unconditional `registerErrorListeners` call above, untouched by this PR.

The flag itself can be deleted in PostHog admin after deploy.

## 🤖 Agent context

This PR was prepared by an automated agent. The change is mechanical: collapse an `if/else` where the `if` branch is provably dead (flag at 0%), then delete the flag constant.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*