### PR TITLE
fix(tracing): compute hasMore/nextCursor on query-apm-spans

### DIFF
--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -11,6 +11,8 @@ No business logic here - that belongs in logic.py via the facade.
 """
 
 import json
+import base64
+from typing import Any
 
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
@@ -46,6 +48,56 @@ from ..logic import (
     run_tree_query,
 )
 from ..sparkline_query_runner import TraceSpansSparklineQueryRunner
+
+
+def _paginate_trace_results(
+    results: list[dict[str, Any]], requested_limit: int, order_by: str
+) -> tuple[list[dict[str, Any]], bool, str | None]:
+    """
+    Compute hasMore and nextCursor from a span result set ordered by the runner.
+
+    The view passes ``limit = requested_limit + 1`` to the runner so the SQL fetches one
+    extra trace as a peek-ahead. This helper detects that overflow by counting distinct
+    trace_ids in result order: if more than ``requested_limit`` distinct trace_ids
+    appear, the result set contains the +1 trace and we drop its spans.
+
+    The cursor is the boundary span of the last *kept* trace:
+    - latest (DESC) order: the earliest span (min timestamp/uuid) of the last kept trace
+    - earliest (ASC) order: the latest span (max timestamp/uuid) of the last kept trace
+
+    These match the strict-inequality filter in ``TraceSpansQueryRunner.where()``.
+
+    Caveat: ``time_sliced_results`` decrements its internal limit by span count rather
+    than trace count, so for queries spanning multiple time slices the runner may exit
+    before the +1 peek-ahead trace is fetched. In that case this helper returns
+    ``hasMore=False`` even when more data exists in earlier time windows. The single-
+    slice case (short windows, the common path) is handled correctly.
+    """
+    seen_trace_ids: list[str] = []
+    seen_set: set[str] = set()
+    for row in results:
+        tid = row["trace_id"]
+        if tid not in seen_set:
+            seen_set.add(tid)
+            seen_trace_ids.append(tid)
+
+    if len(seen_trace_ids) <= requested_limit:
+        return results, False, None
+
+    kept_trace_ids = set(seen_trace_ids[:requested_limit])
+    kept = [row for row in results if row["trace_id"] in kept_trace_ids]
+
+    last_trace_id = seen_trace_ids[requested_limit - 1]
+    last_trace_spans = [row for row in kept if row["trace_id"] == last_trace_id]
+    if order_by == "earliest":
+        boundary = max(last_trace_spans, key=lambda r: (r["timestamp"], r["uuid"]))
+    else:
+        boundary = min(last_trace_spans, key=lambda r: (r["timestamp"], r["uuid"]))
+
+    cursor_payload = json.dumps({"timestamp": boundary["timestamp"].isoformat(), "uuid": boundary["uuid"]})
+    next_cursor = base64.b64encode(cursor_payload.encode("utf-8")).decode("ascii")
+    return kept, True, next_cursor
+
 
 # Serializers below are used exclusively for OpenAPI spec generation via
 # drf-spectacular. They are NOT used for request validation — the existing
@@ -344,11 +396,13 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             )
         )
 
+        results, has_more, next_cursor = _paginate_trace_results(results, requested_limit, order_by)
+
         return Response(
             {
                 "results": results,
-                "hasMore": False,  # TODO: tricky with the traces query as we prefetch an unknown number of spans
-                "nextCursor": None,
+                "hasMore": has_more,
+                "nextCursor": next_cursor,
             },
             status=status.HTTP_200_OK,
         )

--- a/products/tracing/backend/tests/test_presentation.py
+++ b/products/tracing/backend/tests/test_presentation.py
@@ -1,0 +1,122 @@
+import json
+import base64
+import datetime as dt
+
+import pytest
+
+from products.tracing.backend.presentation.views import _paginate_trace_results
+
+
+def _row(trace_id: str, ts: dt.datetime, uuid: str) -> dict:
+    return {
+        "trace_id": trace_id,
+        "timestamp": ts,
+        "uuid": uuid,
+    }
+
+
+def _decode_cursor(cursor: str) -> dict:
+    return json.loads(base64.b64decode(cursor).decode("utf-8"))
+
+
+class TestPaginateTraceResults:
+    def test_empty_results(self):
+        kept, has_more, cursor = _paginate_trace_results([], requested_limit=100, order_by="latest")
+        assert kept == []
+        assert has_more is False
+        assert cursor is None
+
+    @pytest.mark.parametrize("order_by", ["latest", "earliest"])
+    def test_fewer_traces_than_limit(self, order_by):
+        ts = dt.datetime(2026, 1, 1, 12, 0, 0)
+        results = [
+            _row("trace-a", ts, "uuid-a1"),
+            _row("trace-a", ts + dt.timedelta(seconds=1), "uuid-a2"),
+            _row("trace-b", ts + dt.timedelta(seconds=2), "uuid-b1"),
+        ]
+        kept, has_more, cursor = _paginate_trace_results(results, requested_limit=5, order_by=order_by)
+        assert kept == results
+        assert has_more is False
+        assert cursor is None
+
+    @pytest.mark.parametrize("order_by", ["latest", "earliest"])
+    def test_exactly_requested_limit_traces(self, order_by):
+        ts = dt.datetime(2026, 1, 1, 12, 0, 0)
+        results = [
+            _row("trace-a", ts, "uuid-a"),
+            _row("trace-b", ts + dt.timedelta(seconds=1), "uuid-b"),
+            _row("trace-c", ts + dt.timedelta(seconds=2), "uuid-c"),
+        ]
+        kept, has_more, cursor = _paginate_trace_results(results, requested_limit=3, order_by=order_by)
+        assert kept == results
+        assert has_more is False
+        assert cursor is None
+
+    def test_one_extra_trace_latest_order(self):
+        # 3 traces, requested_limit=2 → +1 detected, trace-c dropped.
+        # Cursor: trace-b's earliest span (min ts/uuid) for DESC.
+        ts = dt.datetime(2026, 1, 1, 12, 0, 0)
+        results = [
+            _row("trace-a", ts + dt.timedelta(seconds=10), "uuid-a"),
+            _row("trace-b", ts + dt.timedelta(seconds=8), "uuid-b1"),
+            _row("trace-b", ts + dt.timedelta(seconds=5), "uuid-b2"),
+            _row("trace-c", ts + dt.timedelta(seconds=2), "uuid-c"),
+        ]
+        kept, has_more, cursor = _paginate_trace_results(results, requested_limit=2, order_by="latest")
+
+        assert has_more is True
+        assert {row["trace_id"] for row in kept} == {"trace-a", "trace-b"}
+        assert cursor is not None
+
+        decoded = _decode_cursor(cursor)
+        assert decoded["timestamp"] == (ts + dt.timedelta(seconds=5)).isoformat()
+        assert decoded["uuid"] == "uuid-b2"
+
+    def test_one_extra_trace_earliest_order(self):
+        # ASC order: cursor is the latest span of last kept trace (trace-b).
+        ts = dt.datetime(2026, 1, 1, 12, 0, 0)
+        results = [
+            _row("trace-a", ts, "uuid-a"),
+            _row("trace-b", ts + dt.timedelta(seconds=5), "uuid-b1"),
+            _row("trace-b", ts + dt.timedelta(seconds=8), "uuid-b2"),
+            _row("trace-c", ts + dt.timedelta(seconds=10), "uuid-c"),
+        ]
+        kept, has_more, cursor = _paginate_trace_results(results, requested_limit=2, order_by="earliest")
+
+        assert has_more is True
+        assert {row["trace_id"] for row in kept} == {"trace-a", "trace-b"}
+
+        decoded = _decode_cursor(cursor)
+        assert decoded["timestamp"] == (ts + dt.timedelta(seconds=8)).isoformat()
+        assert decoded["uuid"] == "uuid-b2"
+
+    def test_dropped_trace_spans_removed_from_kept(self):
+        ts = dt.datetime(2026, 1, 1, 12, 0, 0)
+        results = [
+            _row("trace-a", ts, "uuid-a"),
+            _row("trace-b", ts + dt.timedelta(seconds=1), "uuid-b"),
+            _row("trace-c", ts + dt.timedelta(seconds=2), "uuid-c1"),
+            _row("trace-c", ts + dt.timedelta(seconds=3), "uuid-c2"),
+            _row("trace-c", ts + dt.timedelta(seconds=4), "uuid-c3"),
+        ]
+        kept, has_more, _ = _paginate_trace_results(results, requested_limit=2, order_by="latest")
+
+        assert has_more is True
+        assert len(kept) == 2
+        assert all(row["trace_id"] != "trace-c" for row in kept)
+
+    def test_uuid_tiebreaker_on_equal_timestamps(self):
+        # When two spans share a timestamp, uuid breaks the tie deterministically.
+        ts = dt.datetime(2026, 1, 1, 12, 0, 0)
+        results = [
+            _row("trace-a", ts, "uuid-a"),
+            _row("trace-b", ts + dt.timedelta(seconds=1), "uuid-b1"),
+            _row("trace-b", ts + dt.timedelta(seconds=1), "uuid-b2"),
+            _row("trace-c", ts + dt.timedelta(seconds=2), "uuid-c"),
+        ]
+        kept, has_more, cursor = _paginate_trace_results(results, requested_limit=2, order_by="latest")
+
+        assert has_more is True
+        decoded = _decode_cursor(cursor)
+        # DESC: min by (ts, uuid) → both have same ts, uuid-b1 < uuid-b2 lexically.
+        assert decoded["uuid"] == "uuid-b1"

--- a/products/tracing/mcp/tools.yaml
+++ b/products/tracing/mcp/tools.yaml
@@ -141,3 +141,5 @@ tools:
         response:
             include:
                 - results
+                - hasMore
+                - nextCursor

--- a/services/mcp/src/tools/generated/tracing.ts
+++ b/services/mcp/src/tools/generated/tracing.ts
@@ -163,7 +163,7 @@ const queryApmSpans = (): ToolBase<typeof QueryApmSpansSchema, unknown> =>
                 path: `/api/environments/${encodeURIComponent(String(projectId))}/tracing/spans/query/`,
                 body,
             })
-            const filtered = pickResponseFields(result, ['results']) as typeof result
+            const filtered = pickResponseFields(result, ['results', 'hasMore', 'nextCursor']) as typeof result
             return filtered
         },
     })


### PR DESCRIPTION
## Problem

`SpansViewSet.query` (the `/tracing/spans/query/` endpoint, wrapped as the `query-apm-spans` MCP tool) hard-coded `hasMore: False` and `nextCursor: null` in its response, with a TODO noting "tricky with the traces query as we prefetch an unknown number of spans." Agents can't paginate beyond the first batch because they have no signal there's more data, and no cursor to continue from.

Part of Phase 1 of a broader MCP observability effort. Independent of the other Phase 1 PRs.

## Changes

- **`products/tracing/backend/presentation/views.py`** — new private helper `_paginate_trace_results(results, requested_limit, order_by)` that:
  - Walks the result set and counts distinct `trace_id`s in result order
  - If more than `requested_limit` distinct traces appear, the runner returned its +1 peek-ahead trace — drop that trace's spans and set `hasMore=True`
  - Computes the cursor from the boundary span of the last *kept* trace: minimum `(timestamp, uuid)` for `latest`/DESC order, maximum for `earliest`/ASC order. This matches the strict-inequality filter in `TraceSpansQueryRunner.where()`
  - Cursor format: `base64(json({"timestamp": ISO8601, "uuid": ...}))`, identical to what `where()` expects to consume on the next page

- **`products/tracing/backend/tests/test_presentation.py`** — 9 parametrized unit tests for the helper covering: empty results, fewer-than-limit, exact-limit, +1 overflow in both order directions, multi-span-per-trace trimming, and uuid tiebreaker on equal timestamps.

### Known caveat (documented in the helper docstring)

`time_sliced_results` (`posthog/hogql_queries/utils/time_sliced_query.py`) decrements its internal limit by `len(response.results)` — span count — when the runner's `query.limit` is a *trace* count. For long-window queries that span multiple slices, the runner can exit before the +1 peek-ahead trace is fetched, so `hasMore=False` may be a false negative in that case. The single-slice case (short windows, the common path) is now correct. Fixing the multi-slice accounting is its own concern and out of scope for this PR.

## How did you test this code?

I'm an agent. Added 9 unit tests for `_paginate_trace_results` covering each branch and edge case. All pass locally via `hogli test products/tracing/backend/tests/test_presentation.py`.

I did not run an integration test against ClickHouse — that would need realistic trace data with a known per-trace span count, which I don't have a fixture for. Worth manual verification before merging.

## Publish to changelog?

no

## Docs update

`skip-inkeep-docs` — backend behavior change for MCP clients, not user-facing docs.

## 🤖 Agent context

PostHog Code session. Phase 1 cleanup of a known TODO. Considered fixing the `time_sliced_results` decrement bug in the same PR but kept that out of scope to keep this PR narrowly about the visible API change. The helper is module-scope (not a viewset method) and pure — easy to unit-test without Django fixtures.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*