### PR TITLE
chore(llm-gateway): raise background_agents burst limit to $500/week

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -46,8 +46,8 @@ DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
         sustained_window_seconds=2592000,
     ),
     "background_agents": UserCostLimit(
-        burst_limit_usd=100.0,
-        burst_window_seconds=86400,
+        burst_limit_usd=500.0,
+        burst_window_seconds=604800,
         sustained_limit_usd=1000.0,
         sustained_window_seconds=2592000,
     ),


### PR DESCRIPTION
## Problem

Users running background agents in sandboxes are hitting 429s from the LLM gateway — roughly ~30% of background-agent runs fail today. The current per-user cap for the `background_agents` product is `$100 / 24h` (burst) and `$1000 / 30d` (sustained), and the daily burst window is the one being exhausted in practice. We want to reduce the 429 rate without raising the overall spend ceiling for a single user.

## Changes

In `services/llm-gateway/src/llm_gateway/config.py`, update the `background_agents` entry of `DEFAULT_USER_COST_LIMITS`:

- `burst_limit_usd`: `100.0` → `500.0`
- `burst_window_seconds`: `86400` (1 day) → `604800` (7 days)
- `sustained_limit_usd` / `sustained_window_seconds`: unchanged (`$1000 / 30d`)

Net effect: a user can spend more freely day-to-day, but the 30-day cap is unchanged, so total per-user spend is still bounded the same way.

## How did you test this code?

I'm an agent. I did not run any tests for this PR — the change is a 2-line default-value tweak in `DEFAULT_USER_COST_LIMITS` and there are no existing tests that assert on these specific dollar amounts (`background_agents` only appears in product-allowlist tests in `tests/test_product_config.py`, not in cost-limit tests). The values are also overridable at runtime via the `LLM_GATEWAY_USER_COST_LIMITS` env var, so the deployed config can be adjusted independently if needed.

## Publish to changelog?

no

## Docs update

No docs change needed — this is an internal default for the LLM gateway.

## 🤖 Agent context

Authored by PostHog Code on behalf of @joshsny following a discussion about 429 rates on background agent sandboxes. Considered alternatives (lowering signal emission, reducing agents-per-signal, harness-level token reductions) but those are larger and not in scope for this PR — the immediate ask was to widen the burst window so first-come-first-serve prioritization across a week is less spiky, while keeping the sustained monthly cap as the actual spend guardrail. Chose `604800s` (exactly 7 days) for the burst window rather than approximating, to match "$500/week" literally.