### PR TITLE
feat(data-warehouse): allow per-breakdown color customization on SQL insights

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/PieChart.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/PieChart.test.ts
@@ -45,11 +45,13 @@ describe('buildPieSlices', () => {
         const yData: AxisBreakdownSeries<number | null>[] = [
             {
                 name: 'first',
+                breakdownValue: 'first',
                 data: [1, 2, null],
                 settings: { display: { color: '#111111' } },
             },
             {
                 name: 'second',
+                breakdownValue: 'second',
                 data: [3, 4, 5],
                 settings: { display: { color: '#222222' } },
             },

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -4,6 +4,7 @@ import { Form } from 'kea-forms'
 import { IconGear, IconPlusSmall, IconTrash } from '@posthog/icons'
 import {
     LemonButton,
+    LemonColorButton,
     LemonColorGlyph,
     LemonColorPicker,
     LemonInput,
@@ -16,10 +17,12 @@ import {
     Popover,
 } from '@posthog/lemon-ui'
 
-import { getSeriesColor, getSeriesColorPalette } from 'lib/colors'
+import { DataColorToken, getSeriesColor, getSeriesColorPalette } from 'lib/colors'
 import { LemonField } from 'lib/lemon-ui/LemonField'
+import { dataThemeLogic } from 'scenes/dataThemeLogic'
 import { INSIGHT_UNIT_OPTIONS_SHORT } from 'scenes/insights/aggregationAxisFormat'
 
+import { ResultCustomizationBy } from '~/queries/schema/schema-general'
 import { ChartDisplayType } from '~/types'
 
 import { AxisSeries, dataVisualizationLogic } from '../dataVisualizationLogic'
@@ -654,16 +657,34 @@ const BreakdownSeries = ({
     series: AxisBreakdownSeries<number | null>
     index: number
 }): JSX.Element => {
+    const { chartSettings } = useValues(dataVisualizationLogic)
+    const { updateChartSettings } = useActions(dataVisualizationLogic)
+    const { getTheme } = useValues(dataThemeLogic)
+
+    const theme = getTheme(undefined)
+    const themeTokens = theme ? (Object.keys(theme) as DataColorToken[]) : []
+    const selectedToken = chartSettings.resultCustomizations?.[series.breakdownValue]?.color ?? null
     const seriesColor = series.settings?.display?.color ?? getSeriesColor(index)
 
     return (
-        <div className="flex gap-1 mb-2">
-            <div className="flex gap-2">
-                <LemonColorGlyph color={seriesColor} className="mr-2" />
-                <span>{series.name ? series.name : '[No value]'}</span>
-            </div>
-            {/* For now let's keep things simple and not allow too much configuration */}
-            {/* We may just want to add a show/hide button here */}
+        <div className="flex gap-1 mb-2 items-center">
+            <LemonColorPicker
+                colorTokens={themeTokens}
+                selectedColorToken={selectedToken}
+                customButton={<LemonColorButton type="tertiary" color={seriesColor} className="mr-2" />}
+                onSelectColorToken={(token) => {
+                    updateChartSettings({
+                        resultCustomizations: {
+                            ...chartSettings.resultCustomizations,
+                            [series.breakdownValue]: {
+                                assignmentBy: ResultCustomizationBy.Value,
+                                color: token,
+                            },
+                        },
+                    })
+                }}
+            />
+            <span>{series.name ? series.name : '[No value]'}</span>
         </div>
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
@@ -299,6 +299,7 @@ describe('seriesBreakdownLogic', () => {
                 seriesData: [
                     {
                         name: 'Safari',
+                        breakdownValue: 'Safari',
                         data: [11, 32, 282],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -307,6 +308,7 @@ describe('seriesBreakdownLogic', () => {
                     },
                     {
                         name: 'Firefox',
+                        breakdownValue: 'Firefox',
                         data: [22, 60, 820],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -315,6 +317,7 @@ describe('seriesBreakdownLogic', () => {
                     },
                     {
                         name: 'Chrome',
+                        breakdownValue: 'Chrome',
                         data: [59, 173, 2218],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -370,6 +373,7 @@ describe('seriesBreakdownLogic', () => {
                 seriesData: [
                     {
                         name: 'Safari',
+                        breakdownValue: 'Safari',
                         data: [11, 32, null],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -378,6 +382,7 @@ describe('seriesBreakdownLogic', () => {
                     },
                     {
                         name: 'Firefox',
+                        breakdownValue: 'Firefox',
                         data: [null, null, 820],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -434,6 +439,7 @@ describe('seriesBreakdownLogic', () => {
                 seriesData: [
                     {
                         name: 'Safari',
+                        breakdownValue: 'Safari',
                         data: [0, 32, 0],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
@@ -442,6 +448,7 @@ describe('seriesBreakdownLogic', () => {
                     },
                     {
                         name: 'Firefox',
+                        breakdownValue: 'Firefox',
                         data: [0, 0, 820],
                         settings: {
                             formatting: { prefix: '', suffix: '' },

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -6,8 +6,12 @@ import { dataThemeLogic, getColorFromToken } from 'scenes/dataThemeLogic'
 import { AxisSeries, AxisSeriesSettings, SelectedYAxis, dataVisualizationLogic } from '../dataVisualizationLogic'
 import type { seriesBreakdownLogicType } from './seriesBreakdownLogicType'
 
-/** Sentinel used to key result customizations for null / undefined breakdown values. */
-export const BREAKDOWN_NULL_KEY = '__null__'
+/**
+ * Sentinel used to key result customizations for null / undefined breakdown values.
+ * Mirrors `BREAKDOWN_NULL_STRING_LABEL` from `scenes/insights/utils` to keep the
+ * collision-resistance contract consistent with trends/funnels breakdowns.
+ */
+export const BREAKDOWN_NULL_KEY = '$$_posthog_breakdown_null_$$'
 
 export const getBreakdownValueKey = (value: unknown): string =>
     value === null || value === undefined ? BREAKDOWN_NULL_KEY : String(value)

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -1,10 +1,21 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, selectors } from 'kea'
 
+import { DataColorTheme } from 'lib/colors'
+import { dataThemeLogic, getColorFromToken } from 'scenes/dataThemeLogic'
+
 import { AxisSeries, AxisSeriesSettings, SelectedYAxis, dataVisualizationLogic } from '../dataVisualizationLogic'
 import type { seriesBreakdownLogicType } from './seriesBreakdownLogicType'
 
+/** Sentinel used to key result customizations for null / undefined breakdown values. */
+export const BREAKDOWN_NULL_KEY = '__null__'
+
+export const getBreakdownValueKey = (value: unknown): string =>
+    value === null || value === undefined ? BREAKDOWN_NULL_KEY : String(value)
+
 export interface AxisBreakdownSeries<T> {
     name: string
+    /** Stable key derived from the raw breakdown column value, used for result customization lookups. */
+    breakdownValue: string
     data: T[]
     settings?: AxisSeriesSettings
 }
@@ -76,6 +87,8 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
         values: [
             dataVisualizationLogic,
             ['query', 'response', 'columns', 'selectedXAxis', 'selectedYAxis', 'chartSettings'],
+            dataThemeLogic,
+            ['getTheme'],
         ],
     })),
     actions(({ values }) => ({
@@ -120,6 +133,7 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                 s.response,
                 s.columns,
                 s.chartSettings,
+                s.getTheme,
             ],
             (
                 selectedBreakdownColumn,
@@ -128,7 +142,8 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                 xSeries,
                 response,
                 columns,
-                chartSettings
+                chartSettings,
+                getTheme: (themeId: string | number | null | undefined) => DataColorTheme | null
             ): BreakdownSeriesData<number | null> => {
                 if (
                     !response ||
@@ -175,6 +190,8 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
 
                 const multipleYSeries = yAxis.length > 1
                 const showNullsAsZero = chartSettings.showNullsAsZero ?? false
+                const resultCustomizations = chartSettings.resultCustomizations ?? {}
+                const theme = getTheme(undefined)
 
                 const seriesData: AxisBreakdownSeries<number | null>[] = yAxis.flatMap((selectedYAxis) => {
                     const yColumn = columns.find((n) => n.name === selectedYAxis.name)
@@ -186,13 +203,19 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                         const seriesName = multipleYSeries
                             ? `${selectedYAxis.name} - ${value || '[No value]'}`
                             : value || '[No value]'
+                        const breakdownValue = getBreakdownValueKey(value)
+                        const customColorToken = resultCustomizations[breakdownValue]?.color
+                        const customColor =
+                            customColorToken && theme ? getColorFromToken(theme, customColorToken) : undefined
 
                         // first filter data by breakdown column value
                         const filteredData = data.filter((n) => n[breakdownColumn.dataIndex] === value)
                         if (filteredData.length === 0) {
                             return {
                                 name: seriesName,
+                                breakdownValue,
                                 data: [],
+                                settings: customColor ? { display: { color: customColor } } : undefined,
                             }
                         }
 
@@ -223,15 +246,19 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
 
                         return {
                             name: seriesName,
+                            breakdownValue,
                             data: dataset,
                             // we copy supported settings over from the selected
                             // y-axis since we don't support setting these on the
-                            // breakdown series at the moment
+                            // breakdown series at the moment. The per-breakdown
+                            // color customization (if any) wins over the inherited
+                            // y-axis color.
                             settings: {
                                 formatting: selectedYAxis.settings.formatting,
                                 display: {
                                     yAxisPosition: selectedYAxis.settings?.display?.yAxisPosition,
                                     displayType: selectedYAxis.settings?.display?.displayType,
+                                    color: customColor,
                                 },
                             },
                         }

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10487,6 +10487,13 @@
                 "leftYAxisSettings": {
                     "$ref": "#/definitions/YAxisSettings"
                 },
+                "resultCustomizations": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ResultCustomizationByValue"
+                    },
+                    "description": "Per-breakdown-value color customizations. Keyed by the raw breakdown column value.",
+                    "type": "object"
+                },
                 "rightYAxisSettings": {
                     "$ref": "#/definitions/YAxisSettings"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1159,6 +1159,8 @@ export interface ChartSettings {
     showPieTotal?: boolean
     showNullsAsZero?: boolean
     heatmap?: HeatmapSettings
+    /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
+    resultCustomizations?: Record<string, ResultCustomizationByValue>
 }
 
 export interface ConditionalFormattingRule {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -12817,6 +12817,10 @@ class ChartSettings(BaseModel):
     goalLines: list[GoalLine] | None = None
     heatmap: HeatmapSettings | None = None
     leftYAxisSettings: YAxisSettings | None = None
+    resultCustomizations: dict[str, ResultCustomizationByValue] | None = Field(
+        default=None,
+        description="Per-breakdown-value color customizations. Keyed by the raw breakdown column value.",
+    )
     rightYAxisSettings: YAxisSettings | None = None
     seriesBreakdownColumn: str | None = None
     showLegend: bool | None = None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -12819,7 +12819,7 @@ class ChartSettings(BaseModel):
     leftYAxisSettings: YAxisSettings | None = None
     resultCustomizations: dict[str, ResultCustomizationByValue] | None = Field(
         default=None,
-        description="Per-breakdown-value color customizations. Keyed by the raw breakdown column value.",
+        description=("Per-breakdown-value color customizations. Keyed by the raw breakdown column value."),
     )
     rightYAxisSettings: YAxisSettings | None = None
     seriesBreakdownColumn: str | None = None

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -6549,10 +6549,17 @@ export interface ChartAxisApi {
     settings?: SettingsApi | null
 }
 
+/**
+ * Per-breakdown-value color customizations. Keyed by the raw breakdown column value.
+ */
+export type ChartSettingsApiResultCustomizations = { [key: string]: ResultCustomizationByValueApi } | null
+
 export interface ChartSettingsApi {
     goalLines?: GoalLineApi[] | null
     heatmap?: HeatmapSettingsApi | null
     leftYAxisSettings?: YAxisSettingsApi | null
+    /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
+    resultCustomizations?: ChartSettingsApiResultCustomizations
     rightYAxisSettings?: YAxisSettingsApi | null
     seriesBreakdownColumn?: string | null
     showLegend?: boolean | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6833,6 +6833,11 @@ export namespace Schemas {
       settings?: Settings | null;
     }
 
+    /**
+     * Per-breakdown-value color customizations. Keyed by the raw breakdown column value.
+     */
+    export type ChartSettingsResultCustomizations = {[key: string]: ResultCustomizationByValue} | null;
+
     export interface HeatmapGradientStop {
       color: string;
       value: number;
@@ -6890,6 +6895,8 @@ export namespace Schemas {
       goalLines?: GoalLine[] | null;
       heatmap?: HeatmapSettings | null;
       leftYAxisSettings?: YAxisSettings | null;
+      /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
+      resultCustomizations?: ChartSettingsResultCustomizations;
       rightYAxisSettings?: YAxisSettings | null;
       seriesBreakdownColumn?: string | null;
       showLegend?: boolean | null;


### PR DESCRIPTION
## Problem

SQL insights (HogQL via `DataVisualizationNode`) that render a stacked bar chart with a series breakdown already list each breakdown value in the **Series** sidebar, but the color swatch next to each value is purely decorative — there is no way for users to customize per-breakdown colors. The placeholder comment in `BreakdownSeries` even calls this out: _"For now let's keep things simple and not allow too much configuration."_

Trends and funnels already have a "result customizations" feature that solves this exact problem (color per series, persisted on the query). This PR ports the same idea to SQL insights, with an inline picker so users can edit colors directly in the sidebar.

## Changes

<img width="625" height="417" alt="Screenshot 2026-05-19 at 21 39 53" src="https://github.com/user-attachments/assets/d0afa576-623d-43f3-9f25-609bdebbdf9a" />
<img width="584" height="211" alt="Screenshot 2026-05-19 at 21 43 12" src="https://github.com/user-attachments/assets/d5fd9261-3e68-476c-b422-07842f3b0833" />


- New optional field `ChartSettings.resultCustomizations: Record<string, ResultCustomizationByValue>` on `DataVisualizationNode.chartSettings`. Reuses the trends/funnels `ResultCustomizationByValue` shape (`{ assignmentBy: 'value', color: DataColorToken }`), keyed by the raw breakdown column value (with a `__null__` sentinel for null/empty).
- `AxisBreakdownSeries` gains a stable `breakdownValue: string` key so the UI can look up customizations independent of the display name (which gets prefixed when multiple Y-series are present).
- `seriesBreakdownLogic` connects to `dataThemeLogic` and resolves the persisted token to a hex via `getColorFromToken(theme, token)`, populating `settings.display.color` on each breakdown series. The chart picks this up via the existing `settings?.display?.color ?? getSeriesColor(index)` fallback in `LineGraph.tsx`.
- `BreakdownSeries` in `SeriesTab.tsx` swaps the static `LemonColorGlyph` for an inline `LemonColorPicker` in token mode (mirroring the pattern `YSeriesDisplayTab` uses for Y-series colors). Selecting a token writes back via the existing `updateChartSettings` action — no new logic file, no modal.

Token-based (rather than hex) was chosen so colors persist correctly across light/dark theme switches and match the trends/funnels schema.

Existing trends/funnels result customization paths are untouched.

## How did you test this code?

I'm an agent — I did not manually exercise the UI. Automated checks I ran:

- `pnpm --filter=@posthog/frontend exec jest src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts` — all 9 existing tests still pass (updated assertions to include the new `breakdownValue` field).
- `pnpm --filter=@posthog/frontend exec jest src/queries/nodes/DataVisualization/Components/Charts/PieChart.test.ts` — all 3 tests pass (same field-shape update).
- `pnpm --filter=@posthog/frontend typescript:check` — diffed the error set before/after; no new TypeScript errors introduced (pre-existing kea `*LogicType` import errors are unchanged).
- Schema regen: `pnpm --filter=@posthog/frontend run schema:build:json` ran cleanly and produced the expected `resultCustomizations` entry in `frontend/src/queries/schema.json`. `posthog/schema.py` was edited by hand to add the matching field rather than running the full Pydantic regenerator (the locally available `datamodel-code-generator` produces a large unrelated reformat).

Manual verification still owed by a human reviewer: create a SQL insight with `SELECT toStartOfDay(timestamp), properties.\$browser, COUNT(*) FROM events WHERE {filters} GROUP BY 1, 2 ORDER BY 3 DESC`, set X / Y / breakdown to those columns, display = Stacked bar, then click a breakdown row swatch and pick a color. The chart should re-render with that breakdown in the chosen color; saving + reloading should preserve it; switching light/dark theme should re-resolve correctly.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by the PostHog Code agent (Claude Opus 4.7) via the Claude Agent SDK.

Approach decisions worth flagging:
- **In-place picker, no modal.** The first plan proposed reusing the trends/funnels modal (extract the visual into a shared component, add a new kea logic for SQL). The human asked for an in-place picker instead, on the basis that the breakdown list already shows all values; this resulted in a much smaller change (three files of logic + tests).
- **Token-based, not hex.** SQL Y-series colors are stored as hex strings (`chartSettings.yAxis[i].settings.display.color`). For the new field we deliberately picked tokens instead, to keep the schema shape identical to trends/funnels and to survive theme switches. The Y-series migration is left out of scope.
- **No `dataColorTheme` on `DataVisualizationNode`.** Themes resolve via `dataThemeLogic.getTheme(undefined)` (team default) — adding a per-insight theme selector is a follow-up.
- **Known limitation, documented inline:** when multiple Y-series share a breakdown, the persisted color applies to every Y-series for the same breakdown bucket (the key is the breakdown value only). Punted to a follow-up if needed.