### PR TITLE
fix(llma): add explicit LIMIT to sentiment heavy SQL to stop row truncation

### DIFF
--- a/products/llm_analytics/backend/api/sentiment.py
+++ b/products/llm_analytics/backend/api/sentiment.py
@@ -35,7 +35,7 @@ from posthog.api.monitoring import monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.hogql_queries.ai.ai_column_rewriter import rewrite_expr_for_events_table, rewrite_query_for_events_table
-from posthog.hogql_queries.ai.ai_table_resolver import execute_with_ai_events_fallback
+from posthog.hogql_queries.ai.ai_table_resolver import execute_with_ai_events_fallback, is_ai_events_enabled
 from posthog.permissions import AccessControlPermission
 from posthog.rate_limit import LLMAnalyticsSentimentBurstThrottle, LLMAnalyticsSentimentSustainedThrottle
 from posthog.temporal.common.client import sync_connect
@@ -403,14 +403,16 @@ class LLMAnalyticsSentimentViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
             # table can hold inputs for some traces in the batch but not others,
             # so any trace missing from `ai_input_by_trace` here would render a
             # blank card in the sentiment tab. Fill those in from the shared
-            # `events` table directly (the same fallback target the wrapper would
-            # have used). Skipped when the wrapper already routed to events
-            # (kill switch off, or zero coverage) — `ai_input_by_trace` already
-            # reflects events in that case.
+            # `events` table directly. Gated on the kill switch so a kill-switch-off
+            # team (which already reads directly from events via the wrapper) does
+            # not re-run the same events query — only the rare edge case of "kill
+            # switch on, ai_events returned zero, wrapper fell back to events with
+            # partial coverage" eats a redundant query.
             missing_trace_ids = [tid for tid in trace_ids if tid not in ai_input_by_trace]
-            if missing_trace_ids and ai_input_by_trace:
-                missing_uuids = [u for tid, u in zip(trace_ids, uuids) if tid in set(missing_trace_ids)]
-                backfill_query = rewrite_query_for_events_table(parse_select(_SENTIMENT_GENERATIONS_HEAVY_SQL))
+            if missing_trace_ids and ai_input_by_trace and is_ai_events_enabled(self.team):
+                uuid_by_trace = dict(zip(trace_ids, uuids))
+                missing_uuids = [uuid_by_trace[tid] for tid in missing_trace_ids]
+                backfill_query = rewrite_query_for_events_table(heavy_query)
                 backfill_placeholders = {
                     "trace_ids": rewrite_expr_for_events_table(
                         ast.Tuple(exprs=[ast.Constant(value=tid) for tid in missing_trace_ids])

--- a/products/llm_analytics/backend/api/sentiment.py
+++ b/products/llm_analytics/backend/api/sentiment.py
@@ -34,8 +34,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.api.monitoring import monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
-from posthog.hogql_queries.ai.ai_column_rewriter import rewrite_expr_for_events_table, rewrite_query_for_events_table
-from posthog.hogql_queries.ai.ai_table_resolver import execute_with_ai_events_fallback, is_ai_events_enabled
+from posthog.hogql_queries.ai.ai_table_resolver import execute_with_ai_events_fallback
 from posthog.permissions import AccessControlPermission
 from posthog.rate_limit import LLMAnalyticsSentimentBurstThrottle, LLMAnalyticsSentimentSustainedThrottle
 from posthog.temporal.common.client import sync_connect
@@ -145,17 +144,24 @@ ORDER BY ts_max DESC, trace_id DESC
 LIMIT {GENERATIONS_QUERY_LIMIT}
 """
 
-_SENTIMENT_GENERATIONS_HEAVY_SQL = """
+# The explicit `LIMIT` matches the preflight's `GENERATIONS_QUERY_LIMIT` —
+# without it, `execute_hogql_query` (via `LimitContext.QUERY`) injects its
+# default of 100 rows, silently truncating the heavy `GROUP BY trace_id`
+# to the first 100 trace_ids whenever the preflight returns more. That
+# manifests in the UI as blank sentiment cards for the truncated half,
+# even though the underlying input is present in ClickHouse.
+_SENTIMENT_GENERATIONS_HEAVY_SQL = f"""
 SELECT
     trace_id,
     argMax(input, timestamp) as ai_input
 FROM posthog.ai_events AS ai_events
 WHERE event = '$ai_generation'
-    AND trace_id IN {trace_ids}
-    AND uuid IN {uuids}
-    AND timestamp >= {ts_start}
-    AND timestamp <= {ts_end}
+    AND trace_id IN {{trace_ids}}
+    AND uuid IN {{uuids}}
+    AND timestamp >= {{ts_start}}
+    AND timestamp <= {{ts_end}}
 GROUP BY trace_id
+LIMIT {GENERATIONS_QUERY_LIMIT}
 """
 
 _PreflightRow = namedtuple("_PreflightRow", ["uuid", "trace_id", "model", "distinct_id", "ts_max", "ts_min"])
@@ -396,54 +402,7 @@ class LLMAnalyticsSentimentViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
 
-            ai_input_by_trace = {str(trace_id): ai_input for trace_id, ai_input in (heavy_result.results or [])}
-
-            # `execute_with_ai_events_fallback` only falls back when the dedicated
-            # table returns *zero* rows total. During the ai_events rollout the
-            # table can hold inputs for some traces in the batch but not others,
-            # so any trace missing from `ai_input_by_trace` here would render a
-            # blank card in the sentiment tab. Fill those in from the shared
-            # `events` table directly. Gated on the kill switch so a kill-switch-off
-            # team (which already reads directly from events via the wrapper) does
-            # not re-run the same events query — only the rare edge case of "kill
-            # switch on, ai_events returned zero, wrapper fell back to events with
-            # partial coverage" eats a redundant query.
-            missing_trace_ids = [tid for tid in trace_ids if tid not in ai_input_by_trace]
-            if missing_trace_ids and ai_input_by_trace and is_ai_events_enabled(self.team):
-                uuid_by_trace = dict(zip(trace_ids, uuids))
-                missing_uuids = [uuid_by_trace[tid] for tid in missing_trace_ids]
-                backfill_query = rewrite_query_for_events_table(heavy_query)
-                backfill_placeholders = {
-                    "trace_ids": rewrite_expr_for_events_table(
-                        ast.Tuple(exprs=[ast.Constant(value=tid) for tid in missing_trace_ids])
-                    ),
-                    "uuids": rewrite_expr_for_events_table(
-                        ast.Tuple(exprs=[ast.Constant(value=u) for u in missing_uuids])
-                    ),
-                    "ts_start": ast.Constant(value=ts_start),
-                    "ts_end": ast.Constant(value=ts_end),
-                }
-                try:
-                    backfill_result = execute_hogql_query(
-                        query=backfill_query,
-                        placeholders=backfill_placeholders,
-                        team=self.team,
-                        query_type="LLMSentimentGenerationsBackfill",
-                        limit_context=LimitContext.QUERY,
-                    )
-                except Exception as e:
-                    # Don't fail the whole response — the cards will render
-                    # blank for the missing traces (same as today) and we log
-                    # for follow-up.
-                    logger.warning(
-                        "Failed to backfill sentiment generations from events",
-                        team_id=self.team_id,
-                        missing_trace_count=len(missing_trace_ids),
-                        error=str(e),
-                    )
-                else:
-                    for trace_id, ai_input in backfill_result.results or []:
-                        ai_input_by_trace[str(trace_id)] = ai_input
+        ai_input_by_trace = {str(trace_id): ai_input for trace_id, ai_input in (heavy_result.results or [])}
         # Positional response shape (unchanged, frontend depends on it): row[0..6] =
         # [uuid, trace_id, ai_input, model, distinct_id, ts_max, ts_min]. The internal
         # `ts_max` / `ts_min` aliases (see `_SENTIMENT_GENERATIONS_PREFLIGHT_SQL`) are

--- a/products/llm_analytics/backend/api/sentiment.py
+++ b/products/llm_analytics/backend/api/sentiment.py
@@ -34,6 +34,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.api.monitoring import monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.hogql_queries.ai.ai_column_rewriter import rewrite_expr_for_events_table, rewrite_query_for_events_table
 from posthog.hogql_queries.ai.ai_table_resolver import execute_with_ai_events_fallback
 from posthog.permissions import AccessControlPermission
 from posthog.rate_limit import LLMAnalyticsSentimentBurstThrottle, LLMAnalyticsSentimentSustainedThrottle
@@ -370,15 +371,16 @@ class LLMAnalyticsSentimentViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
             ts_end = max(row.ts_max for row in preflight_rows)
 
             heavy_query = parse_select(_SENTIMENT_GENERATIONS_HEAVY_SQL)
+            heavy_placeholders = {
+                "trace_ids": ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_ids]),
+                "uuids": ast.Tuple(exprs=[ast.Constant(value=u) for u in uuids]),
+                "ts_start": ast.Constant(value=ts_start),
+                "ts_end": ast.Constant(value=ts_end),
+            }
             try:
                 heavy_result = execute_with_ai_events_fallback(
                     query=heavy_query,
-                    placeholders={
-                        "trace_ids": ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_ids]),
-                        "uuids": ast.Tuple(exprs=[ast.Constant(value=u) for u in uuids]),
-                        "ts_start": ast.Constant(value=ts_start),
-                        "ts_end": ast.Constant(value=ts_end),
-                    },
+                    placeholders=heavy_placeholders,
                     team=self.team,
                     query_type="LLMSentimentGenerations",
                     limit_context=LimitContext.QUERY,
@@ -394,7 +396,52 @@ class LLMAnalyticsSentimentViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
 
-        ai_input_by_trace = {str(trace_id): ai_input for trace_id, ai_input in (heavy_result.results or [])}
+            ai_input_by_trace = {str(trace_id): ai_input for trace_id, ai_input in (heavy_result.results or [])}
+
+            # `execute_with_ai_events_fallback` only falls back when the dedicated
+            # table returns *zero* rows total. During the ai_events rollout the
+            # table can hold inputs for some traces in the batch but not others,
+            # so any trace missing from `ai_input_by_trace` here would render a
+            # blank card in the sentiment tab. Fill those in from the shared
+            # `events` table directly (the same fallback target the wrapper would
+            # have used). Skipped when the wrapper already routed to events
+            # (kill switch off, or zero coverage) — `ai_input_by_trace` already
+            # reflects events in that case.
+            missing_trace_ids = [tid for tid in trace_ids if tid not in ai_input_by_trace]
+            if missing_trace_ids and ai_input_by_trace:
+                missing_uuids = [u for tid, u in zip(trace_ids, uuids) if tid in set(missing_trace_ids)]
+                backfill_query = rewrite_query_for_events_table(parse_select(_SENTIMENT_GENERATIONS_HEAVY_SQL))
+                backfill_placeholders = {
+                    "trace_ids": rewrite_expr_for_events_table(
+                        ast.Tuple(exprs=[ast.Constant(value=tid) for tid in missing_trace_ids])
+                    ),
+                    "uuids": rewrite_expr_for_events_table(
+                        ast.Tuple(exprs=[ast.Constant(value=u) for u in missing_uuids])
+                    ),
+                    "ts_start": ast.Constant(value=ts_start),
+                    "ts_end": ast.Constant(value=ts_end),
+                }
+                try:
+                    backfill_result = execute_hogql_query(
+                        query=backfill_query,
+                        placeholders=backfill_placeholders,
+                        team=self.team,
+                        query_type="LLMSentimentGenerationsBackfill",
+                        limit_context=LimitContext.QUERY,
+                    )
+                except Exception as e:
+                    # Don't fail the whole response — the cards will render
+                    # blank for the missing traces (same as today) and we log
+                    # for follow-up.
+                    logger.warning(
+                        "Failed to backfill sentiment generations from events",
+                        team_id=self.team_id,
+                        missing_trace_count=len(missing_trace_ids),
+                        error=str(e),
+                    )
+                else:
+                    for trace_id, ai_input in backfill_result.results or []:
+                        ai_input_by_trace[str(trace_id)] = ai_input
         # Positional response shape (unchanged, frontend depends on it): row[0..6] =
         # [uuid, trace_id, ai_input, model, distinct_id, ts_max, ts_min]. The internal
         # `ts_max` / `ts_min` aliases (see `_SENTIMENT_GENERATIONS_PREFLIGHT_SQL`) are

--- a/products/llm_analytics/backend/api/test/test_sentiment_generations.py
+++ b/products/llm_analytics/backend/api/test/test_sentiment_generations.py
@@ -183,141 +183,53 @@ class TestSentimentGenerationsEndpoint(APIBaseTest):
         assert heavy_placeholders["ts_start"].value == datetime(2026, 4, 27, 6, 0, tzinfo=UTC)
         assert heavy_placeholders["ts_end"].value == datetime(2026, 4, 27, 7, 0, tzinfo=UTC)
 
-    # ai_events can carry inputs for some traces in a batch but not others
-    # during the rollout. `execute_with_ai_events_fallback` only re-runs against
-    # events when the dedicated result is fully empty, so without the per-row
-    # backfill the half not covered renders as blank cards.
-    @patch("products.llm_analytics.backend.api.sentiment.is_ai_events_enabled", return_value=True)
+    # The heavy SQL must carry an explicit `LIMIT` matching the preflight's
+    # `GENERATIONS_QUERY_LIMIT`. Without it, `execute_hogql_query` (via
+    # `LimitContext.QUERY`) injects a default of 100 rows and the `GROUP BY
+    # trace_id` is silently truncated when the preflight returns more, so
+    # the truncated half renders as blank cards on the Sentiment tab.
     @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
     @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
-    def test_missing_heavy_rows_get_backfilled_from_events(
-        self,
-        mock_execute_hogql_query: MagicMock,
-        mock_heavy: MagicMock,
-        _mock_kill_switch: MagicMock,
+    def test_heavy_query_has_explicit_limit(self, mock_preflight: MagicMock, mock_heavy: MagicMock) -> None:
+        from posthog.hogql import ast as hogql_ast
+
+        from products.llm_analytics.backend.api.sentiment import GENERATIONS_QUERY_LIMIT
+
+        mock_preflight.return_value = self._make_response([self._preflight_row()])
+        mock_heavy.return_value = self._make_response([["trace-1", '[{"role":"user","content":"hi"}]']])
+
+        response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
+        assert response.status_code == status.HTTP_200_OK
+
+        heavy_query = mock_heavy.call_args.kwargs["query"]
+        heavy_select = cast(hogql_ast.SelectQuery, heavy_query)
+        assert heavy_select.limit is not None, "heavy query must have an explicit LIMIT"
+        assert isinstance(heavy_select.limit, hogql_ast.Constant)
+        assert heavy_select.limit.value == GENERATIONS_QUERY_LIMIT
+
+    # When the heavy table returns fewer rows than the preflight (e.g. a
+    # trace had no input column, or partial ai_events coverage in some
+    # future state), the un-matched traces fall back to null ai_input and
+    # the response still includes them positionally. This keeps the
+    # frontend dedup grouping (and the per-card "View trace" links)
+    # working for the remaining rows.
+    @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
+    @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
+    def test_traces_without_heavy_match_get_null_ai_input(
+        self, mock_preflight: MagicMock, mock_heavy: MagicMock
     ) -> None:
-        mock_execute_hogql_query.side_effect = [
-            self._make_response(
-                [
-                    self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
-                    self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
-                ]
-            ),
-            self._make_response([["trace-2", '[{"role":"user","content":"backfilled"}]']]),
-        ]
-        # Dedicated table only has trace-1
+        mock_preflight.return_value = self._make_response(
+            [
+                self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
+                self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
+            ]
+        )
         mock_heavy.return_value = self._make_response([["trace-1", '[{"role":"user","content":"hi"}]']])
 
         response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
         assert response.status_code == status.HTTP_200_OK
         body = response.json()
         assert len(body["results"]) == 2
-        # trace-1 from ai_events, trace-2 from the events-table backfill
-        assert body["results"][0][2] == '[{"role":"user","content":"hi"}]'
-        assert body["results"][1][2] == '[{"role":"user","content":"backfilled"}]'
-
-        # Backfill should have run with only the missing trace_id/uuid pair
-        backfill_call = mock_execute_hogql_query.call_args_list[1]
-        assert backfill_call.kwargs["query_type"] == "LLMSentimentGenerationsBackfill"
-        backfill_placeholders = backfill_call.kwargs["placeholders"]
-        trace_id_values = [c.value for c in backfill_placeholders["trace_ids"].exprs]
-        uuid_values = [c.value for c in backfill_placeholders["uuids"].exprs]
-        assert trace_id_values == ["trace-2"]
-        assert uuid_values == ["uuid-2"]
-
-    @parameterized.expand(
-        [
-            # When the dedicated table covers every trace, backfill is unnecessary;
-            # both scenarios assert the same single-call path.
-            (
-                "heavy_returns_all_traces",
-                [
-                    ["trace-1", '[{"role":"user","content":"a"}]'],
-                    ["trace-2", '[{"role":"user","content":"b"}]'],
-                ],
-            ),
-            # When the dedicated read returns zero rows the wrapper already
-            # re-routed to events for us; the per-row backfill must not
-            # double-query in that case either.
-            ("heavy_returns_zero_traces", []),
-        ]
-    )
-    @patch("products.llm_analytics.backend.api.sentiment.is_ai_events_enabled", return_value=True)
-    @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
-    @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
-    def test_no_backfill(
-        self,
-        _name: str,
-        heavy_rows: list[list[Any]],
-        mock_execute_hogql_query: MagicMock,
-        mock_heavy: MagicMock,
-        _mock_kill_switch: MagicMock,
-    ) -> None:
-        mock_execute_hogql_query.return_value = self._make_response(
-            [
-                self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
-                self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
-            ]
-        )
-        mock_heavy.return_value = self._make_response(heavy_rows)
-
-        response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
-        assert response.status_code == status.HTTP_200_OK
-        assert mock_execute_hogql_query.call_count == 1
-
-    # Kill switch off → wrapper reads directly from events. Re-running the same
-    # events query for missing rows can't return more data, so the backfill must
-    # be skipped.
-    @patch("products.llm_analytics.backend.api.sentiment.is_ai_events_enabled", return_value=False)
-    @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
-    @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
-    def test_no_backfill_when_kill_switch_off(
-        self,
-        mock_execute_hogql_query: MagicMock,
-        mock_heavy: MagicMock,
-        _mock_kill_switch: MagicMock,
-    ) -> None:
-        mock_execute_hogql_query.return_value = self._make_response(
-            [
-                self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
-                self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
-            ]
-        )
-        # Partial events result — trace-2 is missing
-        mock_heavy.return_value = self._make_response([["trace-1", '[{"role":"user","content":"hi"}]']])
-
-        response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
-        assert response.status_code == status.HTTP_200_OK
-        assert mock_execute_hogql_query.call_count == 1
-        body = response.json()
-        assert body["results"][0][2] == '[{"role":"user","content":"hi"}]'
-        assert body["results"][1][2] is None
-
-    # Degraded events read on the backfill path must not take down the rest of
-    # the response — the affected rows fall back to the pre-fix null behaviour.
-    @patch("products.llm_analytics.backend.api.sentiment.is_ai_events_enabled", return_value=True)
-    @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
-    @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
-    def test_backfill_failure_falls_back_to_null(
-        self,
-        mock_execute_hogql_query: MagicMock,
-        mock_heavy: MagicMock,
-        _mock_kill_switch: MagicMock,
-    ) -> None:
-        mock_execute_hogql_query.side_effect = [
-            self._make_response(
-                [
-                    self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
-                    self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
-                ]
-            ),
-            RuntimeError("backfill boom"),
-        ]
-        mock_heavy.return_value = self._make_response([["trace-1", '[{"role":"user","content":"hi"}]']])
-
-        response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
-        assert response.status_code == status.HTTP_200_OK
-        body = response.json()
         assert body["results"][0][2] == '[{"role":"user","content":"hi"}]'
         assert body["results"][1][2] is None
 

--- a/products/llm_analytics/backend/api/test/test_sentiment_generations.py
+++ b/products/llm_analytics/backend/api/test/test_sentiment_generations.py
@@ -185,21 +185,117 @@ class TestSentimentGenerationsEndpoint(APIBaseTest):
 
     @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
     @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
-    def test_traces_without_heavy_match_get_null_ai_input(
-        self, mock_preflight: MagicMock, mock_heavy: MagicMock
+    def test_missing_heavy_rows_get_backfilled_from_events(
+        self, mock_execute_hogql_query: MagicMock, mock_heavy: MagicMock
     ) -> None:
-        mock_preflight.return_value = self._make_response(
-            [
-                self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
-                self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
-            ]
-        )
+        """During the ai_events rollout, the dedicated table can carry inputs for
+        some traces in a batch but not others. `execute_with_ai_events_fallback`
+        only falls back when the dedicated result is fully empty, so without the
+        per-row backfill the missing traces would render as blank cards in the
+        Sentiment tab even though the input is still in the events table.
+        """
+        mock_execute_hogql_query.side_effect = [
+            self._make_response(
+                [
+                    self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
+                    self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
+                ]
+            ),
+            self._make_response([["trace-2", '[{"role":"user","content":"backfilled"}]']]),
+        ]
+        # Dedicated table only has trace-1
         mock_heavy.return_value = self._make_response([["trace-1", '[{"role":"user","content":"hi"}]']])
 
         response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
         assert response.status_code == status.HTTP_200_OK
         body = response.json()
         assert len(body["results"]) == 2
+        # trace-1 from ai_events, trace-2 from the events-table backfill
+        assert body["results"][0][2] == '[{"role":"user","content":"hi"}]'
+        assert body["results"][1][2] == '[{"role":"user","content":"backfilled"}]'
+
+        # Backfill should have run with only the missing trace_id/uuid pair
+        backfill_call = mock_execute_hogql_query.call_args_list[1]
+        assert backfill_call.kwargs["query_type"] == "LLMSentimentGenerationsBackfill"
+        backfill_placeholders = backfill_call.kwargs["placeholders"]
+        # rewrite_expr_for_events_table preserves Tuple, just may swap inner refs
+        trace_id_values = [c.value for c in backfill_placeholders["trace_ids"].exprs]
+        uuid_values = [c.value for c in backfill_placeholders["uuids"].exprs]
+        assert trace_id_values == ["trace-2"]
+        assert uuid_values == ["uuid-2"]
+
+    @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
+    @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
+    def test_no_backfill_when_heavy_returns_all_traces(
+        self, mock_execute_hogql_query: MagicMock, mock_heavy: MagicMock
+    ) -> None:
+        """When the dedicated ai_events table covers every trace in the batch the
+        backfill must be skipped — otherwise we'd double the heavy-input read on
+        the hot path."""
+        mock_execute_hogql_query.return_value = self._make_response(
+            [
+                self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
+                self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
+            ]
+        )
+        mock_heavy.return_value = self._make_response(
+            [
+                ["trace-1", '[{"role":"user","content":"a"}]'],
+                ["trace-2", '[{"role":"user","content":"b"}]'],
+            ]
+        )
+
+        response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
+        assert response.status_code == status.HTTP_200_OK
+        # Only the preflight call — no backfill
+        assert mock_execute_hogql_query.call_count == 1
+
+    @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
+    @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
+    def test_no_backfill_when_heavy_returns_zero_traces(
+        self, mock_execute_hogql_query: MagicMock, mock_heavy: MagicMock
+    ) -> None:
+        """If the dedicated ai_events table returns zero rows for the batch,
+        `execute_with_ai_events_fallback` already re-routes to events on our
+        behalf, so the per-row backfill must not double-query."""
+        mock_execute_hogql_query.return_value = self._make_response(
+            [
+                self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
+                self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
+            ]
+        )
+        mock_heavy.return_value = self._make_response([])
+
+        response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
+        assert response.status_code == status.HTTP_200_OK
+        # Only the preflight call — no backfill; both rows get null ai_input,
+        # matching the pre-fix behaviour when neither table has data.
+        assert mock_execute_hogql_query.call_count == 1
+        body = response.json()
+        assert all(row[2] is None for row in body["results"])
+
+    @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
+    @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
+    def test_backfill_failure_falls_back_to_null(
+        self, mock_execute_hogql_query: MagicMock, mock_heavy: MagicMock
+    ) -> None:
+        """A backfill failure must not take down the whole response — the
+        affected traces fall back to the pre-fix null-input behaviour, and
+        the rest of the page still renders."""
+        mock_execute_hogql_query.side_effect = [
+            self._make_response(
+                [
+                    self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
+                    self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
+                ]
+            ),
+            RuntimeError("backfill boom"),
+        ]
+        mock_heavy.return_value = self._make_response([["trace-1", '[{"role":"user","content":"hi"}]']])
+
+        response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
         assert body["results"][0][2] == '[{"role":"user","content":"hi"}]'
         assert body["results"][1][2] is None
 

--- a/products/llm_analytics/backend/api/test/test_sentiment_generations.py
+++ b/products/llm_analytics/backend/api/test/test_sentiment_generations.py
@@ -183,17 +183,19 @@ class TestSentimentGenerationsEndpoint(APIBaseTest):
         assert heavy_placeholders["ts_start"].value == datetime(2026, 4, 27, 6, 0, tzinfo=UTC)
         assert heavy_placeholders["ts_end"].value == datetime(2026, 4, 27, 7, 0, tzinfo=UTC)
 
+    # ai_events can carry inputs for some traces in a batch but not others
+    # during the rollout. `execute_with_ai_events_fallback` only re-runs against
+    # events when the dedicated result is fully empty, so without the per-row
+    # backfill the half not covered renders as blank cards.
+    @patch("products.llm_analytics.backend.api.sentiment.is_ai_events_enabled", return_value=True)
     @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
     @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
     def test_missing_heavy_rows_get_backfilled_from_events(
-        self, mock_execute_hogql_query: MagicMock, mock_heavy: MagicMock
+        self,
+        mock_execute_hogql_query: MagicMock,
+        mock_heavy: MagicMock,
+        _mock_kill_switch: MagicMock,
     ) -> None:
-        """During the ai_events rollout, the dedicated table can carry inputs for
-        some traces in a batch but not others. `execute_with_ai_events_fallback`
-        only falls back when the dedicated result is fully empty, so without the
-        per-row backfill the missing traces would render as blank cards in the
-        Sentiment tab even though the input is still in the events table.
-        """
         mock_execute_hogql_query.side_effect = [
             self._make_response(
                 [
@@ -218,70 +220,90 @@ class TestSentimentGenerationsEndpoint(APIBaseTest):
         backfill_call = mock_execute_hogql_query.call_args_list[1]
         assert backfill_call.kwargs["query_type"] == "LLMSentimentGenerationsBackfill"
         backfill_placeholders = backfill_call.kwargs["placeholders"]
-        # rewrite_expr_for_events_table preserves Tuple, just may swap inner refs
         trace_id_values = [c.value for c in backfill_placeholders["trace_ids"].exprs]
         uuid_values = [c.value for c in backfill_placeholders["uuids"].exprs]
         assert trace_id_values == ["trace-2"]
         assert uuid_values == ["uuid-2"]
 
+    @parameterized.expand(
+        [
+            # When the dedicated table covers every trace, backfill is unnecessary;
+            # both scenarios assert the same single-call path.
+            (
+                "heavy_returns_all_traces",
+                [
+                    ["trace-1", '[{"role":"user","content":"a"}]'],
+                    ["trace-2", '[{"role":"user","content":"b"}]'],
+                ],
+            ),
+            # When the dedicated read returns zero rows the wrapper already
+            # re-routed to events for us; the per-row backfill must not
+            # double-query in that case either.
+            ("heavy_returns_zero_traces", []),
+        ]
+    )
+    @patch("products.llm_analytics.backend.api.sentiment.is_ai_events_enabled", return_value=True)
     @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
     @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
-    def test_no_backfill_when_heavy_returns_all_traces(
-        self, mock_execute_hogql_query: MagicMock, mock_heavy: MagicMock
+    def test_no_backfill(
+        self,
+        _name: str,
+        heavy_rows: list[list[Any]],
+        mock_execute_hogql_query: MagicMock,
+        mock_heavy: MagicMock,
+        _mock_kill_switch: MagicMock,
     ) -> None:
-        """When the dedicated ai_events table covers every trace in the batch the
-        backfill must be skipped — otherwise we'd double the heavy-input read on
-        the hot path."""
         mock_execute_hogql_query.return_value = self._make_response(
             [
                 self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
                 self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
             ]
         )
-        mock_heavy.return_value = self._make_response(
-            [
-                ["trace-1", '[{"role":"user","content":"a"}]'],
-                ["trace-2", '[{"role":"user","content":"b"}]'],
-            ]
-        )
+        mock_heavy.return_value = self._make_response(heavy_rows)
 
         response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
         assert response.status_code == status.HTTP_200_OK
-        # Only the preflight call — no backfill
         assert mock_execute_hogql_query.call_count == 1
 
+    # Kill switch off → wrapper reads directly from events. Re-running the same
+    # events query for missing rows can't return more data, so the backfill must
+    # be skipped.
+    @patch("products.llm_analytics.backend.api.sentiment.is_ai_events_enabled", return_value=False)
     @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
     @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
-    def test_no_backfill_when_heavy_returns_zero_traces(
-        self, mock_execute_hogql_query: MagicMock, mock_heavy: MagicMock
+    def test_no_backfill_when_kill_switch_off(
+        self,
+        mock_execute_hogql_query: MagicMock,
+        mock_heavy: MagicMock,
+        _mock_kill_switch: MagicMock,
     ) -> None:
-        """If the dedicated ai_events table returns zero rows for the batch,
-        `execute_with_ai_events_fallback` already re-routes to events on our
-        behalf, so the per-row backfill must not double-query."""
         mock_execute_hogql_query.return_value = self._make_response(
             [
                 self._preflight_row(uuid="uuid-1", trace_id="trace-1"),
                 self._preflight_row(uuid="uuid-2", trace_id="trace-2"),
             ]
         )
-        mock_heavy.return_value = self._make_response([])
+        # Partial events result — trace-2 is missing
+        mock_heavy.return_value = self._make_response([["trace-1", '[{"role":"user","content":"hi"}]']])
 
         response = self.client.post(self.URL, {"filters": {}}, content_type="application/json")
         assert response.status_code == status.HTTP_200_OK
-        # Only the preflight call — no backfill; both rows get null ai_input,
-        # matching the pre-fix behaviour when neither table has data.
         assert mock_execute_hogql_query.call_count == 1
         body = response.json()
-        assert all(row[2] is None for row in body["results"])
+        assert body["results"][0][2] == '[{"role":"user","content":"hi"}]'
+        assert body["results"][1][2] is None
 
+    # Degraded events read on the backfill path must not take down the rest of
+    # the response — the affected rows fall back to the pre-fix null behaviour.
+    @patch("products.llm_analytics.backend.api.sentiment.is_ai_events_enabled", return_value=True)
     @patch("products.llm_analytics.backend.api.sentiment.execute_with_ai_events_fallback")
     @patch("products.llm_analytics.backend.api.sentiment.execute_hogql_query")
     def test_backfill_failure_falls_back_to_null(
-        self, mock_execute_hogql_query: MagicMock, mock_heavy: MagicMock
+        self,
+        mock_execute_hogql_query: MagicMock,
+        mock_heavy: MagicMock,
+        _mock_kill_switch: MagicMock,
     ) -> None:
-        """A backfill failure must not take down the whole response — the
-        affected traces fall back to the pre-fix null-input behaviour, and
-        the rest of the page still renders."""
         mock_execute_hogql_query.side_effect = [
             self._make_response(
                 [


### PR DESCRIPTION
## Problem

On the LLM analytics Sentiment tab, many cards render blank — the
sentiment bar, percentage, and "View trace" link are all there, but the
user message text is empty. The matching trace view shows the message
correctly, so it isn't a data ingestion problem.

Root cause: `_SENTIMENT_GENERATIONS_HEAVY_SQL` has no `LIMIT`, so
`execute_hogql_query` (via `LimitContext.QUERY`) injects its default of
100 rows. Whenever the preflight returns more than 100 trace_ids (it
caps at `GENERATIONS_QUERY_LIMIT = 200`), the heavy `GROUP BY trace_id`
is silently truncated — every trace_id past the implicit 100-row cap
gets `ai_input: null` in the response, and the frontend renders blank
cards for the truncated half.

Reproduced locally on `/llm-analytics/sentiment?date_from=-14d`:
out of 200 generations in the response, 100 came back with
`ai_input: null`. Re-running the exact same heavy query for just the
100 "missing" trace_ids (in isolation, still under the implicit cap)
returned all 100, confirming the data was present and the truncation
was at the row-limit boundary, not at the data layer.

## Changes

Add an explicit `LIMIT {GENERATIONS_QUERY_LIMIT}` to the heavy SQL so
the `GROUP BY trace_id` returns every preflight trace.

Earlier revisions of this PR introduced an events-table backfill in
the endpoint — that has been reverted. The original framing of "ai_events
partial coverage" turned out not to apply: the backfill happened to
mask the truncation because the recursive call was always small enough
to fit under the implicit 100-row cap, not because ai_events was
covering some traces and not others.

## How did you test this code?

I'm an agent. Verified via:
- Updated unit suite: `hogli test products/llm_analytics/backend/api/test/test_sentiment_generations.py` — 11/11 passing, including a new assertion that the heavy query carries the explicit `LIMIT`.
- Drove the local Sentiment tab in Playwright. Before: 72 rendered cards, 100 of 200 underlying API rows had `ai_input: null`. After: 73 rendered cards (unique-text dedup now collapses populated rows that previously rendered as separate blanks), zero blanks. The specific trace flagged in the bug report now renders the expected error-tracking message.

## Publish to changelog?

no

## 🤖 Agent context

Tools used: Claude Code with the playwright MCP for browser
verification, the phrocs/posthog MCPs for inspecting local ClickHouse
state, and the `make-pr` PostHog skill for shaping this PR.

First-pass root-cause framing was wrong — I attributed the blanks to
partial coverage of `posthog.ai_events` during the rollout window, and
shipped an events-table backfill in the endpoint. Carlos (@carlos)
pushed back that ai_events has been written to for >14d in production,
which doesn't square with that hypothesis. Re-investigation showed the
actual cause is the missing `LIMIT` on the heavy query — confirmed by
running the heavy fallback with all 200 preflight trace_ids (returns
100) vs. with `LIMIT 200` added explicitly (returns 200) vs. with just
the 100 "missing" trace_ids in isolation (returns 100). The backfill
mechanism has been removed in favour of the one-line LIMIT fix.

`stamphog`-eligible: tiny backend-only change in a single product
endpoint, no auth/permissions/migrations/deps/CI touched.