### PR TITLE
docs: fix Ruby error tracking examples

### DIFF
--- a/docs/onboarding/error-tracking/ruby.tsx
+++ b/docs/onboarding/error-tracking/ruby.tsx
@@ -37,8 +37,8 @@ export const getRubySteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                 rescue => e
                                   posthog.capture_exception(
                                     e,
-                                    distinct_id: 'user_distinct_id',
-                                    properties: {
+                                    'user_distinct_id',
+                                    {
                                       custom_property: 'custom_value'
                                     }
                                   )
@@ -55,7 +55,7 @@ export const getRubySteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                         | --- | --- | --- |
                         | \`exception\` | \`Exception\` | The exception object to capture (required) |
                         | \`distinct_id\` | \`String\` | The distinct ID of the user (optional) |
-                        | \`properties\` | \`Hash\` | Additional properties to attach to the exception event (optional) |
+                        | \`additional_properties\` | \`Hash\` | Additional properties to attach to the exception event (optional) |
                     `}
                 </Markdown>
             </>


### PR DESCRIPTION
## Summary
- Update Ruby error tracking onboarding docs to use the current `capture_exception(exception, distinct_id, additional_properties)` positional signature.
- Rename the third parameter in the docs table to `additional_properties`.

## Testing
- `git diff --check`
- `pnpm exec oxfmt --check docs/onboarding/error-tracking/ruby.tsx`
- `pnpm exec oxlint --quiet docs/onboarding/error-tracking/ruby.tsx`

Companion .com docs PR: https://github.com/PostHog/posthog.com/pull/16905