### PR TITLE
fix(taxonomic-filter): use per-row key-only check for menu-rebuild gate

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -305,7 +305,7 @@ export function TaxonomicPropertyFilter({
     // legacy path gets a thin positioned wrapper to host the floating toggle.
     const editablePicker = !menuRebuildEnabled ? (
         legacyDropdown
-    ) : useNewMenu && !selectingKeyOnly ? (
+    ) : useNewMenu && !isKeyOnlyRow ? (
         <TaxonomicPopoverMenu
             groupType={filterTaxonomicGroupType ?? groupTypes[0]}
             value={cohortOrOtherValue}


### PR DESCRIPTION
## Problem

The rebuilt taxonomic menu (`taxonomic-filter-menu-rebuild`) silently fell back to the legacy filter on Feature flag release-conditions and Workflows step-trigger pages — even after opting into the new menu via the in-trigger toggle. The flask toggle appeared and flipped state, but the picker itself never swapped.

Root cause: the gate at `TaxonomicPropertyFilter.tsx` read the raw `selectingKeyOnly` prop. That prop is a per-group map on these call sites (`COHORTS_ONLY_SUPPORT_IN_PICKER_PROPS` ships `selectingKeyOnly: { Cohorts: true }`), so `!selectingKeyOnly` is `!{...} === false`, disabling the new menu for **every** row regardless of group — cohort and non-cohort alike.

## Changes

Switch the gate to the existing per-row `isKeyOnlyRow = isKeyOnlyForGroup(selectingKeyOnly, filterTaxonomicGroupType)`. Cohort rows still stay on the classic filter (intended — the rebuilt menu doesn't model key-only selection semantics yet), but person/event-property rows on the same pages now get the rebuilt menu.

## How did you test this code?

I'm an agent. No automated tests added — the gate change is a one-line condition swap against an already-computed local. Verified locally by the human author: with `taxonomic-filter-menu-rebuild` on (and `taxonomic-filter-headless` off), adding a person-property condition on a feature flag's release-conditions page now opens the rebuilt column / preview-pane menu.

## Publish to changelog?

no

## 🤖 Agent context

Claude Code session. Diagnosis started from "new menu works locally but not on prod"; ruled out flag rollout (cloud preflight, persisted flags, kea hydration), then visual confirmation (2 legacy `property-select-toggle-*` buttons rendered, flask toggle visible but no-op on the picker). Traced the gate to the truthy-object case via `cohortPickerProps.ts`. Same `selectingKeyOnly` shape is also passed in `TaxonomicPopover.tsx`'s `newMenuSupportsCallSite` — left untouched as that prop is typed boolean at that call site; worth a follow-up if a non-boolean ever flows through.