### PR TITLE
chore(insights): remove stale always-query-blocking flag check

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -23,7 +23,6 @@ import {
     isHogQLQuery,
     isInsightQueryNode,
     isPersonsNode,
-    shouldQueryBeAsync,
 } from './utils'
 
 export function waitForPageVisible(signal?: AbortSignal): Promise<void> {
@@ -172,18 +171,7 @@ async function executeQuery<N extends DataNode>(
     limitContext?: 'posthog_ai'
 ): Promise<NonNullable<N['response']>> {
     if (!pollOnly) {
-        // Determine the refresh type based on the query node type and refresh parameter
-        let refreshParam: RefreshType
-
-        if (posthog.isFeatureEnabled('always-query-blocking')) {
-            refreshParam = refresh || 'blocking'
-        } else if (shouldQueryBeAsync(queryNode)) {
-            // For insight queries, use async variants but preserve explicit force requests
-            refreshParam = refresh || 'async'
-        } else {
-            // For other queries, use blocking unless explicitly set to a different RefreshType
-            refreshParam = refresh || 'blocking'
-        }
+        const refreshParam: RefreshType = refresh || 'blocking'
 
         const response = await api.query(queryNode, {
             requestOptions: methodOptions,


### PR DESCRIPTION
## Problem

The `always-query-blocking` feature flag is stale and fully rolled out. With the flag enabled (the production state) every query already falls back to `refresh || 'blocking'`, making the `shouldQueryBeAsync(queryNode)` branch in `executeQuery` dead code.

## Changes

In `frontend/src/queries/query.ts`:

- Replaced the three-branch `if / else if / else` that checked `posthog.isFeatureEnabled('always-query-blocking')` with the inlined winning branch: `const refreshParam: RefreshType = refresh || 'blocking'`.
- Removed `shouldQueryBeAsync` from the `./utils` import block — it's no longer referenced in this file. It remains exported from `frontend/src/queries/utils.ts` for the other consumers (DataVisualization, ComputationTimeWithRefresh, InsightVizDisplay, Reload, Paths, PathsV2, insightDataLogic).

After this lands and ships, the flag will be disabled in PostHog (kept disabled, not deleted, in case of rollback).

## How did you test this code?

I'm an agent (PostHog Code). No manual testing was run. The change is a pure dead-code removal that preserves the flag-on behavior already in production — `refreshParam` is set identically to the prior `posthog.isFeatureEnabled('always-query-blocking') === true` branch. A repo-wide grep for `always-query-blocking` confirms no other production references remain (only a mocked `perf-snapshot-key0.jsonl` blob).

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code on behalf of @tobermueller. The user identified the stale flag and the single call site at `frontend/src/queries/query.ts:177` and asked to inline the winning branch. Exploration confirmed only one production reference and that `shouldQueryBeAsync` was no longer used in this file after the cleanup, so the import was removed as well. The `posthog` import is kept because `posthog.capture` is still used elsewhere in the file.