### PR TITLE
feat(hog-functions): tailor feature-flag-change notification verb

### DIFF
--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -133,18 +133,34 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
 
 const FLAG_ACTOR_NAME = "{event.properties.user.first_name ? event.properties.user.first_name : 'PostHog'}"
 
-const FLAG_CHANGE_VERB_PHRASE =
-    "{event.properties.activity == 'created' ? 'created' " +
-    ": event.properties.activity == 'deleted' ? 'deleted' " +
-    ": event.properties.activity == 'restored' ? 'restored' " +
-    ": event.properties.detail.changes[1].field == 'active' ? (event.properties.detail.changes[1].after == 'true' ? 'enabled' : 'disabled') " +
-    ": event.properties.detail.changes[1].field == 'filters' ? (" +
-    "event.properties.detail.changes[1].after.multivariate != null ? 'updated variant rollout for' " +
-    ": length(ifNull(event.properties.detail.changes[1].after.groups, [])) > length(ifNull(event.properties.detail.changes[1].before.groups, [])) ? 'added a release condition to' " +
-    ": length(ifNull(event.properties.detail.changes[1].after.groups, [])) < length(ifNull(event.properties.detail.changes[1].before.groups, [])) ? 'removed a release condition from' " +
-    ": 'updated release conditions on'" +
-    ') ' +
-    ": 'updated'}"
+function buildFlagChangeVerbPhrase(): string {
+    const activity = 'event.properties.activity'
+    const change = 'event.properties.detail.changes[1]'
+    const afterGroups = `length(ifNull(${change}.after.groups, []))`
+    const beforeGroups = `length(ifNull(${change}.before.groups, []))`
+
+    const activeFieldVerb = `${change}.after == 'true' ? 'enabled' : 'disabled'`
+
+    const filtersFieldVerb = [
+        `${change}.after.multivariate != null ? 'updated variant rollout for'`,
+        `${afterGroups} > ${beforeGroups} ? 'added a release condition to'`,
+        `${afterGroups} < ${beforeGroups} ? 'removed a release condition from'`,
+        `'updated release conditions on'`,
+    ].join(' : ')
+
+    const verbPhrase = [
+        `${activity} == 'created' ? 'created'`,
+        `${activity} == 'deleted' ? 'deleted'`,
+        `${activity} == 'restored' ? 'restored'`,
+        `${change}.field == 'active' ? (${activeFieldVerb})`,
+        `${change}.field == 'filters' ? (${filtersFieldVerb})`,
+        `'updated'`,
+    ].join(' : ')
+
+    return `{${verbPhrase}}`
+}
+
+const FLAG_CHANGE_VERB_PHRASE = buildFlagChangeVerbPhrase()
 
 export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, HogFunctionSubTemplateType[]> = {
     'survey-response': [

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -140,8 +140,8 @@ const FLAG_CHANGE_VERB_PHRASE =
     ": event.properties.detail.changes[1].field == 'active' ? (event.properties.detail.changes[1].after == 'true' ? 'enabled' : 'disabled') " +
     ": event.properties.detail.changes[1].field == 'filters' ? (" +
     "event.properties.detail.changes[1].after.multivariate != null ? 'updated variant rollout for' " +
-    ": length(event.properties.detail.changes[1].after.groups) > length(event.properties.detail.changes[1].before.groups) ? 'added a release condition to' " +
-    ": length(event.properties.detail.changes[1].after.groups) < length(event.properties.detail.changes[1].before.groups) ? 'removed a release condition from' " +
+    ": length(ifNull(event.properties.detail.changes[1].after.groups, [])) > length(ifNull(event.properties.detail.changes[1].before.groups, [])) ? 'added a release condition to' " +
+    ": length(ifNull(event.properties.detail.changes[1].after.groups, [])) < length(ifNull(event.properties.detail.changes[1].before.groups, [])) ? 'removed a release condition from' " +
     ": 'updated release conditions on'" +
     ') ' +
     ": 'updated'}"

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -131,6 +131,21 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
     },
 }
 
+const FLAG_ACTOR_NAME = "{event.properties.user.first_name ? event.properties.user.first_name : 'PostHog'}"
+
+const FLAG_CHANGE_VERB_PHRASE =
+    "{event.properties.activity == 'created' ? 'created' " +
+    ": event.properties.activity == 'deleted' ? 'deleted' " +
+    ": event.properties.activity == 'restored' ? 'restored' " +
+    ": event.properties.detail.changes[1].field == 'active' ? (event.properties.detail.changes[1].after == 'true' ? 'enabled' : 'disabled') " +
+    ": event.properties.detail.changes[1].field == 'filters' ? (" +
+    "event.properties.detail.changes[1].after.multivariate != null ? 'updated variant rollout for' " +
+    ": length(event.properties.detail.changes[1].after.groups) > length(event.properties.detail.changes[1].before.groups) ? 'added a release condition to' " +
+    ": length(event.properties.detail.changes[1].after.groups) < length(event.properties.detail.changes[1].before.groups) ? 'removed a release condition from' " +
+    ": 'updated release conditions on'" +
+    ') ' +
+    ": 'updated'}"
+
 export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, HogFunctionSubTemplateType[]> = {
     'survey-response': [
         {
@@ -327,7 +342,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             description: 'Send a webhook when a feature flag is changed',
             inputs: {
                 content: {
-                    value: "**{event.properties.user.first_name ? event.properties.user.first_name : 'PostHog'}** {event.properties.activity} feature flag `{event.properties.detail.name}`",
+                    value: `**${FLAG_ACTOR_NAME}** ${FLAG_CHANGE_VERB_PHRASE} feature flag \`{event.properties.detail.name}\``,
                 },
             },
         },
@@ -338,7 +353,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             description: 'Posts a message to Discord when a feature flag is changed',
             inputs: {
                 content: {
-                    value: "**{event.properties.user.first_name ? event.properties.user.first_name : 'PostHog'}** {event.properties.activity} feature flag `{event.properties.detail.name}`",
+                    value: `**${FLAG_ACTOR_NAME}** ${FLAG_CHANGE_VERB_PHRASE} feature flag \`{event.properties.detail.name}\``,
                 },
             },
         },
@@ -349,7 +364,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             description: 'Posts a message to Microsoft Teams when a feature flag is changed',
             inputs: {
                 content: {
-                    value: "**{event.properties.user.first_name ? event.properties.user.first_name : 'PostHog'}** {event.properties.activity} feature flag `{event.properties.detail.name}`",
+                    value: `**${FLAG_ACTOR_NAME}** ${FLAG_CHANGE_VERB_PHRASE} feature flag \`{event.properties.detail.name}\``,
                 },
             },
         },
@@ -363,7 +378,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                     value: [
                         {
                             text: {
-                                text: "*{event.properties.user.first_name ? event.properties.user.first_name : 'PostHog'}* {event.properties.activity} feature flag `{event.properties.detail.name}`",
+                                text: `*${FLAG_ACTOR_NAME}* ${FLAG_CHANGE_VERB_PHRASE} feature flag \`{event.properties.detail.name}\``,
                                 type: 'mrkdwn',
                             },
                             type: 'section',
@@ -381,7 +396,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                     ],
                 },
                 text: {
-                    value: "*{event.properties.user.first_name ? event.properties.user.first_name : 'PostHog'}* {event.properties.activity} feature flag `{event.properties.detail.name}`",
+                    value: `*${FLAG_ACTOR_NAME}* ${FLAG_CHANGE_VERB_PHRASE} feature flag \`{event.properties.detail.name}\``,
                 },
             },
         },


### PR DESCRIPTION
## Problem

Follow-up to #58989. Feedback from the screenshot of feature-flag activity-log Slack messages:

1. The verb is generic — every change renders as `<user> updated feature flag <name>`, so five very different actions (toggle off, toggle on, two variant-rollout changes, release-condition delete) read identically.
2. The bold around the actor name showed literal `**` in Slack. The Slack sub-template here uses single asterisks (`*`) — that's the `mrkdwn` bold marker — and continues to in this PR. Reports of `**` showing literally come from hooks configured off the generic webhook template (which uses Discord/Teams-style `**`); recreating from the Slack template fixes it.

## Changes

For the `feature-flag-change` sub-template (webhook / Discord / Microsoft Teams / Slack), the existing `{event.properties.activity} feature flag` body is replaced with a verb expression that branches on the first change in `event.properties.detail.changes`:

| Detected change | Rendered verb |
|---|---|
| `activity == 'created'` | created |
| `activity == 'deleted'` | deleted |
| `activity == 'restored'` | restored |
| `changes[1].field == 'active'`, `after == 'true'` | enabled |
| `changes[1].field == 'active'`, `after == 'false'` | disabled |
| `changes[1].field == 'filters'`, multivariate present | updated variant rollout for |
| `changes[1].field == 'filters'`, more `groups` than before | added a release condition to |
| `changes[1].field == 'filters'`, fewer `groups` than before | removed a release condition from |
| `changes[1].field == 'filters'`, same group count | updated release conditions on |
| Anything else | updated |

Only the verb varies — the rest of the sentence (`<user> <verb> feature flag <name>` and the `View feature flag` Slack button) stays identical to #58989. The shared verb expression is hoisted to a `FLAG_CHANGE_VERB_PHRASE` constant so all four channel templates render the same logic.

Limitation: when multiple fields change in one save (e.g. someone flips `active` and edits filters together), only the first change drives the verb. This matches the pattern used in the existing `template-slack` block and avoids unbounded ternary depth.

## How did you test this code?

I am an agent. I did not open the configuration UI to render the templates against a live Slack workspace.

I did run the rendered Hog template through the production-path parser and VM with 12 fixtures hand-crafted from the `ActivityLog` → `UserBasicSerializer` payload shape and from the `Change` shape produced by `changes_between(...)` in `posthog/api/feature_flag.py`. Every fixture produced the expected verb (enabled, disabled, updated variant rollout for, added/removed/updated release conditions, created, deleted, restored, and the empty-`first_name` / `user = null` → `PostHog` fallbacks).

Verified with `parse_string_template` + `create_bytecode` (production string-template parser) and `execute_bytecode` from `common/hogvm/python/execute.py`.

## Publish to changelog?

no

## Docs update

No docs changes required.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7), invoked by @yasenh.

- Confirmed the activity payload shape that reaches the Hog VM:
  `event.properties` is the `ActivityLogSerializer` output (per `posthog/cdp/internal_events.py` → `produce_internal_event`, consumed by `convertInternalEventToHogFunctionInvocationGlobals` at `nodejs/src/cdp/utils.ts:129`). `detail.changes[]` carries entries with `{field, action, before, after}`, and the activity for soft-delete is overridden to `deleted` / `restored` in `_log_feature_flag_activity`.
- Confirmed Hog template capabilities: nested ternaries via `cond ? a : cond2 ? b : c`, `length(...)` STL function, 1-based array indexing (so `changes[1]` is the first element). Missing field traversal returns null rather than throwing, so the unreachable branches in dead ternary arms are safe.
- Considered moving the verb derivation into the backend `_log_feature_flag_activity` instead of the Hog template. Rejected for blast radius — the template change is reversible and ships with the frontend, while a backend payload change would touch every consumer of `$activity_log_entry_created`.
- Considered describing every change in the array (e.g. "enabled and updated release conditions"). Rejected as it requires loops, which Hog templates don't have.