### PR TITLE
feat(batch-import-worker): parameterize endpoint_url 

### DIFF
--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -16,6 +16,7 @@ from rest_framework.response import Response
 from posthog.api.documentation import _FallbackSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.batch_exports.http import resolve_and_validate_url
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
 from posthog.models.activity_logging.batch_import_utils import (
     extract_batch_import_info,
@@ -57,6 +58,15 @@ class BatchImportSerializer(serializers.ModelSerializer):
             "status",
         ]
 
+    def validate_endpoint_url(self, value: str | None) -> str | None:
+        if not value or not value.strip():
+            return None
+        try:
+            resolve_and_validate_url(value)
+        except ValueError:
+            raise serializers.ValidationError(f"Invalid endpoint URL: '{value}'")
+        return value
+
     def create(self, validated_data: dict) -> BatchImport:
         validated_data["team_id"] = self.context["team_id"]
         validated_data["created_by_id"] = self.context["request"].user.id
@@ -94,6 +104,13 @@ class BatchImportS3SourceCreateSerializer(BatchImportSerializer):
     s3_region = serializers.CharField(write_only=True, required=False)
     access_key = serializers.CharField(write_only=True, required=False)
     secret_key = serializers.CharField(write_only=True, required=False)
+    endpoint_url = serializers.CharField(
+        write_only=True,
+        required=False,
+        allow_blank=True,
+        default=None,
+        help_text="Custom endpoint URL for S3-compatible storage (e.g. Cloudflare R2, MinIO).",
+    )
     import_events = serializers.BooleanField(write_only=True, required=False, default=True)
     generate_identify_events = serializers.BooleanField(write_only=True, required=False, default=True)
     generate_group_identify_events = serializers.BooleanField(write_only=True, required=False, default=False)
@@ -116,6 +133,7 @@ class BatchImportS3SourceCreateSerializer(BatchImportSerializer):
             "s3_region",
             "access_key",
             "secret_key",
+            "endpoint_url",
             "import_events",
             "generate_identify_events",
             "generate_group_identify_events",
@@ -152,6 +170,7 @@ class BatchImportS3SourceCreateSerializer(BatchImportSerializer):
             region=validated_data["s3_region"],
             access_key_id=validated_data["access_key"],
             secret_access_key=validated_data["secret_key"],
+            endpoint_url=validated_data.get("endpoint_url"),
         )
 
         if content_type == ContentType.AMPLITUDE:
@@ -185,6 +204,13 @@ class BatchImportS3GzipSourceCreateSerializer(BatchImportSerializer):
     s3_region = serializers.CharField(write_only=True, required=False)
     access_key = serializers.CharField(write_only=True, required=False)
     secret_key = serializers.CharField(write_only=True, required=False)
+    endpoint_url = serializers.CharField(
+        write_only=True,
+        required=False,
+        allow_blank=True,
+        default=None,
+        help_text="Custom endpoint URL for S3-compatible storage (e.g. Cloudflare R2, MinIO).",
+    )
     import_events = serializers.BooleanField(write_only=True, required=False, default=True)
     generate_identify_events = serializers.BooleanField(write_only=True, required=False, default=True)
     generate_group_identify_events = serializers.BooleanField(write_only=True, required=False, default=False)
@@ -207,6 +233,7 @@ class BatchImportS3GzipSourceCreateSerializer(BatchImportSerializer):
             "s3_region",
             "access_key",
             "secret_key",
+            "endpoint_url",
             "import_events",
             "generate_identify_events",
             "generate_group_identify_events",
@@ -243,6 +270,7 @@ class BatchImportS3GzipSourceCreateSerializer(BatchImportSerializer):
             region=validated_data["s3_region"],
             access_key_id=validated_data["access_key"],
             secret_access_key=validated_data["secret_key"],
+            endpoint_url=validated_data.get("endpoint_url"),
         )
 
         if content_type == ContentType.AMPLITUDE:

--- a/posthog/api/test/test_batch_imports.py
+++ b/posthog/api/test/test_batch_imports.py
@@ -62,6 +62,45 @@ class TestBatchImportConfigBuilder(BaseTest):
         self.assertEqual(self.batch_import.secrets["aws_access_key_id"], "AKIATEST")
         self.assertEqual(self.batch_import.secrets["aws_secret_access_key"], "secret123")
 
+    def test_from_s3_with_endpoint_url(self):
+        self.batch_import.config.from_s3(
+            bucket="my-bucket",
+            prefix="data/",
+            region="auto",
+            access_key_id="AKIATEST",
+            secret_access_key="secret123",
+            endpoint_url="https://acct123.r2.cloudflarestorage.com",
+        )
+
+        source = self.batch_import.import_config["source"]
+        self.assertEqual(source["endpoint_url"], "https://acct123.r2.cloudflarestorage.com")
+        self.assertEqual(source["region"], "auto")
+
+    def test_from_s3_without_endpoint_url_omits_key(self):
+        self.batch_import.config.from_s3(
+            bucket="my-bucket",
+            prefix="data/",
+            region="us-east-1",
+            access_key_id="AKIATEST",
+            secret_access_key="secret123",
+        )
+
+        self.assertNotIn("endpoint_url", self.batch_import.import_config["source"])
+
+    def test_from_s3_gzip_with_endpoint_url(self):
+        self.batch_import.config.from_s3_gzip(
+            bucket="my-bucket",
+            prefix="data/",
+            region="auto",
+            access_key_id="AKIATEST",
+            secret_access_key="secret123",
+            endpoint_url="http://localhost:9000",
+        )
+
+        source = self.batch_import.import_config["source"]
+        self.assertEqual(source["type"], "s3_gzip")
+        self.assertEqual(source["endpoint_url"], "http://localhost:9000")
+
     def test_chained_configuration(self):
         urls = ["http://example.com/data.json"]
 
@@ -603,3 +642,98 @@ class TestBatchImportAPI(APIBaseTest):
         self.assertEqual(response.status_code, 200)
         batch_import.refresh_from_db()
         self.assertEqual(getattr(batch_import, attr), expected)
+
+    def test_s3_import_with_endpoint_url(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/managed_migrations",
+            {
+                "source_type": "s3",
+                "content_type": "captured",
+                "s3_bucket": "test-bucket",
+                "s3_region": "auto",
+                "s3_prefix": "data/",
+                "access_key": "test-key",
+                "secret_key": "test-secret",
+                "endpoint_url": "http://localhost:9000",
+            },
+        )
+
+        self.assertEqual(response.status_code, 201)
+        batch_import = BatchImport.objects.get(id=response.json()["id"])
+        self.assertEqual(batch_import.import_config["source"]["endpoint_url"], "http://localhost:9000")
+        self.assertEqual(batch_import.import_config["source"]["region"], "auto")
+
+    def test_s3_gzip_import_with_endpoint_url(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/managed_migrations",
+            {
+                "source_type": "s3_gzip",
+                "content_type": "captured",
+                "s3_bucket": "test-bucket",
+                "s3_region": "auto",
+                "s3_prefix": "exports/",
+                "access_key": "test-key",
+                "secret_key": "test-secret",
+                "endpoint_url": "http://localhost:9000",
+            },
+        )
+
+        self.assertEqual(response.status_code, 201)
+        batch_import = BatchImport.objects.get(id=response.json()["id"])
+        self.assertEqual(batch_import.import_config["source"]["type"], "s3_gzip")
+        self.assertEqual(batch_import.import_config["source"]["endpoint_url"], "http://localhost:9000")
+
+    def test_s3_import_without_endpoint_url_omits_key(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/managed_migrations",
+            {
+                "source_type": "s3",
+                "content_type": "captured",
+                "s3_bucket": "test-bucket",
+                "s3_region": "us-east-1",
+                "s3_prefix": "data/",
+                "access_key": "test-key",
+                "secret_key": "test-secret",
+            },
+        )
+
+        self.assertEqual(response.status_code, 201)
+        batch_import = BatchImport.objects.get(id=response.json()["id"])
+        self.assertNotIn("endpoint_url", batch_import.import_config["source"])
+
+    def test_s3_import_with_empty_endpoint_url_omits_key(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/managed_migrations",
+            {
+                "source_type": "s3",
+                "content_type": "captured",
+                "s3_bucket": "test-bucket",
+                "s3_region": "us-east-1",
+                "s3_prefix": "data/",
+                "access_key": "test-key",
+                "secret_key": "test-secret",
+                "endpoint_url": "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 201)
+        batch_import = BatchImport.objects.get(id=response.json()["id"])
+        self.assertNotIn("endpoint_url", batch_import.import_config["source"])
+
+    def test_s3_import_with_invalid_endpoint_url_returns_400(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/managed_migrations",
+            {
+                "source_type": "s3",
+                "content_type": "captured",
+                "s3_bucket": "test-bucket",
+                "s3_region": "us-east-1",
+                "s3_prefix": "data/",
+                "access_key": "test-key",
+                "secret_key": "test-secret",
+                "endpoint_url": "not-a-url",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("endpoint_url", response.json())

--- a/posthog/api/test/test_batch_imports.py
+++ b/posthog/api/test/test_batch_imports.py
@@ -736,4 +736,4 @@ class TestBatchImportAPI(APIBaseTest):
         )
 
         self.assertEqual(response.status_code, 400)
-        self.assertIn("endpoint_url", response.json())
+        self.assertEqual(response.json()["attr"], "endpoint_url")

--- a/posthog/api/test/test_batch_imports.py
+++ b/posthog/api/test/test_batch_imports.py
@@ -62,22 +62,30 @@ class TestBatchImportConfigBuilder(BaseTest):
         self.assertEqual(self.batch_import.secrets["aws_access_key_id"], "AKIATEST")
         self.assertEqual(self.batch_import.secrets["aws_secret_access_key"], "secret123")
 
-    def test_from_s3_with_endpoint_url(self):
-        self.batch_import.config.from_s3(
+    @parameterized.expand(
+        [
+            ("s3", "from_s3", "https://acct123.r2.cloudflarestorage.com"),
+            ("s3_gzip", "from_s3_gzip", "http://localhost:9000"),
+        ]
+    )
+    def test_from_s3_with_endpoint_url(self, _name, method, endpoint_url):
+        getattr(self.batch_import.config, method)(
             bucket="my-bucket",
             prefix="data/",
             region="auto",
             access_key_id="AKIATEST",
             secret_access_key="secret123",
-            endpoint_url="https://acct123.r2.cloudflarestorage.com",
+            endpoint_url=endpoint_url,
         )
 
         source = self.batch_import.import_config["source"]
-        self.assertEqual(source["endpoint_url"], "https://acct123.r2.cloudflarestorage.com")
+        self.assertEqual(source["type"], _name)
+        self.assertEqual(source["endpoint_url"], endpoint_url)
         self.assertEqual(source["region"], "auto")
 
-    def test_from_s3_without_endpoint_url_omits_key(self):
-        self.batch_import.config.from_s3(
+    @parameterized.expand([("s3", "from_s3"), ("s3_gzip", "from_s3_gzip")])
+    def test_from_s3_without_endpoint_url_omits_key(self, _name, method):
+        getattr(self.batch_import.config, method)(
             bucket="my-bucket",
             prefix="data/",
             region="us-east-1",
@@ -86,20 +94,6 @@ class TestBatchImportConfigBuilder(BaseTest):
         )
 
         self.assertNotIn("endpoint_url", self.batch_import.import_config["source"])
-
-    def test_from_s3_gzip_with_endpoint_url(self):
-        self.batch_import.config.from_s3_gzip(
-            bucket="my-bucket",
-            prefix="data/",
-            region="auto",
-            access_key_id="AKIATEST",
-            secret_access_key="secret123",
-            endpoint_url="http://localhost:9000",
-        )
-
-        source = self.batch_import.import_config["source"]
-        self.assertEqual(source["type"], "s3_gzip")
-        self.assertEqual(source["endpoint_url"], "http://localhost:9000")
 
     def test_chained_configuration(self):
         urls = ["http://example.com/data.json"]
@@ -643,11 +637,12 @@ class TestBatchImportAPI(APIBaseTest):
         batch_import.refresh_from_db()
         self.assertEqual(getattr(batch_import, attr), expected)
 
-    def test_s3_import_with_endpoint_url(self):
+    @parameterized.expand([("s3",), ("s3_gzip",)])
+    def test_s3_import_with_endpoint_url(self, source_type):
         response = self.client.post(
             f"/api/projects/{self.team.id}/managed_migrations",
             {
-                "source_type": "s3",
+                "source_type": source_type,
                 "content_type": "captured",
                 "s3_bucket": "test-bucket",
                 "s3_region": "auto",
@@ -660,28 +655,9 @@ class TestBatchImportAPI(APIBaseTest):
 
         self.assertEqual(response.status_code, 201)
         batch_import = BatchImport.objects.get(id=response.json()["id"])
+        self.assertEqual(batch_import.import_config["source"]["type"], source_type)
         self.assertEqual(batch_import.import_config["source"]["endpoint_url"], "http://localhost:9000")
         self.assertEqual(batch_import.import_config["source"]["region"], "auto")
-
-    def test_s3_gzip_import_with_endpoint_url(self):
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/managed_migrations",
-            {
-                "source_type": "s3_gzip",
-                "content_type": "captured",
-                "s3_bucket": "test-bucket",
-                "s3_region": "auto",
-                "s3_prefix": "exports/",
-                "access_key": "test-key",
-                "secret_key": "test-secret",
-                "endpoint_url": "http://localhost:9000",
-            },
-        )
-
-        self.assertEqual(response.status_code, 201)
-        batch_import = BatchImport.objects.get(id=response.json()["id"])
-        self.assertEqual(batch_import.import_config["source"]["type"], "s3_gzip")
-        self.assertEqual(batch_import.import_config["source"]["endpoint_url"], "http://localhost:9000")
 
     def test_s3_import_without_endpoint_url_omits_key(self):
         response = self.client.post(

--- a/posthog/models/batch_imports.py
+++ b/posthog/models/batch_imports.py
@@ -97,10 +97,11 @@ class BatchImportConfigBuilder:
         region: str,
         access_key_id: str,
         secret_access_key: str,
+        endpoint_url: str | None = None,
         access_key_id_key: str = "aws_access_key_id",
         secret_access_key_key: str = "aws_secret_access_key",
     ) -> Self:
-        self.batch_import.import_config["source"] = {
+        source: dict = {
             "type": "s3",
             "bucket": bucket,
             "prefix": prefix,
@@ -108,6 +109,9 @@ class BatchImportConfigBuilder:
             "access_key_id_key": access_key_id_key,
             "secret_access_key_key": secret_access_key_key,
         }
+        if endpoint_url:
+            source["endpoint_url"] = endpoint_url
+        self.batch_import.import_config["source"] = source
         self.batch_import.secrets[access_key_id_key] = access_key_id
         self.batch_import.secrets[secret_access_key_key] = secret_access_key
         return self
@@ -119,10 +123,11 @@ class BatchImportConfigBuilder:
         region: str,
         access_key_id: str,
         secret_access_key: str,
+        endpoint_url: str | None = None,
         access_key_id_key: str = "aws_access_key_id",
         secret_access_key_key: str = "aws_secret_access_key",
     ) -> Self:
-        self.batch_import.import_config["source"] = {
+        source: dict = {
             "type": "s3_gzip",
             "bucket": bucket,
             "prefix": prefix,
@@ -130,6 +135,9 @@ class BatchImportConfigBuilder:
             "access_key_id_key": access_key_id_key,
             "secret_access_key_key": secret_access_key_key,
         }
+        if endpoint_url:
+            source["endpoint_url"] = endpoint_url
+        self.batch_import.import_config["source"] = source
         self.batch_import.secrets[access_key_id_key] = access_key_id
         self.batch_import.secrets[secret_access_key_key] = secret_access_key
         return self

--- a/products/managed_migrations/frontend/ManagedMigration.tsx
+++ b/products/managed_migrations/frontend/ManagedMigration.tsx
@@ -172,6 +172,20 @@ export function ManagedMigration(): JSX.Element {
                         <LemonField name="s3_prefix" label="S3 Prefix (optional)">
                             <LemonInput placeholder="path/to/files/" />
                         </LemonField>
+
+                        <LemonField
+                            name="endpoint_url"
+                            label="Endpoint URL"
+                            showOptional
+                            info={
+                                <>
+                                    Only required for S3-compatible storage like Cloudflare R2 or MinIO. For R2, use
+                                    https://ACCOUNT_ID.r2.cloudflarestorage.com and set region to "auto".
+                                </>
+                            }
+                        >
+                            <LemonInput placeholder="https://ACCOUNT_ID.r2.cloudflarestorage.com" />
+                        </LemonField>
                     </>
                 )}
                 {(managedMigration.source_type === 'mixpanel' || managedMigration.source_type === 'amplitude') && (

--- a/products/managed_migrations/frontend/managedMigrationLogic.ts
+++ b/products/managed_migrations/frontend/managedMigrationLogic.ts
@@ -23,6 +23,7 @@ export interface ManagedMigrationForm {
     s3_region?: string
     s3_bucket?: string
     s3_prefix?: string
+    endpoint_url?: string
     // date range specific fields
     start_date?: string
     end_date?: string
@@ -41,6 +42,7 @@ const NEW_MANAGED_MIGRATION: ManagedMigrationForm = {
     s3_region: '',
     s3_bucket: '',
     s3_prefix: '',
+    endpoint_url: '',
     content_type: 'captured',
     start_date: '',
     end_date: '',
@@ -155,6 +157,7 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
                         s3_region: values.s3_region,
                         s3_bucket: values.s3_bucket,
                         s3_prefix: values.s3_prefix,
+                        ...(values.endpoint_url ? { endpoint_url: values.endpoint_url } : {}),
                     }
 
                     if (values.content_type === 'amplitude') {

--- a/products/managed_migrations/frontend/types.ts
+++ b/products/managed_migrations/frontend/types.ts
@@ -30,6 +30,7 @@ export interface S3ManagedMigration extends BaseManagedMigration {
     s3_region: string
     s3_bucket: string
     s3_prefix: string
+    endpoint_url?: string
 }
 
 export interface S3GzipManagedMigration extends BaseManagedMigration {
@@ -37,6 +38,7 @@ export interface S3GzipManagedMigration extends BaseManagedMigration {
     s3_region: string
     s3_bucket: string
     s3_prefix: string
+    endpoint_url?: string
 }
 
 export interface DateRangeManagedMigration extends BaseManagedMigration {


### PR DESCRIPTION


<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
An end user of batch imports submitted a support ticket to source S3 imports from a Cloudflare R2 (S3 compatible) source. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add optional `endpoint_url` to batch import config in Django
* Related test changes
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
I think yes; separate PR
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
Eli planned, Claude typed, Eli reviewed
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
