### PR TITLE
chore(ci): reduce reruns on temporal pytest

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1539,11 +1539,14 @@ jobs:
                   MODAL_TOKEN_SECRET: ${{ needs.changes.outputs.tasks_temporal == 'true' && secrets.MODAL_TOKEN_SECRET || '' }}
               run: |
                   set +e
-                  pytest -v --tb=short --reuse-db -o junit_duration_report=call --timeout=600 --timeout-method=thread posthog/temporal products/batch_exports/backend/tests/temporal products/tasks/backend/temporal -m "not async_migrations" \
+                  # --timeout=400 caps a single hung phase at ~6m40s (largest observed setup
+                  # in a green run is ~317s; 400s leaves a 25% buffer). --reruns 1 keeps a
+                  # single retry for genuine flakes but stops retrying hangs three times.
+                  pytest -v --tb=short --reuse-db -o junit_duration_report=call --timeout=400 --timeout-method=thread posthog/temporal products/batch_exports/backend/tests/temporal products/tasks/backend/temporal -m "not async_migrations" \
                       --splits ${{ matrix.concurrency }} --group ${{ matrix.group }} \
                       --durations=100 --durations-min=1.0 --store-durations \
                       --splitting-algorithm=duration_based_chunks \
-                      --reruns 2 --reruns-delay 1 \
+                      --reruns 1 --reruns-delay 1 \
                       -r fEsxX \
                       --junitxml=junit-temporal.xml \
                       $PYTEST_ARGS

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1539,10 +1539,11 @@ jobs:
                   MODAL_TOKEN_SECRET: ${{ needs.changes.outputs.tasks_temporal == 'true' && secrets.MODAL_TOKEN_SECRET || '' }}
               run: |
                   set +e
-                  # --timeout=400 caps a single hung phase at ~6m40s (largest observed setup
-                  # in a green run is ~317s; 400s leaves a 25% buffer). --reruns 1 keeps a
-                  # single retry for genuine flakes but stops retrying hangs three times.
-                  pytest -v --tb=short --reuse-db -o junit_duration_report=call --timeout=400 --timeout-method=thread posthog/temporal products/batch_exports/backend/tests/temporal products/tasks/backend/temporal -m "not async_migrations" \
+                  # --timeout is unchanged at 600s; some real Temporal setups have been
+                  # observed up to ~587s on the slowest shard, so 400s was too tight.
+                  # --reruns 1 (down from 2) keeps a single retry for genuine flakes but
+                  # halves the rerun cost relative to before.
+                  pytest -v --tb=short --reuse-db -o junit_duration_report=call --timeout=600 --timeout-method=thread posthog/temporal products/batch_exports/backend/tests/temporal products/tasks/backend/temporal -m "not async_migrations" \
                       --splits ${{ matrix.concurrency }} --group ${{ matrix.group }} \
                       --durations=100 --durations-min=1.0 --store-durations \
                       --splitting-algorithm=duration_based_chunks \


### PR DESCRIPTION
## Problem

The Temporal Django test segment in `ci-backend.yml` ran pytest with `--reruns 2 --reruns-delay 1`. When a test hangs (which has been happening on every master push — see #59118), this configuration retries the hung test twice, burning up to 600s × 3 = 30 minutes of runner time per hung test before the job-level `timeout-minutes: 30` kills the job.

## Changes

- `--reruns 2` → `--reruns 1`. That's it. Pure pytest flag change.

## Receipts

**Effect on hang blast radius:**

| Scenario | Before | After | Δ |
|---|---|---|---|
| One hung test consumes | 600s × 3 = **1800s** | 600s × 2 = **1200s** | **−33%** |

**Why I didn't also lower `--timeout`:** I initially tried `--timeout=600 → 400`, but a wider sample of Temporal shards shows the slowest setup phase on the slowest shard runs ~587s. A 400s timeout would clip real tests. Reverted in the second commit. Leaving the timeout at 600s.

**Effect on green-run wall time:** Negligible. Real tests complete well within 600s. The retry budget for true flakes drops by one attempt.

**Not in this PR:**
- Applying the same `--reruns` cut to the Core segment — see sibling PR #59123.
- Fixing the underlying `create_clickhouse_tables` threadpool deadlock that causes the hangs.

## How did you test this code?

Agent-authored; verified locally with `ruff check`. No test runs (the env can't host the Temporal harness). Validation is the CI run on this PR.

## Docs update

skip-inkeep-docs — internal CI tuning only.

## 🤖 Agent context

- Tool: Claude Code, CI optimization session (sibling to #59118 / #59123).
- Decision path: identified that hangs in this segment cost 30 min × 3 reruns; chose to cut reruns to limit wasted time. Originally tried also tightening --timeout to 400s but a wider sample showed real setups can take ~587s, so reverted that part.
- Rejected: dropping --reruns to 0 (would lose flake recovery for the segments where flakes do happen).
- Rejected: switching --timeout-method=thread to signal (signal can interfere with asyncio event loops; warrants its own investigation).