### PR TITLE
feat(insights): allow un-setting result customization color

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -683,6 +683,11 @@ const BreakdownSeries = ({
                         },
                     })
                 }}
+                onClearColorToken={() => {
+                    const { [series.breakdownValue]: _removed, ...rest } =
+                        chartSettings.resultCustomizations ?? {}
+                    updateChartSettings({ resultCustomizations: rest })
+                }}
             />
             <span>{series.name ? series.name : '[No value]'}</span>
         </div>

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -684,8 +684,7 @@ const BreakdownSeries = ({
                     })
                 }}
                 onClearColorToken={() => {
-                    const { [series.breakdownValue]: _removed, ...rest } =
-                        chartSettings.resultCustomizations ?? {}
+                    const { [series.breakdownValue]: _removed, ...rest } = chartSettings.resultCustomizations ?? {}
                     updateChartSettings({ resultCustomizations: rest })
                 }}
             />

--- a/frontend/src/queries/nodes/InsightViz/ResultCustomizationsModal.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ResultCustomizationsModal.tsx
@@ -1,9 +1,10 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonButton, LemonColorButton, LemonModal } from '@posthog/lemon-ui'
+import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 
 import { DataColorToken } from 'lib/colors'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
+import { LemonColorList } from 'lib/lemon-ui/LemonColor/LemonColorList'
 import { dataThemeLogic } from 'scenes/dataThemeLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -23,7 +24,9 @@ export function ResultCustomizationsModal(): JSX.Element | null {
     const { modalVisible, dataset, colorToken, resultCustomizationBy } = useValues(
         resultCustomizationsModalLogic(insightProps)
     )
-    const { closeModal, setColorToken, save } = useActions(resultCustomizationsModalLogic(insightProps))
+    const { closeModal, setColorToken, clearColorToken, save } = useActions(
+        resultCustomizationsModalLogic(insightProps)
+    )
 
     const { isTrends, isFunnels, querySource } = useValues(insightVizDataLogic)
 
@@ -63,21 +66,12 @@ export function ResultCustomizationsModal(): JSX.Element | null {
             {isFunnels && <FunnelsInfo dataset={dataset as FlattenedFunnelStepByBreakdown} />}
 
             <h3 className="l4 mt-2 mb-2">Color</h3>
-            <div className="flex flex-wrap gap-1">
-                {Object.keys(theme).map((key) => (
-                    <LemonColorButton
-                        key={key}
-                        colorToken={key as DataColorToken}
-                        type={key === colorToken ? 'secondary' : 'tertiary'}
-                        onClick={(e) => {
-                            e.preventDefault()
-                            e.stopPropagation()
-
-                            setColorToken(key as DataColorToken)
-                        }}
-                    />
-                ))}
-            </div>
+            <LemonColorList
+                colorTokens={Object.keys(theme) as DataColorToken[]}
+                selectedColorToken={colorToken}
+                onSelectColorToken={setColorToken}
+                onClearColorToken={clearColorToken}
+            />
         </LemonModal>
     )
 }

--- a/frontend/src/queries/nodes/InsightViz/resultCustomizationsModalLogic.ts
+++ b/frontend/src/queries/nodes/InsightViz/resultCustomizationsModalLogic.ts
@@ -4,7 +4,12 @@ import { DataColorToken } from 'lib/colors'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
-import { getFunnelDatasetKey, getTrendResultCustomization, getTrendResultCustomizationKey } from 'scenes/insights/utils'
+import {
+    getFunnelDatasetKey,
+    getFunnelResultCustomization,
+    getTrendResultCustomization,
+    getTrendResultCustomizationKey,
+} from 'scenes/insights/utils'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
@@ -35,6 +40,7 @@ export const resultCustomizationsModalLogic = kea<resultCustomizationsModalLogic
         closeModal: true,
 
         setColorToken: (token: DataColorToken) => ({ token }),
+        clearColorToken: true,
 
         save: true,
     }),
@@ -48,10 +54,11 @@ export const resultCustomizationsModalLogic = kea<resultCustomizationsModalLogic
             },
         ],
         localColorToken: [
-            null as DataColorToken | null,
+            undefined as DataColorToken | null | undefined,
             {
                 setColorToken: (_, { token }) => token,
-                closeModal: () => null,
+                clearColorToken: () => null,
+                closeModal: () => undefined,
             },
         ],
     }),
@@ -60,7 +67,12 @@ export const resultCustomizationsModalLogic = kea<resultCustomizationsModalLogic
         modalVisible: [(s) => [s.dataset], (dataset): boolean => dataset !== null],
         colorToken: [
             (s) => [s.localColorToken, s.colorTokenFromQuery],
-            (localColorToken, colorTokenFromQuery): DataColorToken | null => localColorToken || colorTokenFromQuery,
+            (localColorToken, colorTokenFromQuery): DataColorToken | null => {
+                if (localColorToken === undefined) {
+                    return colorTokenFromQuery
+                }
+                return localColorToken
+            },
         ],
         colorTokenFromQuery: [
             (s) => [s.isTrends, s.isStickiness, s.isFunnels, s.getTrendsColorToken, s.getFunnelsColorToken, s.dataset],
@@ -107,10 +119,12 @@ export const resultCustomizationsModalLogic = kea<resultCustomizationsModalLogic
 
     listeners(({ actions, values }) => ({
         save: () => {
-            if (values.localColorToken == null || values.dataset == null) {
+            if (values.localColorToken === undefined || values.dataset == null) {
                 actions.closeModal()
                 return
             }
+
+            const color = values.localColorToken ?? undefined
 
             if (values.isTrends || values.isStickiness) {
                 const resultCustomizationKey = getTrendResultCustomizationKey(
@@ -128,7 +142,7 @@ export const resultCustomizationsModalLogic = kea<resultCustomizationsModalLogic
                         [resultCustomizationKey]: {
                             ...resultCustomization,
                             assignmentBy: values.resultCustomizationBy,
-                            color: values.localColorToken,
+                            color,
                         },
                     },
                 } as Partial<TrendsFilter>)
@@ -136,12 +150,17 @@ export const resultCustomizationsModalLogic = kea<resultCustomizationsModalLogic
 
             if (values.isFunnels) {
                 const resultCustomizationKey = getFunnelDatasetKey(values.dataset as FlattenedFunnelStepByBreakdown)
+                const resultCustomization = getFunnelResultCustomization(
+                    values.dataset as FlattenedFunnelStepByBreakdown,
+                    values.funnelsResultCustomizations
+                )
                 actions.updateInsightFilter({
                     resultCustomizations: {
                         ...values.funnelsResultCustomizations,
                         [resultCustomizationKey]: {
+                            ...resultCustomization,
                             assignmentBy: ResultCustomizationBy.Value,
-                            color: values.localColorToken,
+                            color,
                         },
                     },
                 })

--- a/frontend/src/queries/nodes/InsightViz/resultCustomizationsModalLogic.ts
+++ b/frontend/src/queries/nodes/InsightViz/resultCustomizationsModalLogic.ts
@@ -54,11 +54,19 @@ export const resultCustomizationsModalLogic = kea<resultCustomizationsModalLogic
             },
         ],
         localColorToken: [
-            undefined as DataColorToken | null | undefined,
+            null as DataColorToken | null,
             {
                 setColorToken: (_, { token }) => token,
                 clearColorToken: () => null,
-                closeModal: () => undefined,
+                closeModal: () => null,
+            },
+        ],
+        localColorTokenTouched: [
+            false,
+            {
+                setColorToken: () => true,
+                clearColorToken: () => true,
+                closeModal: () => false,
             },
         ],
     }),
@@ -66,13 +74,9 @@ export const resultCustomizationsModalLogic = kea<resultCustomizationsModalLogic
     selectors({
         modalVisible: [(s) => [s.dataset], (dataset): boolean => dataset !== null],
         colorToken: [
-            (s) => [s.localColorToken, s.colorTokenFromQuery],
-            (localColorToken, colorTokenFromQuery): DataColorToken | null => {
-                if (localColorToken === undefined) {
-                    return colorTokenFromQuery
-                }
-                return localColorToken
-            },
+            (s) => [s.localColorToken, s.localColorTokenTouched, s.colorTokenFromQuery],
+            (localColorToken, localColorTokenTouched, colorTokenFromQuery): DataColorToken | null =>
+                localColorTokenTouched ? localColorToken : colorTokenFromQuery,
         ],
         colorTokenFromQuery: [
             (s) => [s.isTrends, s.isStickiness, s.isFunnels, s.getTrendsColorToken, s.getFunnelsColorToken, s.dataset],
@@ -119,7 +123,7 @@ export const resultCustomizationsModalLogic = kea<resultCustomizationsModalLogic
 
     listeners(({ actions, values }) => ({
         save: () => {
-            if (values.localColorToken === undefined || values.dataset == null) {
+            if (!values.localColorTokenTouched || values.dataset == null) {
                 actions.closeModal()
                 return
             }


### PR DESCRIPTION
## Problem

Insight result customizations (Trends/Stickiness/Funnels) and SQL DataVisualization breakdown series both let users assign a color override per series/breakdown, but the UI offered no way to **remove** an override once set — picking a color was a one-way door. To revert, users had to delete the insight or fall back to manually choosing the palette default, which depends on series position.

The data model already supports an "unset" state (`ResultCustomizationBase.color` is optional), so this is purely a UI gap.

## Changes

- **`ResultCustomizationsModal`** (Trends/Stickiness/Funnels): swapped the hand-rolled color swatch grid for the shared `LemonColorList`, which renders a "No color" clear swatch as the first item when `onClearColorToken` is wired up.
- **`resultCustomizationsModalLogic`**:
  - new `clearColorToken` action.
  - `localColorToken` is now tri-state — `undefined` (untouched, skip save), `null` (explicitly cleared, write `color: undefined`), or a token (picked).
  - `colorToken` selector only falls through to the query's existing color when the user has not interacted with the picker.
  - the funnels save path now spreads the existing customization so a `hidden` flag is preserved alongside a color change (parity with the trends path).
- **`SeriesTab.BreakdownSeries`** (SQL DataVisualization): wired `onClearColorToken` on the inline breakdown picker — clearing removes that breakdown's entry from `chartSettings.resultCustomizations`.

## How did you test this code?

I'm an agent. I did not run the dev server or click through the UI in a browser. No automated tests were added or run locally because the frontend `node_modules` aren't installed in my sandbox (so `kea-typegen` and `tsc` can't run against the new `clearColorToken` action). Reviewers should run `pnpm --filter=@posthog/frontend typegen:write` followed by `pnpm --filter=@posthog/frontend typescript:check`, then verify manually:

- Trends/Stickiness: open the result customizations modal from the Color column, pick a color, save, reopen → confirm the existing color is highlighted. Click "No color" → save → the chart/table reverts to the default palette color for that series; reopening the modal shows "No color" as the selected swatch.
- Funnels: same as above, plus set `hidden` on a step, clear the color, confirm `hidden` is preserved after save.
- SQL DataVisualization with a series breakdown: pick a color on a breakdown value, then click "No color" — the series reverts to the default palette color and the entry is removed from `chartSettings.resultCustomizations`.

## Publish to changelog?

no

## Docs update

No docs change needed — this is a small UX affordance addition to an existing picker.

## 🤖 Agent context

Tool: PostHog Code (Claude Code, Opus 4.7).

Approach: the shared `LemonColorList` / `LemonColorPicker` components already accept `onClearColorToken` and render a "No color" swatch when it's passed — neither of the two call sites had it wired up. The Trends/Funnels modal previously iterated `LemonColorButton`s by hand, so the simplest fix was to switch it to `LemonColorList` rather than duplicate the clear logic.

For the modal's kea logic, the existing `save` listener treated `localColorToken == null` as "the user didn't interact, do nothing", which made a literal `null` indistinguishable from "untouched". The reducer was widened to `DataColorToken | null | undefined` so the three states stay disjoint, and the save listener was rewritten around `undefined`-means-untouched. I also noticed the funnels save branch didn't preserve other customization fields (e.g. `hidden`) the way the trends branch does, and folded that fix into the same change since it would otherwise be regressed by anyone clearing a color on a hidden funnel step.

Scope decision (confirmed with the requester): the Y-series raw-hex picker in `YSeriesDisplayTab` was left alone — only the token-based pickers that drive `resultCustomizations` were updated.