### PR TITLE
fix(dev): acquire bin/start flock after 1Password re-exec

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -5,6 +5,23 @@ set -e
 export REPOSITORY_ROOT=$(realpath "$(dirname "$0")/..")
 export LOCK_FILE="$REPOSITORY_ROOT/bin/start.lock"
 
+# 1Password: auto-resolve op:// references in .env.local.
+# Must run before lock acquisition: `exec op run ...` keeps the bash fds open
+# in the op-run process, so if we held fd 9's flock here the re-exec'd child
+# bin/start would fail to acquire it.
+if [ -f "$REPOSITORY_ROOT/.env.local" ] && grep -q "op://" "$REPOSITORY_ROOT/.env.local" 2>/dev/null; then
+    if [ -z "$_POSTHOG_OP_RESOLVED" ]; then
+        if command -v op &>/dev/null; then
+            echo "🔐 Resolving secrets from .env.local via 1Password"
+            export _POSTHOG_OP_RESOLVED=1
+            exec op run --env-file="$REPOSITORY_ROOT/.env.local" -- "$0" "$@"
+        else
+            echo "⚠️  .env.local contains 1Password refs (op://) but 'op' CLI not found"
+            echo "   Install: brew install 1password-cli"
+        fi
+    fi
+fi
+
 cleanup_lock() {
     rm -f "$LOCK_FILE"
 }
@@ -18,20 +35,6 @@ if ! flock -n 9; then
 fi
 
 trap cleanup_lock EXIT INT TERM
-
-# 1Password: auto-resolve op:// references in .env.local
-if [ -f "$REPOSITORY_ROOT/.env.local" ] && grep -q "op://" "$REPOSITORY_ROOT/.env.local" 2>/dev/null; then
-    if [ -z "$_POSTHOG_OP_RESOLVED" ]; then
-        if command -v op &>/dev/null; then
-            echo "🔐 Resolving secrets from .env.local via 1Password"
-            export _POSTHOG_OP_RESOLVED=1
-            exec op run --env-file="$REPOSITORY_ROOT/.env.local" -- "$0" "$@"
-        else
-            echo "⚠️  .env.local contains 1Password refs (op://) but 'op' CLI not found"
-            echo "   Install: brew install 1password-cli"
-        fi
-    fi
-fi
 
 # Environment variables are defined in:
 #   .env.services     - service connection defaults (shared with containers


### PR DESCRIPTION
## Problem

When `.env.local` contains 1Password `op://` refs, `bin/start` re-execs itself under `op run` to resolve them. The current ordering acquires the flock on `fd 9` **before** that re-exec, so the inherited `fd 9` lives on inside the `op run` process and keeps the lock held. The re-exec'd child `bin/start` then can't acquire the same lock and aborts with:

> ⚠️ Another instance of bin/start is already running (lock file: ...)

…even when nothing else is running. The only workaround was to run `op run` manually as the outer process and set `_POSTHOG_OP_RESOLVED=1` to skip the in-script re-exec.

## Changes

Move the 1Password re-exec block ahead of the flock acquisition. Once the re-exec has happened (or been skipped), the bash process that takes the lock is the one that runs the rest of the script — no lock leaks into `op run`. Same pattern that's already used for the detached-child case at the bottom of the script (`exec 9<&-` before spawning).

No behavior change when `.env.local` doesn't use 1Password.

## How did you test this code?

I'm an agent — manual verification was done by the human author on macOS / flox: removed `bin/start.lock`, re-ran `./bin/start`, confirmed the lock no longer trips itself when 1Password resolution kicks in. No automated tests added; `bin/start` has none.

## Publish to changelog?

no

## 🤖 Agent context

- Author: Claude Opus 4.7 via Claude Code, paired with @georgis
- Diagnosed the issue by reading `bin/start` line-by-line — the symptom (lock present after `rm` + `lsof` empty) matched a process holding an inherited fd. The `exec op run -- "\$0"` on line 28 of the old script is the only place that could carry an inherited fd 9 with a held lock into a separate process tree, since `op run` then forks a fresh `bin/start` child that re-enters lock acquisition.
- Considered marking fd 9 close-on-exec instead, but bash has no portable builtin for that — reordering is simpler and matches the existing detached-child pattern.