### PR TITLE
feat(session-replay): handle null timeOffset on rrweb mouse pos tracking data

### DIFF
--- a/nodejs/src/session-recording/sessions/session-batch-recorder.ts
+++ b/nodejs/src/session-recording/sessions/session-batch-recorder.ts
@@ -5,6 +5,7 @@ import { SessionBlockMetadata } from '../../session-replay/shared/metadata/sessi
 import { SessionMetadataStore } from '../../session-replay/shared/metadata/session-metadata-store'
 import { KeyStore, RecordingEncryptor, SessionKey } from '../../session-replay/shared/types'
 import { logger } from '../../utils/logger'
+import { captureException } from '../../utils/posthog'
 import { KafkaOffsetManager } from '../kafka/offset-manager'
 import { MessageWithTeam } from '../teams/types'
 import { SessionBatchMetrics } from './metrics'
@@ -199,7 +200,11 @@ export class SessionBatchRecorder {
         const [sessionBlockRecorder, consoleLogRecorder, featureRecorder] = sessions.get(teamSessionKey)!
         const bytesWritten = sessionBlockRecorder.recordMessage(message.message)
         await consoleLogRecorder.recordMessage(message)
-        featureRecorder.recordMessage(message.message)
+        try {
+            featureRecorder.recordMessage(message.message)
+        } catch (e) {
+            captureException(e, { tags: { sessionId: message.message.metadata.sessionId } })
+        }
 
         const currentPartitionSize = this.partitionSizes.get(partition)!
         this.partitionSizes.set(partition, currentPartitionSize + bytesWritten)

--- a/nodejs/src/session-recording/sessions/session-batch-recorder.ts
+++ b/nodejs/src/session-recording/sessions/session-batch-recorder.ts
@@ -203,7 +203,14 @@ export class SessionBatchRecorder {
         try {
             featureRecorder.recordMessage(message.message)
         } catch (e) {
-            captureException(e, { tags: { sessionId: message.message.metadata.sessionId } })
+            logger.warn('🔁', 'session_feature_recorder_error', {
+                error: String(e),
+                sessionId,
+                teamId,
+                partition,
+                batchId: this.batchId,
+            })
+            captureException(e, { tags: { sessionId, teamId: String(teamId), partition: String(partition) } })
         }
 
         const currentPartitionSize = this.partitionSizes.get(partition)!

--- a/nodejs/src/session-recording/sessions/session-feature-recorder.test.ts
+++ b/nodejs/src/session-recording/sessions/session-feature-recorder.test.ts
@@ -249,6 +249,23 @@ describe('SessionFeatureRecorder', () => {
 
             expect(result.mousePositionCount).toBe(0)
         })
+
+        it('should skip null entries in positions array', () => {
+            const event = {
+                type: RRWebEventType.IncrementalSnapshot,
+                timestamp: 1000,
+                data: {
+                    source: RRWebEventSource.MouseMove,
+                    positions: [null, { x: 5, y: 10, id: 1, timeOffset: 0 }, null],
+                },
+            } as unknown as SnapshotEvent
+            recorder.recordMessage(createMessage([event]))
+            const result = recorder.end()!
+
+            expect(result.mousePositionCount).toBe(1)
+            expect(result.mouseSumX).toBe(5)
+            expect(result.mouseSumY).toBe(10)
+        })
     })
 
     describe('Mouse movement - distance and direction changes', () => {

--- a/nodejs/src/session-recording/sessions/session-feature-recorder.ts
+++ b/nodejs/src/session-recording/sessions/session-feature-recorder.ts
@@ -418,6 +418,9 @@ export class SessionFeatureRecorder {
         }
 
         for (const pos of positions) {
+            if (!pos) {
+                continue
+            }
             const posTimestamp = e.timestamp + (pos.timeOffset || 0)
 
             this.mousePositionCount++


### PR DESCRIPTION
## Problem
`recordings-blob-ingestion-v2` service in US is seeing `rrweb` mouse position tracking data with `null` timeOffset, causing pod crashes and a hot partition in ingestion when recording feature data.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
log the error and continue when feature recording `rrweb` data won't parse during extraction. blobby will continue parsing and recording the rest of the session/event payload data and proceed.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI + new tests
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
PostHog Logs then Claude + Grafana MCP used to investigate 
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
