### PR TITLE
chore(mcp): address greptile feedback on querying-posthog-data refs

### DIFF
--- a/products/posthog_ai/skills/querying-posthog-data/references/models-logs.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-logs.md
@@ -173,7 +173,7 @@ If you already have the trace_id in base64 form (e.g. selected directly from the
 ```sql
 SELECT timestamp, severity_text, service_name, body
 FROM logs
-WHERE trace_id = 'IepzoCWp7NMq3z5ddUik9A=='
+WHERE trace_id = 'Ie2zoCWp7NMq3z5ddUik9A=='
 ORDER BY timestamp
 ```
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-logs.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-logs.md
@@ -32,11 +32,11 @@ OpenTelemetry log entries. One row per log line. Backed by ClickHouse `logs_dist
 
 ### Sort key
 
-`(team_id, service_name, toUnixTimestamp(timestamp))`. Queries that filter on `service_name` + a time window are very efficient. **Never query without a `service_name` (or `resource_attributes` filter) and a time window** — unfiltered queries can scan terabytes.
+`(team_id, service_name, toUnixTimestamp(timestamp))`. Queries that filter on `service_name` + a time window are very efficient. **Never query without a `service_name` filter and a time window** — unfiltered queries can scan terabytes. `resource_attributes` is a Map column outside the sort key, so a `resource_attributes` filter alone does **not** prune granules the way `service_name` does and is no substitute for it.
 
 ### Important notes
 
-- **`trace_id` and `span_id` are base64-encoded bytes**, not hex. The displayed hex form (e.g. `21EDB3A025A9ECD32ADF3E5D7548A4F4`) comes from the API layer via `hex(tryBase64Decode(trace_id))`. Raw HogQL queries see the 24-character base64 form (e.g. `21EDB3A025A9ECD32ADF...` becomes `IepzoCWp7NMq3z5ddUik9A==`).
+- **`trace_id` and `span_id` are base64-encoded bytes**, not hex. The displayed hex form (e.g. `21EDB3A025A9ECD32ADF3E5D7548A4F4`) comes from the API layer via `hex(tryBase64Decode(trace_id))`. Raw HogQL queries see the 24-character base64 form (e.g. `21EDB3A025A9ECD32ADF3E5D7548A4F4` becomes `Ie2zoCWp7NMq3z5ddUik9A==`).
 - **Unset `trace_id` is `'AAAAAAAAAAAAAAAAAAAAAA=='`** (16 zero bytes encoded), not the hex zero-padded form. Use `trace_id != 'AAAAAAAAAAAAAAAAAAAAAA=='` to find logs with trace context. Or use the explicit decode: `tryBase64Decode(trace_id) != unhex('00000000000000000000000000000000')`.
 - **Use `hex(tryBase64Decode(trace_id))` to display trace_ids in hex** for human-readable output.
 - **Prefer `severity_text` over `severity_number` / `level`** for human-readable filters.

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-metrics.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-metrics.md
@@ -93,19 +93,21 @@ GROUP BY metric_name, metric_type
 ORDER BY n DESC
 ```
 
-**Per-minute mean value of a metric, broken down by service (projection-friendly):**
+**Per-minute mean value of a non-histogram metric, broken down by service (projection-friendly — `count = 1` per row, so `count()` maps to the projection's `event_count`):**
 
 ```sql
 SELECT
     toStartOfMinute(timestamp) AS minute,
     service_name,
-    sum(value) / sum(count) AS mean_value
+    sum(value) / count() AS mean_value
 FROM posthog.metrics
 WHERE metric_name = 'http.server.duration'
   AND timestamp >= now() - INTERVAL 1 HOUR
 GROUP BY minute, service_name
 ORDER BY minute, mean_value DESC
 ```
+
+The `projection_aggregate_counts` projection stores `count() AS event_count` and `sum(value) AS total_value`. `sum(count_column)` (the per-row UInt64) is **not** in the projection — using it forces a base-table scan. For histograms (where `count` per row is the bucket observation count), compute the mean separately and don't expect projection acceleration.
 
 **Top services by counter rate in the last hour:**
 


### PR DESCRIPTION
## Problem

PR [#59084](https://github.com/PostHog/posthog/pull/59084) landed before three greptile review comments could be addressed:

1. **(P1)** `models-metrics.md` "projection-friendly" mean query used `sum(value) / sum(count)` — but `count` is a per-row `UInt64` column (histogram observation count), not the aggregate `count()`. The projection stores `count() AS event_count` and `sum(value) AS total_value`, so `sum(count_column)` forces a base-table scan. An agent following the prompt expecting near-free cost would hit full scans.
2. **(P1)** `models-logs.md` sort-key note implied `resource_attributes` is an acceptable substitute for `service_name`. It isn't — `resource_attributes` is a `Map` column outside the sort key and doesn't prune granules. An agent omitting `service_name` based on the doc could run multi-TB scans.
3. **(P2)** `models-logs.md` illustrative base64 example was fabricated: `21EDB3A025A9ECD32ADF3E5D7548A4F4` actually base64-encodes to `Ie2zoCWp7NMq3z5ddUik9A==`, not `IepzoCWp...`. An agent cross-checking would distrust the surrounding guidance.

## Changes

`products/posthog_ai/skills/querying-posthog-data/references/models-metrics.md`:

- Swap the mean query to `sum(value) / count()` and retitle "projection-friendly for non-histogram metrics where `count = 1`".
- Add a paragraph explaining the projection's exact aggregate set (`event_count`, `total_value`, `min_value`, `max_value`) and the histogram caveat, so the next reader doesn't repeat the mistake.

`products/posthog_ai/skills/querying-posthog-data/references/models-logs.md`:

- Remove the `resource_attributes`-as-equivalent claim and explicitly call out that `resource_attributes` is a Map column outside the sort key.
- Fix the illustrative base64 example to `Ie2zoCWp7NMq3z5ddUik9A==` (verified locally via `python -c "import base64; print(base64.b64encode(bytes.fromhex('21EDB3A025A9ECD32ADF3E5D7548A4F4')))"` → `Ie2zoCWp7NMq3z5ddUik9A==`).

## How did you test this code?

I'm an agent. No automated tests — these are markdown reference files. Verified the base64 conversion with Python, and matched the projection columns against `posthog/clickhouse/metrics/metrics1.py` (`projection_aggregate_counts` definition).

## Publish to changelog?

no

## Docs update

`skip-inkeep-docs` — agent-facing reference materials.

## 🤖 Agent context

PostHog Code session. Follow-up to merged PR #59084 to resolve bot comments left after the merge. The same base64 typo also exists in `services/mcp/src/templates/execute-sql-prompt.md` (introduced by PR #59083); that fix is being added to the parallel follow-up PR #59116 to keep the scope mapping tight.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*