### PR TITLE
feat(mcp): cache context-mill skills in redis for hono runtime

### DIFF
--- a/services/mcp/src/hono/cache/ContextMillResourceCache.ts
+++ b/services/mcp/src/hono/cache/ContextMillResourceCache.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto'
+import { createHash } from 'node:crypto'
 
 import type { ContextMillResource } from '@/resources/manifest-types'
 
@@ -18,17 +18,12 @@ export interface SlimManifestEntry {
 }
 
 export interface SlimManifest {
-    gen: string
     entries: SlimManifestEntry[]
 }
 
 export interface ResourceBody {
     mimeType: string
     text: string
-}
-
-interface StoredBody extends ResourceBody {
-    gen: string
 }
 
 export interface ContextMillResourceCacheOptions extends SharedBlobCacheOptions {
@@ -41,16 +36,21 @@ export interface ContextMillResourceCacheOptions extends SharedBlobCacheOptions 
  * Splits storage into two layers:
  *
  * - A small slim manifest blob (handled by the inner `SharedBlobCache`) that
- *   carries `{ gen, entries: [{ uri, name, mimeType, description }] }` — used
- *   by `resources/list` and warmup. Cheap to fetch on every cold pod.
- * - One body key per resource (`mcp:shared-blob:context-mill:body:<gen>:<sha>`)
+ *   carries `{ entries: [{ uri, name, mimeType, description }] }` — used by
+ *   `resources/list` and warmup. Cheap to fetch on every cold pod.
+ * - One body key per resource (`mcp:shared-blob:context-mill:body:<sha256(uri)>`)
  *   that carries the heavy `{ mimeType, text }` payload — fetched lazily only
  *   when `resources/read` resolves a URI.
  *
- * The body writes happen *inside* the SharedBlobCache writer lambda, so they
- * land before the slim manifest is published. The `gen` token (random per
- * refresh) lets readers detect a republish: stale body lookups return null
- * instead of silently mixing payloads across generations.
+ * Bodies are URI-addressed (no per-publish generation token) so the latest
+ * publish always overwrites the same key. The instant a writer pod finishes
+ * `writeBodies`, every other pod reading by URI sees the new content — no
+ * waiting for individual pods to refresh their in-memory manifest.
+ *
+ * Resources removed upstream are NOT explicitly deleted: their bodies just
+ * stop getting their TTL refreshed and age out naturally. This gives clients
+ * holding stale URIs graceful access to the previous content until the body
+ * fully expires.
  */
 export class ContextMillResourceCache {
     private readonly manifestCache: SharedBlobCache
@@ -72,10 +72,8 @@ export class ContextMillResourceCache {
     async loadOrRefresh(upstream: () => Promise<ContextMillResource[]>): Promise<SlimManifest> {
         const bytes = await this.manifestCache.fetch(async () => {
             const entries = await upstream()
-            const gen = randomUUID()
-            await this.writeBodies(entries, gen)
+            await this.writeBodies(entries)
             const slim: SlimManifest = {
-                gen,
                 entries: entries.map((e) => ({
                     uri: e.uri,
                     name: e.name,
@@ -90,36 +88,32 @@ export class ContextMillResourceCache {
 
     /**
      * Invalidate the slim manifest so the next `loadOrRefresh` is treated as
-     * cold and fetches upstream. Use this from miss-recovery paths — e.g.
-     * when a body lookup returns null because Redis evicted it but the
-     * manifest is still fresh, plain `loadOrRefresh` would short-circuit.
+     * cold and fetches upstream. Use from miss-recovery paths — e.g. when a
+     * body lookup returns null because Redis evicted it but the manifest is
+     * still fresh, plain `loadOrRefresh` would short-circuit.
      */
     async invalidate(): Promise<void> {
         await Promise.all([this.redis.del(this.manifestCache.cacheKey), this.redis.del(this.manifestCache.freshKey)])
     }
 
     /**
-     * Returns the body for `uri` if it exists under the expected `gen`. Returns
-     * null on miss or generation mismatch — callers should treat null as a
-     * signal to trigger a `loadOrRefresh` and degrade the current request.
+     * Returns the body for `uri` if present in Redis. Returns null only when
+     * the body has aged out (TTL elapsed without a republish) or was evicted
+     * under memory pressure. Callers should treat null as "trigger refresh
+     * and degrade the current request to empty contents."
      */
-    async readBody(uri: string, gen: string): Promise<ResourceBody | null> {
-        const raw = await this.redis.get(bodyKey(uri, gen))
+    async readBody(uri: string): Promise<ResourceBody | null> {
+        const raw = await this.redis.get(bodyKey(uri))
         if (raw === null) {
             return null
         }
-        const stored = JSON.parse(raw) as StoredBody
-        if (stored.gen !== gen) {
-            return null
-        }
-        return { mimeType: stored.mimeType, text: stored.text }
+        return JSON.parse(raw) as ResourceBody
     }
 
-    private async writeBodies(entries: readonly ContextMillResource[], gen: string): Promise<void> {
+    private async writeBodies(entries: readonly ContextMillResource[]): Promise<void> {
         await Promise.all(
             entries.map(async (entry) => {
-                const stored: StoredBody = {
-                    gen,
+                const stored: ResourceBody = {
                     mimeType: entry.resource.mimeType,
                     text: entry.resource.text,
                 }
@@ -129,14 +123,14 @@ export class ContextMillResourceCache {
                         `[ContextMillResourceCache] body for "${entry.uri}" is ${serialized.length} bytes — approaching Redis bulk-len limits`
                     )
                 }
-                await this.redis.set(bodyKey(entry.uri, gen), serialized, 'EX', this.bodyTtlSeconds)
+                await this.redis.set(bodyKey(entry.uri), serialized, 'EX', this.bodyTtlSeconds)
             })
         )
     }
 }
 
-function bodyKey(uri: string, gen: string): string {
-    return `${BODY_KEY_PREFIX}:${gen}:${sha256(uri)}`
+function bodyKey(uri: string): string {
+    return `${BODY_KEY_PREFIX}:${sha256(uri)}`
 }
 
 function sha256(input: string): string {

--- a/services/mcp/src/hono/cache/ContextMillResourceCache.ts
+++ b/services/mcp/src/hono/cache/ContextMillResourceCache.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from 'node:crypto'
 import { fetchAndExtractEntries } from '@/resources/internals'
 import type { ContextMillResource } from '@/resources/manifest-types'
 
+import { contextMillBodyReadsTotal, contextMillCacheEventsTotal } from '../metrics'
 import type { RedisLike } from './RedisCache'
 import { SharedBlobCache, type SharedBlobCacheOptions } from './SharedBlobCache'
 
@@ -30,6 +31,13 @@ export interface ResourceBody {
 export interface ContextMillResourceCacheOptions extends SharedBlobCacheOptions {
     bodyTtlSeconds?: number
     localUrl?: string
+}
+
+export type ContextMillCacheResult = 'fresh_hit' | 'stale_hit' | 'cold_refresh' | 'waited' | 'fallback'
+
+export interface ContextMillLoadResult {
+    manifest: SlimManifest
+    result: ContextMillCacheResult
 }
 
 /**
@@ -69,47 +77,57 @@ export class ContextMillResourceCache extends SharedBlobCache {
      * SharedBlobCache writer lock, publish every body key, and only then write
      * back the slim manifest.
      */
-    async loadOrRefresh(): Promise<SlimManifest> {
-        const bytes = await this.fetch()
-        return JSON.parse(new TextDecoder().decode(bytes)) as SlimManifest
+    async loadOrRefresh(): Promise<ContextMillLoadResult> {
+        const { bytes, result } = await this.fetch()
+        return {
+            manifest: JSON.parse(new TextDecoder().decode(bytes)) as SlimManifest,
+            result,
+        }
     }
 
-    private async fetch(): Promise<Uint8Array> {
+    private async fetch(): Promise<{ bytes: Uint8Array; result: ContextMillCacheResult }> {
         const cached = await this.readCache()
 
         if (cached && cached.fresh) {
-            return cached.bytes
+            contextMillCacheEventsTotal.inc({ event: 'fresh_hit' })
+            return { bytes: cached.bytes, result: 'fresh_hit' }
         }
 
         if (cached) {
             // Stale-while-revalidate: serve what we have and try to refresh in
             // the background. The lock guarantees only one instance refreshes
             // even if many requests race here.
+            contextMillCacheEventsTotal.inc({ event: 'stale_hit' })
             void this.refreshInBackground()
-            return cached.bytes
+            return { bytes: cached.bytes, result: 'stale_hit' }
         }
 
         // Cold cache — race for the writer lock.
+        contextMillCacheEventsTotal.inc({ event: 'cold_miss' })
         const token = randomUUID()
         if (await this.acquireLock(token)) {
+            contextMillCacheEventsTotal.inc({ event: 'lock_acquired' })
             try {
                 const bytes = await this.loadBlob()
                 await this.writeCache(bytes)
-                return bytes
+                return { bytes, result: 'cold_refresh' }
             } finally {
                 await this.releaseLock(token)
             }
         }
 
         // Another writer holds the lock — wait for them to publish.
+        contextMillCacheEventsTotal.inc({ event: 'lock_contended' })
         const waited = await this.waitForCache()
         if (waited) {
-            return waited
+            contextMillCacheEventsTotal.inc({ event: 'wait_success' })
+            return { bytes: waited, result: 'waited' }
         }
 
         // Writer never published in time. Fetch ourselves without writing so
         // we don't trample whatever the lock holder eventually produces.
-        return this.loadBlob()
+        contextMillCacheEventsTotal.inc({ event: 'wait_timeout' })
+        return { bytes: await this.loadBlob(), result: 'fallback' }
     }
 
     private async loadBlob(): Promise<Uint8Array> {
@@ -133,12 +151,16 @@ export class ContextMillResourceCache extends SharedBlobCache {
     private async refreshInBackground(): Promise<void> {
         const token = randomUUID()
         if (!(await this.acquireLock(token))) {
+            contextMillCacheEventsTotal.inc({ event: 'lock_contended' })
             return
         }
+        contextMillCacheEventsTotal.inc({ event: 'lock_acquired' })
         try {
             const bytes = await this.loadBlob()
             await this.writeCache(bytes)
+            contextMillCacheEventsTotal.inc({ event: 'background_success' })
         } catch (err) {
+            contextMillCacheEventsTotal.inc({ event: 'background_error' })
             console.error(`[ContextMillResourceCache:${this.lockKey}] background refresh failed:`, err)
         } finally {
             await this.releaseLock(token)
@@ -164,9 +186,17 @@ export class ContextMillResourceCache extends SharedBlobCache {
     async readBody(uri: string): Promise<ResourceBody | null> {
         const raw = await this.redis.get(bodyKey(uri))
         if (raw === null) {
+            contextMillBodyReadsTotal.inc({ status: 'miss' })
             return null
         }
-        return JSON.parse(raw) as ResourceBody
+        try {
+            const body = JSON.parse(raw) as ResourceBody
+            contextMillBodyReadsTotal.inc({ status: 'hit' })
+            return body
+        } catch (err) {
+            contextMillBodyReadsTotal.inc({ status: 'parse_error' })
+            throw err
+        }
     }
 
     private async writeBodies(entries: readonly ContextMillResource[]): Promise<void> {

--- a/services/mcp/src/hono/cache/ContextMillResourceCache.ts
+++ b/services/mcp/src/hono/cache/ContextMillResourceCache.ts
@@ -1,5 +1,6 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 
+import { fetchAndExtractEntries } from '@/resources/internals'
 import type { ContextMillResource } from '@/resources/manifest-types'
 
 import type { RedisLike } from './RedisCache'
@@ -28,6 +29,7 @@ export interface ResourceBody {
 
 export interface ContextMillResourceCacheOptions extends SharedBlobCacheOptions {
     bodyTtlSeconds?: number
+    localUrl?: string
 }
 
 /**
@@ -35,7 +37,7 @@ export interface ContextMillResourceCacheOptions extends SharedBlobCacheOptions 
  *
  * Splits storage into two layers:
  *
- * - A small slim manifest blob (handled by the inner `SharedBlobCache`) that
+ * - A small slim manifest blob (handled by the base `SharedBlobCache`) that
  *   carries `{ entries: [{ uri, name, mimeType, description }] }` — used by
  *   `resources/list` and warmup. Cheap to fetch on every cold pod.
  * - One body key per resource (`mcp:shared-blob:context-mill:body:<sha256(uri)>`)
@@ -52,38 +54,95 @@ export interface ContextMillResourceCacheOptions extends SharedBlobCacheOptions 
  * holding stale URIs graceful access to the previous content until the body
  * fully expires.
  */
-export class ContextMillResourceCache {
-    private readonly manifestCache: SharedBlobCache
+export class ContextMillResourceCache extends SharedBlobCache {
     private readonly bodyTtlSeconds: number
+    private readonly localUrl: string | undefined
 
-    constructor(
-        private readonly redis: RedisLike,
-        opts: ContextMillResourceCacheOptions = {}
-    ) {
-        this.manifestCache = new SharedBlobCache(redis, `${NAMESPACE}:manifest`, opts)
+    constructor(redis: RedisLike, opts: ContextMillResourceCacheOptions = {}) {
+        super(redis, `${NAMESPACE}:manifest`, opts)
+        this.localUrl = opts.localUrl
         this.bodyTtlSeconds = opts.bodyTtlSeconds ?? DEFAULT_BODY_TTL_SECONDS
     }
 
     /**
-     * Returns the slim manifest. Cold/stale paths run `upstream` inside the
+     * Returns the slim manifest. Cold/stale paths load entries inside the
      * SharedBlobCache writer lock, publish every body key, and only then write
      * back the slim manifest.
      */
-    async loadOrRefresh(upstream: () => Promise<ContextMillResource[]>): Promise<SlimManifest> {
-        const bytes = await this.manifestCache.fetch(async () => {
-            const entries = await upstream()
-            await this.writeBodies(entries)
-            const slim: SlimManifest = {
-                entries: entries.map((e) => ({
-                    uri: e.uri,
-                    name: e.name,
-                    mimeType: e.resource.mimeType,
-                    description: e.resource.description,
-                })),
-            }
-            return new TextEncoder().encode(JSON.stringify(slim))
-        })
+    async loadOrRefresh(): Promise<SlimManifest> {
+        const bytes = await this.fetch()
         return JSON.parse(new TextDecoder().decode(bytes)) as SlimManifest
+    }
+
+    private async fetch(): Promise<Uint8Array> {
+        const cached = await this.readCache()
+
+        if (cached && cached.fresh) {
+            return cached.bytes
+        }
+
+        if (cached) {
+            // Stale-while-revalidate: serve what we have and try to refresh in
+            // the background. The lock guarantees only one instance refreshes
+            // even if many requests race here.
+            void this.refreshInBackground()
+            return cached.bytes
+        }
+
+        // Cold cache — race for the writer lock.
+        const token = randomUUID()
+        if (await this.acquireLock(token)) {
+            try {
+                const bytes = await this.loadBlob()
+                await this.writeCache(bytes)
+                return bytes
+            } finally {
+                await this.releaseLock(token)
+            }
+        }
+
+        // Another writer holds the lock — wait for them to publish.
+        const waited = await this.waitForCache()
+        if (waited) {
+            return waited
+        }
+
+        // Writer never published in time. Fetch ourselves without writing so
+        // we don't trample whatever the lock holder eventually produces.
+        return this.loadBlob()
+    }
+
+    private async loadBlob(): Promise<Uint8Array> {
+        const entries = await this.loadEntries()
+        await this.writeBodies(entries)
+        const slim: SlimManifest = {
+            entries: entries.map((e) => ({
+                uri: e.uri,
+                name: e.name,
+                mimeType: e.resource.mimeType,
+                description: e.resource.description,
+            })),
+        }
+        return new TextEncoder().encode(JSON.stringify(slim))
+    }
+
+    protected async loadEntries(): Promise<ContextMillResource[]> {
+        return fetchAndExtractEntries(this.localUrl)
+    }
+
+    private async refreshInBackground(): Promise<void> {
+        const token = randomUUID()
+        if (!(await this.acquireLock(token))) {
+            return
+        }
+        try {
+            const bytes = await this.loadBlob()
+            await this.writeCache(bytes)
+        } catch (err) {
+            console.error(`[ContextMillResourceCache:${this.lockKey}] background refresh failed:`, err)
+        } finally {
+            await this.releaseLock(token)
+        }
     }
 
     /**
@@ -93,7 +152,7 @@ export class ContextMillResourceCache {
      * still fresh, plain `loadOrRefresh` would short-circuit.
      */
     async invalidate(): Promise<void> {
-        await Promise.all([this.redis.del(this.manifestCache.cacheKey), this.redis.del(this.manifestCache.freshKey)])
+        await Promise.all([this.redis.del(this.cacheKey), this.redis.del(this.freshKey)])
     }
 
     /**

--- a/services/mcp/src/hono/cache/ContextMillResourceCache.ts
+++ b/services/mcp/src/hono/cache/ContextMillResourceCache.ts
@@ -1,0 +1,144 @@
+import { createHash, randomUUID } from 'node:crypto'
+
+import type { ContextMillResource } from '@/resources/manifest-types'
+
+import type { RedisLike } from './RedisCache'
+import { SharedBlobCache, type SharedBlobCacheOptions } from './SharedBlobCache'
+
+const NAMESPACE = 'context-mill'
+const BODY_KEY_PREFIX = `mcp:shared-blob:${NAMESPACE}:body`
+const DEFAULT_BODY_TTL_SECONDS = 7 * 24 * 60 * 60
+const BODY_SIZE_WARN_BYTES = 256 * 1024
+
+export interface SlimManifestEntry {
+    uri: string
+    name: string
+    mimeType: string
+    description: string
+}
+
+export interface SlimManifest {
+    gen: string
+    entries: SlimManifestEntry[]
+}
+
+export interface ResourceBody {
+    mimeType: string
+    text: string
+}
+
+interface StoredBody extends ResourceBody {
+    gen: string
+}
+
+export interface ContextMillResourceCacheOptions extends SharedBlobCacheOptions {
+    bodyTtlSeconds?: number
+}
+
+/**
+ * Redis-backed cache for the context-mill resource bundle.
+ *
+ * Splits storage into two layers:
+ *
+ * - A small slim manifest blob (handled by the inner `SharedBlobCache`) that
+ *   carries `{ gen, entries: [{ uri, name, mimeType, description }] }` — used
+ *   by `resources/list` and warmup. Cheap to fetch on every cold pod.
+ * - One body key per resource (`mcp:shared-blob:context-mill:body:<gen>:<sha>`)
+ *   that carries the heavy `{ mimeType, text }` payload — fetched lazily only
+ *   when `resources/read` resolves a URI.
+ *
+ * The body writes happen *inside* the SharedBlobCache writer lambda, so they
+ * land before the slim manifest is published. The `gen` token (random per
+ * refresh) lets readers detect a republish: stale body lookups return null
+ * instead of silently mixing payloads across generations.
+ */
+export class ContextMillResourceCache {
+    private readonly manifestCache: SharedBlobCache
+    private readonly bodyTtlSeconds: number
+
+    constructor(
+        private readonly redis: RedisLike,
+        opts: ContextMillResourceCacheOptions = {}
+    ) {
+        this.manifestCache = new SharedBlobCache(redis, `${NAMESPACE}:manifest`, opts)
+        this.bodyTtlSeconds = opts.bodyTtlSeconds ?? DEFAULT_BODY_TTL_SECONDS
+    }
+
+    /**
+     * Returns the slim manifest. Cold/stale paths run `upstream` inside the
+     * SharedBlobCache writer lock, publish every body key, and only then write
+     * back the slim manifest.
+     */
+    async loadOrRefresh(upstream: () => Promise<ContextMillResource[]>): Promise<SlimManifest> {
+        const bytes = await this.manifestCache.fetch(async () => {
+            const entries = await upstream()
+            const gen = randomUUID()
+            await this.writeBodies(entries, gen)
+            const slim: SlimManifest = {
+                gen,
+                entries: entries.map((e) => ({
+                    uri: e.uri,
+                    name: e.name,
+                    mimeType: e.resource.mimeType,
+                    description: e.resource.description,
+                })),
+            }
+            return new TextEncoder().encode(JSON.stringify(slim))
+        })
+        return JSON.parse(new TextDecoder().decode(bytes)) as SlimManifest
+    }
+
+    /**
+     * Invalidate the slim manifest so the next `loadOrRefresh` is treated as
+     * cold and fetches upstream. Use this from miss-recovery paths — e.g.
+     * when a body lookup returns null because Redis evicted it but the
+     * manifest is still fresh, plain `loadOrRefresh` would short-circuit.
+     */
+    async invalidate(): Promise<void> {
+        await Promise.all([this.redis.del(this.manifestCache.cacheKey), this.redis.del(this.manifestCache.freshKey)])
+    }
+
+    /**
+     * Returns the body for `uri` if it exists under the expected `gen`. Returns
+     * null on miss or generation mismatch — callers should treat null as a
+     * signal to trigger a `loadOrRefresh` and degrade the current request.
+     */
+    async readBody(uri: string, gen: string): Promise<ResourceBody | null> {
+        const raw = await this.redis.get(bodyKey(uri, gen))
+        if (raw === null) {
+            return null
+        }
+        const stored = JSON.parse(raw) as StoredBody
+        if (stored.gen !== gen) {
+            return null
+        }
+        return { mimeType: stored.mimeType, text: stored.text }
+    }
+
+    private async writeBodies(entries: readonly ContextMillResource[], gen: string): Promise<void> {
+        await Promise.all(
+            entries.map(async (entry) => {
+                const stored: StoredBody = {
+                    gen,
+                    mimeType: entry.resource.mimeType,
+                    text: entry.resource.text,
+                }
+                const serialized = JSON.stringify(stored)
+                if (serialized.length > BODY_SIZE_WARN_BYTES) {
+                    console.warn(
+                        `[ContextMillResourceCache] body for "${entry.uri}" is ${serialized.length} bytes — approaching Redis bulk-len limits`
+                    )
+                }
+                await this.redis.set(bodyKey(entry.uri, gen), serialized, 'EX', this.bodyTtlSeconds)
+            })
+        )
+    }
+}
+
+function bodyKey(uri: string, gen: string): string {
+    return `${BODY_KEY_PREFIX}:${gen}:${sha256(uri)}`
+}
+
+function sha256(input: string): string {
+    return createHash('sha256').update(input).digest('hex')
+}

--- a/services/mcp/src/hono/cache/SharedBlobCache.ts
+++ b/services/mcp/src/hono/cache/SharedBlobCache.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto'
-
 import type { RedisLike } from './RedisCache'
 
 const DEFAULT_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60 // 7 days — hard expiry
@@ -16,17 +14,15 @@ export interface SharedBlobCacheOptions {
     waitTimeoutMs?: number
 }
 
-export type BlobUpstream = () => Promise<Uint8Array>
-
 /**
- * Redis-backed cache for an arbitrary binary blob, shared across instances.
+ * Redis-backed helpers for an arbitrary binary blob, shared across instances.
  *
- * - Only the writer that wins the `SET NX EX` race fetches upstream and writes
- *   back the cache. Other concurrent callers either wait for the writer to
- *   publish (cold cache) or serve the previously cached value while a refresh
- *   runs in the background (stale-while-revalidate).
+ * - Callers can coordinate single-writer refreshes with the `SET NX EX` lock,
+ *   wait for another writer to publish on cold cache misses, and read/write
+ *   the shared bytes plus freshness marker.
  * - Hard TTL keeps the cache available across long writer outages; a separate
- *   freshness timestamp triggers a background refresh after the soft window.
+ *   freshness timestamp lets callers decide when to refresh after the soft
+ *   window.
  *
  * Each blob lives under a caller-supplied namespace, so one Redis can host
  * many independent shared blobs (e.g. context-mill archive, future bundles)
@@ -44,7 +40,7 @@ export class SharedBlobCache {
     private waitTimeoutMs: number
 
     constructor(
-        private readonly redis: RedisLike,
+        protected readonly redis: RedisLike,
         namespace: string,
         opts: SharedBlobCacheOptions = {}
     ) {
@@ -60,49 +56,7 @@ export class SharedBlobCache {
         this.waitTimeoutMs = opts.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS
     }
 
-    /**
-     * Return the cached blob bytes, fetching upstream via the single-writer
-     * lock when the cache is cold or stale.
-     */
-    async fetch(upstream: BlobUpstream): Promise<Uint8Array> {
-        const cached = await this.readCache()
-
-        if (cached && cached.fresh) {
-            return cached.bytes
-        }
-
-        if (cached) {
-            // Stale-while-revalidate: serve what we have and try to refresh in
-            // the background. The lock guarantees only one instance refreshes
-            // even if many requests race here.
-            void this.refreshInBackground(upstream)
-            return cached.bytes
-        }
-
-        // Cold cache — race for the writer lock.
-        const token = randomUUID()
-        if (await this.acquireLock(token)) {
-            try {
-                const bytes = await upstream()
-                await this.writeCache(bytes)
-                return bytes
-            } finally {
-                await this.releaseLock(token)
-            }
-        }
-
-        // Another writer holds the lock — wait for them to publish.
-        const waited = await this.waitForCache()
-        if (waited) {
-            return waited
-        }
-
-        // Writer never published in time. Fetch ourselves without writing so
-        // we don't trample whatever the lock holder eventually produces.
-        return upstream()
-    }
-
-    private async readCache(): Promise<{ bytes: Uint8Array; fresh: boolean } | null> {
+    protected async readCache(): Promise<{ bytes: Uint8Array; fresh: boolean } | null> {
         const [raw, freshUntilStr] = await Promise.all([this.redis.get(this.cacheKey), this.redis.get(this.freshKey)])
         if (raw === null) {
             return null
@@ -114,7 +68,7 @@ export class SharedBlobCache {
         return { bytes, fresh }
     }
 
-    private async writeCache(bytes: Uint8Array): Promise<void> {
+    protected async writeCache(bytes: Uint8Array): Promise<void> {
         const b64 = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('base64')
         const freshUntil = Date.now() + this.freshSeconds * 1000
         await Promise.all([
@@ -123,12 +77,12 @@ export class SharedBlobCache {
         ])
     }
 
-    private async acquireLock(token: string): Promise<boolean> {
+    protected async acquireLock(token: string): Promise<boolean> {
         const result = await this.redis.set(this.lockKey, token, 'NX', 'EX', this.lockTtlSeconds)
         return result === 'OK'
     }
 
-    private async releaseLock(_token: string): Promise<void> {
+    protected async releaseLock(_token: string): Promise<void> {
         // Best-effort. The lock TTL bounds the worst case (another writer's
         // entry being deleted on top); a Lua CAS could close that window but
         // would require widening the RedisLike interface.
@@ -139,7 +93,7 @@ export class SharedBlobCache {
         }
     }
 
-    private async waitForCache(): Promise<Uint8Array | null> {
+    protected async waitForCache(): Promise<Uint8Array | null> {
         const start = Date.now()
         while (Date.now() - start < this.waitTimeoutMs) {
             await sleep(this.waitIntervalMs)
@@ -149,21 +103,6 @@ export class SharedBlobCache {
             }
         }
         return null
-    }
-
-    private async refreshInBackground(upstream: BlobUpstream): Promise<void> {
-        const token = randomUUID()
-        if (!(await this.acquireLock(token))) {
-            return
-        }
-        try {
-            const bytes = await upstream()
-            await this.writeCache(bytes)
-        } catch (err) {
-            console.error(`[SharedBlobCache:${this.lockKey}] background refresh failed:`, err)
-        } finally {
-            await this.releaseLock(token)
-        }
     }
 }
 

--- a/services/mcp/src/hono/cache/SharedBlobCache.ts
+++ b/services/mcp/src/hono/cache/SharedBlobCache.ts
@@ -33,9 +33,9 @@ export type BlobUpstream = () => Promise<Uint8Array>
  * without colliding.
  */
 export class SharedBlobCache {
-    private readonly cacheKey: string
-    private readonly freshKey: string
-    private readonly lockKey: string
+    public readonly cacheKey: string
+    public readonly freshKey: string
+    public readonly lockKey: string
 
     private cacheTtlSeconds: number
     private freshSeconds: number

--- a/services/mcp/src/hono/cache/SharedBlobCache.ts
+++ b/services/mcp/src/hono/cache/SharedBlobCache.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from 'node:crypto'
+
+import type { RedisLike } from './RedisCache'
+
+const DEFAULT_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60 // 7 days — hard expiry
+const DEFAULT_FRESH_SECONDS = 60 * 10 // 10 minutes — after this, trigger a refresh
+const DEFAULT_LOCK_TTL_SECONDS = 60 // writer lock auto-expires
+const DEFAULT_WAIT_INTERVAL_MS = 200
+const DEFAULT_WAIT_TIMEOUT_MS = 10_000
+
+export interface SharedBlobCacheOptions {
+    cacheTtlSeconds?: number
+    freshSeconds?: number
+    lockTtlSeconds?: number
+    waitIntervalMs?: number
+    waitTimeoutMs?: number
+}
+
+export type BlobUpstream = () => Promise<Uint8Array>
+
+/**
+ * Redis-backed cache for an arbitrary binary blob, shared across instances.
+ *
+ * - Only the writer that wins the `SET NX EX` race fetches upstream and writes
+ *   back the cache. Other concurrent callers either wait for the writer to
+ *   publish (cold cache) or serve the previously cached value while a refresh
+ *   runs in the background (stale-while-revalidate).
+ * - Hard TTL keeps the cache available across long writer outages; a separate
+ *   freshness timestamp triggers a background refresh after the soft window.
+ *
+ * Each blob lives under a caller-supplied namespace, so one Redis can host
+ * many independent shared blobs (e.g. context-mill archive, future bundles)
+ * without colliding.
+ */
+export class SharedBlobCache {
+    private readonly cacheKey: string
+    private readonly freshKey: string
+    private readonly lockKey: string
+
+    private cacheTtlSeconds: number
+    private freshSeconds: number
+    private lockTtlSeconds: number
+    private waitIntervalMs: number
+    private waitTimeoutMs: number
+
+    constructor(
+        private readonly redis: RedisLike,
+        namespace: string,
+        opts: SharedBlobCacheOptions = {}
+    ) {
+        const prefix = `mcp:shared-blob:${namespace}`
+        this.cacheKey = `${prefix}:bytes`
+        this.freshKey = `${prefix}:fresh`
+        this.lockKey = `${prefix}:lock`
+
+        this.cacheTtlSeconds = opts.cacheTtlSeconds ?? DEFAULT_CACHE_TTL_SECONDS
+        this.freshSeconds = opts.freshSeconds ?? DEFAULT_FRESH_SECONDS
+        this.lockTtlSeconds = opts.lockTtlSeconds ?? DEFAULT_LOCK_TTL_SECONDS
+        this.waitIntervalMs = opts.waitIntervalMs ?? DEFAULT_WAIT_INTERVAL_MS
+        this.waitTimeoutMs = opts.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS
+    }
+
+    /**
+     * Return the cached blob bytes, fetching upstream via the single-writer
+     * lock when the cache is cold or stale.
+     */
+    async fetch(upstream: BlobUpstream): Promise<Uint8Array> {
+        const cached = await this.readCache()
+
+        if (cached && cached.fresh) {
+            return cached.bytes
+        }
+
+        if (cached) {
+            // Stale-while-revalidate: serve what we have and try to refresh in
+            // the background. The lock guarantees only one instance refreshes
+            // even if many requests race here.
+            void this.refreshInBackground(upstream)
+            return cached.bytes
+        }
+
+        // Cold cache — race for the writer lock.
+        const token = randomUUID()
+        if (await this.acquireLock(token)) {
+            try {
+                const bytes = await upstream()
+                await this.writeCache(bytes)
+                return bytes
+            } finally {
+                await this.releaseLock(token)
+            }
+        }
+
+        // Another writer holds the lock — wait for them to publish.
+        const waited = await this.waitForCache()
+        if (waited) {
+            return waited
+        }
+
+        // Writer never published in time. Fetch ourselves without writing so
+        // we don't trample whatever the lock holder eventually produces.
+        return upstream()
+    }
+
+    private async readCache(): Promise<{ bytes: Uint8Array; fresh: boolean } | null> {
+        const [raw, freshUntilStr] = await Promise.all([this.redis.get(this.cacheKey), this.redis.get(this.freshKey)])
+        if (raw === null) {
+            return null
+        }
+        const buf = Buffer.from(raw, 'base64')
+        const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+        const freshUntil = freshUntilStr !== null ? Number(freshUntilStr) : 0
+        const fresh = Number.isFinite(freshUntil) && Date.now() < freshUntil
+        return { bytes, fresh }
+    }
+
+    private async writeCache(bytes: Uint8Array): Promise<void> {
+        const b64 = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('base64')
+        const freshUntil = Date.now() + this.freshSeconds * 1000
+        await Promise.all([
+            this.redis.set(this.cacheKey, b64, 'EX', this.cacheTtlSeconds),
+            this.redis.set(this.freshKey, String(freshUntil), 'EX', this.cacheTtlSeconds),
+        ])
+    }
+
+    private async acquireLock(token: string): Promise<boolean> {
+        const result = await this.redis.set(this.lockKey, token, 'NX', 'EX', this.lockTtlSeconds)
+        return result === 'OK'
+    }
+
+    private async releaseLock(_token: string): Promise<void> {
+        // Best-effort. The lock TTL bounds the worst case (another writer's
+        // entry being deleted on top); a Lua CAS could close that window but
+        // would require widening the RedisLike interface.
+        try {
+            await this.redis.del(this.lockKey)
+        } catch (err) {
+            console.error(`[SharedBlobCache:${this.lockKey}] failed to release lock:`, err)
+        }
+    }
+
+    private async waitForCache(): Promise<Uint8Array | null> {
+        const start = Date.now()
+        while (Date.now() - start < this.waitTimeoutMs) {
+            await sleep(this.waitIntervalMs)
+            const cached = await this.readCache()
+            if (cached) {
+                return cached.bytes
+            }
+        }
+        return null
+    }
+
+    private async refreshInBackground(upstream: BlobUpstream): Promise<void> {
+        const token = randomUUID()
+        if (!(await this.acquireLock(token))) {
+            return
+        }
+        try {
+            const bytes = await upstream()
+            await this.writeCache(bytes)
+        } catch (err) {
+            console.error(`[SharedBlobCache:${this.lockKey}] background refresh failed:`, err)
+        } finally {
+            await this.releaseLock(token)
+        }
+    }
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -194,7 +194,7 @@ class McpDispatcher {
                 case Method.ResourcesList:
                     return jsonRpcResult(id, this.resourceCatalog.getResourcesList())
                 case Method.ResourcesRead:
-                    return jsonRpcResult(id, this.resourceCatalog.readResource(params))
+                    return jsonRpcResult(id, await this.resourceCatalog.readResource(params))
                 case Method.PromptsList:
                     return jsonRpcResult(id, this.resourceCatalog.getPromptsList())
                 case Method.PromptsGet:

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -221,6 +221,7 @@ class McpDispatcher {
                 ? requestedVersion
                 : LATEST_PROTOCOL_VERSION
 
+            await this.resourceCatalog.revalidateContextMillResources('initialize')
             const instructions = await this.instructionsBuilder.build(props, state)
 
             initDurationSeconds.observe(props.requestStartTime ? (Date.now() - props.requestStartTime) / 1000 : 0)

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -17,7 +17,6 @@ import type {
     PingRequest,
     ReadResourceRequest,
 } from '@modelcontextprotocol/sdk/types.js'
-
 import { randomUUID } from 'node:crypto'
 
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
@@ -114,7 +113,7 @@ class McpDispatcher {
     constructor(catalog: ToolCatalog, redis: RedisLike) {
         const env = getEnv()
         this.catalog = catalog
-        this.resourceCatalog = new ResourceCatalog(env)
+        this.resourceCatalog = new ResourceCatalog(env, redis)
         this.stateResolver = new RequestStateResolver(catalog, redis, env)
         this.instructionsBuilder = new InstructionsBuilder(loadGuidelines())
         this.toolExecutor = new ToolExecutor(catalog, this.instructionsBuilder)

--- a/services/mcp/src/hono/metrics.ts
+++ b/services/mcp/src/hono/metrics.ts
@@ -81,6 +81,36 @@ export const rateLimitErrorsTotal = new Counter({
     labelNames: ['scope'] as const,
 })
 
+export const contextMillRevalidationsTotal = new Counter({
+    name: 'mcp_context_mill_revalidations_total',
+    help: 'Context-mill resource revalidation attempts by caller and result.',
+    labelNames: ['source', 'status', 'result'] as const,
+})
+
+export const contextMillRevalidationDurationSeconds = new Histogram({
+    name: 'mcp_context_mill_revalidation_duration_seconds',
+    help: 'Context-mill resource revalidation duration.',
+    labelNames: ['source', 'status'] as const,
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
+})
+
+export const contextMillCacheEventsTotal = new Counter({
+    name: 'mcp_context_mill_cache_events_total',
+    help: 'Context-mill resource cache events.',
+    labelNames: ['event'] as const,
+})
+
+export const contextMillManifestEntries = new Gauge({
+    name: 'mcp_context_mill_manifest_entries',
+    help: 'Latest successfully loaded context-mill slim manifest entry count.',
+})
+
+export const contextMillBodyReadsTotal = new Counter({
+    name: 'mcp_context_mill_body_reads_total',
+    help: 'Context-mill resource body reads by outcome.',
+    labelNames: ['status'] as const,
+})
+
 export function routeLabel(pathname: string): string {
     if (pathname === '/mcp' || pathname.startsWith('/mcp/')) {
         return '/mcp'

--- a/services/mcp/src/hono/resource-catalog.ts
+++ b/services/mcp/src/hono/resource-catalog.ts
@@ -10,7 +10,6 @@ import type {
 } from '@modelcontextprotocol/sdk/types.js'
 
 import { getPromptsFromManifest } from '@/resources'
-import { fetchAndExtractEntries } from '@/resources/internals'
 import { buildAppStubHtml } from '@/resources/ui-apps'
 import { UI_APPS } from '@/resources/ui-apps.generated'
 import type { Env } from '@/tools/types'
@@ -20,7 +19,7 @@ import type { RedisLike } from './cache/RedisCache'
 
 export class ResourceCatalog {
     private readonly env: Env
-    private readonly contextMillCache: ContextMillResourceCache | undefined
+    private readonly contextMillCache: ContextMillResourceCache
 
     private resources: Resource[] = []
     private prompts: Prompt[] = []
@@ -30,9 +29,10 @@ export class ResourceCatalog {
     private allResources: Resource[] = []
     private contextMillEntriesByUri = new Map<string, SlimManifestEntry>()
 
-    constructor(env: Env, redis?: RedisLike) {
+    constructor(env: Env, redis: RedisLike) {
         this.env = env
-        this.contextMillCache = redis ? new ContextMillResourceCache(redis) : undefined
+        const localUrl = this.contextMillLocalUrl()
+        this.contextMillCache = new ContextMillResourceCache(redis, localUrl ? { localUrl } : {})
     }
 
     get contextMillEntries(): readonly SlimManifestEntry[] {
@@ -65,7 +65,7 @@ export class ResourceCatalog {
         }
 
         const slimEntry = this.contextMillEntriesByUri.get(uri)
-        if (!slimEntry || !this.contextMillCache) {
+        if (!slimEntry) {
             return { contents: [] }
         }
         const body = await this.contextMillCache.readBody(uri)
@@ -101,12 +101,7 @@ export class ResourceCatalog {
     }
 
     private async refreshContextMill(): Promise<void> {
-        if (!this.contextMillCache) {
-            return
-        }
-        const localUrlRaw = (this.env as Record<string, string | undefined>)?.POSTHOG_MCP_LOCAL_SKILLS_URL
-        const localUrl = localUrlRaw && localUrlRaw.trim() !== '' ? localUrlRaw : undefined
-        const slim = await this.contextMillCache.loadOrRefresh(() => fetchAndExtractEntries(localUrl))
+        const slim = await this.contextMillCache.loadOrRefresh()
 
         const nextEntriesByUri = new Map<string, SlimManifestEntry>()
         const nextResources: Resource[] = []
@@ -122,6 +117,11 @@ export class ResourceCatalog {
         this.contextMillEntriesByUri = nextEntriesByUri
         this.resources = nextResources
         this.allResources = [...this.resources, ...this.uiAppResources]
+    }
+
+    private contextMillLocalUrl(): string | undefined {
+        const localUrlRaw = (this.env as Record<string, string | undefined>)?.POSTHOG_MCP_LOCAL_SKILLS_URL
+        return localUrlRaw && localUrlRaw.trim() !== '' ? localUrlRaw : undefined
     }
 
     private async warmupResources(): Promise<void> {

--- a/services/mcp/src/hono/resource-catalog.ts
+++ b/services/mcp/src/hono/resource-catalog.ts
@@ -10,41 +10,34 @@ import type {
 } from '@modelcontextprotocol/sdk/types.js'
 
 import { getPromptsFromManifest } from '@/resources'
-import {
-    type ArchiveLoader,
-    fetchContextMillResources,
-    filterValidEntries,
-    loadManifestFromArchive,
-    clearResourceCache,
-} from '@/resources/internals'
-import type { ContextMillResource } from '@/resources/manifest-types'
+import { fetchAndExtractEntries } from '@/resources/internals'
 import { buildAppStubHtml } from '@/resources/ui-apps'
 import { UI_APPS } from '@/resources/ui-apps.generated'
 import type { Env } from '@/tools/types'
 
+import { ContextMillResourceCache, type SlimManifestEntry } from './cache/ContextMillResourceCache'
 import type { RedisLike } from './cache/RedisCache'
-import { SharedBlobCache } from './cache/SharedBlobCache'
 
 export class ResourceCatalog {
     private readonly env: Env
-    private readonly archiveLoader: ArchiveLoader | undefined
+    private readonly contextMillCache: ContextMillResourceCache | undefined
 
     private resources: Resource[] = []
-    private resourcesByUri = new Map<string, TextResourceContents>()
     private prompts: Prompt[] = []
     private promptsByName = new Map<string, GetPromptResult>()
     private uiAppResources: Resource[] = []
     private uiAppReadEntries = new Map<string, TextResourceContents>()
     private allResources: Resource[] = []
-    private contextMillData: readonly ContextMillResource[] = []
+    private contextMillEntriesByUri = new Map<string, SlimManifestEntry>()
+    private contextMillGen: string | undefined
 
     constructor(env: Env, redis?: RedisLike) {
         this.env = env
-        this.archiveLoader = redis ? buildSharedArchiveLoader(redis) : undefined
+        this.contextMillCache = redis ? new ContextMillResourceCache(redis) : undefined
     }
 
-    get contextMillEntries(): readonly ContextMillResource[] {
-        return this.contextMillData
+    get contextMillEntries(): readonly SlimManifestEntry[] {
+        return Array.from(this.contextMillEntriesByUri.values())
     }
 
     async warmup(): Promise<void> {
@@ -56,19 +49,42 @@ export class ResourceCatalog {
         return { resources: this.allResources }
     }
 
-    readResource(params: Record<string, unknown> | undefined): ReadResourceResult {
+    async readResource(params: Record<string, unknown> | undefined): Promise<ReadResourceResult> {
         const uri = (params?.uri as string) ?? ''
-        const entry = this.resourcesByUri.get(uri) ?? this.uiAppReadEntries.get(uri)
-        if (!entry) {
+        const uiEntry = this.uiAppReadEntries.get(uri)
+        if (uiEntry) {
+            return {
+                contents: [
+                    {
+                        uri: uiEntry.uri,
+                        mimeType: uiEntry.mimeType,
+                        text: uiEntry.text,
+                        ...(uiEntry._meta ? { _meta: uiEntry._meta } : {}),
+                    },
+                ],
+            }
+        }
+
+        const slimEntry = this.contextMillEntriesByUri.get(uri)
+        if (!slimEntry || !this.contextMillCache || !this.contextMillGen) {
+            return { contents: [] }
+        }
+        const body = await this.contextMillCache.readBody(uri, this.contextMillGen)
+        if (!body) {
+            // Eviction, partial state, or generation drift. Invalidate the
+            // slim manifest so the background refresh actually re-fetches
+            // upstream (a plain refresh would short-circuit on the still-fresh
+            // manifest), and let subsequent requests resolve once the new
+            // generation is published.
+            void this.contextMillCache.invalidate().then(() => this.refreshContextMill())
             return { contents: [] }
         }
         return {
             contents: [
                 {
-                    uri: entry.uri,
-                    mimeType: entry.mimeType,
-                    text: entry.text,
-                    ...(entry._meta ? { _meta: entry._meta } : {}),
+                    uri: slimEntry.uri,
+                    mimeType: body.mimeType,
+                    text: body.text,
                 },
             ],
         }
@@ -87,26 +103,34 @@ export class ResourceCatalog {
         return { messages: entry.messages }
     }
 
+    private async refreshContextMill(): Promise<void> {
+        if (!this.contextMillCache) {
+            return
+        }
+        const localUrlRaw = (this.env as Record<string, string | undefined>)?.POSTHOG_MCP_LOCAL_SKILLS_URL
+        const localUrl = localUrlRaw && localUrlRaw.trim() !== '' ? localUrlRaw : undefined
+        const slim = await this.contextMillCache.loadOrRefresh(() => fetchAndExtractEntries(localUrl))
+
+        const nextEntriesByUri = new Map<string, SlimManifestEntry>()
+        const nextResources: Resource[] = []
+        for (const entry of slim.entries) {
+            nextEntriesByUri.set(entry.uri, entry)
+            nextResources.push({
+                name: entry.name,
+                uri: entry.uri,
+                mimeType: entry.mimeType,
+                description: entry.description,
+            })
+        }
+        this.contextMillEntriesByUri = nextEntriesByUri
+        this.contextMillGen = slim.gen
+        this.resources = nextResources
+        this.allResources = [...this.resources, ...this.uiAppResources]
+    }
+
     private async warmupResources(): Promise<void> {
         try {
-            const archive = await fetchContextMillResources(undefined, this.archiveLoader)
-            const manifest = loadManifestFromArchive(archive)
-            this.contextMillData = filterValidEntries(manifest.resources, archive)
-            clearResourceCache()
-
-            for (const entry of this.contextMillEntries) {
-                this.resources.push({
-                    name: entry.name,
-                    uri: entry.uri,
-                    mimeType: entry.resource.mimeType,
-                    description: entry.resource.description,
-                })
-                this.resourcesByUri.set(entry.uri, {
-                    uri: entry.uri,
-                    mimeType: entry.resource.mimeType,
-                    text: entry.resource.text,
-                })
-            }
+            await this.refreshContextMill()
         } catch (error) {
             console.error('[ResourceCatalog] Failed to pre-load context-mill resources:', error)
         }
@@ -160,17 +184,4 @@ export class ResourceCatalog {
             })
         }
     }
-}
-
-function buildSharedArchiveLoader(redis: RedisLike): ArchiveLoader {
-    const cache = new SharedBlobCache(redis, 'context-mill:archive')
-    return async (url) =>
-        cache.fetch(async () => {
-            const response = await fetch(url)
-            if (!response.ok) {
-                throw new Error(`Failed to fetch context-mill resources from ${url}: ${response.statusText}`)
-            }
-            const buffer = await response.arrayBuffer()
-            return new Uint8Array(buffer)
-        })
 }

--- a/services/mcp/src/hono/resource-catalog.ts
+++ b/services/mcp/src/hono/resource-catalog.ts
@@ -9,20 +9,25 @@ import type {
     TextResourceContents,
 } from '@modelcontextprotocol/sdk/types.js'
 
+import { getPromptsFromManifest } from '@/resources'
 import {
+    type ArchiveLoader,
     fetchContextMillResources,
     filterValidEntries,
     loadManifestFromArchive,
     clearResourceCache,
 } from '@/resources/internals'
-import { getPromptsFromManifest } from '@/resources'
-import { UI_APPS } from '@/resources/ui-apps.generated'
-import { buildAppStubHtml } from '@/resources/ui-apps'
 import type { ContextMillResource } from '@/resources/manifest-types'
+import { buildAppStubHtml } from '@/resources/ui-apps'
+import { UI_APPS } from '@/resources/ui-apps.generated'
 import type { Env } from '@/tools/types'
+
+import type { RedisLike } from './cache/RedisCache'
+import { SharedBlobCache } from './cache/SharedBlobCache'
 
 export class ResourceCatalog {
     private readonly env: Env
+    private readonly archiveLoader: ArchiveLoader | undefined
 
     private resources: Resource[] = []
     private resourcesByUri = new Map<string, TextResourceContents>()
@@ -33,8 +38,9 @@ export class ResourceCatalog {
     private allResources: Resource[] = []
     private contextMillData: readonly ContextMillResource[] = []
 
-    constructor(env: Env) {
+    constructor(env: Env, redis?: RedisLike) {
         this.env = env
+        this.archiveLoader = redis ? buildSharedArchiveLoader(redis) : undefined
     }
 
     get contextMillEntries(): readonly ContextMillResource[] {
@@ -83,7 +89,7 @@ export class ResourceCatalog {
 
     private async warmupResources(): Promise<void> {
         try {
-            const archive = await fetchContextMillResources()
+            const archive = await fetchContextMillResources(undefined, this.archiveLoader)
             const manifest = loadManifestFromArchive(archive)
             this.contextMillData = filterValidEntries(manifest.resources, archive)
             clearResourceCache()
@@ -154,4 +160,17 @@ export class ResourceCatalog {
             })
         }
     }
+}
+
+function buildSharedArchiveLoader(redis: RedisLike): ArchiveLoader {
+    const cache = new SharedBlobCache(redis, 'context-mill:archive')
+    return async (url) =>
+        cache.fetch(async () => {
+            const response = await fetch(url)
+            if (!response.ok) {
+                throw new Error(`Failed to fetch context-mill resources from ${url}: ${response.statusText}`)
+            }
+            const buffer = await response.arrayBuffer()
+            return new Uint8Array(buffer)
+        })
 }

--- a/services/mcp/src/hono/resource-catalog.ts
+++ b/services/mcp/src/hono/resource-catalog.ts
@@ -29,7 +29,6 @@ export class ResourceCatalog {
     private uiAppReadEntries = new Map<string, TextResourceContents>()
     private allResources: Resource[] = []
     private contextMillEntriesByUri = new Map<string, SlimManifestEntry>()
-    private contextMillGen: string | undefined
 
     constructor(env: Env, redis?: RedisLike) {
         this.env = env
@@ -66,17 +65,15 @@ export class ResourceCatalog {
         }
 
         const slimEntry = this.contextMillEntriesByUri.get(uri)
-        if (!slimEntry || !this.contextMillCache || !this.contextMillGen) {
+        if (!slimEntry || !this.contextMillCache) {
             return { contents: [] }
         }
-        const body = await this.contextMillCache.readBody(uri, this.contextMillGen)
+        const body = await this.contextMillCache.readBody(uri)
         if (!body) {
-            // Eviction, partial state, or generation drift. Invalidate the
-            // slim manifest so the background refresh actually re-fetches
-            // upstream (a plain refresh would short-circuit on the still-fresh
-            // manifest), and let subsequent requests resolve once the new
-            // generation is published.
-            void this.contextMillCache.invalidate().then(() => this.refreshContextMill())
+            // Body has aged out (resource removed upstream + TTL elapsed) or
+            // was evicted. Ack the removal and let the slim manifest catch up
+            // on the next natural refresh; the client's context window has
+            // already cached what it needs from the prior resources/list.
             return { contents: [] }
         }
         return {
@@ -123,7 +120,6 @@ export class ResourceCatalog {
             })
         }
         this.contextMillEntriesByUri = nextEntriesByUri
-        this.contextMillGen = slim.gen
         this.resources = nextResources
         this.allResources = [...this.resources, ...this.uiAppResources]
     }

--- a/services/mcp/src/hono/resource-catalog.ts
+++ b/services/mcp/src/hono/resource-catalog.ts
@@ -14,8 +14,19 @@ import { buildAppStubHtml } from '@/resources/ui-apps'
 import { UI_APPS } from '@/resources/ui-apps.generated'
 import type { Env } from '@/tools/types'
 
-import { ContextMillResourceCache, type SlimManifestEntry } from './cache/ContextMillResourceCache'
+import {
+    ContextMillResourceCache,
+    type ContextMillCacheResult,
+    type SlimManifestEntry,
+} from './cache/ContextMillResourceCache'
 import type { RedisLike } from './cache/RedisCache'
+import {
+    contextMillManifestEntries,
+    contextMillRevalidationDurationSeconds,
+    contextMillRevalidationsTotal,
+} from './metrics'
+
+export type ContextMillRevalidationSource = 'warmup' | 'initialize'
 
 export class ResourceCatalog {
     private readonly env: Env
@@ -37,6 +48,19 @@ export class ResourceCatalog {
 
     get contextMillEntries(): readonly SlimManifestEntry[] {
         return Array.from(this.contextMillEntriesByUri.values())
+    }
+
+    async revalidateContextMillResources(source: ContextMillRevalidationSource): Promise<void> {
+        const stop = contextMillRevalidationDurationSeconds.startTimer({ source })
+        try {
+            const result = await this.refreshContextMill()
+            contextMillRevalidationsTotal.inc({ source, status: 'success', result })
+            stop({ source, status: 'success' })
+        } catch (error) {
+            contextMillRevalidationsTotal.inc({ source, status: 'error', result: 'error' })
+            stop({ source, status: 'error' })
+            console.error('[ResourceCatalog] Failed to revalidate context-mill resources:', error)
+        }
     }
 
     async warmup(): Promise<void> {
@@ -100,8 +124,8 @@ export class ResourceCatalog {
         return { messages: entry.messages }
     }
 
-    private async refreshContextMill(): Promise<void> {
-        const slim = await this.contextMillCache.loadOrRefresh()
+    private async refreshContextMill(): Promise<ContextMillCacheResult> {
+        const { manifest: slim, result } = await this.contextMillCache.loadOrRefresh()
 
         const nextEntriesByUri = new Map<string, SlimManifestEntry>()
         const nextResources: Resource[] = []
@@ -117,6 +141,8 @@ export class ResourceCatalog {
         this.contextMillEntriesByUri = nextEntriesByUri
         this.resources = nextResources
         this.allResources = [...this.resources, ...this.uiAppResources]
+        contextMillManifestEntries.set(slim.entries.length)
+        return result
     }
 
     private contextMillLocalUrl(): string | undefined {
@@ -125,11 +151,7 @@ export class ResourceCatalog {
     }
 
     private async warmupResources(): Promise<void> {
-        try {
-            await this.refreshContextMill()
-        } catch (error) {
-            console.error('[ResourceCatalog] Failed to pre-load context-mill resources:', error)
-        }
+        await this.revalidateContextMillResources('warmup')
 
         try {
             const manifestPrompts = await getPromptsFromManifest()

--- a/services/mcp/src/resources/internals.ts
+++ b/services/mcp/src/resources/internals.ts
@@ -68,3 +68,17 @@ export function filterValidEntries(entries: readonly ContextMillResource[], arch
 export function clearResourceCache(): void {
     cachedResources = null
 }
+
+/**
+ * Fetch + unzip + parse the context-mill manifest, returning the filtered
+ * entries. Does not touch the module-level `cachedResources`; used by the
+ * hono runtime to push entries into a Redis-sharded cache without retaining
+ * the archive in process memory.
+ */
+export async function fetchAndExtractEntries(localUrl?: string): Promise<ContextMillResource[]> {
+    const url = localUrl || CONTEXT_MILL_URL
+    const bytes = await defaultArchiveLoader(url, Boolean(localUrl))
+    const archive = unzipSync(bytes)
+    const manifest = loadManifestFromArchive(archive)
+    return filterValidEntries(manifest.resources, archive)
+}

--- a/services/mcp/src/resources/internals.ts
+++ b/services/mcp/src/resources/internals.ts
@@ -1,27 +1,43 @@
 import { type Unzipped, strFromU8, unzipSync } from 'fflate'
 
-import type { ContextMillManifest, ContextMillResource } from './manifest-types'
 import { loadContextMillManifest } from './manifest-loader'
+import type { ContextMillManifest, ContextMillResource } from './manifest-types'
 
 const CONTEXT_MILL_URL = 'https://github.com/PostHog/context-mill/releases/latest/download/skills-mcp-resources.zip'
 
 let cachedResources: Unzipped | null = null
 
-export async function fetchContextMillResources(localUrl?: string): Promise<Unzipped> {
+export type ArchiveLoader = (url: string) => Promise<Uint8Array>
+
+async function defaultArchiveLoader(url: string, noStore: boolean): Promise<Uint8Array> {
+    const response = await fetch(url, noStore ? { cache: 'no-store' } : {})
+    if (!response.ok) {
+        throw new Error(`Failed to fetch context-mill resources from ${url}: ${response.statusText}`)
+    }
+    const arrayBuffer = await response.arrayBuffer()
+    return new Uint8Array(arrayBuffer)
+}
+
+/**
+ * Fetches and caches the context-mill resources ZIP.
+ *
+ * When `archiveLoader` is provided (hono runtime), the upstream fetch is
+ * delegated to it so multiple instances share a Redis-backed cache with
+ * single-writer coordination. The in-memory `cachedResources` still acts
+ * as a per-process fast path on top of that layer.
+ *
+ * `localUrl` (`POSTHOG_MCP_LOCAL_SKILLS_URL`) always bypasses both caches.
+ */
+export async function fetchContextMillResources(localUrl?: string, archiveLoader?: ArchiveLoader): Promise<Unzipped> {
     const url = localUrl || CONTEXT_MILL_URL
 
     if (cachedResources && !localUrl) {
         return cachedResources
     }
 
-    const response = await fetch(url, localUrl ? { cache: 'no-store' } : {})
-    if (!response.ok) {
-        throw new Error(`Failed to fetch context-mill resources from ${url}: ${response.statusText}`)
-    }
-
-    const arrayBuffer = await response.arrayBuffer()
-    const uint8Array = new Uint8Array(arrayBuffer)
-    const unzipped = unzipSync(uint8Array)
+    const bytes =
+        !localUrl && archiveLoader ? await archiveLoader(url) : await defaultArchiveLoader(url, Boolean(localUrl))
+    const unzipped = unzipSync(bytes)
 
     if (!localUrl) {
         cachedResources = unzipped

--- a/services/mcp/tests/hono/context-mill-resource-cache.test.ts
+++ b/services/mcp/tests/hono/context-mill-resource-cache.test.ts
@@ -1,11 +1,31 @@
 import { createHash } from 'node:crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ContextMillResourceCache } from '@/hono/cache/ContextMillResourceCache'
+import { ContextMillResourceCache, type ContextMillResourceCacheOptions } from '@/hono/cache/ContextMillResourceCache'
 import type { RedisLike } from '@/hono/cache/RedisCache'
 import type { ContextMillResource } from '@/resources/manifest-types'
 
 import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
+
+type EntryLoader = () => Promise<ContextMillResource[]>
+
+class TestContextMillResourceCache extends ContextMillResourceCache {
+    constructor(
+        redis: RedisLike,
+        private loader: EntryLoader,
+        opts?: ContextMillResourceCacheOptions
+    ) {
+        super(redis, opts)
+    }
+
+    setLoader(loader: EntryLoader): void {
+        this.loader = loader
+    }
+
+    protected override loadEntries(): Promise<ContextMillResource[]> {
+        return this.loader()
+    }
+}
 
 interface MockRedis extends RedisLike {
     _store: Map<string, string>
@@ -72,11 +92,11 @@ describe('ContextMillResourceCache', () => {
     })
 
     it('writes every body before publishing the slim manifest on cold load', async () => {
-        const cache = new ContextMillResourceCache(redis)
         const entries = [makeEntry('a'), makeEntry('b'), makeEntry('c')]
         const upstream = vi.fn(async () => entries)
+        const cache = new TestContextMillResourceCache(redis, upstream)
 
-        const slim = await cache.loadOrRefresh(upstream)
+        const slim = await cache.loadOrRefresh()
 
         expect(upstream).toHaveBeenCalledTimes(1)
         expect(slim.entries).toHaveLength(3)
@@ -95,38 +115,39 @@ describe('ContextMillResourceCache', () => {
     })
 
     it('serves manifest from cache on warm hit without calling upstream', async () => {
-        const cache = new ContextMillResourceCache(redis)
         const entries = [makeEntry('a')]
-        await cache.loadOrRefresh(async () => entries)
+        const cache = new TestContextMillResourceCache(redis, async () => entries)
+        await cache.loadOrRefresh()
 
         const upstream = vi.fn(async () => [makeEntry('z')])
-        const slim = await cache.loadOrRefresh(upstream)
+        cache.setLoader(upstream)
+        const slim = await cache.loadOrRefresh()
 
         expect(upstream).not.toHaveBeenCalled()
         expect(slim.entries[0]!.uri).toBe(entries[0]!.uri)
     })
 
     it('reads a body by uri', async () => {
-        const cache = new ContextMillResourceCache(redis)
         const entry = makeEntry('a')
-        await cache.loadOrRefresh(async () => [entry])
+        const cache = new TestContextMillResourceCache(redis, async () => [entry])
+        await cache.loadOrRefresh()
 
         const body = await cache.readBody(entry.uri)
         expect(body).toEqual({ mimeType: 'text/markdown', text: '# body a' })
     })
 
     it('returns null when the body is missing entirely', async () => {
-        const cache = new ContextMillResourceCache(redis)
-        await cache.loadOrRefresh(async () => [makeEntry('a')])
+        const cache = new TestContextMillResourceCache(redis, async () => [makeEntry('a')])
+        await cache.loadOrRefresh()
 
         const body = await cache.readBody('posthog://skill/never-published')
         expect(body).toBeNull()
     })
 
     it('overwrites bodies in place so the latest publish is served immediately', async () => {
-        const cache = new ContextMillResourceCache(redis)
+        const cache = new TestContextMillResourceCache(redis, async () => [makeEntry('a', 'old content')])
 
-        await cache.loadOrRefresh(async () => [makeEntry('a', 'old content')])
+        await cache.loadOrRefresh()
         const beforeRefresh = await cache.readBody('posthog://skill/a')
         expect(beforeRefresh!.text).toBe('old content')
 
@@ -134,17 +155,18 @@ describe('ContextMillResourceCache', () => {
         // bodies, the new value lands at the same Redis key — readers see
         // the update on the next GET, no gen check or in-memory refresh
         // required. Invalidate first so the publish actually runs upstream
-        // (otherwise SharedBlobCache short-circuits on a fresh manifest).
+        // (otherwise ContextMillResourceCache short-circuits on a fresh manifest).
         await cache.invalidate()
-        await cache.loadOrRefresh(async () => [makeEntry('a', 'new content')])
+        cache.setLoader(async () => [makeEntry('a', 'new content')])
+        await cache.loadOrRefresh()
         const afterRefresh = await cache.readBody('posthog://skill/a')
         expect(afterRefresh!.text).toBe('new content')
     })
 
     it('leaves removed-upstream bodies in place to age out via TTL', async () => {
-        const cache = new ContextMillResourceCache(redis)
+        const cache = new TestContextMillResourceCache(redis, async () => [makeEntry('keeper'), makeEntry('removed')])
 
-        await cache.loadOrRefresh(async () => [makeEntry('keeper'), makeEntry('removed')])
+        await cache.loadOrRefresh()
 
         const removedBodyKey = bodyKey('posthog://skill/removed')
         expect(redis._store.has(removedBodyKey)).toBe(true)
@@ -153,7 +175,8 @@ describe('ContextMillResourceCache', () => {
         // body — clients holding the old URI can still resolve it until the
         // TTL expires naturally.
         await cache.invalidate()
-        await cache.loadOrRefresh(async () => [makeEntry('keeper')])
+        cache.setLoader(async () => [makeEntry('keeper')])
+        await cache.loadOrRefresh()
 
         expect(redis._store.has(removedBodyKey)).toBe(true)
         const orphanedBody = await cache.readBody('posthog://skill/removed')
@@ -161,7 +184,6 @@ describe('ContextMillResourceCache', () => {
     })
 
     it('only one writer fetches upstream when many callers race on cold cache', async () => {
-        const cache = new ContextMillResourceCache(redis, { waitIntervalMs: 5, waitTimeoutMs: 200 })
         const entries = [makeEntry('a')]
         let inFlight = 0
         let peak = 0
@@ -172,22 +194,46 @@ describe('ContextMillResourceCache', () => {
             inFlight -= 1
             return entries
         })
+        const cache = new TestContextMillResourceCache(redis, upstream, { waitIntervalMs: 5, waitTimeoutMs: 200 })
 
         const concurrency = 5
-        const results = await Promise.all(Array.from({ length: concurrency }, () => cache.loadOrRefresh(upstream)))
+        const results = await Promise.all(Array.from({ length: concurrency }, () => cache.loadOrRefresh()))
 
         expect(peak).toBe(1)
+        expect(upstream).toHaveBeenCalledTimes(1)
         // Every caller observes the published slim manifest.
         expect(results.every((r) => r.entries[0]!.uri === entries[0]!.uri)).toBe(true)
     })
 
-    it('serves stale manifest and triggers a background republish', async () => {
-        const cache = new ContextMillResourceCache(redis, {
-            freshSeconds: 0,
+    it('non-writers wait for the lock holder to publish and serve that result', async () => {
+        const entries = [makeEntry('waited')]
+        let resolveUpstream: ((entries: ContextMillResource[]) => void) | undefined
+        const upstreamPromise = new Promise<ContextMillResource[]>((resolve) => {
+            resolveUpstream = resolve
+        })
+        const upstream = vi.fn(() => upstreamPromise)
+        const cache = new TestContextMillResourceCache(redis, upstream, {
             waitIntervalMs: 5,
-            waitTimeoutMs: 100,
+            waitTimeoutMs: 1000,
         })
 
+        // First call wins the lock and stalls in upstream.
+        const writerResult = cache.loadOrRefresh()
+        // Give the writer time to seize the lock before the waiter starts.
+        await new Promise((r) => setTimeout(r, 10))
+        const waiterResult = cache.loadOrRefresh()
+
+        // Publish the upstream after both calls are in flight.
+        await new Promise((r) => setTimeout(r, 30))
+        resolveUpstream!(entries)
+
+        const [writerSlim, waiterSlim] = await Promise.all([writerResult, waiterResult])
+        expect(writerSlim.entries[0]!.uri).toBe(entries[0]!.uri)
+        expect(waiterSlim.entries[0]!.uri).toBe(entries[0]!.uri)
+        expect(upstream).toHaveBeenCalledTimes(1)
+    })
+
+    it('serves stale manifest and triggers a background republish', async () => {
         const initial = [makeEntry('a')]
         const refreshed = [makeEntry('a'), makeEntry('b')]
         let call = 0
@@ -195,24 +241,42 @@ describe('ContextMillResourceCache', () => {
             call += 1
             return call === 1 ? initial : refreshed
         })
+        const cache = new TestContextMillResourceCache(redis, upstream, {
+            freshSeconds: 0,
+            waitIntervalMs: 5,
+            waitTimeoutMs: 100,
+        })
 
-        const first = await cache.loadOrRefresh(upstream)
+        const first = await cache.loadOrRefresh()
         expect(first.entries).toHaveLength(1)
 
         // Stale read returns the cached manifest and kicks off a background refresh.
-        const second = await cache.loadOrRefresh(upstream)
+        const second = await cache.loadOrRefresh()
         expect(second.entries).toHaveLength(1)
 
         // Allow the background refresh to settle.
         await new Promise((r) => setTimeout(r, 30))
 
-        const third = await cache.loadOrRefresh(upstream)
+        const third = await cache.loadOrRefresh()
         expect(third.entries).toHaveLength(2)
     })
 
+    it('falls back to a direct load when the writer never publishes', async () => {
+        redis._store.set(MANIFEST_LOCK_KEY, 'someone-else')
+        const entries = [makeEntry('fallback')]
+        const upstream = vi.fn(async () => entries)
+        const cache = new TestContextMillResourceCache(redis, upstream, { waitIntervalMs: 10, waitTimeoutMs: 50 })
+
+        const slim = await cache.loadOrRefresh()
+
+        expect(slim.entries[0]!.uri).toBe(entries[0]!.uri)
+        expect(upstream).toHaveBeenCalledTimes(1)
+        expect(redis._store.has(MANIFEST_BYTES_KEY)).toBe(false)
+    })
+
     it('does not leave the manifest lock held after a successful publish', async () => {
-        const cache = new ContextMillResourceCache(redis)
-        await cache.loadOrRefresh(async () => [makeEntry('a')])
+        const cache = new TestContextMillResourceCache(redis, async () => [makeEntry('a')])
+        await cache.loadOrRefresh()
         expect(redis._store.has(MANIFEST_LOCK_KEY)).toBe(false)
         expect(redis._store.has(MANIFEST_FRESH_KEY)).toBe(true)
     })

--- a/services/mcp/tests/hono/context-mill-resource-cache.test.ts
+++ b/services/mcp/tests/hono/context-mill-resource-cache.test.ts
@@ -1,6 +1,16 @@
 import { createHash } from 'node:crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { mockBodyReadsInc, mockCacheEventsInc } = vi.hoisted(() => ({
+    mockBodyReadsInc: vi.fn(),
+    mockCacheEventsInc: vi.fn(),
+}))
+
+vi.mock('@/hono/metrics', () => ({
+    contextMillBodyReadsTotal: { inc: mockBodyReadsInc },
+    contextMillCacheEventsTotal: { inc: mockCacheEventsInc },
+}))
+
 import { ContextMillResourceCache, type ContextMillResourceCacheOptions } from '@/hono/cache/ContextMillResourceCache'
 import type { RedisLike } from '@/hono/cache/RedisCache'
 import type { ContextMillResource } from '@/resources/manifest-types'
@@ -88,6 +98,8 @@ describe('ContextMillResourceCache', () => {
     let redis: MockRedis
 
     beforeEach(() => {
+        mockBodyReadsInc.mockClear()
+        mockCacheEventsInc.mockClear()
         redis = createMockRedis()
     })
 
@@ -96,9 +108,10 @@ describe('ContextMillResourceCache', () => {
         const upstream = vi.fn(async () => entries)
         const cache = new TestContextMillResourceCache(redis, upstream)
 
-        const slim = await cache.loadOrRefresh()
+        const { manifest: slim, result } = await cache.loadOrRefresh()
 
         expect(upstream).toHaveBeenCalledTimes(1)
+        expect(result).toBe('cold_refresh')
         expect(slim.entries).toHaveLength(3)
         // Manifest exposes slim metadata only (no text).
         expect(slim.entries.map((e) => e.uri).sort()).toEqual(entries.map((e) => e.uri).sort())
@@ -112,6 +125,8 @@ describe('ContextMillResourceCache', () => {
             expect(bodyIdx).toBeGreaterThan(-1)
             expect(bodyIdx).toBeLessThan(manifestIdx)
         }
+        expect(mockCacheEventsInc).toHaveBeenCalledWith({ event: 'cold_miss' })
+        expect(mockCacheEventsInc).toHaveBeenCalledWith({ event: 'lock_acquired' })
     })
 
     it('serves manifest from cache on warm hit without calling upstream', async () => {
@@ -121,10 +136,12 @@ describe('ContextMillResourceCache', () => {
 
         const upstream = vi.fn(async () => [makeEntry('z')])
         cache.setLoader(upstream)
-        const slim = await cache.loadOrRefresh()
+        const { manifest: slim, result } = await cache.loadOrRefresh()
 
         expect(upstream).not.toHaveBeenCalled()
+        expect(result).toBe('fresh_hit')
         expect(slim.entries[0]!.uri).toBe(entries[0]!.uri)
+        expect(mockCacheEventsInc).toHaveBeenCalledWith({ event: 'fresh_hit' })
     })
 
     it('reads a body by uri', async () => {
@@ -134,6 +151,7 @@ describe('ContextMillResourceCache', () => {
 
         const body = await cache.readBody(entry.uri)
         expect(body).toEqual({ mimeType: 'text/markdown', text: '# body a' })
+        expect(mockBodyReadsInc).toHaveBeenCalledWith({ status: 'hit' })
     })
 
     it('returns null when the body is missing entirely', async () => {
@@ -142,6 +160,17 @@ describe('ContextMillResourceCache', () => {
 
         const body = await cache.readBody('posthog://skill/never-published')
         expect(body).toBeNull()
+        expect(mockBodyReadsInc).toHaveBeenCalledWith({ status: 'miss' })
+    })
+
+    it('records parse errors when a body is corrupt', async () => {
+        const cache = new TestContextMillResourceCache(redis, async () => [makeEntry('a')])
+        await cache.loadOrRefresh()
+        redis._store.set(bodyKey('posthog://skill/a'), '{')
+
+        await expect(cache.readBody('posthog://skill/a')).rejects.toThrow()
+
+        expect(mockBodyReadsInc).toHaveBeenCalledWith({ status: 'parse_error' })
     })
 
     it('overwrites bodies in place so the latest publish is served immediately', async () => {
@@ -202,7 +231,10 @@ describe('ContextMillResourceCache', () => {
         expect(peak).toBe(1)
         expect(upstream).toHaveBeenCalledTimes(1)
         // Every caller observes the published slim manifest.
-        expect(results.every((r) => r.entries[0]!.uri === entries[0]!.uri)).toBe(true)
+        expect(results.every((r) => r.manifest.entries[0]!.uri === entries[0]!.uri)).toBe(true)
+        expect(results.some((r) => r.result === 'waited')).toBe(true)
+        expect(mockCacheEventsInc).toHaveBeenCalledWith({ event: 'lock_contended' })
+        expect(mockCacheEventsInc).toHaveBeenCalledWith({ event: 'wait_success' })
     })
 
     it('non-writers wait for the lock holder to publish and serve that result', async () => {
@@ -227,9 +259,11 @@ describe('ContextMillResourceCache', () => {
         await new Promise((r) => setTimeout(r, 30))
         resolveUpstream!(entries)
 
-        const [writerSlim, waiterSlim] = await Promise.all([writerResult, waiterResult])
-        expect(writerSlim.entries[0]!.uri).toBe(entries[0]!.uri)
-        expect(waiterSlim.entries[0]!.uri).toBe(entries[0]!.uri)
+        const [writerResultPayload, waiterResultPayload] = await Promise.all([writerResult, waiterResult])
+        expect(writerResultPayload.manifest.entries[0]!.uri).toBe(entries[0]!.uri)
+        expect(waiterResultPayload.manifest.entries[0]!.uri).toBe(entries[0]!.uri)
+        expect(writerResultPayload.result).toBe('cold_refresh')
+        expect(waiterResultPayload.result).toBe('waited')
         expect(upstream).toHaveBeenCalledTimes(1)
     })
 
@@ -248,17 +282,41 @@ describe('ContextMillResourceCache', () => {
         })
 
         const first = await cache.loadOrRefresh()
-        expect(first.entries).toHaveLength(1)
+        expect(first.manifest.entries).toHaveLength(1)
 
         // Stale read returns the cached manifest and kicks off a background refresh.
         const second = await cache.loadOrRefresh()
-        expect(second.entries).toHaveLength(1)
+        expect(second.manifest.entries).toHaveLength(1)
+        expect(second.result).toBe('stale_hit')
 
         // Allow the background refresh to settle.
         await new Promise((r) => setTimeout(r, 30))
+        expect(mockCacheEventsInc).toHaveBeenCalledWith({ event: 'background_success' })
 
         const third = await cache.loadOrRefresh()
-        expect(third.entries).toHaveLength(2)
+        expect(third.manifest.entries).toHaveLength(2)
+    })
+
+    it('records background refresh errors', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+        try {
+            const cache = new TestContextMillResourceCache(redis, async () => [makeEntry('a')], {
+                freshSeconds: 0,
+                waitIntervalMs: 5,
+                waitTimeoutMs: 100,
+            })
+            await cache.loadOrRefresh()
+            cache.setLoader(async () => {
+                throw new Error('refresh failed')
+            })
+
+            await cache.loadOrRefresh()
+            await new Promise((r) => setTimeout(r, 30))
+
+            expect(mockCacheEventsInc).toHaveBeenCalledWith({ event: 'background_error' })
+        } finally {
+            consoleError.mockRestore()
+        }
     })
 
     it('falls back to a direct load when the writer never publishes', async () => {
@@ -267,11 +325,13 @@ describe('ContextMillResourceCache', () => {
         const upstream = vi.fn(async () => entries)
         const cache = new TestContextMillResourceCache(redis, upstream, { waitIntervalMs: 10, waitTimeoutMs: 50 })
 
-        const slim = await cache.loadOrRefresh()
+        const { manifest: slim, result } = await cache.loadOrRefresh()
 
         expect(slim.entries[0]!.uri).toBe(entries[0]!.uri)
+        expect(result).toBe('fallback')
         expect(upstream).toHaveBeenCalledTimes(1)
         expect(redis._store.has(MANIFEST_BYTES_KEY)).toBe(false)
+        expect(mockCacheEventsInc).toHaveBeenCalledWith({ event: 'wait_timeout' })
     })
 
     it('does not leave the manifest lock held after a successful publish', async () => {

--- a/services/mcp/tests/hono/context-mill-resource-cache.test.ts
+++ b/services/mcp/tests/hono/context-mill-resource-cache.test.ts
@@ -1,0 +1,192 @@
+import { createHash } from 'node:crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ContextMillResourceCache } from '@/hono/cache/ContextMillResourceCache'
+import type { RedisLike } from '@/hono/cache/RedisCache'
+import type { ContextMillResource } from '@/resources/manifest-types'
+
+import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
+
+interface MockRedis extends RedisLike {
+    _store: Map<string, string>
+    _setCalls: string[]
+}
+
+function createMockRedis(): MockRedis {
+    const store = new Map<string, string>()
+    const setCalls: string[] = []
+    return {
+        get: vi.fn(async (key: string) => store.get(key) ?? null),
+        set: vi.fn(async (key: string, value: string, ...args: (string | number)[]) => {
+            setCalls.push(key)
+            const isNx = args.includes('NX')
+            if (isNx && store.has(key)) {
+                return null
+            }
+            store.set(key, value)
+            return 'OK'
+        }),
+        del: vi.fn(async (...keys: string[]) => {
+            let count = 0
+            for (const k of keys) {
+                if (store.delete(k)) {
+                    count++
+                }
+            }
+            return count
+        }),
+        scan: vi.fn(async () => ['0', []] as [string, string[]]),
+        ...makeRedisRateLimitStubs(),
+        _store: store,
+        _setCalls: setCalls,
+    }
+}
+
+const MANIFEST_BYTES_KEY = 'mcp:shared-blob:context-mill:manifest:bytes'
+const MANIFEST_FRESH_KEY = 'mcp:shared-blob:context-mill:manifest:fresh'
+const MANIFEST_LOCK_KEY = 'mcp:shared-blob:context-mill:manifest:lock'
+
+function bodyKey(uri: string, gen: string): string {
+    const hash = createHash('sha256').update(uri).digest('hex')
+    return `mcp:shared-blob:context-mill:body:${gen}:${hash}`
+}
+
+function makeEntry(suffix: string): ContextMillResource {
+    return {
+        id: `entry-${suffix}`,
+        name: `name-${suffix}`,
+        uri: `posthog://skill/${suffix}`,
+        resource: {
+            mimeType: 'text/markdown',
+            description: `desc-${suffix}`,
+            text: `# body ${suffix}`,
+        },
+    }
+}
+
+describe('ContextMillResourceCache', () => {
+    let redis: MockRedis
+
+    beforeEach(() => {
+        redis = createMockRedis()
+    })
+
+    it('writes every body before publishing the slim manifest on cold load', async () => {
+        const cache = new ContextMillResourceCache(redis)
+        const entries = [makeEntry('a'), makeEntry('b'), makeEntry('c')]
+        const upstream = vi.fn(async () => entries)
+
+        const slim = await cache.loadOrRefresh(upstream)
+
+        expect(upstream).toHaveBeenCalledTimes(1)
+        expect(slim.entries).toHaveLength(3)
+        // Manifest exposes slim metadata only (no text).
+        expect(slim.entries.map((e) => e.uri).sort()).toEqual(entries.map((e) => e.uri).sort())
+        expect(slim.entries[0]).not.toHaveProperty('text')
+
+        // Body keys must land before the manifest bytes key in Redis writes.
+        const manifestIdx = redis._setCalls.indexOf(MANIFEST_BYTES_KEY)
+        expect(manifestIdx).toBeGreaterThan(-1)
+        for (const e of entries) {
+            const bodyIdx = redis._setCalls.indexOf(bodyKey(e.uri, slim.gen))
+            expect(bodyIdx).toBeGreaterThan(-1)
+            expect(bodyIdx).toBeLessThan(manifestIdx)
+        }
+    })
+
+    it('serves manifest from cache on warm hit without calling upstream', async () => {
+        const cache = new ContextMillResourceCache(redis)
+        const entries = [makeEntry('a')]
+        await cache.loadOrRefresh(async () => entries)
+
+        const upstream = vi.fn(async () => [makeEntry('z')])
+        const slim = await cache.loadOrRefresh(upstream)
+
+        expect(upstream).not.toHaveBeenCalled()
+        expect(slim.entries[0]!.uri).toBe(entries[0]!.uri)
+    })
+
+    it('reads a body by uri + gen', async () => {
+        const cache = new ContextMillResourceCache(redis)
+        const entry = makeEntry('a')
+        const slim = await cache.loadOrRefresh(async () => [entry])
+
+        const body = await cache.readBody(entry.uri, slim.gen)
+        expect(body).toEqual({ mimeType: 'text/markdown', text: '# body a' })
+    })
+
+    it('returns null when the body gen does not match', async () => {
+        const cache = new ContextMillResourceCache(redis)
+        const entry = makeEntry('a')
+        const slim = await cache.loadOrRefresh(async () => [entry])
+
+        const body = await cache.readBody(entry.uri, `${slim.gen}-stale`)
+        expect(body).toBeNull()
+    })
+
+    it('returns null when the body is missing entirely', async () => {
+        const cache = new ContextMillResourceCache(redis)
+        const slim = await cache.loadOrRefresh(async () => [makeEntry('a')])
+
+        const body = await cache.readBody('posthog://skill/never-published', slim.gen)
+        expect(body).toBeNull()
+    })
+
+    it('only one writer fetches upstream when many callers race on cold cache', async () => {
+        const cache = new ContextMillResourceCache(redis, { waitIntervalMs: 5, waitTimeoutMs: 200 })
+        const entries = [makeEntry('a')]
+        let inFlight = 0
+        let peak = 0
+        const upstream = vi.fn(async () => {
+            inFlight += 1
+            peak = Math.max(peak, inFlight)
+            await new Promise((r) => setTimeout(r, 20))
+            inFlight -= 1
+            return entries
+        })
+
+        const concurrency = 5
+        const results = await Promise.all(Array.from({ length: concurrency }, () => cache.loadOrRefresh(upstream)))
+
+        expect(peak).toBe(1)
+        // Every caller observes the published slim manifest.
+        expect(results.every((r) => r.entries[0]!.uri === entries[0]!.uri)).toBe(true)
+    })
+
+    it('serves stale manifest and triggers a background republish with a fresh gen', async () => {
+        const cache = new ContextMillResourceCache(redis, {
+            freshSeconds: 0,
+            waitIntervalMs: 5,
+            waitTimeoutMs: 100,
+        })
+
+        const initial = [makeEntry('a')]
+        const refreshed = [makeEntry('a'), makeEntry('b')]
+        let call = 0
+        const upstream = vi.fn(async () => {
+            call += 1
+            return call === 1 ? initial : refreshed
+        })
+
+        const first = await cache.loadOrRefresh(upstream)
+        expect(first.entries).toHaveLength(1)
+
+        // Stale read returns the cached manifest and kicks off a background refresh.
+        const second = await cache.loadOrRefresh(upstream)
+        expect(second.entries).toHaveLength(1)
+
+        // Allow the background refresh to settle.
+        await new Promise((r) => setTimeout(r, 30))
+
+        const third = await cache.loadOrRefresh(upstream)
+        expect(third.entries).toHaveLength(2)
+        expect(third.gen).not.toBe(first.gen)
+    })
+
+    it('does not leave the manifest lock held after a successful publish', async () => {
+        const cache = new ContextMillResourceCache(redis)
+        await cache.loadOrRefresh(async () => [makeEntry('a')])
+        expect(redis._store.has(MANIFEST_LOCK_KEY)).toBe(false)
+        expect(redis._store.has(MANIFEST_FRESH_KEY)).toBe(true)
+    })
+})

--- a/services/mcp/tests/hono/context-mill-resource-cache.test.ts
+++ b/services/mcp/tests/hono/context-mill-resource-cache.test.ts
@@ -46,12 +46,12 @@ const MANIFEST_BYTES_KEY = 'mcp:shared-blob:context-mill:manifest:bytes'
 const MANIFEST_FRESH_KEY = 'mcp:shared-blob:context-mill:manifest:fresh'
 const MANIFEST_LOCK_KEY = 'mcp:shared-blob:context-mill:manifest:lock'
 
-function bodyKey(uri: string, gen: string): string {
+function bodyKey(uri: string): string {
     const hash = createHash('sha256').update(uri).digest('hex')
-    return `mcp:shared-blob:context-mill:body:${gen}:${hash}`
+    return `mcp:shared-blob:context-mill:body:${hash}`
 }
 
-function makeEntry(suffix: string): ContextMillResource {
+function makeEntry(suffix: string, text?: string): ContextMillResource {
     return {
         id: `entry-${suffix}`,
         name: `name-${suffix}`,
@@ -59,7 +59,7 @@ function makeEntry(suffix: string): ContextMillResource {
         resource: {
             mimeType: 'text/markdown',
             description: `desc-${suffix}`,
-            text: `# body ${suffix}`,
+            text: text ?? `# body ${suffix}`,
         },
     }
 }
@@ -88,7 +88,7 @@ describe('ContextMillResourceCache', () => {
         const manifestIdx = redis._setCalls.indexOf(MANIFEST_BYTES_KEY)
         expect(manifestIdx).toBeGreaterThan(-1)
         for (const e of entries) {
-            const bodyIdx = redis._setCalls.indexOf(bodyKey(e.uri, slim.gen))
+            const bodyIdx = redis._setCalls.indexOf(bodyKey(e.uri))
             expect(bodyIdx).toBeGreaterThan(-1)
             expect(bodyIdx).toBeLessThan(manifestIdx)
         }
@@ -106,30 +106,58 @@ describe('ContextMillResourceCache', () => {
         expect(slim.entries[0]!.uri).toBe(entries[0]!.uri)
     })
 
-    it('reads a body by uri + gen', async () => {
+    it('reads a body by uri', async () => {
         const cache = new ContextMillResourceCache(redis)
         const entry = makeEntry('a')
-        const slim = await cache.loadOrRefresh(async () => [entry])
+        await cache.loadOrRefresh(async () => [entry])
 
-        const body = await cache.readBody(entry.uri, slim.gen)
+        const body = await cache.readBody(entry.uri)
         expect(body).toEqual({ mimeType: 'text/markdown', text: '# body a' })
-    })
-
-    it('returns null when the body gen does not match', async () => {
-        const cache = new ContextMillResourceCache(redis)
-        const entry = makeEntry('a')
-        const slim = await cache.loadOrRefresh(async () => [entry])
-
-        const body = await cache.readBody(entry.uri, `${slim.gen}-stale`)
-        expect(body).toBeNull()
     })
 
     it('returns null when the body is missing entirely', async () => {
         const cache = new ContextMillResourceCache(redis)
-        const slim = await cache.loadOrRefresh(async () => [makeEntry('a')])
+        await cache.loadOrRefresh(async () => [makeEntry('a')])
 
-        const body = await cache.readBody('posthog://skill/never-published', slim.gen)
+        const body = await cache.readBody('posthog://skill/never-published')
         expect(body).toBeNull()
+    })
+
+    it('overwrites bodies in place so the latest publish is served immediately', async () => {
+        const cache = new ContextMillResourceCache(redis)
+
+        await cache.loadOrRefresh(async () => [makeEntry('a', 'old content')])
+        const beforeRefresh = await cache.readBody('posthog://skill/a')
+        expect(beforeRefresh!.text).toBe('old content')
+
+        // Second publish for the same URI with new content. With URI-keyed
+        // bodies, the new value lands at the same Redis key — readers see
+        // the update on the next GET, no gen check or in-memory refresh
+        // required. Invalidate first so the publish actually runs upstream
+        // (otherwise SharedBlobCache short-circuits on a fresh manifest).
+        await cache.invalidate()
+        await cache.loadOrRefresh(async () => [makeEntry('a', 'new content')])
+        const afterRefresh = await cache.readBody('posthog://skill/a')
+        expect(afterRefresh!.text).toBe('new content')
+    })
+
+    it('leaves removed-upstream bodies in place to age out via TTL', async () => {
+        const cache = new ContextMillResourceCache(redis)
+
+        await cache.loadOrRefresh(async () => [makeEntry('keeper'), makeEntry('removed')])
+
+        const removedBodyKey = bodyKey('posthog://skill/removed')
+        expect(redis._store.has(removedBodyKey)).toBe(true)
+
+        // Second publish drops one entry. We should NOT delete the removed
+        // body — clients holding the old URI can still resolve it until the
+        // TTL expires naturally.
+        await cache.invalidate()
+        await cache.loadOrRefresh(async () => [makeEntry('keeper')])
+
+        expect(redis._store.has(removedBodyKey)).toBe(true)
+        const orphanedBody = await cache.readBody('posthog://skill/removed')
+        expect(orphanedBody).not.toBeNull()
     })
 
     it('only one writer fetches upstream when many callers race on cold cache', async () => {
@@ -153,7 +181,7 @@ describe('ContextMillResourceCache', () => {
         expect(results.every((r) => r.entries[0]!.uri === entries[0]!.uri)).toBe(true)
     })
 
-    it('serves stale manifest and triggers a background republish with a fresh gen', async () => {
+    it('serves stale manifest and triggers a background republish', async () => {
         const cache = new ContextMillResourceCache(redis, {
             freshSeconds: 0,
             waitIntervalMs: 5,
@@ -180,7 +208,6 @@ describe('ContextMillResourceCache', () => {
 
         const third = await cache.loadOrRefresh(upstream)
         expect(third.entries).toHaveLength(2)
-        expect(third.gen).not.toBe(first.gen)
     })
 
     it('does not leave the manifest lock held after a successful publish', async () => {

--- a/services/mcp/tests/hono/dispatcher-init-revalidation.test.ts
+++ b/services/mcp/tests/hono/dispatcher-init-revalidation.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+    mockBuildInstructions,
+    mockInitDurationObserve,
+    mockInitTotalInc,
+    mockRevalidateContextMillResources,
+    mockResolveState,
+    mockTrackInitEvent,
+} = vi.hoisted(() => ({
+    mockBuildInstructions: vi.fn(),
+    mockInitDurationObserve: vi.fn(),
+    mockInitTotalInc: vi.fn(),
+    mockRevalidateContextMillResources: vi.fn(),
+    mockResolveState: vi.fn(),
+    mockTrackInitEvent: vi.fn(),
+}))
+
+vi.mock('@/hono/analytics', () => ({
+    trackInitEvent: mockTrackInitEvent,
+}))
+
+vi.mock('@/hono/instructions', () => ({
+    InstructionsBuilder: vi.fn().mockImplementation(() => ({
+        build: mockBuildInstructions,
+    })),
+}))
+
+vi.mock('@/hono/metrics', () => ({
+    initDurationSeconds: { observe: mockInitDurationObserve },
+    initTotal: { inc: mockInitTotalInc },
+}))
+
+vi.mock('@/hono/request-state-resolver', () => ({
+    RequestStateResolver: vi.fn().mockImplementation(() => ({
+        resolve: mockResolveState,
+    })),
+}))
+
+vi.mock('@/hono/resource-catalog', () => ({
+    ResourceCatalog: vi.fn().mockImplementation(() => ({
+        getPrompt: vi.fn(() => ({ messages: [] })),
+        getPromptsList: vi.fn(() => ({ prompts: [] })),
+        getResourcesList: vi.fn(() => ({ resources: [] })),
+        readResource: vi.fn(async () => ({ contents: [] })),
+        revalidateContextMillResources: mockRevalidateContextMillResources,
+        warmup: vi.fn(async () => {}),
+    })),
+}))
+
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js'
+
+import type { RedisLike } from '@/hono/cache/RedisCache'
+import { McpDispatcher } from '@/hono/dispatcher'
+import type { RequestProperties } from '@/lib/request-properties'
+
+import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
+
+function createMockRedis(): RedisLike {
+    const store = new Map<string, string>()
+    return {
+        get: vi.fn(async (key: string) => store.get(key) ?? null),
+        set: vi.fn(async (key: string, value: string) => {
+            store.set(key, value)
+            return 'OK'
+        }),
+        del: vi.fn(async (...keys: string[]) => {
+            let count = 0
+            for (const key of keys) {
+                if (store.delete(key)) {
+                    count++
+                }
+            }
+            return count
+        }),
+        scan: vi.fn(async () => ['0', []] as [string, string[]]),
+        ...makeRedisRateLimitStubs(),
+    }
+}
+
+function makeProps(): RequestProperties {
+    return {
+        apiToken: 'phx_test',
+        mcpClientName: 'test-client',
+        mcpClientVersion: '1.0.0',
+        mcpProtocolVersion: LATEST_PROTOCOL_VERSION,
+        requestStartTime: Date.now(),
+        transport: 'streamable-http',
+        userHash: 'test-user',
+    }
+}
+
+function makeInitializeRequest(): Request {
+    return new Request('https://mcp.test/mcp', {
+        body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'initialize',
+            params: {
+                capabilities: {},
+                clientInfo: { name: 'test-client', version: '1.0.0' },
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+            },
+        }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+    })
+}
+
+describe('McpDispatcher initialize resource revalidation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockBuildInstructions.mockResolvedValue('')
+        mockResolveState.mockResolvedValue({ distinctId: 'test-distinct-id' })
+        mockTrackInitEvent.mockResolvedValue(undefined)
+        mockRevalidateContextMillResources.mockResolvedValue(undefined)
+    })
+
+    it('awaits context-mill resource revalidation before returning initialize', async () => {
+        let resolveRevalidation: (() => void) | undefined
+        const revalidationPromise = new Promise<void>((resolve) => {
+            resolveRevalidation = resolve
+        })
+        mockRevalidateContextMillResources.mockReturnValueOnce(revalidationPromise)
+
+        const dispatcher = new McpDispatcher({} as any, createMockRedis())
+        const responsePromise = dispatcher.handleRequest(makeInitializeRequest(), makeProps())
+        let responseSettled = false
+        void responsePromise.then(() => {
+            responseSettled = true
+        })
+
+        await new Promise((resolve) => setTimeout(resolve, 0))
+
+        expect(mockRevalidateContextMillResources).toHaveBeenCalledWith('initialize')
+        expect(responseSettled).toBe(false)
+
+        resolveRevalidation!()
+        const response = await responsePromise
+        const body = (await response.json()) as any
+
+        expect(response.status).toBe(200)
+        expect(body.result.protocolVersion).toBe(LATEST_PROTOCOL_VERSION)
+        expect(mockBuildInstructions).toHaveBeenCalled()
+    })
+})

--- a/services/mcp/tests/hono/resource-catalog.test.ts
+++ b/services/mcp/tests/hono/resource-catalog.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/resources/internals', () => ({
-    fetchContextMillResources: vi.fn(),
-    filterValidEntries: vi.fn(),
-    loadManifestFromArchive: vi.fn(),
-    clearResourceCache: vi.fn(),
+    fetchAndExtractEntries: vi.fn(),
 }))
 
 vi.mock('@/resources', () => ({
@@ -14,44 +11,74 @@ vi.mock('@/resources', () => ({
 vi.mock('@/resources/ui-apps.generated', async (importOriginal) => importOriginal())
 vi.mock('@/resources/ui-apps', async (importOriginal) => importOriginal())
 
-import { fetchContextMillResources, filterValidEntries, loadManifestFromArchive } from '@/resources/internals'
-import { getPromptsFromManifest } from '@/resources'
+import type { RedisLike } from '@/hono/cache/RedisCache'
 import { ResourceCatalog } from '@/hono/resource-catalog'
+import { getPromptsFromManifest } from '@/resources'
+import { fetchAndExtractEntries } from '@/resources/internals'
+import type { ContextMillResource } from '@/resources/manifest-types'
+
+import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
 
 const mockEnv = {
     MCP_APPS_BASE_URL: 'https://apps.test',
     POSTHOG_MCP_APPS_ANALYTICS_BASE_URL: undefined,
 } as any
 
-function makeContextMillEntry(
-    name: string,
-    uri: string
-): { name: string; uri: string; resource: { mimeType: string; description: string; text: string } } {
+interface MockRedis extends RedisLike {
+    _store: Map<string, string>
+}
+
+function createMockRedis(): MockRedis {
+    const store = new Map<string, string>()
     return {
-        name,
-        uri,
+        get: vi.fn(async (key: string) => store.get(key) ?? null),
+        set: vi.fn(async (key: string, value: string, ...args: (string | number)[]) => {
+            const isNx = args.includes('NX')
+            if (isNx && store.has(key)) {
+                return null
+            }
+            store.set(key, value)
+            return 'OK'
+        }),
+        del: vi.fn(async (...keys: string[]) => {
+            let count = 0
+            for (const k of keys) {
+                if (store.delete(k)) {
+                    count++
+                }
+            }
+            return count
+        }),
+        scan: vi.fn(async () => ['0', []] as [string, string[]]),
+        ...makeRedisRateLimitStubs(),
+        _store: store,
+    }
+}
+
+function makeEntry(suffix: string): ContextMillResource {
+    return {
+        id: `id-${suffix}`,
+        name: `name-${suffix}`,
+        uri: `posthog://${suffix}`,
         resource: {
             mimeType: 'text/plain',
-            description: `${name} desc`,
-            text: `content of ${name}`,
+            description: `${suffix} desc`,
+            text: `content of ${suffix}`,
         },
     }
 }
 
 describe('ResourceCatalog', () => {
+    let redis: MockRedis
+
     beforeEach(() => {
         vi.clearAllMocks()
+        redis = createMockRedis()
     })
 
     describe('warmup and resource listing', () => {
-        it('serves resources and prompts after warmup', async () => {
-            const entries = [
-                makeContextMillEntry('guide', 'posthog://guide'),
-                makeContextMillEntry('faq', 'posthog://faq'),
-            ]
-            vi.mocked(fetchContextMillResources).mockResolvedValue('archive' as any)
-            vi.mocked(loadManifestFromArchive).mockReturnValue({ resources: [] } as any)
-            vi.mocked(filterValidEntries).mockReturnValue(entries as any)
+        it('serves slim metadata for context-mill resources after warmup', async () => {
+            vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('guide'), makeEntry('faq')])
             vi.mocked(getPromptsFromManifest).mockResolvedValue([
                 {
                     name: 'greet',
@@ -61,25 +88,38 @@ describe('ResourceCatalog', () => {
                 },
             ] as any)
 
-            const catalog = new ResourceCatalog(mockEnv)
+            const catalog = new ResourceCatalog(mockEnv, redis)
             await catalog.warmup()
 
             const { resources } = catalog.getResourcesList()
-            expect(resources.map((r) => r.name)).toContain('guide')
-            expect(resources.map((r) => r.name)).toContain('faq')
+            const names = resources.map((r) => r.name)
+            expect(names).toContain('name-guide')
+            expect(names).toContain('name-faq')
+            // List endpoint must not carry body text.
+            expect(resources.every((r) => !('text' in r))).toBe(true)
 
             const { prompts } = catalog.getPromptsList()
             expect(prompts).toHaveLength(1)
             expect(prompts[0]!.name).toBe('greet')
         })
 
-        it('pre-merges resource list so getResourcesList returns a stable array', async () => {
-            vi.mocked(fetchContextMillResources).mockResolvedValue('archive' as any)
-            vi.mocked(loadManifestFromArchive).mockReturnValue({ resources: [] } as any)
-            vi.mocked(filterValidEntries).mockReturnValue([makeContextMillEntry('a', 'posthog://a')] as any)
+        it('skips context-mill warmup when no redis is provided', async () => {
             vi.mocked(getPromptsFromManifest).mockResolvedValue([])
 
             const catalog = new ResourceCatalog(mockEnv)
+            await catalog.warmup()
+
+            const { resources } = catalog.getResourcesList()
+            // Only UI apps should be present; fetchAndExtractEntries must not run.
+            expect(vi.mocked(fetchAndExtractEntries)).not.toHaveBeenCalled()
+            expect(resources.every((r) => !r.name.startsWith('name-'))).toBe(true)
+        })
+
+        it('pre-merges resource list so getResourcesList returns a stable array', async () => {
+            vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('a')])
+            vi.mocked(getPromptsFromManifest).mockResolvedValue([])
+
+            const catalog = new ResourceCatalog(mockEnv, redis)
             await catalog.warmup()
 
             const list1 = catalog.getResourcesList().resources
@@ -89,39 +129,61 @@ describe('ResourceCatalog', () => {
     })
 
     describe('readResource', () => {
-        it('returns contents for a known URI', async () => {
-            vi.mocked(fetchContextMillResources).mockResolvedValue('archive' as any)
-            vi.mocked(loadManifestFromArchive).mockReturnValue({ resources: [] } as any)
-            vi.mocked(filterValidEntries).mockReturnValue([makeContextMillEntry('doc', 'posthog://doc')] as any)
+        it('lazy-loads a context-mill body from Redis on first read', async () => {
+            vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('doc')])
             vi.mocked(getPromptsFromManifest).mockResolvedValue([])
 
-            const catalog = new ResourceCatalog(mockEnv)
+            const catalog = new ResourceCatalog(mockEnv, redis)
             await catalog.warmup()
 
-            const result = catalog.readResource({ uri: 'posthog://doc' }) as any
+            const result = await catalog.readResource({ uri: 'posthog://doc' })
             expect(result.contents).toHaveLength(1)
-            expect(result.contents[0].text).toBe('content of doc')
+            const content = result.contents[0]! as { uri: string; text: string; mimeType: string }
+            expect(content.text).toBe('content of doc')
+            expect(content.uri).toBe('posthog://doc')
         })
 
         it('returns empty contents for unknown URI', async () => {
-            vi.mocked(fetchContextMillResources).mockResolvedValue('archive' as any)
-            vi.mocked(loadManifestFromArchive).mockReturnValue({ resources: [] } as any)
-            vi.mocked(filterValidEntries).mockReturnValue([])
+            vi.mocked(fetchAndExtractEntries).mockResolvedValue([])
             vi.mocked(getPromptsFromManifest).mockResolvedValue([])
 
-            const catalog = new ResourceCatalog(mockEnv)
+            const catalog = new ResourceCatalog(mockEnv, redis)
             await catalog.warmup()
 
-            const result = catalog.readResource({ uri: 'posthog://nonexistent' }) as any
+            const result = await catalog.readResource({ uri: 'posthog://nonexistent' })
             expect(result.contents).toEqual([])
+        })
+
+        it('returns empty contents and triggers a refresh when a body is missing', async () => {
+            vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('doc')])
+            vi.mocked(getPromptsFromManifest).mockResolvedValue([])
+
+            const catalog = new ResourceCatalog(mockEnv, redis)
+            await catalog.warmup()
+
+            // Evict the body key but keep the manifest in place. The body lookup
+            // misses, so the read returns empty and fires a fire-and-forget
+            // refresh under the hood.
+            for (const key of Array.from(redis._store.keys())) {
+                if (key.startsWith('mcp:shared-blob:context-mill:body:')) {
+                    redis._store.delete(key)
+                }
+            }
+            vi.mocked(fetchAndExtractEntries).mockClear()
+            vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('doc')])
+
+            const result = await catalog.readResource({ uri: 'posthog://doc' })
+            expect(result.contents).toEqual([])
+
+            // Allow the fire-and-forget refresh to settle and re-publish bodies.
+            await new Promise((r) => setTimeout(r, 20))
+            expect(vi.mocked(fetchAndExtractEntries)).toHaveBeenCalled()
         })
     })
 
     describe('getPrompt', () => {
         it('returns messages for a known prompt name', async () => {
-            vi.mocked(fetchContextMillResources).mockResolvedValue('archive' as any)
-            vi.mocked(loadManifestFromArchive).mockReturnValue({ resources: [] } as any)
-            vi.mocked(filterValidEntries).mockReturnValue([])
+            vi.mocked(fetchAndExtractEntries).mockResolvedValue([])
             vi.mocked(getPromptsFromManifest).mockResolvedValue([
                 {
                     name: 'test-prompt',
@@ -131,52 +193,48 @@ describe('ResourceCatalog', () => {
                 },
             ] as any)
 
-            const catalog = new ResourceCatalog(mockEnv)
+            const catalog = new ResourceCatalog(mockEnv, redis)
             await catalog.warmup()
 
-            const result = catalog.getPrompt({ name: 'test-prompt' }) as any
+            const result = catalog.getPrompt({ name: 'test-prompt' })
             expect(result.messages).toHaveLength(1)
         })
 
         it('returns empty messages for unknown prompt', async () => {
-            vi.mocked(fetchContextMillResources).mockResolvedValue('archive' as any)
-            vi.mocked(loadManifestFromArchive).mockReturnValue({ resources: [] } as any)
-            vi.mocked(filterValidEntries).mockReturnValue([])
+            vi.mocked(fetchAndExtractEntries).mockResolvedValue([])
             vi.mocked(getPromptsFromManifest).mockResolvedValue([])
 
-            const catalog = new ResourceCatalog(mockEnv)
+            const catalog = new ResourceCatalog(mockEnv, redis)
             await catalog.warmup()
 
-            const result = catalog.getPrompt({ name: 'nope' }) as any
+            const result = catalog.getPrompt({ name: 'nope' })
             expect(result.messages).toEqual([])
         })
     })
 
     describe('error resilience', () => {
         it('continues serving prompts when resource fetch fails', async () => {
-            vi.mocked(fetchContextMillResources).mockRejectedValue(new Error('network'))
+            vi.mocked(fetchAndExtractEntries).mockRejectedValue(new Error('network'))
             vi.mocked(getPromptsFromManifest).mockResolvedValue([
                 { name: 'p', title: 'P', description: 'D', messages: [] },
             ] as any)
 
-            const catalog = new ResourceCatalog(mockEnv)
+            const catalog = new ResourceCatalog(mockEnv, redis)
             await catalog.warmup()
 
             const names = catalog.getResourcesList().resources.map((r) => r.name)
-            expect(names).not.toContain('guide')
+            expect(names).not.toContain('name-guide')
             expect(catalog.getPromptsList().prompts).toHaveLength(1)
         })
 
         it('continues serving resources when prompt fetch fails', async () => {
-            vi.mocked(fetchContextMillResources).mockResolvedValue('archive' as any)
-            vi.mocked(loadManifestFromArchive).mockReturnValue({ resources: [] } as any)
-            vi.mocked(filterValidEntries).mockReturnValue([makeContextMillEntry('r', 'posthog://r')] as any)
+            vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('r')])
             vi.mocked(getPromptsFromManifest).mockRejectedValue(new Error('fail'))
 
-            const catalog = new ResourceCatalog(mockEnv)
+            const catalog = new ResourceCatalog(mockEnv, redis)
             await catalog.warmup()
 
-            expect(catalog.getResourcesList().resources.map((r) => r.name)).toContain('r')
+            expect(catalog.getResourcesList().resources.map((r) => r.name)).toContain('name-r')
             expect(catalog.getPromptsList().prompts).toEqual([])
         })
     })

--- a/services/mcp/tests/hono/resource-catalog.test.ts
+++ b/services/mcp/tests/hono/resource-catalog.test.ts
@@ -1,5 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const {
+    mockBodyReadsInc,
+    mockCacheEventsInc,
+    mockManifestEntriesSet,
+    mockRevalidationDurationStartTimer,
+    mockRevalidationDurationStop,
+    mockRevalidationsInc,
+} = vi.hoisted(() => {
+    const stop = vi.fn()
+    return {
+        mockBodyReadsInc: vi.fn(),
+        mockCacheEventsInc: vi.fn(),
+        mockManifestEntriesSet: vi.fn(),
+        mockRevalidationDurationStartTimer: vi.fn(() => stop),
+        mockRevalidationDurationStop: stop,
+        mockRevalidationsInc: vi.fn(),
+    }
+})
+
+vi.mock('@/hono/metrics', () => ({
+    contextMillBodyReadsTotal: { inc: mockBodyReadsInc },
+    contextMillCacheEventsTotal: { inc: mockCacheEventsInc },
+    contextMillManifestEntries: { set: mockManifestEntriesSet },
+    contextMillRevalidationDurationSeconds: { startTimer: mockRevalidationDurationStartTimer },
+    contextMillRevalidationsTotal: { inc: mockRevalidationsInc },
+}))
+
 vi.mock('@/resources/internals', () => ({
     fetchAndExtractEntries: vi.fn(),
 }))
@@ -68,11 +95,15 @@ function makeEntry(suffix: string): ContextMillResource {
     }
 }
 
+const MANIFEST_BYTES_KEY = 'mcp:shared-blob:context-mill:manifest:bytes'
+const MANIFEST_FRESH_KEY = 'mcp:shared-blob:context-mill:manifest:fresh'
+
 describe('ResourceCatalog', () => {
     let redis: MockRedis
 
     beforeEach(() => {
         vi.clearAllMocks()
+        mockRevalidationDurationStop.mockClear()
         redis = createMockRedis()
     })
 
@@ -101,6 +132,14 @@ describe('ResourceCatalog', () => {
             const { prompts } = catalog.getPromptsList()
             expect(prompts).toHaveLength(1)
             expect(prompts[0]!.name).toBe('greet')
+            expect(mockRevalidationsInc).toHaveBeenCalledWith({
+                source: 'warmup',
+                status: 'success',
+                result: 'cold_refresh',
+            })
+            expect(mockRevalidationDurationStartTimer).toHaveBeenCalledWith({ source: 'warmup' })
+            expect(mockRevalidationDurationStop).toHaveBeenCalledWith({ source: 'warmup', status: 'success' })
+            expect(mockManifestEntriesSet).toHaveBeenCalledWith(2)
         })
 
         it('pre-merges resource list so getResourcesList returns a stable array', async () => {
@@ -113,6 +152,60 @@ describe('ResourceCatalog', () => {
             const list1 = catalog.getResourcesList().resources
             const list2 = catalog.getResourcesList().resources
             expect(list1).toBe(list2)
+        })
+
+        it('revalidates context-mill resources on demand', async () => {
+            vi.mocked(fetchAndExtractEntries).mockResolvedValueOnce([makeEntry('old')])
+            vi.mocked(getPromptsFromManifest).mockResolvedValue([])
+
+            const catalog = new ResourceCatalog(mockEnv, redis)
+            await catalog.warmup()
+
+            redis._store.delete(MANIFEST_BYTES_KEY)
+            redis._store.delete(MANIFEST_FRESH_KEY)
+            vi.mocked(fetchAndExtractEntries).mockResolvedValueOnce([makeEntry('new')])
+
+            await catalog.revalidateContextMillResources('initialize')
+
+            const names = catalog.getResourcesList().resources.map((r) => r.name)
+            expect(names).toContain('name-new')
+            expect(names).not.toContain('name-old')
+            expect(mockRevalidationsInc).toHaveBeenCalledWith({
+                source: 'initialize',
+                status: 'success',
+                result: 'cold_refresh',
+            })
+        })
+
+        it('keeps existing context-mill resources when revalidation fails', async () => {
+            const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+            try {
+                vi.mocked(fetchAndExtractEntries).mockResolvedValueOnce([makeEntry('stable')])
+                vi.mocked(getPromptsFromManifest).mockResolvedValue([])
+
+                const catalog = new ResourceCatalog(mockEnv, redis)
+                await catalog.warmup()
+
+                redis._store.delete(MANIFEST_BYTES_KEY)
+                redis._store.delete(MANIFEST_FRESH_KEY)
+                vi.mocked(fetchAndExtractEntries).mockRejectedValueOnce(new Error('network'))
+
+                await catalog.revalidateContextMillResources('initialize')
+
+                expect(catalog.getResourcesList().resources.map((r) => r.name)).toContain('name-stable')
+                expect(mockRevalidationsInc).toHaveBeenCalledWith({
+                    source: 'initialize',
+                    status: 'error',
+                    result: 'error',
+                })
+                expect(mockRevalidationDurationStop).toHaveBeenCalledWith({ source: 'initialize', status: 'error' })
+                expect(consoleError).toHaveBeenCalledWith(
+                    '[ResourceCatalog] Failed to revalidate context-mill resources:',
+                    expect.any(Error)
+                )
+            } finally {
+                consoleError.mockRestore()
+            }
         })
     })
 

--- a/services/mcp/tests/hono/resource-catalog.test.ts
+++ b/services/mcp/tests/hono/resource-catalog.test.ts
@@ -103,18 +103,6 @@ describe('ResourceCatalog', () => {
             expect(prompts[0]!.name).toBe('greet')
         })
 
-        it('skips context-mill warmup when no redis is provided', async () => {
-            vi.mocked(getPromptsFromManifest).mockResolvedValue([])
-
-            const catalog = new ResourceCatalog(mockEnv)
-            await catalog.warmup()
-
-            const { resources } = catalog.getResourcesList()
-            // Only UI apps should be present; fetchAndExtractEntries must not run.
-            expect(vi.mocked(fetchAndExtractEntries)).not.toHaveBeenCalled()
-            expect(resources.every((r) => !r.name.startsWith('name-'))).toBe(true)
-        })
-
         it('pre-merges resource list so getResourcesList returns a stable array', async () => {
             vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('a')])
             vi.mocked(getPromptsFromManifest).mockResolvedValue([])

--- a/services/mcp/tests/hono/resource-catalog.test.ts
+++ b/services/mcp/tests/hono/resource-catalog.test.ts
@@ -154,30 +154,30 @@ describe('ResourceCatalog', () => {
             expect(result.contents).toEqual([])
         })
 
-        it('returns empty contents and triggers a refresh when a body is missing', async () => {
+        it('returns empty contents when a body has aged out without triggering a refresh', async () => {
             vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('doc')])
             vi.mocked(getPromptsFromManifest).mockResolvedValue([])
 
             const catalog = new ResourceCatalog(mockEnv, redis)
             await catalog.warmup()
 
-            // Evict the body key but keep the manifest in place. The body lookup
-            // misses, so the read returns empty and fires a fire-and-forget
-            // refresh under the hood.
+            // Drop the body key. The read should acknowledge the removal —
+            // the resource has aged out — without triggering any upstream
+            // refresh. The slim manifest is left in place; the LLM client's
+            // context-window cache is the source of truth for what it knows.
             for (const key of Array.from(redis._store.keys())) {
                 if (key.startsWith('mcp:shared-blob:context-mill:body:')) {
                     redis._store.delete(key)
                 }
             }
             vi.mocked(fetchAndExtractEntries).mockClear()
-            vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('doc')])
 
             const result = await catalog.readResource({ uri: 'posthog://doc' })
             expect(result.contents).toEqual([])
 
-            // Allow the fire-and-forget refresh to settle and re-publish bodies.
+            // No refresh fired on the miss path.
             await new Promise((r) => setTimeout(r, 20))
-            expect(vi.mocked(fetchAndExtractEntries)).toHaveBeenCalled()
+            expect(vi.mocked(fetchAndExtractEntries)).not.toHaveBeenCalled()
         })
     })
 

--- a/services/mcp/tests/hono/shared-blob-cache.test.ts
+++ b/services/mcp/tests/hono/shared-blob-cache.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RedisLike } from '@/hono/cache/RedisCache'
+import { SharedBlobCache } from '@/hono/cache/SharedBlobCache'
+
+import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
+
+interface MockRedis extends RedisLike {
+    _store: Map<string, string>
+    _setCalls: Array<{ key: string; value: string; args: (string | number)[] }>
+}
+
+function createMockRedis(): MockRedis {
+    const store = new Map<string, string>()
+    const setCalls: Array<{ key: string; value: string; args: (string | number)[] }> = []
+    return {
+        get: vi.fn(async (key: string) => store.get(key) ?? null),
+        set: vi.fn(async (key: string, value: string, ...args: (string | number)[]) => {
+            setCalls.push({ key, value, args })
+            const isNx = args.includes('NX')
+            if (isNx && store.has(key)) {
+                return null
+            }
+            store.set(key, value)
+            return 'OK'
+        }),
+        del: vi.fn(async (...keys: string[]) => {
+            let count = 0
+            for (const k of keys) {
+                if (store.delete(k)) {
+                    count++
+                }
+            }
+            return count
+        }),
+        scan: vi.fn(async () => ['0', []] as [string, string[]]),
+        ...makeRedisRateLimitStubs(),
+        _store: store,
+        _setCalls: setCalls,
+    }
+}
+
+const NAMESPACE = 'test-blob'
+const BYTES_KEY = `mcp:shared-blob:${NAMESPACE}:bytes`
+const FRESH_KEY = `mcp:shared-blob:${NAMESPACE}:fresh`
+const LOCK_KEY = `mcp:shared-blob:${NAMESPACE}:lock`
+
+describe('SharedBlobCache', () => {
+    let redis: MockRedis
+
+    beforeEach(() => {
+        redis = createMockRedis()
+    })
+
+    it('fetches upstream on cold cache and writes bytes + freshness', async () => {
+        const cache = new SharedBlobCache(redis, NAMESPACE)
+        const bytes = new Uint8Array([1, 2, 3, 4, 5])
+        const upstream = vi.fn(async () => bytes)
+
+        const result = await cache.fetch(upstream)
+
+        expect(result).toEqual(bytes)
+        expect(upstream).toHaveBeenCalledTimes(1)
+        expect(redis._store.has(BYTES_KEY)).toBe(true)
+        expect(redis._store.has(FRESH_KEY)).toBe(true)
+        // Lock acquired then released.
+        expect(redis._store.has(LOCK_KEY)).toBe(false)
+    })
+
+    it('serves the cached bytes on fresh hit without calling upstream', async () => {
+        const cache = new SharedBlobCache(redis, NAMESPACE)
+        const bytes = new Uint8Array([9, 8, 7])
+        await cache.fetch(async () => bytes)
+
+        const upstream = vi.fn(async () => new Uint8Array([0]))
+        const result = await cache.fetch(upstream)
+
+        expect(result).toEqual(bytes)
+        expect(upstream).not.toHaveBeenCalled()
+    })
+
+    it('isolates blobs by namespace', async () => {
+        const a = new SharedBlobCache(redis, 'alpha')
+        const b = new SharedBlobCache(redis, 'beta')
+        await a.fetch(async () => new Uint8Array([1]))
+        await b.fetch(async () => new Uint8Array([2]))
+
+        expect(redis._store.has('mcp:shared-blob:alpha:bytes')).toBe(true)
+        expect(redis._store.has('mcp:shared-blob:beta:bytes')).toBe(true)
+
+        const upstream = vi.fn(async () => new Uint8Array([9]))
+        const result = await a.fetch(upstream)
+        expect(result).toEqual(new Uint8Array([1]))
+        expect(upstream).not.toHaveBeenCalled()
+    })
+
+    it('only one writer fetches upstream when many clients race on cold cache', async () => {
+        const cache = new SharedBlobCache(redis, NAMESPACE, { waitIntervalMs: 5, waitTimeoutMs: 200 })
+        const bytes = new Uint8Array([42])
+        let inFlight = 0
+        let peak = 0
+        const upstream = vi.fn(async () => {
+            inFlight += 1
+            peak = Math.max(peak, inFlight)
+            await new Promise((r) => setTimeout(r, 20))
+            inFlight -= 1
+            return bytes
+        })
+
+        const concurrency = 5
+        const results = await Promise.all(Array.from({ length: concurrency }, () => cache.fetch(upstream)))
+
+        expect(results.every((r) => r.toString() === bytes.toString())).toBe(true)
+        expect(peak).toBe(1)
+        // Exactly one writer fetched upstream. Non-writers either waited for the
+        // cache to publish or fell back to a direct fetch (with no cache write).
+        expect(upstream.mock.calls.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('non-writers wait for the lock holder to publish and serve that result', async () => {
+        const cache = new SharedBlobCache(redis, NAMESPACE, { waitIntervalMs: 5, waitTimeoutMs: 1000 })
+        const bytes = new Uint8Array([55, 56])
+        let resolveUpstream: ((b: Uint8Array) => void) | undefined
+        const upstreamPromise = new Promise<Uint8Array>((resolve) => {
+            resolveUpstream = resolve
+        })
+        const writerUpstream = vi.fn(() => upstreamPromise)
+        const waiterUpstream = vi.fn(async () => new Uint8Array([99]))
+
+        // First call wins the lock and stalls in upstream.
+        const writerResult = cache.fetch(writerUpstream)
+        // Give the writer time to seize the lock before the waiter starts.
+        await new Promise((r) => setTimeout(r, 10))
+        const waiterResult = cache.fetch(waiterUpstream)
+
+        // Publish the upstream after both calls are in flight.
+        await new Promise((r) => setTimeout(r, 30))
+        resolveUpstream!(bytes)
+
+        const [w, r] = await Promise.all([writerResult, waiterResult])
+        expect(w).toEqual(bytes)
+        expect(r).toEqual(bytes)
+        // The waiter must not have written its own value upstream.
+        expect(waiterUpstream).not.toHaveBeenCalled()
+    })
+
+    it('serves stale cache while triggering a background refresh', async () => {
+        // freshSeconds = 0 forces stale on read; waitTimeoutMs tightened to keep
+        // the test fast in case anything goes sideways.
+        const cache = new SharedBlobCache(redis, NAMESPACE, {
+            freshSeconds: 0,
+            waitIntervalMs: 5,
+            waitTimeoutMs: 100,
+        })
+
+        const initial = new Uint8Array([1, 1])
+        const refreshed = new Uint8Array([2, 2])
+        let upstreamCalls = 0
+        const upstream = vi.fn(async () => {
+            upstreamCalls += 1
+            return upstreamCalls === 1 ? initial : refreshed
+        })
+
+        // Seed the cache (writes initial and immediately marks it stale).
+        const first = await cache.fetch(upstream)
+        expect(first).toEqual(initial)
+        expect(upstream).toHaveBeenCalledTimes(1)
+
+        // Stale read returns the cached value, kicks off a background refresh.
+        const second = await cache.fetch(upstream)
+        expect(second).toEqual(initial)
+
+        // Allow the background refresh to settle.
+        await new Promise((r) => setTimeout(r, 30))
+
+        expect(upstream).toHaveBeenCalledTimes(2)
+        // After refresh, the cache reflects the new bytes.
+        const third = await cache.fetch(upstream)
+        expect(third).toEqual(refreshed)
+    })
+
+    it('falls back to a direct fetch when the writer never publishes', async () => {
+        // Lock is pre-held by another writer that we simulate as stuck.
+        redis._store.set(LOCK_KEY, 'someone-else')
+        const cache = new SharedBlobCache(redis, NAMESPACE, { waitIntervalMs: 10, waitTimeoutMs: 50 })
+
+        const fallback = new Uint8Array([7])
+        const upstream = vi.fn(async () => fallback)
+        const result = await cache.fetch(upstream)
+
+        expect(result).toEqual(fallback)
+        // Fallback must not write the cache — that's reserved for the lock holder.
+        expect(redis._store.has(BYTES_KEY)).toBe(false)
+    })
+})

--- a/services/mcp/tests/hono/shared-blob-cache.test.ts
+++ b/services/mcp/tests/hono/shared-blob-cache.test.ts
@@ -1,9 +1,35 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { RedisLike } from '@/hono/cache/RedisCache'
-import { SharedBlobCache } from '@/hono/cache/SharedBlobCache'
+import { SharedBlobCache, type SharedBlobCacheOptions } from '@/hono/cache/SharedBlobCache'
 
 import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
+
+class TestSharedBlobCache extends SharedBlobCache {
+    constructor(redis: RedisLike, namespace: string, opts?: SharedBlobCacheOptions) {
+        super(redis, namespace, opts)
+    }
+
+    read(): Promise<{ bytes: Uint8Array; fresh: boolean } | null> {
+        return this.readCache()
+    }
+
+    write(bytes: Uint8Array): Promise<void> {
+        return this.writeCache(bytes)
+    }
+
+    acquire(token: string): Promise<boolean> {
+        return this.acquireLock(token)
+    }
+
+    release(token: string): Promise<void> {
+        return this.releaseLock(token)
+    }
+
+    wait(): Promise<Uint8Array | null> {
+        return this.waitForCache()
+    }
+}
 
 interface MockRedis extends RedisLike {
     _store: Map<string, string>
@@ -52,144 +78,73 @@ describe('SharedBlobCache', () => {
         redis = createMockRedis()
     })
 
-    it('fetches upstream on cold cache and writes bytes + freshness', async () => {
-        const cache = new SharedBlobCache(redis, NAMESPACE)
+    it('writes bytes + freshness and reads them back', async () => {
         const bytes = new Uint8Array([1, 2, 3, 4, 5])
-        const upstream = vi.fn(async () => bytes)
+        const cache = new TestSharedBlobCache(redis, NAMESPACE)
 
-        const result = await cache.fetch(upstream)
+        await cache.write(bytes)
+        const cached = await cache.read()
 
-        expect(result).toEqual(bytes)
-        expect(upstream).toHaveBeenCalledTimes(1)
+        expect(cached).toEqual({ bytes, fresh: true })
         expect(redis._store.has(BYTES_KEY)).toBe(true)
         expect(redis._store.has(FRESH_KEY)).toBe(true)
-        // Lock acquired then released.
-        expect(redis._store.has(LOCK_KEY)).toBe(false)
     })
 
-    it('serves the cached bytes on fresh hit without calling upstream', async () => {
-        const cache = new SharedBlobCache(redis, NAMESPACE)
-        const bytes = new Uint8Array([9, 8, 7])
-        await cache.fetch(async () => bytes)
+    it('marks cached bytes stale after the freshness window', async () => {
+        const cache = new TestSharedBlobCache(redis, NAMESPACE, { freshSeconds: 0 })
+        await cache.write(new Uint8Array([9, 8, 7]))
 
-        const upstream = vi.fn(async () => new Uint8Array([0]))
-        const result = await cache.fetch(upstream)
+        const cached = await cache.read()
 
-        expect(result).toEqual(bytes)
-        expect(upstream).not.toHaveBeenCalled()
+        expect(cached?.bytes).toEqual(new Uint8Array([9, 8, 7]))
+        expect(cached?.fresh).toBe(false)
     })
 
     it('isolates blobs by namespace', async () => {
-        const a = new SharedBlobCache(redis, 'alpha')
-        const b = new SharedBlobCache(redis, 'beta')
-        await a.fetch(async () => new Uint8Array([1]))
-        await b.fetch(async () => new Uint8Array([2]))
+        const a = new TestSharedBlobCache(redis, 'alpha')
+        const b = new TestSharedBlobCache(redis, 'beta')
+        await a.write(new Uint8Array([1]))
+        await b.write(new Uint8Array([2]))
 
         expect(redis._store.has('mcp:shared-blob:alpha:bytes')).toBe(true)
         expect(redis._store.has('mcp:shared-blob:beta:bytes')).toBe(true)
 
-        const upstream = vi.fn(async () => new Uint8Array([9]))
-        const result = await a.fetch(upstream)
-        expect(result).toEqual(new Uint8Array([1]))
-        expect(upstream).not.toHaveBeenCalled()
+        expect((await a.read())?.bytes).toEqual(new Uint8Array([1]))
+        expect((await b.read())?.bytes).toEqual(new Uint8Array([2]))
     })
 
-    it('only one writer fetches upstream when many clients race on cold cache', async () => {
-        const cache = new SharedBlobCache(redis, NAMESPACE, { waitIntervalMs: 5, waitTimeoutMs: 200 })
-        const bytes = new Uint8Array([42])
-        let inFlight = 0
-        let peak = 0
-        const upstream = vi.fn(async () => {
-            inFlight += 1
-            peak = Math.max(peak, inFlight)
-            await new Promise((r) => setTimeout(r, 20))
-            inFlight -= 1
-            return bytes
-        })
+    it('allows only one lock holder', async () => {
+        const cache = new TestSharedBlobCache(redis, NAMESPACE)
 
-        const concurrency = 5
-        const results = await Promise.all(Array.from({ length: concurrency }, () => cache.fetch(upstream)))
+        expect(await cache.acquire('first')).toBe(true)
+        expect(await cache.acquire('second')).toBe(false)
 
-        expect(results.every((r) => r.toString() === bytes.toString())).toBe(true)
-        expect(peak).toBe(1)
-        // Exactly one writer fetched upstream. Non-writers either waited for the
-        // cache to publish or fell back to a direct fetch (with no cache write).
-        expect(upstream.mock.calls.length).toBeGreaterThanOrEqual(1)
+        expect(redis._store.get(LOCK_KEY)).toBe('first')
     })
 
-    it('non-writers wait for the lock holder to publish and serve that result', async () => {
-        const cache = new SharedBlobCache(redis, NAMESPACE, { waitIntervalMs: 5, waitTimeoutMs: 1000 })
+    it('releases the lock', async () => {
+        const cache = new TestSharedBlobCache(redis, NAMESPACE)
+
+        await cache.acquire('token')
+        await cache.release('token')
+
+        expect(redis._store.has(LOCK_KEY)).toBe(false)
+    })
+
+    it('waits for another writer to publish', async () => {
+        const cache = new TestSharedBlobCache(redis, NAMESPACE, { waitIntervalMs: 5, waitTimeoutMs: 200 })
         const bytes = new Uint8Array([55, 56])
-        let resolveUpstream: ((b: Uint8Array) => void) | undefined
-        const upstreamPromise = new Promise<Uint8Array>((resolve) => {
-            resolveUpstream = resolve
-        })
-        const writerUpstream = vi.fn(() => upstreamPromise)
-        const waiterUpstream = vi.fn(async () => new Uint8Array([99]))
 
-        // First call wins the lock and stalls in upstream.
-        const writerResult = cache.fetch(writerUpstream)
-        // Give the writer time to seize the lock before the waiter starts.
-        await new Promise((r) => setTimeout(r, 10))
-        const waiterResult = cache.fetch(waiterUpstream)
+        const waited = cache.wait()
+        await new Promise((r) => setTimeout(r, 20))
+        await cache.write(bytes)
 
-        // Publish the upstream after both calls are in flight.
-        await new Promise((r) => setTimeout(r, 30))
-        resolveUpstream!(bytes)
-
-        const [w, r] = await Promise.all([writerResult, waiterResult])
-        expect(w).toEqual(bytes)
-        expect(r).toEqual(bytes)
-        // The waiter must not have written its own value upstream.
-        expect(waiterUpstream).not.toHaveBeenCalled()
+        expect(await waited).toEqual(bytes)
     })
 
-    it('serves stale cache while triggering a background refresh', async () => {
-        // freshSeconds = 0 forces stale on read; waitTimeoutMs tightened to keep
-        // the test fast in case anything goes sideways.
-        const cache = new SharedBlobCache(redis, NAMESPACE, {
-            freshSeconds: 0,
-            waitIntervalMs: 5,
-            waitTimeoutMs: 100,
-        })
+    it('times out while waiting for another writer', async () => {
+        const cache = new TestSharedBlobCache(redis, NAMESPACE, { waitIntervalMs: 10, waitTimeoutMs: 50 })
 
-        const initial = new Uint8Array([1, 1])
-        const refreshed = new Uint8Array([2, 2])
-        let upstreamCalls = 0
-        const upstream = vi.fn(async () => {
-            upstreamCalls += 1
-            return upstreamCalls === 1 ? initial : refreshed
-        })
-
-        // Seed the cache (writes initial and immediately marks it stale).
-        const first = await cache.fetch(upstream)
-        expect(first).toEqual(initial)
-        expect(upstream).toHaveBeenCalledTimes(1)
-
-        // Stale read returns the cached value, kicks off a background refresh.
-        const second = await cache.fetch(upstream)
-        expect(second).toEqual(initial)
-
-        // Allow the background refresh to settle.
-        await new Promise((r) => setTimeout(r, 30))
-
-        expect(upstream).toHaveBeenCalledTimes(2)
-        // After refresh, the cache reflects the new bytes.
-        const third = await cache.fetch(upstream)
-        expect(third).toEqual(refreshed)
-    })
-
-    it('falls back to a direct fetch when the writer never publishes', async () => {
-        // Lock is pre-held by another writer that we simulate as stuck.
-        redis._store.set(LOCK_KEY, 'someone-else')
-        const cache = new SharedBlobCache(redis, NAMESPACE, { waitIntervalMs: 10, waitTimeoutMs: 50 })
-
-        const fallback = new Uint8Array([7])
-        const upstream = vi.fn(async () => fallback)
-        const result = await cache.fetch(upstream)
-
-        expect(result).toEqual(fallback)
-        // Fallback must not write the cache — that's reserved for the lock holder.
-        expect(redis._store.has(BYTES_KEY)).toBe(false)
+        expect(await cache.wait()).toBeNull()
     })
 })


### PR DESCRIPTION
## Problem

Roughly 20% context-mill requests to github are throttled. This will do a single request in 10 minutes.

After these changes, the flow will be:
- Revalidate on warmup, serve stale while revalidating.
- Revalidate in init, serve stale while revalidating.
- Only one parallel lock is possible.
- If all fail for some reason, serve from the network.


  ## Changes

  - Add a Redis-backed shared blob cache for context-mill resources.
  - Store a slim manifest separately from per-resource body payloads, so `resources/list` stays lightweight and `resources/
  read` loads bodies lazily.
  - Add stale-while-revalidate behavior with a Redis writer lock, cold-cache waiting, and fallback fetching when a lock holder
  does not publish in time.
  - Require Redis when constructing `ResourceCatalog`, and revalidate context-mill resources during both warmup and MCP
  `initialize`.
  - Add context-mill-only Prometheus metrics for revalidation outcomes, duration, cache events, manifest size, and body reads.
  - Add focused Hono tests for the shared cache, context-mill cache behavior, resource catalog revalidation, and init-time
  revalidation.

  ## How did you test this code?

  Agent-tested with:

  - `pnpm --filter=@posthog/mcp exec oxfmt src/hono/metrics.ts src/hono/cache/ContextMillResourceCache.ts src/hono/resource-
  catalog.ts src/hono/dispatcher.ts tests/hono/context-mill-resource-cache.test.ts tests/hono/resource-catalog.test.ts tests/
  hono/dispatcher-init-revalidation.test.ts`
  - `pnpm --filter=@posthog/mcp exec vitest run --config vitest.hono.config.mts tests/hono/shared-blob-cache.test.ts tests/
  hono/context-mill-resource-cache.test.ts tests/hono/resource-catalog.test.ts tests/hono/dispatcher-init-
  revalidation.test.ts`
  - `pnpm --filter=@posthog/mcp exec tsc --noEmit`
  - `pnpm --filter=@posthog/mcp exec vitest run --config vitest.hono.config.mts tests/hono/mcp-protocol.test.ts`

  ## Publish to changelog?

  do not publish to changelog

  ## Docs update

  No docs update needed. This changes MCP server runtime caching and observability behavior.

  ## 🤖 Agent context

  Implemented with Codex. The implementation keeps the generic Redis blob coordination in `SharedBlobCache` and puts context-
  mill-specific fetching, body storage, stale-while-revalidate behavior, and metrics in `ContextMillResourceCache`. The
  resource catalog now consumes that cache instead of owning archive loading directly, so request-time reads can load resource
  bodies from Redis while init and warmup only refresh the catalog view.