### PR TITLE
feat(alerts): drop dead is_calculating column (phase 2)

### DIFF
--- a/posthog/migrations/1168_drop_alertconfiguration_is_calculating_column.py
+++ b/posthog/migrations/1168_drop_alertconfiguration_is_calculating_column.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """
+    Phase 2 of 2: Drop the is_calculating column from posthog_alertconfiguration.
+
+    The field was removed from Django state in the phase-1
+    ``remove_alertconfiguration_is_calculating`` migration. This migration drops
+    the physical column. Safe to deploy once that migration has rolled out
+    everywhere — any old code still reading the column would have failed by then.
+    """
+
+    dependencies = [("posthog", "1167_remove_alertconfiguration_is_calculating")]
+
+    operations = [
+        migrations.RunSQL(
+            sql="ALTER TABLE posthog_alertconfiguration DROP COLUMN IF EXISTS is_calculating;",
+            reverse_sql="ALTER TABLE posthog_alertconfiguration ADD COLUMN IF NOT EXISTS is_calculating boolean DEFAULT false;",
+        ),
+    ]

--- a/posthog/migrations/1175_drop_alertconfiguration_is_calculating_column.py
+++ b/posthog/migrations/1175_drop_alertconfiguration_is_calculating_column.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
     everywhere — any old code still reading the column would have failed by then.
     """
 
-    dependencies = [("posthog", "1167_remove_alertconfiguration_is_calculating")]
+    dependencies = [("posthog", "1174_taggeditem_account_unique_constraint")]
 
     operations = [
         migrations.RunSQL(

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1174_taggeditem_account_unique_constraint
+1175_drop_alertconfiguration_is_calculating_column


### PR DESCRIPTION
## Problem

Phase 2 of removing the dead `is_calculating` column from `AlertConfiguration`. Stacked on top of #53837.

## Changes

- Physical `ALTER TABLE ... DROP COLUMN IF EXISTS is_calculating` (migration `1164`), depending on the state-removal migration in #53837.

Shipped separately from the state removal so the two phases deploy in sequence: #53837 (remove from Django state) goes out first, then this drops the now-unreferenced column. Any old code still reading the column would already have failed once #53837 is live, so the column drop is safe by the time this lands.

## How did you test this code?

Automated only — `makemigrations --check` is clean and `sqlmigrate` confirms the column drop. Reversible (`reverse_sql` re-adds the column). No application code changes.

## 🤖 Agent context

Agent-assisted. Created by splitting the column drop out of #53837 so the two migration phases land in separate deploys.
