### PR TITLE
fix(playwright): drop stale data-attr click after LemonRadio refactor

### DIFF
--- a/playwright/e2e/surveys/crud.spec.ts
+++ b/playwright/e2e/surveys/crud.spec.ts
@@ -197,7 +197,9 @@ test.describe('CRUD Survey', () => {
         await page.locator('[data-attr="survey-popup-delay-input"]').fill('5')
 
         await page.locator('.LemonButton').getByText('Display conditions').click()
-        await page.locator('[data-attr="survey-display-conditions-select"]').click()
+        // Display conditions is now a LemonRadio whose outer data-attr is not
+        // forwarded to the DOM (only inner option `data-attr`s are). Click the
+        // "match conditions" radio option directly.
         await page.locator('[data-attr="survey-display-conditions-select-users"]').click()
 
         await expect(page.getByText('Cancel survey on events')).toBeVisible()


### PR DESCRIPTION
## Problem

E2E Playwright workflow has been failing on every non-cancelled master run since [#58893](https://github.com/PostHog/posthog/pull/58893) landed. Across the most recent 200 completed runs, **48/71 non-cancelled runs failed (67.6%)**, and **29/29 (100%) of the runs that started after the refactor merged** failed.

The dominant pattern: `e2e/surveys/crud.spec.ts:184:9 > CRUD Survey > can set cancellation events` failed on **12 of the 13 most recent sampled failures** (the lone non-survey failure was due to unrelated flake reaching the `--max-failures=5` cap after this one already failed). Across all 3 retries the test timed out on the same line:

```
Test timeout of 90000ms exceeded.
Error: locator.click: Test timeout of 90000ms exceeded.
Call log:
  - waiting for locator('[data-attr="survey-display-conditions-select"]')
> 200 | await page.locator('[data-attr="survey-display-conditions-select"]').click()
```

### Root cause

[#58893](https://github.com/PostHog/posthog/pull/58893) (`refactor(surveys): tidy legacy Display conditions section`) replaced `LemonSelect` with `LemonRadio` for the "Display conditions" choice. `data-attr="survey-display-conditions-select"` still appears on the React element in `SurveyEdit.tsx`, but `LemonRadio` only forwards `data-attr` to the inner `<input type=\"radio\">` of each option — the outer container drops it. So the attribute simply no longer exists in the DOM, and the click waits forever.

The inner option's `data-attr="survey-display-conditions-select-users"` is still forwarded correctly, and clicking it is the actual interaction the test needs (it toggles the radio from "All users" to "Only users who match conditions").

## Changes

- Removed the stale `[data-attr=\"survey-display-conditions-select\"]` click in `playwright/e2e/surveys/crud.spec.ts` so the test interacts with the new `LemonRadio` directly.

## How did you test this code?

I'm an agent. I did not run the Playwright suite locally. Validation:

- Read `LemonRadio.tsx` to confirm `data-attr` is forwarded only to inner `<input>` elements, not the outer `<div>`.
- Bisected via `gh run view --log` across 13 recent failed E2E runs — confirmed all hit the same locator on the same line.
- Confirmed `survey-display-conditions-select-users` still exists in the DOM (it is in `LemonRadioOption.optionProps` which is spread onto the `<input>`).
- Pre-commit hooks (`bin/hogli format:js`, husky) ran cleanly against the change.

## Publish to changelog?

no

## 🤖 Agent context

- Agent (Claude Code, Opus 4.7) ran as part of a CI optimization sweep that is sampling failing master workflows and shipping the smallest fix per dominant cause.
- Failure pattern was identified by listing the 14 most recent failing E2E Playwright runs on master and reading `gh run view --log` for each — every one of them named `crud.spec.ts:184 > can set cancellation events` as the only hard failure (other named failures were retried as "flaky" and ultimately passed; this one fails all 3 retries).
- The fix was scoped to a single line + comment. Considered (a) `test.fixme` and (b) restoring the outer `data-attr` on the React component, but the simplest and most correct change was to drop the redundant click — the radio interaction is what the test cares about.
- Before: 29/29 (100%) failure rate on master since the refactor merged. After: expected near-baseline (the previous flakes — trends formula, dashboards delete — are noisy but already retried as flaky and pass).