### PR TITLE
feat(user-interviews): move api+webhooks into presentation/, enforce isolation

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -114,7 +114,7 @@ from products.product_tours.backend.api import ProductTourViewSet
 from products.replay_vision.backend.api import ReplayLensViewSet, ReplayObservationViewSet
 from products.signals.backend.views import SignalViewSet
 from products.tracing.backend.presentation.views import SpansViewSet as TracingSpansViewSet
-from products.user_interviews.backend.api import (
+from products.user_interviews.backend.presentation.views import (
     IntervieweeContextViewSet,
     UserInterviewTopicViewSet,
     UserInterviewViewSet,

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -57,7 +57,7 @@ from products.signals.backend import views as signals_views
 from products.signals.backend.views import SignalUserAutonomyConfigView as signals_user_autonomy_view
 from products.slack_app.backend.api import posthog_code_event_handler, posthog_code_interactivity_handler
 from products.surveys.backend.api.survey import public_survey_page
-from products.user_interviews.backend.webhooks import (
+from products.user_interviews.backend.presentation.webhooks import (
     start_call as user_interviews_start_call,
     vapi_webhook,
 )

--- a/products/user_interviews/backend/presentation/views.py
+++ b/products/user_interviews/backend/presentation/views.py
@@ -39,9 +39,9 @@ from posthog.models.user import User
 from posthog.permissions import PostHogFeatureFlagPermission
 from posthog.utils import absolute_uri
 
-from .facade.api import UserInterviewsAPI
-from .facade.enums import SEARCH_DOCUMENT_TYPES
-from .models import EmailWithDisplayNameValidator, IntervieweeContext, UserInterview, UserInterviewTopic
+from ..facade.api import UserInterviewsAPI
+from ..facade.enums import SEARCH_DOCUMENT_TYPES
+from ..models import EmailWithDisplayNameValidator, IntervieweeContext, UserInterview, UserInterviewTopic
 
 logger = structlog.get_logger(__name__)
 

--- a/products/user_interviews/backend/presentation/webhooks.py
+++ b/products/user_interviews/backend/presentation/webhooks.py
@@ -37,7 +37,7 @@ from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.team import Team
 from posthog.storage.llm_prompt_cache import get_prompt_by_name_from_cache
 
-from .models import UserInterview, UserInterviewTopic
+from ..models import UserInterview, UserInterviewTopic
 
 logger = structlog.get_logger(__name__)
 
@@ -209,7 +209,7 @@ def start_call(request: Request, access_token: str) -> Response:
     they also use it to actually start the call. The win is removing the leak from the
     initial HTML and giving us a single, auditable, rate-limitable surface.
     """
-    from .api import _merge_agent_context, _parse_identifier
+    from .views import _merge_agent_context, _parse_identifier
 
     if not settings.VAPI_PUBLIC_KEY or not settings.VAPI_ASSISTANT_ID:
         logger.warning("user_interviews_start_call_misconfigured")

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -18,9 +18,9 @@ from rest_framework import status
 from posthog.api.test.test_sharing import mock_exporter_template
 from posthog.models.sharing_configuration import SharingConfiguration
 
-from products.user_interviews.backend.api import UserInterviewTopicSerializer
 from products.user_interviews.backend.models import IntervieweeContext, UserInterview, UserInterviewTopic
-from products.user_interviews.backend.webhooks import (
+from products.user_interviews.backend.presentation.views import UserInterviewTopicSerializer
+from products.user_interviews.backend.presentation.webhooks import (
     DEFAULT_FIRST_MESSAGE_TEMPLATE,
     EMBEDDING_CONTENT_MAX_BYTES,
     FIRST_MESSAGE_PROMPT_NAME,
@@ -661,7 +661,7 @@ class TestVapiWebhook(APIBaseTest):
         self.assertEqual(response.json()["status"], "ignored")
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    @patch("products.user_interviews.backend.webhooks.posthoganalytics.capture")
+    @patch("products.user_interviews.backend.presentation.webhooks.posthoganalytics.capture")
     def test_webhook_status_update_in_progress_captures_started_event(self, mock_capture):
         share = self._create_share()
         self.client.logout()
@@ -688,7 +688,7 @@ class TestVapiWebhook(APIBaseTest):
         self.assertEqual(kwargs["properties"]["call_id"], "call_xyz")
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    @patch("products.user_interviews.backend.webhooks.posthoganalytics.capture")
+    @patch("products.user_interviews.backend.presentation.webhooks.posthoganalytics.capture")
     def test_webhook_status_update_duplicate_in_progress_emits_same_insert_id(self, mock_capture):
         # Vapi re-fires `status-update / in-progress` on transient drops + warm-transfer flows.
         # We tag every started event with `$insert_id` = "user_interview_conversation_started:<call_id>"
@@ -711,7 +711,7 @@ class TestVapiWebhook(APIBaseTest):
 
     @parameterized.expand([("ringing",), ("ended",), ("queued",), ("forwarding",), ("scheduled",)])
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    @patch("products.user_interviews.backend.webhooks.posthoganalytics.capture")
+    @patch("products.user_interviews.backend.presentation.webhooks.posthoganalytics.capture")
     def test_webhook_status_update_other_statuses_do_not_capture(self, call_status: str, mock_capture):
         share = self._create_share()
         self.client.logout()
@@ -729,7 +729,7 @@ class TestVapiWebhook(APIBaseTest):
         mock_capture.assert_not_called()
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    @patch("products.user_interviews.backend.webhooks.posthoganalytics.capture")
+    @patch("products.user_interviews.backend.presentation.webhooks.posthoganalytics.capture")
     def test_webhook_end_of_call_report_captures_ended_event(self, mock_capture):
         share = self._create_share()
         self.client.logout()
@@ -758,7 +758,7 @@ class TestVapiWebhook(APIBaseTest):
         self.assertEqual(UserInterview.objects.filter(team=self.team).count(), 1)
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    @patch("products.user_interviews.backend.webhooks.emit_embedding_request")
+    @patch("products.user_interviews.backend.presentation.webhooks.emit_embedding_request")
     def test_webhook_emits_transcript_and_summary_embeddings(self, mock_emit):
         share = self._create_share()
         self.client.logout()
@@ -794,7 +794,7 @@ class TestVapiWebhook(APIBaseTest):
         ]
     )
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    @patch("products.user_interviews.backend.webhooks.emit_embedding_request")
+    @patch("products.user_interviews.backend.presentation.webhooks.emit_embedding_request")
     def test_webhook_skips_empty_content(self, _name, transcript, summary, expected_types, mock_emit):
         share = self._create_share()
         self.client.logout()
@@ -810,7 +810,7 @@ class TestVapiWebhook(APIBaseTest):
         self.assertEqual(emitted_types, expected_types)
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    @patch("products.user_interviews.backend.webhooks.emit_embedding_request")
+    @patch("products.user_interviews.backend.presentation.webhooks.emit_embedding_request")
     def test_webhook_does_not_re_emit_on_duplicate(self, mock_emit):
         share = self._create_share()
         self.client.logout()
@@ -828,7 +828,10 @@ class TestVapiWebhook(APIBaseTest):
         self.assertEqual(mock_emit.call_count, first_call_count)
 
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    @patch("products.user_interviews.backend.webhooks.emit_embedding_request", side_effect=RuntimeError("kafka down"))
+    @patch(
+        "products.user_interviews.backend.presentation.webhooks.emit_embedding_request",
+        side_effect=RuntimeError("kafka down"),
+    )
     def test_webhook_succeeds_when_embedding_emit_fails(self, _mock_emit):
         share = self._create_share()
         self.client.logout()
@@ -845,7 +848,7 @@ class TestVapiWebhook(APIBaseTest):
         ]
     )
     @override_settings(VAPI_WEBHOOK_SECRET="topsecret")
-    @patch("products.user_interviews.backend.webhooks.emit_embedding_request")
+    @patch("products.user_interviews.backend.presentation.webhooks.emit_embedding_request")
     def test_webhook_truncates_oversized_content_before_emit(
         self, _name, oversize_transcript, oversize_summary, mock_emit
     ):
@@ -897,8 +900,8 @@ class TestSendInterviewInvites(_FeatureFlagEnabledMixin):
         topic = self._create_topic()
 
         with (
-            patch("products.user_interviews.backend.api.EmailMessage") as mock_message_cls,
-            patch("products.user_interviews.backend.api.is_email_available", return_value=True),
+            patch("products.user_interviews.backend.presentation.views.EmailMessage") as mock_message_cls,
+            patch("products.user_interviews.backend.presentation.views.is_email_available", return_value=True),
         ):
             mock_message = mock_message_cls.return_value
             response = self.client.post(self._url(str(topic.id)), data={"send_async": False}, format="json")
@@ -921,8 +924,8 @@ class TestSendInterviewInvites(_FeatureFlagEnabledMixin):
         topic = self._create_topic(interviewee_emails=["alex@example.com"], interviewee_distinct_ids=[])
 
         with (
-            patch("products.user_interviews.backend.api.EmailMessage") as mock_message_cls,
-            patch("products.user_interviews.backend.api.is_email_available", return_value=True),
+            patch("products.user_interviews.backend.presentation.views.EmailMessage") as mock_message_cls,
+            patch("products.user_interviews.backend.presentation.views.is_email_available", return_value=True),
         ):
             self.client.post(self._url(str(topic.id)), data={}, format="json")
 
@@ -937,8 +940,8 @@ class TestSendInterviewInvites(_FeatureFlagEnabledMixin):
         topic = self._create_topic(interviewee_emails=["alex@example.com"], interviewee_distinct_ids=[])
 
         with (
-            patch("products.user_interviews.backend.api.EmailMessage") as mock_message_cls,
-            patch("products.user_interviews.backend.api.is_email_available", return_value=True),
+            patch("products.user_interviews.backend.presentation.views.EmailMessage") as mock_message_cls,
+            patch("products.user_interviews.backend.presentation.views.is_email_available", return_value=True),
         ):
             self.client.post(
                 self._url(str(topic.id)),
@@ -952,13 +955,13 @@ class TestSendInterviewInvites(_FeatureFlagEnabledMixin):
 
     def test_send_invites_503_when_email_disabled(self):
         topic = self._create_topic()
-        with patch("products.user_interviews.backend.api.is_email_available", return_value=False):
+        with patch("products.user_interviews.backend.presentation.views.is_email_available", return_value=False):
             response = self.client.post(self._url(str(topic.id)), data={}, format="json")
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
 
     def test_send_invites_400_when_topic_has_no_identifiers(self):
         topic = self._create_topic(interviewee_emails=[], interviewee_distinct_ids=[])
-        with patch("products.user_interviews.backend.api.is_email_available", return_value=True):
+        with patch("products.user_interviews.backend.presentation.views.is_email_available", return_value=True):
             response = self.client.post(self._url(str(topic.id)), data={}, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -981,8 +984,8 @@ class TestSendInterviewInvites(_FeatureFlagEnabledMixin):
                     raise RuntimeError("smtp down")
 
         with (
-            patch("products.user_interviews.backend.api.EmailMessage", FlakyEmail),
-            patch("products.user_interviews.backend.api.is_email_available", return_value=True),
+            patch("products.user_interviews.backend.presentation.views.EmailMessage", FlakyEmail),
+            patch("products.user_interviews.backend.presentation.views.is_email_available", return_value=True),
         ):
             response = self.client.post(self._url(str(topic.id)), data={"send_async": False}, format="json")
 

--- a/products/user_interviews/backend/test_interviewee_context_bulk_create.py
+++ b/products/user_interviews/backend/test_interviewee_context_bulk_create.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 from parameterized import parameterized
 from rest_framework import status
 
-from products.user_interviews.backend.api import BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS
 from products.user_interviews.backend.models import IntervieweeContext, UserInterviewTopic
+from products.user_interviews.backend.presentation.views import BULK_INTERVIEWEE_CONTEXT_MAX_ITEMS
 
 
 class _FeatureFlagEnabledMixin(APIBaseTest):

--- a/products/user_interviews/backend/test_search.py
+++ b/products/user_interviews/backend/test_search.py
@@ -62,8 +62,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         result.results = rows
         return result
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_returns_ranked_matches(self, mock_embed, mock_hogql):
         mock_embed.return_value = self._embedding_response()
         mock_hogql.return_value = self._hogql_rows(
@@ -99,8 +99,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
             ("negative_distance_clamps_to_one", -0.01, 1.0),
         ]
     )
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_clamps_similarity_to_unit_interval(self, _name, distance, expected, mock_embed, mock_hogql):
         mock_embed.return_value = self._embedding_response()
         mock_hogql.return_value = self._hogql_rows([(str(self.interview_a.id), "transcript", distance)])
@@ -108,8 +108,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()[0]["similarity"], expected)
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_snippet_reflects_current_postgres_content(self, mock_embed, mock_hogql):
         """The snippet must come from the live UserInterview row, not the embedding row's
         snapshot — otherwise editing or trimming a transcript leaves stale content visible
@@ -123,8 +123,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         response = self.client.post(self._url(), {"query": "x"}, content_type="application/json")
         self.assertEqual(response.json()[0]["content_snippet"], "alex's edited transcript: replay is faster now")
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_truncates_long_content_snippet(self, mock_embed, mock_hogql):
         mock_embed.return_value = self._embedding_response()
         self.interview_a.transcript = "x" * 1000
@@ -133,8 +133,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         response = self.client.post(self._url(), {"query": "x"}, content_type="application/json")
         self.assertEqual(len(response.json()[0]["content_snippet"]), 500)
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_skips_rows_for_deleted_interviews(self, mock_embed, mock_hogql):
         mock_embed.return_value = self._embedding_response()
         ghost_id = "00000000-0000-0000-0000-000000000000"
@@ -156,8 +156,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
             ("both_explicit", ["transcript", "summary"], {"transcript", "summary"}),
         ]
     )
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_forwards_document_types_filter(
         self, _name, document_types, expected_in_placeholders, mock_embed, mock_hogql
     ):
@@ -174,8 +174,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         placeholders = mock_hogql.call_args.kwargs["placeholders"]
         self.assertEqual(set(placeholders["document_types"].value), expected_in_placeholders)
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_resolves_topic_id_via_current_postgres_linkage(self, mock_embed, mock_hogql):
         mock_embed.return_value = self._embedding_response()
         mock_hogql.return_value = self._hogql_rows([])
@@ -197,8 +197,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         self.assertIn("document_id IN {scoped_document_ids}", hogql_query)
         self.assertNotIn("JSONExtractString(metadata, 'topic_id')", hogql_query)
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_excludes_interviews_detached_from_topic(self, mock_embed, mock_hogql):
         mock_embed.return_value = self._embedding_response()
         mock_hogql.return_value = self._hogql_rows([])
@@ -216,8 +216,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         placeholders = mock_hogql.call_args.kwargs["placeholders"]
         self.assertEqual(set(placeholders["scoped_document_ids"].value), {str(self.interview_a.id)})
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_short_circuits_when_topic_has_no_interviews(self, mock_embed, mock_hogql):
         mock_embed.return_value = self._embedding_response()
         # No call to HogQL should happen when the topic resolves to zero interview IDs.
@@ -241,8 +241,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         mock_hogql.assert_not_called()
         mock_embed.assert_not_called()
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_defaults_to_both_document_types_when_unset(self, mock_embed, mock_hogql):
         mock_embed.return_value = self._embedding_response()
         mock_hogql.return_value = self._hogql_rows([])
@@ -252,8 +252,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         placeholders = mock_hogql.call_args.kwargs["placeholders"]
         self.assertEqual(set(placeholders["document_types"].value), {"transcript", "summary"})
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_enforces_default_limit_when_omitted(self, mock_embed, mock_hogql):
         mock_embed.return_value = self._embedding_response()
         mock_hogql.return_value = self._hogql_rows([])
@@ -277,13 +277,13 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_search_action_declares_read_scope(self):
-        from products.user_interviews.backend.api import UserInterviewViewSet
+        from products.user_interviews.backend.presentation.views import UserInterviewViewSet
 
         self.assertEqual(UserInterviewViewSet.search.kwargs["required_scopes"], ["user_interview:read"])
 
-    @patch("products.user_interviews.backend.api.tag_queries")
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.tag_queries")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_tags_clickhouse_query_for_attribution(self, mock_embed, mock_hogql, mock_tag):
         from posthog.clickhouse.query_tagging import Feature, Product
 
@@ -294,9 +294,9 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
 
         mock_tag.assert_called_once_with(product=Product.USER_INTERVIEWS, feature=Feature.SEMANTIC_SEARCH)
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
     @patch(
-        "products.user_interviews.backend.api.generate_embedding",
+        "products.user_interviews.backend.presentation.views.generate_embedding",
         side_effect=RuntimeError("embedding service down"),
     )
     def test_search_returns_502_when_embedding_service_fails(self, _mock_embed, mock_hogql):
@@ -305,10 +305,10 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         self.assertIn("Embedding service", response.json()["detail"])
         mock_hogql.assert_not_called()
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_caps_scoped_document_ids_for_pathological_topic_size(self, mock_embed, mock_hogql):
-        from products.user_interviews.backend.api import SEARCH_TOPIC_INTERVIEW_CAP
+        from products.user_interviews.backend.presentation.views import SEARCH_TOPIC_INTERVIEW_CAP
 
         mock_embed.return_value = self._embedding_response()
         mock_hogql.return_value = self._hogql_rows([])
@@ -337,8 +337,8 @@ class TestUserInterviewSearch(_FeatureFlagEnabledMixin):
         placeholders = mock_hogql.call_args.kwargs["placeholders"]
         self.assertEqual(len(placeholders["scoped_document_ids"].value), SEARCH_TOPIC_INTERVIEW_CAP)
 
-    @patch("products.user_interviews.backend.api.execute_hogql_query")
-    @patch("products.user_interviews.backend.api.generate_embedding")
+    @patch("products.user_interviews.backend.presentation.views.execute_hogql_query")
+    @patch("products.user_interviews.backend.presentation.views.generate_embedding")
     def test_search_does_not_leak_across_teams(self, mock_embed, mock_hogql):
         mock_embed.return_value = self._embedding_response()
         mock_hogql.return_value = self._hogql_rows([])

--- a/products/user_interviews/package.json
+++ b/products/user_interviews/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-user-interviews",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -480,6 +480,8 @@ ignore_imports = [
     "products.notifications.backend.presentation.views -> products.notifications.backend.models",
     "products.tracing.backend.presentation.views -> products.tracing.backend.logic",
     "products.tracing.backend.presentation.views -> products.tracing.backend.sparkline_query_runner",
+    "products.user_interviews.backend.presentation.views -> products.user_interviews.backend.models",
+    "products.user_interviews.backend.presentation.webhooks -> products.user_interviews.backend.models",
 ]
 
 [tool.ty.rules]

--- a/tach.toml
+++ b/tach.toml
@@ -516,7 +516,7 @@ expose = [
     "backend\\.presentation\\.views.*",
 ]
 from = [
-    "products\\.(experiments|mcp_analytics|mcp_store|metrics|notifications|tracing|visual_review)",
+    "products\\.(experiments|mcp_analytics|mcp_store|metrics|notifications|tracing|user_interviews|visual_review)",
 ]
 
 # TODO: Experiments-specific temporary interface
@@ -528,6 +528,15 @@ expose = [
 ]
 from = [
     "products.experiments",
+]
+
+# user_interviews exposes Vapi webhook handlers that are routed directly from posthog/urls.py.
+[[interfaces]]
+expose = [
+    "backend\\.presentation\\.webhooks.*",
+]
+from = [
+    "products.user_interviews",
 ]
 
 # Legacy leaks — core (posthog/ee) imports these internals directly.


### PR DESCRIPTION
## Problem

After #59132 and #59133, the only remaining cross-product imports of `user_interviews` internals are:

- `posthog/api/__init__.py` importing the three viewsets from `backend/api.py`
- `posthog/urls.py` importing the Vapi webhook handlers from `backend/webhooks.py`

Both are presentation concerns. Moving them under `backend/presentation/` lets us tighten the `tach` boundary so the product is treated as fully isolated, which unlocks `backend:contract-check` and selective testing via turbo. See [products/architecture.md](https://github.com/PostHog/posthog/blob/master/products/architecture.md) for the target layout.

## Changes

- `backend/api.py` → `backend/presentation/views.py` (git rename — blame preserved)
- `backend/webhooks.py` → `backend/presentation/webhooks.py` (git rename — blame preserved)
- New `backend/presentation/__init__.py`
- `posthog/api/__init__.py` and `posthog/urls.py` updated to import from the new presentation paths
- Internal test patch paths (`@patch("products.user_interviews.backend.api…")`) updated to point at `…backend.presentation.views.*` / `…backend.presentation.webhooks.*`
- `tach.toml` — `user_interviews` joins the canonical isolated-products interface block (exposes `backend.facade.*` and `backend.presentation.views.*`) plus a small product-specific block exposing `backend.presentation.webhooks.*` for the Vapi handlers in `posthog/urls.py`
- `products/user_interviews/package.json` — adds `backend:contract-check` so turbo-discover treats the product as isolated for selective CI
- `pyproject.toml` import-linter — adds the two existing `presentation -> models` edges (`views -> models`, `webhooks -> models`) to the TODO allowlist; future refactors will route them through the facade

## Verification

- `tach check --interfaces` ✓
- `lint-imports` ✓
- `ruff check` / `ruff format` ✓ on changed paths

After this merges, any change to `user_interviews` internals will no longer re-run the full Django suite, and unrelated changes to core will no longer re-run `user_interviews` tests.

## Follow-ups (not in this PR)

- Split `presentation/views.py` (a 1100-LOC file post-rename) into `views.py` + `serializers.py` + `logic.py` per the architecture doc. Pure internal cleanup; no boundary impact.
- Migrate `max_tools.py` to use the facade instead of reaching into `.models` directly (intra-product, so neither tach nor import-linter flag it today, but cleaner if we ever split the product into a separate service).
- Route the two TODO `presentation -> models` allowlist entries through facade methods.

## How did you test this code?

I'm an agent. I ran `ruff check`, `ruff format`, `tach check --interfaces`, and `lint-imports` locally. I did not run the test suite locally — CI will exercise the moved viewsets, webhooks, and the updated test patch paths.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus) as the final step in the user_interviews isolation stack.
- Considered making `presentation/views.py` and `presentation/webhooks.py` thin re-export shims that pointed back at the existing `backend/api.py` and `backend/webhooks.py`. Rejected because `mock.patch` paths in tests would still need updating (`patch` rebinds names in the target namespace), so the re-export gives us nothing while doubling the surface to maintain.
- Considered extending the canonical isolated-products `[[interfaces]]` block to also expose `backend.presentation.webhooks.*` globally. Rejected because only `user_interviews` currently has presentation-level webhooks — a product-specific block keeps the canonical interface narrow.
- Did not split `presentation/views.py` into `views.py` + `serializers.py` + `logic.py` in this PR — that's pure internal cleanup with no boundary impact, and keeping this PR a `git mv` plus boundary wiring makes the diff easier to review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*