### PR TITLE
feat(hog-charts): drag-to-zoom on TimeSeriesLineChart

### DIFF
--- a/frontend/src/lib/hog-charts/README.md
+++ b/frontend/src/lib/hog-charts/README.md
@@ -52,21 +52,22 @@ Pass a render prop to `tooltip`. It receives `TooltipContext` — `seriesData`,
 ## Drag-to-zoom
 
 Pass `onDateRangeZoom` to let the user drag a horizontal range across the plot.
-The chart emits `(startLabel, endLabel)` from the labels array — it does not
-manage zoom state itself, so the parent decides what to do with the range
-(typically updating a date filter).
+The chart emits `{ startLabel, endLabel, startIndex, endIndex }` from the
+labels array — it does not manage zoom state itself, so the parent decides
+what to do with the range (typically updating a date filter).
 
 ```tsx
 <TimeSeriesLineChart
   series={SERIES}
   labels={LABELS}
   theme={THEME}
-  onDateRangeZoom={(start, end) => updateDateRange(start, end)}
+  onDateRangeZoom={({ startLabel, endLabel }) => updateDateRange(startLabel, endLabel)}
 />
 ```
 
-The cursor switches to `crosshair` while enabled. A plain click without
-movement still pins the tooltip or fires `onPointClick`.
+The cursor switches to `crosshair` while enabled, except over an
+actionable point (`onPointClick` is set) where it stays `pointer`. A
+plain click without movement still pins the tooltip or fires `onPointClick`.
 
 ## Custom overlays
 

--- a/frontend/src/lib/hog-charts/README.md
+++ b/frontend/src/lib/hog-charts/README.md
@@ -49,6 +49,25 @@ Pass a render prop to `tooltip`. It receives `TooltipContext` — `seriesData`,
 />
 ```
 
+## Drag-to-zoom
+
+Pass `onDateRangeZoom` to let the user drag a horizontal range across the plot.
+The chart emits `(startLabel, endLabel)` from the labels array — it does not
+manage zoom state itself, so the parent decides what to do with the range
+(typically updating a date filter).
+
+```tsx
+<TimeSeriesLineChart
+  series={SERIES}
+  labels={LABELS}
+  theme={THEME}
+  onDateRangeZoom={(start, end) => updateDateRange(start, end)}
+/>
+```
+
+The cursor switches to `crosshair` while enabled. A plain click without
+movement still pins the tooltip or fires `onPointClick`.
+
 ## Custom overlays
 
 Render any React component as a child of the chart and read layout / hover

--- a/frontend/src/lib/hog-charts/charts/LineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.test.tsx
@@ -1,6 +1,8 @@
+import { act, fireEvent } from '@testing-library/react'
+
 import type { ChartTheme, Series } from '../core/types'
 import { ReferenceLine } from '../overlays/ReferenceLine'
-import { renderHogChart } from '../testing'
+import { dimensions as testDimensions, renderHogChart } from '../testing'
 import { LineChart } from './LineChart'
 
 const THEME: ChartTheme = {
@@ -192,7 +194,12 @@ describe('LineChart', () => {
             )
             chart.dragSelection(1, 3)
             expect(onDateRangeZoom).toHaveBeenCalledTimes(1)
-            expect(onDateRangeZoom).toHaveBeenCalledWith('Tue', 'Thu')
+            expect(onDateRangeZoom).toHaveBeenCalledWith({
+                startLabel: 'Tue',
+                endLabel: 'Thu',
+                startIndex: 1,
+                endIndex: 3,
+            })
         })
 
         it('normalizes a right-to-left drag', () => {
@@ -201,7 +208,12 @@ describe('LineChart', () => {
                 <LineChart series={LONG_SERIES} labels={LONG_LABELS} theme={THEME} onDateRangeZoom={onDateRangeZoom} />
             )
             chart.dragSelection(3, 1)
-            expect(onDateRangeZoom).toHaveBeenCalledWith('Tue', 'Thu')
+            expect(onDateRangeZoom).toHaveBeenCalledWith({
+                startLabel: 'Tue',
+                endLabel: 'Thu',
+                startIndex: 1,
+                endIndex: 3,
+            })
         })
 
         it('does not fire onPointClick when a drag completes', async () => {
@@ -243,6 +255,64 @@ describe('LineChart', () => {
                 <LineChart series={LONG_SERIES} labels={LONG_LABELS} theme={THEME} onDateRangeZoom={jest.fn()} />
             )
             expect(chart.element.style.cursor).toBe('crosshair')
+        })
+
+        it('a drag that releases outside the wrapper does not swallow the next unrelated click', async () => {
+            const onDateRangeZoom = jest.fn()
+            const onPointClick = jest.fn()
+            const { chart } = renderHogChart(
+                <LineChart
+                    series={LONG_SERIES}
+                    labels={LONG_LABELS}
+                    theme={THEME}
+                    onDateRangeZoom={onDateRangeZoom}
+                    onPointClick={onPointClick}
+                />
+            )
+
+            act(() => {
+                fireEvent.mouseDown(chart.element, {
+                    button: 0,
+                    clientX: testDimensions.plotLeft + 10,
+                    clientY: testDimensions.plotTop + testDimensions.plotHeight / 2,
+                })
+                fireEvent.mouseMove(chart.element, {
+                    clientX: testDimensions.plotLeft + 200,
+                    clientY: testDimensions.plotTop + testDimensions.plotHeight / 2,
+                })
+                fireEvent(window, new MouseEvent('mouseup', { bubbles: true, clientX: 9999, clientY: 9999 }))
+            })
+            expect(onDateRangeZoom).toHaveBeenCalledTimes(1)
+
+            await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+            await chart.clickAtIndex(2)
+            expect(onPointClick).toHaveBeenCalledTimes(1)
+        })
+
+        it('click-without-drag still dismisses a pinned tooltip when onDateRangeZoom is set', async () => {
+            const onDateRangeZoom = jest.fn()
+            const onPointClick = jest.fn()
+            const { chart } = renderHogChart(
+                <LineChart
+                    series={[
+                        { key: 'a', label: 'A', data: [10, 20, 30, 40, 50] },
+                        { key: 'b', label: 'B', data: [5, 15, 25, 35, 45] },
+                    ]}
+                    labels={LONG_LABELS}
+                    theme={THEME}
+                    config={{ tooltip: { pinnable: true } }}
+                    onDateRangeZoom={onDateRangeZoom}
+                    onPointClick={onPointClick}
+                />
+            )
+            await chart.clickAtIndex(2)
+            const pinned = await chart.waitForTooltip()
+            expect(pinned.isPinned).toBe(true)
+
+            await chart.clickAtIndex(2)
+            expect(onDateRangeZoom).not.toHaveBeenCalled()
+            expect(onPointClick).not.toHaveBeenCalled()
         })
     })
 

--- a/frontend/src/lib/hog-charts/charts/LineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.test.tsx
@@ -181,6 +181,71 @@ describe('LineChart', () => {
         })
     })
 
+    describe('drag-to-zoom', () => {
+        const LONG_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
+        const LONG_SERIES: Series[] = [{ key: 'a', label: 'A', data: [10, 20, 30, 40, 50] }]
+
+        it('fires onDateRangeZoom with the start and end labels of the dragged range', () => {
+            const onDateRangeZoom = jest.fn()
+            const { chart } = renderHogChart(
+                <LineChart series={LONG_SERIES} labels={LONG_LABELS} theme={THEME} onDateRangeZoom={onDateRangeZoom} />
+            )
+            chart.dragSelection(1, 3)
+            expect(onDateRangeZoom).toHaveBeenCalledTimes(1)
+            expect(onDateRangeZoom).toHaveBeenCalledWith('Tue', 'Thu')
+        })
+
+        it('normalizes a right-to-left drag', () => {
+            const onDateRangeZoom = jest.fn()
+            const { chart } = renderHogChart(
+                <LineChart series={LONG_SERIES} labels={LONG_LABELS} theme={THEME} onDateRangeZoom={onDateRangeZoom} />
+            )
+            chart.dragSelection(3, 1)
+            expect(onDateRangeZoom).toHaveBeenCalledWith('Tue', 'Thu')
+        })
+
+        it('does not fire onPointClick when a drag completes', async () => {
+            const onDateRangeZoom = jest.fn()
+            const onPointClick = jest.fn()
+            const { chart } = renderHogChart(
+                <LineChart
+                    series={LONG_SERIES}
+                    labels={LONG_LABELS}
+                    theme={THEME}
+                    onDateRangeZoom={onDateRangeZoom}
+                    onPointClick={onPointClick}
+                />
+            )
+            chart.dragSelection(1, 3)
+            expect(onDateRangeZoom).toHaveBeenCalled()
+            expect(onPointClick).not.toHaveBeenCalled()
+        })
+
+        it('still fires onPointClick on a plain click when onDateRangeZoom is set', async () => {
+            const onDateRangeZoom = jest.fn()
+            const onPointClick = jest.fn()
+            const { chart } = renderHogChart(
+                <LineChart
+                    series={LONG_SERIES}
+                    labels={LONG_LABELS}
+                    theme={THEME}
+                    onDateRangeZoom={onDateRangeZoom}
+                    onPointClick={onPointClick}
+                />
+            )
+            await chart.clickAtIndex(2)
+            expect(onDateRangeZoom).not.toHaveBeenCalled()
+            expect(onPointClick).toHaveBeenCalledWith(expect.objectContaining({ dataIndex: 2, label: 'Wed' }))
+        })
+
+        it('switches the wrapper cursor to crosshair when onDateRangeZoom is provided', () => {
+            const { chart } = renderHogChart(
+                <LineChart series={LONG_SERIES} labels={LONG_LABELS} theme={THEME} onDateRangeZoom={jest.fn()} />
+            )
+            expect(chart.element.style.cursor).toBe('crosshair')
+        })
+    })
+
     describe('children & error boundary', () => {
         it('renders custom overlay children', () => {
             const { chart } = renderHogChart(

--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -20,6 +20,7 @@ import type {
     ChartScales,
     ChartTheme,
     CreateScalesFn,
+    DateRangeZoomData,
     LineChartConfig,
     PointClickData,
     ResolvedSeries,
@@ -41,7 +42,7 @@ export interface LineChartProps<Meta = unknown> {
     theme: ChartTheme
     tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
     onPointClick?: (data: PointClickData<Meta>) => void
-    onDateRangeZoom?: (startLabel: string, endLabel: string) => void
+    onDateRangeZoom?: (data: DateRangeZoomData) => void
     className?: string
     /** `data-attr` applied to the chart wrapper. See `ChartProps.dataAttr`. */
     dataAttr?: string

--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -41,6 +41,7 @@ export interface LineChartProps<Meta = unknown> {
     theme: ChartTheme
     tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
     onPointClick?: (data: PointClickData<Meta>) => void
+    onDateRangeZoom?: (startLabel: string, endLabel: string) => void
     className?: string
     /** `data-attr` applied to the chart wrapper. See `ChartProps.dataAttr`. */
     dataAttr?: string
@@ -63,6 +64,7 @@ function LineChartInner<Meta = unknown>({
     theme,
     tooltip,
     onPointClick,
+    onDateRangeZoom,
     className,
     dataAttr,
     children,
@@ -241,6 +243,7 @@ function LineChartInner<Meta = unknown>({
             drawHover={drawHover}
             tooltip={tooltip}
             onPointClick={onPointClick}
+            onDateRangeZoom={onDateRangeZoom}
             className={className}
             dataAttr={dataAttr}
             resolveValue={resolveValue}

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
@@ -62,7 +62,7 @@ export const DragToZoom: Story = {
                         labels={DAYS}
                         theme={theme}
                         config={{ yAxis: { showGrid: true } }}
-                        onDateRangeZoom={(start, end) => setRange([start, end])}
+                        onDateRangeZoom={({ startLabel, endLabel }) => setRange([startLabel, endLabel])}
                     />
                 </Stage>
             </div>

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
 
 import { ciRanges, TimeSeriesLineChart } from 'lib/hog-charts'
 import type { Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
@@ -41,6 +42,30 @@ export const Basic: Story = {
                     config={{ yAxis: { showGrid: true } }}
                 />
             </Stage>
+        )
+    },
+}
+
+export const DragToZoom: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const [range, setRange] = useState<[string, string] | null>(null)
+        return (
+            // eslint-disable-next-line react/forbid-dom-props
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <span className="text-xs text-muted">
+                    {range ? `Selected: ${range[0]} → ${range[1]}` : 'Drag a horizontal range to zoom'}
+                </span>
+                <Stage>
+                    <TimeSeriesLineChart
+                        series={SERIES}
+                        labels={DAYS}
+                        theme={theme}
+                        config={{ yAxis: { showGrid: true } }}
+                        onDateRangeZoom={(start, end) => setRange([start, end])}
+                    />
+                </Stage>
+            </div>
         )
     },
 }

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 
 import type {
     ChartTheme,
+    DateRangeZoomData,
     LineChartConfig,
     PointClickData,
     Series,
@@ -57,7 +58,7 @@ export interface TimeSeriesLineChartProps<Meta = unknown> {
     config?: TimeSeriesLineChartConfig
     tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
     onPointClick?: (data: PointClickData<Meta>) => void
-    onDateRangeZoom?: (startLabel: string, endLabel: string) => void
+    onDateRangeZoom?: (data: DateRangeZoomData) => void
     dataAttr?: string
     className?: string
     children?: React.ReactNode

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -57,6 +57,7 @@ export interface TimeSeriesLineChartProps<Meta = unknown> {
     config?: TimeSeriesLineChartConfig
     tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
     onPointClick?: (data: PointClickData<Meta>) => void
+    onDateRangeZoom?: (startLabel: string, endLabel: string) => void
     dataAttr?: string
     className?: string
     children?: React.ReactNode
@@ -70,6 +71,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
     config,
     tooltip,
     onPointClick,
+    onDateRangeZoom,
     dataAttr,
     className,
     children,
@@ -125,6 +127,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
             theme={theme}
             tooltip={tooltip}
             onPointClick={onPointClick}
+            onDateRangeZoom={onDateRangeZoom}
             className={className}
             dataAttr={dataAttr}
             onError={onError}

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import { AxisLabels } from '../overlays/AxisLabels'
 import { DefaultTooltip } from '../overlays/DefaultTooltip'
 import { Tooltip } from '../overlays/Tooltip'
-import { composeDrawHoverWithCrosshair } from './canvas-renderer'
+import { composeDrawHoverWithCrosshair, composeDrawHoverWithSelection } from './canvas-renderer'
 import { ChartHoverContext, ChartLayoutContext } from './chart-context'
 import type { ChartHoverContextValue, ChartLayoutContextValue } from './chart-context'
 import { useChartCanvas } from './hooks/useChartCanvas'
@@ -44,6 +44,7 @@ const WRAPPER_STYLE_BASE: React.CSSProperties = {
 }
 const WRAPPER_STYLE_DEFAULT: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'default' }
 const WRAPPER_STYLE_POINTER: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'pointer' }
+const WRAPPER_STYLE_CROSSHAIR: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'crosshair' }
 
 const STATIC_CANVAS_STYLE: React.CSSProperties = { position: 'absolute', top: 0, left: 0 }
 const OVERLAY_CANVAS_STYLE: React.CSSProperties = {
@@ -69,6 +70,7 @@ export interface ChartProps<Meta = unknown> {
     drawHover: (args: ChartDrawArgs) => void
     tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
     onPointClick?: (data: PointClickData<Meta>) => void
+    onDateRangeZoom?: (startLabel: string, endLabel: string) => void
     className?: string
     dataAttr?: string
     children?: React.ReactNode
@@ -95,6 +97,7 @@ export function Chart<Meta = unknown>({
     drawHover,
     tooltip: renderTooltip = DefaultTooltip,
     onPointClick,
+    onDateRangeZoom,
     className,
     dataAttr,
     children,
@@ -148,7 +151,7 @@ export function Chart<Meta = unknown>({
 
     const { left: resolvedYFormatter, right: resolvedYRightFormatter } = useResolvedYFormatters(scales, yTickFormatter)
 
-    const { hoverIndex, hoverPosition, tooltipCtx, handlers } = useChartInteraction<Meta>({
+    const { hoverIndex, hoverPosition, tooltipCtx, dragRect, handlers } = useChartInteraction<Meta>({
         scales,
         dimensions,
         labels,
@@ -158,6 +161,7 @@ export function Chart<Meta = unknown>({
         showTooltip,
         pinnable: pinnableTooltip,
         onPointClick,
+        onDateRangeZoom,
         resolveValue,
         interactionAxis,
         labelToCoord,
@@ -165,16 +169,15 @@ export function Chart<Meta = unknown>({
 
     // ref keeps composedDrawHover stable across drawHover identity changes
     const drawHoverRef = useLatest(drawHover)
-    const composedDrawHover = useMemo(
-        () =>
-            composeDrawHoverWithCrosshair(() => drawHoverRef.current, {
-                crosshairColor: theme.crosshairColor,
-                showCrosshair,
-                axisOrientation,
-                labelToCoord,
-            }),
-        [showCrosshair, theme.crosshairColor, axisOrientation, labelToCoord, drawHoverRef.current]
-    )
+    const composedDrawHover = useMemo(() => {
+        const withCrosshair = composeDrawHoverWithCrosshair(() => drawHoverRef.current, {
+            crosshairColor: theme.crosshairColor,
+            showCrosshair,
+            axisOrientation,
+            labelToCoord,
+        })
+        return composeDrawHoverWithSelection(() => withCrosshair)
+    }, [showCrosshair, theme.crosshairColor, axisOrientation, labelToCoord, drawHoverRef.current])
 
     useChartDraw({
         ctx,
@@ -186,11 +189,16 @@ export function Chart<Meta = unknown>({
         hoverIndex,
         hoverPosition,
         theme,
+        dragRect,
         drawStatic,
         drawHover: composedDrawHover,
     })
 
-    const wrapperStyle = hoverIndex >= 0 && onPointClick ? WRAPPER_STYLE_POINTER : WRAPPER_STYLE_DEFAULT
+    const wrapperStyle = onDateRangeZoom
+        ? WRAPPER_STYLE_CROSSHAIR
+        : hoverIndex >= 0 && onPointClick
+          ? WRAPPER_STYLE_POINTER
+          : WRAPPER_STYLE_DEFAULT
 
     const ariaLabel = useMemo(() => {
         const visible = coloredSeries.reduce((n, s) => n + (s.visibility?.excluded ? 0 : 1), 0)
@@ -235,6 +243,7 @@ export function Chart<Meta = unknown>({
                     className={className}
                     data-attr={dataAttr}
                     style={wrapperStyle}
+                    onMouseDown={handlers.onMouseDown}
                     onMouseMove={handlers.onMouseMove}
                     onMouseLeave={handlers.onMouseLeave}
                     onClick={handlers.onClick}

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -19,6 +19,7 @@ import type {
     ChartScales,
     ChartTheme,
     CreateScalesFn,
+    DateRangeZoomData,
     PointClickData,
     ResolvedSeries,
     ResolveValueFn,
@@ -46,6 +47,16 @@ const WRAPPER_STYLE_DEFAULT: React.CSSProperties = { ...WRAPPER_STYLE_BASE, curs
 const WRAPPER_STYLE_POINTER: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'pointer' }
 const WRAPPER_STYLE_CROSSHAIR: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'crosshair' }
 
+function pickWrapperStyle(hasDragToZoom: boolean, hasPointClick: boolean, isOverPoint: boolean): React.CSSProperties {
+    if (hasPointClick && isOverPoint) {
+        return WRAPPER_STYLE_POINTER
+    }
+    if (hasDragToZoom) {
+        return WRAPPER_STYLE_CROSSHAIR
+    }
+    return WRAPPER_STYLE_DEFAULT
+}
+
 const STATIC_CANVAS_STYLE: React.CSSProperties = { position: 'absolute', top: 0, left: 0 }
 const OVERLAY_CANVAS_STYLE: React.CSSProperties = {
     position: 'absolute',
@@ -70,7 +81,7 @@ export interface ChartProps<Meta = unknown> {
     drawHover: (args: ChartDrawArgs) => void
     tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
     onPointClick?: (data: PointClickData<Meta>) => void
-    onDateRangeZoom?: (startLabel: string, endLabel: string) => void
+    onDateRangeZoom?: (data: DateRangeZoomData) => void
     className?: string
     dataAttr?: string
     children?: React.ReactNode
@@ -176,7 +187,7 @@ export function Chart<Meta = unknown>({
             axisOrientation,
             labelToCoord,
         })
-        return composeDrawHoverWithSelection(() => withCrosshair)
+        return composeDrawHoverWithSelection(withCrosshair)
     }, [showCrosshair, theme.crosshairColor, axisOrientation, labelToCoord, drawHoverRef.current])
 
     useChartDraw({
@@ -194,11 +205,7 @@ export function Chart<Meta = unknown>({
         drawHover: composedDrawHover,
     })
 
-    const wrapperStyle = onDateRangeZoom
-        ? WRAPPER_STYLE_CROSSHAIR
-        : hoverIndex >= 0 && onPointClick
-          ? WRAPPER_STYLE_POINTER
-          : WRAPPER_STYLE_DEFAULT
+    const wrapperStyle = pickWrapperStyle(!!onDateRangeZoom, !!onPointClick, hoverIndex >= 0)
 
     const ariaLabel = useMemo(() => {
         const visible = coloredSeries.reduce((n, s) => n + (s.visibility?.excluded ? 0 : 1), 0)

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -548,8 +548,7 @@ export function composeDrawHoverWithCrosshair(
     }
 }
 
-/** Colors for the drag-to-zoom selection rectangle. Match the values used by the
- *  Chart.js implementation so the two paths look identical. */
+// Match chartjs-plugin-zoom selection colors.
 const SELECTION_FILL = 'rgba(59, 130, 246, 0.15)'
 const SELECTION_STROKE = 'rgba(59, 130, 246, 0.5)'
 
@@ -559,8 +558,6 @@ export interface DrawSelectionRectOptions {
     lineWidth?: number
 }
 
-/** Paints a 1px-bordered, translucent rectangle. Used by the drag-to-zoom overlay; the rect
- *  spans the full plot height regardless of how far the cursor moved vertically. */
 export function drawSelectionRect(
     ctx: CanvasRenderingContext2D,
     rect: { x: number; y: number; width: number; height: number },
@@ -576,26 +573,28 @@ export function drawSelectionRect(
     ctx.strokeRect(rect.x + 0.5, rect.y + 0.5, rect.width - 1, rect.height - 1)
 }
 
-/** Wraps a base hover-draw fn and paints the drag-to-zoom selection rectangle on top
- *  whenever `args.dragRect` is set. The rect always spans the full plot height — this
- *  mirrors `chartjs-plugin-zoom`'s `mode: 'x'` behavior. */
-export function composeDrawHoverWithSelection(getDrawHover: () => DrawHoverFn): DrawHoverFn {
+// Always spans full plot height; mirrors chartjs-plugin-zoom mode: 'x'.
+export function composeDrawHoverWithSelection(baseDrawHover: DrawHoverFn): DrawHoverFn {
     return (args) => {
-        getDrawHover()(args)
+        baseDrawHover(args)
         const dragRect = args.dragRect
         if (!dragRect) {
             return
         }
-        const lo = Math.max(args.dimensions.plotLeft, Math.min(dragRect.x0, dragRect.x1))
-        const hi = Math.min(args.dimensions.plotLeft + args.dimensions.plotWidth, Math.max(dragRect.x0, dragRect.x1))
-        if (hi <= lo) {
+        const x0 = Math.max(args.dimensions.plotLeft, Math.min(dragRect.x0, dragRect.x1))
+        const x1 = Math.min(args.dimensions.plotLeft + args.dimensions.plotWidth, Math.max(dragRect.x0, dragRect.x1))
+        if (x1 <= x0) {
             return
         }
-        drawSelectionRect(args.ctx, {
-            x: lo,
-            y: args.dimensions.plotTop,
-            width: hi - lo,
-            height: args.dimensions.plotHeight,
-        })
+        drawSelectionRect(
+            args.ctx,
+            {
+                x: x0,
+                y: args.dimensions.plotTop,
+                width: x1 - x0,
+                height: args.dimensions.plotHeight,
+            },
+            { fill: args.theme.selectionFill, stroke: args.theme.selectionStroke }
+        )
     }
 }

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -547,3 +547,55 @@ export function composeDrawHoverWithCrosshair(
         getDrawHover()(args)
     }
 }
+
+/** Colors for the drag-to-zoom selection rectangle. Match the values used by the
+ *  Chart.js implementation so the two paths look identical. */
+const SELECTION_FILL = 'rgba(59, 130, 246, 0.15)'
+const SELECTION_STROKE = 'rgba(59, 130, 246, 0.5)'
+
+export interface DrawSelectionRectOptions {
+    fill?: string
+    stroke?: string
+    lineWidth?: number
+}
+
+/** Paints a 1px-bordered, translucent rectangle. Used by the drag-to-zoom overlay; the rect
+ *  spans the full plot height regardless of how far the cursor moved vertically. */
+export function drawSelectionRect(
+    ctx: CanvasRenderingContext2D,
+    rect: { x: number; y: number; width: number; height: number },
+    options: DrawSelectionRectOptions = {}
+): void {
+    if (rect.width <= 0 || rect.height <= 0) {
+        return
+    }
+    ctx.fillStyle = options.fill ?? SELECTION_FILL
+    ctx.fillRect(rect.x, rect.y, rect.width, rect.height)
+    ctx.strokeStyle = options.stroke ?? SELECTION_STROKE
+    ctx.lineWidth = options.lineWidth ?? 1
+    ctx.strokeRect(rect.x + 0.5, rect.y + 0.5, rect.width - 1, rect.height - 1)
+}
+
+/** Wraps a base hover-draw fn and paints the drag-to-zoom selection rectangle on top
+ *  whenever `args.dragRect` is set. The rect always spans the full plot height — this
+ *  mirrors `chartjs-plugin-zoom`'s `mode: 'x'` behavior. */
+export function composeDrawHoverWithSelection(getDrawHover: () => DrawHoverFn): DrawHoverFn {
+    return (args) => {
+        getDrawHover()(args)
+        const dragRect = args.dragRect
+        if (!dragRect) {
+            return
+        }
+        const lo = Math.max(args.dimensions.plotLeft, Math.min(dragRect.x0, dragRect.x1))
+        const hi = Math.min(args.dimensions.plotLeft + args.dimensions.plotWidth, Math.max(dragRect.x0, dragRect.x1))
+        if (hi <= lo) {
+            return
+        }
+        drawSelectionRect(args.ctx, {
+            x: lo,
+            y: args.dimensions.plotTop,
+            width: hi - lo,
+            height: args.dimensions.plotHeight,
+        })
+    }
+}

--- a/frontend/src/lib/hog-charts/core/hooks/useChartDraw.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartDraw.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 
-import type { ChartDimensions, ChartDrawArgs, ChartScales, ChartTheme, ResolvedSeries } from '../types'
+import type { ChartDimensions, ChartDrawArgs, ChartScales, ChartTheme, DragRect, ResolvedSeries } from '../types'
 
 interface UseChartDrawOptions {
     /** Context for the static layer (grid, lines, areas, points). Redrawn only when chart inputs change. */
@@ -14,8 +14,7 @@ interface UseChartDrawOptions {
     hoverIndex: number
     hoverPosition: { x: number; y: number } | null
     theme: ChartTheme
-    /** Live drag-to-zoom selection rect — drives an overlay redraw whenever it changes. */
-    dragRect: { x0: number; x1: number } | null
+    dragRect: DragRect | null
     drawStatic: (args: ChartDrawArgs) => void
     drawHover: (args: ChartDrawArgs) => void
 }

--- a/frontend/src/lib/hog-charts/core/hooks/useChartDraw.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartDraw.ts
@@ -14,6 +14,8 @@ interface UseChartDrawOptions {
     hoverIndex: number
     hoverPosition: { x: number; y: number } | null
     theme: ChartTheme
+    /** Live drag-to-zoom selection rect — drives an overlay redraw whenever it changes. */
+    dragRect: { x0: number; x1: number } | null
     drawStatic: (args: ChartDrawArgs) => void
     drawHover: (args: ChartDrawArgs) => void
 }
@@ -35,6 +37,7 @@ export function useChartDraw({
     hoverIndex,
     hoverPosition,
     theme,
+    dragRect,
     drawStatic,
     drawHover,
 }: UseChartDrawOptions): void {
@@ -83,7 +86,17 @@ export function useChartDraw({
         hoverRafRef.current = requestAnimationFrame(() => {
             hoverRafRef.current = null
             clearAndPrepare(overlayCtx, dimensions)
-            drawHover({ ctx: overlayCtx, dimensions, scales, series, labels, hoverIndex, hoverPosition, theme })
+            drawHover({
+                ctx: overlayCtx,
+                dimensions,
+                scales,
+                series,
+                labels,
+                hoverIndex,
+                hoverPosition,
+                theme,
+                dragRect,
+            })
             overlayCtx.restore()
         })
         return () => {
@@ -92,5 +105,5 @@ export function useChartDraw({
                 hoverRafRef.current = null
             }
         }
-    }, [overlayCtx, dimensions, scales, series, labels, hoverIndex, hoverPosition, theme, drawHover])
+    }, [overlayCtx, dimensions, scales, series, labels, hoverIndex, hoverPosition, theme, dragRect, drawHover])
 }

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -1,9 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
     buildLabelPositions,
     buildPointClickData,
     buildTooltipContext,
+    dragRectToLabelRange,
     findNearestIndexFromPositions,
     isInPlotArea,
 } from '../interaction'
@@ -17,6 +18,8 @@ import type {
     TooltipContext,
 } from '../types'
 import { useLatest } from './useLatest'
+
+const DRAG_THRESHOLD_PX = 4
 
 function isTooltipContextEquivalent<Meta>(a: TooltipContext<Meta>, b: TooltipContext<Meta>): boolean {
     if (a.dataIndex !== b.dataIndex || a.label !== b.label) {
@@ -57,6 +60,7 @@ interface UseChartInteractionOptions<Meta> {
     showTooltip: boolean
     pinnable: boolean
     onPointClick?: (data: PointClickData<Meta>) => void
+    onDateRangeZoom?: (startLabel: string, endLabel: string) => void
     resolveValue?: ResolveValueFn
     interactionAxis?: 'x' | 'y'
     labelToCoord?: (label: string) => number | undefined
@@ -66,7 +70,9 @@ interface UseChartInteractionResult<Meta> {
     hoverIndex: number
     hoverPosition: { x: number; y: number } | null
     tooltipCtx: TooltipContext<Meta> | null
+    dragRect: { x0: number; x1: number } | null
     handlers: {
+        onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void
         onMouseMove: (e: React.MouseEvent<HTMLDivElement>) => void
         onMouseLeave: () => void
         onClick: () => void
@@ -83,6 +89,7 @@ export function useChartInteraction<Meta = unknown>({
     showTooltip,
     pinnable,
     onPointClick,
+    onDateRangeZoom,
     resolveValue = defaultResolveValue,
     interactionAxis = 'x',
     labelToCoord,
@@ -90,6 +97,9 @@ export function useChartInteraction<Meta = unknown>({
     const [hoverIndex, setHoverIndex] = useState<number>(-1)
     const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null)
     const [tooltipCtx, setTooltipCtx] = useState<TooltipContext<Meta> | null>(null)
+    const [dragRect, setDragRect] = useState<{ x0: number; x1: number } | null>(null)
+    const dragOriginRef = useRef<{ x: number; y: number; active: boolean } | null>(null)
+    const dragJustCompletedRef = useRef(false)
     // Read by onClick to decide pin/unpin/passthrough. Event handlers fire after the
     // most recent commit, so an effect-deferred ref is correct here.
     const hoverIndexRef = useLatest(hoverIndex)
@@ -111,6 +121,9 @@ export function useChartInteraction<Meta = unknown>({
         () => (scales ? buildLabelPositions(labels, labelToCoord ?? scales.x) : []),
         [labels, scales, labelToCoord]
     )
+    const labelsRef = useLatest(labels)
+    const labelPositionsRef = useLatest(labelPositions)
+    const onDateRangeZoomRef = useLatest(onDateRangeZoom)
 
     // Rebuild or clear the pinned tooltip when its underlying inputs change.
     // Without this, the pin keeps stale values at stale pixel positions after the
@@ -223,15 +236,85 @@ export function useChartInteraction<Meta = unknown>({
         }
     }, [isPinned, wrapperRef, clearTooltip])
 
+    const completeDrag = useCallback(
+        (mouseX: number) => {
+            const origin = dragOriginRef.current
+            if (!origin) {
+                return
+            }
+            if (origin.active) {
+                const range = dragRectToLabelRange({ x0: origin.x, x1: mouseX }, labelPositionsRef.current)
+                if (range && onDateRangeZoomRef.current) {
+                    const ls = labelsRef.current
+                    onDateRangeZoomRef.current(ls[range.startIndex], ls[range.endIndex])
+                }
+                dragJustCompletedRef.current = true
+            }
+            dragOriginRef.current = null
+            setDragRect(null)
+        },
+        [labelPositionsRef, labelsRef, onDateRangeZoomRef]
+    )
+
+    // Global mouseup catches gestures that end outside the chart wrapper.
+    useEffect(() => {
+        if (!onDateRangeZoom) {
+            return
+        }
+        const handler = (e: MouseEvent): void => {
+            if (!dragOriginRef.current) {
+                return
+            }
+            const wrapper = wrapperRef.current
+            const mouseX = wrapper ? e.clientX - wrapper.getBoundingClientRect().left : 0
+            completeDrag(mouseX)
+        }
+        window.addEventListener('mouseup', handler)
+        return () => window.removeEventListener('mouseup', handler)
+    }, [onDateRangeZoom, wrapperRef, completeDrag])
+
+    const onMouseDown = useCallback(
+        (e: React.MouseEvent<HTMLDivElement>) => {
+            if (!onDateRangeZoom || !scales || !dimensions || e.button !== 0) {
+                return
+            }
+            const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+            const mouseX = e.clientX - rect.left
+            const mouseY = e.clientY - rect.top
+            if (!isInPlotArea(mouseX, mouseY, dimensions)) {
+                return
+            }
+            dragOriginRef.current = { x: mouseX, y: mouseY, active: false }
+            setTooltipCtx((prev) => (prev?.isPinned ? null : prev))
+        },
+        [onDateRangeZoom, scales, dimensions]
+    )
+
     const onMouseMove = useCallback(
         (e: React.MouseEvent<HTMLDivElement>) => {
-            if (!scales || !dimensions || isPinned) {
+            if (!scales || !dimensions) {
                 return
             }
 
             const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
             const mouseX = e.clientX - rect.left
             const mouseY = e.clientY - rect.top
+
+            const origin = dragOriginRef.current
+            if (origin) {
+                if (!origin.active && Math.hypot(mouseX - origin.x, mouseY - origin.y) >= DRAG_THRESHOLD_PX) {
+                    origin.active = true
+                    clearTooltip()
+                }
+                if (origin.active) {
+                    setDragRect({ x0: origin.x, x1: mouseX })
+                    return
+                }
+            }
+
+            if (isPinned) {
+                return
+            }
 
             if (!isInPlotArea(mouseX, mouseY, dimensions)) {
                 clearTooltip()
@@ -286,6 +369,10 @@ export function useChartInteraction<Meta = unknown>({
     }, [isPinned, clearTooltip])
 
     const onClick = useCallback(() => {
+        if (dragJustCompletedRef.current) {
+            dragJustCompletedRef.current = false
+            return
+        }
         const currentIndex = hoverIndexRef.current
         if (currentIndex < 0) {
             return
@@ -313,7 +400,10 @@ export function useChartInteraction<Meta = unknown>({
         }
     }, [onPointClick, series, labels, resolveValue, pinnable, tooltipCtx, isPinned, clearTooltip, unpin, hoverIndexRef])
 
-    const handlers = useMemo(() => ({ onMouseMove, onMouseLeave, onClick }), [onMouseMove, onMouseLeave, onClick])
+    const handlers = useMemo(
+        () => ({ onMouseDown, onMouseMove, onMouseLeave, onClick }),
+        [onMouseDown, onMouseMove, onMouseLeave, onClick]
+    )
 
-    return { hoverIndex, hoverPosition, tooltipCtx, handlers }
+    return { hoverIndex, hoverPosition, tooltipCtx, dragRect, handlers }
 }

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -12,6 +12,8 @@ import { defaultResolveValue } from '../types'
 import type {
     ChartDimensions,
     ChartScales,
+    DateRangeZoomData,
+    DragRect,
     PointClickData,
     ResolvedSeries,
     ResolveValueFn,
@@ -60,7 +62,7 @@ interface UseChartInteractionOptions<Meta> {
     showTooltip: boolean
     pinnable: boolean
     onPointClick?: (data: PointClickData<Meta>) => void
-    onDateRangeZoom?: (startLabel: string, endLabel: string) => void
+    onDateRangeZoom?: (data: DateRangeZoomData) => void
     resolveValue?: ResolveValueFn
     interactionAxis?: 'x' | 'y'
     labelToCoord?: (label: string) => number | undefined
@@ -70,7 +72,7 @@ interface UseChartInteractionResult<Meta> {
     hoverIndex: number
     hoverPosition: { x: number; y: number } | null
     tooltipCtx: TooltipContext<Meta> | null
-    dragRect: { x0: number; x1: number } | null
+    dragRect: DragRect | null
     handlers: {
         onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void
         onMouseMove: (e: React.MouseEvent<HTMLDivElement>) => void
@@ -97,7 +99,7 @@ export function useChartInteraction<Meta = unknown>({
     const [hoverIndex, setHoverIndex] = useState<number>(-1)
     const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null)
     const [tooltipCtx, setTooltipCtx] = useState<TooltipContext<Meta> | null>(null)
-    const [dragRect, setDragRect] = useState<{ x0: number; x1: number } | null>(null)
+    const [dragRect, setDragRect] = useState<DragRect | null>(null)
     const dragOriginRef = useRef<{ x: number; y: number; active: boolean } | null>(null)
     const dragJustCompletedRef = useRef(false)
     // Read by onClick to decide pin/unpin/passthrough. Event handlers fire after the
@@ -246,9 +248,17 @@ export function useChartInteraction<Meta = unknown>({
                 const range = dragRectToLabelRange({ x0: origin.x, x1: mouseX }, labelPositionsRef.current)
                 if (range && onDateRangeZoomRef.current) {
                     const ls = labelsRef.current
-                    onDateRangeZoomRef.current(ls[range.startIndex], ls[range.endIndex])
+                    onDateRangeZoomRef.current({
+                        startLabel: ls[range.startIndex],
+                        endLabel: ls[range.endIndex],
+                        startIndex: range.startIndex,
+                        endIndex: range.endIndex,
+                    })
                 }
                 dragJustCompletedRef.current = true
+                setTimeout(() => {
+                    dragJustCompletedRef.current = false
+                }, 0)
             }
             dragOriginRef.current = null
             setDragRect(null)
@@ -285,7 +295,6 @@ export function useChartInteraction<Meta = unknown>({
                 return
             }
             dragOriginRef.current = { x: mouseX, y: mouseY, active: false }
-            setTooltipCtx((prev) => (prev?.isPinned ? null : prev))
         },
         [onDateRangeZoom, scales, dimensions]
     )

--- a/frontend/src/lib/hog-charts/core/interaction.test.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.test.ts
@@ -1,5 +1,12 @@
 import { dimensions, makeSeries } from '../testing'
-import { buildPointClickData, buildTooltipContext, findNearestIndex, isInPlotArea } from './interaction'
+import {
+    buildLabelPositions,
+    buildPointClickData,
+    buildTooltipContext,
+    dragRectToLabelRange,
+    findNearestIndex,
+    isInPlotArea,
+} from './interaction'
 import type { ResolveValueFn } from './types'
 
 const defaultResolveValue: ResolveValueFn = (s, i) => s.data[i]
@@ -268,6 +275,37 @@ describe('hog-charts interaction', () => {
             )
             expect(result?.position.x).toBe(400)
             expect(result?.position.y).toBe(150)
+        })
+    })
+
+    describe('dragRectToLabelRange', () => {
+        const xScale = (label: string): number | undefined => ({ a: 100, b: 200, c: 300, d: 400, e: 500 })[label]
+        const positions = buildLabelPositions(['a', 'b', 'c', 'd', 'e'], xScale)
+
+        it('returns null when fewer than two labels are positioned', () => {
+            const single = buildLabelPositions(['a'], xScale)
+            expect(dragRectToLabelRange({ x0: 50, x1: 500 }, single)).toBeNull()
+        })
+
+        it('returns the [start,end] range for a left-to-right drag', () => {
+            // 160 → nearest 200 (index 1); 340 → nearest 300 (index 2)
+            expect(dragRectToLabelRange({ x0: 160, x1: 340 }, positions)).toEqual({ startIndex: 1, endIndex: 2 })
+        })
+
+        it('normalizes a right-to-left drag', () => {
+            expect(dragRectToLabelRange({ x0: 340, x1: 160 }, positions)).toEqual({ startIndex: 1, endIndex: 2 })
+        })
+
+        it('clamps to the outermost label when the drag extends past the plot edges', () => {
+            expect(dragRectToLabelRange({ x0: -100, x1: 9999 }, positions)).toEqual({ startIndex: 0, endIndex: 4 })
+        })
+
+        it('returns null when both edges of the drag land on the same label', () => {
+            expect(dragRectToLabelRange({ x0: 195, x1: 205 }, positions)).toBeNull()
+        })
+
+        it('returns null for a zero-width drag', () => {
+            expect(dragRectToLabelRange({ x0: 250, x1: 250 }, positions)).toBeNull()
         })
     })
 

--- a/frontend/src/lib/hog-charts/core/interaction.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.ts
@@ -2,6 +2,7 @@ import { bisector } from 'd3'
 
 import type {
     ChartDimensions,
+    DragRect,
     PointClickData,
     ResolvedSeries,
     ResolveValueFn,
@@ -9,6 +10,8 @@ import type {
     YAxisScale,
 } from './types'
 import { DEFAULT_Y_AXIS_ID } from './types'
+
+export type { DragRect } from './types'
 
 export interface LabelPosition {
     x: number
@@ -59,17 +62,7 @@ export function isInPlotArea(mouseX: number, mouseY: number, dimensions: ChartDi
     )
 }
 
-/** Pixel x-range of an in-progress drag selection on the plot. `x0` and `x1` are canvas pixels
- *  (not necessarily ordered). The chart renders this as a translucent rectangle that spans
- *  the full plot height. */
-export interface DragRect {
-    x0: number
-    x1: number
-}
-
-/** Maps a drag rectangle to the [startIndex, endIndex] range it selects, in label-array order.
- *  Returns null when the rectangle collapses to fewer than two distinct labels — a drag that
- *  short shouldn't zoom anything. Always normalizes right-to-left drags. */
+// Returns null when fewer than 2 distinct labels are spanned.
 export function dragRectToLabelRange(
     rect: DragRect,
     labelPositions: LabelPosition[]
@@ -84,7 +77,8 @@ export function dragRectToLabelRange(
     if (startIndex < 0 || endIndex < 0 || startIndex === endIndex) {
         return null
     }
-    return startIndex < endIndex ? { startIndex, endIndex } : { startIndex: endIndex, endIndex: startIndex }
+    const [s, e] = startIndex < endIndex ? [startIndex, endIndex] : [endIndex, startIndex]
+    return { startIndex: s, endIndex: e }
 }
 
 export function buildTooltipContext<Meta = unknown>(

--- a/frontend/src/lib/hog-charts/core/interaction.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.ts
@@ -59,6 +59,34 @@ export function isInPlotArea(mouseX: number, mouseY: number, dimensions: ChartDi
     )
 }
 
+/** Pixel x-range of an in-progress drag selection on the plot. `x0` and `x1` are canvas pixels
+ *  (not necessarily ordered). The chart renders this as a translucent rectangle that spans
+ *  the full plot height. */
+export interface DragRect {
+    x0: number
+    x1: number
+}
+
+/** Maps a drag rectangle to the [startIndex, endIndex] range it selects, in label-array order.
+ *  Returns null when the rectangle collapses to fewer than two distinct labels — a drag that
+ *  short shouldn't zoom anything. Always normalizes right-to-left drags. */
+export function dragRectToLabelRange(
+    rect: DragRect,
+    labelPositions: LabelPosition[]
+): { startIndex: number; endIndex: number } | null {
+    if (labelPositions.length < 2) {
+        return null
+    }
+    const lo = Math.min(rect.x0, rect.x1)
+    const hi = Math.max(rect.x0, rect.x1)
+    const startIndex = findNearestIndexFromPositions(lo, labelPositions)
+    const endIndex = findNearestIndexFromPositions(hi, labelPositions)
+    if (startIndex < 0 || endIndex < 0 || startIndex === endIndex) {
+        return null
+    }
+    return startIndex < endIndex ? { startIndex, endIndex } : { startIndex: endIndex, endIndex: startIndex }
+}
+
 export function buildTooltipContext<Meta = unknown>(
     dataIndex: number,
     series: ResolvedSeries<Meta>[],

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -214,6 +214,9 @@ export interface ChartDrawArgs {
     hoverPosition: { x: number; y: number } | null
     /** Chart theme colors. */
     theme: ChartTheme
+    /** Live pixel range of an in-progress drag-to-zoom selection, x-axis only. Null when
+     *  no drag is active. Only the hover overlay reads this — the static layer ignores it. */
+    dragRect?: { x0: number; x1: number } | null
 }
 
 /** Resolves the y-value for a series at a given data index. Used by interaction/tooltip layer. */

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -7,6 +7,8 @@ export interface ChartTheme {
     crosshairColor?: string
     tooltipBackground?: string
     tooltipColor?: string
+    selectionFill?: string
+    selectionStroke?: string
 }
 
 /** Default axis id used when a series doesn't specify one. */
@@ -216,7 +218,20 @@ export interface ChartDrawArgs {
     theme: ChartTheme
     /** Live pixel range of an in-progress drag-to-zoom selection, x-axis only. Null when
      *  no drag is active. Only the hover overlay reads this — the static layer ignores it. */
-    dragRect?: { x0: number; x1: number } | null
+    dragRect?: DragRect | null
+}
+
+// x0/x1 are canvas pixels, not necessarily ordered.
+export interface DragRect {
+    x0: number
+    x1: number
+}
+
+export interface DateRangeZoomData {
+    startLabel: string
+    endLabel: string
+    startIndex: number
+    endIndex: number
 }
 
 /** Resolves the y-value for a series at a given data index. Used by interaction/tooltip layer. */

--- a/frontend/src/lib/hog-charts/docs/TESTING.md
+++ b/frontend/src/lib/hog-charts/docs/TESTING.md
@@ -176,7 +176,7 @@ it('fires onDateRangeZoom with the dragged label range', () => {
   )
 
   chart.dragSelection(1, 3)
-  expect(onDateRangeZoom).toHaveBeenCalledWith('Tue', 'Thu')
+  expect(onDateRangeZoom).toHaveBeenCalledWith(expect.objectContaining({ startLabel: 'Tue', endLabel: 'Thu' }))
 })
 ```
 

--- a/frontend/src/lib/hog-charts/docs/TESTING.md
+++ b/frontend/src/lib/hog-charts/docs/TESTING.md
@@ -62,14 +62,17 @@ For interactions, use the module-level helpers:
 - `hoverAtIndex(wrapper, i, totalLabels)` — `mouseMove` over labels[i].
 - `clickAtIndex(wrapper, i, totalLabels)` — hover-then-click. Resolves
   after the click handler runs.
+- `dragSelection(wrapper, fromIndex, toIndex, totalLabels)` — simulates a
+  drag-to-zoom gesture between two label indices.
 - `waitForHogChartTooltip()` — resolves with the rendered tooltip element
   once it mounts in the `FloatingPortal`.
 
-`chart.hoverAtIndex(i)` and `chart.waitForTooltip()` (returning a
-structured `TooltipSnapshot` with `seriesData`, `isPinned`, etc.) need
-`renderHogChart` — they read label count and the captured `TooltipContext`
-that only the library's own render wrapper sets up. For most consumer
-tests, DOM assertions through the accessor are enough.
+`chart.hoverAtIndex(i)`, `chart.dragSelection(i, j)`, and
+`chart.waitForTooltip()` (returning a structured `TooltipSnapshot` with
+`seriesData`, `isPinned`, etc.) need `renderHogChart` — they read label
+count and the captured `TooltipContext` that only the library's own render
+wrapper sets up. For most consumer tests, DOM assertions through the
+accessor are enough.
 
 ## Testing the library itself
 
@@ -160,6 +163,20 @@ it('renders a right axis when a series opts in', () => {
 
   expect(chart.hasRightAxis).toBe(true)
   expect(chart.yRightTicks().length).toBeGreaterThan(0)
+})
+```
+
+#### Drag to zoom
+
+```tsx
+it('fires onDateRangeZoom with the dragged label range', () => {
+  const onDateRangeZoom = jest.fn()
+  const { chart } = renderHogChart(
+    <LineChart series={SERIES} labels={LABELS} theme={THEME} onDateRangeZoom={onDateRangeZoom} />
+  )
+
+  chart.dragSelection(1, 3)
+  expect(onDateRangeZoom).toHaveBeenCalledWith('Tue', 'Thu')
 })
 ```
 

--- a/frontend/src/lib/hog-charts/testing/accessor.ts
+++ b/frontend/src/lib/hog-charts/testing/accessor.ts
@@ -67,7 +67,6 @@ export interface HogChart<Meta = unknown> {
     /** Hover at the index, wait for the tooltip to settle, then click. Mirrors the
      *  hover-then-click sequence the chart's onClick handler relies on. */
     clickAtIndex(index: number): Promise<void>
-    /** Simulate a drag-to-zoom gesture from one label index to another. */
     dragSelection(fromIndex: number, toIndex: number): void
     /** Wait for the tooltip to mount, then return a snapshot — every `TooltipContext` field
      *  plus the rendered portal element and an `isPinned` getter. Only available when the

--- a/frontend/src/lib/hog-charts/testing/accessor.ts
+++ b/frontend/src/lib/hog-charts/testing/accessor.ts
@@ -9,6 +9,7 @@
 import { fireEvent } from '@testing-library/react'
 
 import type { TooltipContext } from '../core/types'
+import { dragSelection } from './interactions'
 import { dimensions } from './jsdom'
 import { type HogChartTooltip, waitForHogChartTooltip } from './tooltip'
 
@@ -66,6 +67,8 @@ export interface HogChart<Meta = unknown> {
     /** Hover at the index, wait for the tooltip to settle, then click. Mirrors the
      *  hover-then-click sequence the chart's onClick handler relies on. */
     clickAtIndex(index: number): Promise<void>
+    /** Simulate a drag-to-zoom gesture from one label index to another. */
+    dragSelection(fromIndex: number, toIndex: number): void
     /** Wait for the tooltip to mount, then return a snapshot — every `TooltipContext` field
      *  plus the rendered portal element and an `isPinned` getter. Only available when the
      *  chart was rendered via `renderHogChart`; throws otherwise. */
@@ -196,6 +199,12 @@ export function getHogChart<Meta = unknown>(
             // synchronously to choose between pinning and onPointClick.
             await waitForHogChartTooltip()
             fireEvent.click(wrapper)
+        },
+        dragSelection(fromIndex: number, toIndex: number): void {
+            if (totalLabels === undefined) {
+                throw new Error('chart.dragSelection requires renderHogChart (which captures labels.length)')
+            }
+            dragSelection(wrapper, fromIndex, toIndex, totalLabels)
         },
         async waitForTooltip(timeout?: number): Promise<TooltipSnapshot<Meta>> {
             const element = await waitForHogChartTooltip(timeout)

--- a/frontend/src/lib/hog-charts/testing/index.ts
+++ b/frontend/src/lib/hog-charts/testing/index.ts
@@ -1,5 +1,5 @@
 export { dimensions, ensureJsdom, makeSeries, mockRect, setupJsdom, setupSyncRaf } from './jsdom'
-export { clickAtIndex, hoverAtIndex } from './interactions'
+export { clickAtIndex, dragSelection, hoverAtIndex } from './interactions'
 export { getHogChart } from './accessor'
 export type { GetHogChartOptions, HogChart, TooltipSnapshot } from './accessor'
 export { renderHogChart } from './render'

--- a/frontend/src/lib/hog-charts/testing/interactions.ts
+++ b/frontend/src/lib/hog-charts/testing/interactions.ts
@@ -3,15 +3,19 @@ import { act, fireEvent } from '@testing-library/react'
 import { dimensions } from './jsdom'
 import { waitForHogChartTooltip } from './tooltip'
 
+function clientForIndex(index: number, totalLabels: number): { clientX: number; clientY: number } {
+    const step = dimensions.plotWidth / Math.max(1, totalLabels - 1)
+    return {
+        clientX: dimensions.plotLeft + step * index,
+        clientY: dimensions.plotTop + dimensions.plotHeight / 2,
+    }
+}
+
 /** Fire a mouseMove on a chart wrapper element at the pixel position
  *  corresponding to the given label index. */
 export function hoverAtIndex(wrapper: HTMLElement, index: number, totalLabels: number): void {
-    const step = dimensions.plotWidth / (totalLabels - 1)
     act(() => {
-        fireEvent.mouseMove(wrapper, {
-            clientX: dimensions.plotLeft + step * index,
-            clientY: dimensions.plotTop + dimensions.plotHeight / 2,
-        })
+        fireEvent.mouseMove(wrapper, clientForIndex(index, totalLabels))
     })
 }
 
@@ -21,4 +25,18 @@ export async function clickAtIndex(wrapper: HTMLElement, index: number, totalLab
     // to decide between pinning and onPointClick, and a stale null takes the wrong branch.
     await waitForHogChartTooltip()
     fireEvent.click(wrapper)
+}
+
+/** Simulate a drag-to-zoom gesture between two label indices. Fires the same
+ *  mousedown → mousemove → mouseup sequence the real DOM produces, including
+ *  the global mouseup the chart's drag handler listens for. */
+export function dragSelection(wrapper: HTMLElement, fromIndex: number, toIndex: number, totalLabels: number): void {
+    const from = clientForIndex(fromIndex, totalLabels)
+    const to = clientForIndex(toIndex, totalLabels)
+    act(() => {
+        fireEvent.mouseDown(wrapper, { button: 0, ...from })
+        fireEvent.mouseMove(wrapper, to)
+        fireEvent(window, new MouseEvent('mouseup', { bubbles: true, clientX: to.clientX, clientY: to.clientY }))
+        fireEvent.click(wrapper, to)
+    })
 }

--- a/frontend/src/lib/hog-charts/testing/interactions.ts
+++ b/frontend/src/lib/hog-charts/testing/interactions.ts
@@ -27,9 +27,7 @@ export async function clickAtIndex(wrapper: HTMLElement, index: number, totalLab
     fireEvent.click(wrapper)
 }
 
-/** Simulate a drag-to-zoom gesture between two label indices. Fires the same
- *  mousedown → mousemove → mouseup sequence the real DOM produces, including
- *  the global mouseup the chart's drag handler listens for. */
+// Fires mouseup on window (the chart's drag handler listens globally).
 export function dragSelection(wrapper: HTMLElement, fromIndex: number, toIndex: number, totalLabels: number): void {
     const from = clientForIndex(fromIndex, totalLabels)
     const to = clientForIndex(toIndex, totalLabels)

--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
@@ -33,6 +33,7 @@ interface TrendsLineChartProps {
 }
 
 const TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
+const EMPTY_STRINGS: string[] = []
 
 const handleChartError = (error: Error, info: ErrorInfo): void => {
     posthog.captureException(error, {
@@ -87,26 +88,26 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
               ? ''
               : aggregationLabel(labelGroupType).plural)
 
-    const labels = currentPeriodResult?.labels ?? []
-    const days = currentPeriodResult?.days ?? []
+    const labels = currentPeriodResult?.labels ?? EMPTY_STRINGS
+    const days = currentPeriodResult?.days ?? EMPTY_STRINGS
     const contextOnDateRangeZoom = context?.onDateRangeZoom
     const onDateRangeZoom = useMemo(() => {
         if (days.length === 0) {
             return undefined
         }
-        return (startLabel: string, endLabel: string): void => {
-            const i0 = labels.indexOf(startLabel)
-            const i1 = labels.indexOf(endLabel)
-            if (i0 < 0 || i1 < 0 || !days[i0] || !days[i1]) {
+        return ({ startIndex, endIndex }: { startIndex: number; endIndex: number }): void => {
+            const dateFrom = days[startIndex]
+            const dateTo = days[endIndex]
+            if (!dateFrom || !dateTo) {
                 return
             }
             if (contextOnDateRangeZoom) {
-                contextOnDateRangeZoom(days[i0], days[i1])
+                contextOnDateRangeZoom(dateFrom, dateTo)
             } else {
-                updateDateRange({ date_from: days[i0], date_to: days[i1] }, true)
+                updateDateRange({ date_from: dateFrom, date_to: dateTo }, true)
             }
         }
-    }, [contextOnDateRangeZoom, labels, days, updateDateRange])
+    }, [contextOnDateRangeZoom, days, updateDateRange])
 
     const hasData =
         indexedResults &&

--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
@@ -1,4 +1,4 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useCallback, useMemo, type ErrorInfo } from 'react'
 
@@ -8,6 +8,7 @@ import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipConfig, 
 import { formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -75,6 +76,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
     } = useValues(trendsDataLogic(insightProps))
     const { timezone, weekStartDay, baseCurrency } = useValues(teamLogic)
     const { aggregationLabel } = useValues(groupsModel)
+    const { updateDateRange } = useActions(insightVizDataLogic(insightProps))
 
     const isPercentStackView = !!showPercentStackView && !!supportsPercentStackView
     const resolvedGroupTypeLabel =
@@ -86,6 +88,25 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
               : aggregationLabel(labelGroupType).plural)
 
     const labels = currentPeriodResult?.labels ?? []
+    const days = currentPeriodResult?.days ?? []
+    const contextOnDateRangeZoom = context?.onDateRangeZoom
+    const onDateRangeZoom = useMemo(() => {
+        if (days.length === 0) {
+            return undefined
+        }
+        return (startLabel: string, endLabel: string): void => {
+            const i0 = labels.indexOf(startLabel)
+            const i1 = labels.indexOf(endLabel)
+            if (i0 < 0 || i1 < 0 || !days[i0] || !days[i1]) {
+                return
+            }
+            if (contextOnDateRangeZoom) {
+                contextOnDateRangeZoom(days[i0], days[i1])
+            } else {
+                updateDateRange({ date_from: days[i0], date_to: days[i1] }, true)
+            }
+        }
+    }, [contextOnDateRangeZoom, labels, days, updateDateRange])
 
     const hasData =
         indexedResults &&
@@ -279,6 +300,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             config={chartConfig}
             tooltip={renderTooltip}
             onPointClick={canHandleClick ? onPointClick : undefined}
+            onDateRangeZoom={onDateRangeZoom}
             className="LineGraph"
             dataAttr="trend-line-graph"
             onError={handleChartError}


### PR DESCRIPTION
## Problem

The new hog-charts `TimeSeriesLineChart` had no drag-to-zoom equivalent of the chart.js `chartjs-plugin-zoom` integration that powers the old `LineGraph` (used by web analytics today via `WEB_ANALYTICS_DRAG_TO_ZOOM`). Product analytics, where the new chart is rolling out behind `PRODUCT_ANALYTICS_HOG_CHARTS`, also never had drag-to-zoom on the old chart because nothing in the trends scene wired `context.onDateRangeZoom`.

## Changes

- New `onDateRangeZoom?: (startLabel, endLabel) => void` prop on `Chart` / `LineChart` / `TimeSeriesLineChart`. When set, dragging a horizontal range on the plot paints a translucent rectangle on the overlay canvas and emits the selected labels on release. Cursor switches to `crosshair`. Click-without-drag still pins / fires `onPointClick`.
- Drag state machine in `useChartInteraction` with a 4px movement threshold, a global `mouseup` listener so gestures complete cleanly outside the chart, and click-swallow after a real drag.
- Pure `dragRectToLabelRange(rect, labelPositions)` helper in `core/interaction.ts`, plus a `drawSelectionRect` canvas primitive and a `composeDrawHoverWithSelection` composer in `core/canvas-renderer.ts`.
- `dragSelection(wrapper, from, to, total)` testing helper + matching `chart.dragSelection(from, to)` accessor on `renderHogChart`.
- `TrendsLineChart` forwards `context?.onDateRangeZoom` if present, otherwise falls back to `insightVizDataLogic.updateDateRange` so product analytics gets drag-to-zoom for the first time (only when the hog-charts version of the chart renders).
- Storybook story (`DragToZoom`), README section, TESTING.md entry + recipe.

## How did you test this code?

I'm an agent. I ran:

- `hogli test frontend/src/lib/hog-charts/` — 875 tests pass, including 5 new chart-level cases for `LineChart` drag-to-zoom and 5 new pure-geometry cases for `dragRectToLabelRange`.
- `hogli test frontend/src/scenes/trends/viz/trends-line-chart/` — 94 tests pass, no regressions from the `TrendsLineChart` wiring change.

No manual browser testing on my end.

## Publish to changelog?

## 🤖 Agent context

Claude Code (Opus 4.7, 1M context). Followed the hog-charts contributing/testing docs: pure geometry isolated in `core/interaction.ts`, stateless drawing primitive in `core/canvas-renderer.ts`, hook-level state machine, no canvas-pixel assertions in tests (everything goes through the `HogChart` accessor).

Decisions worth flagging for review:

- `onDateRangeZoom` is a top-level prop, not part of `config`, matching the existing `onPointClick` / `onError` callback placement. If we add more zoom-related options later (axis, colors, modifier keys), they'd live in `config.zoom`, with the callback staying at the top level — same shape as the existing `tooltip` render prop + `config.tooltip` behaviour split.
- x-axis only for v1 (selection spans the full plot height) to match what `chartjs-plugin-zoom` `mode: 'x'` does today. y-axis / box selection deferred.
- No internal "zoom state" or reset semantics on the chart — parent owns the date range. Old impl's `chart.resetZoom()` after callback is moot because hog-charts doesn't have a zoom transform.
- Product analytics integration: drag-to-zoom calls `insightVizDataLogic.updateDateRange({ date_from, date_to })` directly. There's no equivalent of web analytics' `preZoomDateFilter`/`resetZoom` — users back out via the regular date-range picker. If that's not enough, a small "reset" affordance is a fine follow-up.
- Follow-up captured in agent memory: drag-on-x-axis to extend/pan the visible window with a loading overlay on the new range. The architecture supports it cleanly via `stroke.partial` + an overlay child; only the gesture itself needs adding.
