### PR TITLE
perf(clickhouse): prime Postgres from cached schema in multinode smoke

### DIFF
--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -91,20 +91,32 @@ jobs:
 
             - name: Compute Postgres schema cache key
               id: schema-key
-              if: github.event_name == 'pull_request'
+              if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
+                  # On merge_group the queue branch is built directly on top of
+                  # this base SHA (latest master), so it is exactly the SHA the
+                  # cache producer keyed off — no merge-base computation needed.
+                  MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
               run: |
                   # ci-backend.yml's "Validate migrations" job dumps the post-PR
-                  # schema and caches it keyed by master SHA. PR test jobs key
-                  # off the merge base so they restore the dump produced by the
-                  # commit their branch diverged from.
-                  MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
-                  if [ -n "$MERGE_BASE" ]; then
-                      echo "key=posthog-schema-master-${MERGE_BASE}" >> "$GITHUB_OUTPUT"
+                  # schema and caches it keyed by master SHA. PR jobs key off the
+                  # merge base so they restore the dump produced by the commit
+                  # their branch diverged from; merge_group jobs key off the
+                  # queue's base SHA directly.
+                  if [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then
+                      BASE_SHA="${MERGE_GROUP_BASE_SHA}"
+                  else
+                      # fetch-depth: 1000 on checkout bounds how far back the
+                      # merge base can be found; older divergence yields an empty
+                      # result and the graceful fallback to `migrate` below.
+                      BASE_SHA=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                  fi
+                  if [ -n "$BASE_SHA" ]; then
+                      echo "key=posthog-schema-master-${BASE_SHA}" >> "$GITHUB_OUTPUT"
                   else
                       echo "key=" >> "$GITHUB_OUTPUT"
-                      echo "::notice::merge-base not found — Postgres schema cache will be skipped"
+                      echo "::notice::base SHA not found — Postgres schema cache will be skipped"
                   fi
 
             - name: Restore Postgres schema cache

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -7,7 +7,6 @@ on:
     pull_request:
         paths:
             - 'posthog/clickhouse/migrations/**'
-            - 'posthog/models/**/sql.py'
             - 'posthog/settings/data_stores.py'
             - 'posthog/clickhouse/cluster.py'
             - 'posthog/clickhouse/client/migration_tools.py'

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -61,6 +61,15 @@ jobs:
                   fetch-depth: 1000
                   filter: blob:none
 
+            - name: Fetch current PR base for schema cache key
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              # actions/checkout only populates the synthetic PR merge ref; the
+              # base ref has to be fetched explicitly for `git merge-base` to
+              # resolve it.
+              run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
             - name: Add multinode hostnames to /etc/hosts
               run: |
                   echo "127.0.0.1 clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions kafka zookeeper" | sudo tee -a /etc/hosts

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -44,8 +44,23 @@ jobs:
             REDIS_URL: 'redis://localhost'
             # unsafe - for testing only
             SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
+            # PostHogConfig.ready() calls setup_async_migrations() which reads
+            # posthog_asyncmigration / posthog_instancesetting. Skip it so the
+            # smoke can run against a schema-only Postgres dump.
+            SKIP_ASYNC_MIGRATIONS_SETUP: '1'
+            # If the "Restore Postgres schema cache" step below succeeds, this
+            # file exists and the smoke script primes Postgres from it instead
+            # of running a full `manage.py migrate`. Cache miss → file absent →
+            # script falls back to migrate automatically.
+            PRIME_POSTGRES_FROM: schema.sql.gz
         steps:
             - uses: actions/checkout@v6
+              with:
+                  # Needed for `git merge-base HEAD^2 origin/master` so we can key
+                  # the Postgres schema cache by the PR's merge base, matching
+                  # the producer in ci-backend.yml.
+                  fetch-depth: 1000
+                  filter: blob:none
 
             - name: Add multinode hostnames to /etc/hosts
               run: |
@@ -65,6 +80,31 @@ jobs:
 
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
+
+            - name: Compute Postgres schema cache key
+              id: schema-key
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: |
+                  # ci-backend.yml's "Validate migrations" job dumps the post-PR
+                  # schema and caches it keyed by master SHA. PR test jobs key
+                  # off the merge base so they restore the dump produced by the
+                  # commit their branch diverged from.
+                  MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                  if [ -n "$MERGE_BASE" ]; then
+                      echo "key=posthog-schema-master-${MERGE_BASE}" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "key=" >> "$GITHUB_OUTPUT"
+                      echo "::notice::merge-base not found — Postgres schema cache will be skipped"
+                  fi
+
+            - name: Restore Postgres schema cache
+              if: steps.schema-key.outputs.key != ''
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  path: schema.sql.gz
+                  key: ${{ steps.schema-key.outputs.key }}
 
             - name: Run smoke test
               run: tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke

--- a/tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke
+++ b/tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke
@@ -157,12 +157,30 @@ export DATABASE_URL="${DATABASE_URL:-postgres://posthog:posthog@localhost:5432/p
 export REDIS_URL="${REDIS_URL:-redis://localhost:6379}"
 export SECRET_KEY="${SECRET_KEY:-multinode-smoke-not-a-real-secret}"
 
-if [ "${KEEP_POSTGRES:-0}" = "1" ]; then
+if [ -n "${PRIME_POSTGRES_FROM:-}" ] && [ -f "${PRIME_POSTGRES_FROM}" ]; then
+    # CI primes Postgres from a cached schema dump produced by the
+    # "Validate migrations" job in ci-backend.yml. Loading via psql is much
+    # faster than running every Django migration from scratch. Pair this with
+    # SKIP_ASYNC_MIGRATIONS_SETUP=1 because PostHogConfig.ready() otherwise
+    # calls setup_async_migrations() and reads posthog_asyncmigration /
+    # posthog_instancesetting on every Django management command.
+    #
+    # The dump is created with `pg_dump --schema-only --clean --if-exists`
+    # plus a data-only dump of django_migrations, so it's idempotent against
+    # an existing fresh database (drops then recreates each object).
+    SMOKE_STAGE="prime_postgres"
+    echo "==> Priming Postgres from ${PRIME_POSTGRES_FROM}..."
+    gunzip -c "${PRIME_POSTGRES_FROM}" | psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 >/dev/null
+elif [ "${KEEP_POSTGRES:-0}" = "1" ]; then
     echo "==> KEEP_POSTGRES=1: skipping Django (Postgres) migrations"
 else
     SMOKE_STAGE="migrate_postgres"
-    # migrate_clickhouse reads `posthog_instancesetting` from Postgres, so the
-    # Django schema must exist before the ClickHouse step runs.
+    # migrate_clickhouse itself doesn't query Postgres, but every Django
+    # management command runs PostHogConfig.ready(), which calls
+    # setup_async_migrations() and reads posthog_asyncmigration /
+    # posthog_instancesetting. Set SKIP_ASYNC_MIGRATIONS_SETUP=1 to skip that
+    # read path; CI does that and points PRIME_POSTGRES_FROM at a cached
+    # schema dump so this branch is only taken on cache miss.
     echo "==> Running Django (Postgres) migrations..."
     python manage.py migrate --noinput
 fi


### PR DESCRIPTION
tl;dr; cache postgres schemas

## Problem

The multinode ClickHouse migration smoke (`ci-clickhouse-multinode-migrations.yml`) runs `python manage.py migrate --noinput` before `migrate_clickhouse`, paying ~30–90s to set up a Postgres schema the smoke doesn't actually exercise. `migrate_clickhouse` itself never queries Postgres — the dependency comes from `PostHogConfig.ready()` calling `setup_async_migrations()`, which reads `posthog_asyncmigration` and `posthog_instancesetting` on every Django management command.

## Changes

Reuse the schema cache that the "Validate migrations and OpenAPI types" job in `ci-backend.yml` already produces (`posthog-schema-master-<sha>` — a `pg_dump --schema-only --clean --if-exists` plus a data-only dump of `django_migrations`).

- **Smoke script** (`tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke`): when `PRIME_POSTGRES_FROM` points at a `.sql.gz`, gunzip + psql-load it instead of running migrate. Cache miss (file absent) falls back to the existing migrate path.
- **CI workflow** (`.github/workflows/ci-clickhouse-multinode-migrations.yml`): set `SKIP_ASYNC_MIGRATIONS_SETUP=1` (neutralizes the only known ORM read in the import chain), compute the merge-base cache key matching the producer's convention, restore the dump, and let the script auto-detect via `PRIME_POSTGRES_FROM`.

Local invocation of the smoke script is unchanged — without `PRIME_POSTGRES_FROM` set the script runs `manage.py migrate` exactly as before.

## How did you test this code?

Logic was syntax-checked locally; pushing for CI to exercise the real cache hit / miss paths end-to-end against the multinode stack.

## Publish to changelog?

do not publish to changelog