### PR TITLE
chore(toolbox): default each pool to its own namespace

### DIFF
--- a/tools/infra-scripts/clitools/test_toolbox.py
+++ b/tools/infra-scripts/clitools/test_toolbox.py
@@ -852,10 +852,11 @@ class TestToolbox(unittest.TestCase):
             claim_pod("toolbox-pod-1", user_labels, 1234567890, namespace="posthog")
 
     def test_pools_definition(self):
-        """POOLS contains both pools with the expected app and claim labels."""
+        """POOLS contains both pools with the expected app/claim labels and default namespaces."""
         self.assertEqual(
             toolbox_script.POOLS["toolbox-django"],
             {
+                "default_namespace": "posthog-toolbox-django",
                 "app_label": "posthog-toolbox-django",
                 "claimed_label_key": "toolbox-claimed",
                 "extra_selectors_by_namespace": {
@@ -865,7 +866,11 @@ class TestToolbox(unittest.TestCase):
         )
         self.assertEqual(
             toolbox_script.POOLS["flags-cache-jumphost"],
-            {"app_label": "flags-cache-jumphost", "claimed_label_key": "flags-jumphost-claimed"},
+            {
+                "default_namespace": "posthog",
+                "app_label": "flags-cache-jumphost",
+                "claimed_label_key": "flags-jumphost-claimed",
+            },
         )
 
     def test_exit_for_signal_raises_systemexit_for_sigterm(self):
@@ -1202,19 +1207,22 @@ class TestToolbox(unittest.TestCase):
     def test_main_default_pool_dispatches_toolbox_django_kwargs(self):
         """--pool toolbox-django (the default) threads the right kwargs per active namespace.
 
-        The legacy `posthog` namespace gets no `extra_selector`. The golden-chart per-app
-        namespace `posthog-toolbox-django` adds `app.kubernetes.io/component=app` so the
+        With no KUBE_NAMESPACE the pool resolves to its `default_namespace`
+        (`posthog-toolbox-django`) and the `component=app` selector is added so the
         wrapper can't claim a pgbouncer pod (the chart's pgbouncers share
         `app.kubernetes.io/name=posthog-toolbox-django` with the toolbox itself).
+        `KUBE_NAMESPACE=posthog` remains an escape hatch back to the legacy stack,
+        which doesn't need (or have) the `component=app` discriminator.
         """
         cases = [
-            ("posthog", None),  # legacy default — KUBE_NAMESPACE unset
-            ("posthog-toolbox-django", "app.kubernetes.io/component=app"),
+            # (env_namespace_override, resolved_namespace, expected_extra_selector)
+            (None, "posthog-toolbox-django", "app.kubernetes.io/component=app"),
+            ("posthog", "posthog", None),
         ]
-        for namespace, expected_extra in cases:
-            with self.subTest(namespace=namespace):
+        for env_namespace, resolved_namespace, expected_extra in cases:
+            with self.subTest(env_namespace=env_namespace):
                 patches = self._patch_main_collaborators()
-                env_override = {"KUBE_NAMESPACE": namespace} if namespace != "posthog" else {}
+                env_override = {"KUBE_NAMESPACE": env_namespace} if env_namespace else {}
                 with (
                     patches["get_current_user"],
                     patches["get_toolbox_pod"] as m_get_pod,
@@ -1228,7 +1236,7 @@ class TestToolbox(unittest.TestCase):
                 ):
                     os.environ.pop("KUBE_CONTEXT", None)
                     os.environ.pop("FLOX_ENV", None)
-                    if namespace == "posthog":
+                    if env_namespace is None:
                         os.environ.pop("KUBE_NAMESPACE", None)
                     with self.assertRaises(SystemExit):
                         toolbox_script.main()
@@ -1238,7 +1246,7 @@ class TestToolbox(unittest.TestCase):
                     check_claimed=True,
                     app_label="posthog-toolbox-django",
                     claimed_label_key="toolbox-claimed",
-                    namespace=namespace,
+                    namespace=resolved_namespace,
                     context="posthog-dev",
                     extra_selector=expected_extra,
                 )
@@ -1369,7 +1377,7 @@ class TestToolbox(unittest.TestCase):
         m_atexit.assert_called_once_with(
             m_delete,
             "toolbox-pod-1",
-            namespace="posthog",
+            namespace="posthog-toolbox-django",
             context="posthog-dev",
             auto_yes=True,
             expected_label_key="toolbox-claimed",
@@ -1433,7 +1441,7 @@ class TestToolbox(unittest.TestCase):
         m_atexit.assert_called_once_with(
             m_delete,
             "toolbox-pod-1",
-            namespace="posthog",
+            namespace="posthog-toolbox-django",
             context="posthog-dev",
             auto_yes=True,
             expected_label_key="toolbox-claimed",
@@ -1503,7 +1511,7 @@ class TestToolbox(unittest.TestCase):
         self.assertEqual(m_get_pod.call_count, 2)
         self.assertEqual(m_claim.call_count, 2)
         # We connected to the pod we won, not the one we lost.
-        m_connect.assert_called_once_with("toolbox-pod-B", namespace="posthog", context="posthog-dev")
+        m_connect.assert_called_once_with("toolbox-pod-B", namespace="posthog-toolbox-django", context="posthog-dev")
         # atexit was registered twice (once per candidate pod) and unregistered once
         # to clear the stale registration after the race.
         self.assertEqual(m_atexit.call_count, 2)
@@ -1593,7 +1601,7 @@ class TestToolbox(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 toolbox_script.main()
 
-        m_connect.assert_called_once_with("toolbox-pod-mine", namespace="posthog", context="posthog-dev")
+        m_connect.assert_called_once_with("toolbox-pod-mine", namespace="posthog-toolbox-django", context="posthog-dev")
         # claim_pod was called once (the racing one) and not retried since we found our own pod.
         self.assertEqual(m_claim.call_count, 1)
         # First atexit register armed cleanup for pod-A; on the race we unregistered;

--- a/tools/infra-scripts/clitools/toolbox.py
+++ b/tools/infra-scripts/clitools/toolbox.py
@@ -18,15 +18,19 @@ from toolbox.kubernetes import select_context, validate_context
 from toolbox.pod import ClaimRaceError, claim_pod, connect_to_pod, delete_pod, get_toolbox_pod
 from toolbox.user import get_current_user
 
-# Extra label selectors ANDed onto the base `app.kubernetes.io/name=<app_label>`
-# selector. Keyed by namespace because the legacy and golden-chart deployments
-# share the same `app_label` but live in different namespaces with different
-# co-tenants (pgbouncer pods in the golden chart's per-app namespace also carry
-# `app.kubernetes.io/name=posthog-toolbox-django`, so we need `component=app` to
-# pick out only the main pool). The legacy `posthog` namespace doesn't need a
-# discriminator because its pgbouncers have a different `name` label.
+# `default_namespace` is where the pool lives when KUBE_NAMESPACE isn't set.
+#
+# `extra_selectors_by_namespace` ANDs onto the base
+# `app.kubernetes.io/name=<app_label>` selector. Keyed by namespace because the
+# golden-chart deployment co-locates the toolbox release's own pgbouncer pods
+# under the same `name` label, so we need `component=app` there to pick only
+# the main pool pods. The legacy `posthog` namespace doesn't need a
+# discriminator because its pgbouncers carry a different `name`.
 POOLS = {
     "toolbox-django": {
+        # Golden-chart deployment in the per-app namespace; the legacy `posthog`
+        # namespace is still available via `KUBE_NAMESPACE=posthog`.
+        "default_namespace": "posthog-toolbox-django",
         "app_label": "posthog-toolbox-django",
         "claimed_label_key": "toolbox-claimed",
         "extra_selectors_by_namespace": {
@@ -34,6 +38,7 @@ POOLS = {
         },
     },
     "flags-cache-jumphost": {
+        "default_namespace": "posthog",
         "app_label": "flags-cache-jumphost",
         "claimed_label_key": "flags-jumphost-claimed",
     },
@@ -92,7 +97,10 @@ def main():
         pool = POOLS[args.pool]
         app_label = pool["app_label"]
         claimed_label_key = pool["claimed_label_key"]
-        namespace = os.environ.get("KUBE_NAMESPACE", "posthog")
+        # Each pool advertises its own default namespace; `KUBE_NAMESPACE`
+        # remains the escape hatch (e.g. to point the toolbox-django pool back
+        # at the legacy `posthog` namespace during migration).
+        namespace = os.environ.get("KUBE_NAMESPACE", pool["default_namespace"])
         # The base selector is `app.kubernetes.io/name=<app_label>`. Some
         # namespaces also host other workloads that share that label (e.g. the
         # golden chart deploys a per-app pgbouncer under the same name in the


### PR DESCRIPTION
## Problem

With the golden-chart toolbox now live in dev / prod-us / prod-eu, engineers should land on it by default — no env vars to set, no flags to pass. The other pool (`flags-cache-jumphost`) still belongs in the `posthog` namespace, so a single global default doesn't work.

## Changes

- New `default_namespace` field on each pool entry. `toolbox-django` → `posthog-toolbox-django`, `flags-cache-jumphost` → `posthog` (unchanged in practice).
- `main()` reads the namespace as `os.environ.get("KUBE_NAMESPACE", pool["default_namespace"])`, so the env override is still the escape hatch — useful during the migration window if anyone needs to point the toolbox back at the legacy stack (`KUBE_NAMESPACE=posthog toolbox.py`).
- The existing `extra_selectors_by_namespace` keying still applies — golden-chart namespace adds `component=app`, legacy namespace stays without.

Behaviour matrix after this PR:

| Pool | KUBE_NAMESPACE unset | KUBE_NAMESPACE=posthog |
|------|----------------------|------------------------|
| toolbox-django (default) | new stack (`posthog-toolbox-django` + `component=app` selector) | legacy stack |
| flags-cache-jumphost | unchanged (`posthog`) | unchanged (`posthog`) |

Companion to chart-side rollout PostHog/charts#11148, which puts the new toolbox in prod-us and prod-eu. Follows on from #58988 (the wrapper-side selector plumbing).

## How did you test this code?

I'm Claude (PostHog Code). End-to-end testing against a real cluster is for the human reviewer; I haven't claimed it here.

Automated:
- `python3 -m unittest test_toolbox` — 67 tests, all green.
- Parametrised `test_main_default_pool_dispatches_toolbox_django_kwargs` updated to cover both the no-env default (now goes to golden-chart namespace) and the `KUBE_NAMESPACE=posthog` legacy override.
- `test_pools_definition` now asserts the new `default_namespace` field on both pools.
- Four `main()` integration tests that asserted on `namespace="posthog"` updated to expect `posthog-toolbox-django` (they exercise default-namespace paths through atexit/claim-race wiring).

## Publish to changelog?

no

## Docs update

Not applicable — usage surface (env vars, flags) is unchanged.

## 🤖 Agent context

Authored by Claude (PostHog Code).

Considered alternatives:

- Keeping a single global `DEFAULT_NAMESPACE = "posthog-toolbox-django"` at module level. Rejected because the `flags-cache-jumphost` pool still lives in `posthog`, and putting per-pool concerns in a top-level constant would re-create the kind of action-at-a-distance we keep cleaning up.
- A `--namespace` CLI flag. Rejected — `KUBE_NAMESPACE` already exists and engineers know it; one input not two.
- Migrating in-place by switching `DEFAULT_NAMESPACE` and tagging the legacy pods with a matching component label. Rejected — bigger blast radius and not needed; the per-pool default keeps the wiring local.