### PR TITLE
feat(workflows): Switch cyclotron_jobs.person_id from UUID to TEXT

### DIFF
--- a/rust/cyclotron-node-migrations/20260519000001_replace_person_id_with_text.sql
+++ b/rust/cyclotron-node-migrations/20260519000001_replace_person_id_with_text.sql
@@ -1,0 +1,10 @@
+-- The wait-until-event feature is not yet live, so we drop existing data and
+-- re-create the column as TEXT so non-UUID person identifiers (UUIDT, group keys)
+-- flow through without coercion.
+--
+-- DROP + ADD in a single ALTER keeps the column atomic from other sessions'
+-- view: they see the table either with the old UUID column or with the new TEXT
+-- column, never with no `person_id` at all. The dependent index is dropped here
+-- and recreated CONCURRENTLY in the next migration.
+SET lock_timeout = '5s';
+ALTER TABLE cyclotron_jobs DROP COLUMN IF EXISTS person_id, ADD COLUMN person_id TEXT;

--- a/rust/cyclotron-node-migrations/20260519000002_add_person_id_index.sql
+++ b/rust/cyclotron-node-migrations/20260519000002_add_person_id_index.sql
@@ -1,0 +1,4 @@
+-- no-transaction
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_person_id
+    ON cyclotron_jobs (team_id, person_id)
+    WHERE person_id IS NOT NULL;


### PR DESCRIPTION
## Problem

`cyclotron_jobs.person_id` is typed as `UUID`, but person identifiers can actually take non-UUID shapes - e.g. UUIDT-style ids with non-standard version bits - that Postgres's `UUID` type rejects. Today the producers coerce non-UUID values to null so inserts don't fail, which means the matcher (and any other consumer) can never wake parked jobs keyed by those identifiers.

The wait-until-event feature is not yet live, so we can drop existing data and re-create the column as TEXT without a backfill or dual-column dance.

## Changes

Two migrations on the cyclotron-node database:

- `ALTER TABLE cyclotron_jobs DROP COLUMN IF EXISTS person_id, ADD COLUMN person_id TEXT;` — single ALTER so DROP and ADD are atomic from other sessions' view (they see either the old UUID column or the new TEXT column, never neither). `SET lock_timeout = '5s'` so the runner bounces off any contended lock instead of stalling writers.
- Recreate `idx_cyclotron_jobs_person_id` on `(team_id, person_id)` as a `CONCURRENTLY` partial index (the original was dropped with the column).

DDLs are metadata-only (no row rewrite). The previous column-add migration in this table applied in under a second per region; this one should be similar.

Code follow-up (#59115, separate PR, **must merge after this deploys**) drops the producer-side UUID coercion in cyclotron-v2 and swaps the `$10::uuid[]` cast in the bulk insert for `$10::text[]`. The reverse direction (text[] → UUID column) fails with `column "person_id" is of type uuid but expression is of type text`, so if the follow-up landed first the producer would crashloop on every INSERT.

## How did you test this code?

Agent-authored. The migrations themselves are simple DDLs; CI runs them against an ephemeral test DB as part of the cyclotron-v2 integration suite. I confirmed locally that the existing tests fail loudly (`invalid input syntax for type uuid`) without the migration, which is the expected pre-state, and the follow-up branch's tests pass once the schema is in place.

Also tested end-to-end on the prototype branch with the migration applied locally: 50/50 cyclotron-v2 integration tests pass against the migrated schema with master's `$10::uuid[]` producer code (via PG's implicit `uuid → text` assignment cast on INSERT).

## Publish to changelog?

No