### PR TITLE
feat(property-values): wire kafka I/O into aggregator service

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7309,12 +7309,15 @@ dependencies = [
 name = "property-values-aggregator"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum 0.7.9",
  "common-alloc",
  "common-continuous-profiling",
  "common-kafka",
  "envconfig",
  "lifecycle",
+ "metrics",
+ "rdkafka",
  "serde",
  "serde_json",
  "serve-metrics",

--- a/rust/property-values-aggregator/Cargo.toml
+++ b/rust/property-values-aggregator/Cargo.toml
@@ -5,12 +5,15 @@ edition = "2021"
 publish = false
 
 [dependencies]
+anyhow = { workspace = true }
 axum = { workspace = true }
 common-alloc = { path = "../common/alloc" }
 common-continuous-profiling = { path = "../common/continuous_profiling" }
 common-kafka = { path = "../common/kafka" }
 envconfig = { workspace = true }
 lifecycle = { path = "../common/lifecycle" }
+metrics = { workspace = true }
+rdkafka = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serve-metrics = { path = "../common/serve_metrics" }

--- a/rust/property-values-aggregator/src/app_context.rs
+++ b/rust/property-values-aggregator/src/app_context.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::config::{Config, TeamFilterMode, TeamList};
+use crate::producer::AggregatedProducer;
+
+/// Shared state handed to every worker loop.
+pub struct AppContext {
+    pub producer: Arc<AggregatedProducer>,
+    pub filter_mode: TeamFilterMode,
+    pub filtered_teams: TeamList,
+    pub flush_interval: Duration,
+    pub max_entries_per_partition: usize,
+    pub producer_flush_timeout: Duration,
+}
+
+impl AppContext {
+    pub fn new(config: &Config, producer: AggregatedProducer) -> Self {
+        Self {
+            producer: Arc::new(producer),
+            filter_mode: config.filter_mode,
+            filtered_teams: config.filtered_teams.clone(),
+            flush_interval: Duration::from_secs(config.flush_interval_secs),
+            max_entries_per_partition: config.max_entries_per_partition,
+            producer_flush_timeout: Duration::from_secs(30),
+        }
+    }
+
+    pub fn should_process(&self, team_id: i64) -> bool {
+        self.filter_mode
+            .should_process(&self.filtered_teams.teams, team_id)
+    }
+}

--- a/rust/property-values-aggregator/src/config.rs
+++ b/rust/property-values-aggregator/src/config.rs
@@ -31,6 +31,12 @@ pub struct Config {
     #[envconfig(default = "500000")]
     pub max_entries_per_partition: usize,
 
+    /// Number of worker tasks per pod consuming from the shared Kafka consumer.
+    /// rdkafka serializes recv across them, so this is concurrency for the
+    /// fan-out + aggregate path, not extra Kafka connections.
+    #[envconfig(default = "4")]
+    pub worker_loop_count: usize,
+
     /// Teams to opt-in or opt-out of property-values aggregation.
     #[envconfig(default = "")]
     pub filtered_teams: TeamList,

--- a/rust/property-values-aggregator/src/lib.rs
+++ b/rust/property-values-aggregator/src/lib.rs
@@ -1,4 +1,8 @@
 pub mod aggregator;
+pub mod app_context;
 pub mod config;
 pub mod fan_out;
+pub mod metrics_consts;
+pub mod producer;
 pub mod types;
+pub mod worker;

--- a/rust/property-values-aggregator/src/main.rs
+++ b/rust/property-values-aggregator/src/main.rs
@@ -1,8 +1,13 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{response::IntoResponse, routing::get, Router};
+use common_kafka::kafka_consumer::SingleTopicConsumer;
+use common_kafka::kafka_producer::create_kafka_producer;
 use lifecycle::{ComponentOptions, Manager};
-use property_values_aggregator::config::Config;
+use property_values_aggregator::{
+    app_context::AppContext, config::Config, producer::AggregatedProducer, worker::worker_loop,
+};
 use serve_metrics::setup_metrics_routes;
 use tokio::net::TcpListener;
 use tracing::level_filters::LevelFilter;
@@ -44,6 +49,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_global_shutdown_timeout(Duration::from_secs(60))
         .build();
 
+    let worker_handle = manager.register(
+        "worker",
+        ComponentOptions::new()
+            .with_graceful_shutdown(Duration::from_secs(30))
+            .with_liveness_deadline(Duration::from_secs(60))
+            .with_stall_threshold(3),
+    );
+
     let metrics_handle =
         manager.register("metrics", ComponentOptions::new().is_observability(true));
 
@@ -55,10 +68,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         consumer_group = %config.consumer.kafka_consumer_group,
         output_topic = %config.output_topic,
         flush_interval_secs = config.flush_interval_secs,
+        worker_loop_count = config.worker_loop_count,
         "config loaded"
     );
 
+    let consumer = SingleTopicConsumer::new(config.kafka.clone(), config.consumer.clone())?;
+    let raw_producer = create_kafka_producer(&config.kafka, worker_handle.clone()).await?;
+    let producer = AggregatedProducer::new(raw_producer, config.output_topic.clone());
+
+    let ctx = Arc::new(AppContext::new(&config, producer));
+
     let guard = manager.monitor_background();
+
+    for _ in 0..config.worker_loop_count {
+        tokio::spawn(worker_loop(
+            ctx.clone(),
+            consumer.clone(),
+            worker_handle.clone(),
+        ));
+    }
+    drop(worker_handle);
 
     let app = Router::new()
         .route("/", get(index))

--- a/rust/property-values-aggregator/src/metrics_consts.rs
+++ b/rust/property-values-aggregator/src/metrics_consts.rs
@@ -1,0 +1,12 @@
+pub const EVENTS_RECEIVED: &str = "property_values_aggregator_events_received_total";
+pub const EVENTS_FILTERED: &str = "property_values_aggregator_events_filtered_total";
+pub const TUPLES_AGGREGATED: &str = "property_values_aggregator_tuples_aggregated_total";
+pub const FLUSH_TUPLES: &str = "property_values_aggregator_flush_tuples";
+pub const FLUSH_TOTAL: &str = "property_values_aggregator_flushes_total";
+pub const FLUSH_REASON_TIMER: &str = "timer";
+pub const FLUSH_REASON_BACKPRESSURE: &str = "backpressure";
+pub const FLUSH_REASON_SHUTDOWN: &str = "shutdown";
+pub const PRODUCE_FAILED: &str = "property_values_aggregator_produce_failed_total";
+pub const PRODUCER_FLUSH_FAILED: &str = "property_values_aggregator_producer_flush_failed_total";
+pub const OFFSET_STORE_FAILED: &str = "property_values_aggregator_offset_store_failed_total";
+pub const KAFKA_RECV_ERRORS: &str = "property_values_aggregator_kafka_recv_errors_total";

--- a/rust/property-values-aggregator/src/producer.rs
+++ b/rust/property-values-aggregator/src/producer.rs
@@ -1,0 +1,57 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use common_kafka::kafka_producer::KafkaContext;
+use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
+
+use crate::types::{OutputMessage, TupleKey};
+
+/// Wrapper around a Kafka producer that serializes accumulated tuple counts
+/// to JSON and produces them to the output topic. Fire-and-forget per record;
+/// `flush` blocks until rdkafka's in-flight queue is empty.
+pub struct AggregatedProducer {
+    producer: FutureProducer<KafkaContext>,
+    topic: String,
+}
+
+impl AggregatedProducer {
+    pub fn new(producer: FutureProducer<KafkaContext>, topic: String) -> Self {
+        Self { producer, topic }
+    }
+
+    /// Enqueue one aggregated tuple into rdkafka's internal buffer.
+    /// rdkafka handles batching, retries, and delivery in the background.
+    pub fn emit(&self, tuple: &TupleKey, count: u64) -> Result<()> {
+        let payload = OutputMessage {
+            team_id: tuple.team_id,
+            property_type: tuple.property_type.as_str(),
+            property_key: &tuple.property_key,
+            property_value: &tuple.property_value,
+            property_count: count,
+        };
+
+        let payload_bytes = serde_json::to_vec(&payload)?;
+        let key = tuple.team_id.to_string();
+        let record = FutureRecord::to(&self.topic)
+            .payload(&payload_bytes)
+            .key(&key);
+
+        self.producer
+            .send_result(record)
+            .map_err(|(e, _)| anyhow!("failed to enqueue record: {e}"))?;
+        Ok(())
+    }
+
+    /// Block until all in-flight records have been acknowledged by the broker.
+    /// Called after each flush window so we know the output is durable before
+    /// committing input offsets.
+    pub async fn flush(&self, timeout: Duration) -> Result<()> {
+        let producer = self.producer.clone();
+        // rdkafka's flush is sync; run it on a blocking task so we don't stall the runtime.
+        tokio::task::spawn_blocking(move || producer.flush(timeout))
+            .await
+            .map_err(|e| anyhow!("flush join error: {e}"))?
+            .map_err(|e| anyhow!("kafka flush error: {e}"))?;
+        Ok(())
+    }
+}

--- a/rust/property-values-aggregator/src/worker.rs
+++ b/rust/property-values-aggregator/src/worker.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common_kafka::kafka_consumer::{Offset, RecvErr, SingleTopicConsumer};
+use tracing::{error, info, warn};
+
+use crate::aggregator::Aggregator;
+use crate::app_context::AppContext;
+use crate::fan_out::fan_out;
+use crate::metrics_consts::*;
+use crate::types::Event;
+
+/// One worker loop: consumes events from Kafka, fans them out into tuples,
+/// accumulates per-tuple counts in an in-memory buffer, and on each flush
+/// timer drains the buffer to the output topic and stores input offsets.
+///
+/// Multiple workers can run concurrently against the same shared
+/// `SingleTopicConsumer`; rdkafka multiplexes partition assignments
+/// across them and each holds its own independent buffer.
+pub async fn worker_loop(
+    ctx: Arc<AppContext>,
+    consumer: SingleTopicConsumer,
+    handle: lifecycle::Handle,
+) {
+    let _guard = handle.process_scope();
+
+    let mut aggregator = Aggregator::new();
+    // Latest seen offset per partition; replaced as newer offsets arrive,
+    // stored at flush time so commits trail durable produce.
+    let mut pending_offsets: HashMap<i32, Offset> = HashMap::new();
+
+    let mut flush_timer = tokio::time::interval(ctx.flush_interval);
+    // Skip the immediate tick at startup; first flush fires after one interval.
+    flush_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    flush_timer.reset();
+
+    loop {
+        tokio::select! {
+            _ = handle.shutdown_recv() => {
+                info!("worker received shutdown; draining final flush");
+                flush(&mut aggregator, &mut pending_offsets, &ctx, FLUSH_REASON_SHUTDOWN).await;
+                return;
+            }
+            _ = flush_timer.tick() => {
+                flush(&mut aggregator, &mut pending_offsets, &ctx, FLUSH_REASON_TIMER).await;
+            }
+            recv = consumer.json_recv::<Event>() => {
+                match recv {
+                    Ok((event, offset)) => {
+                        handle.report_healthy();
+                        metrics::counter!(EVENTS_RECEIVED).increment(1);
+
+                        if ctx.should_process(event.team_id) {
+                            let tuples = fan_out(&event);
+                            metrics::counter!(TUPLES_AGGREGATED).increment(tuples.len() as u64);
+                            aggregator.record_many(tuples);
+                        } else {
+                            metrics::counter!(EVENTS_FILTERED).increment(1);
+                        }
+
+                        pending_offsets.insert(offset.partition(), offset);
+
+                        // Memory-pressure flush: if the buffer hits the cap before
+                        // the timer fires, flush early to bound memory.
+                        if aggregator.len() >= ctx.max_entries_per_partition {
+                            flush(&mut aggregator, &mut pending_offsets, &ctx, FLUSH_REASON_BACKPRESSURE).await;
+                        }
+                    }
+                    Err(RecvErr::Empty) | Err(RecvErr::Serde(_)) => {
+                        // SingleTopicConsumer auto-stores poison-pill offsets.
+                    }
+                    Err(RecvErr::Kafka(e)) => {
+                        metrics::counter!(KAFKA_RECV_ERRORS).increment(1);
+                        warn!(error = %e, "kafka recv error");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Drain the aggregator, produce one message per unique tuple, wait for the
+/// produce queue to ack, then store the input offsets we've collected so far.
+async fn flush(
+    aggregator: &mut Aggregator,
+    pending_offsets: &mut HashMap<i32, Offset>,
+    ctx: &AppContext,
+    reason: &'static str,
+) {
+    let counts = aggregator.drain();
+    if counts.is_empty() && pending_offsets.is_empty() {
+        return;
+    }
+
+    metrics::counter!(FLUSH_TOTAL, "reason" => reason).increment(1);
+    metrics::histogram!(FLUSH_TUPLES).record(counts.len() as f64);
+
+    for (tuple, count) in &counts {
+        if let Err(e) = ctx.producer.emit(tuple, *count) {
+            metrics::counter!(PRODUCE_FAILED).increment(1);
+            error!(error = %e, "producer emit failed; tuple dropped");
+        }
+    }
+
+    if !counts.is_empty() {
+        if let Err(e) = ctx.producer.flush(ctx.producer_flush_timeout).await {
+            // If we can't confirm durability, hold the offsets — they'll be
+            // re-tried on the next flush. We'd rather replay events than lose
+            // counts. AggregatingMergeTree absorbs any resulting duplicates.
+            metrics::counter!(PRODUCER_FLUSH_FAILED).increment(1);
+            error!(error = %e, "producer flush failed; deferring offset commits");
+            return;
+        }
+    }
+
+    // Produce confirmed; safe to advance our position.
+    let to_store = std::mem::take(pending_offsets);
+    for (partition, offset) in to_store {
+        if let Err(e) = offset.store() {
+            metrics::counter!(OFFSET_STORE_FAILED).increment(1);
+            warn!(partition, error = %e, "offset store failed");
+        }
+    }
+}


### PR DESCRIPTION
**Part 2 of the property-values-aggregator rollout.** Part 1 added the ClickHouse `property_count` column; Part 3 ships the deployment infra. Part 2 is split across two PRs.

- [`posthog` #59141](https://github.com/PostHog/posthog/pull/59141), Part 1: ClickHouse schema
- [`posthog` #59144](https://github.com/PostHog/posthog/pull/59144), Part 2: fan-out + aggregator core (scaffold)
- this PR, Part 2: Kafka I/O wiring
- Part 3 (deployment infra): [`posthog` #59194](https://github.com/PostHog/posthog/pull/59194), [`posthog-cloud-infra` #8180](https://github.com/PostHog/posthog-cloud-infra/pull/8180), [`charts` #11180](https://github.com/PostHog/charts/pull/11180)

See the [architecture comment](https://github.com/PostHog/posthog/issues/52301#issuecomment-4494041841) for the full design.

## Problem

The scaffold from the previous PR in this stack has the fan-out and aggregator core but no Kafka I/O, so the service does nothing on its own. This PR wires the consumer, producer, and per-worker flush loop so the binary can actually run end to end against `team_event_partitioned_events_json` and emit aggregated tuples to `clickhouse_property_values`.

## Changes

- New `worker::worker_loop` polls events from the shared `SingleTopicConsumer`, fans them out, accumulates into the in-memory buffer, and flushes on a timer or when the buffer hits `max_entries_per_partition`.
- Flush path produces one message per unique tuple, awaits the rdkafka producer flush, and only then stores input offsets. On producer flush failure we hold the offsets so events replay rather than counts being lost. The storage-side `AggregatingMergeTree` reconciles any resulting duplicates.
- New `producer::AggregatedProducer` wraps `FutureProducer<KafkaContext>` with `emit` and `flush` helpers. Output payload is the serialized `OutputMessage` from the previous PR.
- New `app_context::AppContext` is the shared state handed to every worker (producer handle, filter mode, flush interval, etc.).
- `main.rs` spawns `worker_loop_count` worker tasks (default 4) that share a single cloned `SingleTopicConsumer`. rdkafka serializes recv across them, so the count is concurrency for the fan-out and aggregate path, not extra Kafka connections.
- Adds counters for events received, filtered, tuples aggregated, flushes by reason (timer, backpressure, shutdown), and produce or offset failures; plus a histogram of tuples per flush.

## How did you test this code?

Agent-authored. Verified with `cargo check`, `cargo test` (20 unit tests, same as before, Kafka I/O paths are integration-tested in the next stack stage), `cargo build`, `cargo clippy -- -D warnings`, and `cargo shear` (no unused deps). Production behavior will be validated in the cutover stage once the service is deployed.

## Publish to changelog?

no

## 🤖 Agent context

Agent: Claude Opus 4.7 (Claude Code).

Decisions:
- Single shared `SingleTopicConsumer` cloned across N worker tasks, modeled on `property-defs-rs`. Each worker keeps its own buffer, so cross-worker duplication on the same partition is possible but absorbed by AggregatingMergeTree.
- Offsets are stored after produce is durably flushed. Considered the inverse order but a crash between offset commit and produce would lose counts; replaying duplicates is the safer failure mode for this workload.
- Producer flush failure holds pending offsets rather than dropping the buffer. Counts already drained from the aggregator are gone for that window, but the offsets stay un-committed so the same input range replays on next flush, refilling the buffer.
- Backpressure flush at `max_entries_per_partition` (default 500k) caps memory regardless of input rate.
