### PR TITLE
feat(lemmon ui): add disabled reason to the LemonSlider component.

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2980,6 +2980,10 @@ snapshots:
         hash: v1.k794b7964.55f0a8aa301c8c6c826f0381963ab22bf29ef293a52ea4866820414e3ae05afa.iVkEzxCk5LWW7bIo474oOPSED1OAlH3JQyADEopMY2M
     lemon-ui-lemon-slider--basic--light:
         hash: v1.k794b7964.3ce7063df047bab335eba869c449700d362e04f738a6f41c5d210eb0a0c28743.U3LD4dMe2t6xo8JJ8jHgIERa8GEUm6fKsYCZzoKRfHA
+    lemon-ui-lemon-slider--disabled--dark:
+        hash: v1.k794b7964.763c670c8ce084abd3ef04254c15f33b5d1971da62cb10152586b810af33ee3e.BcITfcCY7uAnH1Onvk9e_27j_CPNygvCdm9In-lYRa8
+    lemon-ui-lemon-slider--disabled--light:
+        hash: v1.k794b7964.734b67b36e0186e82672812d2790304c16c06ffa7d7e20d875179191e8eb4109.i-cHQxeZsr8bheJ87NLn6kPaulHFf9YxUyptuzjhcL4
     lemon-ui-lemon-snack--complex-content--dark:
         hash: v1.k794b7964.5bf965af252a4536412c245ca8b02a1c386389df8f962bc88ec01ce60f246cda.VH1M28qY61gkbj0BWKpTi3fVOAApzwUvZ91au4cpai4
     lemon-ui-lemon-snack--complex-content--light:

--- a/frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.stories.tsx
@@ -23,3 +23,18 @@ export function Basic(): JSX.Element {
         </>
     )
 }
+
+export function Disabled(): JSX.Element {
+    const [value, setValue] = useState(42)
+
+    return (
+        <LemonSlider
+            value={value}
+            min={0}
+            max={100}
+            step={1}
+            onChange={setValue}
+            disabledReason="You don't have permission to change this value"
+        />
+    )
+}

--- a/frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx'
 import { useRef, useState } from 'react'
 
+import { Tooltip } from '@posthog/lemon-ui'
+
 import { useEventListener } from 'lib/hooks/useEventListener'
 
 export interface LemonSliderTick {
@@ -18,6 +20,8 @@ export interface LemonSliderProps {
     className?: string
     /** Optional tick marks with labels that can be clicked to jump to that value */
     ticks?: LemonSliderTick[]
+    /** Reason the slider is disabled - shown in a tooltip. */
+    disabledReason?: React.ReactNode | null | false
 }
 
 export function LemonSlider({
@@ -28,7 +32,9 @@ export function LemonSlider({
     step = 1,
     className,
     ticks,
+    disabledReason,
 }: LemonSliderProps): JSX.Element {
+    const isDisabled = !!disabledReason
     const trackRef = useRef<HTMLDivElement>(null)
     const movementStartValueWithX = useRef<[number, number] | null>(null)
     const [dragging, setDragging] = useState(false)
@@ -113,87 +119,107 @@ export function LemonSlider({
     const proportion = isNaN(value) ? 0 : Math.round(((constrainedValue - min) / (max - min)) * 100) / 100
 
     return (
-        <div className={clsx('select-none', ticks ? 'pb-5' : '', className)}>
-            <div className="flex items-center relative my-2.5 min-w-16">
-                <div
-                    className="w-full h-3 flex items-center cursor-pointer"
-                    ref={trackRef}
-                    onMouseDown={(e) => {
-                        const rect = e.currentTarget.getBoundingClientRect()
-                        const x = e.clientX - (rect.left + 8) // 4px = half the handle
-                        const adjustedWidth = rect.width - 16 // 8px = handle width
-                        let newValue = (x / adjustedWidth) * (max - min) + min
-                        newValue = Math.max(min, Math.min(max, newValue)) // Clamped
-                        if (step !== undefined) {
-                            newValue = Math.round(newValue / step) * step // Adjusted to step
+        <Tooltip title={disabledReason ?? undefined}>
+            <div className={clsx('select-none', ticks ? 'pb-5' : '', isDisabled && 'opacity-50', className)}>
+                <div className="flex items-center relative my-2.5 min-w-16">
+                    <div
+                        className={clsx(
+                            'w-full h-3 flex items-center',
+                            isDisabled ? 'cursor-not-allowed' : 'cursor-pointer'
+                        )}
+                        ref={trackRef}
+                        onMouseDown={
+                            isDisabled
+                                ? undefined
+                                : (e) => {
+                                      const rect = e.currentTarget.getBoundingClientRect()
+                                      const x = e.clientX - (rect.left + 8) // 4px = half the handle
+                                      const adjustedWidth = rect.width - 16 // 8px = handle width
+                                      let newValue = (x / adjustedWidth) * (max - min) + min
+                                      newValue = Math.max(min, Math.min(max, newValue)) // Clamped
+                                      if (step !== undefined) {
+                                          newValue = Math.round(newValue / step) * step // Adjusted to step
+                                      }
+                                      onChange?.(newValue)
+                                      movementStartValueWithX.current = [newValue, e.clientX]
+                                      setDragging(true)
+                                  }
                         }
-                        onChange?.(newValue)
-                        movementStartValueWithX.current = [newValue, e.clientX]
-                        setDragging(true)
-                    }}
-                >
-                    <div className="w-full bg-fill-slider-rail rounded-full h-[6px]" />
-                </div>
-                <div
-                    className="absolute h-[6px] bg-accent rounded-full pointer-events-none"
-                    // eslint-disable-next-line react/forbid-dom-props
-                    style={{ width: `${proportion * 100}%` }}
-                />
-                <button
-                    className={clsx(
-                        'absolute size-3 box-content border-2 border-primary rounded-full cursor-pointer bg-accent transition-shadow duration-75',
-                        dragging ? 'ring-2 scale-90' : 'ring-0 hover:ring-2 focus:ring-2'
-                    )}
-                    // eslint-disable-next-line react/forbid-dom-props
-                    style={{
-                        left: `calc(${proportion * 100}% - ${proportion}rem)`,
-                    }}
-                    role="slider"
-                    type="button"
-                    aria-valuemin={min}
-                    aria-valuemax={max}
-                    aria-valuenow={constrainedValue}
-                    aria-label={`Slider value: ${constrainedValue}`}
-                    aria-valuetext={`${constrainedValue}`}
-                    tabIndex={0}
-                    onKeyDown={handleKeyDown}
-                    onMouseDown={(e) => {
-                        movementStartValueWithX.current = [constrainedValue, e.clientX]
-                        setDragging(true)
-                    }}
-                    onTouchStart={(e) => {
-                        movementStartValueWithX.current = [constrainedValue, e.touches[0].clientX]
-                        setDragging(true)
-                    }}
-                />
-                {/* Tick marks */}
-                {ticks && (
-                    <div className="absolute top-full left-0 right-0 mt-1">
-                        {ticks.map((tick) => {
-                            const tickProportion = (tick.value - min) / (max - min)
-                            return (
-                                <button
-                                    key={tick.value}
-                                    type="button"
-                                    className={clsx(
-                                        'absolute text-xs cursor-pointer transition-all px-1 py-0.5 -translate-x-1/2 rounded',
-                                        constrainedValue === tick.value
-                                            ? 'text-primary-3000 font-semibold bg-primary-highlight'
-                                            : 'text-muted hover:text-primary hover:bg-primary-highlight'
-                                    )}
-                                    // eslint-disable-next-line react/forbid-dom-props
-                                    style={{
-                                        left: `calc(${tickProportion * 100}% - ${tickProportion - 0.5}rem)`,
-                                    }}
-                                    onClick={() => onChange?.(tick.value)}
-                                >
-                                    {tick.label ?? tick.value}
-                                </button>
-                            )
-                        })}
+                    >
+                        <div className="w-full bg-fill-slider-rail rounded-full h-[6px]" />
                     </div>
-                )}
+                    <div
+                        className="absolute h-[6px] bg-accent rounded-full pointer-events-none"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ width: `${proportion * 100}%` }}
+                    />
+                    <button
+                        className={clsx(
+                            'absolute size-3 box-content border-2 border-primary rounded-full bg-accent transition-shadow duration-75',
+                            isDisabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                            dragging ? 'ring-2 scale-90' : isDisabled ? 'ring-0' : 'ring-0 hover:ring-2 focus:ring-2'
+                        )}
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{
+                            left: `calc(${proportion * 100}% - ${proportion}rem)`,
+                        }}
+                        role="slider"
+                        type="button"
+                        aria-valuemin={min}
+                        aria-valuemax={max}
+                        aria-valuenow={constrainedValue}
+                        aria-label={`Slider value: ${constrainedValue}`}
+                        aria-valuetext={`${constrainedValue}`}
+                        aria-disabled={isDisabled}
+                        tabIndex={isDisabled ? -1 : 0}
+                        onKeyDown={isDisabled ? undefined : handleKeyDown}
+                        onMouseDown={
+                            isDisabled
+                                ? undefined
+                                : (e) => {
+                                      movementStartValueWithX.current = [constrainedValue, e.clientX]
+                                      setDragging(true)
+                                  }
+                        }
+                        onTouchStart={
+                            isDisabled
+                                ? undefined
+                                : (e) => {
+                                      movementStartValueWithX.current = [constrainedValue, e.touches[0].clientX]
+                                      setDragging(true)
+                                  }
+                        }
+                    />
+                    {/* Tick marks */}
+                    {ticks && (
+                        <div className="absolute top-full left-0 right-0 mt-1">
+                            {ticks.map((tick) => {
+                                const tickProportion = (tick.value - min) / (max - min)
+                                return (
+                                    <button
+                                        key={tick.value}
+                                        type="button"
+                                        className={clsx(
+                                            'absolute text-xs transition-all px-1 py-0.5 -translate-x-1/2 rounded',
+                                            isDisabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                                            constrainedValue === tick.value
+                                                ? 'text-primary-3000 font-semibold bg-primary-highlight'
+                                                : 'text-muted hover:text-primary hover:bg-primary-highlight'
+                                        )}
+                                        // eslint-disable-next-line react/forbid-dom-props
+                                        style={{
+                                            left: `calc(${tickProportion * 100}% - ${tickProportion - 0.5}rem)`,
+                                        }}
+                                        onClick={isDisabled ? undefined : () => onChange?.(tick.value)}
+                                    >
+                                        {tick.label ?? tick.value}
+                                    </button>
+                                )
+                            })}
+                        </div>
+                    )}
+                </div>
             </div>
-        </div>
+        </Tooltip>
     )
 }


### PR DESCRIPTION
## Problem

The `LemonSlider` component lacked a disabled state, making it impossible to prevent interaction when users lack permission to change the value. This was needed for the experiments MDE setting, which should be admin-only.

## Changes

**`frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.tsx`**
- Added `disabledReason` prop following the pattern used by `LemonInput`.
- When disabled: reduces opacity, shows `cursor-not-allowed`, wraps in Tooltip showing the reason.
- All interaction handlers (mouse, touch, keyboard, tick clicks) are guarded.
- Added `aria-disabled` and `tabIndex={-1}` for accessibility.

**`frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.stories.tsx`**
- Added `Disabled` story demonstrating the new prop.

| disabled state |
| - |
| <img width="1028" height="202" alt="image" src="https://github.com/user-attachments/assets/503c4815-2772-4051-9065-bdbb4eb03fde" /> |

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/3d6202e8-046a-4a20-a0ec-423324f9ea02)