### PR TITLE
fix(llma): render sentiment cards with non-standard text blocks

### DIFF
--- a/products/llm_analytics/frontend/sentimentUtils.test.ts
+++ b/products/llm_analytics/frontend/sentimentUtils.test.ts
@@ -1,4 +1,11 @@
-import { buildSentimentBarTooltip, buildTagTooltip, capitalize, computeExtremes, formatScore } from './sentimentUtils'
+import {
+    buildSentimentBarTooltip,
+    buildTagTooltip,
+    capitalize,
+    computeExtremes,
+    extractContentText,
+    formatScore,
+} from './sentimentUtils'
 
 describe('sentimentUtils', () => {
     describe('capitalize', () => {
@@ -75,6 +82,50 @@ describe('sentimentUtils', () => {
             ['messages without scores', { 0: { label: 'positive' } }, { maxPositive: 0, maxNegative: 0 }],
         ] as const)('%s', (_name, messages, expected) => {
             expect(computeExtremes(messages as any)).toEqual(expected)
+        })
+    })
+
+    describe('extractContentText', () => {
+        it.each([
+            ['null', null, ''],
+            ['undefined', undefined, ''],
+            ['empty string', '', ''],
+            ['plain string', 'hello', 'hello'],
+            ['empty array', [], ''],
+            ['array of strings', ['a', 'b'], 'a b'],
+            // Anthropic-style text block
+            ['text block with type', [{ type: 'text', text: 'hello' }], 'hello'],
+            // OpenAI Responses API uses input_text / output_text — both have a `text` field.
+            // The previous implementation only looked at type='text' blocks, so these
+            // rendered as blank sentiment cards even though the backend classified them.
+            ['input_text block', [{ type: 'input_text', text: 'user said this' }], 'user said this'],
+            ['output_text block', [{ type: 'output_text', text: 'model said this' }], 'model said this'],
+            // Block with a `text` field but no recognized `type` — backend would still extract
+            // text via `_extract_content_text`, frontend must agree.
+            ['text block without type', [{ text: 'naked text' }], 'naked text'],
+            // Anthropic tool_result blocks carry the result under `content`, not `text`.
+            [
+                'tool_result-style block uses content fallback',
+                [{ type: 'tool_result', tool_use_id: 'X', content: 'fallback text' }],
+                'fallback text',
+            ],
+            // Multiple blocks join with a space.
+            [
+                'mixed text blocks join',
+                [
+                    { type: 'text', text: 'first' },
+                    { type: 'input_text', text: 'second' },
+                ],
+                'first second',
+            ],
+            // No text or content fields → empty string, signalling the call site to fall back.
+            ['image-only block', [{ type: 'image', image_url: 'data:...' }], ''],
+            ['tool_use block', [{ type: 'tool_use', id: 'X', name: 'fn' }], ''],
+            // Single-object content (not wrapped in an array) — also handled.
+            ['single object with text', { type: 'text', text: 'plain' }, 'plain'],
+            ['single object with content', { content: 'nested' }, 'nested'],
+        ] as const)('%s', (_name, content, expected) => {
+            expect(extractContentText(content)).toBe(expected)
         })
     })
 

--- a/products/llm_analytics/frontend/sentimentUtils.test.ts
+++ b/products/llm_analytics/frontend/sentimentUtils.test.ts
@@ -104,10 +104,24 @@ describe('sentimentUtils', () => {
             // text via `_extract_content_text`, frontend must agree.
             ['text block without type', [{ text: 'naked text' }], 'naked text'],
             // Anthropic tool_result blocks carry the result under `content`, not `text`.
+            // The SDK most commonly emits `content` as either a bare string or a list of
+            // typed sub-blocks, and the recursion path in `extractContentText` has to handle
+            // both so the renderer agrees with the backend classifier.
             [
-                'tool_result-style block uses content fallback',
+                'tool_result-style block with string content uses content fallback',
                 [{ type: 'tool_result', tool_use_id: 'X', content: 'fallback text' }],
                 'fallback text',
+            ],
+            [
+                'tool_result-style block with array content recurses into sub-blocks',
+                [
+                    {
+                        type: 'tool_result',
+                        tool_use_id: 'X',
+                        content: [{ type: 'text', text: 'nested result' }],
+                    },
+                ],
+                'nested result',
             ],
             // Multiple blocks join with a space.
             [

--- a/products/llm_analytics/frontend/sentimentUtils.ts
+++ b/products/llm_analytics/frontend/sentimentUtils.ts
@@ -49,8 +49,18 @@ export function computeExtremes(messages?: Record<string | number, MessageScore>
 }
 
 /**
- * Extract plain text from message content, mirroring the backend's _extract_content_text.
- * Handles string content, Anthropic-style content block arrays, and nested structures.
+ * Extract plain text from message content, mirroring the backend's `_extract_content_text`
+ * in `posthog/temporal/llm_analytics/message_utils.py`. Both sides must agree on what
+ * text exists at a given message index — otherwise the sentiment classifier labels a
+ * message that the sentiment card then renders blank.
+ *
+ * Resolution order for each block (matches the backend):
+ *   1. A `text` field — used regardless of the block's `type`, so non-standard or
+ *      missing types (`input_text`, `output_text`, no type at all, ...) still render.
+ *   2. A `content` field — recursed into so nested structures unwrap.
+ *   3. Otherwise the block has no human-readable text — skip it. The backend stringifies
+ *      unknown blocks as a last resort, but raw JSON in a sentiment card is worse than
+ *      a clean fallback indicator handled at the call site.
  */
 export function extractContentText(content: unknown): string {
     if (!content) {
@@ -66,7 +76,7 @@ export function extractContentText(content: unknown): string {
                     return block
                 }
                 if (block && typeof block === 'object') {
-                    if ('type' in block && block.type === 'text' && 'text' in block) {
+                    if ('text' in block && typeof (block as { text: unknown }).text === 'string') {
                         return (block as { text: string }).text
                     }
                     if ('content' in block) {
@@ -78,7 +88,16 @@ export function extractContentText(content: unknown): string {
             .filter(Boolean)
             .join(' ')
     }
-    return String(content)
+    if (typeof content === 'object') {
+        const obj = content as Record<string, unknown>
+        if (typeof obj.text === 'string') {
+            return obj.text
+        }
+        if ('content' in obj) {
+            return extractContentText(obj.content)
+        }
+    }
+    return ''
 }
 
 export function buildSentimentBarTooltip(

--- a/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
+++ b/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
@@ -164,6 +164,11 @@ function SentimentCardRow({
     // The classifier only sees the last CLASSIFIER_WINDOW chars — show that slice
     const classifierText = fullText.slice(-CLASSIFIER_WINDOW)
     const collapsedText = truncateMiddle(classifierText)
+    // Backend classified this message but the frontend couldn't extract human-readable text
+    // from any content block (e.g. image-only or unrecognized block shape). Surface a hint
+    // instead of an empty paragraph so the row isn't visually blank.
+    const hasText = classifierText.trim().length > 0
+    const fallbackText = '(no readable text)'
     const accentColor = SENTIMENT_BAR_COLOR[sentiment.label as SentimentLabel] ?? 'bg-border'
 
     return (
@@ -182,8 +187,10 @@ function SentimentCardRow({
                 )}
 
                 <div className="flex items-start gap-2">
-                    <p className="flex-1 min-w-0 text-sm text-default m-0 break-words leading-relaxed">
-                        {expanded ? classifierText : collapsedText}
+                    <p
+                        className={`flex-1 min-w-0 text-sm m-0 break-words leading-relaxed ${hasText ? 'text-default' : 'text-muted italic'}`}
+                    >
+                        {hasText ? (expanded ? classifierText : collapsedText) : fallbackText}
                     </p>
                     <div className="shrink-0 flex items-center gap-1">
                         {traceCount > 1 && (


### PR DESCRIPTION
## Problem

In the [LLM analytics sentiment tab](https://us.posthog.com/project/2/llm-analytics/sentiment) some cards rendered with no visible message text — the side accent, sentiment bar and score were drawn but the message preview area was empty.

Root cause: the frontend's `extractContentText` (`products/llm_analytics/frontend/sentimentUtils.ts`) and the backend's `_extract_content_text` (`posthog/temporal/llm_analytics/message_utils.py`) had drifted. The backend pulls a block's text from a `text` field _regardless of its `type`_ (and falls back to `content`). The frontend only pulled `text` when `type === 'text'` exactly. So whenever a user message contained a content block with a `text` payload but a non-`text` type (`input_text` / `output_text` from the OpenAI Responses API, blocks where the SDK omitted `type`, etc.), the backend classifier happily produced a sentiment label and message index for it, the sentiment generations endpoint surfaced the card, and then the card rendered with `classifierText === ''`.

A separate but related papercut: even when the asymmetry was legitimate (e.g. the only content block was an image with no text at all), the card just rendered an empty paragraph rather than indicating what happened, which is what made it look broken.

## Changes

- `extractContentText` now extracts `text` from a block whenever the block has a string `text` field, regardless of `type`. It still falls back to recursing into `content`, so Anthropic-style `tool_result` blocks with a string body keep working. The dead `String(content)` final branch (which would render `"[object Object]"` for non-array non-string objects) is replaced with the same text/content resolution applied to a single object, then an empty string — letting the call site render a clean fallback.
- `SentimentCardRow` now shows a muted italic `(no readable text)` placeholder when the extracted text is empty. Previously the cell was just a flex-sized empty `<p>`, which is what made the cards look blank in the screenshot. This matches the `(empty)` fallback the `ContextMessage` component already uses for the expanded context rows.
- Doc-style tests for `extractContentText` in `sentimentUtils.test.ts` lock in the new behavior across the SDK content block shapes that show up in practice (Anthropic `text` + `tool_result`, OpenAI Responses `input_text` / `output_text`, bare `text`-only blocks, and content types with no text at all).

## How did you test this code?

I'm a [PostHog Code](https://posthog.com/code) agent — I did not click through the UI. Verification was limited to the automated tests added in `sentimentUtils.test.ts` for `extractContentText` (block-shape coverage for the cases that previously rendered blank). The frontend Jest/TypeScript toolchain wasn't installed in the workspace, so they were not executed locally — they will run in CI.

Reviewers should manually open the sentiment tab on a project that has \$ai_generation events with `input_text`/`output_text` content blocks or non-text-only user messages to confirm the cards now show either the real text or the `(no readable text)` placeholder.

## Publish to changelog?

no

## Docs update

No docs change — internal sentiment tab rendering only.

## 🤖 Agent context

- Tool: PostHog Code (agent session).
- Investigation traced the screenshot through `LLMAnalyticsSentiment.tsx` → `getMessageAtIndex` → `normalizeMessages` → `getTextContent` → `extractContentText`. The asymmetry between the backend (`_extract_content_text` in `posthog/temporal/llm_analytics/message_utils.py`) and the frontend was the load-bearing finding — they disagree on what counts as "the text of message N", so the classifier and the renderer drift.
- Considered (and rejected) widening the backend stringify fallback to the frontend — surfacing raw JSON in a sentiment card is worse than a labelled placeholder, and the classifier itself benefits from the backend's existing \`if text:\` guard.
- The example URL the user shared (\`event=5d9d6bf8…&msg=32\`) points at a regular \`{"type":"text","text":"Yes please do this globally"}\` block that should render fine even before this fix — the screenshot likely contained _other_ cards from the same view that hit the asymmetry. The fix is aimed at the general case rather than that specific message.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*