### PR TITLE
fix(quill): exclude stories from quill-components dts build

### DIFF
--- a/packages/quill/packages/components/tsconfig.build.json
+++ b/packages/quill/packages/components/tsconfig.build.json
@@ -15,5 +15,6 @@
             "@/*": ["./src/*"]
         }
     },
-    "include": ["src"]
+    "include": ["src"],
+    "exclude": ["src/**/*.stories.tsx", "src/**/*.stories.ts"]
 }


### PR DESCRIPTION
## Problem

100% of the recent **Frontend CI master failures** (3 of 3 in the sampled window) hit the same TS2307 error in `@posthog/quill-components`:

```
src/date-time-picker.stories.tsx:1:37 - error TS2307: Cannot find module '@storybook/react'
```

`vite-plugin-dts` runs during the package's `vite build`, type-checks the entire `src/` tree, and chokes because:
- `date-time-picker.stories.tsx` imports `@storybook/react`
- `@posthog/quill-components` doesn't list `@storybook/react` in any dependency block (and shouldn't — story files are only consumed by the Storybook app)

The sibling package `@posthog/quill-primitives` already handles this correctly:

```json
"exclude": ["src/**/*.stories.tsx", "src/**/*.stories.ts"]
```

`@posthog/quill-components/tsconfig.build.json` was missing the same exclusion.

## Changes

One-line change to `packages/quill/packages/components/tsconfig.build.json`: add the same `exclude` block that `primitives` already has.

```json
"exclude": ["src/**/*.stories.tsx", "src/**/*.stories.ts"]
```

That's the entire diff.

## Receipts

**Before:** 3/3 recent Frontend CI master failures attributable to this TS2307 error (deterministic, same job: `Jest test (EE - 1)` → upstream `pnpm build:products` step).

**After:** The dts build no longer reads story files at all. The story is still discoverable by Storybook (which has its own root config and entry points). Other story files in the `primitives` package have been working under this exclusion pattern for some time, so the precedent is well-established.

## How did you test this code?

Agent-authored. Verified that:
- `@posthog/quill-primitives/tsconfig.build.json` ships the exact same `exclude` pattern today and its build is green.
- The diff is a one-line config addition.
- Pre-commit hooks ran clean.

No local test runs (the env can't host the full pnpm/turbo pipeline). CI on this PR will validate.

## Docs update

skip-inkeep-docs — internal build config fix.

## 🤖 Agent context

- Tool: Claude Code, CI optimization session.
- Decision path: surveyed Frontend CI master failures, found all 3 had identical TS2307 fingerprints pointing at `date-time-picker.stories.tsx`. Confirmed sibling `primitives` package already uses the exclude pattern; copy-pasted it onto `components`.
- Rejected: adding `@storybook/react` as a devDependency of `components` (would pull a tooling dep into a runtime package; doesn't match the architecture where stories are only consumed by the Storybook app).
- Rejected: deleting the story file (it's the actual Storybook documentation for the date-time-picker component).