### PR TITLE
feat(user-interviews): migrate cross-product callers to facade

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -1014,13 +1014,13 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             except Exception:
                 raise NotFound("No heatmap found")
         elif isinstance(resource, SharingConfiguration) and resource.interviewee_context:
-            from products.user_interviews.backend.api import _parse_identifier
+            from products.user_interviews.backend.facade.api import UserInterviewsAPI
 
             ic = resource.interviewee_context
             topic = ic.topic
             asset_title = topic.topic or "User interview"
             asset_description = "PostHog AI user interview"
-            user_name, _ = _parse_identifier(ic.interviewee_identifier)
+            user_name = UserInterviewsAPI.parse_interviewee_identifier(ic.interviewee_identifier).display_name
             # Keep agent_context, questions, and Vapi credentials OUT of the public HTML —
             # the recipient would otherwise see their own internal-notes context in view-source.
             # The exporter scene fetches those server-side via /start_call/ when the user clicks Start.

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -438,7 +438,7 @@ SPECTACULAR_SETTINGS = {
         "LensProviderEnum": "products.replay_vision.backend.models.replay_lens.LensProvider",
         "ObservationStatusEnum": "products.replay_vision.backend.models.replay_observation.ObservationStatus",
         "ObservationTriggerEnum": "products.replay_vision.backend.models.replay_observation.ObservationTrigger",
-        "UserInterviewSearchDocumentTypeEnum": "products.user_interviews.backend.api.SEARCH_DOCUMENT_TYPES",
+        "UserInterviewSearchDocumentTypeEnum": "products.user_interviews.backend.facade.enums.SEARCH_DOCUMENT_TYPES",
         # --- Inline value lists (type-hint enums, no x-spec-enum-id) ---
         "PropertyGroupOperator": ["AND", "OR"],
         "PropertyFilterTypeEnum": [

--- a/products/user_interviews/backend/api.py
+++ b/products/user_interviews/backend/api.py
@@ -39,6 +39,8 @@ from posthog.models.user import User
 from posthog.permissions import PostHogFeatureFlagPermission
 from posthog.utils import absolute_uri
 
+from .facade.api import UserInterviewsAPI
+from .facade.enums import SEARCH_DOCUMENT_TYPES
 from .models import EmailWithDisplayNameValidator, IntervieweeContext, UserInterview, UserInterviewTopic
 
 logger = structlog.get_logger(__name__)
@@ -243,7 +245,6 @@ Record the agreed-upon next steps, including any additional actions that need to
         return str(uuid4())
 
 
-SEARCH_DOCUMENT_TYPES = ("transcript", "summary")
 SEARCH_EMBEDDING_MODEL = EmbeddingModelName.TEXT_EMBEDDING_3_LARGE_3072.value
 SEARCH_CONTENT_SNIPPET_LIMIT = 500
 SEARCH_MAX_LIMIT = 50
@@ -537,20 +538,9 @@ class UserInterviewTopicSerializer(serializers.ModelSerializer):
 
 
 def _parse_identifier(identifier: str) -> tuple[str, str | None]:
-    """Split an interviewee identifier into a display name and (optional) email.
-
-    Accepts the same display-name format the topic validator accepts —
-    ``"Display Name <email@host>"`` — falling back to a best-effort
-    title-cased local-part for raw emails and the identifier as-is for
-    distinct IDs.
-    """
-    display_match = re.match(EmailWithDisplayNameValidator.display_name_regex, identifier)
-    if display_match:
-        return display_match.group(1).strip(), display_match.group(2).strip()
-    if "@" in identifier:
-        local_part = identifier.split("@", 1)[0]
-        return local_part.replace(".", " ").replace("_", " ").strip().title() or identifier, identifier
-    return identifier, None
+    """Tuple-shaped shim around the facade's identifier parser for legacy internal callers."""
+    identity = UserInterviewsAPI.parse_interviewee_identifier(identifier)
+    return identity.display_name, identity.email
 
 
 def _merge_agent_context(topic_context: str, personal_context: str) -> str:


### PR DESCRIPTION
## Problem

`posthog/api/sharing.py` and `posthog/settings/web.py` both reach into `products/user_interviews/backend/api.py` directly — a private helper (`_parse_identifier`) and a module-level constant (`SEARCH_DOCUMENT_TYPES`). With the facade introduced in #59132 in place, those two callers can now go through the public surface instead.

## Changes

- `posthog/api/sharing.py` uses `UserInterviewsAPI.parse_interviewee_identifier(...).display_name` instead of the private `_parse_identifier` tuple
- `posthog/settings/web.py` points the OpenAPI enum mapping at `products.user_interviews.backend.facade.enums.SEARCH_DOCUMENT_TYPES` (was `…backend.api.SEARCH_DOCUMENT_TYPES`)
- Inside the product, `_parse_identifier` and `SEARCH_DOCUMENT_TYPES` in `backend/api.py` now delegate to the facade so there is only one implementation. The tuple-shaped `_parse_identifier` shim is kept because several internal call sites still rely on the tuple shape — it can be cleaned up in a follow-up

After this PR, the only remaining cross-product imports of `user_interviews` internals are the viewsets in `posthog/api/__init__.py` and the webhook handlers in `posthog/urls.py` — both addressed in #59134.

## How did you test this code?

I'm an agent. I ran `ruff check` and `ruff format` and confirmed no other call sites of `_parse_identifier` or `SEARCH_DOCUMENT_TYPES` exist outside the product. I did not run the test suite locally — CI will exercise the sharing flow.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus) as part of the user_interviews isolation stack on top of #58896.
- Considered leaving `_parse_identifier` as a duplicate implementation but chose to collapse to a single source of truth in the facade — the tuple shim is the smallest possible glue for legacy internal callers and disappears once their callers are migrated.
- `has_replied` is also wired in the facade (PR #59132) but isn't called from this branch — the `already_replied` consumer lives on a separate branch (#58876) and will pick up the facade when it merges.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*