### PR TITLE
fix(flags): show client/server runtime flags in person flags tab

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -3457,6 +3457,7 @@ class FeatureFlagViewSet(
             token=self.team.api_token,
             distinct_id=distinct_id,
             groups=groups,
+            evaluation_runtime="all",
         )
 
         # Result from Rust service is always a dictionary with a "flags" key. Parse it to get the flags data.

--- a/posthog/api/services/flags_service.py
+++ b/posthog/api/services/flags_service.py
@@ -25,6 +25,7 @@ def get_flags_from_service(
     flag_keys: list[str] | None = None,
     internal_request_token: str | None = None,
     override_flags_definitions: dict[str, dict[str, Any]] | None = None,
+    evaluation_runtime: str | None = None,
 ) -> dict[str, Any]:
     """
     Proxy a request to the Rust feature flags service /flags endpoint.
@@ -39,6 +40,8 @@ def get_flags_from_service(
         flag_keys: Optional list of specific flag keys to evaluate (default: None, evaluates all flags)
         internal_request_token: Optional token to mark request as internal (non-billable) (default: None)
         override_flags_definitions: Optional dict of flag key -> flag definition to override database flags (default: None)
+        evaluation_runtime: Optional override for runtime filtering: "all" | "client" | "server".
+            When None, the Rust service auto-detects from request headers (User-Agent, origin, sec-fetch-*).
 
     Returns:
         The full response from the flags service as a dict, typically containing:
@@ -79,6 +82,9 @@ def get_flags_from_service(
 
     if override_flags_definitions:
         payload["override_flags_definitions"] = override_flags_definitions
+
+    if evaluation_runtime:
+        payload["evaluation_runtime"] = evaluation_runtime
 
     params: dict[str, str] = {"v": "2"}
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -13437,3 +13437,49 @@ class TestFeatureFlagTestEvaluation(APIBaseTest, ClickhouseTestMixin):
 
         # Verify the mock was called
         mock_reconstruct.assert_called_once()
+
+
+class TestFeatureFlagEvaluationReasons(APIBaseTest, ClickhouseTestMixin):
+    @patch("posthog.api.feature_flag.get_flags_from_service")
+    def test_evaluation_reasons_passes_runtime_all_and_returns_every_runtime(self, mock_get_flags):
+        """The Person → Feature flags tab must show flags regardless of stored
+        evaluation_runtime. evaluation_reasons must (a) call the Rust service
+        with evaluation_runtime="all" so runtime-based exclusion is bypassed,
+        and (b) surface every returned flag with its evaluation.reason — which
+        is the shape relatedFeatureFlagsLogic.ts depends on."""
+        flag_all = FeatureFlag.objects.create(team=self.team, key="flag-all", evaluation_runtime="all")
+        flag_client = FeatureFlag.objects.create(team=self.team, key="flag-client", evaluation_runtime="client")
+        flag_server = FeatureFlag.objects.create(team=self.team, key="flag-server", evaluation_runtime="server")
+
+        mock_get_flags.return_value = {
+            "flags": {
+                flag_all.key: {
+                    "enabled": True,
+                    "variant": None,
+                    "reason": {"code": "condition_match", "condition_index": 0},
+                },
+                flag_client.key: {
+                    "enabled": True,
+                    "variant": None,
+                    "reason": {"code": "condition_match", "condition_index": 0},
+                },
+                flag_server.key: {
+                    "enabled": True,
+                    "variant": None,
+                    "reason": {"code": "condition_match", "condition_index": 0},
+                },
+            }
+        }
+
+        response = self.client.get(
+            f"/api/projects/{self.team.pk}/feature_flags/evaluation_reasons/",
+            {"distinct_id": "user-1"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(mock_get_flags.call_args.kwargs["evaluation_runtime"], "all")
+
+        data = response.json()
+        for key in (flag_all.key, flag_client.key, flag_server.key):
+            self.assertIn(key, data)
+            self.assertEqual(data[key]["evaluation"]["reason"], "condition_match")

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -13441,29 +13441,36 @@ class TestFeatureFlagTestEvaluation(APIBaseTest, ClickhouseTestMixin):
 
 class TestFeatureFlagEvaluationReasons(APIBaseTest, ClickhouseTestMixin):
     @patch("posthog.api.feature_flag.get_flags_from_service")
-    def test_evaluation_reasons_passes_runtime_all_and_returns_every_runtime(self, mock_get_flags):
-        """The Person → Feature flags tab must show flags regardless of stored
-        evaluation_runtime. evaluation_reasons must (a) call the Rust service
-        with evaluation_runtime="all" so runtime-based exclusion is bypassed,
-        and (b) surface every returned flag with its evaluation.reason — which
-        is the shape relatedFeatureFlagsLogic.ts depends on."""
-        flag_all = FeatureFlag.objects.create(team=self.team, key="flag-all", evaluation_runtime="all")
-        flag_client = FeatureFlag.objects.create(team=self.team, key="flag-client", evaluation_runtime="client")
-        flag_server = FeatureFlag.objects.create(team=self.team, key="flag-server", evaluation_runtime="server")
+    def test_evaluation_reasons_passes_runtime_all(self, mock_get_flags):
+        """The Person → Feature flags tab must bypass Rust's header-based
+        runtime detection — otherwise flags whose evaluation_runtime is
+        "client" or "server" disappear from the tab."""
+        mock_get_flags.return_value = {"flags": {}}
 
+        response = self.client.get(
+            f"/api/projects/{self.team.pk}/feature_flags/evaluation_reasons/",
+            {"distinct_id": "user-1"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(mock_get_flags.call_args.kwargs["evaluation_runtime"], "all")
+
+    @parameterized.expand(
+        [
+            ("all",),
+            ("client",),
+            ("server",),
+        ]
+    )
+    @patch("posthog.api.feature_flag.get_flags_from_service")
+    def test_evaluation_reasons_surfaces_flag_for_runtime(self, runtime, mock_get_flags):
+        """Each stored runtime must round-trip through evaluation_reasons with
+        its evaluation.reason intact — this is the shape
+        relatedFeatureFlagsLogic.ts depends on."""
+        flag = FeatureFlag.objects.create(team=self.team, key=f"flag-{runtime}", evaluation_runtime=runtime)
         mock_get_flags.return_value = {
             "flags": {
-                flag_all.key: {
-                    "enabled": True,
-                    "variant": None,
-                    "reason": {"code": "condition_match", "condition_index": 0},
-                },
-                flag_client.key: {
-                    "enabled": True,
-                    "variant": None,
-                    "reason": {"code": "condition_match", "condition_index": 0},
-                },
-                flag_server.key: {
+                flag.key: {
                     "enabled": True,
                     "variant": None,
                     "reason": {"code": "condition_match", "condition_index": 0},
@@ -13477,9 +13484,6 @@ class TestFeatureFlagEvaluationReasons(APIBaseTest, ClickhouseTestMixin):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(mock_get_flags.call_args.kwargs["evaluation_runtime"], "all")
-
         data = response.json()
-        for key in (flag_all.key, flag_client.key, flag_server.key):
-            self.assertIn(key, data)
-            self.assertEqual(data[key]["evaluation"]["reason"], "condition_match")
+        self.assertIn(flag.key, data)
+        self.assertEqual(data[flag.key]["evaluation"]["reason"], "condition_match")


### PR DESCRIPTION
## Problem

The Person → Feature flags tab silently omits any flag whose stored `evaluation_runtime` is `"client"` or `"server"`. Customers debugging "why isn't this user getting this flag?" see correctly-targeted flags disappear from the tab, which makes flag debugging untrustworthy.

**Root cause:** `evaluation_reasons` proxies to the Rust flags service via an internal Django→Rust HTTP call. Rust's `detect_evaluation_runtime_from_request` infers `EvaluationRuntime` from `User-Agent`, `origin`, `referer`, and `sec-fetch-*` headers — none of which the internal call carries. Rust resolves runtime to `None`, then `collect_excluded_by_runtime` matches `(None, Some(_))` and excludes every flag whose runtime is not `"all"`. The `FlagRequest` struct already accepts a JSON body override (`evaluation_runtime: "all" | "client" | "server"`) — the Python proxy just wasn't using it.

## Changes

- `posthog/api/services/flags_service.py` — add optional `evaluation_runtime` kwarg to `get_flags_from_service`; passed through into the JSON body. When unset, Rust keeps auto-detecting from headers.
- `posthog/api/feature_flag.py` — `evaluation_reasons` action passes `evaluation_runtime="all"` so the tab sees every flag regardless of stored runtime. Other call sites (`my_flags`, `test_evaluation`, toolbar) are deliberately untouched — they're real client/server contexts where the header heuristic is correct.

Frontend needs no change: once the API returns all flags, `relatedFeatureFlagsLogic.ts:115` passes them through unchanged.

## How did you test this code?

Authored by an agent. Automated coverage only:

- Added `TestFeatureFlagEvaluationReasons` in `posthog/api/test/test_feature_flag.py`. One test asserts (a) the action calls `get_flags_from_service` with `evaluation_runtime="all"`, and (b) flags configured with `all`, `client`, and `server` runtimes all appear in the response with their `evaluation.reason`.
- `ruff check` and `ruff format` clean on touched files; `uv run ty check` passed via lint-staged on commit.
- Test execution was **not** run locally — Docker/Postgres weren't available in this environment. CI will exercise it.

No manual end-to-end browser verification was performed; the manual repro steps are documented in the implementation plan for reviewer follow-up.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Approach: the Rust side already had the override path landed; the cheapest fix is a Python-only thread-through. Considered (and rejected) changing Rust's default behavior or forwarding browser headers from Django — both have a much wider blast radius and would affect call sites that intentionally rely on runtime detection. Chose the narrowest fix: a single kwarg, used by one call site.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*