### PR TITLE
fix(slack): keep thread root when collecting context for @PostHog tasks

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -674,9 +674,13 @@ def _collect_thread_messages(
         return re.sub(r"<@([A-Z0-9]+)>", replace_mention, text)
 
     messages = []
-    for msg in raw_messages:
+    for index, msg in enumerate(raw_messages):
         # Skip our own bot's posts to avoid loops where the agent ingests its own replies.
-        if our_bot_id and msg.get("bot_id") == our_bot_id:
+        # Never skip the thread root: the agent only ever posts as a reply, so msg 0 is
+        # always the originating message (e.g. a PostHog alert) that's the actual context
+        # for the task. Filtering it by bot_id breaks workspaces where the alerting Slack
+        # app and the `@PostHog` code app share an installation identity.
+        if index > 0 and our_bot_id and msg.get("bot_id") == our_bot_id:
             continue
 
         user_id = msg.get("user")

--- a/products/slack_app/backend/tests/test_collect_thread_messages.py
+++ b/products/slack_app/backend/tests/test_collect_thread_messages.py
@@ -215,19 +215,60 @@ class TestCollectThreadMessages:
         assert result[1]["user"] == "andy"
         assert "was that really an anomaly?" in result[1]["text"]
 
-    def test_skips_our_own_bot_messages(self, mock_get_user_info):
+    def test_skips_our_own_bot_reply_messages(self, mock_get_user_info):
+        # Our own bot replies (e.g. "Working on it...") must be filtered so the agent
+        # doesn't ingest its own status updates as context on a re-mention.
         self._set_thread(
             [
-                {"bot_id": "B_OUR_CODE_BOT", "text": "Working on it..."},
-                {"user": "U_ANDY", "text": "thanks"},
+                {"user": "U_ANDY", "text": "@PostHog please look at this", "ts": "1.000"},
+                {"bot_id": "B_OUR_CODE_BOT", "text": "Working on it...", "ts": "2.000"},
+                {"user": "U_ANDY", "text": "thanks", "ts": "3.000"},
             ]
         )
         mock_get_user_info.return_value = {"user": {"profile": {"display_name": "andy"}}}
 
         result = _collect_thread_messages(self.slack, self.integration, "C001", "1.234", our_bot_id="B_OUR_CODE_BOT")
 
-        assert len(result) == 1
-        assert result[0]["user"] == "andy"
+        assert [m["ts"] for m in result] == ["1.000", "3.000"]
+        assert all(m["user"] == "andy" for m in result)
+
+    def test_keeps_thread_root_even_when_bot_id_matches_our_own(self, mock_get_user_info):
+        # Regression: in workspaces where the alerting Slack app and the `@PostHog` code
+        # app share an installation identity, the alert that opened the thread has the same
+        # `bot_id` as `our_bot_id`. We must still include it — the agent only posts as a
+        # reply, never as a thread root, so msg 0 is always the originating context.
+        self._set_thread(
+            [
+                {
+                    "bot_id": "B_OUR_CODE_BOT",
+                    "bot_profile": {"name": "PostHog"},
+                    "text": "",
+                    "blocks": [
+                        {
+                            "type": "header",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Alert 'Headline anomaly: Trial activated' firing for insight",
+                            },
+                        },
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": "Anomaly detected on 2026-05-19"},
+                        },
+                    ],
+                    "ts": "1.000",
+                },
+                {"user": "U_ANDY", "text": "<@UBOT> lets investigate this one", "ts": "2.000"},
+            ]
+        )
+        mock_get_user_info.return_value = {"user": {"profile": {"display_name": "andy"}}}
+
+        result = _collect_thread_messages(self.slack, self.integration, "C001", "1.234", our_bot_id="B_OUR_CODE_BOT")
+
+        assert len(result) == 2
+        assert result[0]["user"] == "PostHog"
+        assert "Alert 'Headline anomaly: Trial activated'" in result[0]["text"]
+        assert result[1]["user"] == "andy"
 
     def test_other_bot_uses_bot_profile_name(self, mock_get_user_info):
         self._set_thread(


### PR DESCRIPTION
## Problem

When a user replies to a PostHog Slack alert with \`@PostHog lets investigate this\`, the task that gets created should pick up the alert message as its context. In practice the task description was just the user's reply text, so the agent had to ask "what should I look at?" — losing all the alert detail (insight, breach values, dates).

The cause is in [\`_collect_thread_messages\`](https://github.com/PostHog/posthog/blob/master/products/slack_app/backend/api.py#L651): it filters every message whose \`bot_id\` matches the @PostHog code app's auth identity. That filter was meant to drop the agent's own status replies ("Working on task…") so re-mentions don't ingest them as context. But in workspaces where the alerting Slack app (\`kind=\"slack\"\`) and the code app (\`kind=\"slack-posthog-code\"\`) resolve to the same Slack installation identity, the alert that *opened* the thread also matches \`our_bot_id\` and gets dropped — even though it's the whole reason the user is asking the agent for help.

## Changes

The agent only ever posts as a reply in a thread; it never starts a thread. So a same-bot-id message at index 0 of \`conversations.replies\` is always the originating message we want as context, not one of our own replies. Guard the filter with \`index > 0\` so the thread root is always preserved, then keep the existing skip behavior for replies further down the thread.

- Updated \`test_skips_our_own_bot_messages\` → \`test_skips_our_own_bot_reply_messages\` to make the reply intent explicit and assert the user messages still survive on both sides of an agent reply.
- Added \`test_keeps_thread_root_even_when_bot_id_matches_our_own\` as a regression test for the exact scenario above.

## How did you test this code?

I'm an agent (Claude). I ran the file's pytest suite — 29/29 pass, including the new regression test. I did not manually test against a live Slack workspace; the regression test mirrors the production failure mode using \`conversations.replies\` shape from the existing alert-block test.

\`\`\`
hogli test products/slack_app/backend/tests/test_collect_thread_messages.py
============================== 29 passed in 3.86s ==============================
\`\`\`

## Publish to changelog?

no

## 🤖 Agent context

- **Tool/session:** Claude Code (Opus 4.7). Single-session investigation triggered by a screenshot showing the alert content missing from a freshly-created task.
- **Diagnosis path:** traced the workflow from \`PostHogCodeSlackMentionWorkflow.run\` → \`collect_posthog_code_thread_messages_activity\` → \`_collect_thread_messages\` → \`_build_posthog_code_task_description\`. Confirmed the description-builder returns just the user's prompt when the context list is empty, and traced "empty context list" back to the bot_id filter at line 679.
- **Considered alternatives:**
  - Track every \`ts\` the agent posts on \`SlackThreadTaskMapping\` and filter only those. More precise but needs a schema change, plus the chicken-and-egg problem that no mapping exists on the *first* mention (when the bug actually fires).
  - Match on \`app_id\` instead of \`bot_id\`, or whitelist hog-function alert block patterns. Both are workarounds for "shared identity" rather than fixes for the over-broad filter.
  - Chose the \`index > 0\` guard because the actual invariant — "the agent posts replies, not thread roots" — is what makes the filter safe to skip for msg 0, and it's a two-line change with no state.