### PR TITLE
feat(data-visualization): allow per-breakdown color overrides on sql insights

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -589,7 +589,7 @@ export const SeriesBreakdownSelector = (): JSX.Element => {
     const { columns, responseLoading, selectedXAxis, selectedYAxis, dataVisualizationProps } =
         useValues(dataVisualizationLogic)
     const breakdownLogic = seriesBreakdownLogic({ key: dataVisualizationProps.key })
-    const { selectedSeriesBreakdownColumn, seriesBreakdownData, breakdownColumnValues } = useValues(breakdownLogic)
+    const { selectedSeriesBreakdownColumn, seriesBreakdownData } = useValues(breakdownLogic)
     const { addSeriesBreakdown, deleteSeriesBreakdown } = useActions(breakdownLogic)
 
     const availableBreakdownColumns = getAvailableSeriesBreakdownColumns(columns, selectedXAxis, selectedYAxis)
@@ -639,16 +639,7 @@ export const SeriesBreakdownSelector = (): JSX.Element => {
                     <div className="text-danger font-bold mt-1">{seriesBreakdownData.error}</div>
                 ) : (
                     seriesBreakdownData.seriesData.map((series, index) => (
-                        <BreakdownSeries
-                            series={series}
-                            index={index}
-                            breakdownValue={
-                                breakdownColumnValues.length > 0
-                                    ? (breakdownColumnValues[index % breakdownColumnValues.length] ?? null)
-                                    : null
-                            }
-                            key={`${series.name}-${index}`}
-                        />
+                        <BreakdownSeries series={series} index={index} key={`${series.name}-${index}`} />
                     ))
                 )}
             </div>
@@ -659,25 +650,21 @@ export const SeriesBreakdownSelector = (): JSX.Element => {
 const BreakdownSeries = ({
     series,
     index,
-    breakdownValue,
 }: {
     series: AxisBreakdownSeries<number | null>
     index: number
-    breakdownValue: string | null
 }): JSX.Element => {
     const { chartSettings } = useValues(dataVisualizationLogic)
     const { updateChartSettings } = useActions(dataVisualizationLogic)
 
-    const overrideKey = breakdownValue == null ? '__null__' : String(breakdownValue)
-    const existingOverride = chartSettings.seriesBreakdownColorOverrides?.[overrideKey]
+    const overrideKey = series.breakdownValue == null ? '__null__' : series.breakdownValue
     const seriesColor = series.settings?.display?.color ?? getSeriesColor(index)
-    const displayedColor = existingOverride ?? seriesColor
 
     return (
         <div className="flex gap-2 items-center mb-2">
             <LemonColorPicker
-                selectedColor={displayedColor}
-                customColorValue={displayedColor}
+                selectedColor={seriesColor}
+                customColorValue={seriesColor}
                 onSelectColor={(color) => {
                     const next = {
                         ...chartSettings.seriesBreakdownColorOverrides,

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -589,7 +589,7 @@ export const SeriesBreakdownSelector = (): JSX.Element => {
     const { columns, responseLoading, selectedXAxis, selectedYAxis, dataVisualizationProps } =
         useValues(dataVisualizationLogic)
     const breakdownLogic = seriesBreakdownLogic({ key: dataVisualizationProps.key })
-    const { selectedSeriesBreakdownColumn, seriesBreakdownData } = useValues(breakdownLogic)
+    const { selectedSeriesBreakdownColumn, seriesBreakdownData, breakdownColumnValues } = useValues(breakdownLogic)
     const { addSeriesBreakdown, deleteSeriesBreakdown } = useActions(breakdownLogic)
 
     const availableBreakdownColumns = getAvailableSeriesBreakdownColumns(columns, selectedXAxis, selectedYAxis)
@@ -639,7 +639,16 @@ export const SeriesBreakdownSelector = (): JSX.Element => {
                     <div className="text-danger font-bold mt-1">{seriesBreakdownData.error}</div>
                 ) : (
                     seriesBreakdownData.seriesData.map((series, index) => (
-                        <BreakdownSeries series={series} index={index} key={`${series.name}-${index}`} />
+                        <BreakdownSeries
+                            series={series}
+                            index={index}
+                            breakdownValue={
+                                breakdownColumnValues.length > 0
+                                    ? (breakdownColumnValues[index % breakdownColumnValues.length] ?? null)
+                                    : null
+                            }
+                            key={`${series.name}-${index}`}
+                        />
                     ))
                 )}
             </div>
@@ -650,20 +659,38 @@ export const SeriesBreakdownSelector = (): JSX.Element => {
 const BreakdownSeries = ({
     series,
     index,
+    breakdownValue,
 }: {
     series: AxisBreakdownSeries<number | null>
     index: number
+    breakdownValue: string | null
 }): JSX.Element => {
+    const { chartSettings } = useValues(dataVisualizationLogic)
+    const { updateChartSettings } = useActions(dataVisualizationLogic)
+
+    const overrideKey = breakdownValue == null ? '__null__' : String(breakdownValue)
+    const existingOverride = chartSettings.seriesBreakdownColorOverrides?.[overrideKey]
     const seriesColor = series.settings?.display?.color ?? getSeriesColor(index)
+    const displayedColor = existingOverride ?? seriesColor
 
     return (
-        <div className="flex gap-1 mb-2">
-            <div className="flex gap-2">
-                <LemonColorGlyph color={seriesColor} className="mr-2" />
-                <span>{series.name ? series.name : '[No value]'}</span>
-            </div>
-            {/* For now let's keep things simple and not allow too much configuration */}
-            {/* We may just want to add a show/hide button here */}
+        <div className="flex gap-2 items-center mb-2">
+            <LemonColorPicker
+                selectedColor={displayedColor}
+                customColorValue={displayedColor}
+                onSelectColor={(color) => {
+                    const next = {
+                        ...chartSettings.seriesBreakdownColorOverrides,
+                        [overrideKey]: color,
+                    }
+                    updateChartSettings({ seriesBreakdownColorOverrides: next })
+                }}
+                colors={getSeriesColorPalette()}
+                showCustomColor
+                hideDropdown
+                preventPopoverClose
+            />
+            <span>{series.name ? series.name : '[No value]'}</span>
         </div>
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
@@ -299,6 +299,7 @@ describe('seriesBreakdownLogic', () => {
                 seriesData: [
                     {
                         name: 'Safari',
+                        breakdownValue: 'Safari',
                         data: [11, 32, 282],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -307,6 +308,7 @@ describe('seriesBreakdownLogic', () => {
                     },
                     {
                         name: 'Firefox',
+                        breakdownValue: 'Firefox',
                         data: [22, 60, 820],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -315,6 +317,7 @@ describe('seriesBreakdownLogic', () => {
                     },
                     {
                         name: 'Chrome',
+                        breakdownValue: 'Chrome',
                         data: [59, 173, 2218],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -370,6 +373,7 @@ describe('seriesBreakdownLogic', () => {
                 seriesData: [
                     {
                         name: 'Safari',
+                        breakdownValue: 'Safari',
                         data: [11, 32, null],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -378,6 +382,7 @@ describe('seriesBreakdownLogic', () => {
                     },
                     {
                         name: 'Firefox',
+                        breakdownValue: 'Firefox',
                         data: [null, null, 820],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -434,6 +439,7 @@ describe('seriesBreakdownLogic', () => {
                 seriesData: [
                     {
                         name: 'Safari',
+                        breakdownValue: 'Safari',
                         data: [0, 32, 0],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -442,6 +448,7 @@ describe('seriesBreakdownLogic', () => {
                     },
                     {
                         name: 'Firefox',
+                        breakdownValue: 'Firefox',
                         data: [0, 0, 820],
                         settings: {
                             formatting: { prefix: '', suffix: '' },

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -182,10 +182,14 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                         return []
                     }
 
+                    const overrides = chartSettings.seriesBreakdownColorOverrides ?? {}
+
                     return breakdownColumnValues.map<AxisBreakdownSeries<number | null>>((value) => {
                         const seriesName = multipleYSeries
                             ? `${selectedYAxis.name} - ${value || '[No value]'}`
                             : value || '[No value]'
+                        const overrideKey = value == null ? '__null__' : String(value)
+                        const colorOverride = overrides[overrideKey]
 
                         // first filter data by breakdown column value
                         const filteredData = data.filter((n) => n[breakdownColumn.dataIndex] === value)
@@ -226,12 +230,14 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                             data: dataset,
                             // we copy supported settings over from the selected
                             // y-axis since we don't support setting these on the
-                            // breakdown series at the moment
+                            // breakdown series at the moment, except for the
+                            // per-value color override stored on chartSettings
                             settings: {
                                 formatting: selectedYAxis.settings.formatting,
                                 display: {
                                     yAxisPosition: selectedYAxis.settings?.display?.yAxisPosition,
                                     displayType: selectedYAxis.settings?.display?.displayType,
+                                    ...(colorOverride ? { color: colorOverride } : {}),
                                 },
                             },
                         }

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -7,6 +7,12 @@ export interface AxisBreakdownSeries<T> {
     name: string
     data: T[]
     settings?: AxisSeriesSettings
+    /**
+     * Raw breakdown column value the series was built from. `null` for null /
+     * undefined values. Carried so consumers can look up per-value overrides
+     * without depending on positional ordering of `seriesData`.
+     */
+    breakdownValue?: string | null
 }
 
 export interface BreakdownSeriesData<T> {
@@ -228,6 +234,7 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                         return {
                             name: seriesName,
                             data: dataset,
+                            breakdownValue: value == null ? null : String(value),
                             // we copy supported settings over from the selected
                             // y-axis since we don't support setting these on the
                             // breakdown series at the moment, except for the

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10489,6 +10489,13 @@
                 "rightYAxisSettings": {
                     "$ref": "#/definitions/YAxisSettings"
                 },
+                "seriesBreakdownColorOverrides": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Per-breakdown-value color overrides for the series-breakdown column. Keyed by the raw breakdown value as a string. The literal \"__null__\" is used as the key for null / undefined values. Hex color string (matches `color` on yAxis series display settings). When multiple Y series exist, rows for the same breakdown value share the override.",
+                    "type": "object"
+                },
                 "seriesBreakdownColumn": {
                     "type": ["string", "null"]
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1150,6 +1150,14 @@ export interface ChartSettings {
     /** Whether we fill the bars to 100% in stacked mode */
     stackBars100?: boolean
     seriesBreakdownColumn?: string | null
+    /**
+     * Per-breakdown-value color overrides for the series-breakdown column.
+     * Keyed by the raw breakdown value as a string. The literal "__null__"
+     * is used as the key for null / undefined values. Hex color string
+     * (matches `color` on yAxis series display settings). When multiple Y
+     * series exist, rows for the same breakdown value share the override.
+     */
+    seriesBreakdownColorOverrides?: Record<string, string>
     showXAxisTicks?: boolean
     showXAxisBorder?: boolean
     showYAxisBorder?: boolean

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -12817,6 +12817,16 @@ class ChartSettings(BaseModel):
     heatmap: HeatmapSettings | None = None
     leftYAxisSettings: YAxisSettings | None = None
     rightYAxisSettings: YAxisSettings | None = None
+    seriesBreakdownColorOverrides: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Per-breakdown-value color overrides for the series-breakdown column. Keyed"
+            ' by the raw breakdown value as a string. The literal "__null__" is used as'
+            " the key for null / undefined values. Hex color string (matches `color` on"
+            " yAxis series display settings). When multiple Y series exist, rows for"
+            " the same breakdown value share the override."
+        ),
+    )
     seriesBreakdownColumn: str | None = None
     showLegend: bool | None = None
     showNullsAsZero: bool | None = None

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -6549,11 +6549,18 @@ export interface ChartAxisApi {
     settings?: SettingsApi | null
 }
 
+/**
+ * Per-breakdown-value color overrides for the series-breakdown column. Keyed by the raw breakdown value as a string. The literal "__null__" is used as the key for null / undefined values. Hex color string (matches `color` on yAxis series display settings). When multiple Y series exist, rows for the same breakdown value share the override.
+ */
+export type ChartSettingsApiSeriesBreakdownColorOverrides = { [key: string]: string } | null
+
 export interface ChartSettingsApi {
     goalLines?: GoalLineApi[] | null
     heatmap?: HeatmapSettingsApi | null
     leftYAxisSettings?: YAxisSettingsApi | null
     rightYAxisSettings?: YAxisSettingsApi | null
+    /** Per-breakdown-value color overrides for the series-breakdown column. Keyed by the raw breakdown value as a string. The literal "__null__" is used as the key for null / undefined values. Hex color string (matches `color` on yAxis series display settings). When multiple Y series exist, rows for the same breakdown value share the override. */
+    seriesBreakdownColorOverrides?: ChartSettingsApiSeriesBreakdownColorOverrides
     seriesBreakdownColumn?: string | null
     showLegend?: boolean | null
     showNullsAsZero?: boolean | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6833,6 +6833,11 @@ export namespace Schemas {
       settings?: Settings | null;
     }
 
+    /**
+     * Per-breakdown-value color overrides for the series-breakdown column. Keyed by the raw breakdown value as a string. The literal "__null__" is used as the key for null / undefined values. Hex color string (matches `color` on yAxis series display settings). When multiple Y series exist, rows for the same breakdown value share the override.
+     */
+    export type ChartSettingsSeriesBreakdownColorOverrides = {[key: string]: string} | null;
+
     export interface HeatmapGradientStop {
       color: string;
       value: number;
@@ -6891,6 +6896,8 @@ export namespace Schemas {
       heatmap?: HeatmapSettings | null;
       leftYAxisSettings?: YAxisSettings | null;
       rightYAxisSettings?: YAxisSettings | null;
+      /** Per-breakdown-value color overrides for the series-breakdown column. Keyed by the raw breakdown value as a string. The literal "__null__" is used as the key for null / undefined values. Hex color string (matches `color` on yAxis series display settings). When multiple Y series exist, rows for the same breakdown value share the override. */
+      seriesBreakdownColorOverrides?: ChartSettingsSeriesBreakdownColorOverrides;
       seriesBreakdownColumn?: string | null;
       showLegend?: boolean | null;
       showNullsAsZero?: boolean | null;


### PR DESCRIPTION
## Problem

For SQL / DataVisualization insights with a series breakdown column (e.g. a stacked bar chart of events grouped by `properties.$browser`), each breakdown value gets an auto-assigned palette color and there was no way to override it. The breakdown rows in the Series tab already listed every value, but each row only showed a read-only color glyph — a deliberate placeholder ("for now let's keep things simple"). Meanwhile, the result-customizations feature on Trends and Funnels has supported this for a while.

## Changes

- New optional field `ChartSettings.seriesBreakdownColorOverrides: Record<string, string>` — a hex-color map keyed by the raw breakdown value. The literal `"__null__"` is used as the key for null / undefined values so the map can distinguish them from the empty string.
- `seriesBreakdownLogic.seriesBreakdownData` now reads the map and injects `settings.display.color` per breakdown series. The existing `settings?.display?.color ?? getSeriesColor(index)` fallback in `LineGraph.tsx` then carries the color through to stacked bar, line, side-by-side bar, etc. without changes downstream.
- In `SeriesTab.tsx`, `BreakdownSeries` swaps the read-only `LemonColorGlyph` for an inline `LemonColorPicker` (default `LemonColorButton` trigger, `showCustomColor`, `hideDropdown`, `preventPopoverClose`). This matches the pattern used by `YSeriesDisplayTab` for non-breakdown Y series. `SeriesBreakdownSelector` passes the raw breakdown value (not the formatted `${y} - ${value}` series name) so the override key stays stable across multi-Y configurations.
- Persistence goes through the existing `updateChartSettings` action with a read-merge-write at the call site, because `mergeChartSettings` does a shallow spread for unknown keys. No new action was needed.
- `frontend/src/queries/schema.json` is the regenerated artifact from `pnpm schema:build:json`.

## How did you test this code?

I'm an agent. I did **not** perform manual UI testing. Verification I actually ran:

- `pnpm schema:build:json` regenerated `schema.json` cleanly and the new field is present.
- `pnpm typegen:write` then `pnpm typescript:check` — no type errors in the four files touched here. (The repo still has pre-existing type errors in unrelated workflows/settings files; none are introduced by this change.)
- `pnpm format` on the changed files. One side-effect from oxlint `--fix-dangerously` modified unrelated hog-charts files; those were reverted.

Manual verification a reviewer can run end-to-end:
1. Create a SQL insight: `SELECT toStartOfDay(timestamp) AS day, properties.$browser AS browser, COUNT(*) AS cnt FROM events WHERE {filters} GROUP BY 1, 2 ORDER BY 3 DESC`.
2. Switch visualization to Stacked bar chart, set X=`day`, Y=`cnt`, add series breakdown on `browser`.
3. Click a swatch in the breakdown list, pick a custom color, confirm the bar updates immediately and the override survives a refresh / chart-type toggle / `null` breakdown value.
4. Add a second Y series and confirm rows for the same browser value share the override.

## Publish to changelog?

no

## Docs update

n/a — no documented feature surface changed.

## 🤖 Agent context

Authored end-to-end by PostHog Code (Claude Opus 4.7) with human direction. Tool calls used: filesystem (Read / Edit / Glob / Grep), Bash for `pnpm` schema and typecheck flows, and parallel Explore + Plan subagents for the initial codebase survey and plan design.

Key decisions:
- **Storage location:** kept the override map in `ChartSettings` (DataViz-local) rather than reusing `TrendsFilter.resultCustomizations`. The trends/funnel modal logic is tightly coupled to `trendsDataLogic` / `funnelDataLogic` and threading it into DataViz would have been a much bigger refactor for no real reuse.
- **Color format:** hex string. Every other DataViz color path (Y-series display, conditional formatting, goal lines) uses hex via `getSeriesColorPalette()`. Mixing `DataColorToken` here would be inconsistent.
- **UI:** inline `LemonColorPicker` (auto-save on select) rather than a `LemonColorButton` that opens a modal. The inline pattern mirrors `YSeriesDisplayTab` already in the same file, and the picker's default trigger is already a `LemonColorButton` so the visual affordance matches the "color picker button" requested in the task.
- **Keying:** by raw breakdown value, not by formatted series name. When multiple Y series exist, all `${y} - ${value}` rows for the same `value` share the override. Documented in the schema comment; can be extended to composite keys later without breaking saved insights.
- **Edge cases left for follow-ups:** clearing an override (no reset icon today), and clearing orphaned overrides when the user toggles the breakdown column off (they stay in `chartSettings` but are harmless).

Out of scope (intentionally): no changes to `TrendsFilter.resultCustomizations`, `ResultCustomizationsModal`, or `resultCustomizationsModalLogic`; no new kea action; no merger change to `mergeChartSettings`.