### PR TITLE
feat(alerts): add every_15_minutes interval schema and model

### DIFF
--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -58,6 +58,7 @@ export function canCheckOngoingInterval(alert?: AlertType | AlertFormType): bool
 
 export function getDefaultSimulationRange(interval: AlertCalculationInterval): string {
     switch (interval) {
+        case AlertCalculationInterval.EVERY_15_MINUTES:
         case AlertCalculationInterval.HOURLY:
             return '-48h'
         case AlertCalculationInterval.DAILY:
@@ -242,9 +243,10 @@ export const alertFormLogic = kea<alertFormLogicType>([
                     ...alert,
                     subscribed_users: alert.subscribed_users?.map(({ id }) => id),
                     insight: props.insightId,
-                    // can only skip weekends for hourly/daily alerts
+                    // can only skip weekends for sub-daily alerts
                     skip_weekend:
-                        (alert.calculation_interval === AlertCalculationInterval.DAILY ||
+                        (alert.calculation_interval === AlertCalculationInterval.EVERY_15_MINUTES ||
+                            alert.calculation_interval === AlertCalculationInterval.DAILY ||
                             alert.calculation_interval === AlertCalculationInterval.HOURLY) &&
                         alert.skip_weekend,
                     // can only check ongoing interval for absolute value/increase alerts with upper threshold

--- a/frontend/src/lib/components/Alerts/views/DetectorSelector.tsx
+++ b/frontend/src/lib/components/Alerts/views/DetectorSelector.tsx
@@ -28,9 +28,11 @@ import {
 const DEFAULT_THRESHOLD = 0.95
 
 /** Default window size based on how often the alert checks.
- *  Hourly: 168 (7 days), Daily: 90, Weekly: 26 (6 months), Monthly: 12 (1 year). */
+ *  Every 15 minutes: 672 (7 days), Hourly: 168 (7 days), Daily: 90, Weekly: 26 (6 months), Monthly: 12 (1 year). */
 export function getDefaultWindow(interval?: AlertCalculationInterval): number {
     switch (interval) {
+        case AlertCalculationInterval.EVERY_15_MINUTES:
+            return 672
         case AlertCalculationInterval.HOURLY:
             return 168
         case AlertCalculationInterval.WEEKLY:

--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -52,6 +52,7 @@ import { SimulationSummary } from './SimulationSummary'
 
 function getSimulationRangeOptions(interval: AlertCalculationInterval): { label: string; value: string }[] {
     switch (interval) {
+        case AlertCalculationInterval.EVERY_15_MINUTES:
         case AlertCalculationInterval.HOURLY:
             return [
                 { label: 'Last 24h', value: '-24h' },
@@ -84,6 +85,8 @@ function getSimulationRangeOptions(interval: AlertCalculationInterval): { label:
 
 function alertCalculationIntervalToLabel(interval: AlertCalculationInterval): string {
     switch (interval) {
+        case AlertCalculationInterval.EVERY_15_MINUTES:
+            return '15 minutes'
         case AlertCalculationInterval.HOURLY:
             return 'hour'
         case AlertCalculationInterval.DAILY:
@@ -209,7 +212,8 @@ export function EditAlertModal({
             n += 1
         }
         if (
-            (alertForm.calculation_interval === AlertCalculationInterval.DAILY ||
+            (alertForm.calculation_interval === AlertCalculationInterval.EVERY_15_MINUTES ||
+                alertForm.calculation_interval === AlertCalculationInterval.DAILY ||
                 alertForm.calculation_interval === AlertCalculationInterval.HOURLY) &&
             alertForm.skip_weekend
         ) {
@@ -769,7 +773,9 @@ export function EditAlertModal({
                                                         <LemonCheckbox
                                                             checked={
                                                                 (alertForm?.calculation_interval ===
-                                                                    AlertCalculationInterval.DAILY ||
+                                                                    AlertCalculationInterval.EVERY_15_MINUTES ||
+                                                                    alertForm?.calculation_interval ===
+                                                                        AlertCalculationInterval.DAILY ||
                                                                     alertForm?.calculation_interval ===
                                                                         AlertCalculationInterval.HOURLY) &&
                                                                 alertForm?.skip_weekend
@@ -779,10 +785,12 @@ export function EditAlertModal({
                                                             label="Skip checking on weekends"
                                                             disabledReason={
                                                                 alertForm?.calculation_interval !==
+                                                                    AlertCalculationInterval.EVERY_15_MINUTES &&
+                                                                alertForm?.calculation_interval !==
                                                                     AlertCalculationInterval.DAILY &&
                                                                 alertForm?.calculation_interval !==
                                                                     AlertCalculationInterval.HOURLY &&
-                                                                'Can only skip weekend checking for hourly/daily alerts'
+                                                                'Can only skip weekend checking for 15-minute, hourly, or daily alerts'
                                                             }
                                                         />
                                                     </LemonField>

--- a/frontend/src/lib/components/Alerts/views/QuietHoursFields.tsx
+++ b/frontend/src/lib/components/Alerts/views/QuietHoursFields.tsx
@@ -86,13 +86,14 @@ export function QuietHoursFields({
     )
 
     const nonHourlyInterval =
-        calculationInterval !== AlertCalculationInterval.HOURLY
-            ? calculationInterval === AlertCalculationInterval.DAILY
-                ? 'day'
-                : calculationInterval === AlertCalculationInterval.WEEKLY
-                  ? 'week'
-                  : 'month'
-            : null
+        calculationInterval === AlertCalculationInterval.EVERY_15_MINUTES ||
+        calculationInterval === AlertCalculationInterval.HOURLY
+            ? null
+            : calculationInterval === AlertCalculationInterval.DAILY
+              ? 'day'
+              : calculationInterval === AlertCalculationInterval.WEEKLY
+                ? 'week'
+                : 'month'
 
     const atWindowLimit = windows.length >= MAX_BLOCKED_WINDOWS
     const addWindowButtonLabel = atWindowLimit ? `Maximum of ${MAX_BLOCKED_WINDOWS} time windows` : 'Add time window'
@@ -120,7 +121,8 @@ export function QuietHoursFields({
                             Preset: overnight (10pm–7am)
                         </LemonButton>
                     </div>
-                    {calculationInterval === AlertCalculationInterval.HOURLY &&
+                    {(calculationInterval === AlertCalculationInterval.EVERY_15_MINUTES ||
+                        calculationInterval === AlertCalculationInterval.HOURLY) &&
                     hourlyApprox != null &&
                     hourlyApprox < 24 ? (
                         <div className="text-muted text-sm">

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -229,8 +229,9 @@ export const FEATURE_FLAGS = {
     ACTION_REFERENCE_COUNT: 'action-reference-count', // owner: @andyzzhao #team-product-analytics, gates bulk action reference counting on actions list
     ADVANCE_MARKETING_ANALYTICS_SETTINGS: 'advance-marketing-analytics-settings', // owner: @jabahamondes  #team-web-analytics
     AI_EVENTS_TABLE_ROLLOUT: 'ai-events-table-rollout', // owner: #team-llm-analytics, gates reads off the dedicated ai_events table
-    ALERTS_ANOMALY_DETECTION: 'alerts-anomaly-detection', // owner: @andrewm4894
     /** Alert edit modal: check history chart + chart/table toggle (table remains when off). */
+    ALERTS_15_MINUTE_INTERVAL: 'alerts-15-minute-interval', // owner: #team-analytics-platform, gates 15-minute insight alert interval
+    ALERTS_ANOMALY_DETECTION: 'alerts-anomaly-detection', // owner: @andrewm4894
     ALERTS_HISTORY_CHART: 'alerts-history-chart', // owner: #team-analytics-platform
     ALERTS_INLINE_NOTIFICATIONS: 'alerts-inline-notifications', // owner: @vdekrijger
     ALERTS_INVESTIGATION_AGENT: 'alerts-investigation-agent', // owner: @andrewm4894, anomaly alerts — investigation agent on firing

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -421,7 +421,7 @@
             "type": "string"
         },
         "AlertCalculationInterval": {
-            "enum": ["hourly", "daily", "weekly", "monthly"],
+            "enum": ["every_15_minutes", "hourly", "daily", "weekly", "monthly"],
             "type": "string"
         },
         "AlertCondition": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -4322,6 +4322,7 @@ export enum AlertState {
 }
 
 export enum AlertCalculationInterval {
+    EVERY_15_MINUTES = 'every_15_minutes',
     HOURLY = 'hourly',
     DAILY = 'daily',
     WEEKLY = 'weekly',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -205,6 +205,7 @@ export enum AvailableFeature {
     AUTOMATIC_PROVISIONING = 'automatic_provisioning',
     MANAGED_REVERSE_PROXY = 'managed_reverse_proxy',
     ALERTS = 'alerts',
+    HIGH_FREQUENCY_ALERTS = 'high_frequency_alerts',
     DATA_COLOR_THEMES = 'data_color_themes',
     ORGANIZATION_INVITE_SETTINGS = 'organization_invite_settings',
     ORGANIZATION_SECURITY_SETTINGS = 'organization_security_settings',

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -38,6 +38,7 @@ class AvailableFeature(StrEnum):
     MANAGED_REVERSE_PROXY = "managed_reverse_proxy"
     DATA_PIPELINES = "data_pipelines"
     ALERTS = "alerts"
+    HIGH_FREQUENCY_ALERTS = "high_frequency_alerts"
     DATA_COLOR_THEMES = "data_color_themes"
     API_QUERIES_CONCURRENCY = "api_queries_concurrency"
     ORGANIZATION_INVITE_SETTINGS = "organization_invite_settings"
@@ -315,6 +316,7 @@ PRODUCT_TOUR_TARGETING_FLAG_PREFIX = "product-tour-targeting-"
 # Server-side evaluation via posthoganalytics; keep in sync with frontend FEATURE_FLAGS.
 HACKATHONS_SUBSCRIPTIONS_FEATURE_FLAG_KEY = "hackathons_subscriptions"
 SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY = "subscription-ai-summary-prompt-guide"
+ALERTS_15_MINUTE_INTERVAL_FEATURE_FLAG_KEY = "alerts-15-minute-interval"
 EXPERIMENTS_SYNC_QUERIES_FEATURE_FLAG_KEY = "experiments-sync-queries"
 GENERATED_DASHBOARD_PREFIX = "Generated Dashboard"
 

--- a/posthog/migrations/1164_alter_alertconfiguration_calculation_interval.py
+++ b/posthog/migrations/1164_alter_alertconfiguration_calculation_interval.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+import posthog.schema
+
+
+class Migration(migrations.Migration):
+    dependencies = [("posthog", "1163_alter_batchexportrun_batch_export_and_more")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="alertconfiguration",
+            name="calculation_interval",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    (posthog.schema.AlertCalculationInterval["EVERY_15_MINUTES"], "every_15_minutes"),
+                    (posthog.schema.AlertCalculationInterval["HOURLY"], "hourly"),
+                    (posthog.schema.AlertCalculationInterval["DAILY"], "daily"),
+                    (posthog.schema.AlertCalculationInterval["WEEKLY"], "weekly"),
+                    (posthog.schema.AlertCalculationInterval["MONTHLY"], "monthly"),
+                ],
+                default=posthog.schema.AlertCalculationInterval["DAILY"],
+                max_length=20,
+                null=True,
+            ),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1163_alter_batchexportrun_batch_export_and_more
+1164_alter_alertconfiguration_calculation_interval

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -118,13 +118,14 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
 
     # how often to recalculate the alert
     CALCULATION_INTERVAL_CHOICES = [
+        (AlertCalculationInterval.EVERY_15_MINUTES, AlertCalculationInterval.EVERY_15_MINUTES.value),
         (AlertCalculationInterval.HOURLY, AlertCalculationInterval.HOURLY.value),
         (AlertCalculationInterval.DAILY, AlertCalculationInterval.DAILY.value),
         (AlertCalculationInterval.WEEKLY, AlertCalculationInterval.WEEKLY.value),
         (AlertCalculationInterval.MONTHLY, AlertCalculationInterval.MONTHLY.value),
     ]
     calculation_interval = models.CharField(
-        max_length=10,
+        max_length=20,
         choices=CALCULATION_INTERVAL_CHOICES,
         default=AlertCalculationInterval.DAILY,
         null=True,
@@ -250,6 +251,7 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
             "alert_name": self.name,
             "condition_type": self.condition.get("type") if self.condition else None,
             "calculation_interval": self.calculation_interval,
+            "is_high_frequency_interval": self.calculation_interval == AlertCalculationInterval.EVERY_15_MINUTES,
             "enabled": self.enabled,
             "skip_weekend": bool(self.skip_weekend),
             "has_schedule_restriction": has_schedule_restriction,
@@ -293,6 +295,10 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
                 return f"Your plan is limited to {cls.ALERTS_ALLOWED_ON_FREE_TIER} alerts."
 
         return None
+
+    @classmethod
+    def supports_high_frequency_intervals(cls, organization: Organization) -> bool:
+        return organization.is_feature_available(AvailableFeature.HIGH_FREQUENCY_ALERTS)
 
 
 class AlertSubscription(ModelActivityMixin, CreatedMetaFields, UUIDTModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -63,6 +63,7 @@ class AggregationAxisFormat(StrEnum):
 
 
 class AlertCalculationInterval(StrEnum):
+    EVERY_15_MINUTES = "every_15_minutes"
     HOURLY = "hourly"
     DAILY = "daily"
     WEEKLY = "weekly"

--- a/posthog/temporal/alerts/schedule.py
+++ b/posthog/temporal/alerts/schedule.py
@@ -25,7 +25,7 @@ async def create_schedule_due_alert_checks_schedule(client: Client) -> None:
             task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
             execution_timeout=dt.timedelta(minutes=10),
         ),
-        spec=ScheduleSpec(cron_expressions=["*/2 * * * *"]),
+        spec=ScheduleSpec(cron_expressions=["*/1 * * * *"]),
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),
     )
 
@@ -49,7 +49,7 @@ async def create_run_investigation_safety_net_schedule(client: Client) -> None:
             task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
             execution_timeout=dt.timedelta(minutes=5),
         ),
-        spec=ScheduleSpec(cron_expressions=["*/2 * * * *"]),
+        spec=ScheduleSpec(cron_expressions=["*/1 * * * *"]),
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -381,7 +381,8 @@ export type DetectorConfigApi =
     | PCADetectorConfigApi
 
 /**
- * * `hourly` - hourly
+ * * `every_15_minutes` - every_15_minutes
+ * `hourly` - hourly
  * `daily` - daily
  * `weekly` - weekly
  * `monthly` - monthly
@@ -389,6 +390,7 @@ export type DetectorConfigApi =
 export type CalculationIntervalEnumApi = (typeof CalculationIntervalEnumApi)[keyof typeof CalculationIntervalEnumApi]
 
 export const CalculationIntervalEnumApi = {
+    Every15Minutes: 'every_15_minutes',
     Hourly: 'hourly',
     Daily: 'daily',
     Weekly: 'weekly',
@@ -455,6 +457,7 @@ export interface AlertApi {
     detector_config?: DetectorConfigApi | null
     /** How often the alert is checked: hourly, daily, weekly, or monthly.
 
+  * `every_15_minutes` - every_15_minutes
   * `hourly` - hourly
   * `daily` - daily
   * `weekly` - weekly
@@ -533,6 +536,7 @@ export interface PatchedAlertApi {
     detector_config?: DetectorConfigApi | null
     /** How often the alert is checked: hourly, daily, weekly, or monthly.
 
+  * `every_15_minutes` - every_15_minutes
   * `hourly` - hourly
   * `daily` - daily
   * `weekly` - weekly

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3955,7 +3955,8 @@ export namespace Schemas {
     export type DetectorConfig = EnsembleDetectorConfig | ZScoreDetectorConfig | MADDetectorConfig | IQRDetectorConfig | ThresholdDetectorConfig | ECODDetectorConfig | COPODDetectorConfig | IsolationForestDetectorConfig | KNNDetectorConfig | HBOSDetectorConfig | LOFDetectorConfig | OCSVMDetectorConfig | PCADetectorConfig;
 
     /**
-     * * `hourly` - hourly
+     * * `every_15_minutes` - every_15_minutes
+    * `hourly` - hourly
     * `daily` - daily
     * `weekly` - weekly
     * `monthly` - monthly
@@ -3964,6 +3965,7 @@ export namespace Schemas {
 
 
     export const CalculationIntervalEnum = {
+      Every15Minutes: 'every_15_minutes',
       Hourly: 'hourly',
       Daily: 'daily',
       Weekly: 'weekly',
@@ -4030,6 +4032,7 @@ export namespace Schemas {
       detector_config?: DetectorConfig | null;
       /** How often the alert is checked: hourly, daily, weekly, or monthly.
 
+      * `every_15_minutes` - every_15_minutes
       * `hourly` - hourly
       * `daily` - daily
       * `weekly` - weekly
@@ -25485,6 +25488,7 @@ export namespace Schemas {
       detector_config?: DetectorConfig | null;
       /** How often the alert is checked: hourly, daily, weekly, or monthly.
 
+      * `every_15_minutes` - every_15_minutes
       * `hourly` - hourly
       * `daily` - daily
       * `weekly` - weekly

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -1477,11 +1477,13 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     calculation_interval: zod
-        .enum(['hourly', 'daily', 'weekly', 'monthly'])
-        .describe('* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly')
+        .enum(['every_15_minutes', 'hourly', 'daily', 'weekly', 'monthly'])
+        .describe(
+            '* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
+        )
         .optional()
         .describe(
-            'How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
+            'How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),
     snoozed_until: zod
         .string()
@@ -3136,11 +3138,13 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     calculation_interval: zod
-        .enum(['hourly', 'daily', 'weekly', 'monthly'])
-        .describe('* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly')
+        .enum(['every_15_minutes', 'hourly', 'daily', 'weekly', 'monthly'])
+        .describe(
+            '* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
+        )
         .optional()
         .describe(
-            'How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
+            'How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),
     snoozed_until: zod
         .string()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-create.json
@@ -2,8 +2,8 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
-            "enum": ["hourly", "daily", "weekly", "monthly"],
+            "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
+            "enum": ["every_15_minutes", "hourly", "daily", "weekly", "monthly"],
             "type": "string"
         },
         "condition": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-update.json
@@ -2,8 +2,8 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
-            "enum": ["hourly", "daily", "weekly", "monthly"],
+            "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
+            "enum": ["every_15_minutes", "hourly", "daily", "weekly", "monthly"],
             "type": "string"
         },
         "condition": {


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

- Want to allow more fined tuned runs for alerts, going down to 15 minutes. Currently p99 run times are at 60s (last I checked with Vasco) so we have lots of leeway to allow more frequent runs without worrying about performance issues.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- DB change to allow 15 min runs on the schema side

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Locally

## Publish to changelog?

No.

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->