### PR TITLE
feat(modeling): bounded resolver for hogql to cap depth and time during query resolution

### DIFF
--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -100,7 +100,7 @@ def prepare_ast_for_printing(
 
     if context.modifiers.inCohortVia == InCohortVia.LEFTJOIN_CONJOINED:
         with context.timings.measure("resolve_in_cohorts_conjoined"):
-            resolve_in_cohorts_conjoined(node, dialect, context, stack)
+            resolve_in_cohorts_conjoined(node, dialect, context, stack, resolver_factory=resolver_factory)
 
     with context.timings.measure("resolve_types"):
         node = resolve_types(
@@ -123,7 +123,7 @@ def prepare_ast_for_printing(
 
     if dialect in ("postgres", "duckdb"):
         with context.timings.measure("resolve_lazy_tables"):
-            resolve_lazy_tables(node, dialect, stack, context)
+            resolve_lazy_tables(node, dialect, stack, context, resolver_factory=resolver_factory)
 
     if dialect == "clickhouse":
         with context.timings.measure("resolve_property_types"):
@@ -146,7 +146,7 @@ def prepare_ast_for_printing(
             ).visit(node)
 
         with context.timings.measure("resolve_lazy_tables"):
-            resolve_lazy_tables(node, dialect, stack, context)
+            resolve_lazy_tables(node, dialect, stack, context, resolver_factory=resolver_factory)
 
         with context.timings.measure("swap_properties"):
             node = PropertySwapper(
@@ -168,7 +168,7 @@ def prepare_ast_for_printing(
 
     if context.modifiers.inCohortVia == InCohortVia.LEFTJOIN:
         with context.timings.measure("resolve_in_cohorts"):
-            resolve_in_cohorts(node, dialect, stack, context)
+            resolve_in_cohorts(node, dialect, stack, context, resolver_factory=resolver_factory)
 
     # We add a team_id guard right before printing. It's not a separate step here.
     return node

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -14,7 +14,7 @@ from posthog.hogql.printer.clickhouse import ClickHousePrinter
 from posthog.hogql.printer.duckdb import DuckDBPrinter
 from posthog.hogql.printer.hogql import HogQLPrinter
 from posthog.hogql.printer.postgres import PostgresPrinter
-from posthog.hogql.resolver import resolve_types
+from posthog.hogql.resolver import ResolverFactory, resolve_types
 from posthog.hogql.transforms.in_cohort import resolve_in_cohorts, resolve_in_cohorts_conjoined
 from posthog.hogql.transforms.lazy_tables import resolve_lazy_tables
 from posthog.hogql.transforms.projection_pushdown import pushdown_projections
@@ -72,6 +72,7 @@ def prepare_ast_for_printing(
     dialect: HogQLDialect,
     stack: list[ast.SelectQuery] | None = None,
     settings: HogQLGlobalSettings | None = None,
+    resolver_factory: ResolverFactory | None = None,
 ) -> _T_AST | None:
     if context.database is None:
         with context.timings.measure("create_hogql_database"):  # Legacy name to keep backwards compatibility
@@ -107,6 +108,7 @@ def prepare_ast_for_printing(
             context,
             dialect=dialect,
             scopes=[node.type for node in stack if node.type is not None] if stack else None,
+            resolver_factory=resolver_factory,
         )
 
     # Detect workload from resolved table types and store on context

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -1,4 +1,5 @@
 import dataclasses
+from collections.abc import Callable
 from datetime import date, datetime
 from typing import Any, Optional, cast
 from uuid import UUID
@@ -125,13 +126,24 @@ def resolve_types_from_table(
     return resolve_types(expr, context, dialect, [select_node_with_types.type])
 
 
+ResolverFactory = Callable[
+    [HogQLContext, HogQLDialect, Optional[list["ast.SelectQueryType"]]],
+    "Resolver",
+]
+
+
 def resolve_types(
     node: _T_AST,
     context: HogQLContext,
     dialect: HogQLDialect,
     scopes: Optional[list[ast.SelectQueryType]] = None,
+    resolver_factory: ResolverFactory | None = None,
 ) -> _T_AST:
-    return Resolver(scopes=scopes, context=context, dialect=dialect).visit(node)
+    if resolver_factory is None:
+        resolver = Resolver(scopes=scopes, context=context, dialect=dialect)
+    else:
+        resolver = resolver_factory(context, dialect, scopes)
+    return resolver.visit(node)
 
 
 class AliasCollector(TraversingVisitor):

--- a/posthog/hogql/transforms/in_cohort.py
+++ b/posthog/hogql/transforms/in_cohort.py
@@ -7,7 +7,7 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import QueryError
 from posthog.hogql.escape_sql import escape_clickhouse_string
 from posthog.hogql.parser import parse_expr, parse_select
-from posthog.hogql.resolver import resolve_types
+from posthog.hogql.resolver import ResolverFactory, resolve_types
 from posthog.hogql.visitor import TraversingVisitor, clone_expr
 
 
@@ -16,10 +16,11 @@ def resolve_in_cohorts(
     dialect: HogQLDialect,
     stack: Optional[list[ast.SelectQuery]] = None,
     context: HogQLContext | None = None,
+    resolver_factory: ResolverFactory | None = None,
 ):
     if context is None:
         raise QueryError("context is required to resolve IN COHORT")
-    InCohortResolver(stack=stack, dialect=dialect, context=context).visit(node)
+    InCohortResolver(stack=stack, dialect=dialect, context=context, resolver_factory=resolver_factory).visit(node)
 
 
 def resolve_in_cohorts_conjoined(
@@ -27,8 +28,11 @@ def resolve_in_cohorts_conjoined(
     dialect: HogQLDialect,
     context: HogQLContext,
     stack: Optional[list[ast.SelectQuery]] = None,
+    resolver_factory: ResolverFactory | None = None,
 ):
-    MultipleInCohortResolver(stack=stack, dialect=dialect, context=context).visit(node)
+    MultipleInCohortResolver(stack=stack, dialect=dialect, context=context, resolver_factory=resolver_factory).visit(
+        node
+    )
 
 
 class CohortCompareOperationTraverser(TraversingVisitor):
@@ -54,11 +58,15 @@ class MultipleInCohortResolver(TraversingVisitor):
         dialect: HogQLDialect,
         context: HogQLContext,
         stack: Optional[list[ast.SelectQuery]] = None,
+        resolver_factory: ResolverFactory | None = None,
     ):
         super().__init__()
         self.stack: list[ast.SelectQuery] = stack or []
         self.context = context
         self.dialect = dialect
+        # accepted for signature parity with InCohortResolver; this resolver does not
+        # currently invoke resolve_types itself, so the factory is held but unused
+        self.resolver_factory = resolver_factory
 
     def visit_cte(self, node: ast.CTE):
         self.visit(node.expr)
@@ -282,11 +290,15 @@ class InCohortResolver(TraversingVisitor):
         dialect: HogQLDialect,
         context: HogQLContext,
         stack: Optional[list[ast.SelectQuery]] = None,
+        resolver_factory: ResolverFactory | None = None,
     ):
         super().__init__()
         self.stack: list[ast.SelectQuery] = stack or []
         self.context = context
         self.dialect = dialect
+        # forwarded to nested resolve_types/resolve_lazy_tables calls so a caller-supplied
+        # factory (e.g. BoundedResolver) applies to cohort-join subqueries built mid-transform
+        self.resolver_factory = resolver_factory
 
     def visit_select_query(self, node: ast.SelectQuery):
         self.stack.append(node)
@@ -415,10 +427,14 @@ class InCohortResolver(TraversingVisitor):
                 raise QueryError("Could not resolve current select scope")
             new_join = cast(
                 ast.JoinExpr,
-                resolve_types(new_join, self.context, self.dialect, [current_scope]),
+                resolve_types(
+                    new_join, self.context, self.dialect, [current_scope], resolver_factory=self.resolver_factory
+                ),
             )
             if inline_ast is not None:
-                resolve_lazy_tables(new_join, self.dialect, [self.stack[-1]], self.context)
+                resolve_lazy_tables(
+                    new_join, self.dialect, [self.stack[-1]], self.context, resolver_factory=self.resolver_factory
+                )
                 if self.context.property_swapper:
                     new_join = cast(
                         ast.JoinExpr,
@@ -431,6 +447,7 @@ class InCohortResolver(TraversingVisitor):
                 self.context,
                 self.dialect,
                 [current_scope],
+                resolver_factory=self.resolver_factory,
             )
             new_join.constraint.expr.right = clone_expr(compare.left)
             if last_join:
@@ -447,5 +464,8 @@ class InCohortResolver(TraversingVisitor):
             self.context,
             self.dialect,
             [current_scope],
+            resolver_factory=self.resolver_factory,
         )
-        compare.right = resolve_types(ast.Constant(value=1), self.context, self.dialect, [current_scope])
+        compare.right = resolve_types(
+            ast.Constant(value=1), self.context, self.dialect, [current_scope], resolver_factory=self.resolver_factory
+        )

--- a/posthog/hogql/transforms/lazy_tables.py
+++ b/posthog/hogql/transforms/lazy_tables.py
@@ -7,7 +7,7 @@ from posthog.hogql.constants import HogQLDialect
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import LazyJoinToAdd, LazyTableToAdd
 from posthog.hogql.errors import ResolutionError
-from posthog.hogql.resolver import resolve_types
+from posthog.hogql.resolver import ResolverFactory, resolve_types
 from posthog.hogql.resolver_utils import get_long_table_name
 from posthog.hogql.transforms.property_types import PropertySwapper
 from posthog.hogql.visitor import CloningVisitor, TraversingVisitor, clone_expr
@@ -19,8 +19,9 @@ def resolve_lazy_tables(
     dialect: HogQLDialect,
     stack: Optional[list[ast.SelectQuery]],
     context: HogQLContext,
+    resolver_factory: ResolverFactory | None = None,
 ):
-    LazyTableResolver(stack=stack, context=context, dialect=dialect).visit(node)
+    LazyTableResolver(stack=stack, context=context, dialect=dialect, resolver_factory=resolver_factory).visit(node)
 
 
 @dataclasses.dataclass
@@ -178,11 +179,15 @@ class LazyTableResolver(TraversingVisitor):
         dialect: HogQLDialect,
         stack: Optional[list[ast.SelectQuery]],
         context: HogQLContext,
+        resolver_factory: ResolverFactory | None = None,
     ):
         super().__init__()
         self.field_collectors: list[list[ast.FieldType | ast.PropertyType]] = [[]] if stack else []
         self.context = context
         self.dialect: HogQLDialect = dialect
+        # forwarded to nested resolve_types/resolve_lazy_tables calls so a caller-supplied
+        # factory (e.g. BoundedResolver) applies to subqueries built mid-transform
+        self.resolver_factory = resolver_factory
 
     def _find_tables_needing_lazy_preresolution(
         self,
@@ -242,8 +247,11 @@ class LazyTableResolver(TraversingVisitor):
         )
 
         # Resolve types and lazy tables within the subquery
-        subquery = cast(ast.SelectQuery, resolve_types(subquery, self.context, self.dialect, []))
-        resolve_lazy_tables(subquery, self.dialect, [subquery], self.context)
+        subquery = cast(
+            ast.SelectQuery,
+            resolve_types(subquery, self.context, self.dialect, [], resolver_factory=self.resolver_factory),
+        )
+        resolve_lazy_tables(subquery, self.dialect, [subquery], self.context, resolver_factory=self.resolver_factory)
         assert subquery.type is not None
 
         # Replace the table with the subquery
@@ -557,7 +565,12 @@ class LazyTableResolver(TraversingVisitor):
         for table_name, table_to_add in tables_to_add.items():
             subquery = table_to_add.lazy_table.lazy_select(table_to_add, self.context, node=node)
             subquery = cast(ast.SelectQuery, clone_expr(subquery, clear_locations=True))
-            subquery = cast(ast.SelectQuery, resolve_types(subquery, self.context, self.dialect, [select_type]))
+            subquery = cast(
+                ast.SelectQuery,
+                resolve_types(
+                    subquery, self.context, self.dialect, [select_type], resolver_factory=self.resolver_factory
+                ),
+            )
             if self.context.property_swapper is not None:
                 subquery = PropertySwapper(
                     timezone=self.context.property_swapper.timezone,
@@ -600,7 +613,12 @@ class LazyTableResolver(TraversingVisitor):
                 FieldChainReplacer(overrides).visit(join_to_add)
 
             join_to_add = cast(ast.JoinExpr, clone_expr(join_to_add, clear_locations=True, clear_types=True))
-            join_to_add = cast(ast.JoinExpr, resolve_types(join_to_add, self.context, self.dialect, [select_type]))
+            join_to_add = cast(
+                ast.JoinExpr,
+                resolve_types(
+                    join_to_add, self.context, self.dialect, [select_type], resolver_factory=self.resolver_factory
+                ),
+            )
             if self.context.property_swapper is not None:
                 join_to_add = PropertySwapper(
                     timezone=self.context.property_swapper.timezone,

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -233,7 +233,18 @@ def _transform_unsupported_decimals(batch: pa.RecordBatch) -> pa.RecordBatch:
     return pa.RecordBatch.from_arrays(new_columns, schema=pa.schema(new_fields, metadata=new_metadata))
 
 
-async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogger) -> int:
+def _bounded_resolver_factory(view_name: str | None):
+    """Build a resolver factory that bounds depth, cycles, and deadline using the saved query's name as the seed."""
+
+    def factory(context, dialect, scopes):
+        return BoundedResolver(scopes=scopes, context=context, dialect=dialect, initial_view_name=view_name)
+
+    return factory
+
+
+async def get_query_row_count(
+    query: str, team: Team, logger: FilteringBoundLogger, view_name: str | None = None
+) -> int:
     """Get the total row count for a HogQL query."""
     count_query = f"SELECT count() FROM ({query})"
 
@@ -251,7 +262,12 @@ async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogg
     context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
 
     prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-        query_node, context=context, dialect="clickhouse", settings=settings, stack=[]
+        query_node,
+        context=context,
+        dialect="clickhouse",
+        settings=settings,
+        stack=[],
+        resolver_factory=_bounded_resolver_factory(view_name),
     )
 
     if prepared_hogql_query is None:
@@ -273,7 +289,7 @@ async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogg
         return count
 
 
-async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
+async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view_name: str | None = None):
     """Execute a HogQL query and yield batches of results."""
     query_node = parse_select(query)
     if query_node is None:
@@ -289,8 +305,14 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
     )
     context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
 
+    factory = _bounded_resolver_factory(view_name)
     prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-        query_node, context=context, dialect="clickhouse", settings=settings, stack=[]
+        query_node,
+        context=context,
+        dialect="clickhouse",
+        settings=settings,
+        stack=[],
+        resolver_factory=factory,
     )
     if prepared_hogql_query is None:
         raise EmptyHogQLResponseColumnsError()
@@ -364,7 +386,12 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
     settings.preferred_block_size_bytes = MB_100_IN_BYTES
 
     arrow_prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-        query_node, context=context, dialect="clickhouse", stack=[], settings=settings
+        query_node,
+        context=context,
+        dialect="clickhouse",
+        stack=[],
+        settings=settings,
+        resolver_factory=factory,
     )
 
     if arrow_prepared_hogql_query is None:
@@ -454,7 +481,7 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
 
         hogql_query = typing.cast(dict, saved_query.query)["query"]
         try:
-            rows_expected = await get_query_row_count(hogql_query, team, logger)
+            rows_expected = await get_query_row_count(hogql_query, team, logger, view_name=saved_query.name)
             await logger.ainfo(f"Expected rows: {rows_expected}")
             job.rows_expected = rows_expected
             await database_sync_to_async(job.save)()
@@ -466,7 +493,9 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
         row_count = 0
         storage_options = _get_aws_storage_options()
         delta_table: deltalake.DeltaTable | None = None
-        async for index, res in asyncstdlib.enumerate(hogql_table(hogql_query, team, logger)):
+        async for index, res in asyncstdlib.enumerate(
+            hogql_table(hogql_query, team, logger, view_name=saved_query.name)
+        ):
             batch, ch_types = res
             batch = _transform_unsupported_decimals(batch)
             batch = _transform_date_and_datetimes(batch, ch_types)

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -34,6 +34,7 @@ from posthog.temporal.common.logger import get_logger
 from products.data_modeling.backend.models import Node, NodeType
 from products.data_modeling.backend.models.data_modeling_job import DataModelingJob
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_modeling.backend.models.modeling import bounded_resolver_factory_for_view
 from products.data_warehouse.backend.s3 import ensure_bucket_exists, get_s3_client
 from products.endpoints.backend.services.endpoint_materialization_service import prepare_executable_query
 
@@ -233,15 +234,6 @@ def _transform_unsupported_decimals(batch: pa.RecordBatch) -> pa.RecordBatch:
     return pa.RecordBatch.from_arrays(new_columns, schema=pa.schema(new_fields, metadata=new_metadata))
 
 
-def _bounded_resolver_factory(view_name: str | None):
-    """Build a resolver factory that bounds depth, cycles, and deadline using the saved query's name as the seed."""
-
-    def factory(context, dialect, scopes):
-        return BoundedResolver(scopes=scopes, context=context, dialect=dialect, initial_view_name=view_name)
-
-    return factory
-
-
 async def get_query_row_count(
     query: str, team: Team, logger: FilteringBoundLogger, view_name: str | None = None
 ) -> int:
@@ -267,7 +259,7 @@ async def get_query_row_count(
         dialect="clickhouse",
         settings=settings,
         stack=[],
-        resolver_factory=_bounded_resolver_factory(view_name),
+        resolver_factory=bounded_resolver_factory_for_view(view_name),
     )
 
     if prepared_hogql_query is None:
@@ -305,7 +297,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
     )
     context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
 
-    factory = _bounded_resolver_factory(view_name)
+    factory = bounded_resolver_factory_for_view(view_name)
     prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
         query_node,
         context=context,

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -68,7 +68,7 @@ from posthog.temporal.ducklake.types import DataModelingDuckLakeCopyInputs, Duck
 
 from products.data_modeling.backend.models.data_modeling_job import DataModelingJob
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
-from products.data_modeling.backend.models.modeling import DataWarehouseModelPath
+from products.data_modeling.backend.models.modeling import BoundedResolver, DataWarehouseModelPath
 from products.data_warehouse.backend.data_load.create_table import create_table_from_saved_query
 from products.data_warehouse.backend.data_load.saved_query_service import a_pause_saved_query_schedule
 from products.data_warehouse.backend.s3 import ensure_bucket_exists, get_s3_client
@@ -522,7 +522,7 @@ async def materialize_model(
             await logger.adebug(f"Table at {table_uri} not found - skipping deletion")
 
         try:
-            rows_expected = await get_query_row_count(hogql_query, team, logger)
+            rows_expected = await get_query_row_count(hogql_query, team, logger, view_name=saved_query.name)
             await logger.ainfo(f"Expected rows: {rows_expected}")
             # Set expected rows on the job
             job.rows_expected = rows_expected
@@ -539,7 +539,9 @@ async def materialize_model(
 
         delta_table: deltalake.DeltaTable | None = None
 
-        async for index, res in asyncstdlib.enumerate(hogql_table(hogql_query, team, logger)):
+        async for index, res in asyncstdlib.enumerate(
+            hogql_table(hogql_query, team, logger, view_name=saved_query.name)
+        ):
             batch, ch_types = res
             batch = _transform_unsupported_decimals(batch)
             batch = _transform_date_and_datetimes(batch, ch_types)
@@ -799,7 +801,18 @@ async def update_table_row_count(
         await logger.aexception("Failed to update row count for table %s: %s", saved_query.name, str(e))
 
 
-async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogger) -> int:
+def _bounded_resolver_factory(view_name: str | None):
+    """Build a resolver factory that bounds depth, cycles, and deadline using the saved query's name as the seed."""
+
+    def factory(context, dialect, scopes):
+        return BoundedResolver(scopes=scopes, context=context, dialect=dialect, initial_view_name=view_name)
+
+    return factory
+
+
+async def get_query_row_count(
+    query: str, team: Team, logger: FilteringBoundLogger, view_name: str | None = None
+) -> int:
     """Get the total row count for a HogQL query. Differs in extraction with std query since it's a count query."""
     count_query = f"SELECT count() FROM ({query})"
 
@@ -820,7 +833,12 @@ async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogg
     context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
 
     prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-        query_node, context=context, dialect="clickhouse", settings=settings, stack=[]
+        query_node,
+        context=context,
+        dialect="clickhouse",
+        settings=settings,
+        stack=[],
+        resolver_factory=_bounded_resolver_factory(view_name),
     )
 
     if prepared_hogql_query is None:
@@ -845,7 +863,7 @@ async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogg
 MB_100_IN_BYTES = 100 * 1000 * 1000
 
 
-async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
+async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view_name: str | None = None):
     """A HogQL table given by a HogQL query."""
 
     await logger.adebug("Configuring hogql_table")
@@ -866,8 +884,14 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
     )
     context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
 
+    factory = _bounded_resolver_factory(view_name)
     prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-        query_node, context=context, dialect="clickhouse", settings=settings, stack=[]
+        query_node,
+        context=context,
+        dialect="clickhouse",
+        settings=settings,
+        stack=[],
+        resolver_factory=factory,
     )
     if prepared_hogql_query is None:
         raise EmptyHogQLResponseColumnsError()
@@ -978,7 +1002,12 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
     settings.preferred_block_size_bytes = MB_100_IN_BYTES
 
     arrow_prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-        query_node, context=context, dialect="clickhouse", stack=[], settings=settings
+        query_node,
+        context=context,
+        dialect="clickhouse",
+        stack=[],
+        settings=settings,
+        resolver_factory=factory,
     )
 
     if arrow_prepared_hogql_query is None:

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -68,7 +68,7 @@ from posthog.temporal.ducklake.types import DataModelingDuckLakeCopyInputs, Duck
 
 from products.data_modeling.backend.models.data_modeling_job import DataModelingJob
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
-from products.data_modeling.backend.models.modeling import BoundedResolver, DataWarehouseModelPath
+from products.data_modeling.backend.models.modeling import DataWarehouseModelPath
 from products.data_warehouse.backend.data_load.create_table import create_table_from_saved_query
 from products.data_warehouse.backend.data_load.saved_query_service import a_pause_saved_query_schedule
 from products.data_warehouse.backend.s3 import ensure_bucket_exists, get_s3_client
@@ -522,7 +522,7 @@ async def materialize_model(
             await logger.adebug(f"Table at {table_uri} not found - skipping deletion")
 
         try:
-            rows_expected = await get_query_row_count(hogql_query, team, logger, view_name=saved_query.name)
+            rows_expected = await get_query_row_count(hogql_query, team, logger)
             await logger.ainfo(f"Expected rows: {rows_expected}")
             # Set expected rows on the job
             job.rows_expected = rows_expected
@@ -539,9 +539,7 @@ async def materialize_model(
 
         delta_table: deltalake.DeltaTable | None = None
 
-        async for index, res in asyncstdlib.enumerate(
-            hogql_table(hogql_query, team, logger, view_name=saved_query.name)
-        ):
+        async for index, res in asyncstdlib.enumerate(hogql_table(hogql_query, team, logger)):
             batch, ch_types = res
             batch = _transform_unsupported_decimals(batch)
             batch = _transform_date_and_datetimes(batch, ch_types)
@@ -801,18 +799,7 @@ async def update_table_row_count(
         await logger.aexception("Failed to update row count for table %s: %s", saved_query.name, str(e))
 
 
-def _bounded_resolver_factory(view_name: str | None):
-    """Build a resolver factory that bounds depth, cycles, and deadline using the saved query's name as the seed."""
-
-    def factory(context, dialect, scopes):
-        return BoundedResolver(scopes=scopes, context=context, dialect=dialect, initial_view_name=view_name)
-
-    return factory
-
-
-async def get_query_row_count(
-    query: str, team: Team, logger: FilteringBoundLogger, view_name: str | None = None
-) -> int:
+async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogger) -> int:
     """Get the total row count for a HogQL query. Differs in extraction with std query since it's a count query."""
     count_query = f"SELECT count() FROM ({query})"
 
@@ -833,12 +820,7 @@ async def get_query_row_count(
     context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
 
     prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-        query_node,
-        context=context,
-        dialect="clickhouse",
-        settings=settings,
-        stack=[],
-        resolver_factory=_bounded_resolver_factory(view_name),
+        query_node, context=context, dialect="clickhouse", settings=settings, stack=[]
     )
 
     if prepared_hogql_query is None:
@@ -863,7 +845,7 @@ async def get_query_row_count(
 MB_100_IN_BYTES = 100 * 1000 * 1000
 
 
-async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view_name: str | None = None):
+async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
     """A HogQL table given by a HogQL query."""
 
     await logger.adebug("Configuring hogql_table")
@@ -884,14 +866,8 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
     )
     context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
 
-    factory = _bounded_resolver_factory(view_name)
     prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-        query_node,
-        context=context,
-        dialect="clickhouse",
-        settings=settings,
-        stack=[],
-        resolver_factory=factory,
+        query_node, context=context, dialect="clickhouse", settings=settings, stack=[]
     )
     if prepared_hogql_query is None:
         raise EmptyHogQLResponseColumnsError()
@@ -1002,12 +978,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
     settings.preferred_block_size_bytes = MB_100_IN_BYTES
 
     arrow_prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-        query_node,
-        context=context,
-        dialect="clickhouse",
-        stack=[],
-        settings=settings,
-        resolver_factory=factory,
+        query_node, context=context, dialect="clickhouse", stack=[], settings=settings
     )
 
     if arrow_prepared_hogql_query is None:

--- a/products/data_modeling/backend/models/modeling.py
+++ b/products/data_modeling/backend/models/modeling.py
@@ -137,14 +137,15 @@ class BoundedResolver(Resolver):
     (`DAG_RESOLUTION_*`) are emitted from the outermost `visit()` invocation, so
     every construction-then-visit usage gets a single counter increment.
 
-    `deadline_anchor` is an optional single-element list that lets multiple
+    `deadline_anchor` is an optional monotonic timestamp that lets multiple
     BoundedResolver instances share a deadline clock. `prepare_ast_for_printing`
     invokes nested resolve_types/resolve_lazy_tables calls each of which builds
     a fresh BoundedResolver via the factory — without a shared anchor, each
     instance would get its own deadline_seconds budget and the bound would
-    compound. The factory in `bounded_resolver_factory_for_view` allocates one
+    compound. The factory in `bounded_resolver_factory_for_view` seeds one
     anchor and passes it to every resolver it produces, so the deadline binds
-    end-to-end across the whole query.
+    end-to-end across the whole query. When omitted, the resolver falls back
+    to its own `start_time`, so standalone construction still works.
     """
 
     def __init__(
@@ -154,7 +155,7 @@ class BoundedResolver(Resolver):
         max_view_depth: int = DEFAULT_RESOLUTION_MAX_VIEW_DEPTH,
         deadline_seconds: float | None = DEFAULT_RESOLUTION_DEADLINE_SECONDS,
         enforce_bounds: bool = True,
-        deadline_anchor: list[float | None] | None = None,
+        deadline_anchor: float | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -176,12 +177,9 @@ class BoundedResolver(Resolver):
             self._check_deadline()
             return super().visit(node)
 
-        # outermost call owns deadline seeding and metric emission
+        # outermost call owns metric emission
         start_time = time.monotonic()
         self.start_time = start_time
-        # first resolver from a shared factory seeds the deadline clock
-        if self.deadline_anchor is not None and self.deadline_anchor[0] is None:
-            self.deadline_anchor[0] = start_time
         self._check_deadline()
         status: str = "ok"
         try:
@@ -203,7 +201,7 @@ class BoundedResolver(Resolver):
     def _check_deadline(self) -> None:
         if self.deadline_seconds is None:
             return
-        anchor = self.deadline_anchor[0] if self.deadline_anchor is not None else self.start_time
+        anchor = self.deadline_anchor if self.deadline_anchor is not None else self.start_time
         if anchor is None:
             return
         elapsed = time.monotonic() - anchor
@@ -250,6 +248,7 @@ class BoundedResolver(Resolver):
 def bounded_resolver_factory_for_view(
     view_name: str | None,
     *,
+    deadline_anchor: float | None = None,
     max_view_depth: int = DEFAULT_RESOLUTION_MAX_VIEW_DEPTH,
     deadline_seconds: float | None = DEFAULT_RESOLUTION_DEADLINE_SECONDS,
     enforce_bounds: bool = True,
@@ -265,10 +264,11 @@ def bounded_resolver_factory_for_view(
     mid-transform also resolve through BoundedResolver. All resolvers produced
     by one factory call share a `deadline_anchor`, so `deadline_seconds` is the
     total wall-clock budget for the whole `prepare_ast_for_printing` pass, not
-    a per-call budget.
+    a per-call budget. Callers may pass an explicit `deadline_anchor` to anchor
+    the clock to an earlier event (e.g. a test fixture); when omitted the
+    factory seeds it with the current monotonic time.
     """
-    # shared across every resolver this factory hands out — seeded by the first one to visit()
-    deadline_anchor: list[float | None] = [None]
+    anchor = deadline_anchor if deadline_anchor is not None else time.monotonic()
 
     def factory(
         context: HogQLContext,
@@ -283,7 +283,7 @@ def bounded_resolver_factory_for_view(
             max_view_depth=max_view_depth,
             deadline_seconds=deadline_seconds,
             enforce_bounds=enforce_bounds,
-            deadline_anchor=deadline_anchor,
+            deadline_anchor=anchor,
         )
 
     return factory

--- a/products/data_modeling/backend/models/modeling.py
+++ b/products/data_modeling/backend/models/modeling.py
@@ -31,8 +31,8 @@ from products.warehouse_sources.backend.models.table import DataWarehouseTable
 LabelPath = list[str]
 
 
-DEFAULT_RESOLUTION_MAX_VIEW_DEPTH = 25
-DEFAULT_RESOLUTION_DEADLINE_SECONDS = 30.0
+DEFAULT_RESOLUTION_MAX_VIEW_DEPTH = 100
+DEFAULT_RESOLUTION_DEADLINE_SECONDS = 60.0
 
 
 class BoundedResolverError(QueryError):

--- a/products/data_modeling/backend/models/modeling.py
+++ b/products/data_modeling/backend/models/modeling.py
@@ -172,18 +172,17 @@ class BoundedResolver(Resolver):
         self.deadline_violated = False
 
     def visit(self, node: ast.AST | None):
-        is_outermost = self.start_time is None
-        if is_outermost:
-            now = time.monotonic()
-            self.start_time = now
-            # first resolver from a shared factory seeds the deadline clock
-            if self.deadline_anchor is not None and self.deadline_anchor[0] is None:
-                self.deadline_anchor[0] = now
-        self._check_deadline()
-        if not is_outermost:
+        if self.start_time is not None:
+            self._check_deadline()
             return super().visit(node)
 
-        # outermost call owns metric emission
+        # outermost call owns deadline seeding and metric emission
+        start_time = time.monotonic()
+        self.start_time = start_time
+        # first resolver from a shared factory seeds the deadline clock
+        if self.deadline_anchor is not None and self.deadline_anchor[0] is None:
+            self.deadline_anchor[0] = start_time
+        self._check_deadline()
         status: str = "ok"
         try:
             return super().visit(node)
@@ -195,7 +194,7 @@ class BoundedResolver(Resolver):
             raise
         finally:
             DAG_RESOLUTION_TOTAL.labels(status=status).inc()
-            DAG_RESOLUTION_DURATION_SECONDS.observe(time.monotonic() - self.start_time)
+            DAG_RESOLUTION_DURATION_SECONDS.observe(time.monotonic() - start_time)
             if status == "ok":
                 DAG_RESOLUTION_VIEW_DEPTH.observe(self.max_view_depth_observed)
             if self.deadline_violated:

--- a/products/data_modeling/backend/models/modeling.py
+++ b/products/data_modeling/backend/models/modeling.py
@@ -2,6 +2,7 @@ import enum
 import time
 import uuid
 import dataclasses
+from typing import ClassVar
 
 from django.contrib.postgres import indexes as pg_indexes
 from django.core.exceptions import ObjectDoesNotExist
@@ -10,12 +11,14 @@ from django.db import connection, models, transaction
 from prometheus_client import Counter, Histogram
 
 from posthog.hogql import ast
+from posthog.hogql.constants import HogQLDialect
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import SavedQuery
 from posthog.hogql.database.s3_table import DataWarehouseTable as HogQLDataWarehouseTable
 from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_select
-from posthog.hogql.resolver import Resolver
+from posthog.hogql.resolver import Resolver, ResolverFactory
 from posthog.hogql.resolver_utils import extract_select_queries
 
 from posthog.models.team import Team
@@ -32,26 +35,33 @@ DEFAULT_RESOLUTION_MAX_VIEW_DEPTH = 25
 DEFAULT_RESOLUTION_DEADLINE_SECONDS = 30.0
 
 
-class ResolutionError(Exception):
-    """Base class for HogQL view-dependency resolution failures.
+class BoundedResolverError(QueryError):
+    """Base class for bounded HogQL view-dependency resolution failures.
 
-    `initial_view` names the saved query whose resolution was in progress when
-    the failure occurred — set by the resolver so callers can attribute, log,
-    and surface the failure without having to plumb context through themselves.
+    Inherits from QueryError so callers that catch the public HogQL exception
+    hierarchy (DRF handlers, workflow error mappers) keep treating cycle/depth/
+    timeout failures as user-facing 4xx errors rather than 500s. `initial_view`
+    names the saved query whose resolution was in progress when the failure
+    occurred — set by the resolver so callers can attribute and log the failure
+    without having to plumb context through themselves.
     """
+
+    status_label: ClassVar[str] = "error"
 
     def __init__(self, message: str, initial_view: str | None = None):
         super().__init__(message)
         self.initial_view = initial_view
 
 
-class ResolutionCycleError(ResolutionError):
+class ResolutionCycleError(BoundedResolverError):
     """A view references itself through other views.
 
     `view_name` is the inner view at which the cycle was detected (the one
     already on the resolution stack). `initial_view` is the saved query the
     caller asked to resolve.
     """
+
+    status_label: ClassVar[str] = "cycle"
 
     def __init__(self, view_name: str, initial_view: str | None = None):
         message = f"Circular dependency detected in view '{view_name}'"
@@ -61,8 +71,10 @@ class ResolutionCycleError(ResolutionError):
         self.view_name = view_name
 
 
-class ResolutionDepthExceededError(ResolutionError):
+class ResolutionDepthExceededError(BoundedResolverError):
     """View resolution would exceed the configured nesting depth."""
+
+    status_label: ClassVar[str] = "depth_exceeded"
 
     def __init__(self, depth: int, max_depth: int, initial_view: str | None = None):
         message = f"View resolution depth {depth} exceeded max {max_depth}"
@@ -73,8 +85,10 @@ class ResolutionDepthExceededError(ResolutionError):
         self.max_depth = max_depth
 
 
-class ResolutionTimeoutError(ResolutionError):
+class ResolutionTimeoutError(BoundedResolverError):
     """View resolution exceeded its wall-clock deadline."""
+
+    status_label: ClassVar[str] = "timeout"
 
     def __init__(self, elapsed_seconds: float, deadline_seconds: float, initial_view: str | None = None):
         message = f"View resolution exceeded deadline ({elapsed_seconds:.2f}s > {deadline_seconds:.2f}s)"
@@ -97,8 +111,12 @@ DAG_RESOLUTION_DURATION_SECONDS = Histogram(
 )
 DAG_RESOLUTION_VIEW_DEPTH = Histogram(
     "data_modeling_dag_resolution_view_depth",
-    "Maximum nested view depth observed during HogQL dependency resolution.",
+    "Maximum nested view depth observed on successful HogQL dependency resolution.",
     buckets=(1, 2, 4, 8, 16, 25, 50, 100),
+)
+DAG_RESOLUTION_DEADLINE_VIOLATIONS = Counter(
+    "data_modeling_dag_resolution_deadline_violations_total",
+    "Resolutions where the deadline elapsed; in soft mode this is observed without raising.",
 )
 
 
@@ -109,6 +127,24 @@ class BoundedResolver(Resolver):
     resolution stack, (b) cap the nested view depth, and (c) abort if total
     wall-clock time exceeds a deadline. These guards protect callers from
     pathological views that would otherwise consume a worker indefinitely.
+
+    When `enforce_bounds=False`, depth and deadline violations emit metrics but
+    do not raise. Cycle detection still raises unconditionally — without it the
+    resolver would loop forever and the deadline check would never run.
+
+    The deadline is checked on every `visit()` call, not only at view boundaries,
+    so expensive non-join work between views is also interruptible. Metrics
+    (`DAG_RESOLUTION_*`) are emitted from the outermost `visit()` invocation, so
+    every construction-then-visit usage gets a single counter increment.
+
+    `deadline_anchor` is an optional single-element list that lets multiple
+    BoundedResolver instances share a deadline clock. `prepare_ast_for_printing`
+    invokes nested resolve_types/resolve_lazy_tables calls each of which builds
+    a fresh BoundedResolver via the factory — without a shared anchor, each
+    instance would get its own deadline_seconds budget and the bound would
+    compound. The factory in `bounded_resolver_factory_for_view` allocates one
+    anchor and passes it to every resolver it produces, so the deadline binds
+    end-to-end across the whole query.
     """
 
     def __init__(
@@ -117,33 +153,70 @@ class BoundedResolver(Resolver):
         initial_view_name: str | None = None,
         max_view_depth: int = DEFAULT_RESOLUTION_MAX_VIEW_DEPTH,
         deadline_seconds: float | None = DEFAULT_RESOLUTION_DEADLINE_SECONDS,
+        enforce_bounds: bool = True,
+        deadline_anchor: list[float | None] | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.initial_view_name = initial_view_name
-        # seeded with the current view name so its "visited"
+        # seeded with the current view name so it counts as "visited" for cycle detection
         self.resolving_views: set[str] = {initial_view_name} if initial_view_name else set()
         self.max_view_depth = max_view_depth
         self.deadline_seconds = deadline_seconds
-        # set lazily on first visit() so the deadline tracks actual walk time, not construct-to-visit gap
+        self.enforce_bounds = enforce_bounds
+        self.deadline_anchor = deadline_anchor
+        # local clock — for per-resolver metric duration, distinct from deadline_anchor which
+        # may span multiple resolvers from the same factory
         self.start_time: float | None = None
         self.max_view_depth_observed = 0
+        self.deadline_violated = False
 
     def visit(self, node: ast.AST | None):
-        if self.start_time is None:
-            self.start_time = time.monotonic()
-        return super().visit(node)
+        is_outermost = self.start_time is None
+        if is_outermost:
+            now = time.monotonic()
+            self.start_time = now
+            # first resolver from a shared factory seeds the deadline clock
+            if self.deadline_anchor is not None and self.deadline_anchor[0] is None:
+                self.deadline_anchor[0] = now
+        self._check_deadline()
+        if not is_outermost:
+            return super().visit(node)
+
+        # outermost call owns metric emission
+        status: str = "ok"
+        try:
+            return super().visit(node)
+        except BoundedResolverError as e:
+            status = e.status_label
+            raise
+        except Exception:
+            status = "error"
+            raise
+        finally:
+            DAG_RESOLUTION_TOTAL.labels(status=status).inc()
+            DAG_RESOLUTION_DURATION_SECONDS.observe(time.monotonic() - self.start_time)
+            if status == "ok":
+                DAG_RESOLUTION_VIEW_DEPTH.observe(self.max_view_depth_observed)
+            if self.deadline_violated:
+                DAG_RESOLUTION_DEADLINE_VIOLATIONS.inc()
 
     def _check_deadline(self) -> None:
-        if self.deadline_seconds is None or self.start_time is None:
+        if self.deadline_seconds is None:
             return
-        elapsed = time.monotonic() - self.start_time
-        if elapsed > self.deadline_seconds:
+        anchor = self.deadline_anchor[0] if self.deadline_anchor is not None else self.start_time
+        if anchor is None:
+            return
+        elapsed = time.monotonic() - anchor
+        if elapsed <= self.deadline_seconds:
+            return
+        if self.enforce_bounds:
             raise ResolutionTimeoutError(elapsed, self.deadline_seconds, initial_view=self.initial_view_name)
+        # soft mode: record and keep walking — caller opted into observe-only deadlines
+        self.deadline_violated = True
 
     def visit_join_expr(self, node: ast.JoinExpr):
-        """Override to add cycle detection, depth limiting, and deadline enforcement."""
-        self._check_deadline()
+        """Override to add cycle detection and depth limiting for view tables."""
         # CTEs are handled entirely by the parent class, but for views we track visited for cycle detection
         if isinstance(node.table, ast.Field) and self.database is not None:
             try:
@@ -154,12 +227,16 @@ class BoundedResolver(Resolver):
                 if isinstance(database_table, SavedQuery):
                     view_name = database_table.name
                     if view_name in self.resolving_views:
+                        # cycles always raise — observe-only mode would loop forever
                         raise ResolutionCycleError(view_name, initial_view=self.initial_view_name)
+                    # current_view_depth is incremented by Resolver.visit_join_expr inside super(); look ahead by one
                     next_depth = self.current_view_depth + 1
                     if next_depth > self.max_view_depth:
-                        raise ResolutionDepthExceededError(
-                            next_depth, self.max_view_depth, initial_view=self.initial_view_name
-                        )
+                        if self.enforce_bounds:
+                            raise ResolutionDepthExceededError(
+                                next_depth, self.max_view_depth, initial_view=self.initial_view_name
+                            )
+                        # soft mode: still expand, but record the overshoot via max_view_depth_observed
                     if next_depth > self.max_view_depth_observed:
                         self.max_view_depth_observed = next_depth
                     self.resolving_views.add(view_name)
@@ -169,6 +246,48 @@ class BoundedResolver(Resolver):
                         self.resolving_views.discard(view_name)
 
         return super().visit_join_expr(node)
+
+
+def bounded_resolver_factory_for_view(
+    view_name: str | None,
+    *,
+    max_view_depth: int = DEFAULT_RESOLUTION_MAX_VIEW_DEPTH,
+    deadline_seconds: float | None = DEFAULT_RESOLUTION_DEADLINE_SECONDS,
+    enforce_bounds: bool = True,
+) -> ResolverFactory:
+    """Build a ResolverFactory bound to a specific saved-query view.
+
+    The returned factory matches the signature expected by `prepare_ast_for_printing`
+    and `resolve_types`: it accepts (context, dialect, scopes) and returns a
+    BoundedResolver pre-seeded with the view name so cycle detection works.
+
+    `prepare_ast_for_printing` forwards the factory through `resolve_lazy_tables`,
+    `resolve_in_cohorts`, and `resolve_in_cohorts_conjoined`, so subqueries built
+    mid-transform also resolve through BoundedResolver. All resolvers produced
+    by one factory call share a `deadline_anchor`, so `deadline_seconds` is the
+    total wall-clock budget for the whole `prepare_ast_for_printing` pass, not
+    a per-call budget.
+    """
+    # shared across every resolver this factory hands out — seeded by the first one to visit()
+    deadline_anchor: list[float | None] = [None]
+
+    def factory(
+        context: HogQLContext,
+        dialect: HogQLDialect,
+        scopes: list[ast.SelectQueryType] | None,
+    ) -> Resolver:
+        return BoundedResolver(
+            scopes=scopes,
+            context=context,
+            dialect=dialect,
+            initial_view_name=view_name,
+            max_view_depth=max_view_depth,
+            deadline_seconds=deadline_seconds,
+            enforce_bounds=enforce_bounds,
+            deadline_anchor=deadline_anchor,
+        )
+
+    return factory
 
 
 class LabelTreeField(models.Field):
@@ -243,117 +362,104 @@ def get_parents_from_model_query(team: Team, model_name: str, model_query: str) 
 
     The parents of a query are any names in the `FROM` clause of the query.
     Uses BoundedResolver to detect circular dependencies, cap nested view
-    depth, and enforce a wall-clock deadline on view references.
+    depth, and enforce a wall-clock deadline on view references. Resolver-level
+    metrics (`DAG_RESOLUTION_*`) are emitted from the resolver itself, so this
+    function does not need its own try/except/metric cascade.
+
+    Args:
+        team: The team context for database resolution.
+        model_name: The name of the saved query being parsed; used as the
+            initial view so cycles back to it are detected.
+        model_query: The HogQL query string to parse.
     """
-    from posthog.hogql.context import HogQLContext
-
-    start = time.monotonic()
-    status = "ok"
-    resolver: BoundedResolver | None = None
-    try:
-        hogql_query = parse_select(model_query)
-        context = HogQLContext(
-            team_id=team.pk,
-            team=team,
-            enable_select_queries=True,
+    hogql_query = parse_select(model_query)
+    context = HogQLContext(
+        team_id=team.pk,
+        team=team,
+        enable_select_queries=True,
+    )
+    if context.database is None:
+        context.database = Database.create_for(
+            context.team_id,
+            modifiers=context.modifiers,
+            team=context.team,
         )
-        if context.database is None:
-            context.database = Database.create_for(
-                context.team_id,
-                modifiers=context.modifiers,
-                team=context.team,
-            )
 
-        resolver = BoundedResolver(context=context, dialect="hogql", initial_view_name=model_name)
-        prepared_ast = resolver.visit(hogql_query)
+    resolver = BoundedResolver(context=context, dialect="hogql", initial_view_name=model_name)
+    prepared_ast = resolver.visit(hogql_query)
 
-        if prepared_ast is None:
-            return set()
+    if prepared_ast is None:
+        return set()
 
-        if isinstance(prepared_ast, ast.SelectSetQuery):
-            queries = list(extract_select_queries(prepared_ast))
-        else:
-            queries = [prepared_ast]
+    if isinstance(prepared_ast, ast.SelectSetQuery):
+        queries = list(extract_select_queries(prepared_ast))
+    else:
+        queries = [prepared_ast]
 
-        # collect CTE definitions so we can resolve through them to find real tables
-        ctes: dict[str, ast.CTE] = {}
-        for q in queries:
-            if q.ctes:
-                ctes.update(q.ctes)
+    # collect CTE definitions so we can resolve through them to find real tables
+    ctes: dict[str, ast.CTE] = {}
+    for q in queries:
+        if q.ctes:
+            ctes.update(q.ctes)
 
-        parents: set[str] = set()
+    parents: set[str] = set()
 
-        # track by object id so that a recursive CTE (same object) is only
-        # expanded once, while an inner CTE that shadows an outer name (different
-        # object) is still expanded
-        expanded_ctes: set[int] = set()
+    # track by object id so that a recursive CTE (same object) is only
+    # expanded once, while an inner CTE that shadows an outer name (different
+    # object) is still expanded. The CTE dict holds a strong reference for the
+    # lifetime of this function, so the id() identity is stable.
+    expanded_ctes: set[int] = set()
 
-        while queries:
-            query = queries.pop()
+    while queries:
+        query = queries.pop()
 
-            # collect CTEs from each query as it's processed so that nested CTEs
-            # (inner WITH clauses resolved through from outer CTEs) are available
-            if query.ctes:
-                ctes.update(query.ctes)
+        # collect CTEs from each query as it's processed so that nested CTEs
+        # (inner WITH clauses resolved through from outer CTEs) are available
+        if query.ctes:
+            ctes.update(query.ctes)
 
-            join = query.select_from
+        join = query.select_from
 
-            if join is None:
-                continue
+        if join is None:
+            continue
 
-            while join is not None:
-                if isinstance(join.table, ast.SelectQuery):
-                    if join.table.view_name is not None:
-                        parents.add(join.table.view_name)
-                        break
-
-                    queries.append(join.table)
-                    break
-                elif isinstance(join.table, ast.SelectSetQuery):
-                    queries.extend(list(extract_select_queries(join.table)))
+        while join is not None:
+            if isinstance(join.table, ast.SelectQuery):
+                if join.table.view_name is not None:
+                    parents.add(join.table.view_name)
                     break
 
-                if join.table_args is not None:
-                    # Table functions like numbers(), s3(), etc. are not real parents
-                    join = join.next_join
-                    continue
-                elif isinstance(join.table, ast.Placeholder):
-                    parent_name = join.table.field
-                elif isinstance(join.table, ast.Field):
-                    parent_name = ".".join(str(s) for s in join.table.chain)
-                else:
-                    raise ValueError(f"No handler for {join.table.__class__.__name__} in get_parents_from_model_query")
+                queries.append(join.table)
+                break
+            elif isinstance(join.table, ast.SelectSetQuery):
+                queries.extend(list(extract_select_queries(join.table)))
+                break
 
-                if isinstance(parent_name, str):
-                    if parent_name in ctes and id(ctes[parent_name]) not in expanded_ctes:
-                        expanded_ctes.add(id(ctes[parent_name]))
-                        cte_expr = ctes[parent_name].expr
-                        if isinstance(cte_expr, ast.SelectSetQuery):
-                            queries.extend(list(extract_select_queries(cte_expr)))
-                        elif isinstance(cte_expr, ast.SelectQuery):
-                            queries.append(cte_expr)
-                    elif parent_name not in ctes:
-                        parents.add(parent_name)
-
+            if join.table_args is not None:
+                # Table functions like numbers(), s3(), etc. are not real parents
                 join = join.next_join
+                continue
+            elif isinstance(join.table, ast.Placeholder):
+                parent_name = join.table.field
+            elif isinstance(join.table, ast.Field):
+                parent_name = ".".join(str(s) for s in join.table.chain)
+            else:
+                raise ValueError(f"No handler for {join.table.__class__.__name__} in get_parents_from_model_query")
 
-        return parents
-    except ResolutionCycleError:
-        status = "cycle"
-        raise
-    except ResolutionDepthExceededError:
-        status = "depth_exceeded"
-        raise
-    except ResolutionTimeoutError:
-        status = "timeout"
-        raise
-    except Exception:
-        status = "error"
-        raise
-    finally:
-        DAG_RESOLUTION_TOTAL.labels(status=status).inc()
-        DAG_RESOLUTION_DURATION_SECONDS.observe(time.monotonic() - start)
-        DAG_RESOLUTION_VIEW_DEPTH.observe(resolver.max_view_depth_observed if resolver is not None else 0)
+            if isinstance(parent_name, str):
+                if parent_name in ctes and id(ctes[parent_name]) not in expanded_ctes:
+                    expanded_ctes.add(id(ctes[parent_name]))
+                    cte_expr = ctes[parent_name].expr
+                    if isinstance(cte_expr, ast.SelectSetQuery):
+                        queries.extend(list(extract_select_queries(cte_expr)))
+                    elif isinstance(cte_expr, ast.SelectQuery):
+                        queries.append(cte_expr)
+                elif parent_name not in ctes:
+                    parents.add(parent_name)
+
+            join = join.next_join
+
+    return parents
 
 
 class NodeType(enum.Enum):

--- a/products/data_modeling/backend/models/modeling.py
+++ b/products/data_modeling/backend/models/modeling.py
@@ -1,10 +1,13 @@
 import enum
+import time
 import uuid
 import dataclasses
 
 from django.contrib.postgres import indexes as pg_indexes
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection, models, transaction
+
+from prometheus_client import Counter, Histogram
 
 from posthog.hogql import ast
 from posthog.hogql.database.database import Database
@@ -25,20 +28,122 @@ from products.warehouse_sources.backend.models.table import DataWarehouseTable
 LabelPath = list[str]
 
 
-class CycleDetectingResolver(Resolver):
-    """A resolver that detects circular dependencies in view references.
+DEFAULT_RESOLUTION_MAX_VIEW_DEPTH = 25
+DEFAULT_RESOLUTION_DEADLINE_SECONDS = 30.0
 
-    This extends the base Resolver to track which views are currently being
-    resolved, raising a QueryError if a cycle is detected.
+
+class ResolutionError(Exception):
+    """Base class for HogQL view-dependency resolution failures.
+
+    `initial_view` names the saved query whose resolution was in progress when
+    the failure occurred — set by the resolver so callers can attribute, log,
+    and surface the failure without having to plumb context through themselves.
     """
 
-    def __init__(self, *args, initial_view_name: str | None = None, **kwargs):
+    def __init__(self, message: str, initial_view: str | None = None):
+        super().__init__(message)
+        self.initial_view = initial_view
+
+
+class ResolutionCycleError(ResolutionError):
+    """A view references itself through other views.
+
+    `view_name` is the inner view at which the cycle was detected (the one
+    already on the resolution stack). `initial_view` is the saved query the
+    caller asked to resolve.
+    """
+
+    def __init__(self, view_name: str, initial_view: str | None = None):
+        message = f"Circular dependency detected in view '{view_name}'"
+        if initial_view and initial_view != view_name:
+            message += f" while resolving '{initial_view}'"
+        super().__init__(message, initial_view=initial_view)
+        self.view_name = view_name
+
+
+class ResolutionDepthExceededError(ResolutionError):
+    """View resolution would exceed the configured nesting depth."""
+
+    def __init__(self, depth: int, max_depth: int, initial_view: str | None = None):
+        message = f"View resolution depth {depth} exceeded max {max_depth}"
+        if initial_view:
+            message += f" while resolving '{initial_view}'"
+        super().__init__(message, initial_view=initial_view)
+        self.depth = depth
+        self.max_depth = max_depth
+
+
+class ResolutionTimeoutError(ResolutionError):
+    """View resolution exceeded its wall-clock deadline."""
+
+    def __init__(self, elapsed_seconds: float, deadline_seconds: float, initial_view: str | None = None):
+        message = f"View resolution exceeded deadline ({elapsed_seconds:.2f}s > {deadline_seconds:.2f}s)"
+        if initial_view:
+            message += f" while resolving '{initial_view}'"
+        super().__init__(message, initial_view=initial_view)
+        self.elapsed_seconds = elapsed_seconds
+        self.deadline_seconds = deadline_seconds
+
+
+DAG_RESOLUTION_TOTAL = Counter(
+    "data_modeling_dag_resolution_total",
+    "Total HogQL view-dependency resolutions performed, labelled by terminal status.",
+    labelnames=["status"],  # ok | cycle | depth_exceeded | timeout | error
+)
+DAG_RESOLUTION_DURATION_SECONDS = Histogram(
+    "data_modeling_dag_resolution_duration_seconds",
+    "Wall-clock time spent resolving HogQL view dependencies.",
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+)
+DAG_RESOLUTION_VIEW_DEPTH = Histogram(
+    "data_modeling_dag_resolution_view_depth",
+    "Maximum nested view depth observed during HogQL dependency resolution.",
+    buckets=(1, 2, 4, 8, 16, 25, 50, 100),
+)
+
+
+class BoundedResolver(Resolver):
+    """A resolver bounded by view-depth, cycle detection, and a wall-clock deadline.
+
+    Extends the base Resolver to (a) refuse re-entry into a view already on the
+    resolution stack, (b) cap the nested view depth, and (c) abort if total
+    wall-clock time exceeds a deadline. These guards protect callers from
+    pathological views that would otherwise consume a worker indefinitely.
+    """
+
+    def __init__(
+        self,
+        *args,
+        initial_view_name: str | None = None,
+        max_view_depth: int = DEFAULT_RESOLUTION_MAX_VIEW_DEPTH,
+        deadline_seconds: float | None = DEFAULT_RESOLUTION_DEADLINE_SECONDS,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
+        self.initial_view_name = initial_view_name
         # seeded with the current view name so its "visited"
         self.resolving_views: set[str] = {initial_view_name} if initial_view_name else set()
+        self.max_view_depth = max_view_depth
+        self.deadline_seconds = deadline_seconds
+        # set lazily on first visit() so the deadline tracks actual walk time, not construct-to-visit gap
+        self.start_time: float | None = None
+        self.max_view_depth_observed = 0
+
+    def visit(self, node: ast.AST | None):
+        if self.start_time is None:
+            self.start_time = time.monotonic()
+        return super().visit(node)
+
+    def _check_deadline(self) -> None:
+        if self.deadline_seconds is None or self.start_time is None:
+            return
+        elapsed = time.monotonic() - self.start_time
+        if elapsed > self.deadline_seconds:
+            raise ResolutionTimeoutError(elapsed, self.deadline_seconds, initial_view=self.initial_view_name)
 
     def visit_join_expr(self, node: ast.JoinExpr):
-        """Override to add cycle detection when resolving views."""
+        """Override to add cycle detection, depth limiting, and deadline enforcement."""
+        self._check_deadline()
         # CTEs are handled entirely by the parent class, but for views we track visited for cycle detection
         if isinstance(node.table, ast.Field) and self.database is not None:
             try:
@@ -49,7 +154,14 @@ class CycleDetectingResolver(Resolver):
                 if isinstance(database_table, SavedQuery):
                     view_name = database_table.name
                     if view_name in self.resolving_views:
-                        raise QueryError(f"Circular dependency detected in view '{view_name}'")
+                        raise ResolutionCycleError(view_name, initial_view=self.initial_view_name)
+                    next_depth = self.current_view_depth + 1
+                    if next_depth > self.max_view_depth:
+                        raise ResolutionDepthExceededError(
+                            next_depth, self.max_view_depth, initial_view=self.initial_view_name
+                        )
+                    if next_depth > self.max_view_depth_observed:
+                        self.max_view_depth_observed = next_depth
                     self.resolving_views.add(view_name)
                     try:
                         return super().visit_join_expr(node)
@@ -130,104 +242,118 @@ def get_parents_from_model_query(team: Team, model_name: str, model_query: str) 
     """Get parents from a given query.
 
     The parents of a query are any names in the `FROM` clause of the query.
-    Uses CycleDetectingResolver to detect circular dependencies in view references.
-
-    Args:
-        model_query: The HogQL query string to parse
-        team: The team context for database resolution
-        view_name: Optional name of the view being parsed. If provided, cycles back to
-                   this view through other views will be detected.
+    Uses BoundedResolver to detect circular dependencies, cap nested view
+    depth, and enforce a wall-clock deadline on view references.
     """
     from posthog.hogql.context import HogQLContext
 
-    hogql_query = parse_select(model_query)
-    context = HogQLContext(
-        team_id=team.pk,
-        team=team,
-        enable_select_queries=True,
-    )
-    if context.database is None:
-        context.database = Database.create_for(
-            context.team_id,
-            modifiers=context.modifiers,
-            team=context.team,
+    start = time.monotonic()
+    status = "ok"
+    resolver: BoundedResolver | None = None
+    try:
+        hogql_query = parse_select(model_query)
+        context = HogQLContext(
+            team_id=team.pk,
+            team=team,
+            enable_select_queries=True,
         )
+        if context.database is None:
+            context.database = Database.create_for(
+                context.team_id,
+                modifiers=context.modifiers,
+                team=context.team,
+            )
 
-    # use cycledetectingresolver to resolve types and detect circular view dependencies
-    resolver = CycleDetectingResolver(context=context, dialect="hogql", initial_view_name=model_name)
-    prepared_ast = resolver.visit(hogql_query)
+        resolver = BoundedResolver(context=context, dialect="hogql", initial_view_name=model_name)
+        prepared_ast = resolver.visit(hogql_query)
 
-    if prepared_ast is None:
-        return set()
+        if prepared_ast is None:
+            return set()
 
-    if isinstance(prepared_ast, ast.SelectSetQuery):
-        queries = list(extract_select_queries(prepared_ast))
-    else:
-        queries = [prepared_ast]
+        if isinstance(prepared_ast, ast.SelectSetQuery):
+            queries = list(extract_select_queries(prepared_ast))
+        else:
+            queries = [prepared_ast]
 
-    # collect CTE definitions so we can resolve through them to find real tables
-    ctes: dict[str, ast.CTE] = {}
-    for q in queries:
-        if q.ctes:
-            ctes.update(q.ctes)
+        # collect CTE definitions so we can resolve through them to find real tables
+        ctes: dict[str, ast.CTE] = {}
+        for q in queries:
+            if q.ctes:
+                ctes.update(q.ctes)
 
-    parents: set[str] = set()
+        parents: set[str] = set()
 
-    # track by object id so that a recursive CTE (same object) is only
-    # expanded once, while an inner CTE that shadows an outer name (different
-    # object) is still expanded
-    expanded_ctes: set[int] = set()
+        # track by object id so that a recursive CTE (same object) is only
+        # expanded once, while an inner CTE that shadows an outer name (different
+        # object) is still expanded
+        expanded_ctes: set[int] = set()
 
-    while queries:
-        query = queries.pop()
+        while queries:
+            query = queries.pop()
 
-        # collect CTEs from each query as it's processed so that nested CTEs
-        # (inner WITH clauses resolved through from outer CTEs) are available
-        if query.ctes:
-            ctes.update(query.ctes)
+            # collect CTEs from each query as it's processed so that nested CTEs
+            # (inner WITH clauses resolved through from outer CTEs) are available
+            if query.ctes:
+                ctes.update(query.ctes)
 
-        join = query.select_from
+            join = query.select_from
 
-        if join is None:
-            continue
+            if join is None:
+                continue
 
-        while join is not None:
-            if isinstance(join.table, ast.SelectQuery):
-                if join.table.view_name is not None:
-                    parents.add(join.table.view_name)
+            while join is not None:
+                if isinstance(join.table, ast.SelectQuery):
+                    if join.table.view_name is not None:
+                        parents.add(join.table.view_name)
+                        break
+
+                    queries.append(join.table)
+                    break
+                elif isinstance(join.table, ast.SelectSetQuery):
+                    queries.extend(list(extract_select_queries(join.table)))
                     break
 
-                queries.append(join.table)
-                break
-            elif isinstance(join.table, ast.SelectSetQuery):
-                queries.extend(list(extract_select_queries(join.table)))
-                break
+                if join.table_args is not None:
+                    # Table functions like numbers(), s3(), etc. are not real parents
+                    join = join.next_join
+                    continue
+                elif isinstance(join.table, ast.Placeholder):
+                    parent_name = join.table.field
+                elif isinstance(join.table, ast.Field):
+                    parent_name = ".".join(str(s) for s in join.table.chain)
+                else:
+                    raise ValueError(f"No handler for {join.table.__class__.__name__} in get_parents_from_model_query")
 
-            if join.table_args is not None:
-                # Table functions like numbers(), s3(), etc. are not real parents
+                if isinstance(parent_name, str):
+                    if parent_name in ctes and id(ctes[parent_name]) not in expanded_ctes:
+                        expanded_ctes.add(id(ctes[parent_name]))
+                        cte_expr = ctes[parent_name].expr
+                        if isinstance(cte_expr, ast.SelectSetQuery):
+                            queries.extend(list(extract_select_queries(cte_expr)))
+                        elif isinstance(cte_expr, ast.SelectQuery):
+                            queries.append(cte_expr)
+                    elif parent_name not in ctes:
+                        parents.add(parent_name)
+
                 join = join.next_join
-                continue
-            elif isinstance(join.table, ast.Placeholder):
-                parent_name = join.table.field
-            elif isinstance(join.table, ast.Field):
-                parent_name = ".".join(str(s) for s in join.table.chain)
-            else:
-                raise ValueError(f"No handler for {join.table.__class__.__name__} in get_parents_from_model_query")
 
-            if isinstance(parent_name, str):
-                if parent_name in ctes and id(ctes[parent_name]) not in expanded_ctes:
-                    expanded_ctes.add(id(ctes[parent_name]))
-                    cte_expr = ctes[parent_name].expr
-                    if isinstance(cte_expr, ast.SelectSetQuery):
-                        queries.extend(list(extract_select_queries(cte_expr)))
-                    elif isinstance(cte_expr, ast.SelectQuery):
-                        queries.append(cte_expr)
-                elif parent_name not in ctes:
-                    parents.add(parent_name)
-
-            join = join.next_join
-
-    return parents
+        return parents
+    except ResolutionCycleError:
+        status = "cycle"
+        raise
+    except ResolutionDepthExceededError:
+        status = "depth_exceeded"
+        raise
+    except ResolutionTimeoutError:
+        status = "timeout"
+        raise
+    except Exception:
+        status = "error"
+        raise
+    finally:
+        DAG_RESOLUTION_TOTAL.labels(status=status).inc()
+        DAG_RESOLUTION_DURATION_SECONDS.observe(time.monotonic() - start)
+        DAG_RESOLUTION_VIEW_DEPTH.observe(resolver.max_view_depth_observed if resolver is not None else 0)
 
 
 class NodeType(enum.Enum):

--- a/products/data_modeling/backend/test/test_saved_query_dag_sync.py
+++ b/products/data_modeling/backend/test/test_saved_query_dag_sync.py
@@ -8,6 +8,7 @@ from posthog.hogql.errors import QueryError
 from products.data_modeling.backend.models import Edge, Node
 from products.data_modeling.backend.models.dag import DAG, DEFAULT_DAG_NAME
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_modeling.backend.models.modeling import ResolutionCycleError
 from products.data_modeling.backend.models.node import NodeType
 from products.data_modeling.backend.services.saved_query_dag_sync import (
     HasDependentsError,
@@ -199,7 +200,7 @@ class TestSyncSavedQueryToDag(BaseTest):
         # update a to depend on b (cycle) — should fail
         query_a.query = {"query": "SELECT * FROM view_b", "kind": "HogQLQuery"}
         query_a.save()
-        with self.assertRaises(QueryError):
+        with self.assertRaises(ResolutionCycleError):
             sync_saved_query_to_dag(query_a)
 
         # node for query_a should be cleaned up

--- a/products/data_warehouse/backend/models/test/test_modeling.py
+++ b/products/data_warehouse/backend/models/test/test_modeling.py
@@ -704,7 +704,7 @@ class TestResolverFactoryInjection(BaseTest):
         Without a shared anchor, each resolver would get its own deadline_seconds budget
         and prepare_ast_for_printing's multi-pass resolution would compound the bound.
         """
-        from products.data_warehouse.backend.models.modeling import bounded_resolver_factory_for_view
+        from products.data_modeling.backend.models.modeling import bounded_resolver_factory_for_view
 
         factory = bounded_resolver_factory_for_view("caller", deadline_seconds=10.0)
         context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
@@ -727,7 +727,7 @@ class TestResolverFactoryInjection(BaseTest):
         """
         from posthog.hogql.printer import prepare_ast_for_printing
 
-        from products.data_warehouse.backend.models.modeling import bounded_resolver_factory_for_view
+        from products.data_modeling.backend.models.modeling import bounded_resolver_factory_for_view
 
         # Use the shared factory helper so the deadline is end-to-end across passes
         factory = bounded_resolver_factory_for_view("caller", max_view_depth=DEFAULT_RESOLUTION_MAX_VIEW_DEPTH)

--- a/products/data_warehouse/backend/models/test/test_modeling.py
+++ b/products/data_warehouse/backend/models/test/test_modeling.py
@@ -2,19 +2,27 @@ import pytest
 from posthog.test.base import BaseTest
 
 from parameterized import parameterized
+from prometheus_client import REGISTRY
 
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
 from posthog.hogql.errors import QueryError
+from posthog.hogql.parser import parse_select
 
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_modeling.backend.models.modeling import (
+    DEFAULT_RESOLUTION_DEADLINE_SECONDS,
+    DEFAULT_RESOLUTION_MAX_VIEW_DEPTH,
+    BoundedResolver,
     DataWarehouseModelPath,
     NodeType,
+    ResolutionCycleError,
+    ResolutionDepthExceededError,
+    ResolutionTimeoutError,
     get_parents_from_model_query,
 )
 from products.data_warehouse.backend.types import ExternalDataSourceType
-from products.warehouse_sources.backend.models import DataWarehouseTable
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.models import DataWarehouseTable, ExternalDataSchema, ExternalDataSource
 
 GET_PARENTS_TEST_CASES = [
     ("select events.*, persons.* from events, persons", {"events", "persons"}),
@@ -441,5 +449,195 @@ class TestModelPath(BaseTest):
         child_saved_query.query = {"query": "select * from my_model union all select * from my_model_grand_child"}
         child_saved_query.save()
 
-        with pytest.raises(QueryError, match="[Cc]ircular dependency"):
+        with pytest.raises(ResolutionCycleError, match="[Cc]ircular dependency"):
             DataWarehouseModelPath.objects.update_from_saved_query(child_saved_query)
+
+
+class TestBoundedResolver(BaseTest):
+    def _resolve(
+        self,
+        query: str,
+        initial_view_name: str = "test_model",
+        max_view_depth: int = DEFAULT_RESOLUTION_MAX_VIEW_DEPTH,
+        deadline_seconds: float | None = DEFAULT_RESOLUTION_DEADLINE_SECONDS,
+    ) -> BoundedResolver:
+        context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
+        context.database = Database.create_for(team_id=context.team_id, modifiers=context.modifiers, team=context.team)
+        resolver = BoundedResolver(
+            context=context,
+            dialect="hogql",
+            initial_view_name=initial_view_name,
+            max_view_depth=max_view_depth,
+            deadline_seconds=deadline_seconds,
+        )
+        resolver.visit(parse_select(query))
+        return resolver
+
+    def _make_chain(self, length: int) -> None:
+        """Create a chain of saved-query views: v0 → v1 → … → events."""
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="v0",
+            query={"query": "select event from events"},
+        )
+        for i in range(1, length):
+            DataWarehouseSavedQuery.objects.create(
+                team=self.team,
+                name=f"v{i}",
+                query={"query": f"select * from v{i - 1}"},
+            )
+
+    def test_cycle_raises_typed_error_with_initial_view(self):
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="a",
+            query={"query": "select * from b"},
+        )
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="b",
+            query={"query": "select * from a"},
+        )
+
+        with pytest.raises(ResolutionCycleError) as exc_info:
+            get_parents_from_model_query(self.team, "a", "select * from b")
+
+        # the inner view where the cycle was detected is `a` (already on the stack), and the caller is also `a`
+        assert exc_info.value.view_name == "a"
+        assert exc_info.value.initial_view == "a"
+
+    def test_depth_limit_raises_when_chain_too_deep(self):
+        self._make_chain(length=4)  # v0 → v1 → v2 → v3
+
+        with pytest.raises(ResolutionDepthExceededError) as exc_info:
+            self._resolve("select * from v3", initial_view_name="caller", max_view_depth=2)
+
+        assert exc_info.value.max_depth == 2
+        assert exc_info.value.depth == 3
+        assert exc_info.value.initial_view == "caller"
+
+    def test_depth_limit_allows_chain_within_budget(self):
+        self._make_chain(length=3)  # v0 → v1 → v2
+
+        resolver = self._resolve("select * from v2", initial_view_name="caller", max_view_depth=10)
+
+        assert resolver.max_view_depth_observed == 3
+
+    def test_negative_deadline_triggers_timeout_immediately(self):
+        # A negative deadline is "already expired": the first visit_join_expr raises
+        # without depending on clock precision between init and first visit.
+        with pytest.raises(ResolutionTimeoutError) as exc_info:
+            self._resolve("select * from events", initial_view_name="caller", deadline_seconds=-1.0)
+
+        assert exc_info.value.deadline_seconds == -1.0
+        assert exc_info.value.elapsed_seconds >= 0.0
+        assert exc_info.value.initial_view == "caller"
+
+    def test_deadline_none_disables_timeout(self):
+        # No deadline: even with synthetic delay the resolver should not raise timeout.
+        resolver = self._resolve("select * from events", initial_view_name="caller", deadline_seconds=None)
+        assert resolver.deadline_seconds is None
+
+
+class TestResolutionMetrics(BaseTest):
+    def _counter(self, status: str) -> float:
+        return REGISTRY.get_sample_value("data_modeling_dag_resolution_total", {"status": status}) or 0.0
+
+    def test_ok_path_increments_counter_and_records_depth(self):
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="leaf",
+            query={"query": "select event from events"},
+        )
+        before_ok = self._counter("ok")
+        before_count = REGISTRY.get_sample_value("data_modeling_dag_resolution_duration_seconds_count") or 0.0
+
+        parents = get_parents_from_model_query(self.team, "caller", "select * from leaf")
+
+        assert parents == {"leaf"}
+        assert self._counter("ok") - before_ok == 1.0
+        assert (
+            REGISTRY.get_sample_value("data_modeling_dag_resolution_duration_seconds_count") or 0.0
+        ) - before_count == 1.0
+
+    def test_cycle_increments_cycle_status(self):
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="a",
+            query={"query": "select * from b"},
+        )
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="b",
+            query={"query": "select * from a"},
+        )
+        before_cycle = self._counter("cycle")
+
+        with pytest.raises(ResolutionCycleError):
+            get_parents_from_model_query(self.team, "a", "select * from b")
+
+        assert self._counter("cycle") - before_cycle == 1.0
+
+    def test_unknown_table_increments_error_status(self):
+        before_error = self._counter("error")
+
+        with pytest.raises(QueryError):
+            get_parents_from_model_query(self.team, "caller", "select * from some_random_view")
+
+        assert self._counter("error") - before_error == 1.0
+
+
+class TestResolverFactoryInjection(BaseTest):
+    """Confirms prepare_ast_for_printing honors resolver_factory — proves the workflow path can
+    swap in BoundedResolver instead of the unbounded base Resolver."""
+
+    def test_prepare_ast_for_printing_uses_injected_bounded_resolver(self):
+        from posthog.hogql.printer import prepare_ast_for_printing
+
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="v0",
+            query={"query": "select event from events"},
+        )
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="v1",
+            query={"query": "select * from v0"},
+        )
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="v2",
+            query={"query": "select * from v1"},
+        )
+
+        query_node = parse_select("select * from v2")
+        context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
+
+        def factory(ctx, dialect, scopes):
+            return BoundedResolver(
+                scopes=scopes, context=ctx, dialect=dialect, initial_view_name="caller", max_view_depth=1
+            )
+
+        with pytest.raises(ResolutionDepthExceededError):
+            prepare_ast_for_printing(query_node, context=context, dialect="clickhouse", resolver_factory=factory)
+
+    def test_prepare_ast_for_printing_default_resolver_is_unbounded(self):
+        """Sanity check: without the factory, no depth bound is applied — proves the kwarg is the opt-in."""
+        from posthog.hogql.printer import prepare_ast_for_printing
+
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="v0",
+            query={"query": "select event from events"},
+        )
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="v1",
+            query={"query": "select * from v0"},
+        )
+
+        query_node = parse_select("select * from v1")
+        context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
+
+        # Should not raise — the default base Resolver has no depth bound.
+        prepare_ast_for_printing(query_node, context=context, dialect="clickhouse")

--- a/products/data_warehouse/backend/models/test/test_modeling.py
+++ b/products/data_warehouse/backend/models/test/test_modeling.py
@@ -710,20 +710,13 @@ class TestResolverFactoryInjection(BaseTest):
         context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
         context.database = Database.create_for(team_id=context.team_id, modifiers=context.modifiers, team=context.team)
 
-        # First resolver seeds the anchor; second resolver reads it. Both must see the same value.
+        # Factory seeds one anchor and hands the same value to every resolver it produces.
         r1 = factory(context, "hogql", None)
         r2 = factory(context, "hogql", None)
         assert isinstance(r1, BoundedResolver)
         assert isinstance(r2, BoundedResolver)
-        assert r1.deadline_anchor is r2.deadline_anchor
-        assert r1.deadline_anchor == [None]
-
-        r1.visit(parse_select("select * from events"))
         assert r1.deadline_anchor is not None
-        assert r2.deadline_anchor is not None
-        assert r1.deadline_anchor[0] is not None
-        # second resolver inherits the anchor set by the first
-        assert r2.deadline_anchor[0] == r1.deadline_anchor[0]
+        assert r2.deadline_anchor == r1.deadline_anchor
 
     def test_factory_threaded_through_resolve_lazy_tables(self):
         """Lazy-table resolution invokes the factory on subqueries it builds — depth bound applies.

--- a/products/data_warehouse/backend/models/test/test_modeling.py
+++ b/products/data_warehouse/backend/models/test/test_modeling.py
@@ -719,6 +719,8 @@ class TestResolverFactoryInjection(BaseTest):
         assert r1.deadline_anchor == [None]
 
         r1.visit(parse_select("select * from events"))
+        assert r1.deadline_anchor is not None
+        assert r2.deadline_anchor is not None
         assert r1.deadline_anchor[0] is not None
         # second resolver inherits the anchor set by the first
         assert r2.deadline_anchor[0] == r1.deadline_anchor[0]

--- a/products/data_warehouse/backend/models/test/test_modeling.py
+++ b/products/data_warehouse/backend/models/test/test_modeling.py
@@ -538,6 +538,62 @@ class TestBoundedResolver(BaseTest):
         resolver = self._resolve("select * from events", initial_view_name="caller", deadline_seconds=None)
         assert resolver.deadline_seconds is None
 
+    def test_bounded_resolver_errors_inherit_query_error(self):
+        # Locks in the public contract: callers that catch QueryError (DRF exception
+        # handlers, workflow error mappers) keep working when cycles/depth/timeouts fire.
+        DataWarehouseSavedQuery.objects.create(team=self.team, name="a", query={"query": "select * from b"})
+        DataWarehouseSavedQuery.objects.create(team=self.team, name="b", query={"query": "select * from a"})
+
+        with pytest.raises(QueryError) as exc_info:
+            get_parents_from_model_query(self.team, "a", "select * from b")
+
+        assert isinstance(exc_info.value, ResolutionCycleError)
+
+    def test_soft_mode_depth_observes_without_raising(self):
+        self._make_chain(length=4)  # v0 → v1 → v2 → v3, would breach max_view_depth=2
+
+        # enforce_bounds=False: depth overshoot is recorded but the walk continues
+        context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
+        context.database = Database.create_for(team_id=context.team_id, modifiers=context.modifiers, team=context.team)
+        resolver = BoundedResolver(
+            context=context,
+            dialect="hogql",
+            initial_view_name="caller",
+            max_view_depth=2,
+            enforce_bounds=False,
+        )
+        resolver.visit(parse_select("select * from v3"))
+
+        assert resolver.max_view_depth_observed > resolver.max_view_depth
+
+    def test_soft_mode_deadline_observes_without_raising(self):
+        # Negative deadline = already expired. In soft mode we record but don't raise.
+        context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
+        context.database = Database.create_for(team_id=context.team_id, modifiers=context.modifiers, team=context.team)
+        resolver = BoundedResolver(
+            context=context,
+            dialect="hogql",
+            initial_view_name="caller",
+            deadline_seconds=-1.0,
+            enforce_bounds=False,
+        )
+        resolver.visit(parse_select("select * from events"))
+
+        assert resolver.deadline_violated is True
+
+    def test_soft_mode_cycle_still_raises(self):
+        # Cycles MUST raise even in soft mode — observe-only would loop forever
+        # because the resolver re-enters the same view.
+        DataWarehouseSavedQuery.objects.create(team=self.team, name="a", query={"query": "select * from b"})
+        DataWarehouseSavedQuery.objects.create(team=self.team, name="b", query={"query": "select * from a"})
+
+        context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
+        context.database = Database.create_for(team_id=context.team_id, modifiers=context.modifiers, team=context.team)
+        resolver = BoundedResolver(context=context, dialect="hogql", initial_view_name="a", enforce_bounds=False)
+
+        with pytest.raises(ResolutionCycleError):
+            resolver.visit(parse_select("select * from b"))
+
 
 class TestResolutionMetrics(BaseTest):
     def _counter(self, status: str) -> float:
@@ -641,3 +697,51 @@ class TestResolverFactoryInjection(BaseTest):
 
         # Should not raise — the default base Resolver has no depth bound.
         prepare_ast_for_printing(query_node, context=context, dialect="clickhouse")
+
+    def test_shared_deadline_anchor_spans_multiple_resolvers(self):
+        """Two BoundedResolvers built from the same factory must share a deadline clock.
+
+        Without a shared anchor, each resolver would get its own deadline_seconds budget
+        and prepare_ast_for_printing's multi-pass resolution would compound the bound.
+        """
+        from products.data_warehouse.backend.models.modeling import bounded_resolver_factory_for_view
+
+        factory = bounded_resolver_factory_for_view("caller", deadline_seconds=10.0)
+        context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
+        context.database = Database.create_for(team_id=context.team_id, modifiers=context.modifiers, team=context.team)
+
+        # First resolver seeds the anchor; second resolver reads it. Both must see the same value.
+        r1 = factory(context, "hogql", None)
+        r2 = factory(context, "hogql", None)
+        assert isinstance(r1, BoundedResolver)
+        assert isinstance(r2, BoundedResolver)
+        assert r1.deadline_anchor is r2.deadline_anchor
+        assert r1.deadline_anchor == [None]
+
+        r1.visit(parse_select("select * from events"))
+        assert r1.deadline_anchor[0] is not None
+        # second resolver inherits the anchor set by the first
+        assert r2.deadline_anchor[0] == r1.deadline_anchor[0]
+
+    def test_factory_threaded_through_resolve_lazy_tables(self):
+        """Lazy-table resolution invokes the factory on subqueries it builds — depth bound applies.
+
+        Queries against events touch lazy joins (persons, etc.) which `resolve_lazy_tables`
+        materializes as subqueries and re-resolves. Threading the factory means those
+        re-resolutions go through BoundedResolver too.
+        """
+        from posthog.hogql.printer import prepare_ast_for_printing
+
+        from products.data_warehouse.backend.models.modeling import bounded_resolver_factory_for_view
+
+        # Use the shared factory helper so the deadline is end-to-end across passes
+        factory = bounded_resolver_factory_for_view("caller", max_view_depth=DEFAULT_RESOLUTION_MAX_VIEW_DEPTH)
+
+        query_node = parse_select("select event from events")
+        context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
+
+        # Should not raise — a simple events query is well within bounds, but it does
+        # exercise the lazy-table path (events has lazy joins to persons/sessions).
+        # Success here proves the factory is invoked at lazy_tables.resolve_types and
+        # those nested resolutions don't error.
+        prepare_ast_for_printing(query_node, context=context, dialect="clickhouse", resolver_factory=factory)


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

hogql resolution uses 70% of our cpu time in our temporal workers 

## Changes

this is part 1 of a two pronged approach to address this. it creates a bounded resolver for hogql and an optional resolver factory param in hogql resolution functions. the bounded resolver can cap query resolution in two ways. 1) resolution depth of 100 recursive calls and 2) timeout at 60s whichever occurs first.

prong 2 will "cache" the prepared AST and printed query as readonly fields on the saved query model in django. on create / update on the node or any of its dependencies, the stored value is invalidated and re-computed. 

## How did you test this code?

unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->

<!-- gg:stack-start -->
## gg stack

- **#59149 `andrew/bounded-resolver` 👈 this PR**
<!-- gg:stack-end -->
