### PR TITLE
feat(wizard): stream session updates via SSE

### DIFF
--- a/products/wizard/backend/facade/api.py
+++ b/products/wizard/backend/facade/api.py
@@ -8,8 +8,8 @@ dataclasses. Never return ORM instances or import DRF.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 from products.wizard.backend.facade.contracts import UpsertWizardSessionInput, WizardSessionDTO
@@ -17,12 +17,7 @@ from products.wizard.backend.logic import pubsub, sessions
 
 
 def upsert(params: UpsertWizardSessionInput) -> tuple[WizardSessionDTO, bool]:
-    """Upsert a session and report whether the row was newly created.
-
-    Returns `(dto, created)` so consumers can distinguish 201 from 200 in
-    their response semantics, and so retry-aware clients can short-circuit
-    after the first successful write.
-    """
+    """Returns `(dto, created)` so callers can pick 201 vs 200."""
     return sessions.upsert_session(params)
 
 
@@ -42,12 +37,6 @@ def list_for_team(
     offset: int = 0,
     limit: int | None = None,
 ) -> list[WizardSessionDTO]:
-    """List sessions for a team, ordered by started_at desc.
-
-    `offset`/`limit` are applied at the SQL layer; callers should pass a
-    bounded `limit` for any user-facing list endpoint so the read cost stays
-    bounded regardless of per-team row count.
-    """
     return sessions.list_sessions(
         team_id,
         workflow_id=workflow_id,
@@ -57,16 +46,15 @@ def list_for_team(
     )
 
 
-@contextmanager
-def subscribe_to_updates(
+@asynccontextmanager
+async def subscribe_to_updates(
     team_id: int,
     workflow_id: str,
     skill_id: str | None = None,
-) -> Iterator[Any]:
-    """Subscribe to wizard-session pub/sub updates for SSE fanout.
-
-    Exposed through the facade so the presentation layer doesn't import
-    from `logic` directly (enforced by import-linter).
-    """
-    with pubsub.subscribe(team_id, workflow_id, skill_id) as ps:
+) -> AsyncIterator[Any]:
+    async with pubsub.subscribe(team_id, workflow_id, skill_id) as ps:
         yield ps
+
+
+def serialize_dto(dto: WizardSessionDTO) -> bytes:
+    return pubsub.serialize_dto(dto)

--- a/products/wizard/backend/facade/api.py
+++ b/products/wizard/backend/facade/api.py
@@ -26,7 +26,7 @@ def get(team_id: int, session_id: str) -> WizardSessionDTO | None:
     return sessions.get_session(team_id, session_id)
 
 
-def get_latest(team_id: int, workflow_id: str, skill_id: str) -> WizardSessionDTO | None:
+def get_latest(team_id: int, workflow_id: str, skill_id: str | None = None) -> WizardSessionDTO | None:
     return sessions.get_latest_session(team_id, workflow_id, skill_id)
 
 

--- a/products/wizard/backend/facade/api.py
+++ b/products/wizard/backend/facade/api.py
@@ -8,8 +8,12 @@ dataclasses. Never return ORM instances or import DRF.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
 from products.wizard.backend.facade.contracts import UpsertWizardSessionInput, WizardSessionDTO
-from products.wizard.backend.logic import sessions
+from products.wizard.backend.logic import pubsub, sessions
 
 
 def upsert(params: UpsertWizardSessionInput) -> tuple[WizardSessionDTO, bool]:
@@ -51,3 +55,18 @@ def list_for_team(
         offset=offset,
         limit=limit,
     )
+
+
+@contextmanager
+def subscribe_to_updates(
+    team_id: int,
+    workflow_id: str,
+    skill_id: str | None = None,
+) -> Iterator[Any]:
+    """Subscribe to wizard-session pub/sub updates for SSE fanout.
+
+    Exposed through the facade so the presentation layer doesn't import
+    from `logic` directly (enforced by import-linter).
+    """
+    with pubsub.subscribe(team_id, workflow_id, skill_id) as ps:
+        yield ps

--- a/products/wizard/backend/logic/pubsub.py
+++ b/products/wizard/backend/logic/pubsub.py
@@ -65,7 +65,7 @@ def subscribe(team_id: int, workflow_id: str, skill_id: str) -> Iterator[Any]:
 
 
 def _json_default(value: Any) -> Any:
-    if dataclasses.is_dataclass(value):
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return dataclasses.asdict(value)
     if isinstance(value, Enum):
         return value.value

--- a/products/wizard/backend/logic/pubsub.py
+++ b/products/wizard/backend/logic/pubsub.py
@@ -17,16 +17,24 @@ from typing import Any
 from django.db import transaction
 
 import orjson
+import structlog
 
 from posthog.redis import get_client
 
 from products.wizard.backend.facade.contracts import WizardSessionDTO
+
+logger = structlog.get_logger(__name__)
 
 CHANNEL_PREFIX = "wizard_sessions"
 
 
 def channel_name(team_id: int, workflow_id: str, skill_id: str) -> str:
     return f"{CHANNEL_PREFIX}:team:{team_id}:workflow:{workflow_id}:skill:{skill_id}"
+
+
+def channel_pattern(team_id: int, workflow_id: str) -> str:
+    """Pattern for subscribing to all skills under a (team, workflow_id)."""
+    return f"{CHANNEL_PREFIX}:team:{team_id}:workflow:{workflow_id}:skill:*"
 
 
 def publish_session_update(dto: WizardSessionDTO) -> None:
@@ -38,28 +46,47 @@ def publish_session_update(dto: WizardSessionDTO) -> None:
     channel = channel_name(dto.team_id, dto.workflow_id, dto.skill_id)
 
     def _publish() -> None:
-        get_client().publish(channel, payload)
+        receivers = get_client().publish(channel, payload)
+        logger.info(
+            "wizard_sessions publish",
+            channel=channel,
+            session_id=dto.session_id,
+            run_phase=dto.run_phase.value if hasattr(dto.run_phase, "value") else str(dto.run_phase),
+            payload_bytes=len(payload),
+            receivers=receivers,
+        )
 
     transaction.on_commit(_publish)
 
 
 @contextmanager
-def subscribe(team_id: int, workflow_id: str, skill_id: str) -> Iterator[Any]:
-    """Subscribe to a wizard-session channel. Yields a pubsub object whose
-    `listen()` produces dicts with `{type, data, ...}`.
+def subscribe(team_id: int, workflow_id: str, skill_id: str | None = None) -> Iterator[Any]:
+    """Subscribe to wizard-session events.
 
-    The caller is responsible for iterating; this context manager only owns
-    the connection lifecycle.
+    If `skill_id` is provided, subscribes to the exact channel for that
+    (team, workflow, skill). If omitted, pattern-subscribes to every skill
+    under that (team, workflow). Pattern messages arrive as `{type: 'pmessage', ...}`;
+    direct messages as `{type: 'message', ...}`. Callers should accept both.
     """
     redis = get_client()
     pubsub = redis.pubsub(ignore_subscribe_messages=True)
-    channel = channel_name(team_id, workflow_id, skill_id)
-    pubsub.subscribe(channel)
+    if skill_id:
+        target = channel_name(team_id, workflow_id, skill_id)
+        pubsub.subscribe(target)
+        logger.info("wizard_sessions subscribe", channel=target)
+    else:
+        target = channel_pattern(team_id, workflow_id)
+        pubsub.psubscribe(target)
+        logger.info("wizard_sessions subscribe", pattern=target)
     try:
         yield pubsub
     finally:
+        logger.info("wizard_sessions unsubscribe", target=target)
         try:
-            pubsub.unsubscribe(channel)
+            if skill_id:
+                pubsub.unsubscribe(target)
+            else:
+                pubsub.punsubscribe(target)
         finally:
             pubsub.close()
 

--- a/products/wizard/backend/logic/pubsub.py
+++ b/products/wizard/backend/logic/pubsub.py
@@ -1,0 +1,74 @@
+"""
+Redis pub/sub fanout for wizard session updates.
+
+Publish happens inside `transaction.on_commit` so subscribers never see
+uncommitted state. Subscribers (SSE endpoint) consume via `subscribe()`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from django.db import transaction
+
+import orjson
+
+from posthog.redis import get_client
+
+from products.wizard.backend.facade.contracts import WizardSessionDTO
+
+CHANNEL_PREFIX = "wizard_sessions"
+
+
+def channel_name(team_id: int, workflow_id: str, skill_id: str) -> str:
+    return f"{CHANNEL_PREFIX}:team:{team_id}:workflow:{workflow_id}:skill:{skill_id}"
+
+
+def publish_session_update(dto: WizardSessionDTO) -> None:
+    """Schedule a Redis publish for after the current transaction commits.
+
+    Safe to call outside a transaction (publishes immediately).
+    """
+    payload = orjson.dumps(dto, default=_json_default)
+    channel = channel_name(dto.team_id, dto.workflow_id, dto.skill_id)
+
+    def _publish() -> None:
+        get_client().publish(channel, payload)
+
+    transaction.on_commit(_publish)
+
+
+@contextmanager
+def subscribe(team_id: int, workflow_id: str, skill_id: str) -> Iterator[Any]:
+    """Subscribe to a wizard-session channel. Yields a pubsub object whose
+    `listen()` produces dicts with `{type, data, ...}`.
+
+    The caller is responsible for iterating; this context manager only owns
+    the connection lifecycle.
+    """
+    redis = get_client()
+    pubsub = redis.pubsub(ignore_subscribe_messages=True)
+    channel = channel_name(team_id, workflow_id, skill_id)
+    pubsub.subscribe(channel)
+    try:
+        yield pubsub
+    finally:
+        try:
+            pubsub.unsubscribe(channel)
+        finally:
+            pubsub.close()
+
+
+def _json_default(value: Any) -> Any:
+    if dataclasses.is_dataclass(value):
+        return dataclasses.asdict(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")

--- a/products/wizard/backend/logic/pubsub.py
+++ b/products/wizard/backend/logic/pubsub.py
@@ -2,14 +2,17 @@
 Redis pub/sub fanout for wizard session updates.
 
 Publish happens inside `transaction.on_commit` so subscribers never see
-uncommitted state. Subscribers (SSE endpoint) consume via `subscribe()`.
+uncommitted state. Subscribers (SSE endpoint) use the async client so each
+idle connection is a coroutine on the event loop, not a thread pinning the
+asgiref pool.
 """
 
 from __future__ import annotations
 
+import re
 import dataclasses
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime
 from enum import Enum
 from typing import Any
@@ -19,7 +22,7 @@ from django.db import transaction
 import orjson
 import structlog
 
-from posthog.redis import get_client
+from posthog.redis import get_async_client, get_client
 
 from products.wizard.backend.facade.contracts import WizardSessionDTO
 
@@ -27,31 +30,57 @@ logger = structlog.get_logger(__name__)
 
 CHANNEL_PREFIX = "wizard_sessions"
 
+# workflow_id / skill_id appear unescaped in Redis channel names / patterns;
+# reject anything that could be a glob metacharacter (`*?[]\`) or the `:` delimiter.
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_.\-]{1,255}$")
+
+
+def _validate_id(value: str, name: str) -> None:
+    if not _SAFE_ID_RE.match(value):
+        raise ValueError(f"{name} must match {_SAFE_ID_RE.pattern}; got {value!r}")
+
 
 def channel_name(team_id: int, workflow_id: str, skill_id: str) -> str:
+    _validate_id(workflow_id, "workflow_id")
+    _validate_id(skill_id, "skill_id")
     return f"{CHANNEL_PREFIX}:team:{team_id}:workflow:{workflow_id}:skill:{skill_id}"
 
 
 def channel_pattern(team_id: int, workflow_id: str) -> str:
     """Pattern for subscribing to all skills under a (team, workflow_id)."""
+    _validate_id(workflow_id, "workflow_id")
     return f"{CHANNEL_PREFIX}:team:{team_id}:workflow:{workflow_id}:skill:*"
 
 
-def publish_session_update(dto: WizardSessionDTO) -> None:
-    """Schedule a Redis publish for after the current transaction commits.
+def serialize_dto(dto: WizardSessionDTO) -> bytes:
+    return orjson.dumps(dto, default=_json_default)
 
-    Safe to call outside a transaction (publishes immediately).
+
+def publish_session_update(dto: WizardSessionDTO) -> None:
+    """Schedule a Redis publish after the current transaction commits.
+
+    Publish failures are logged and swallowed — fanout is best-effort and
+    must not fail the already-committed upsert.
     """
-    payload = orjson.dumps(dto, default=_json_default)
+    payload = serialize_dto(dto)
     channel = channel_name(dto.team_id, dto.workflow_id, dto.skill_id)
 
     def _publish() -> None:
-        receivers = get_client().publish(channel, payload)
-        logger.info(
+        try:
+            receivers = get_client().publish(channel, payload)
+        except Exception:
+            logger.exception(
+                "wizard_sessions publish failed",
+                channel=channel,
+                session_id=dto.session_id,
+                payload_bytes=len(payload),
+            )
+            return
+        logger.debug(
             "wizard_sessions publish",
             channel=channel,
             session_id=dto.session_id,
-            run_phase=dto.run_phase.value if hasattr(dto.run_phase, "value") else str(dto.run_phase),
+            run_phase=dto.run_phase.value,
             payload_bytes=len(payload),
             receivers=receivers,
         )
@@ -59,36 +88,50 @@ def publish_session_update(dto: WizardSessionDTO) -> None:
     transaction.on_commit(_publish)
 
 
-@contextmanager
-def subscribe(team_id: int, workflow_id: str, skill_id: str | None = None) -> Iterator[Any]:
+@asynccontextmanager
+async def subscribe(team_id: int, workflow_id: str, skill_id: str | None = None) -> AsyncIterator[Any]:
     """Subscribe to wizard-session events.
 
-    If `skill_id` is provided, subscribes to the exact channel for that
-    (team, workflow, skill). If omitted, pattern-subscribes to every skill
-    under that (team, workflow). Pattern messages arrive as `{type: 'pmessage', ...}`;
-    direct messages as `{type: 'message', ...}`. Callers should accept both.
+    With `skill_id`, subscribes to the exact `(team, workflow, skill)` channel.
+    Without it, pattern-subscribes to every skill under `(team, workflow)`;
+    messages arrive as `{type: 'pmessage', ...}` instead of `{type: 'message'}`.
     """
-    redis = get_client()
-    pubsub = redis.pubsub(ignore_subscribe_messages=True)
-    if skill_id:
+    if skill_id is not None:
         target = channel_name(team_id, workflow_id, skill_id)
-        pubsub.subscribe(target)
-        logger.info("wizard_sessions subscribe", channel=target)
+        is_pattern = False
     else:
         target = channel_pattern(team_id, workflow_id)
-        pubsub.psubscribe(target)
-        logger.info("wizard_sessions subscribe", pattern=target)
+        is_pattern = True
+
+    redis = get_async_client()
+    pubsub = redis.pubsub(ignore_subscribe_messages=True)
+    try:
+        if is_pattern:
+            await pubsub.psubscribe(target)
+        else:
+            await pubsub.subscribe(target)
+    except Exception:
+        try:
+            await pubsub.close()
+        except Exception:
+            pass
+        raise
+
     try:
         yield pubsub
     finally:
-        logger.info("wizard_sessions unsubscribe", target=target)
         try:
-            if skill_id:
-                pubsub.unsubscribe(target)
+            if is_pattern:
+                await pubsub.punsubscribe(target)
             else:
-                pubsub.punsubscribe(target)
+                await pubsub.unsubscribe(target)
+        except Exception:
+            logger.warning("wizard_sessions unsubscribe failed", target=target)
         finally:
-            pubsub.close()
+            try:
+                await pubsub.close()
+            except Exception:
+                logger.warning("wizard_sessions pubsub close failed", target=target)
 
 
 def _json_default(value: Any) -> Any:

--- a/products/wizard/backend/logic/sessions.py
+++ b/products/wizard/backend/logic/sessions.py
@@ -4,6 +4,7 @@ Business logic for Wizard sessions.
 
 from products.wizard.backend.facade.contracts import UpsertWizardSessionInput, WizardSessionDTO, WizardTaskDTO
 from products.wizard.backend.facade.enums import RunPhase, TaskStatus
+from products.wizard.backend.logic.pubsub import publish_session_update
 from products.wizard.backend.logic.utils import is_stale
 from products.wizard.backend.models import WizardSession
 
@@ -37,7 +38,9 @@ def upsert_session(params: UpsertWizardSessionInput) -> tuple[WizardSessionDTO, 
             "error": params.error,
         },
     )
-    return _to_dto(instance), created
+    dto = _to_dto(instance)
+    publish_session_update(dto)
+    return dto, created
 
 
 def get_session(team_id: int, session_id: str) -> WizardSessionDTO | None:

--- a/products/wizard/backend/logic/sessions.py
+++ b/products/wizard/backend/logic/sessions.py
@@ -48,12 +48,11 @@ def get_session(team_id: int, session_id: str) -> WizardSessionDTO | None:
     return _to_dto(instance) if instance else None
 
 
-def get_latest_session(team_id: int, workflow_id: str, skill_id: str) -> WizardSessionDTO | None:
-    instance = (
-        WizardSession.objects.filter(team_id=team_id, workflow_id=workflow_id, skill_id=skill_id)
-        .order_by("-started_at")
-        .first()
-    )
+def get_latest_session(team_id: int, workflow_id: str, skill_id: str | None = None) -> WizardSessionDTO | None:
+    qs = WizardSession.objects.filter(team_id=team_id, workflow_id=workflow_id)
+    if skill_id:
+        qs = qs.filter(skill_id=skill_id)
+    instance = qs.order_by("-started_at").first()
     return _to_dto(instance) if instance else None
 
 

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -5,11 +5,20 @@ Validates JSON via serializers, routes everything through the facade,
 returns DTO-shaped responses. No model imports.
 """
 
+import time
+import dataclasses
+from collections.abc import Iterator
+from datetime import datetime
+from enum import Enum
 from typing import Any
 
+from django.http import StreamingHttpResponse
+
+import orjson
 import structlog
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import status, viewsets
+from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -17,7 +26,12 @@ from rest_framework.response import Response
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
 from products.wizard.backend.facade import api as wizard_facade
-from products.wizard.backend.facade.contracts import UpsertWizardSessionInput, UpsertWizardSessionRequest
+from products.wizard.backend.facade.contracts import (
+    UpsertWizardSessionInput,
+    UpsertWizardSessionRequest,
+    WizardSessionDTO,
+)
+from products.wizard.backend.logic.pubsub import subscribe
 from products.wizard.backend.presentation.serializers import (
     UpsertWizardSessionRequestSerializer,
     WizardSessionSerializer,
@@ -73,9 +87,13 @@ def _log_request_auth(request: Request, *, action: str, team_id: int | None) -> 
     )
 
 
+SSE_HEARTBEAT_INTERVAL_SECONDS = 15.0
+SSE_POLL_TIMEOUT_SECONDS = 1.0
+
+
 class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "wizard_session"
-    scope_object_read_actions = ["list", "retrieve"]
+    scope_object_read_actions = ["list", "retrieve", "stream"]
     scope_object_write_actions = ["create"]
     http_method_names = ["get", "post", "head", "options"]
     lookup_field = "session_id"
@@ -180,3 +198,85 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         )
         response_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response(WizardSessionSerializer(dto).data, status=response_status)
+
+    @extend_schema(
+        description=(
+            "Server-Sent Events stream of wizard session updates for a "
+            "(workflow_id, skill_id) pair. On connect, the current latest "
+            "session (if any) is emitted as the first event; subsequent "
+            "upserts are streamed in real time."
+        ),
+        parameters=[
+            OpenApiParameter(name="workflow_id", required=True, type=str),
+            OpenApiParameter(name="skill_id", required=True, type=str),
+        ],
+        responses={
+            (200, "text/event-stream"): {
+                "type": "string",
+                "description": "SSE stream of WizardSession events.",
+            }
+        },
+    )
+    @action(detail=False, methods=["get"], url_path="stream")
+    def stream(self, request: Request, *args: Any, **kwargs: Any) -> StreamingHttpResponse:
+        workflow_id = request.query_params.get("workflow_id")
+        skill_id = request.query_params.get("skill_id")
+        if not workflow_id or not skill_id:
+            raise ValidationError({"detail": "workflow_id and skill_id are required."})
+
+        generator = _wizard_session_event_stream(
+            team_id=self.team_id,
+            workflow_id=workflow_id,
+            skill_id=skill_id,
+        )
+        return StreamingHttpResponse(
+            generator,
+            status=status.HTTP_200_OK,
+            content_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+
+def _wizard_session_event_stream(team_id: int, workflow_id: str, skill_id: str) -> Iterator[bytes]:
+    """Yield SSE-formatted bytes for a (workflow_id, skill_id) subscription.
+
+    Emits the current latest session (if any) first, then forwards Redis
+    pub/sub messages. Yields heartbeat comments roughly every
+    SSE_HEARTBEAT_INTERVAL_SECONDS so proxies don't time the connection out.
+    """
+    latest = wizard_facade.get_latest(team_id, workflow_id, skill_id)
+    if latest is not None:
+        yield _format_event(latest)
+
+    with subscribe(team_id, workflow_id, skill_id) as pubsub:
+        last_heartbeat = time.monotonic()
+        while True:
+            message = pubsub.get_message(timeout=SSE_POLL_TIMEOUT_SECONDS)
+            now = time.monotonic()
+
+            if message and message.get("type") == "message":
+                yield b"data: " + message["data"] + b"\n\n"
+                last_heartbeat = now
+                continue
+
+            if now - last_heartbeat >= SSE_HEARTBEAT_INTERVAL_SECONDS:
+                yield b": ping\n\n"
+                last_heartbeat = now
+
+
+def _format_event(dto: WizardSessionDTO) -> bytes:
+    payload = orjson.dumps(dto, default=_json_default)
+    return b"data: " + payload + b"\n\n"
+
+
+def _json_default(value: Any) -> Any:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return dataclasses.asdict(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -25,6 +25,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models.scoping import team_scope
 
 from products.wizard.backend.facade import api as wizard_facade
 from products.wizard.backend.facade.contracts import (
@@ -265,8 +266,14 @@ def _wizard_session_event_stream(team_id: int, workflow_id: str, skill_id: str) 
     Emits the current latest session (if any) first, then forwards Redis
     pub/sub messages. Yields heartbeat comments roughly every
     SSE_HEARTBEAT_INTERVAL_SECONDS so proxies don't time the connection out.
+
+    Note: streaming generators run after the view returns, on a sync worker
+    thread that no longer has the request's team-scope thread-local set.
+    The fail-closed manager on `WizardSession` would refuse any DB query
+    here, so we re-establish team_scope explicitly for any DB access.
     """
-    latest = wizard_facade.get_latest(team_id, workflow_id, skill_id)
+    with team_scope(team_id):
+        latest = wizard_facade.get_latest(team_id, workflow_id, skill_id)
     if latest is not None:
         yield _format_event(latest)
 

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -6,16 +6,12 @@ returns DTO-shaped responses. No model imports.
 """
 
 import time
-import asyncio
-import dataclasses
 from collections.abc import AsyncIterator
-from datetime import datetime
-from enum import Enum
 from typing import Any
 
+from django.conf import settings
 from django.http import StreamingHttpResponse
 
-import orjson
 import structlog
 from asgiref.sync import sync_to_async
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
@@ -45,14 +41,7 @@ logger = structlog.get_logger(__name__)
 
 
 class EventStreamRenderer(BaseRenderer):
-    """SSE pass-through renderer.
-
-    DRF's content negotiation 406s any request whose Accept header doesn't match
-    a registered renderer. EventSource sends `Accept: text/event-stream`, which
-    nothing else in PostHog handles, so we register a minimal renderer that
-    advertises the media type. The actual response body comes from
-    StreamingHttpResponse — this renderer is never invoked to render.
-    """
+    """Satisfies DRF content negotiation for `Accept: text/event-stream`; never actually invoked."""
 
     media_type = "text/event-stream"
     format = "event-stream"
@@ -63,12 +52,6 @@ class EventStreamRenderer(BaseRenderer):
 
 
 def _log_request_auth(request: Request, *, action: str, team_id: int | None) -> None:
-    """Debug-only dump of how the incoming wizard_sessions request authenticated.
-
-    Fires only at DEBUG level — kept around for diagnosing 401/403 chains during
-    rollout. Once the wizard CLI auth flow is stable, this can be removed
-    entirely.
-    """
     if not logger.isEnabledFor(10):  # logging.DEBUG
         return
 
@@ -110,6 +93,7 @@ def _log_request_auth(request: Request, *, action: str, team_id: int | None) -> 
 
 SSE_HEARTBEAT_INTERVAL_SECONDS = 15.0
 SSE_POLL_TIMEOUT_SECONDS = 1.0
+SSE_MAX_DURATION_SECONDS = 30 * 60
 
 
 class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
@@ -118,12 +102,11 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object_write_actions = ["create"]
     http_method_names = ["get", "post", "head", "options"]
     lookup_field = "session_id"
-    lookup_value_regex = r"[^/]+"
+    # Negative lookahead so a session_id of `stream` can't collide with the
+    # `@action(url_path="stream")` detail-vs-action route.
+    lookup_value_regex = r"(?!stream$)[^/]+"
 
     def check_permissions(self, request: Request) -> None:
-        """Log the auth state before DRF decides allow/deny. Fires for both 200 and 403."""
-        # team_id is a cached_property that can raise on malformed URLs — don't
-        # let the diagnostic logger mask a clean 4xx with a 500.
         try:
             team_id = self.team_id
         except (KeyError, ValidationError, NotFound, AttributeError):
@@ -164,8 +147,6 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             offset=page_offset,
             limit=page_limit,
         )
-        # `sessions` is already a bounded slice; DRF's paginator can still wrap
-        # it so the response shape (count/next/previous) stays consistent.
         page = self.paginate_queryset(sessions)
         if page is not None:
             return self.get_paginated_response(WizardSessionSerializer(page, many=True).data)
@@ -225,11 +206,27 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             "Server-Sent Events stream of wizard session updates for a "
             "(workflow_id, skill_id) pair. On connect, the current latest "
             "session (if any) is emitted as the first event; subsequent "
-            "upserts are streamed in real time."
+            "upserts are streamed in real time. The server closes the "
+            f"connection after {SSE_MAX_DURATION_SECONDS} seconds with an "
+            "`event: end` line so the client (EventSource) can reconnect.\n\n"
+            "**SDK consumers**: do not call the generated fetch wrapper for "
+            "this path — it will buffer the entire infinite stream. Use the "
+            "URL builder (`getWizardSessionsStreamRetrieveUrl`) with the "
+            "browser's `EventSource` API instead."
         ),
         parameters=[
-            OpenApiParameter(name="workflow_id", required=True, type=str),
-            OpenApiParameter(name="skill_id", required=False, type=str),
+            OpenApiParameter(
+                name="workflow_id",
+                required=True,
+                type=str,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="skill_id",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+            ),
         ],
         responses={
             (200, "text/event-stream"): {
@@ -240,6 +237,10 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     @action(detail=False, methods=["get"], url_path="stream", renderer_classes=[EventStreamRenderer])
     def stream(self, request: Request, *args: Any, **kwargs: Any) -> StreamingHttpResponse:
+        # The generator is `async def` — WSGI can't consume an async iterator.
+        if getattr(settings, "SERVER_GATEWAY_INTERFACE", "ASGI") != "ASGI":
+            raise RuntimeError("wizard_sessions.stream requires ASGI.")
+
         workflow_id = request.query_params.get("workflow_id")
         skill_id = request.query_params.get("skill_id") or None
         if not workflow_id:
@@ -249,58 +250,61 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             team_id=self.team_id,
             workflow_id=workflow_id,
             skill_id=skill_id,
+            request=request,
         )
         return StreamingHttpResponse(
             generator,
             status=status.HTTP_200_OK,
             content_type="text/event-stream",
             headers={
-                "Cache-Control": "no-cache",
+                "Cache-Control": "no-cache, no-transform",
                 "X-Accel-Buffering": "no",
             },
         )
 
 
 async def _wizard_session_event_stream(
-    team_id: int, workflow_id: str, skill_id: str | None = None
+    team_id: int,
+    workflow_id: str,
+    skill_id: str | None,
+    request: Request | None = None,
 ) -> AsyncIterator[bytes]:
-    """Yield SSE-formatted bytes for a wizard session subscription.
+    """Stream SSE bytes for a wizard session subscription.
 
-    If `skill_id` is provided, scope to that exact pair. Otherwise pattern-
-    subscribe to all skills under (team, workflow_id).
-
-    Emits the current latest session (if any) first, then forwards Redis
-    pub/sub messages. Yields heartbeat comments roughly every
-    SSE_HEARTBEAT_INTERVAL_SECONDS so proxies don't time the connection out.
-
-    Async-iterator on purpose: Django's ASGI handler collects sync iterators
-    into a list before serving (see StreamingHttpResponse.__aiter__'s sync
-    fallback). With our infinite loop that never completes, so no bytes ever
-    reach the client. An async generator lets Django stream chunk-by-chunk.
-
-    Blocking Redis calls are dispatched through sync_to_async so the event
-    loop stays responsive. The fail-closed `TeamScopedManager` is re-entered
-    inside each sync helper because team_scope is a thread-local that doesn't
-    survive the request boundary.
+    Subscribes first, then fetches initial state, so publishes that race the
+    snapshot are buffered on the pubsub socket and drained on the next tick.
     """
+    started_at = time.monotonic()
 
-    def _get_initial() -> WizardSessionDTO | None:
-        with team_scope(team_id):
-            return wizard_facade.get_latest(team_id, workflow_id, skill_id)
+    async with wizard_facade.subscribe_to_updates(team_id, workflow_id, skill_id) as pubsub:
 
-    latest = await sync_to_async(_get_initial, thread_sensitive=False)()
-    if latest is not None:
-        yield _format_event(latest)
+        def _get_initial() -> WizardSessionDTO | None:
+            with team_scope(team_id):
+                return wizard_facade.get_latest(team_id, workflow_id, skill_id)
 
-    pubsub_cm = wizard_facade.subscribe_to_updates(team_id, workflow_id, skill_id)
-    pubsub = await sync_to_async(pubsub_cm.__enter__, thread_sensitive=False)()
-    try:
+        latest = await sync_to_async(_get_initial, thread_sensitive=False)()
+        if latest is not None:
+            yield b"data: " + wizard_facade.serialize_dto(latest) + b"\n\n"
+
         last_heartbeat = time.monotonic()
         while True:
-            message = await sync_to_async(pubsub.get_message, thread_sensitive=False)(timeout=SSE_POLL_TIMEOUT_SECONDS)
+            if time.monotonic() - started_at >= SSE_MAX_DURATION_SECONDS:
+                yield b"event: end\ndata: reconnect\n\n"
+                return
+
+            if request is not None:
+                is_disconnected = getattr(request, "is_disconnected", None)
+                if is_disconnected is not None:
+                    try:
+                        if await is_disconnected():
+                            return
+                    except Exception:
+                        pass
+
+            message = await pubsub.get_message(timeout=SSE_POLL_TIMEOUT_SECONDS)
             now = time.monotonic()
 
-            # `message` type is direct-channel; `pmessage` is pattern subscribe.
+            # `pmessage` arrives via pattern subscribe; `message` via exact.
             if message and message.get("type") in ("message", "pmessage"):
                 yield b"data: " + message["data"] + b"\n\n"
                 last_heartbeat = now
@@ -309,23 +313,3 @@ async def _wizard_session_event_stream(
             if now - last_heartbeat >= SSE_HEARTBEAT_INTERVAL_SECONDS:
                 yield b": ping\n\n"
                 last_heartbeat = now
-
-            # Cooperate with the event loop so other ASGI work can progress.
-            await asyncio.sleep(0)
-    finally:
-        await sync_to_async(pubsub_cm.__exit__, thread_sensitive=False)(None, None, None)
-
-
-def _format_event(dto: WizardSessionDTO) -> bytes:
-    payload = orjson.dumps(dto, default=_json_default)
-    return b"data: " + payload + b"\n\n"
-
-
-def _json_default(value: Any) -> Any:
-    if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        return dataclasses.asdict(value)
-    if isinstance(value, Enum):
-        return value.value
-    if isinstance(value, datetime):
-        return value.isoformat()
-    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -35,7 +35,6 @@ from products.wizard.backend.facade.contracts import (
     UpsertWizardSessionRequest,
     WizardSessionDTO,
 )
-from products.wizard.backend.logic.pubsub import subscribe
 from products.wizard.backend.presentation.serializers import (
     UpsertWizardSessionRequestSerializer,
     WizardSessionSerializer,
@@ -293,7 +292,7 @@ async def _wizard_session_event_stream(
     if latest is not None:
         yield _format_event(latest)
 
-    pubsub_cm = subscribe(team_id, workflow_id, skill_id)
+    pubsub_cm = wizard_facade.subscribe_to_updates(team_id, workflow_id, skill_id)
     pubsub = await sync_to_async(pubsub_cm.__enter__, thread_sensitive=False)()
     try:
         last_heartbeat = time.monotonic()

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -20,6 +20,7 @@ from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_sche
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.renderers import BaseRenderer
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -39,6 +40,24 @@ from products.wizard.backend.presentation.serializers import (
 from products.wizard.backend.presentation.utils import pagination_window
 
 logger = structlog.get_logger(__name__)
+
+
+class EventStreamRenderer(BaseRenderer):
+    """SSE pass-through renderer.
+
+    DRF's content negotiation 406s any request whose Accept header doesn't match
+    a registered renderer. EventSource sends `Accept: text/event-stream`, which
+    nothing else in PostHog handles, so we register a minimal renderer that
+    advertises the media type. The actual response body comes from
+    StreamingHttpResponse — this renderer is never invoked to render.
+    """
+
+    media_type = "text/event-stream"
+    format = "event-stream"
+    charset = "utf-8"
+
+    def render(self, data: Any, accepted_media_type: str | None = None, renderer_context: Any = None) -> bytes:
+        return data if isinstance(data, bytes) else b""
 
 
 def _log_request_auth(request: Request, *, action: str, team_id: int | None) -> None:
@@ -217,7 +236,7 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             }
         },
     )
-    @action(detail=False, methods=["get"], url_path="stream")
+    @action(detail=False, methods=["get"], url_path="stream", renderer_classes=[EventStreamRenderer])
     def stream(self, request: Request, *args: Any, **kwargs: Any) -> StreamingHttpResponse:
         workflow_id = request.query_params.get("workflow_id")
         skill_id = request.query_params.get("skill_id")

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -6,8 +6,9 @@ returns DTO-shaped responses. No model imports.
 """
 
 import time
+import asyncio
 import dataclasses
-from collections.abc import Iterator
+from collections.abc import AsyncIterator
 from datetime import datetime
 from enum import Enum
 from typing import Any
@@ -16,6 +17,7 @@ from django.http import StreamingHttpResponse
 
 import orjson
 import structlog
+from asgiref.sync import sync_to_async
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
@@ -260,7 +262,9 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         )
 
 
-def _wizard_session_event_stream(team_id: int, workflow_id: str, skill_id: str | None = None) -> Iterator[bytes]:
+async def _wizard_session_event_stream(
+    team_id: int, workflow_id: str, skill_id: str | None = None
+) -> AsyncIterator[bytes]:
     """Yield SSE-formatted bytes for a wizard session subscription.
 
     If `skill_id` is provided, scope to that exact pair. Otherwise pattern-
@@ -270,20 +274,31 @@ def _wizard_session_event_stream(team_id: int, workflow_id: str, skill_id: str |
     pub/sub messages. Yields heartbeat comments roughly every
     SSE_HEARTBEAT_INTERVAL_SECONDS so proxies don't time the connection out.
 
-    Note: streaming generators run after the view returns, on a sync worker
-    thread that no longer has the request's team-scope thread-local set.
-    The fail-closed manager on `WizardSession` would refuse any DB query
-    here, so we re-establish team_scope explicitly for any DB access.
+    Async-iterator on purpose: Django's ASGI handler collects sync iterators
+    into a list before serving (see StreamingHttpResponse.__aiter__'s sync
+    fallback). With our infinite loop that never completes, so no bytes ever
+    reach the client. An async generator lets Django stream chunk-by-chunk.
+
+    Blocking Redis calls are dispatched through sync_to_async so the event
+    loop stays responsive. The fail-closed `TeamScopedManager` is re-entered
+    inside each sync helper because team_scope is a thread-local that doesn't
+    survive the request boundary.
     """
-    with team_scope(team_id):
-        latest = wizard_facade.get_latest(team_id, workflow_id, skill_id)
+
+    def _get_initial() -> WizardSessionDTO | None:
+        with team_scope(team_id):
+            return wizard_facade.get_latest(team_id, workflow_id, skill_id)
+
+    latest = await sync_to_async(_get_initial, thread_sensitive=False)()
     if latest is not None:
         yield _format_event(latest)
 
-    with subscribe(team_id, workflow_id, skill_id) as pubsub:
+    pubsub_cm = subscribe(team_id, workflow_id, skill_id)
+    pubsub = await sync_to_async(pubsub_cm.__enter__, thread_sensitive=False)()
+    try:
         last_heartbeat = time.monotonic()
         while True:
-            message = pubsub.get_message(timeout=SSE_POLL_TIMEOUT_SECONDS)
+            message = await sync_to_async(pubsub.get_message, thread_sensitive=False)(timeout=SSE_POLL_TIMEOUT_SECONDS)
             now = time.monotonic()
 
             # `message` type is direct-channel; `pmessage` is pattern subscribe.
@@ -295,6 +310,11 @@ def _wizard_session_event_stream(team_id: int, workflow_id: str, skill_id: str |
             if now - last_heartbeat >= SSE_HEARTBEAT_INTERVAL_SECONDS:
                 yield b": ping\n\n"
                 last_heartbeat = now
+
+            # Cooperate with the event loop so other ASGI work can progress.
+            await asyncio.sleep(0)
+    finally:
+        await sync_to_async(pubsub_cm.__exit__, thread_sensitive=False)(None, None, None)
 
 
 def _format_event(dto: WizardSessionDTO) -> bytes:

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -240,9 +240,9 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(detail=False, methods=["get"], url_path="stream", renderer_classes=[EventStreamRenderer])
     def stream(self, request: Request, *args: Any, **kwargs: Any) -> StreamingHttpResponse:
         workflow_id = request.query_params.get("workflow_id")
-        skill_id = request.query_params.get("skill_id")
-        if not workflow_id or not skill_id:
-            raise ValidationError({"detail": "workflow_id and skill_id are required."})
+        skill_id = request.query_params.get("skill_id") or None
+        if not workflow_id:
+            raise ValidationError({"detail": "workflow_id is required."})
 
         generator = _wizard_session_event_stream(
             team_id=self.team_id,
@@ -260,8 +260,11 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         )
 
 
-def _wizard_session_event_stream(team_id: int, workflow_id: str, skill_id: str) -> Iterator[bytes]:
-    """Yield SSE-formatted bytes for a (workflow_id, skill_id) subscription.
+def _wizard_session_event_stream(team_id: int, workflow_id: str, skill_id: str | None = None) -> Iterator[bytes]:
+    """Yield SSE-formatted bytes for a wizard session subscription.
+
+    If `skill_id` is provided, scope to that exact pair. Otherwise pattern-
+    subscribe to all skills under (team, workflow_id).
 
     Emits the current latest session (if any) first, then forwards Redis
     pub/sub messages. Yields heartbeat comments roughly every
@@ -283,7 +286,8 @@ def _wizard_session_event_stream(team_id: int, workflow_id: str, skill_id: str) 
             message = pubsub.get_message(timeout=SSE_POLL_TIMEOUT_SECONDS)
             now = time.monotonic()
 
-            if message and message.get("type") == "message":
+            # `message` type is direct-channel; `pmessage` is pattern subscribe.
+            if message and message.get("type") in ("message", "pmessage"):
                 yield b"data: " + message["data"] + b"\n\n"
                 last_heartbeat = now
                 continue

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -237,14 +237,14 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     @action(detail=False, methods=["get"], url_path="stream", renderer_classes=[EventStreamRenderer])
     def stream(self, request: Request, *args: Any, **kwargs: Any) -> StreamingHttpResponse:
-        # The generator is `async def` — WSGI can't consume an async iterator.
-        if getattr(settings, "SERVER_GATEWAY_INTERFACE", "ASGI") != "ASGI":
-            raise RuntimeError("wizard_sessions.stream requires ASGI.")
-
         workflow_id = request.query_params.get("workflow_id")
         skill_id = request.query_params.get("skill_id") or None
         if not workflow_id:
             raise ValidationError({"detail": "workflow_id is required."})
+
+        # The generator is `async def` — WSGI can't consume an async iterator.
+        if getattr(settings, "SERVER_GATEWAY_INTERFACE", "ASGI") != "ASGI":
+            raise RuntimeError("wizard_sessions.stream requires ASGI.")
 
         generator = _wizard_session_event_stream(
             team_id=self.team_id,

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -229,7 +229,7 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         ),
         parameters=[
             OpenApiParameter(name="workflow_id", required=True, type=str),
-            OpenApiParameter(name="skill_id", required=True, type=str),
+            OpenApiParameter(name="skill_id", required=False, type=str),
         ],
         responses={
             (200, "text/event-stream"): {

--- a/products/wizard/backend/tests/test_presentation.py
+++ b/products/wizard/backend/tests/test_presentation.py
@@ -193,6 +193,8 @@ class TestWizardSessionViewSet(APIBaseTest):
         self.assertEqual(data["event_plan"], {"events": [{"name": "$pageview"}]})
         self.assertEqual(data["error"], {"type": "TimeoutError", "message": "Anthropic API timed out"})
 
-    def test_stream_requires_workflow_and_skill(self):
+    def test_stream_requires_workflow_id(self):
+        # No params → 400 from the view-level validation (workflow_id is the
+        # only required query param; skill_id is optional for pattern subscribe).
         response = self.client.get(f"{self._url()}stream/")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/products/wizard/backend/tests/test_presentation.py
+++ b/products/wizard/backend/tests/test_presentation.py
@@ -192,3 +192,7 @@ class TestWizardSessionViewSet(APIBaseTest):
         data = response.json()
         self.assertEqual(data["event_plan"], {"events": [{"name": "$pageview"}]})
         self.assertEqual(data["error"], {"type": "TimeoutError", "message": "Anthropic API timed out"})
+
+    def test_stream_requires_workflow_and_skill(self):
+        response = self.client.get(f"{self._url()}stream/")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/products/wizard/backend/tests/test_pubsub.py
+++ b/products/wizard/backend/tests/test_pubsub.py
@@ -29,7 +29,7 @@ def test_channel_name_is_deterministic():
     assert channel_name(1, "onboarding", "nextjs") == "wizard_sessions:team:1:workflow:onboarding:skill:nextjs"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_publish_session_update_publishes_after_commit():
     """In transaction.atomic, the publish should defer to on_commit."""
     redis_mock = MagicMock()

--- a/products/wizard/backend/tests/test_pubsub.py
+++ b/products/wizard/backend/tests/test_pubsub.py
@@ -19,6 +19,7 @@ def _dto(team_id: int = 1) -> WizardSessionDTO:
         skill_id="nextjs",
         started_at=now,
         run_phase=RunPhase.RUNNING,
+        is_stale=False,
         tasks=(WizardTaskDTO(id="1", title="Install SDK", status=TaskStatus.IN_PROGRESS),),
         event_plan=None,
         error=None,

--- a/products/wizard/backend/tests/test_pubsub.py
+++ b/products/wizard/backend/tests/test_pubsub.py
@@ -1,0 +1,65 @@
+from datetime import UTC, datetime
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from products.wizard.backend.facade.contracts import WizardSessionDTO, WizardTaskDTO
+from products.wizard.backend.facade.enums import RunPhase, TaskStatus
+from products.wizard.backend.logic.pubsub import channel_name, publish_session_update
+
+
+def _dto(team_id: int = 1) -> WizardSessionDTO:
+    now = datetime(2026, 5, 19, 10, 0, 0, tzinfo=UTC)
+    return WizardSessionDTO(
+        session_id="onboarding-nextjs-2026-05-19T10:00:00Z",
+        team_id=team_id,
+        workflow_id="onboarding",
+        skill_id="nextjs",
+        started_at=now,
+        run_phase=RunPhase.RUNNING,
+        tasks=(WizardTaskDTO(id="1", title="Install SDK", status=TaskStatus.IN_PROGRESS),),
+        event_plan=None,
+        error=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_channel_name_is_deterministic():
+    assert channel_name(1, "onboarding", "nextjs") == "wizard_sessions:team:1:workflow:onboarding:skill:nextjs"
+
+
+@pytest.mark.django_db
+def test_publish_session_update_publishes_after_commit():
+    """In transaction.atomic, the publish should defer to on_commit."""
+    redis_mock = MagicMock()
+    with patch("products.wizard.backend.logic.pubsub.get_client", return_value=redis_mock):
+        from django.db import transaction
+
+        with transaction.atomic():
+            publish_session_update(_dto())
+            assert redis_mock.publish.call_count == 0  # not yet committed
+
+        # After atomic block exits, on_commit hooks fire.
+        assert redis_mock.publish.call_count == 1
+        channel, payload = redis_mock.publish.call_args.args
+        assert channel == "wizard_sessions:team:1:workflow:onboarding:skill:nextjs"
+        assert b'"session_id":"onboarding-nextjs-2026-05-19T10:00:00Z"' in payload
+        assert b'"run_phase":"running"' in payload
+        assert b'"status":"in_progress"' in payload
+
+
+@pytest.mark.django_db
+def test_publish_session_update_does_not_publish_on_rollback():
+    redis_mock = MagicMock()
+    with patch("products.wizard.backend.logic.pubsub.get_client", return_value=redis_mock):
+        from django.db import transaction
+
+        try:
+            with transaction.atomic():
+                publish_session_update(_dto())
+                raise RuntimeError("force rollback")
+        except RuntimeError:
+            pass
+
+        assert redis_mock.publish.call_count == 0

--- a/products/wizard/backend/tests/test_pubsub.py
+++ b/products/wizard/backend/tests/test_pubsub.py
@@ -13,7 +13,11 @@ from products.wizard.backend.logic.pubsub import channel_name, publish_session_u
 def _dto(team_id: int = 1) -> WizardSessionDTO:
     now = datetime(2026, 5, 19, 10, 0, 0, tzinfo=UTC)
     return WizardSessionDTO(
-        session_id="onboarding-nextjs-2026-05-19T10:00:00Z",
+        # session_id has no colons because channel_name validates the safe-id
+        # alphabet on workflow_id/skill_id. session_id itself isn't part of
+        # the channel name, but we still keep the format safe for downstream
+        # consumers.
+        session_id="onboarding-nextjs-2026-05-19T10-00-00Z",
         team_id=team_id,
         workflow_id="onboarding",
         skill_id="nextjs",
@@ -32,6 +36,18 @@ def test_channel_name_is_deterministic():
     assert channel_name(1, "onboarding", "nextjs") == "wizard_sessions:team:1:workflow:onboarding:skill:nextjs"
 
 
+def test_channel_name_rejects_unsafe_ids():
+    """workflow_id / skill_id can't smuggle Redis glob metacharacters or `:`."""
+    with pytest.raises(ValueError):
+        channel_name(1, "onboarding", "next*")
+    with pytest.raises(ValueError):
+        channel_name(1, "*", "nextjs")
+    with pytest.raises(ValueError):
+        channel_name(1, "onboarding:malicious", "nextjs")
+    with pytest.raises(ValueError):
+        channel_name(1, "onboarding", "next[js]")
+
+
 @pytest.mark.django_db(transaction=True)
 def test_publish_session_update_publishes_after_commit():
     """In transaction.atomic, the publish should defer to on_commit."""
@@ -45,7 +61,7 @@ def test_publish_session_update_publishes_after_commit():
         assert redis_mock.publish.call_count == 1
         channel, payload = redis_mock.publish.call_args.args
         assert channel == "wizard_sessions:team:1:workflow:onboarding:skill:nextjs"
-        assert b'"session_id":"onboarding-nextjs-2026-05-19T10:00:00Z"' in payload
+        assert b'"session_id":"onboarding-nextjs-2026-05-19T10-00-00Z"' in payload
         assert b'"run_phase":"running"' in payload
         assert b'"status":"in_progress"' in payload
 
@@ -62,3 +78,16 @@ def test_publish_session_update_does_not_publish_on_rollback():
             pass
 
         assert redis_mock.publish.call_count == 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_publish_session_update_swallows_redis_errors():
+    """Redis publish failure must not fail the upsert request."""
+    redis_mock = MagicMock()
+    redis_mock.publish.side_effect = ConnectionError("redis is down")
+
+    with patch("products.wizard.backend.logic.pubsub.get_client", return_value=redis_mock):
+        with transaction.atomic():
+            publish_session_update(_dto())
+        # If the exception escaped on_commit, this assertion wouldn't run.
+        assert redis_mock.publish.call_count == 1

--- a/products/wizard/backend/tests/test_pubsub.py
+++ b/products/wizard/backend/tests/test_pubsub.py
@@ -3,6 +3,8 @@ from datetime import UTC, datetime
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.db import transaction
+
 from products.wizard.backend.facade.contracts import WizardSessionDTO, WizardTaskDTO
 from products.wizard.backend.facade.enums import RunPhase, TaskStatus
 from products.wizard.backend.logic.pubsub import channel_name, publish_session_update
@@ -34,8 +36,6 @@ def test_publish_session_update_publishes_after_commit():
     """In transaction.atomic, the publish should defer to on_commit."""
     redis_mock = MagicMock()
     with patch("products.wizard.backend.logic.pubsub.get_client", return_value=redis_mock):
-        from django.db import transaction
-
         with transaction.atomic():
             publish_session_update(_dto())
             assert redis_mock.publish.call_count == 0  # not yet committed
@@ -53,8 +53,6 @@ def test_publish_session_update_publishes_after_commit():
 def test_publish_session_update_does_not_publish_on_rollback():
     redis_mock = MagicMock()
     with patch("products.wizard.backend.logic.pubsub.get_client", return_value=redis_mock):
-        from django.db import transaction
-
         try:
             with transaction.atomic():
                 publish_session_update(_dto())

--- a/products/wizard/backend/tests/test_stream.py
+++ b/products/wizard/backend/tests/test_stream.py
@@ -1,0 +1,109 @@
+from datetime import UTC, datetime
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from products.wizard.backend.facade.contracts import UpsertWizardSessionInput, WizardTaskDTO
+from products.wizard.backend.facade.enums import RunPhase, TaskStatus
+from products.wizard.backend.presentation.views import _wizard_session_event_stream
+
+
+class _StopStream(Exception):
+    """Helper to break the infinite generator after we've collected what we want."""
+
+
+def _input(team_id: int, **overrides) -> UpsertWizardSessionInput:
+    params: dict = {
+        "team_id": team_id,
+        "session_id": "onboarding-nextjs-2026-05-19T10:00:00Z",
+        "workflow_id": "onboarding",
+        "skill_id": "nextjs",
+        "started_at": datetime(2026, 5, 19, 10, 0, 0, tzinfo=UTC),
+        "run_phase": RunPhase.RUNNING,
+        "tasks": (WizardTaskDTO(id="1", title="Install SDK", status=TaskStatus.IN_PROGRESS),),
+        "event_plan": None,
+        "error": None,
+    }
+    params.update(overrides)
+    return UpsertWizardSessionInput(**params)
+
+
+def _drain(generator, max_events: int):
+    """Pull up to max_events from generator, stopping early if it raises _StopStream."""
+    events = []
+    try:
+        for _ in range(max_events):
+            events.append(next(generator))
+    except _StopStream:
+        pass
+    return events
+
+
+@pytest.mark.django_db
+def test_stream_emits_initial_state_when_session_exists(team):
+    from products.wizard.backend.facade import api as wizard_facade
+
+    wizard_facade.upsert(_input(team.id))
+
+    pubsub_mock = MagicMock()
+    pubsub_mock.get_message.side_effect = _StopStream()
+
+    with patch("products.wizard.backend.presentation.views.subscribe") as subscribe_mock:
+        subscribe_mock.return_value.__enter__.return_value = pubsub_mock
+        gen = _wizard_session_event_stream(team_id=team.id, workflow_id="onboarding", skill_id="nextjs")
+        events = _drain(gen, max_events=2)
+
+    assert len(events) == 1
+    assert events[0].startswith(b"data: ")
+    assert b'"session_id":"onboarding-nextjs-2026-05-19T10:00:00Z"' in events[0]
+    assert events[0].endswith(b"\n\n")
+
+
+@pytest.mark.django_db
+def test_stream_skips_initial_event_when_no_session(team):
+    pubsub_mock = MagicMock()
+    pubsub_mock.get_message.side_effect = _StopStream()
+
+    with patch("products.wizard.backend.presentation.views.subscribe") as subscribe_mock:
+        subscribe_mock.return_value.__enter__.return_value = pubsub_mock
+        gen = _wizard_session_event_stream(team_id=team.id, workflow_id="missing", skill_id="missing")
+        events = _drain(gen, max_events=2)
+
+    assert events == []
+
+
+@pytest.mark.django_db
+def test_stream_forwards_pubsub_messages(team):
+    pubsub_mock = MagicMock()
+    pubsub_mock.get_message.side_effect = [
+        {"type": "message", "data": b'{"session_id":"a"}'},
+        {"type": "message", "data": b'{"session_id":"b"}'},
+        _StopStream(),
+    ]
+
+    with patch("products.wizard.backend.presentation.views.subscribe") as subscribe_mock:
+        subscribe_mock.return_value.__enter__.return_value = pubsub_mock
+        gen = _wizard_session_event_stream(team_id=team.id, workflow_id="missing", skill_id="missing")
+        events = _drain(gen, max_events=5)
+
+    assert events == [
+        b'data: {"session_id":"a"}\n\n',
+        b'data: {"session_id":"b"}\n\n',
+    ]
+
+
+@pytest.mark.django_db
+def test_stream_emits_heartbeat_when_idle(team):
+    pubsub_mock = MagicMock()
+    pubsub_mock.get_message.side_effect = [None, None, _StopStream()]
+
+    # Force the heartbeat threshold to be zero so any idle tick emits one.
+    with (
+        patch("products.wizard.backend.presentation.views.subscribe") as subscribe_mock,
+        patch("products.wizard.backend.presentation.views.SSE_HEARTBEAT_INTERVAL_SECONDS", 0.0),
+    ):
+        subscribe_mock.return_value.__enter__.return_value = pubsub_mock
+        gen = _wizard_session_event_stream(team_id=team.id, workflow_id="missing", skill_id="missing")
+        events = _drain(gen, max_events=4)
+
+    assert events == [b": ping\n\n", b": ping\n\n"]

--- a/products/wizard/backend/tests/test_stream.py
+++ b/products/wizard/backend/tests/test_stream.py
@@ -1,7 +1,8 @@
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from asgiref.sync import sync_to_async
 
@@ -18,7 +19,7 @@ class _StopStream(Exception):
 def _input(team_id: int, **overrides) -> UpsertWizardSessionInput:
     params: dict = {
         "team_id": team_id,
-        "session_id": "onboarding-nextjs-2026-05-19T10:00:00Z",
+        "session_id": "onboarding-nextjs-2026-05-19T10-00-00Z",
         "workflow_id": "onboarding",
         "skill_id": "nextjs",
         "started_at": datetime(2026, 5, 19, 10, 0, 0, tzinfo=UTC),
@@ -39,18 +40,50 @@ async def _drain(generator, max_events: int):
             events.append(await anext(generator))
     except (_StopStream, StopAsyncIteration):
         pass
+    finally:
+        # Close the generator so its `async with` runs cleanup (closes the
+        # Redis subscription). Without this, leaked subscriptions would pass
+        # the tests silently.
+        await generator.aclose()
     return events
 
 
+def _async_subscribe_cm(pubsub_mock):
+    """Build an async context manager that yields the given pubsub mock.
+
+    Tracks enter/exit calls on the returned tuple `(cm_factory, exit_marker)`
+    so tests can assert cleanup ran.
+    """
+    exit_marker = MagicMock(name="exit_marker")
+
+    @asynccontextmanager
+    async def _cm(team_id, workflow_id, skill_id):
+        try:
+            yield pubsub_mock
+        finally:
+            exit_marker(team_id, workflow_id, skill_id)
+
+    return _cm, exit_marker
+
+
 def _patch_subscribe(pubsub_mock):
-    """Patch the facade's pubsub subscribe to yield the given mock."""
-    return patch(
-        "products.wizard.backend.facade.api.pubsub.subscribe",
-        return_value=MagicMock(
-            __enter__=MagicMock(return_value=pubsub_mock),
-            __exit__=MagicMock(return_value=False),
+    """Patch the facade's `subscribe_to_updates` async context manager.
+
+    Returns the patch object plus a sentinel that records cleanup so tests
+    can confirm the Redis subscription's `__aexit__` ran.
+    """
+    cm_factory, exit_marker = _async_subscribe_cm(pubsub_mock)
+    return (
+        patch(
+            "products.wizard.backend.presentation.views.wizard_facade.subscribe_to_updates",
+            cm_factory,
         ),
+        exit_marker,
     )
+
+
+def _async_get_message(side_effects):
+    return AsyncMock(side_effect=side_effects)
 
 
 @pytest.mark.asyncio
@@ -59,42 +92,51 @@ async def test_stream_emits_initial_state_when_session_exists(team):
     await sync_to_async(wizard_facade.upsert)(_input(team.id))
 
     pubsub_mock = MagicMock()
-    pubsub_mock.get_message.side_effect = _StopStream()
+    pubsub_mock.get_message = _async_get_message([_StopStream()])
 
-    with _patch_subscribe(pubsub_mock):
+    patcher, exit_marker = _patch_subscribe(pubsub_mock)
+    with patcher:
         gen = _wizard_session_event_stream(team_id=team.id, workflow_id="onboarding", skill_id="nextjs")
         events = await _drain(gen, max_events=2)
 
     assert len(events) == 1
     assert events[0].startswith(b"data: ")
-    assert b'"session_id":"onboarding-nextjs-2026-05-19T10:00:00Z"' in events[0]
+    assert b'"session_id":"onboarding-nextjs-2026-05-19T10-00-00Z"' in events[0]
     assert events[0].endswith(b"\n\n")
+    # Cleanup must run — otherwise we'd leak Redis subscriptions on every
+    # client disconnect.
+    exit_marker.assert_called_once_with(team.id, "onboarding", "nextjs")
 
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_stream_skips_initial_event_when_no_session(team):
     pubsub_mock = MagicMock()
-    pubsub_mock.get_message.side_effect = _StopStream()
+    pubsub_mock.get_message = _async_get_message([_StopStream()])
 
-    with _patch_subscribe(pubsub_mock):
+    patcher, exit_marker = _patch_subscribe(pubsub_mock)
+    with patcher:
         gen = _wizard_session_event_stream(team_id=team.id, workflow_id="missing", skill_id="missing")
         events = await _drain(gen, max_events=2)
 
     assert events == []
+    exit_marker.assert_called_once()
 
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_stream_forwards_pubsub_messages(team):
     pubsub_mock = MagicMock()
-    pubsub_mock.get_message.side_effect = [
-        {"type": "message", "data": b'{"session_id":"a"}'},
-        {"type": "message", "data": b'{"session_id":"b"}'},
-        _StopStream(),
-    ]
+    pubsub_mock.get_message = _async_get_message(
+        [
+            {"type": "message", "data": b'{"session_id":"a"}'},
+            {"type": "message", "data": b'{"session_id":"b"}'},
+            _StopStream(),
+        ]
+    )
 
-    with _patch_subscribe(pubsub_mock):
+    patcher, exit_marker = _patch_subscribe(pubsub_mock)
+    with patcher:
         gen = _wizard_session_event_stream(team_id=team.id, workflow_id="missing", skill_id="missing")
         events = await _drain(gen, max_events=5)
 
@@ -102,20 +144,44 @@ async def test_stream_forwards_pubsub_messages(team):
         b'data: {"session_id":"a"}\n\n',
         b'data: {"session_id":"b"}\n\n',
     ]
+    exit_marker.assert_called_once()
 
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_stream_emits_heartbeat_when_idle(team):
     pubsub_mock = MagicMock()
-    pubsub_mock.get_message.side_effect = [None, None, _StopStream()]
+    pubsub_mock.get_message = _async_get_message([None, None, _StopStream()])
 
-    # Force the heartbeat threshold to be zero so any idle tick emits one.
+    patcher, exit_marker = _patch_subscribe(pubsub_mock)
+    # Force heartbeat threshold to zero so any idle tick emits one.
     with (
-        _patch_subscribe(pubsub_mock),
+        patcher,
         patch("products.wizard.backend.presentation.views.SSE_HEARTBEAT_INTERVAL_SECONDS", 0.0),
     ):
         gen = _wizard_session_event_stream(team_id=team.id, workflow_id="missing", skill_id="missing")
         events = await _drain(gen, max_events=4)
 
     assert events == [b": ping\n\n", b": ping\n\n"]
+    exit_marker.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_stream_terminates_on_max_duration(team):
+    """SSE_MAX_DURATION_SECONDS=0 -> first loop tick emits `event: end` and exits."""
+    pubsub_mock = MagicMock()
+    pubsub_mock.get_message = _async_get_message([None] * 10)
+
+    patcher, exit_marker = _patch_subscribe(pubsub_mock)
+    with (
+        patcher,
+        patch("products.wizard.backend.presentation.views.SSE_MAX_DURATION_SECONDS", 0),
+    ):
+        gen = _wizard_session_event_stream(team_id=team.id, workflow_id="missing", skill_id="missing")
+        events = await _drain(gen, max_events=5)
+
+    # Generator emits `event: end` then returns — clean close, no leaked
+    # subscription.
+    assert events == [b"event: end\ndata: reconnect\n\n"]
+    exit_marker.assert_called_once()

--- a/products/wizard/backend/tests/test_stream.py
+++ b/products/wizard/backend/tests/test_stream.py
@@ -3,6 +3,9 @@ from datetime import UTC, datetime
 import pytest
 from unittest.mock import MagicMock, patch
 
+from asgiref.sync import sync_to_async
+
+from products.wizard.backend.facade import api as wizard_facade
 from products.wizard.backend.facade.contracts import UpsertWizardSessionInput, WizardTaskDTO
 from products.wizard.backend.facade.enums import RunPhase, TaskStatus
 from products.wizard.backend.presentation.views import _wizard_session_event_stream
@@ -28,30 +31,39 @@ def _input(team_id: int, **overrides) -> UpsertWizardSessionInput:
     return UpsertWizardSessionInput(**params)
 
 
-def _drain(generator, max_events: int):
-    """Pull up to max_events from generator, stopping early if it raises _StopStream."""
+async def _drain(generator, max_events: int):
+    """Pull up to max_events from the async generator, stopping early on _StopStream."""
     events = []
     try:
         for _ in range(max_events):
-            events.append(next(generator))
-    except _StopStream:
+            events.append(await anext(generator))
+    except (_StopStream, StopAsyncIteration):
         pass
     return events
 
 
-@pytest.mark.django_db
-def test_stream_emits_initial_state_when_session_exists(team):
-    from products.wizard.backend.facade import api as wizard_facade
+def _patch_subscribe(pubsub_mock):
+    """Patch the facade's pubsub subscribe to yield the given mock."""
+    return patch(
+        "products.wizard.backend.facade.api.pubsub.subscribe",
+        return_value=MagicMock(
+            __enter__=MagicMock(return_value=pubsub_mock),
+            __exit__=MagicMock(return_value=False),
+        ),
+    )
 
-    wizard_facade.upsert(_input(team.id))
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_stream_emits_initial_state_when_session_exists(team):
+    await sync_to_async(wizard_facade.upsert)(_input(team.id))
 
     pubsub_mock = MagicMock()
     pubsub_mock.get_message.side_effect = _StopStream()
 
-    with patch("products.wizard.backend.presentation.views.subscribe") as subscribe_mock:
-        subscribe_mock.return_value.__enter__.return_value = pubsub_mock
+    with _patch_subscribe(pubsub_mock):
         gen = _wizard_session_event_stream(team_id=team.id, workflow_id="onboarding", skill_id="nextjs")
-        events = _drain(gen, max_events=2)
+        events = await _drain(gen, max_events=2)
 
     assert len(events) == 1
     assert events[0].startswith(b"data: ")
@@ -59,21 +71,22 @@ def test_stream_emits_initial_state_when_session_exists(team):
     assert events[0].endswith(b"\n\n")
 
 
-@pytest.mark.django_db
-def test_stream_skips_initial_event_when_no_session(team):
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_stream_skips_initial_event_when_no_session(team):
     pubsub_mock = MagicMock()
     pubsub_mock.get_message.side_effect = _StopStream()
 
-    with patch("products.wizard.backend.presentation.views.subscribe") as subscribe_mock:
-        subscribe_mock.return_value.__enter__.return_value = pubsub_mock
+    with _patch_subscribe(pubsub_mock):
         gen = _wizard_session_event_stream(team_id=team.id, workflow_id="missing", skill_id="missing")
-        events = _drain(gen, max_events=2)
+        events = await _drain(gen, max_events=2)
 
     assert events == []
 
 
-@pytest.mark.django_db
-def test_stream_forwards_pubsub_messages(team):
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_stream_forwards_pubsub_messages(team):
     pubsub_mock = MagicMock()
     pubsub_mock.get_message.side_effect = [
         {"type": "message", "data": b'{"session_id":"a"}'},
@@ -81,10 +94,9 @@ def test_stream_forwards_pubsub_messages(team):
         _StopStream(),
     ]
 
-    with patch("products.wizard.backend.presentation.views.subscribe") as subscribe_mock:
-        subscribe_mock.return_value.__enter__.return_value = pubsub_mock
+    with _patch_subscribe(pubsub_mock):
         gen = _wizard_session_event_stream(team_id=team.id, workflow_id="missing", skill_id="missing")
-        events = _drain(gen, max_events=5)
+        events = await _drain(gen, max_events=5)
 
     assert events == [
         b'data: {"session_id":"a"}\n\n',
@@ -92,18 +104,18 @@ def test_stream_forwards_pubsub_messages(team):
     ]
 
 
-@pytest.mark.django_db
-def test_stream_emits_heartbeat_when_idle(team):
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_stream_emits_heartbeat_when_idle(team):
     pubsub_mock = MagicMock()
     pubsub_mock.get_message.side_effect = [None, None, _StopStream()]
 
     # Force the heartbeat threshold to be zero so any idle tick emits one.
     with (
-        patch("products.wizard.backend.presentation.views.subscribe") as subscribe_mock,
+        _patch_subscribe(pubsub_mock),
         patch("products.wizard.backend.presentation.views.SSE_HEARTBEAT_INTERVAL_SECONDS", 0.0),
     ):
-        subscribe_mock.return_value.__enter__.return_value = pubsub_mock
         gen = _wizard_session_event_stream(team_id=team.id, workflow_id="missing", skill_id="missing")
-        events = _drain(gen, max_events=4)
+        events = await _drain(gen, max_events=4)
 
     assert events == [b": ping\n\n", b": ping\n\n"]

--- a/products/wizard/frontend/generated/api.schemas.ts
+++ b/products/wizard/frontend/generated/api.schemas.ts
@@ -155,3 +155,8 @@ export type WizardSessionsListParams = {
      */
     workflow_id?: string
 }
+
+export type WizardSessionsStreamRetrieveParams = {
+    skill_id: string
+    workflow_id: string
+}

--- a/products/wizard/frontend/generated/api.schemas.ts
+++ b/products/wizard/frontend/generated/api.schemas.ts
@@ -157,6 +157,6 @@ export type WizardSessionsListParams = {
 }
 
 export type WizardSessionsStreamRetrieveParams = {
-    skill_id: string
+    skill_id?: string
     workflow_id: string
 }

--- a/products/wizard/frontend/generated/api.ts
+++ b/products/wizard/frontend/generated/api.ts
@@ -101,7 +101,9 @@ export const getWizardSessionsStreamRetrieveUrl = (projectId: string, params: Wi
 }
 
 /**
- * Server-Sent Events stream of wizard session updates for a (workflow_id, skill_id) pair. On connect, the current latest session (if any) is emitted as the first event; subsequent upserts are streamed in real time.
+ * Server-Sent Events stream of wizard session updates for a (workflow_id, skill_id) pair. On connect, the current latest session (if any) is emitted as the first event; subsequent upserts are streamed in real time. The server closes the connection after 1800 seconds with an `event: end` line so the client (EventSource) can reconnect.
+
+**SDK consumers**: do not call the generated fetch wrapper for this path — it will buffer the entire infinite stream. Use the URL builder (`getWizardSessionsStreamRetrieveUrl`) with the browser's `EventSource` API instead.
  */
 export const wizardSessionsStreamRetrieve = async (
     projectId: string,

--- a/products/wizard/frontend/generated/api.ts
+++ b/products/wizard/frontend/generated/api.ts
@@ -13,6 +13,7 @@ import type {
     UpsertWizardSessionRequestApi,
     WizardSessionDTOApi,
     WizardSessionsListParams,
+    WizardSessionsStreamRetrieveParams,
 } from './api.schemas'
 
 export const getWizardSessionsListUrl = (projectId: string, params?: WizardSessionsListParams) => {
@@ -78,6 +79,36 @@ export const wizardSessionsRetrieve = async (
     options?: RequestInit
 ): Promise<WizardSessionDTOApi> => {
     return apiMutator<WizardSessionDTOApi>(getWizardSessionsRetrieveUrl(projectId, sessionId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getWizardSessionsStreamRetrieveUrl = (projectId: string, params: WizardSessionsStreamRetrieveParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/wizard/sessions/stream/?${stringifiedParams}`
+        : `/api/projects/${projectId}/wizard/sessions/stream/`
+}
+
+/**
+ * Server-Sent Events stream of wizard session updates for a (workflow_id, skill_id) pair. On connect, the current latest session (if any) is emitted as the first event; subsequent upserts are streamed in real time.
+ */
+export const wizardSessionsStreamRetrieve = async (
+    projectId: string,
+    params: WizardSessionsStreamRetrieveParams,
+    options?: RequestInit
+): Promise<string> => {
+    return apiMutator<string>(getWizardSessionsStreamRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
     })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -46919,6 +46919,11 @@ export namespace Schemas {
     workflow_id?: string;
     };
 
+    export type WizardSessionsStreamRetrieveParams = {
+    skill_id: string;
+    workflow_id: string;
+    };
+
     export type PublicHogFunctionTemplatesListParams = {
     /**
      * Number of results to return per page.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -46920,7 +46920,7 @@ export namespace Schemas {
     };
 
     export type WizardSessionsStreamRetrieveParams = {
-    skill_id: string;
+    skill_id?: string;
     workflow_id: string;
     };
 


### PR DESCRIPTION
## Problem

The REST endpoint from #59062 lets the CLI push state, but the web app would have to poll to see updates. The [RFC](https://github.com/PostHog/requests-for-comments-public/pull/514) recommends SSE. This PR adds the SSE fanout so a connected client gets pushes in real time, regardless of which workflow / framework the wizard is running.

## Changes

- **`GET /api/projects/{id}/wizard_sessions/stream/?workflow_id=…`** returns a `text/event-stream` connection. `skill_id` is optional — when omitted, the server pattern-subscribes to **every** skill under that workflow, so the web app doesn't need to know the framework up front.
- **Async streaming generator.** Django's ASGI handler buffers sync iterators into a list before serving (which never completes on an infinite loop), so the generator is now `async def` and dispatches blocking Redis calls through `sync_to_async`. Chunks reach the browser as they're produced.
- **Redis pub/sub fanout.** Publish happens inside `transaction.on_commit` so subscribers never see uncommitted state and rolled-back upserts don't broadcast phantom updates. Workflow-only subscribers use Redis `PSUBSCRIBE` with a channel pattern; both `message` and `pmessage` types are forwarded.
- **`team_scope` re-entry** inside the generator. Streaming runs after the view returns on a sync worker thread without the request's thread-local team scope, so any DB access inside the generator is wrapped explicitly.
- **`EventStreamRenderer`** registered on the stream action. DRF's content negotiation 406s `Accept: text/event-stream` otherwise; the renderer is never invoked to render (the response is a `StreamingHttpResponse`), it just satisfies negotiation.
- **Idle connections** receive `: ping` heartbeats every 15s so proxies don't time them out.
- **Diagnostic logs** on publish (channel, receivers, payload size) and subscribe (channel or pattern) — narrows debugging when nothing flows.

## How did you test this code?

- Unit tests for the pub/sub helper (publish fires after commit, skipped on rollback, channel naming deterministic).
- Generator-level tests for the SSE stream (initial state emitted, pub/sub messages forwarded, heartbeat fires when idle).
- HTTP-level test that the stream endpoint 400s without required query params.
- Tests use `@pytest.mark.django_db(transaction=True)` where `transaction.on_commit` semantics need to fire.
- Manually verified end-to-end: wizard CLI POSTs, EventSource receives updates in the browser.

Agent-authored.

## Publish to changelog?

no

## Docs update

n/a — internal endpoint, no public docs yet.

## 🤖 Agent context

Claude Code (Opus 4.7, 1M context). Notable decisions:

- **One sync WSGI worker per active SSE connection** when ASGI isn't fully wired. Fine for onboarding-scale traffic; worth revisiting for broader fanout.
- **Pattern subscribe over per-skill registration.** The wizard CLI emits `workflow_id="posthog-integration"` with skill keyed to the detected framework (`laravel`, `nextjs`, `django`, …). The frontend doesn't know the framework up front, so subscribing by workflow alone removes a chicken-and-egg problem.
- **No reconnect/replay protocol.** A disconnected client gets the current latest state on reconnect and skips intermediate transitions — matches the RFC's "each push is the new source of truth" framing.
