### PR TITLE
chore: forbid new wildcard imports via ruff F403

### DIFF
--- a/ee/clickhouse/queries/retention/__init__.py
+++ b/ee/clickhouse/queries/retention/__init__.py
@@ -1,1 +1,0 @@
-from .retention import *

--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from posthog.conftest import *
+from posthog.conftest import *  # noqa: F401, F403  # legacy: pytest fixtures inherited from root conftest

--- a/ee/hogai/research_agent/prompts/__init__.py
+++ b/ee/hogai/research_agent/prompts/__init__.py
@@ -1,3 +1,3 @@
-from ee.hogai.research_agent.prompts.base import *
-from ee.hogai.research_agent.prompts.plan import *
-from ee.hogai.research_agent.prompts.research import *
+from ee.hogai.research_agent.prompts.base import *  # noqa: F403  # legacy: re-exports prompt strings
+from ee.hogai.research_agent.prompts.plan import *  # noqa: F403  # legacy: re-exports prompt strings
+from ee.hogai.research_agent.prompts.research import *  # noqa: F403  # legacy: re-exports prompt strings

--- a/ee/hogai/utils/types/__init__.py
+++ b/ee/hogai/utils/types/__init__.py
@@ -1,3 +1,1 @@
-from .base import *
-
-# NOTE: we do not export `composed` types due to circular imports
+from .base import *  # noqa: F403  # legacy: re-exports ~40 assistant types; composed.py is intentionally excluded due to circular imports

--- a/posthog/dags/common/__init__.py
+++ b/posthog/dags/common/__init__.py
@@ -1,1 +1,10 @@
-from .common import *
+from .common import check_for_concurrent_runs, dagster_tags, settings_with_log_comment, skip_if_already_running
+from .owners import JobOwners
+
+__all__ = [
+    "JobOwners",
+    "check_for_concurrent_runs",
+    "dagster_tags",
+    "settings_with_log_comment",
+    "skip_if_already_running",
+]

--- a/posthog/dags/common/common.py
+++ b/posthog/dags/common/common.py
@@ -7,7 +7,6 @@ import dagster
 
 from posthog.clickhouse import query_tagging
 from posthog.clickhouse.query_tagging import DagsterTags
-from posthog.dags.common.owners import JobOwners  # noqa: F401
 
 
 def dagster_tags(

--- a/posthog/dags/common/health/framework.py
+++ b/posthog/dags/common/health/framework.py
@@ -3,7 +3,7 @@ from types import MappingProxyType
 
 import dagster
 
-from posthog.dags.common.common import JobOwners, check_for_concurrent_runs
+from posthog.dags.common import JobOwners, check_for_concurrent_runs
 from posthog.dags.common.health.detectors import HealthDetector, resolve_execution_policy
 from posthog.dags.common.health.observability import push_health_check_metrics
 from posthog.dags.common.health.processing import _process_batch_detection

--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -37,7 +37,7 @@ from posthog.clickhouse.client.connection import NodeRole, Workload
 from posthog.clickhouse.cluster import get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
-from posthog.dags.common.common import JobOwners, dagster_tags, settings_with_log_comment
+from posthog.dags.common import JobOwners, dagster_tags, settings_with_log_comment
 from posthog.ducklake.common import attach_catalog, escape, get_config
 from posthog.ducklake.storage import DuckLakeStorageConfig, configure_connection
 from posthog.settings.base_variables import DEBUG

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -62,7 +62,7 @@ from posthog.clickhouse.client.connection import NodeRole, Workload
 from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
-from posthog.dags.common.common import JobOwners, dagster_tags, settings_with_log_comment
+from posthog.dags.common import JobOwners, dagster_tags, settings_with_log_comment
 from posthog.dags.events_backfill_to_ducklake import (
     DEFAULT_CLICKHOUSE_SETTINGS,
     EXPECTED_DUCKLAKE_COLUMNS,

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -32,7 +32,7 @@ from posthog.clickhouse.client.connection import (
 from posthog.clickhouse.cluster import get_cluster
 from posthog.clickhouse.query_tagging import Feature, tags_context
 from posthog.cloud_utils import is_cloud
-from posthog.dags.common.common import JobOwners, dagster_tags
+from posthog.dags.common import JobOwners, dagster_tags
 from posthog.git import get_git_commit_short
 from posthog.models.raw_sessions.sessions_v3 import (
     DISTRIBUTED_RAW_SESSIONS_TABLE_V3,

--- a/posthog/models/async_deletion/__init__.py
+++ b/posthog/models/async_deletion/__init__.py
@@ -1,1 +1,3 @@
-from .async_deletion import *
+from .async_deletion import AsyncDeletion, DeletionType
+
+__all__ = ["AsyncDeletion", "DeletionType"]

--- a/posthog/models/cohort/__init__.py
+++ b/posthog/models/cohort/__init__.py
@@ -1,3 +1,24 @@
-from .calculation_history import *
-from .cohort import *
-from .dependencies import *
+from . import dependencies as _dependencies  # noqa: F401 — import for Django signal handler registration
+from .calculation_history import CohortCalculationHistory
+from .cohort import (
+    DEFAULT_COHORT_INSERT_BATCH_SIZE,
+    Cohort,
+    CohortKind,
+    CohortManager,
+    CohortOrEmpty,
+    CohortPeople,
+    CohortType,
+    get_or_create_internal_test_users_cohort,
+)
+
+__all__ = [
+    "DEFAULT_COHORT_INSERT_BATCH_SIZE",
+    "Cohort",
+    "CohortCalculationHistory",
+    "CohortKind",
+    "CohortManager",
+    "CohortOrEmpty",
+    "CohortPeople",
+    "CohortType",
+    "get_or_create_internal_test_users_cohort",
+]

--- a/posthog/models/element/__init__.py
+++ b/posthog/models/element/__init__.py
@@ -1,1 +1,3 @@
-from .element import *
+from .element import Element, chain_to_elements, elements_to_string
+
+__all__ = ["Element", "chain_to_elements", "elements_to_string"]

--- a/posthog/models/entity/__init__.py
+++ b/posthog/models/entity/__init__.py
@@ -1,1 +1,3 @@
-from .entity import *
+from .entity import Entity, ExclusionEntity, MathType
+
+__all__ = ["Entity", "ExclusionEntity", "MathType"]

--- a/posthog/models/event/__init__.py
+++ b/posthog/models/event/__init__.py
@@ -1,1 +1,3 @@
-from .event import *
+from .event import DEFAULT_EARLIEST_TIME_DELTA, Event, Selector, SelectorPart
+
+__all__ = ["DEFAULT_EARLIEST_TIME_DELTA", "Event", "Selector", "SelectorPart"]

--- a/posthog/models/group/__init__.py
+++ b/posthog/models/group/__init__.py
@@ -1,1 +1,3 @@
-from .group import *
+from .group import Group
+
+__all__ = ["Group"]

--- a/posthog/models/hog_flow/__init__.py
+++ b/posthog/models/hog_flow/__init__.py
@@ -1,2 +1,4 @@
-from .hog_flow import *
-from .hog_flow_template import *
+from .hog_flow import HogFlow
+from .hog_flow_template import HogFlowTemplate
+
+__all__ = ["HogFlow", "HogFlowTemplate"]

--- a/posthog/models/hog_functions/__init__.py
+++ b/posthog/models/hog_functions/__init__.py
@@ -1,1 +1,3 @@
-from .hog_function import *
+from .hog_function import HogFunction
+
+__all__ = ["HogFunction"]

--- a/posthog/models/product_intent/__init__.py
+++ b/posthog/models/product_intent/__init__.py
@@ -1,1 +1,3 @@
-from .product_intent import *
+from .product_intent import ProductIntent
+
+__all__ = ["ProductIntent"]

--- a/posthog/models/property/__init__.py
+++ b/posthog/models/property/__init__.py
@@ -1,1 +1,1 @@
-from .property import *
+from .property import *  # noqa: F403  # legacy: many callers depend on transitively-leaked GroupTypeIndex / PropertyOperatorType from property.py imports — TODO clean up call sites

--- a/posthog/models/team/__init__.py
+++ b/posthog/models/team/__init__.py
@@ -1,6 +1,6 @@
 from .extensions import get_or_create_team_extension, register_team_extension_signal  # noqa: F401
 from .js_snippet_config import TeamJsSnippetConfig  # noqa: F401
-from .team import *
+from .team import *  # noqa: F403  # legacy: team.py has a large surface (Team, Manager, constants, signals); TODO enumerate explicit re-exports
 from .team_caching import get_team_in_cache, set_team_in_cache  # noqa: F401
 from .team_marketing_analytics_config import TeamMarketingAnalyticsConfig  # noqa: F401
 from .team_provisioning_config import TeamProvisioningConfig  # noqa: F401

--- a/posthog/models/test/test_entity_model.py
+++ b/posthog/models/test/test_entity_model.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
-from posthog.models.entity import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS, Entity
+from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS
+from posthog.models.entity import Entity
 
 
 class TestEntity(TestCase):

--- a/posthog/models/user_group/__init__.py
+++ b/posthog/models/user_group/__init__.py
@@ -1,1 +1,3 @@
-from .user_group import *
+from .user_group import UserGroup, UserGroupMembership
+
+__all__ = ["UserGroup", "UserGroupMembership"]

--- a/posthog/temporal/tests/session_replay/session_summary/conftest.py
+++ b/posthog/temporal/tests/session_replay/session_summary/conftest.py
@@ -15,7 +15,7 @@ from posthog.temporal.session_replay.session_summary_group.workflow import Sessi
 from ee.hogai.session_summaries.constants import SESSION_SUMMARIES_DB_DATA_REDIS_TTL, SESSION_SUMMARIES_MODEL
 from ee.hogai.session_summaries.session.output_data import SessionSummarySerializer
 from ee.hogai.session_summaries.session.summarize_session import SingleSessionSummaryLlmInputs
-from ee.hogai.session_summaries.tests.conftest import *
+from ee.hogai.session_summaries.tests.conftest import *  # noqa: F401, F403  # legacy: pytest fixtures inherited from session-summaries conftest
 from ee.models.session_summaries import ExtraSummaryContext, SessionSummaryRunMeta, SingleSessionSummary
 
 

--- a/posthog/temporal/tests/session_replay/session_summary_group/conftest.py
+++ b/posthog/temporal/tests/session_replay/session_summary_group/conftest.py
@@ -1,1 +1,1 @@
-from posthog.temporal.tests.session_replay.session_summary.conftest import *  # noqa: F401, F403
+from posthog.temporal.tests.session_replay.session_summary.conftest import *  # noqa: F401, F403  # legacy: pytest fixtures inherited from sibling conftest

--- a/products/analytics_platform/backend/models/__init__.py
+++ b/products/analytics_platform/backend/models/__init__.py
@@ -1,1 +1,3 @@
-from .preaggregation_job import *
+from .preaggregation_job import PreaggregationJob
+
+__all__ = ["PreaggregationJob"]

--- a/products/conftest.py
+++ b/products/conftest.py
@@ -1,4 +1,4 @@
 # NOTE: We attempt to keep this file in sync with posthog/conftest.py
 # by importing all of the declarations in that file.
 
-from posthog.conftest import *
+from posthog.conftest import *  # noqa: F401, F403  # legacy: pytest fixtures inherited from root conftest

--- a/products/data_modeling/backend/models/__init__.py
+++ b/products/data_modeling/backend/models/__init__.py
@@ -1,6 +1,23 @@
-from .dag import *
-from .edge import *
-from .github_sync_config import *
-from .github_sync_plan import *
-from .github_synced_model import *
-from .node import *
+from .dag import DAG, DEFAULT_DAG_NAME
+from .edge import CycleDetectionError, DAGMismatchError, DataModelingEdgeManager, DataModelingEdgeQuerySet, Edge
+from .github_sync_config import GitHubSyncConfig, GitHubSyncStatus
+from .github_sync_plan import GitHubSyncPlan, GitHubSyncPlanStatus
+from .github_synced_model import GitHubSyncedModel
+from .node import Node, NodeType
+
+__all__ = [
+    "DAG",
+    "DEFAULT_DAG_NAME",
+    "CycleDetectionError",
+    "DAGMismatchError",
+    "DataModelingEdgeManager",
+    "DataModelingEdgeQuerySet",
+    "Edge",
+    "GitHubSyncConfig",
+    "GitHubSyncStatus",
+    "GitHubSyncPlan",
+    "GitHubSyncPlanStatus",
+    "GitHubSyncedModel",
+    "Node",
+    "NodeType",
+]

--- a/products/data_warehouse/backend/models/__init__.py
+++ b/products/data_warehouse/backend/models/__init__.py
@@ -1,15 +1,19 @@
-from .credential import *
-from .data_modeling_job import *
-from .datawarehouse_managed_viewset import *
-from .datawarehouse_saved_query import *
-from .datawarehouse_saved_query_draft import *
-from .datawarehouse_saved_query_folder import *
-from .external_data_job import *
-from .external_data_schema import *
-from .external_data_source import *
-from .join import *
-from .modeling import *
-from .query_tab_state import *
-from .revenue_analytics_config import *
-from .table import *
-from .team_data_warehouse_config import *
+# TODO: replace these wildcard imports with explicit re-exports.
+# Callers rely on transitively-leaked helpers (CLICKHOUSE_HOGQL_MAPPING, clean_type,
+# get_s3_client, ExternalDataSourceType, …) that come from util.py / ../s3.py / ../types.py
+# via the submodules' own imports — enumerating them takes care to avoid breaking imports.
+from .credential import *  # noqa: F403  # legacy: see TODO above
+from .data_modeling_job import *  # noqa: F403  # legacy: see TODO above
+from .datawarehouse_managed_viewset import *  # noqa: F403  # legacy: see TODO above
+from .datawarehouse_saved_query import *  # noqa: F403  # legacy: see TODO above
+from .datawarehouse_saved_query_draft import *  # noqa: F403  # legacy: see TODO above
+from .datawarehouse_saved_query_folder import *  # noqa: F403  # legacy: see TODO above
+from .external_data_job import *  # noqa: F403  # legacy: see TODO above
+from .external_data_schema import *  # noqa: F403  # legacy: see TODO above
+from .external_data_source import *  # noqa: F403  # legacy: see TODO above
+from .join import *  # noqa: F403  # legacy: see TODO above
+from .modeling import *  # noqa: F403  # legacy: see TODO above
+from .query_tab_state import *  # noqa: F403  # legacy: see TODO above
+from .revenue_analytics_config import *  # noqa: F403  # legacy: see TODO above
+from .table import *  # noqa: F403  # legacy: see TODO above
+from .team_data_warehouse_config import *  # noqa: F403  # legacy: see TODO above

--- a/products/workflows/backend/models/__init__.py
+++ b/products/workflows/backend/models/__init__.py
@@ -1,1 +1,3 @@
-from .hog_flow_batch_job import *
+from .hog_flow_batch_job import HogFlowBatchJob
+
+__all__ = ["HogFlowBatchJob"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,7 +317,6 @@ ignore = [
     "E501",  # ~4697: line too long
     "E722",  # ~62: bare except
     "E731",  # ~185: lambda assignment
-    "F403",  # ~67: import * undefined
     "F541",  # ~1139: f-string missing placeholders
     "UP007",  # ~377: Union[X,Y] → X | Y (auto-fixable)
     "UP032",  # ~175: use f-string (auto-fixable)
@@ -352,6 +351,9 @@ select = [
 # descriptors into the pool before AddSerializedFile() — ruff must not strip them.
 "posthog/personhog_client/proto/generated/**/*.pyi" = ["F401"]
 "posthog/personhog_client/proto/generated/**/*_pb2.py" = ["F401", "E402"]
+# Django settings aggregator: star imports are how settings modules merge into one namespace.
+# Not portable to explicit re-exports without losing the settings-loading semantics.
+"posthog/settings/**" = ["F403", "F405"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10


### PR DESCRIPTION
## Problem

The codebase had 84 `from X import *` statements across 28 files. Wildcard imports
hide a module's public surface, make refactors risky (transitive name leaks can
break callers far away), and slow down static analysis. There was no rule to stop
new ones from creeping in — `F403` was in the global ruff `ignore` list with a
stale comment claiming "~67" occurrences.

## Changes

- **Enforce going forward:** removed `F403` from `[tool.ruff.lint] ignore` so any
  new `from X import *` fails CI. F405 was already covered by the `F` select.
- **Settings carve-out:** added `posthog/settings/**` to `per-file-ignores` for
  F403/F405. Django settings genuinely depend on namespace merging via star
  imports and aren't portable to explicit re-exports without rewriting the
  settings loader (33 sites covered by this).
- **Cleaned up where reasonable** — replaced wildcard imports with explicit
  `from .X import A, B, C` plus an `__all__` in 14 `__init__.py` files (model
  packages, dags/common, data_modeling models, hog_flow, cohort, etc.).
- **Deleted dead code:** `ee/clickhouse/queries/retention/__init__.py` was
  importing from a `.retention` submodule that no longer existed, and nothing
  referenced the package.
- **One caller fix:** `posthog/models/test/test_entity_model.py` was relying on
  `TREND_FILTER_TYPE_ACTIONS` / `TREND_FILTER_TYPE_EVENTS` leaking through
  `posthog.models.entity` (they live in `posthog.constants`). Updated the import
  to point at the source.
- **Justified noqa elsewhere:** the remaining wildcard sites (data_warehouse
  models, research_agent prompts, hogai utils types, property/team models,
  pytest conftests) carry a `# noqa: F403  # legacy: …` comment with a short
  reason — TODO markers on the data_warehouse and team/property cases that are
  worth a future cleanup.

Net: 84 → 61 wildcard imports. Of the 61 remaining, 33 are settings (per-file
ignore), 3 are antlr-generated grammar (already in ruff `exclude`), and 25
carry an explicit justified `# noqa: F403`.

## How did you test this code?

I'm an agent (Claude Code). I did not run the full test suite. Verification was:

- `ruff check --select F403 .` → all checks passed.
- `ruff check --select F405 .` → all checks passed.
- `ruff check .` (full lint) → all checks passed.
- Smoke-tested the rule by adding `from os.path import *` to a scratch file and
  confirming ruff flags it as F403.
- For each `__init__.py` I converted to explicit imports, cross-checked the
  external import surface (`grep -rE "from <package> import"`) against the
  exported names to ensure no caller was relying on a name I dropped. Found and
  fixed one missed transitive re-export (`JobOwners` in `posthog.dags.common`).
- No Python runtime / Django boot check ran in this environment — CI will cover
  that.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude Code at the user's request. Conversation focused on
identifying worst offenders (data_warehouse 15 sites was the biggest non-settings
case, settings/__init__.py the absolute biggest at 33), agreeing on the strategy
(inline `# noqa: F403` with TODO/legacy justification rather than a config-level
per-file allowlist, so the suppressions are visible at the call site), and
deciding which sites to actually clean up vs leave with noqa. Cleanup was scoped
to packages with a clear, small public surface and no significant transitive
leaks used by external callers; data_warehouse and team/property were left with
noqa+TODO because their wildcards leak helpers from sibling modules that callers
depend on, making a safe cleanup non-trivial. The pre-commit hook was bypassed
once on this commit because the sandbox env couldn't rebuild the stale venv
(hogli moved paths, uv was too old to install the required Python, and the
network couldn't reach astral.sh) — ruff was verified manually instead; the
user explicitly authorized `--no-verify` for this single commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5UKTfJKbK57UusPWNpsGY)_