### PR TITLE
fix(devex): bin/start silent exit + 1Password CLI graceful fallback

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -56,10 +56,18 @@ source_env_defaults() {
         echo "⚠️  Expected env file missing: $1 — skipping. Did your checkout get truncated?" >&2
         return 0
     fi
+    # Use explicit if/fi (not `[[ ... ]] && cmd`) so the loop body always
+    # returns 0. With `&&`, the last iteration's `[[ -z … ]]` returning false
+    # (variable already set) makes the function return non-zero, and `set -e`
+    # silently kills the entire script — no error, no output, just exit. This
+    # was the root cause of "hogli start" failing in Cursor and other terminals
+    # where some of the trailing env vars happened to already be in the shell.
     while IFS='=' read -r name value; do
         [[ -z "$name" || "$name" == \#* ]] && continue
         [[ "$value" == op://* ]] && continue
-        [[ -z "${!name:-}" ]] && export "$name=$value"
+        if [[ -z "${!name:-}" ]]; then
+            export "$name=$value"
+        fi
     done < "$1"
 }
 # .env.local: already in env if processed by op run, otherwise source directly

--- a/bin/start
+++ b/bin/start
@@ -16,8 +16,10 @@ if [ -f "$REPOSITORY_ROOT/.env.local" ] && grep -q "op://" "$REPOSITORY_ROOT/.en
             export _POSTHOG_OP_RESOLVED=1
             exec op run --env-file="$REPOSITORY_ROOT/.env.local" -- "$0" "$@"
         else
-            echo "⚠️  .env.local contains 1Password refs (op://) but 'op' CLI not found"
-            echo "   Install: brew install 1password-cli"
+            echo "⚠️  .env.local contains 1Password refs (op://) but 'op' CLI is not installed."
+            echo "   These refs will be skipped — services that depend on them will fail with their own"
+            echo "   'missing key' errors. To resolve them automatically, install: brew install 1password-cli"
+            echo "   Or replace op:// refs with literal values in .env.local."
         fi
     fi
 fi
@@ -45,16 +47,27 @@ trap cleanup_lock EXIT INT TERM
 #
 # Source env files respecting precedence:
 #   shell env > .env.local > .env.development > .env.services
-# Only set vars that aren't already in the environment
+# Only set vars that aren't already in the environment.
+# op:// refs are always skipped here — they only get resolved by `op run` in
+# the re-exec block above. Sourcing them as literals would set env vars to
+# garbage strings that break downstream services with cryptic errors.
 source_env_defaults() {
+    if [[ ! -f "$1" ]]; then
+        echo "⚠️  Expected env file missing: $1 — skipping. Did your checkout get truncated?" >&2
+        return 0
+    fi
     while IFS='=' read -r name value; do
         [[ -z "$name" || "$name" == \#* ]] && continue
+        [[ "$value" == op://* ]] && continue
         [[ -z "${!name:-}" ]] && export "$name=$value"
     done < "$1"
 }
 # .env.local: already in env if processed by op run, otherwise source directly
 if [[ -f "$REPOSITORY_ROOT/.env.local" ]] && [[ -z "$_POSTHOG_OP_RESOLVED" ]]; then
     source_env_defaults "$REPOSITORY_ROOT/.env.local"
+elif [[ ! -f "$REPOSITORY_ROOT/.env.local" ]] && [[ -f "$REPOSITORY_ROOT/.env.local.example" ]]; then
+    echo "💡 No .env.local found — running with committed defaults only."
+    echo "   For personal overrides or secrets: cp .env.local.example .env.local"
 fi
 source_env_defaults "$REPOSITORY_ROOT/.env.development"
 source_env_defaults "$REPOSITORY_ROOT/.env.services"

--- a/bin/start
+++ b/bin/start
@@ -64,7 +64,9 @@ source_env_defaults() {
     # where some of the trailing env vars happened to already be in the shell.
     while IFS='=' read -r name value; do
         [[ -z "$name" || "$name" == \#* ]] && continue
-        [[ "$value" == op://* ]] && continue
+        # Substring match so quoted ("op://...") and space-padded values are
+        # also caught — mirrors what op run itself accepts.
+        [[ "$value" == *op://* ]] && continue
         if [[ -z "${!name:-}" ]]; then
             export "$name=$value"
         fi

--- a/docs/published/handbook/engineering/developing-locally.md
+++ b/docs/published/handbook/engineering/developing-locally.md
@@ -170,6 +170,8 @@ hogli start                                 # auto-resolves op:// via `op run`
 
 If `bin/start` sees any `op://` reference in `.env.local`, it re-execs itself under `op run --env-file=.env.local`. No need to remember the wrapper command.
 
+If the `op` CLI isn't installed, `op://` lines are skipped (rather than sourced as literal `op://...` strings that break downstream services with cryptic errors). Services that need those secrets will fail with their own "missing key" errors — install `1password-cli` or replace the refs with literal values.
+
 ### Running in detached mode
 
 By default, `hogli start` runs interactively with a terminal UI (phrocs) that displays logs from all processes. If you prefer to run the dev stack in the background without an attached terminal, use detached mode:

--- a/tools/hogli/src/hogli/cli.py
+++ b/tools/hogli/src/hogli/cli.py
@@ -272,7 +272,11 @@ def _load_env_file(path: os.PathLike[str], only_if_unset: bool = True) -> None:
         if not line or line.startswith("#") or "=" not in line:
             continue
         name, _, value = line.partition("=")
-        if value.startswith("op://"):
+        # Substring match so quoted (`KEY="op://..."`) and space-padded
+        # (`KEY= op://...`) forms are also skipped — matches what op run itself
+        # accepts. Leaking these as literals would break downstream services
+        # with cryptic API errors.
+        if "op://" in value:
             continue
         if only_if_unset and name in os.environ:
             continue
@@ -301,8 +305,11 @@ def run_with_env(command: tuple[str, ...]) -> None:
     has_op_refs = env_local.exists() and "op://" in env_local.read_text()
 
     if has_op_refs and shutil.which("op"):
-        # Load .env.development and .env.services first (only if not already set in shell).
-        # op run then layers .env.local on top — overriding our files but not shell.
+        # Pre-load .env.development and .env.services (only if not already set in shell)
+        # so op run's child inherits them. op run then layers .env.local on top,
+        # overriding any variable it defines — including ones from shell. That's
+        # the precedence the docstring above promises: shell env > .env.local
+        # only applies to vars NOT defined in .env.local.
         _load_env_file(env_dev, only_if_unset=True)
         _load_env_file(env_services, only_if_unset=True)
         os.execvp("op", ["op", "run", f"--env-file={env_local}", "--", *command])

--- a/tools/hogli/src/hogli/cli.py
+++ b/tools/hogli/src/hogli/cli.py
@@ -255,7 +255,12 @@ def concepts() -> None:
 
 
 def _load_env_file(path: os.PathLike[str], only_if_unset: bool = True) -> None:
-    """Load environment variables from a file (KEY=VALUE per line, # comments)."""
+    """Load environment variables from a file (KEY=VALUE per line, # comments).
+
+    op:// refs are always skipped — they only get resolved by `op run`, never by
+    sourcing the file directly. Setting them as literal strings would break
+    downstream services with cryptic API errors.
+    """
     from pathlib import Path
 
     env_file = Path(path)
@@ -267,6 +272,8 @@ def _load_env_file(path: os.PathLike[str], only_if_unset: bool = True) -> None:
         if not line or line.startswith("#") or "=" not in line:
             continue
         name, _, value = line.partition("=")
+        if value.startswith("op://"):
+            continue
         if only_if_unset and name in os.environ:
             continue
         os.environ[name] = value
@@ -293,21 +300,27 @@ def run_with_env(command: tuple[str, ...]) -> None:
 
     has_op_refs = env_local.exists() and "op://" in env_local.read_text()
 
-    if has_op_refs:
-        if not shutil.which("op"):
-            click.echo("⚠️  .env.local contains 1Password refs (op://) but 'op' CLI not found", err=True)
-            click.echo("   Install: brew install 1password-cli", err=True)
-            raise SystemExit(1)
+    if has_op_refs and shutil.which("op"):
         # Load .env.development and .env.services first (only if not already set in shell).
         # op run then layers .env.local on top — overriding our files but not shell.
         _load_env_file(env_dev, only_if_unset=True)
         _load_env_file(env_services, only_if_unset=True)
         os.execvp("op", ["op", "run", f"--env-file={env_local}", "--", *command])
-    else:
-        _load_env_file(env_local, only_if_unset=True)
-        _load_env_file(env_dev, only_if_unset=True)
-        _load_env_file(env_services, only_if_unset=True)
-        os.execvp(command[0], list(command))
+        return
+
+    # No op refs OR op CLI not installed — source files directly. _load_env_file
+    # skips op:// lines, so missing op CLI degrades gracefully: vars that needed
+    # 1Password are simply unset, and the downstream command fails with its own
+    # "missing key" error rather than swallowing a literal "op://..." string.
+    if has_op_refs:
+        click.echo("⚠️  .env.local contains 1Password refs (op://) but 'op' CLI is not installed.", err=True)
+        click.echo("   These refs will be skipped. Install: brew install 1password-cli", err=True)
+        click.echo("   Or replace op:// refs with literal values in .env.local.", err=True)
+
+    _load_env_file(env_local, only_if_unset=True)
+    _load_env_file(env_dev, only_if_unset=True)
+    _load_env_file(env_services, only_if_unset=True)
+    os.execvp(command[0], list(command))
 
 
 def _register_script_commands() -> None:

--- a/tools/hogli/tests/test_cli.py
+++ b/tools/hogli/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 import pytest
@@ -200,3 +201,54 @@ class TestHelpText:
         lines = result.output.split("\n")
         # Look for section headers (typically uppercase or titled)
         assert len(lines) > 10
+
+
+class TestLoadEnvFile:
+    """Test _load_env_file behavior — esp. graceful handling of op:// refs."""
+
+    def _write_env(self, tmp_path, content: str):
+        env_file = tmp_path / ".env.test"
+        env_file.write_text(content)
+        return env_file
+
+    def test_skips_op_refs_so_they_dont_leak_as_literals(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """op:// values must never be set as literal env vars — they'd break downstream services."""
+        from hogli.cli import _load_env_file
+
+        env_file = self._write_env(
+            tmp_path,
+            "OPENAI_API_KEY=op://General/abc/credential\nLITERAL_VAR=actual_value\n",
+        )
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("LITERAL_VAR", raising=False)
+
+        _load_env_file(env_file)
+
+        assert "OPENAI_API_KEY" not in os.environ
+        assert os.environ["LITERAL_VAR"] == "actual_value"
+
+    def test_missing_file_is_silent(self, tmp_path) -> None:
+        """Missing env files should not raise — caller may pass an optional file."""
+        from hogli.cli import _load_env_file
+
+        _load_env_file(tmp_path / "does_not_exist.env")
+
+    def test_only_if_unset_preserves_shell_env(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from hogli.cli import _load_env_file
+
+        env_file = self._write_env(tmp_path, "MY_VAR=from_file\n")
+        monkeypatch.setenv("MY_VAR", "from_shell")
+
+        _load_env_file(env_file, only_if_unset=True)
+
+        assert os.environ["MY_VAR"] == "from_shell"
+
+    def test_ignores_comments_and_blanks(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from hogli.cli import _load_env_file
+
+        env_file = self._write_env(tmp_path, "# comment\n\nREAL_VAR=42\n# another\n")
+        monkeypatch.delenv("REAL_VAR", raising=False)
+
+        _load_env_file(env_file)
+
+        assert os.environ["REAL_VAR"] == "42"

--- a/tools/hogli/tests/test_cli.py
+++ b/tools/hogli/tests/test_cli.py
@@ -211,14 +211,26 @@ class TestLoadEnvFile:
         env_file.write_text(content)
         return env_file
 
-    def test_skips_op_refs_so_they_dont_leak_as_literals(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """op:// values must never be set as literal env vars — they'd break downstream services."""
+    @pytest.mark.parametrize(
+        "op_line",
+        [
+            "OPENAI_API_KEY=op://General/abc/credential",
+            'OPENAI_API_KEY="op://General/abc/credential"',
+            "OPENAI_API_KEY= op://General/abc/credential",
+        ],
+        ids=["bare", "double-quoted", "leading-space"],
+    )
+    def test_skips_op_refs_so_they_dont_leak_as_literals(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, op_line: str
+    ) -> None:
+        """op:// values must never be set as literal env vars — they'd break downstream services.
+
+        Covers bare, quoted, and space-padded forms (op run itself accepts all three,
+        so users may write any of them).
+        """
         from hogli.cli import _load_env_file
 
-        env_file = self._write_env(
-            tmp_path,
-            "OPENAI_API_KEY=op://General/abc/credential\nLITERAL_VAR=actual_value\n",
-        )
+        env_file = self._write_env(tmp_path, f"{op_line}\nLITERAL_VAR=actual_value\n")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("LITERAL_VAR", raising=False)
 


### PR DESCRIPTION
## Problem

Follow-up to #45696. Three related issues hitting devs since the consolidation landed:

1. **`bin/start` silently exits with no output** — reported by multiple folks running through Cursor's integrated terminal or via `op run` re-exec. Output looks like:

   ```
   $ hogli start
   🚀 .../bin/start
   💥 Command failed: .../bin/start
   ```

   Root cause: `source_env_defaults` ended each loop iteration with `[[ -z "${!name:-}" ]] && export …`. When the LAST line of the env file named a variable already in the shell (e.g. `PYDEVD_DISABLE_FILE_VALIDATION`, or anything propagated through `op run`), the `[[ ]]` returned false, the `&&` made that the function's return code, and `set -e` killed the script with zero output.

2. **`.env.local` with `op://` refs but no `op` CLI** — `bin/start` printed a warning then sourced the file anyway, setting `OPENAI_API_KEY` to the literal string `op://General/abc/credential`. Downstream services then failed with confusing 401s far from the actual config problem. `hogli run` did the opposite — exited hard, no fallback.

3. **No `.env.local` at all** — fresh users got no hint that they could/should copy `.env.local.example`.

## Changes

- `source_env_defaults`: switched the loop body to `if/then/fi`. Loop body always returns 0, so `set -e` no longer kills the script. Comment explains the gotcha for future readers.
- `bin/start` + `hogli run`: when `op://` refs exist but `op` CLI is missing, skip those lines entirely instead of sourcing them as literal strings (or exiting hard, in hogli's case). Downstream services then fail with their own clean \"missing key\" errors.
- `bin/start`: prints one-line hint when `.env.local` is missing, pointing at `.env.local.example`.
- `source_env_defaults`: warns and skips when a committed env file is missing instead of bash's cryptic \"No such file\" + `set -e` exit.
- Docs note added for the op-CLI-missing fallback.

## How did you test this code?

Agent-authored (Claude Opus 4.7, fast mode) with human review/direction throughout.

Automated:
- 4 new pytest cases for `_load_env_file` covering op:// skip, missing file, only-if-unset shell precedence, and comment/blank handling.
- All 75 existing hogli tests still pass.
- `ruff check`, `ruff format --check`, semgrep against `.semgrep/devex-rules/` all clean.
- `bash -n bin/start` syntax-OK.

Reproducer for the silent-exit bug (before fix):

```bash
export PYDEVD_DISABLE_FILE_VALIDATION=1
bash -ec 'set -e
f() { while IFS== read -r n v; do [[ -z \"\${!n:-}\" ]] && export \"\$n=\$v\"; done < .env.development; }
f
echo \"reached\"'
# exits 1, \"reached\" never prints
```

Manual scenarios exercised via a stripped-down replica of the script (no full `bin/start` boot since the local env is busy):
- no `.env.local` → friendly hint, defaults loaded
- `.env.local` with op:// + no op CLI → those vars unset, literal vars still loaded
- missing `.env.development` → warning instead of bash's \"No such file\" + silent exit
- last var pre-set → no longer kills the script

Did NOT do an end-to-end `hogli start` here.

## Publish to changelog?

no

## 🤖 Agent context

Claude Opus 4.7 (Claude Code, fast mode) drove the investigation and patch.

Investigation path: started from the user-reported \"silent crash without .env.local\" and \"op CLI not installed\" symptoms, looked at the merged PR + the lock-fix follow-up (#59173), then traced the actual silent-exit path by replicating `source_env_defaults` in isolation. Found that `[[ -z … ]] && export` propagates the test's exit status as the loop body's last status, which then becomes the function's return code, which `set -e` treats as a fatal error. Confirmed with the reproducer above.

Aleksander suggested wrapping `{\"1\": 100}` in `''` as a workaround — verified that's not the fix (the silent exit still happens with the wrap, and the literal single quotes break JSON parsing downstream). The if/then/fi restructure is the real one.

Decisions:
- Always skip `op://` lines in the bash loader, not just when `op` is missing. Defensive — if op-resolved values somehow reach the loader, they'd already be plain strings, not `op://` refs.
- Kept the hint about missing `.env.local` short (one line) so it isn't noisy on every run.
- Did not add a deprecation path for the old `.env` file. Out of scope and would muddy the migration.