### PR TITLE
chore(ci): retry transient docker pulls in dagster CI

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -236,6 +236,11 @@ jobs:
               env:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image }}
+                  # Retry transient image-pull failures (TLS handshake timeouts,
+                  # registry-1.docker.io / docker.redpanda.com flakes) so a single
+                  # blip doesn't sink the whole shard. Matches ci-backend/ci-nodejs/ci-rust.
+                  WAIT_FOR_DOCKER_LAUNCH_RETRIES: 3
+                  WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY: 5
               run: |
                   bin/ci-wait-for-docker launch --down
 


### PR DESCRIPTION
## Problem

**Every Dagster CI master failure in the sampled history was a one-attempt Docker Compose launch failure, not a test failure.** 7 of 7 push runs that completed with `failure` over the historical window hit `Docker Compose launch failed after 1 attempt(s)` during the "Start stack with Docker Compose" step — caused by a transient network blip while pulling images from `registry-1.docker.io` or `docker.redpanda.com`.

Sampled failures (all push events on `master`):

| Run | Date | Failing shard(s) | Root error |
|-----|------|----|---|
| [25427675089](https://github.com/PostHog/posthog/actions/runs/25427675089) | 2026-05-06 | 1/3, 2/3, 3/3 | `docker.redpanda.com … TLS handshake timeout` |
| [25427871266](https://github.com/PostHog/posthog/actions/runs/25427871266) | 2026-05-06 | 1/3, 2/3, 3/3 | `docker.redpanda.com … TLS handshake timeout` |
| [25471067510](https://github.com/PostHog/posthog/actions/runs/25471067510) | 2026-05-07 | 1/3, 2/3, 3/3 | `docker.redpanda.com … Client.Timeout` |
| [25471330491](https://github.com/PostHog/posthog/actions/runs/25471330491) | 2026-05-07 | 1/3, 2/3, 3/3 | `docker.redpanda.com … connection refused` |
| [25510549823](https://github.com/PostHog/posthog/actions/runs/25510549823) | 2026-05-07 | 1/3, 2/3, 3/3 | `docker.redpanda.com … TLS handshake timeout` |
| [25529055409](https://github.com/PostHog/posthog/actions/runs/25529055409) | 2026-05-08 | 2/3 | `registry-1.docker.io … context deadline exceeded` |
| [25643697690](https://github.com/PostHog/posthog/actions/runs/25643697690) | 2026-05-11 | 1/3 | (logs expired; matching `Docker Compose launch failed after 1 attempt(s)` pattern) |

The Compose launch helper (`bin/ci-wait-for-docker`) already supports launch retries via `WAIT_FOR_DOCKER_LAUNCH_RETRIES`, but defaults to a single attempt. Dagster CI didn't opt in; the three sibling workflows did (see Receipts below). The result: a single registry hiccup nukes every shard in lockstep.

## Changes

Add `WAIT_FOR_DOCKER_LAUNCH_RETRIES: 3` and `WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY: 5` to the "Start stack with Docker Compose" step in `.github/workflows/ci-dagster.yml`. No script changes; the retry logic in `bin/ci-wait-for-docker` (lines 221–241) already implements exponential backoff once these vars are set. Matches the existing config in `ci-backend.yml`, `ci-nodejs.yml`, and `ci-rust.yml`.

## How did you test this code?

I'm an agent. I did not run the workflow locally — Dagster CI requires the full Docker Compose stack which I cannot reproduce in this environment. Verification is by inspection:

- `bin/ci-wait-for-docker` already has the retry loop wired (`run_launch` → `launch_runner`, lines 184–241); the new env vars feed straight into it.
- The same env vars are in production use in `ci-backend.yml` (line 1283), `ci-nodejs.yml` (line 186), and `ci-rust.yml` (line 232).
- The fix is additive — `WAIT_FOR_DOCKER_LAUNCH_RETRIES` defaults to 1 today, so this only changes the failure path.

CI on this PR will exercise the new env on the standard Dagster shards. Each retry adds at most ~5s × 2 of backoff plus the `compose up` attempt itself, so worst-case launch budget grows by ~20–30s.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- **Agent:** Claude (Opus 4.7), via Claude Code as part of a CI-optimization push.
- **Tool calls used:** `gh run list` / `gh run view` / `gh api` to walk the recent Dagster CI runs on master and pull the per-job failure logs; `Read` + `Edit` on `.github/workflows/ci-dagster.yml`; `git diff` / `git commit` / `git push`.
- **Investigation:** Sampled the most recent 1000 push runs of `ci-dagster.yml` on master. Of those: 461 success, 7 failure, 531 cancelled (superseded fork PR pushes), 1 in-progress. Pulled the failure logs for all 7 — every one terminates with `Docker Compose launch failed after 1 attempt(s)` in the "Start stack with Docker Compose" step, with a registry-pull error one line above. Verified the failures cluster on the launch step itself, not on the readiness wait, dependency install, migrations, or `pytest` invocation, which means the cheap launch-retry knob is the right lever.
- **Decisions:**
  - Considered widening the path filter or quarantining a specific test — neither applies; no test ever ran in the failing jobs.
  - Considered switching to `--background` launches like ci-backend uses — out of scope for a single-shot fix, since it also requires restructuring the wait step and rearranging job ordering.
  - Chose the smallest possible change: copy the launch-retry env knobs that ci-backend / ci-nodejs / ci-rust already set, since the retry loop is already implemented in `bin/ci-wait-for-docker`.
- **Concerns / follow-ups (not in this PR):**
  - Most "cancelled" runs in the sample come from fork PRs whose head is `master` — the concurrency group collapses them into the canonical master run. Worth a separate look at whether to filter fork pushes off the workflow entirely, but it's not causing failures today.
  - The actual flake source (registry pulls) deserves a mirror or pre-pulled images, but that's an infra change beyond this PR.