### PR TITLE
fix(alerts): use absolute notebook url in investigation breach line

### DIFF
--- a/posthog/temporal/ai/anomaly_investigation/workflow.py
+++ b/posthog/temporal/ai/anomaly_investigation/workflow.py
@@ -24,6 +24,7 @@ from temporalio.common import RetryPolicy
 from posthog.models import Team, User
 from posthog.models.alert import AlertCheck, AlertConfiguration, InvestigationStatus
 from posthog.tasks.alerts.utils import dispatch_alert_notification, record_alert_delivery
+from posthog.utils import absolute_uri
 from posthog.temporal.ai.anomaly_investigation.charts import png_to_b64, render_series_chart
 from posthog.temporal.ai.anomaly_investigation.notebook import NotebookRenderContext, build_investigation_notebook
 from posthog.temporal.ai.anomaly_investigation.prompts import build_anomaly_context
@@ -270,7 +271,8 @@ def _build_breach_descriptions(
     if summary:
         lines.append(summary)
     if notebook_short_id:
-        lines.append(f"See /notebooks/{notebook_short_id} for the full investigation.")
+        notebook_url = absolute_uri(f"/notebooks/{notebook_short_id}")
+        lines.append(f"See {notebook_url} for the full investigation.")
     return lines
 
 

--- a/posthog/temporal/ai/anomaly_investigation/workflow.py
+++ b/posthog/temporal/ai/anomaly_investigation/workflow.py
@@ -24,7 +24,6 @@ from temporalio.common import RetryPolicy
 from posthog.models import Team, User
 from posthog.models.alert import AlertCheck, AlertConfiguration, InvestigationStatus
 from posthog.tasks.alerts.utils import dispatch_alert_notification, record_alert_delivery
-from posthog.utils import absolute_uri
 from posthog.temporal.ai.anomaly_investigation.charts import png_to_b64, render_series_chart
 from posthog.temporal.ai.anomaly_investigation.notebook import NotebookRenderContext, build_investigation_notebook
 from posthog.temporal.ai.anomaly_investigation.prompts import build_anomaly_context
@@ -32,6 +31,7 @@ from posthog.temporal.ai.anomaly_investigation.runner import run_investigation
 from posthog.temporal.ai.anomaly_investigation.tools import _run_detector_simulation
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
+from posthog.utils import absolute_uri
 
 from products.notebooks.backend.models import Notebook
 


### PR DESCRIPTION
## Problem

The anomaly investigation agent appends a "See /notebooks/<short_id> for the full investigation." line to the breach descriptions that flow into the firing Slack message and the email notification. Because the URL is relative, Slack and email clients render it as plain text, so users can't jump straight to the notebook from the alert.

## Changes

`posthog/temporal/ai/anomaly_investigation/workflow.py` — build the notebook URL via `absolute_uri()` so it resolves against `SITE_URL` (e.g. `https://us.posthog.com/notebooks/<short_id>`). The breach line now contains a full URL, which most email clients auto-link and which Slack can detect.

Note: in Block Kit, the alert-firing Slack template renders the breaches blob as `plain_text`, which doesn't auto-link bare URLs. Flipping that section to `mrkdwn` is a separate follow-up and only affects newly-created Slack HogFunctions; tracking that separately.

## How did you test this code?

Agent-authored PR. No manual testing of the Slack/email render — relied on the change being a string-construction tweak that routes through the existing `absolute_uri()` helper (`posthog/utils.py:112`). Existing tests under `posthog/temporal/tests/ai/` don't assert on this breach-line text, so nothing needed updating. CI will run the full suite.

## Publish to changelog?

no

## 🤖 Agent context

PostHog Code authored this PR. The user spotted that the notebook link in a real Slack alert wasn't clickable and asked for the URL to be made absolute. We confirmed the link source was the breach-line in `_build_breach_descriptions` and reused the existing `absolute_uri()` helper rather than threading `SITE_URL` through manually. Considered also flipping the Slack sub-template's section type to `mrkdwn`, but the user wants to handle that separately since it only changes newly-created HogFunctions.