### PR TITLE
chore(ci): reduce reruns on core backend pytest

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1472,11 +1472,11 @@ jobs:
               shell: bash
               run: | # async_migrations covered in ci-async-migrations.yml
                   set +e
-                  # --timeout=400 caps a single hung phase at ~6m40s — a safety net for the
-                  # Core segment, which previously relied solely on the 30-minute job-level
-                  # kill. --reruns 1 keeps a single retry for genuine flakes while halving
-                  # the rerun cost relative to the previous --reruns 2.
-                  pytest -v --tb=short --reuse-db -o junit_duration_report=call --timeout=400 --timeout-method=thread ${{
+                  # --reruns 1 (down from 2) keeps a single retry for genuine flakes but
+                  # halves the rerun cost when a test fails. No per-test --timeout: real
+                  # Core setups can run ~600s on the heaviest shards (Django+Clickhouse
+                  # fixture warmup), so a tight per-phase cap would falsely fail them.
+                  pytest -v --tb=short --reuse-db -o junit_duration_report=call ${{
                       matrix.compat
                       && env.CLICKHOUSE_COMPAT_PYTEST_TARGETS
                       || (

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1472,7 +1472,11 @@ jobs:
               shell: bash
               run: | # async_migrations covered in ci-async-migrations.yml
                   set +e
-                  pytest -v --tb=short --reuse-db -o junit_duration_report=call ${{
+                  # --timeout=400 caps a single hung phase at ~6m40s — a safety net for the
+                  # Core segment, which previously relied solely on the 30-minute job-level
+                  # kill. --reruns 1 keeps a single retry for genuine flakes while halving
+                  # the rerun cost relative to the previous --reruns 2.
+                  pytest -v --tb=short --reuse-db -o junit_duration_report=call --timeout=400 --timeout-method=thread ${{
                       matrix.compat
                       && env.CLICKHOUSE_COMPAT_PYTEST_TARGETS
                       || (
@@ -1489,7 +1493,7 @@ jobs:
                       --splits ${{ matrix.concurrency }} --group ${{ matrix.group }} \
                       --durations=1000 --durations-min=1.0 --store-durations \
                       --splitting-algorithm=duration_based_chunks \
-                      --reruns 2 --reruns-delay 1 \
+                      --reruns 1 --reruns-delay 1 \
                       -r fEsxX \
                       --junitxml=junit-core.xml \
                       $PYTEST_ARGS


### PR DESCRIPTION
## Problem

The Core test segment ran pytest with `--reruns 2 --reruns-delay 1`, retrying a failed test up to two times before giving up. For real failures and hangs, the extra retries multiply wasted runner time without changing the outcome.

## Changes

- `--reruns 2` → `--reruns 1`. Pure pytest flag change.

## Receipts

**Why this is safe:**
- `--reruns 1` still recovers genuine flakes — just stops re-running an already-failed test three times.
- No timeout change. Sampling all Core shards in the most recent green master ci-backend run shows the slowest setup phase is ~600s (Django + Clickhouse fixture warmup on the first test of each TestCase class). A tight per-phase `--timeout` would falsely fail those real tests, so I'm leaving the existing 30-minute job-level kill as the safety net.

**Effect on real Core tests:** None. Pass-on-first-try tests are unchanged.

**Effect when a test fails:** Wasted retry time drops by ~33% (one fewer retry).

**Not in this PR:**
- `async_migrations` pytest call also uses `--reruns 2`. Migration tests legitimately can take longer, separate decision needed.
- A per-phase `--timeout` for Core. Out of scope until the ~600s first-test setup is sped up.

## How did you test this code?

Agent-authored; pre-commit hooks ran clean. No test runs (the env can't host the harness). CI on this PR will validate.

## Docs update

skip-inkeep-docs — CI tuning only.

## 🤖 Agent context

- Tool: Claude Code, sibling PR to #59119.
- Decision: tried adding `--timeout=400` on top of the `--reruns 2 → 1` change. A wider sample (all Core shards in a recent green run) showed real setups take ~600s, so a 400s cap would have failed real tests. Reverted the timeout add. Kept the unambiguously-safe reruns reduction.
- Rejected: applying the same to async_migrations (not safe without further investigation of legitimate slow migrations).
- Rejected: dropping --reruns to 0 (would lose flake recovery without enough data to justify).