### PR TITLE
fix(support): prevent duplicate Zendesk tickets on rapid Submit clicks

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
@@ -264,9 +264,11 @@ const SupportResponseTimesTable = ({
 function SupportFormBlock({
     onCancel,
     billing,
+    isSubmitting,
 }: {
     onCancel: () => void
     billing: BillingType | null | undefined
+    isSubmitting: boolean
 }): JSX.Element {
     return (
         <Section title="Email an engineer">
@@ -279,6 +281,7 @@ function SupportFormBlock({
                 fullWidth
                 center
                 className="mt-4"
+                loading={isSubmitting}
             >
                 Submit
             </LemonButton>
@@ -307,7 +310,12 @@ export function SidePanelSupport(): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     useValues(userLogic)
-    const { isEmailFormOpen, title: supportPanelTitle, targetArea } = useValues(supportLogic)
+    const {
+        isEmailFormOpen,
+        title: supportPanelTitle,
+        targetArea,
+        isSendSupportRequestSubmitting,
+    } = useValues(supportLogic)
     const { closeEmailForm, openEmailForm, closeSupportForm, resetSendSupportRequest } = useActions(supportLogic)
     const { billing, billingLoading, billingPlan } = useValues(billingLogic)
     const { isCurrentOrganizationNew } = useValues(organizationLogic)
@@ -344,6 +352,7 @@ export function SidePanelSupport(): JSX.Element {
                     {isEmailFormOpen && showEmailSupport && isBillingLoaded && !useProductSupportSidePanel ? (
                         <SupportFormBlock
                             billing={billing}
+                            isSubmitting={isSendSupportRequestSubmitting}
                             onCancel={() => {
                                 closeEmailForm()
                                 closeSupportForm()

--- a/frontend/src/lib/components/Support/SupportModal.tsx
+++ b/frontend/src/lib/components/Support/SupportModal.tsx
@@ -13,7 +13,7 @@ import { SupportForm } from './SupportForm'
 import { supportLogic } from './supportLogic'
 
 function SupportModal({ onAfterClose }: { onAfterClose: () => void }): JSX.Element | null {
-    const { sendSupportRequest, isSupportFormOpen, title } = useValues(supportLogic)
+    const { sendSupportRequest, isSupportFormOpen, title, isSendSupportRequestSubmitting } = useValues(supportLogic)
     const { closeSupportForm, resetSendSupportRequest } = useActions(supportLogic)
     const { isCloudOrDev } = useValues(preflightLogic)
     const { sidePanelAvailable } = useValues(sidePanelStateLogic)
@@ -45,7 +45,13 @@ function SupportModal({ onAfterClose }: { onAfterClose: () => void }): JSX.Eleme
                     >
                         Cancel
                     </LemonButton>
-                    <LemonButton form="support-modal-form" htmlType="submit" type="primary" data-attr="submit">
+                    <LemonButton
+                        form="support-modal-form"
+                        htmlType="submit"
+                        type="primary"
+                        data-attr="submit"
+                        loading={isSendSupportRequestSubmitting}
+                    >
                         Submit
                     </LemonButton>
                 </div>

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -471,8 +471,6 @@ export const supportLogic = kea<supportLogicType>([
             } as SupportFormFields,
             errors: ({ name, email, message, kind, target_area, severity_level }) => {
                 return {
-                    // Return undefined (not '') for non-errors — LemonField renders an empty
-                    // red error icon for any string value, including the empty string.
                     name: !values.user && !name ? 'Please enter your name' : undefined,
                     email: !values.user && !email ? 'Please enter your email' : undefined,
                     message: !message ? 'Please enter a message' : undefined,
@@ -485,8 +483,6 @@ export const supportLogic = kea<supportLogicType>([
                 // name must be present for zendesk to accept the ticket
                 formValues.name = values.user?.first_name ?? formValues.name ?? 'name not set'
                 formValues.email = values.user?.email ?? formValues.email ?? ''
-                // Await so kea-forms' isSendSupportRequestSubmitting stays true for the whole fetch,
-                // which is what disables the Submit button and prevents duplicate tickets.
                 await supportLogic.asyncActions.submitZendeskTicket(formValues)
             },
         },

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -459,7 +459,7 @@ export const supportLogic = kea<supportLogicType>([
             },
         ],
     })),
-    forms(({ actions, values }) => ({
+    forms(({ values }) => ({
         sendSupportRequest: {
             defaults: {
                 name: '',
@@ -471,9 +471,11 @@ export const supportLogic = kea<supportLogicType>([
             } as SupportFormFields,
             errors: ({ name, email, message, kind, target_area, severity_level }) => {
                 return {
-                    name: !values.user ? (!name ? 'Please enter your name' : '') : '',
-                    email: !values.user ? (!email ? 'Please enter your email' : '') : '',
-                    message: !message ? 'Please enter a message' : '',
+                    // Return undefined (not '') for non-errors — LemonField renders an empty
+                    // red error icon for any string value, including the empty string.
+                    name: !values.user && !name ? 'Please enter your name' : undefined,
+                    email: !values.user && !email ? 'Please enter your email' : undefined,
+                    message: !message ? 'Please enter a message' : undefined,
                     kind: !kind ? 'Please choose' : undefined,
                     severity_level: !severity_level ? 'Please choose' : undefined,
                     target_area: !target_area ? 'Please choose' : undefined,
@@ -483,9 +485,9 @@ export const supportLogic = kea<supportLogicType>([
                 // name must be present for zendesk to accept the ticket
                 formValues.name = values.user?.first_name ?? formValues.name ?? 'name not set'
                 formValues.email = values.user?.email ?? formValues.email ?? ''
-                actions.submitZendeskTicket(formValues)
-                // Form closing and resetting is now handled in submitZendeskTicket listener
-                // based on success/failure of the submission
+                // Await so kea-forms' isSendSupportRequestSubmitting stays true for the whole fetch,
+                // which is what disables the Submit button and prevents duplicate tickets.
+                await supportLogic.asyncActions.submitZendeskTicket(formValues)
             },
         },
     })),


### PR DESCRIPTION
## Problem

Users submitting support tickets via the in-app side panel (and the legacy modal) could occasionally end up with **two Zendesk tickets** for a single submission. The trigger was a fast double-click — or a slow connection that gave the user time for a follow-up click before the network call returned.

The form's kea-forms `submit` dispatched `actions.submitZendeskTicket(formValues)` and returned immediately (fire-and-forget). Because `submit` didn't `await`, the auto-generated `isSendSupportRequestSubmitting` flag flipped back to `false` within microseconds — long before the actual `fetch` to `posthoghelp.zendesk.com` completed. Neither Submit button (`SupportModal.tsx`, `SidePanelSupport.tsx`) was wired to a loading state, so a second click was free to fire a second `fetch`.

## Changes

- **`supportLogic.ts`** — the form's `submit` now `await`s `submitZendeskTicket` via `supportLogic.asyncActions`, matching the pattern already used by `featurePreviewsLogic.tsx`. With this in place, `isSendSupportRequestSubmitting` stays `true` for the entire fetch (including the Beacon-API fallback) and resets cleanly in both success and error branches of the listener.
- **`SupportModal.tsx`** and **`SidePanelSupport.tsx`** — both Submit buttons now pass `loading={isSendSupportRequestSubmitting}`. `LemonButton.loading` disables the button and shows a spinner; kea-forms also blocks duplicate submit dispatches while the flag is true, so this is defence in depth.
- **`supportLogic.ts` `errors` function** — return `undefined` (not empty string `''`) for non-error states. `LemonField` renders its red error icon for any string value, including `''`, which was producing a phantom warning icon next to the message field once the form had been submitted at least once.

## How did you test this code?

Agent-authored (PostHog Code). Verification was performed locally in a browser:

- DevTools → Network throttled to **Slow 3G** to make the Zendesk fetch hang long enough to be testable.
- With the form filled out, clicked Submit then mashed the button 4-5 more times — the Submit button correctly switched to its spinner state on the first click and stayed disabled until the request returned. Exactly **one** `POST posthoghelp.zendesk.com/api/v2/requests.json` showed up in the Network tab, no duplicates.
- Confirmed the phantom red error icon next to the message field is no longer rendered after a submit attempt.
- `pnpm --filter=@posthog/frontend typescript:check` produced no new errors in any of the three edited files (the remaining errors in the report pre-exist on master in unrelated `products/workflows`, `products/conversations`, and `products/llm_analytics` code).

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7).

The root cause was identified by tracing the kea-forms submission pipeline: the form's `submit` dispatched the listener and returned synchronously, so the auto-generated `isSendSupportRequestSubmitting` selector was effectively useless for guarding the button — by the time React rendered, it was already `false` again. Considered adding a separate manual boolean reducer to track the in-flight state, but reusing the existing kea-forms flag plus `LemonButton.loading` produced a smaller, more idiomatic change that aligns with the convention already used elsewhere in the codebase (and called out in `CLAUDE.md`).

The phantom-error-icon polish was spotted during manual verification on a throttled connection and was small enough to fold into the same patch since it lives in the same `errors` function and surfaces along the same submit path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*