### PR TITLE
fix(llma): correct gemini-3-pro-image cost undercounted 10x

### DIFF
--- a/nodejs/src/ingestion/ai/costs/provider-matching.test.ts
+++ b/nodejs/src/ingestion/ai/costs/provider-matching.test.ts
@@ -453,6 +453,19 @@ describe('resolveModelCostForProvider()', () => {
             expect(result!.provider).toBe('deepinfra-turbo')
         })
 
+        it('partial matches against the canonical alias key, not just the raw provider name', () => {
+            const costs = createMockCosts({
+                default: { prompt_token: 0.000002, completion_token: 0.000012 },
+                'google-ai-studio-global': { prompt_token: 0.000002, completion_token: 0.000012 },
+                'google-vertex-global': { prompt_token: 0.000002, completion_token: 0.000012 },
+            })
+
+            const result = resolveModelCostForProvider(costs, 'gemini', 'gemini-3-pro-image-preview')
+
+            expect(result).toBeDefined()
+            expect(result!.provider).toBe('google-ai-studio-global')
+        })
+
         it('does not partially match when exact match exists', () => {
             const costs = createMockCosts({
                 openai: { prompt_token: 0.00001, completion_token: 0.00002 },

--- a/nodejs/src/ingestion/ai/costs/provider-matching.test.ts
+++ b/nodejs/src/ingestion/ai/costs/provider-matching.test.ts
@@ -455,15 +455,17 @@ describe('resolveModelCostForProvider()', () => {
 
         it('partial matches against the canonical alias key, not just the raw provider name', () => {
             const costs = createMockCosts({
-                default: { prompt_token: 0.000002, completion_token: 0.000012 },
+                default: { prompt_token: 0.000001, completion_token: 0.00001 },
                 'google-ai-studio-global': { prompt_token: 0.000002, completion_token: 0.000012 },
-                'google-vertex-global': { prompt_token: 0.000002, completion_token: 0.000012 },
+                'google-vertex-global': { prompt_token: 0.000003, completion_token: 0.000014 },
             })
 
             const result = resolveModelCostForProvider(costs, 'gemini', 'gemini-3-pro-image-preview')
 
             expect(result).toBeDefined()
             expect(result!.provider).toBe('google-ai-studio-global')
+            expect(result!.cost.prompt_token).toBe(0.000002)
+            expect(result!.cost.completion_token).toBe(0.000012)
         })
 
         it('does not partially match when exact match exists', () => {

--- a/nodejs/src/ingestion/ai/costs/provider-matching.ts
+++ b/nodejs/src/ingestion/ai/costs/provider-matching.ts
@@ -156,16 +156,22 @@ export const resolveModelCostForProvider = (
             }
         }
 
-        // Try partial matching
-        const partialMatchKey: string | undefined = Object.keys(providerCosts).find((key: string) =>
-            key.includes(normalizedProvider)
-        )
+        // Search against the canonical key too so regional-only cost records
+        // (e.g. `google-ai-studio-global`) still match when the event uses an alias like `gemini`.
+        const partialMatchSearches: string[] =
+            canonicalKey === normalizedProvider ? [normalizedProvider] : [canonicalKey, normalizedProvider]
 
-        if (partialMatchKey) {
-            const partialMatch: ResolvedModelCost | undefined = findProviderMatch(partialMatchKey)
+        for (const search of partialMatchSearches) {
+            const partialMatchKey: string | undefined = Object.keys(providerCosts).find((key: string) =>
+                key.includes(search)
+            )
 
-            if (partialMatch) {
-                return partialMatch
+            if (partialMatchKey) {
+                const partialMatch: ResolvedModelCost | undefined = findProviderMatch(partialMatchKey)
+
+                if (partialMatch) {
+                    return partialMatch
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

LLM Analytics undercounts cost for `gemini-3-pro-image-preview` by roughly 10x.

Root cause is in `resolveModelCostForProvider`. For an event with `$ai_provider="gemini"` and `$ai_model="gemini-3-pro-image-preview"`:

1. The alias map resolves `gemini` to the canonical key `google-ai-studio`.
2. The exact lookup against `google-ai-studio` misses — the cost record for that model only ships `default`, `google-ai-studio-global`, and `google-vertex-global` keys.
3. The partial-match step then searched for keys containing `normalizedProvider` (`gemini`), never the canonical key. `"google-ai-studio-global".includes("gemini")` is false, so it fell through to `default`.
4. The `default` provider for this model has no `image_output` rate, so image output tokens were billed at `completion_token` ($0.000012/tok) instead of the correct `image_output` ($0.00012/tok) — a 10x undercharge.

## Changes

In the partial-matching step of `resolveModelCostForProvider`, also search using the canonical alias key. When `canonicalKey === normalizedProvider` (unknown provider with no alias), behavior is unchanged.

## How did you test this code?

I am an agent. I ran the automated tests only — no manual verification.

- `hogli test nodejs/src/ingestion/ai/costs/provider-matching.test.ts` — 72/72 pass (including the new regression test).
- `hogli test nodejs/src/ingestion/ai/costs/` — 302/302 pass across the whole costs module.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code. The fix was scoped tightly to the partial-match step rather than touching the cost JSON, so any future model that only ships `-global` provider variants will also resolve correctly. I considered the data-only patch (adding a plain `google-ai-studio` entry to the affected model) but rejected it because it leaves the underlying matching bug in place. I also kept the partial-match ordering with `canonicalKey` first, then `normalizedProvider`, since the canonical key is strictly more specific.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*