### PR TITLE
fix(web-analytics): tag product and feature in base query runner

### DIFF
--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -35,7 +35,7 @@ from posthog.hogql.property import action_to_expr, apply_path_cleaning, property
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.caching.insights_api import BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL, REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL
-from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, get_query_tag_value, tag_queries
 from posthog.hogql_queries.query_runner import AnalyticsQueryResponseProtocol, AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -82,6 +82,12 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
         return user_access_control.assert_access_level_for_resource("web_analytics", "viewer")
 
     def calculate(self) -> WAR:
+        # Every web analytics query runner produces user-facing dashboard
+        # queries. Tag here so all downstream `sync_execute` calls (live and
+        # preagg paths) inherit product/feature and don't trip DEBUG-mode
+        # `UntaggedQueryError`.
+        tag_queries(product=Product.WEB_ANALYTICS, feature=Feature.QUERY)
+
         query_kind = getattr(self.query, "kind", "Unknown")
         breakdown_value = getattr(self.query, "breakdownBy", None)
         breakdown_label = breakdown_value.value if breakdown_value is not None else "none"


### PR DESCRIPTION
## Problem

Every web analytics query runner reaches `sync_execute` without `product`/`feature` tags set, because:
- `execute_hogql_query` tags `query_type` as snake_case (e.g. `web_overview_query`), which the `NodeKind` fallback in `add_fallback_query_tags` cannot map (it expects PascalCase `WebOverviewQuery`).
- The `WebAnalytics` scene maps to `None` in `SCENE_TO_TAGS`, so the scene fallback also yields nothing.

In production this surfaces as continuous `sync_execute called with missing query tags` warnings; in local dev with `DEBUG=True` it surfaces as a fail-fast `UntaggedQueryError` 500 on every web analytics request (browser SWR retries silently, presenting as a perpetual loading state).

## Changes

One tag call at the top of `WebAnalyticsQueryRunner.calculate()` — applies before any subclass `_calculate` runs, so live, preagg, and downstream sync_execute call sites all inherit the tags.

## How did you test this code?

I'm an agent — no manual UI testing claimed. Verified by:

- Firing all 12 web analytics query types via the local Query API and a personal API key.
- Reading `system.query_log.log_comment` on the local ClickHouse: every distinct `query_type` row now carries `product=web_analytics, feature=query` (`stats_table_main_query`, `stats_table_entry_bounce_query`, `stats_table_frustration_metrics_query`, `web_overview_query`, `web_goals_query`, `web_vitals_path_breakdown_query`, `web_external_clicks_query`).
- Before vs after on master: WebOverview returns 500 `UntaggedQueryError` in ~5s → after fix returns 200 in ~1s with real data.

Existing `posthog/hogql_queries/web_analytics/test/` suite still passes locally.

## Publish to changelog?

no

## 🤖 Agent context

Agent-authored. Found while debugging unrelated UI symptoms on `lricoy/web-overview-lazy-precompute` — surfaced a pre-existing master bug that's separate from that PR's scope, so split out here. Sanity-checked on a clean master checkout that the symptom and fix were independent of the lazy precompute work.