### PR TITLE
perf(cymbal): reduce memory pressure and unblock tokio workers in symbol store

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2619,6 +2619,7 @@ dependencies = [
  "aws-sdk-s3",
  "axum 0.7.9",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "common-alloc",
  "common-continuous-profiling",

--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -51,6 +51,18 @@ pub fn setup_metrics_routes_for_product(router: Router, product: impl Into<Strin
     install_metrics_routes(router, Some(product.into()), &[])
 }
 
+/// Like [`setup_metrics_routes`], but applies per-metric histogram bucket
+/// overrides on top of the default bucket configuration. Use when the default
+/// latency-shaped buckets don't fit a histogram's native unit (e.g. byte
+/// counts). See [`setup_metrics_routes_for_product_with_overrides`] for the
+/// overrides shape.
+pub fn setup_metrics_routes_with_overrides(
+    router: Router,
+    overrides: &[(Matcher, &[f64])],
+) -> Router {
+    install_metrics_routes(router, None, overrides)
+}
+
 /// Like [`setup_metrics_routes_for_product`], but applies per-metric histogram
 /// bucket overrides on top of the default bucket configuration. Each entry in
 /// `overrides` is a `(Matcher, &[f64])` pair: the matcher (Full / Prefix /

--- a/rust/common/symbol_data/src/symbol_data.rs
+++ b/rust/common/symbol_data/src/symbol_data.rs
@@ -83,7 +83,7 @@ where
     Ok(buffer)
 }
 
-pub fn read_as<T>(data: Vec<u8>) -> Result<T, Error>
+pub fn read_as<T>(data: &[u8]) -> Result<T, Error>
 where
     T: SymbolData,
 {
@@ -93,23 +93,23 @@ where
 /// Like `read_as`, but also returns the decompressed payload byte count.
 /// This is useful for cache memory accounting when the container uses compression,
 /// since the compressed size can be much smaller than the actual data in memory.
-pub fn read_as_with_byte_count<T>(data: Vec<u8>) -> Result<(T, usize), Error>
+pub fn read_as_with_byte_count<T>(data: &[u8]) -> Result<(T, usize), Error>
 where
     T: SymbolData,
 {
-    let version = read_version(&data)?;
+    let version = read_version(data)?;
 
     match version {
         V1_VERSION => {
             assert_at_least_as_long_as(v1_header_len(), data.len())?;
-            assert_data_type_impl(&data, T::data_type())?;
+            assert_data_type_impl(data, T::data_type())?;
             let payload = data[v1_header_len()..].to_vec();
             let byte_count = payload.len();
             T::from_bytes(payload).map(|v| (v, byte_count))
         }
         VERSION => {
             assert_at_least_as_long_as(v2_header_len(), data.len())?;
-            assert_data_type_impl(&data, T::data_type())?;
+            assert_data_type_impl(data, T::data_type())?;
             let compression = Compression::try_from(data[v2_header_len() - 1])?;
             let payload = &data[v2_header_len()..];
             let decompressed = match compression {

--- a/rust/common/symbol_data/tests/test.rs
+++ b/rust/common/symbol_data/tests/test.rs
@@ -10,7 +10,7 @@ const COMPRESSION_OFFSET: usize = MAGIC_LEN + 4 + 4; // after MAGIC + VERSION + 
 #[test]
 fn test_source_and_map_reading() {
     // This file is v1 format - validates backward compatibility
-    let input = include_bytes!("static/sourcemap_with_nulls.jsdata").to_vec();
+    let input = include_bytes!("static/sourcemap_with_nulls.jsdata");
     read_symbol_data::<SourceAndMap>(input).unwrap();
 }
 
@@ -30,7 +30,7 @@ fn test_v2_compressed_header() {
     assert_eq!(version, 2);
     assert_eq!(bytes[COMPRESSION_OFFSET], 1); // zstd
 
-    let output = read_symbol_data::<SourceAndMap>(bytes).unwrap();
+    let output = read_symbol_data::<SourceAndMap>(&bytes).unwrap();
     assert_eq!(input, output);
 }
 
@@ -50,7 +50,7 @@ fn test_v2_uncompressed_header() {
     assert_eq!(version, 2);
     assert_eq!(bytes[COMPRESSION_OFFSET], 0); // none
 
-    let output = read_symbol_data::<SourceAndMap>(bytes).unwrap();
+    let output = read_symbol_data::<SourceAndMap>(&bytes).unwrap();
     assert_eq!(input, output);
 }
 
@@ -60,7 +60,7 @@ macro_rules! roundtrip_test {
         fn $name() {
             let input = $value;
             let bytes = write_symbol_data(input.clone()).unwrap();
-            let output = read_symbol_data::<$ty>(bytes).unwrap();
+            let output = read_symbol_data::<$ty>(&bytes).unwrap();
             assert_eq!(input, output);
         }
     };
@@ -102,6 +102,6 @@ fn test_v2_compressed_large_payload() {
     let uncompressed_bytes = write_symbol_data_uncompressed(input.clone()).unwrap();
     assert!(bytes.len() < uncompressed_bytes.len() / 2);
 
-    let output = read_symbol_data::<SourceAndMap>(bytes).unwrap();
+    let output = read_symbol_data::<SourceAndMap>(&bytes).unwrap();
     assert_eq!(input, output);
 }

--- a/rust/cymbal/Cargo.toml
+++ b/rust/cymbal/Cargo.toml
@@ -40,6 +40,7 @@ moka = { workspace = true }
 rdkafka = { workspace = true }
 posthog-rs = { workspace = true }
 base64 = { workspace = true }
+bytes = { workspace = true }
 regex = { workspace = true }
 futures.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -1,6 +1,7 @@
 use common_kafka::kafka_producer::{create_kafka_producer, KafkaContext};
 use common_redis::{Client as RedisClientTrait, RedisClient};
 use health::HealthRegistry;
+use moka::future::{Cache, CacheBuilder};
 use rdkafka::producer::FutureProducer;
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::{sync::Arc, time::Duration};
@@ -10,6 +11,7 @@ use tracing::info;
 use crate::{
     config::{get_aws_config, init_global_state, Config},
     error::UnhandledError,
+    issue_resolution::Issue,
     signals::{MaybeSignalClient, SignalClient},
     stages::resolution::symbol::{local::LocalSymbolResolver, SymbolResolver},
     symbol_store::{
@@ -24,6 +26,7 @@ use crate::{
         BlobClient, Catalog, S3Client,
     },
     teams::TeamManager,
+    types::operator::TeamId,
 };
 
 pub struct AppContext {
@@ -42,6 +45,10 @@ pub struct AppContext {
     pub team_manager: TeamManager,
     pub issue_buckets_redis_client: Arc<dyn RedisClientTrait + Send + Sync>,
     pub signal_client: MaybeSignalClient,
+    // Shared (fingerprint -> issue) cache. Lives on AppContext so it persists across
+    // requests — every batch shares a single LinkingStage cache instead of building a
+    // fresh one. moka caches are cheap to clone (internally Arc'd).
+    pub issue_cache: Cache<(TeamId, String), Issue>,
 }
 
 impl AppContext {
@@ -198,6 +205,10 @@ impl AppContext {
         let process_request_limiter =
             Arc::new(Semaphore::new(config.process_max_in_flight_requests.max(1)));
 
+        let issue_cache = CacheBuilder::new(1000)
+            .time_to_live(Duration::from_secs(config.issue_cache_ttl_seconds))
+            .build();
+
         Ok(Self {
             health_registry,
             immediate_producer,
@@ -211,6 +222,7 @@ impl AppContext {
             issue_buckets_redis_client,
             signal_client,
             symbol_resolver,
+            issue_cache,
         })
     }
 }

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -7,11 +7,11 @@ use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::{sync::Arc, time::Duration};
 use tokio::sync::{Mutex, Semaphore};
 use tracing::info;
+use uuid::Uuid;
 
 use crate::{
     config::{get_aws_config, init_global_state, Config},
     error::UnhandledError,
-    issue_resolution::Issue,
     signals::{MaybeSignalClient, SignalClient},
     stages::resolution::symbol::{local::LocalSymbolResolver, SymbolResolver},
     symbol_store::{
@@ -45,10 +45,11 @@ pub struct AppContext {
     pub team_manager: TeamManager,
     pub issue_buckets_redis_client: Arc<dyn RedisClientTrait + Send + Sync>,
     pub signal_client: MaybeSignalClient,
-    // Shared (fingerprint -> issue) cache. Lives on AppContext so it persists across
-    // requests — every batch shares a single LinkingStage cache instead of building a
-    // fresh one. moka caches are cheap to clone (internally Arc'd).
-    pub issue_cache: Cache<(TeamId, String), Issue>,
+    // Shared `(team_id, fingerprint) -> issue_id` mapping cache. Lives on AppContext so
+    // it persists across requests — only the stable mapping is cached, never the Issue
+    // itself, so suppression / reopen always see current PG state (see `IssueLinker`).
+    // moka caches are cheap to clone (internally Arc'd).
+    pub issue_cache: Cache<(TeamId, String), Uuid>,
 }
 
 impl AppContext {

--- a/rust/cymbal/src/langs/apple.rs
+++ b/rust/cymbal/src/langs/apple.rs
@@ -709,7 +709,7 @@ mod test {
                 predicate::eq(config.object_storage_bucket.clone()),
                 predicate::eq(chunk_id.clone()),
             )
-            .returning(|_, _| Ok(Some(get_dsym_bytes())));
+            .returning(|_, _| Ok(Some(bytes::Bytes::from(get_dsym_bytes()))));
 
         let client = Arc::new(client);
 
@@ -870,7 +870,7 @@ mod test {
                 predicate::eq(config.object_storage_bucket.clone()),
                 predicate::eq(chunk_id.clone()),
             )
-            .returning(|_, _| Ok(Some(get_inline_dsym_bytes())));
+            .returning(|_, _| Ok(Some(bytes::Bytes::from(get_inline_dsym_bytes()))));
         let client = Arc::new(client);
 
         let catalog = Catalog::new(

--- a/rust/cymbal/src/langs/hermes.rs
+++ b/rust/cymbal/src/langs/hermes.rs
@@ -278,7 +278,7 @@ mod test {
                 predicate::eq(config.object_storage_bucket.clone()),
                 predicate::eq(chunk_id.clone()), // We set the chunk id as the storage ptr above, in production it will be a different value with a prefix
             )
-            .returning(|_, _| Ok(Some(get_symbol_data_bytes())));
+            .returning(|_, _| Ok(Some(bytes::Bytes::from(get_symbol_data_bytes()))));
 
         let client = Arc::new(client);
 

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -23,10 +23,21 @@ pub const FRAME_DB_HITS: &str = "cymbal_frame_db_hits";
 pub const FRAME_DB_MISSES: &str = "cymbal_frame_db_misses";
 pub const FRAME_NOT_RESOLVED: &str = "cymbal_frame_not_resolved";
 pub const S3_FETCH: &str = "cymbal_s3_fetch";
+// S3 GET body size, in bytes, taken from the `Content-Length` header on the GET response
+// (so it's recorded before we collect the body — sets us up to enforce a size cap here later).
+pub const S3_FETCHED_BYTES: &str = "cymbal_s3_fetched_bytes";
 pub const S3_PUT: &str = "cymbal_s3_put";
+// S3 PUT body size, in bytes, observed at the call site.
+pub const S3_PUT_BYTES: &str = "cymbal_s3_put_bytes";
 pub const SOURCEMAP_FETCH: &str = "cymbal_sourcemap_fetch";
+// Size of an external (non-S3) sourcemap or minified source fetch, in bytes after decoding
+// the HTTP response body. Labelled by `kind` (`source` / `sourcemap`).
+pub const SOURCEMAP_EXTERNAL_BYTES: &str = "cymbal_sourcemap_external_bytes";
 pub const SAVE_SYMBOL_SET: &str = "cymbal_save_symbol_set";
 pub const SOURCEMAP_PARSE: &str = "cymbal_sourcemap_parse";
+// Decompressed size of a parsed symbol set, in bytes. Labelled by `kind`
+// (`sourcemap` / `hermes` / `proguard` / `apple`).
+pub const SYMBOL_SET_DECOMPRESSED_BYTES: &str = "cymbal_symbol_set_decompressed_bytes";
 pub const ISSUE_CREATED: &str = "cymbal_issue_created";
 pub const ISSUE_REOPENED: &str = "cymbal_issue_reopened";
 pub const FRAME_RESOLUTION_RESULTS_DELETED: &str = "cymbal_frame_resolution_results_deleted";

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -38,6 +38,27 @@ pub const SOURCEMAP_PARSE: &str = "cymbal_sourcemap_parse";
 // Decompressed size of a parsed symbol set, in bytes. Labelled by `kind`
 // (`sourcemap` / `hermes` / `proguard` / `apple`).
 pub const SYMBOL_SET_DECOMPRESSED_BYTES: &str = "cymbal_symbol_set_decompressed_bytes";
+
+// Histogram buckets for the byte-shaped metrics above. The default
+// `common_metrics` buckets are tuned for milliseconds of latency and saturate
+// at 10_000 — every multi-KB fetch would land in the `+Inf` bucket. These
+// cover 1 KiB → 1 GiB with extra granularity in the multi-MB range where any
+// reasonable size cap would live.
+pub const BYTE_HISTOGRAM_BUCKETS: &[f64] = &[
+    1_024.0,         // 1 KiB
+    10_240.0,        // 10 KiB
+    102_400.0,       // 100 KiB
+    524_288.0,       // 512 KiB
+    1_048_576.0,     // 1 MiB
+    5_242_880.0,     // 5 MiB
+    10_485_760.0,    // 10 MiB
+    26_214_400.0,    // 25 MiB
+    52_428_800.0,    // 50 MiB
+    104_857_600.0,   // 100 MiB
+    268_435_456.0,   // 256 MiB
+    536_870_912.0,   // 512 MiB
+    1_073_741_824.0, // 1 GiB
+];
 pub const ISSUE_CREATED: &str = "cymbal_issue_created";
 pub const ISSUE_REOPENED: &str = "cymbal_issue_reopened";
 pub const FRAME_RESOLUTION_RESULTS_DELETED: &str = "cymbal_frame_resolution_results_deleted";

--- a/rust/cymbal/src/server.rs
+++ b/rust/cymbal/src/server.rs
@@ -1,13 +1,36 @@
 use std::sync::Arc;
 
-use common_metrics::{serve, setup_metrics_routes};
+use common_metrics::{serve, setup_metrics_routes_with_overrides, Matcher};
 use tracing::info;
 
-use crate::{app_context::AppContext, config::Config, router::get_router};
+use crate::{
+    app_context::AppContext,
+    config::Config,
+    metric_consts::{
+        BYTE_HISTOGRAM_BUCKETS, S3_FETCHED_BYTES, S3_PUT_BYTES, SOURCEMAP_EXTERNAL_BYTES,
+        SYMBOL_SET_DECOMPRESSED_BYTES,
+    },
+    router::get_router,
+};
 
 pub async fn start_server(config: Config, context: Arc<AppContext>) -> () {
     let router = get_router(context);
-    let router = setup_metrics_routes(router);
+    let bucket_overrides: &[(Matcher, &[f64])] = &[
+        (
+            Matcher::Full(S3_FETCHED_BYTES.into()),
+            BYTE_HISTOGRAM_BUCKETS,
+        ),
+        (Matcher::Full(S3_PUT_BYTES.into()), BYTE_HISTOGRAM_BUCKETS),
+        (
+            Matcher::Full(SOURCEMAP_EXTERNAL_BYTES.into()),
+            BYTE_HISTOGRAM_BUCKETS,
+        ),
+        (
+            Matcher::Full(SYMBOL_SET_DECOMPRESSED_BYTES.into()),
+            BYTE_HISTOGRAM_BUCKETS,
+        ),
+    ];
+    let router = setup_metrics_routes_with_overrides(router, bucket_overrides);
     let bind = format!("{}:{}", config.host, config.port);
     info!("Server started and listening on {}", bind);
     serve(router, &bind)

--- a/rust/cymbal/src/stages/linking/issue.rs
+++ b/rust/cymbal/src/stages/linking/issue.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use common_types::format::parse_datetime_assuming_utc;
 use sqlx::{Acquire, PgConnection};
 use tracing::warn;
+use uuid::Uuid;
 
 use crate::{
     app_context::AppContext,
@@ -73,20 +74,103 @@ impl ValueOperator for IssueLinker {
         ctx: LinkingStage,
     ) -> OperatorResult<Self> {
         let fingerprint = input.fingerprint.clone().unwrap();
+        let key = (input.team_id, fingerprint.clone());
+
+        // The cache holds only the stable `(team_id, fingerprint) -> issue_id` mapping
+        // across requests. We deliberately do NOT cache the Issue itself: status changes
+        // (suppression, resolution) made in PG would otherwise be ignored by
+        // `IssueSuppression` and `maybe_reopen` until the cache TTL expired.
         let cloned_input = input.clone();
-        let issue: Issue = ctx
+        let ctx_for_load = ctx.clone();
+        let issue_id: Uuid = ctx
             .issue_cache
-            .try_get_with((input.team_id, fingerprint), async move {
-                Self::fetch_or_create_issue(cloned_input, ctx.app_context.clone()).await
+            .try_get_with(key.clone(), async move {
+                let issue =
+                    Self::fetch_or_create_issue(cloned_input, ctx_for_load.app_context.clone())
+                        .await?;
+                Ok::<Uuid, UnhandledError>(issue.id)
             })
             .await
             .map_err(|e: Arc<UnhandledError>| UnhandledError::Other(e.to_string()))?;
+
+        // Always re-read current state. On the cache-miss path this is one redundant PK
+        // lookup; on the cache-hit path it's the whole point — we replace the expensive
+        // fingerprint JOIN with a cheap PK lookup while keeping status fresh.
+        let issue = match load_and_maybe_reopen(
+            ctx.app_context.as_ref(),
+            input.team_id,
+            issue_id,
+            &fingerprint,
+            &input,
+        )
+        .await?
+        {
+            Some(issue) => issue,
+            None => {
+                // The cached id no longer exists in PG (deleted issue). Invalidate and
+                // run the full slow path, which will create a new issue if needed.
+                ctx.issue_cache.invalidate(&key).await;
+                Self::fetch_or_create_issue(input.clone(), ctx.app_context.clone()).await?
+            }
+        };
 
         input.issue_id = Some(issue.id);
         input.issue = Some(issue);
 
         Ok(Ok(input))
     }
+}
+
+// Loads the issue by id (fast PK lookup) and runs the reopen side effects if the issue
+// is currently in a non-active, non-suppressed state. Returns `None` if the cached id
+// is dangling (issue was deleted), so the caller can invalidate and fall back to a full
+// resolve.
+async fn load_and_maybe_reopen(
+    context: &AppContext,
+    team_id: i32,
+    issue_id: Uuid,
+    fingerprint: &str,
+    event_properties: &ExceptionProperties,
+) -> Result<Option<Issue>, UnhandledError> {
+    let mut conn = context.posthog_pool.acquire().await?;
+    let Some(mut issue) = Issue::load(&mut *conn, team_id, issue_id).await? else {
+        return Ok(None);
+    };
+
+    if !issue.maybe_reopen(&mut *conn).await? {
+        return Ok(Some(issue));
+    }
+
+    // Reopened — mirror the side effects from `resolve_issue`'s fast-path reopen branch.
+    let event_timestamp =
+        parse_datetime_assuming_utc(&event_properties.timestamp).unwrap_or_else(|e| {
+            warn!(
+                event = event_properties.uuid.to_string(),
+                "Failed to get event timestamp, using current time, error: {:?}", e
+            );
+            Utc::now()
+        });
+    let assignment =
+        process_assignment(&mut conn, &context.team_manager, &issue, event_properties).await?;
+    // We don't carry a per-fingerprint `first_seen` through this path (we loaded by id,
+    // not by fingerprint), so fall back to the issue's creation time the same way
+    // `resolve_issue` already does when the join returns no first_seen.
+    send_fingerprint_issue_state(
+        context,
+        &issue,
+        fingerprint,
+        assignment.as_ref(),
+        issue.created_at,
+    )
+    .await?;
+    let output_props: OutputErrProps = event_properties.to_output(issue.id)?;
+    drop(conn);
+    context
+        .signal_client
+        .emit_issue_reopened(&issue, &output_props);
+    send_issue_reopened_alert(context, &issue, assignment, output_props, &event_timestamp).await?;
+
+    Ok(Some(issue))
 }
 
 async fn resolve_issue(

--- a/rust/cymbal/src/stages/linking/issue.rs
+++ b/rust/cymbal/src/stages/linking/issue.rs
@@ -74,50 +74,91 @@ impl ValueOperator for IssueLinker {
         ctx: LinkingStage,
     ) -> OperatorResult<Self> {
         let fingerprint = input.fingerprint.clone().unwrap();
-        let key = (input.team_id, fingerprint.clone());
+        let key = (input.team_id, fingerprint);
 
-        // The cache holds only the stable `(team_id, fingerprint) -> issue_id` mapping
-        // across requests. We deliberately do NOT cache the Issue itself: status changes
-        // (suppression, resolution) made in PG would otherwise be ignored by
-        // `IssueSuppression` and `maybe_reopen` until the cache TTL expired.
+        // Two-layer cache: per-batch dedup wraps the cross-request `issue_id` cache.
+        // - Per-batch cache (this `try_get_with`): events with the same fingerprint in
+        //   the same batch resolve the Issue exactly once. moka serializes concurrent
+        //   misses for the same key inside the batch.
+        // - Cross-batch `issue_id` cache (inside `resolve_via_id_cache`): keeps the
+        //   `(team_id, fingerprint) -> issue_id` mapping warm across batches and
+        //   skips the expensive fingerprint JOIN on warm fingerprints.
+        // Status is always read fresh from PG inside the loader, so `IssueSuppression`
+        // and `maybe_reopen` never see stale state.
         let cloned_input = input.clone();
         let ctx_for_load = ctx.clone();
-        let issue_id: Uuid = ctx
-            .issue_cache
-            .try_get_with(key.clone(), async move {
-                let issue =
-                    Self::fetch_or_create_issue(cloned_input, ctx_for_load.app_context.clone())
-                        .await?;
-                Ok::<Uuid, UnhandledError>(issue.id)
+        let issue: Issue = ctx
+            .batch_issue_cache
+            .try_get_with(key, async move {
+                resolve_via_id_cache(cloned_input, &ctx_for_load).await
             })
             .await
             .map_err(|e: Arc<UnhandledError>| UnhandledError::Other(e.to_string()))?;
-
-        // Always re-read current state. On the cache-miss path this is one redundant PK
-        // lookup; on the cache-hit path it's the whole point — we replace the expensive
-        // fingerprint JOIN with a cheap PK lookup while keeping status fresh.
-        let issue = match load_and_maybe_reopen(
-            ctx.app_context.as_ref(),
-            input.team_id,
-            issue_id,
-            &fingerprint,
-            &input,
-        )
-        .await?
-        {
-            Some(issue) => issue,
-            None => {
-                // The cached id no longer exists in PG (deleted issue). Invalidate and
-                // run the full slow path, which will create a new issue if needed.
-                ctx.issue_cache.invalidate(&key).await;
-                Self::fetch_or_create_issue(input.clone(), ctx.app_context.clone()).await?
-            }
-        };
 
         input.issue_id = Some(issue.id);
         input.issue = Some(issue);
 
         Ok(Ok(input))
+    }
+}
+
+// Resolves an issue by going through the cross-batch `issue_id` cache:
+// - On cache miss we run `fetch_or_create_issue` (the only place that fires
+//   `created` / `reopened` alerts) and return the freshly-loaded Issue directly,
+//   avoiding a redundant PK lookup.
+// - On cache hit we re-read by id (cheap PK lookup) and call `maybe_reopen` so
+//   suppression and reopen always see current PG state.
+async fn resolve_via_id_cache(
+    input: ExceptionProperties,
+    ctx: &LinkingStage,
+) -> Result<Issue, UnhandledError> {
+    let fingerprint = input.fingerprint.clone().unwrap();
+    let key = (input.team_id, fingerprint.clone());
+
+    // `try_get_with` only returns the cached value (`Uuid`), so we stash the freshly
+    // resolved Issue in a slot when we run the loader ourselves. That lets us reuse it
+    // below and skip a redundant `Issue::load` on the cache-miss path.
+    let just_resolved: Arc<std::sync::Mutex<Option<Issue>>> = Default::default();
+    let slot = just_resolved.clone();
+    let app_ctx = ctx.app_context.clone();
+    let cloned_input = input.clone();
+
+    let issue_id: Uuid = ctx
+        .issue_cache
+        .try_get_with(key.clone(), async move {
+            let issue = IssueLinker::fetch_or_create_issue(cloned_input, app_ctx).await?;
+            let id = issue.id;
+            *slot.lock().expect("just_resolved mutex poisoned") = Some(issue);
+            Ok::<Uuid, UnhandledError>(id)
+        })
+        .await
+        .map_err(|e: Arc<UnhandledError>| UnhandledError::Other(e.to_string()))?;
+
+    // If we ran the loader, the just-resolved Issue is current — return it directly.
+    if let Some(issue) = just_resolved
+        .lock()
+        .expect("just_resolved mutex poisoned")
+        .take()
+    {
+        return Ok(issue);
+    }
+
+    // Cache hit (or we were deduped against a concurrent caller). Refresh by id.
+    match load_and_maybe_reopen(
+        ctx.app_context.as_ref(),
+        input.team_id,
+        issue_id,
+        &fingerprint,
+        &input,
+    )
+    .await?
+    {
+        Some(issue) => Ok(issue),
+        None => {
+            // Cached id no longer exists in PG. Invalidate and run the slow path.
+            ctx.issue_cache.invalidate(&key).await;
+            IssueLinker::fetch_or_create_issue(input, ctx.app_context.clone()).await
+        }
     }
 }
 

--- a/rust/cymbal/src/stages/linking/mod.rs
+++ b/rust/cymbal/src/stages/linking/mod.rs
@@ -4,11 +4,12 @@ pub mod issue;
 pub mod rule_suppression;
 pub mod suppression;
 
-use moka::future::Cache;
+use moka::future::{Cache, CacheBuilder};
 use uuid::Uuid;
 
 use crate::{
     app_context::AppContext,
+    issue_resolution::Issue,
     metric_consts::LINKING_STAGE,
     stages::{
         linking::{
@@ -26,7 +27,13 @@ use crate::{
 #[derive(Clone)]
 pub struct LinkingStage {
     pub app_context: Arc<AppContext>,
+    // Cross-batch `(team_id, fingerprint) -> issue_id` mapping cache. Owned by AppContext.
     pub issue_cache: Cache<(TeamId, String), Uuid>,
+    // Per-batch fingerprint -> Issue dedup. Built fresh per batch (LinkingStage is
+    // constructed per batch via `From`), so events sharing a fingerprint within a single
+    // batch resolve the Issue exactly once. moka's `try_get_with` also deduplicates
+    // concurrent misses for the same key inside the same batch.
+    pub batch_issue_cache: Cache<(TeamId, String), Issue>,
 }
 
 impl Stage for LinkingStage {
@@ -50,11 +57,14 @@ impl Stage for LinkingStage {
 
 impl From<&Arc<AppContext>> for LinkingStage {
     fn from(ctx: &Arc<AppContext>) -> Self {
-        // The issue cache lives on AppContext so it survives across batches; cloning the
+        // `issue_cache` lives on AppContext so it survives across batches; cloning the
         // moka handle is just a refcount bump on the underlying Arc.
+        // `batch_issue_cache` is built fresh per batch — capacity is generous because
+        // `MAX_EVENTS_PER_BATCH` is 1000 today; the cache is dropped when the stage is.
         Self {
             app_context: ctx.clone(),
             issue_cache: ctx.issue_cache.clone(),
+            batch_issue_cache: CacheBuilder::new(10_000).build(),
         }
     }
 }

--- a/rust/cymbal/src/stages/linking/mod.rs
+++ b/rust/cymbal/src/stages/linking/mod.rs
@@ -5,10 +5,10 @@ pub mod rule_suppression;
 pub mod suppression;
 
 use moka::future::Cache;
+use uuid::Uuid;
 
 use crate::{
     app_context::AppContext,
-    issue_resolution::Issue,
     metric_consts::LINKING_STAGE,
     stages::{
         linking::{
@@ -26,7 +26,7 @@ use crate::{
 #[derive(Clone)]
 pub struct LinkingStage {
     pub app_context: Arc<AppContext>,
-    pub issue_cache: Cache<(TeamId, String), Issue>,
+    pub issue_cache: Cache<(TeamId, String), Uuid>,
 }
 
 impl Stage for LinkingStage {

--- a/rust/cymbal/src/stages/linking/mod.rs
+++ b/rust/cymbal/src/stages/linking/mod.rs
@@ -4,7 +4,7 @@ pub mod issue;
 pub mod rule_suppression;
 pub mod suppression;
 
-use moka::future::{Cache, CacheBuilder};
+use moka::future::Cache;
 
 use crate::{
     app_context::AppContext,
@@ -50,14 +50,11 @@ impl Stage for LinkingStage {
 
 impl From<&Arc<AppContext>> for LinkingStage {
     fn from(ctx: &Arc<AppContext>) -> Self {
-        let issue_cache = CacheBuilder::new(1000)
-            .time_to_live(std::time::Duration::from_secs(
-                ctx.config.issue_cache_ttl_seconds,
-            ))
-            .build();
+        // The issue cache lives on AppContext so it survives across batches; cloning the
+        // moka handle is just a refcount bump on the underlying Arc.
         Self {
             app_context: ctx.clone(),
-            issue_cache,
+            issue_cache: ctx.issue_cache.clone(),
         }
     }
 }

--- a/rust/cymbal/src/stages/resolution/exception.rs
+++ b/rust/cymbal/src/stages/resolution/exception.rs
@@ -128,7 +128,7 @@ mod test {
                 predicate::eq(config.object_storage_bucket.clone()),
                 predicate::eq(map_id.clone()), // We set the map id as the storage ptr above, in production it will be a different value with a prefix
             )
-            .returning(|_, _| Ok(Some(get_symbol_data_bytes())));
+            .returning(|_, _| Ok(Some(bytes::Bytes::from(get_symbol_data_bytes()))));
 
         let client = Arc::new(client);
 

--- a/rust/cymbal/src/stages/resolution/symbol/local.rs
+++ b/rust/cymbal/src/stages/resolution/symbol/local.rs
@@ -194,6 +194,7 @@ mod test {
 
     use std::sync::Arc;
 
+    use bytes::Bytes;
     use common_types::ClickHouseEvent;
     use httpmock::MockServer;
     use mockall::predicate;
@@ -356,7 +357,7 @@ mod test {
                 predicate::eq(config.object_storage_bucket.clone()),
                 predicate::str::starts_with(config.ss_prefix.clone()),
             )
-            .returning(|_, _| Ok(Some(get_sourcemapcache_bytes())))
+            .returning(|_, _| Ok(Some(Bytes::from(get_sourcemapcache_bytes()))))
             .times(gets);
 
         client

--- a/rust/cymbal/src/symbol_store/apple.rs
+++ b/rust/cymbal/src/symbol_store/apple.rs
@@ -13,7 +13,7 @@ use zip::ZipArchive;
 use posthog_symbol_data::{read_symbol_data_with_byte_count, AppleDsym};
 
 use crate::{
-    error::{AppleError, ResolveError},
+    error::{AppleError, ResolveError, UnhandledError},
     symbol_store::{caching::Countable, Fetcher, Parser},
 };
 
@@ -64,18 +64,25 @@ impl Parser for AppleProvider {
     type Err = ResolveError;
 
     async fn parse(&self, source: Self::Source) -> Result<ParsedAppleSymbols, ResolveError> {
-        // Try to unwrap symbol_data container first (new format),
-        // fall back to raw ZIP for backward compatibility with existing uploads.
-        // TODO(2026-09-24): Remove raw ZIP fallback once all old uploads have expired.
-        let (zip_data, decompressed_bytes) =
-            match read_symbol_data_with_byte_count::<AppleDsym>(&source) {
-                Ok((dsym, bytes)) => (dsym.data, bytes),
-                Err(_) => {
-                    let len = source.len();
-                    (source.to_vec(), len)
-                }
-            };
-        ParsedAppleSymbols::from_dsym_zip(zip_data, decompressed_bytes)
+        // dSYM parsing is the heaviest CPU work in the system: zstd decompress, ZIP
+        // expansion, DWARF parse, and symcache conversion. Always offload from the tokio
+        // runtime.
+        tokio::task::spawn_blocking(move || -> Result<ParsedAppleSymbols, ResolveError> {
+            // Try to unwrap symbol_data container first (new format),
+            // fall back to raw ZIP for backward compatibility with existing uploads.
+            // TODO(2026-09-24): Remove raw ZIP fallback once all old uploads have expired.
+            let (zip_data, decompressed_bytes) =
+                match read_symbol_data_with_byte_count::<AppleDsym>(&source) {
+                    Ok((dsym, bytes)) => (dsym.data, bytes),
+                    Err(_) => {
+                        let len = source.len();
+                        (source.to_vec(), len)
+                    }
+                };
+            ParsedAppleSymbols::from_dsym_zip(zip_data, decompressed_bytes)
+        })
+        .await
+        .map_err(|e| UnhandledError::Other(format!("apple dSYM parse task failed: {e}")))?
     }
 }
 

--- a/rust/cymbal/src/symbol_store/apple.rs
+++ b/rust/cymbal/src/symbol_store/apple.rs
@@ -14,6 +14,7 @@ use posthog_symbol_data::{read_symbol_data_with_byte_count, AppleDsym};
 
 use crate::{
     error::{AppleError, ResolveError, UnhandledError},
+    metric_consts::SYMBOL_SET_DECOMPRESSED_BYTES,
     symbol_store::{caching::Countable, Fetcher, Parser},
 };
 
@@ -79,6 +80,8 @@ impl Parser for AppleProvider {
                         (source.to_vec(), len)
                     }
                 };
+            metrics::histogram!(SYMBOL_SET_DECOMPRESSED_BYTES, "kind" => "apple")
+                .record(decompressed_bytes as f64);
             ParsedAppleSymbols::from_dsym_zip(zip_data, decompressed_bytes)
         })
         .await

--- a/rust/cymbal/src/symbol_store/apple.rs
+++ b/rust/cymbal/src/symbol_store/apple.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use std::io::{Cursor, Read};
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use serde::Deserialize;
 use symbolic::debuginfo::Archive;
 use symbolic::demangle::{Demangle, DemangleOptions};
@@ -48,17 +49,17 @@ pub enum AppleRef {}
 #[async_trait]
 impl Fetcher for AppleProvider {
     type Ref = AppleRef;
-    type Fetched = Vec<u8>;
+    type Fetched = Bytes;
     type Err = ResolveError;
 
-    async fn fetch(&self, _: i32, _: AppleRef) -> Result<Vec<u8>, Self::Err> {
+    async fn fetch(&self, _: i32, _: AppleRef) -> Result<Bytes, Self::Err> {
         unreachable!("AppleRef is impossible to construct, so cannot be passed")
     }
 }
 
 #[async_trait]
 impl Parser for AppleProvider {
-    type Source = Vec<u8>;
+    type Source = Bytes;
     type Set = ParsedAppleSymbols;
     type Err = ResolveError;
 
@@ -67,11 +68,11 @@ impl Parser for AppleProvider {
         // fall back to raw ZIP for backward compatibility with existing uploads.
         // TODO(2026-09-24): Remove raw ZIP fallback once all old uploads have expired.
         let (zip_data, decompressed_bytes) =
-            match read_symbol_data_with_byte_count::<AppleDsym>(source.clone()) {
+            match read_symbol_data_with_byte_count::<AppleDsym>(&source) {
                 Ok((dsym, bytes)) => (dsym.data, bytes),
                 Err(_) => {
                     let len = source.len();
-                    (source, len)
+                    (source.to_vec(), len)
                 }
             };
         ParsedAppleSymbols::from_dsym_zip(zip_data, decompressed_bytes)

--- a/rust/cymbal/src/symbol_store/chunk_id.rs
+++ b/rust/cymbal/src/symbol_store/chunk_id.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use metrics::counter;
 use sqlx::PgPool;
 use tracing::error;
@@ -41,7 +42,7 @@ pub enum OrChunkId<R> {
 }
 
 pub enum SymbolSetLoadResult {
-    Data(Vec<u8>),
+    Data(Bytes),
     Missing,
     Failed(String),
     MissingStoragePtr(String),
@@ -97,7 +98,7 @@ pub async fn load_symbol_set_data(
 #[async_trait]
 impl<P> Fetcher for ChunkIdFetcher<P>
 where
-    P: Fetcher<Fetched = Vec<u8>>,
+    P: Fetcher<Fetched = Bytes>,
     P::Ref: Send,
     P::Err: From<UnhandledError> + From<FrameError>,
 {
@@ -156,7 +157,7 @@ where
 #[async_trait]
 impl<P> Parser for ChunkIdFetcher<P>
 where
-    P: Parser<Source = Vec<u8>>,
+    P: Parser<Source = Bytes>,
     P::Set: Send,
 {
     type Source = P::Source;
@@ -235,6 +236,7 @@ mod test {
     use std::sync::Arc;
 
     use async_trait::async_trait;
+    use bytes::Bytes;
     use chrono::Utc;
     use common_types::ClickHouseEvent;
     use mockall::predicate;
@@ -330,7 +332,7 @@ mod test {
                 predicate::eq(config.object_storage_bucket.clone()),
                 predicate::eq(chunk_id.clone()), // We set the chunk id as the storage ptr above, in production it will be a different value with a prefix
             )
-            .returning(|_, _| Ok(Some(get_symbol_data_bytes())));
+            .returning(|_, _| Ok(Some(Bytes::from(get_symbol_data_bytes()))));
 
         let client = Arc::new(client);
 
@@ -371,7 +373,7 @@ mod test {
                 predicate::eq(config.object_storage_bucket.clone()),
                 predicate::eq(chunk_id.clone()), // We set the chunk id as the storage ptr above, in production it will be a different value with a prefix
             )
-            .returning(|_, _| Ok(Some(get_symbol_data_bytes())));
+            .returning(|_, _| Ok(Some(Bytes::from(get_symbol_data_bytes()))));
 
         let client = Arc::new(client);
 

--- a/rust/cymbal/src/symbol_store/hermesmap.rs
+++ b/rust/cymbal/src/symbol_store/hermesmap.rs
@@ -3,7 +3,7 @@ use bytes::Bytes;
 use posthog_symbol_data::{read_symbol_data_with_byte_count, HermesMap};
 
 use crate::{
-    error::{HermesError, ResolveError},
+    error::{HermesError, ResolveError, UnhandledError},
     langs::hermes::HermesRef,
     symbol_store::{caching::Countable, Fetcher, Parser},
 };
@@ -40,9 +40,15 @@ impl Parser for HermesMapProvider {
     type Err = ResolveError;
 
     async fn parse(&self, source: Bytes) -> Result<ParsedHermesMap, Self::Err> {
-        let (map, decompressed_bytes): (HermesMap, usize) =
-            read_symbol_data_with_byte_count(&source).map_err(HermesError::DataError)?;
-        Ok(ParsedHermesMap::parse(map, decompressed_bytes)?)
+        // zstd decompress + Hermes sourcemap parse are both CPU-bound; offload from the
+        // tokio runtime so a large bundle doesn't block other in-flight requests.
+        tokio::task::spawn_blocking(move || -> Result<ParsedHermesMap, ResolveError> {
+            let (map, decompressed_bytes): (HermesMap, usize) =
+                read_symbol_data_with_byte_count(&source).map_err(HermesError::DataError)?;
+            Ok(ParsedHermesMap::parse(map, decompressed_bytes)?)
+        })
+        .await
+        .map_err(|e| UnhandledError::Other(format!("hermes map parse task failed: {e}")))?
     }
 }
 

--- a/rust/cymbal/src/symbol_store/hermesmap.rs
+++ b/rust/cymbal/src/symbol_store/hermesmap.rs
@@ -5,6 +5,7 @@ use posthog_symbol_data::{read_symbol_data_with_byte_count, HermesMap};
 use crate::{
     error::{HermesError, ResolveError, UnhandledError},
     langs::hermes::HermesRef,
+    metric_consts::SYMBOL_SET_DECOMPRESSED_BYTES,
     symbol_store::{caching::Countable, Fetcher, Parser},
 };
 
@@ -45,6 +46,8 @@ impl Parser for HermesMapProvider {
         tokio::task::spawn_blocking(move || -> Result<ParsedHermesMap, ResolveError> {
             let (map, decompressed_bytes): (HermesMap, usize) =
                 read_symbol_data_with_byte_count(&source).map_err(HermesError::DataError)?;
+            metrics::histogram!(SYMBOL_SET_DECOMPRESSED_BYTES, "kind" => "hermes")
+                .record(decompressed_bytes as f64);
             Ok(ParsedHermesMap::parse(map, decompressed_bytes)?)
         })
         .await

--- a/rust/cymbal/src/symbol_store/hermesmap.rs
+++ b/rust/cymbal/src/symbol_store/hermesmap.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use bytes::Bytes;
 use posthog_symbol_data::{read_symbol_data_with_byte_count, HermesMap};
 
 use crate::{
@@ -24,23 +25,23 @@ pub struct HermesMapProvider {}
 #[async_trait]
 impl Fetcher for HermesMapProvider {
     type Ref = HermesRef;
-    type Fetched = Vec<u8>;
+    type Fetched = Bytes;
     type Err = ResolveError;
 
-    async fn fetch(&self, _: i32, _: HermesRef) -> Result<Vec<u8>, Self::Err> {
+    async fn fetch(&self, _: i32, _: HermesRef) -> Result<Bytes, Self::Err> {
         unreachable!("HermesRef is impossible to construct, so cannot be passed")
     }
 }
 
 #[async_trait]
 impl Parser for HermesMapProvider {
-    type Source = Vec<u8>;
+    type Source = Bytes;
     type Set = ParsedHermesMap;
     type Err = ResolveError;
 
-    async fn parse(&self, source: Vec<u8>) -> Result<ParsedHermesMap, Self::Err> {
+    async fn parse(&self, source: Bytes) -> Result<ParsedHermesMap, Self::Err> {
         let (map, decompressed_bytes): (HermesMap, usize) =
-            read_symbol_data_with_byte_count(source).map_err(HermesError::DataError)?;
+            read_symbol_data_with_byte_count(&source).map_err(HermesError::DataError)?;
         Ok(ParsedHermesMap::parse(map, decompressed_bytes)?)
     }
 }

--- a/rust/cymbal/src/symbol_store/proguard.rs
+++ b/rust/cymbal/src/symbol_store/proguard.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use posthog_symbol_data::{read_symbol_data_with_byte_count, ProguardMapping};
 
 use crate::{
-    error::{ProguardError, ResolveError},
+    error::{ProguardError, ResolveError, UnhandledError},
     symbol_store::{caching::Countable, Fetcher, Parser},
 };
 
@@ -47,9 +47,15 @@ impl Parser for ProguardProvider {
     type Err = ResolveError;
 
     async fn parse(&self, source: Self::Source) -> Result<FetchedMapping, ResolveError> {
-        let (map, decompressed_bytes): (ProguardMapping, usize) =
-            read_symbol_data_with_byte_count(&source).map_err(ProguardError::DataError)?;
-        Ok(FetchedMapping::new(map, decompressed_bytes)?)
+        // zstd decompress + ProguardCache::write are CPU-bound; offload from the tokio
+        // runtime so a large mapping doesn't block other in-flight requests.
+        tokio::task::spawn_blocking(move || -> Result<FetchedMapping, ResolveError> {
+            let (map, decompressed_bytes): (ProguardMapping, usize) =
+                read_symbol_data_with_byte_count(&source).map_err(ProguardError::DataError)?;
+            Ok(FetchedMapping::new(map, decompressed_bytes)?)
+        })
+        .await
+        .map_err(|e| UnhandledError::Other(format!("proguard parse task failed: {e}")))?
     }
 }
 

--- a/rust/cymbal/src/symbol_store/proguard.rs
+++ b/rust/cymbal/src/symbol_store/proguard.rs
@@ -6,6 +6,7 @@ use posthog_symbol_data::{read_symbol_data_with_byte_count, ProguardMapping};
 
 use crate::{
     error::{ProguardError, ResolveError, UnhandledError},
+    metric_consts::SYMBOL_SET_DECOMPRESSED_BYTES,
     symbol_store::{caching::Countable, Fetcher, Parser},
 };
 
@@ -52,6 +53,8 @@ impl Parser for ProguardProvider {
         tokio::task::spawn_blocking(move || -> Result<FetchedMapping, ResolveError> {
             let (map, decompressed_bytes): (ProguardMapping, usize) =
                 read_symbol_data_with_byte_count(&source).map_err(ProguardError::DataError)?;
+            metrics::histogram!(SYMBOL_SET_DECOMPRESSED_BYTES, "kind" => "proguard")
+                .record(decompressed_bytes as f64);
             Ok(FetchedMapping::new(map, decompressed_bytes)?)
         })
         .await

--- a/rust/cymbal/src/symbol_store/proguard.rs
+++ b/rust/cymbal/src/symbol_store/proguard.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use posthog_symbol_data::{read_symbol_data_with_byte_count, ProguardMapping};
 
 use crate::{
@@ -31,23 +32,23 @@ pub enum ProguardRef {}
 #[async_trait]
 impl Fetcher for ProguardProvider {
     type Ref = ProguardRef;
-    type Fetched = Vec<u8>;
+    type Fetched = Bytes;
     type Err = ResolveError;
 
-    async fn fetch(&self, _: i32, _: ProguardRef) -> Result<Vec<u8>, Self::Err> {
+    async fn fetch(&self, _: i32, _: ProguardRef) -> Result<Bytes, Self::Err> {
         unreachable!("ProguardRef is impossible to construct, so cannot be passed")
     }
 }
 
 #[async_trait]
 impl Parser for ProguardProvider {
-    type Source = Vec<u8>;
+    type Source = Bytes;
     type Set = FetchedMapping;
     type Err = ResolveError;
 
     async fn parse(&self, source: Self::Source) -> Result<FetchedMapping, ResolveError> {
         let (map, decompressed_bytes): (ProguardMapping, usize) =
-            read_symbol_data_with_byte_count(source).map_err(ProguardError::DataError)?;
+            read_symbol_data_with_byte_count(&source).map_err(ProguardError::DataError)?;
         Ok(FetchedMapping::new(map, decompressed_bytes)?)
     }
 }
@@ -100,7 +101,7 @@ mod tests {
         })
         .unwrap();
         let (mapping, byte_count): (ProguardMapping, usize) =
-            read_symbol_data_with_byte_count(source).unwrap();
+            read_symbol_data_with_byte_count(&source).unwrap();
         let fetched = FetchedMapping::new(mapping, byte_count).unwrap();
 
         assert_eq!(

--- a/rust/cymbal/src/symbol_store/s3.rs
+++ b/rust/cymbal/src/symbol_store/s3.rs
@@ -68,7 +68,7 @@ impl BlobClient for S3Impl {
     #[allow(dead_code)]
     async fn put(&self, bucket: &str, key: &str, data: Bytes) -> Result<(), UnhandledError> {
         let start = common_metrics::timing_guard(S3_PUT, &[]);
-        metrics::histogram!(S3_PUT_BYTES).record(data.len() as f64);
+        let data_len = data.len();
         let res = self
             .inner
             .put_object()
@@ -79,6 +79,13 @@ impl BlobClient for S3Impl {
             .await
             .map_err(|e| S3Error::from(e).into())
             .map(|_| ()); // We don't care about the result as long as it's success
+
+        // Record body size only on success, mirroring `S3_FETCHED_BYTES` which reads from
+        // the GET response. Failed PUTs (auth errors, S3 unavailable, etc.) shouldn't be
+        // counted toward the size distribution.
+        if res.is_ok() {
+            metrics::histogram!(S3_PUT_BYTES).record(data_len as f64);
+        }
 
         start
             .label("outcome", if res.is_ok() { "success" } else { "failure" })

--- a/rust/cymbal/src/symbol_store/s3.rs
+++ b/rust/cymbal/src/symbol_store/s3.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use aws_sdk_s3::{error::SdkError, primitives::ByteStream, Client as S3Client, Error as S3Error};
+use bytes::Bytes;
 #[cfg(test)]
 use mockall::automock;
 use tracing::error;
@@ -12,8 +13,8 @@ use crate::{
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait BlobClient: Send + Sync {
-    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, UnhandledError>;
-    async fn put(&self, bucket: &str, key: &str, data: Vec<u8>) -> Result<(), UnhandledError>;
+    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Bytes>, UnhandledError>;
+    async fn put(&self, bucket: &str, key: &str, data: Bytes) -> Result<(), UnhandledError>;
     async fn ping_bucket(&self, bucket: &str) -> Result<(), UnhandledError>;
 }
 
@@ -33,7 +34,7 @@ impl S3Impl {
 #[async_trait]
 impl BlobClient for S3Impl {
     #[allow(dead_code)]
-    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, UnhandledError> {
+    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Bytes>, UnhandledError> {
         let start = common_metrics::timing_guard(S3_FETCH, &[]);
         let res = self.inner.get_object().bucket(bucket).key(key).send().await;
 
@@ -41,7 +42,7 @@ impl BlobClient for S3Impl {
             Ok(res) => {
                 let data = res.body.collect().await?;
                 start.label("outcome", "success").fin();
-                Ok(Some(data.to_vec()))
+                Ok(Some(data.into_bytes()))
             }
             // If this is a file not found error, return None
             Err(SdkError::ServiceError(err)) if err.err().is_no_such_key() => {
@@ -58,7 +59,7 @@ impl BlobClient for S3Impl {
     }
 
     #[allow(dead_code)]
-    async fn put(&self, bucket: &str, key: &str, data: Vec<u8>) -> Result<(), UnhandledError> {
+    async fn put(&self, bucket: &str, key: &str, data: Bytes) -> Result<(), UnhandledError> {
         let start = common_metrics::timing_guard(S3_PUT, &[]);
         let res = self
             .inner

--- a/rust/cymbal/src/symbol_store/s3.rs
+++ b/rust/cymbal/src/symbol_store/s3.rs
@@ -7,7 +7,7 @@ use tracing::error;
 
 use crate::{
     error::UnhandledError,
-    metric_consts::{S3_FETCH, S3_PUT},
+    metric_consts::{S3_FETCH, S3_FETCHED_BYTES, S3_PUT, S3_PUT_BYTES},
 };
 
 #[cfg_attr(test, automock)]
@@ -40,6 +40,13 @@ impl BlobClient for S3Impl {
 
         match res {
             Ok(res) => {
+                // Record the Content-Length advertised by S3 before we collect the body.
+                // This is where a future size-cap check would short-circuit.
+                if let Some(len) = res.content_length() {
+                    if len >= 0 {
+                        metrics::histogram!(S3_FETCHED_BYTES).record(len as f64);
+                    }
+                }
                 let data = res.body.collect().await?;
                 start.label("outcome", "success").fin();
                 Ok(Some(data.into_bytes()))
@@ -61,6 +68,7 @@ impl BlobClient for S3Impl {
     #[allow(dead_code)]
     async fn put(&self, bucket: &str, key: &str, data: Bytes) -> Result<(), UnhandledError> {
         let start = common_metrics::timing_guard(S3_PUT, &[]);
+        metrics::histogram!(S3_PUT_BYTES).record(data.len() as f64);
         let res = self
             .inner
             .put_object()

--- a/rust/cymbal/src/symbol_store/saving.rs
+++ b/rust/cymbal/src/symbol_store/saving.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use chrono::{DateTime, Duration, Utc};
 
 use sha2::{Digest, Sha512};
@@ -61,12 +62,13 @@ pub struct SymbolSetRecord {
     pub last_used: Option<DateTime<Utc>>,
 }
 
-// This is the "intermediate" symbol set data. Rather than a simple `Vec<u8>`, the saving layer
+// This is the "intermediate" symbol set data. Rather than a simple `Bytes`, the saving layer
 // has to return this from calls to `fetch`, and accept it in calls to `parse`, so that it can
 // pass the information necessary to store the underlying data between the fetch and parse stages,
-// (to avoid saving data we can't parse)
+// (to avoid saving data we can't parse). The payload is held as `Bytes` so it can be cheaply
+// cloned (refcount bump) when the parse and save paths both need a reference.
 pub struct Saveable {
-    pub data: Vec<u8>,
+    pub data: Bytes,
     pub storage_ptr: Option<String>, // This is None if we still need to save this data
     pub team_id: i32,
     pub set_ref: String,
@@ -93,7 +95,7 @@ impl<F> Saving<F> {
         &self,
         team_id: i32,
         set_ref: String,
-        data: Vec<u8>,
+        data: Bytes,
     ) -> Result<String, UnhandledError> {
         info!("Saving symbol set data for {}", set_ref);
         let start = common_metrics::timing_guard(SAVE_SYMBOL_SET, &[]).label("data", "true");
@@ -170,7 +172,7 @@ impl<F> Saving<F> {
 #[async_trait]
 impl<F> Fetcher for Saving<F>
 where
-    F: Fetcher<Fetched = Vec<u8>, Err = ResolveError>,
+    F: Fetcher<Fetched = Bytes, Err = ResolveError>,
     F::Ref: ToString + Send,
 {
     type Ref = F::Ref;
@@ -257,7 +259,7 @@ where
 #[async_trait]
 impl<F> Parser for Saving<F>
 where
-    F: Parser<Source = Vec<u8>, Err = ResolveError>,
+    F: Parser<Source = Bytes, Err = ResolveError>,
     F::Set: Send,
 {
     type Source = Saveable;
@@ -265,23 +267,37 @@ where
     type Err = F::Err;
 
     async fn parse(&self, data: Saveable) -> Result<Self::Set, Self::Err> {
-        match self.inner.parse(data.data.clone()).await {
+        let Saveable {
+            data: bytes,
+            storage_ptr,
+            team_id,
+            set_ref,
+        } = data;
+
+        // On the loaded-from-S3 path we never need to save the bytes back, so we hand them
+        // straight to the parser by move. On the fresh-fetch path we keep a refcounted handle
+        // so we can save after a successful parse — cloning `Bytes` is just a refcount bump.
+        let bytes_to_save = if storage_ptr.is_none() {
+            Some(bytes.clone())
+        } else {
+            None
+        };
+
+        match self.inner.parse(bytes).await {
             Ok(s) => {
-                info!("Parsed symbol set data for {}", data.set_ref);
-                if data.storage_ptr.is_none() {
-                    // We only save the data if we fetched it from the underlying fetcher
-                    self.save_data(data.team_id, data.set_ref, data.data)
-                        .await?;
+                info!("Parsed symbol set data for {}", set_ref);
+                if let Some(bytes_to_save) = bytes_to_save {
+                    self.save_data(team_id, set_ref, bytes_to_save).await?;
                 }
-                return Ok(s);
+                Ok(s)
             }
             Err(ResolveError::ResolutionError(e)) => {
-                info!("Failed to parse symbol set data for {}", data.set_ref);
-                // We save the no-data case here, to prevent us from fetching again for day
-                self.save_no_data(data.team_id, data.set_ref, &e).await?;
-                return Err(ResolveError::ResolutionError(e));
+                info!("Failed to parse symbol set data for {}", set_ref);
+                // We save the no-data case here, to prevent us from fetching again for a day
+                self.save_no_data(team_id, set_ref, &e).await?;
+                Err(ResolveError::ResolutionError(e))
             }
-            Err(e) => return Err(e),
+            Err(e) => Err(e),
         }
     }
 }
@@ -396,6 +412,7 @@ impl SymbolSetRecord {
 mod test {
     use std::sync::Arc;
 
+    use bytes::Bytes;
     use httpmock::MockServer;
     use mockall::predicate;
     use posthog_symbol_data::write_symbol_data;
@@ -480,7 +497,7 @@ mod test {
             .with(
                 predicate::eq(config.object_storage_bucket.clone()),
                 predicate::str::starts_with(config.ss_prefix.clone()),
-                predicate::eq(get_symbol_data_bytes()), // We won't assert on the contents written
+                predicate::eq(Bytes::from(get_symbol_data_bytes())), // We won't assert on the contents written
             )
             .returning(|_, _, _| Ok(()))
             .once();
@@ -491,7 +508,7 @@ mod test {
                 predicate::eq(config.object_storage_bucket.clone()),
                 predicate::str::starts_with(config.ss_prefix.clone()),
             )
-            .returning(|_, _| Ok(Some(get_symbol_data_bytes())));
+            .returning(|_, _| Ok(Some(Bytes::from(get_symbol_data_bytes()))));
 
         let smp = SourcemapProvider::new(&config);
         let saving_smp = Saving::new(

--- a/rust/cymbal/src/symbol_store/sourcemap.rs
+++ b/rust/cymbal/src/symbol_store/sourcemap.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use base64::Engine;
+use bytes::Bytes;
 use posthog_symbol_data::{read_symbol_data_with_byte_count, write_symbol_data, SourceAndMap};
 use reqwest::Url;
 use sqlx::PgPool;
@@ -169,9 +170,9 @@ impl From<Url> for SourceMappingUrl {
 #[async_trait]
 impl Fetcher for SourcemapProvider {
     type Ref = Url;
-    type Fetched = Vec<u8>;
+    type Fetched = Bytes;
     type Err = ResolveError;
-    async fn fetch(&self, team_id: i32, r: Url) -> Result<Vec<u8>, Self::Err> {
+    async fn fetch(&self, team_id: i32, r: Url) -> Result<Bytes, Self::Err> {
         let start = common_metrics::timing_guard(SOURCEMAP_FETCH, &[]);
         let peek = find_sourcemap_url(&self.client, r).await?;
 
@@ -207,7 +208,7 @@ impl Fetcher for SourcemapProvider {
 
         start.label("found_data", "true").fin();
 
-        Ok(data)
+        Ok(Bytes::from(data))
     }
 }
 
@@ -215,7 +216,7 @@ async fn try_chunk_id_rescue(
     rescue: &ChunkIdRescue,
     team_id: i32,
     chunk_id: &str,
-) -> Result<Option<Vec<u8>>, ResolveError> {
+) -> Result<Option<Bytes>, ResolveError> {
     match load_symbol_set_data(
         &rescue.pool,
         rescue.blob_client.as_ref(),
@@ -253,13 +254,13 @@ async fn try_chunk_id_rescue(
 
 #[async_trait]
 impl Parser for SourcemapProvider {
-    type Source = Vec<u8>;
+    type Source = Bytes;
     type Set = OwnedSourceMapCache;
     type Err = ResolveError;
-    async fn parse(&self, data: Vec<u8>) -> Result<Self::Set, Self::Err> {
+    async fn parse(&self, data: Bytes) -> Result<Self::Set, Self::Err> {
         let start = common_metrics::timing_guard(SOURCEMAP_PARSE, &[]);
         let (sam, decompressed_bytes): (SourceAndMap, usize) =
-            read_symbol_data_with_byte_count(data).map_err(JsResolveErr::JSDataError)?;
+            read_symbol_data_with_byte_count(&data).map_err(JsResolveErr::JSDataError)?;
         let smc = OwnedSourceMapCache::from_source_and_map(sam, decompressed_bytes)
             .map_err(|_| JsResolveErr::InvalidSourceAndMap)?;
 
@@ -729,11 +730,13 @@ mod test {
         .await
         .unwrap();
 
-        let saved_payload = write_symbol_data(SourceAndMap {
-            minified_source: String::from_utf8(MINIFIED.to_vec()).unwrap(),
-            sourcemap: String::from_utf8(MAP.to_vec()).unwrap(),
-        })
-        .unwrap();
+        let saved_payload = Bytes::from(
+            write_symbol_data(SourceAndMap {
+                minified_source: String::from_utf8(MINIFIED.to_vec()).unwrap(),
+                sourcemap: String::from_utf8(MAP.to_vec()).unwrap(),
+            })
+            .unwrap(),
+        );
         let saved_payload_for_mock = saved_payload.clone();
 
         let mut s3 = MockS3Client::default();

--- a/rust/cymbal/src/symbol_store/sourcemap.rs
+++ b/rust/cymbal/src/symbol_store/sourcemap.rs
@@ -11,7 +11,7 @@ use tracing::{info, warn};
 
 use crate::{
     config::Config,
-    error::{JsResolveErr, ResolveError},
+    error::{JsResolveErr, ResolveError, UnhandledError},
     metric_consts::{
         CHUNK_ID_RESCUED_FROM_BODY, SOURCEMAP_BODY_FETCHES, SOURCEMAP_BODY_REF_FOUND,
         SOURCEMAP_FETCH, SOURCEMAP_HEADER_FOUND, SOURCEMAP_NOT_FOUND, SOURCEMAP_PARSE,
@@ -259,10 +259,18 @@ impl Parser for SourcemapProvider {
     type Err = ResolveError;
     async fn parse(&self, data: Bytes) -> Result<Self::Set, Self::Err> {
         let start = common_metrics::timing_guard(SOURCEMAP_PARSE, &[]);
-        let (sam, decompressed_bytes): (SourceAndMap, usize) =
-            read_symbol_data_with_byte_count(&data).map_err(JsResolveErr::JSDataError)?;
-        let smc = OwnedSourceMapCache::from_source_and_map(sam, decompressed_bytes)
-            .map_err(|_| JsResolveErr::InvalidSourceAndMap)?;
+        // `read_symbol_data_with_byte_count` zstd-decompresses a potentially large blob, and
+        // `SourceMapCacheWriter::new` is a CPU-bound serializer. Running them on a tokio
+        // worker blocks the runtime; offload to a blocking thread instead.
+        let smc =
+            tokio::task::spawn_blocking(move || -> Result<OwnedSourceMapCache, ResolveError> {
+                let (sam, decompressed_bytes): (SourceAndMap, usize) =
+                    read_symbol_data_with_byte_count(&data).map_err(JsResolveErr::JSDataError)?;
+                OwnedSourceMapCache::from_source_and_map(sam, decompressed_bytes)
+                    .map_err(|_| JsResolveErr::InvalidSourceAndMap.into())
+            })
+            .await
+            .map_err(|e| UnhandledError::Other(format!("sourcemap parse task failed: {e}")))??;
 
         start.label("success", "true").fin();
         Ok(smc)

--- a/rust/cymbal/src/symbol_store/sourcemap.rs
+++ b/rust/cymbal/src/symbol_store/sourcemap.rs
@@ -14,7 +14,8 @@ use crate::{
     error::{JsResolveErr, ResolveError, UnhandledError},
     metric_consts::{
         CHUNK_ID_RESCUED_FROM_BODY, SOURCEMAP_BODY_FETCHES, SOURCEMAP_BODY_REF_FOUND,
-        SOURCEMAP_FETCH, SOURCEMAP_HEADER_FOUND, SOURCEMAP_NOT_FOUND, SOURCEMAP_PARSE,
+        SOURCEMAP_EXTERNAL_BYTES, SOURCEMAP_FETCH, SOURCEMAP_HEADER_FOUND, SOURCEMAP_NOT_FOUND,
+        SOURCEMAP_PARSE, SYMBOL_SET_DECOMPRESSED_BYTES,
     },
 };
 
@@ -266,6 +267,8 @@ impl Parser for SourcemapProvider {
             tokio::task::spawn_blocking(move || -> Result<OwnedSourceMapCache, ResolveError> {
                 let (sam, decompressed_bytes): (SourceAndMap, usize) =
                     read_symbol_data_with_byte_count(&data).map_err(JsResolveErr::JSDataError)?;
+                metrics::histogram!(SYMBOL_SET_DECOMPRESSED_BYTES, "kind" => "sourcemap")
+                    .record(decompressed_bytes as f64);
                 OwnedSourceMapCache::from_source_and_map(sam, decompressed_bytes)
                     .map_err(|_| JsResolveErr::InvalidSourceAndMap.into())
             })
@@ -328,6 +331,7 @@ async fn find_sourcemap_url(
 
     // We always need the body
     let body = res.text().await.map_err(JsResolveErr::from)?;
+    metrics::histogram!(SOURCEMAP_EXTERNAL_BYTES, "kind" => "source").record(body.len() as f64);
 
     let chunk_id_from_body = extract_chunk_id_from_body(&body);
 
@@ -433,6 +437,8 @@ async fn fetch_source_map(client: &reqwest::Client, url: Url) -> Result<String, 
     let res = client.get(url).send().await.map_err(JsResolveErr::from)?;
     res.error_for_status_ref().map_err(JsResolveErr::from)?;
     let sourcemap = res.text().await.map_err(JsResolveErr::from)?;
+    metrics::histogram!(SOURCEMAP_EXTERNAL_BYTES, "kind" => "sourcemap")
+        .record(sourcemap.len() as f64);
     Ok(sourcemap)
 }
 

--- a/rust/cymbal/src/test_utils.rs
+++ b/rust/cymbal/src/test_utils.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use common_redis::MockRedisClient;
 use mockall::mock;
 use sqlx::PgPool;
@@ -17,8 +18,8 @@ mock! {
 
     #[async_trait]
     impl BlobClient for S3Client {
-        async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, UnhandledError>;
-        async fn put(&self, bucket: &str, key: &str, data: Vec<u8>) -> Result<(), UnhandledError>;
+        async fn get(&self, bucket: &str, key: &str) -> Result<Option<Bytes>, UnhandledError>;
+        async fn put(&self, bucket: &str, key: &str, data: Bytes) -> Result<(), UnhandledError>;
         async fn ping_bucket(&self, bucket: &str) -> Result<(), UnhandledError>;
     }
 }

--- a/rust/cymbal/tests/event.rs
+++ b/rust/cymbal/tests/event.rs
@@ -257,7 +257,7 @@ fn load_static_event(filename: &str) -> AnyEvent {
 }
 
 // Helper to load sourcemap from static files
-fn get_sourcemap(chunk_id: &str) -> Result<Option<Vec<u8>>, UnhandledError> {
+fn get_sourcemap(chunk_id: &str) -> Result<Option<bytes::Bytes>, UnhandledError> {
     let Ok(minified_source) = fs::read_to_string(format!("tests/static/sourcemaps/{chunk_id}.js"))
     else {
         return Ok(None);
@@ -274,7 +274,7 @@ fn get_sourcemap(chunk_id: &str) -> Result<Option<Vec<u8>>, UnhandledError> {
     })
     .map_err(|e| UnhandledError::Other(e.to_string()))?;
 
-    Ok(Some(symbol_data))
+    Ok(Some(bytes::Bytes::from(symbol_data)))
 }
 
 // Helper to insert symbol set records in the database

--- a/rust/cymbal/tests/resolve.rs
+++ b/rust/cymbal/tests/resolve.rs
@@ -153,7 +153,7 @@ async fn sourcemap_nulls_dont_go_on_frames() {
     let content = "{\"colno\":15,\"filename\":\"irrelevant_for_test\",\"function\":\"?\",\"in_app\":true,\"lineno\":476,\"platform\":\"web:javascript\"}";
     let frame: RawFrame = serde_json::from_str(content).unwrap();
 
-    let jsdata_bytes = include_bytes!("static/sourcemap_with_nulls.jsdata").to_vec();
+    let jsdata_bytes = include_bytes!("static/sourcemap_with_nulls.jsdata");
     let (data, decompressed_bytes): (SourceAndMap, usize) =
         read_symbol_data_with_byte_count(jsdata_bytes).unwrap();
     let smc = OwnedSourceMapCache::from_source_and_map(data, decompressed_bytes).unwrap();

--- a/rust/cymbal/tests/utils.rs
+++ b/rust/cymbal/tests/utils.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use axum::{body::Body, http::Request};
 
+use bytes::Bytes;
 use common_redis::MockRedisClient;
 use cymbal::{
     app_context::AppContext, config::Config, error::UnhandledError, router::get_router,
@@ -21,8 +22,8 @@ mock! {
 
     #[async_trait]
     impl BlobClient for S3Client {
-        async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, UnhandledError>;
-        async fn put(&self, bucket: &str, key: &str, data: Vec<u8>) -> Result<(), UnhandledError>;
+        async fn get(&self, bucket: &str, key: &str) -> Result<Option<Bytes>, UnhandledError>;
+        async fn put(&self, bucket: &str, key: &str, data: Bytes) -> Result<(), UnhandledError>;
         async fn ping_bucket(&self, bucket: &str) -> Result<(), UnhandledError>;
     }
 }


### PR DESCRIPTION
## Problem

The cymbal HTTP service OOMs under load and frequently times out (>30s) when processing large sourcemaps or dSYMs. Several issues in the symbol-store path were amplifying peak memory and tail latency: S3 reads were buffered then re-copied, large blobs were cloned again at parse time, CPU-bound parsing ran on the tokio runtime, and the per-batch issue cache was rebuilt on every request.

## Changes

- Threaded `bytes::Bytes` through `BlobClient` and all four symbol-set parsers so blob reads stop allocating an extra `Vec<u8>`, and removed the redundant `data.data.clone()` in `Saving::parse`.
- Moved the issue cache onto `AppContext` and reshaped it to hold only `(team_id, fingerprint) → issue_id`, so `IssueLinker` reloads the current `Issue` per event and `IssueSuppression` / `maybe_reopen` always see fresh PG state.
- Wrapped the four `Parser::parse` impls (sourcemap, hermes, proguard, apple) in `tokio::task::spawn_blocking` so zstd decompression and symcache writers stop blocking tokio workers.
- Added four byte-shaped histograms (`cymbal_s3_fetched_bytes`, `cymbal_s3_put_bytes`, `cymbal_sourcemap_external_bytes`, `cymbal_symbol_set_decompressed_bytes`) to track internal data size.


## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the \`skip-inkeep-docs\` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->