### PR TITLE
feat(llma): filter read-data-warehouse-schema by table names

### DIFF
--- a/ee/hogai/tools/read_data_warehouse_schema/mcp_tool.py
+++ b/ee/hogai/tools/read_data_warehouse_schema/mcp_tool.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Union
 
 from pydantic import BaseModel, Field
 
@@ -11,20 +11,27 @@ _PERSONS_DB_TABLES = {"group_type_mappings", "groups"}
 _CORE_TABLE_NAMES = ["events", "groups", "persons", "sessions"]
 
 
-class ReadDataWarehouseSchemaQuery(BaseModel):
-    kind: Literal["data_warehouse_schema"] = "data_warehouse_schema"
-    table_names: list[str] | None = Field(
-        default=None,
-        description=(
-            "Optional list of specific warehouse, system, view, or core table names. "
-            "If provided, returns schemas only for those tables (catalog sections are omitted). "
-            "If omitted, returns core tables plus the full catalog."
-        ),
+class ListDataWarehouseCatalog(BaseModel):
+    """Returns core PostHog table schemas (events, groups, persons, sessions) plus a catalog listing of every available warehouse table, system table, and view by name. Call this first if you don't yet know which tables exist."""
+
+    kind: Literal["data_warehouse_catalog"] = "data_warehouse_catalog"
+
+
+class GetDataWarehouseTables(BaseModel):
+    """Returns full column schemas for the named warehouse, system, view, or core tables. Use this after `data_warehouse_catalog` once you know which tables you need."""
+
+    kind: Literal["data_warehouse_tables"] = "data_warehouse_tables"
+    table_names: list[str] = Field(
+        min_length=1,
+        description="Specific warehouse, system, view, or core table names to fetch schemas for.",
     )
 
 
+DataWarehouseSchemaQuery = Union[ListDataWarehouseCatalog, GetDataWarehouseTables]
+
+
 class ReadDataWarehouseSchemaMCPToolArgs(BaseModel):
-    query: ReadDataWarehouseSchemaQuery
+    query: DataWarehouseSchemaQuery = Field(..., discriminator="kind")
 
 
 @mcp_tool_registry.register(scopes=["warehouse_table:read", "warehouse_view:read"])
@@ -39,9 +46,11 @@ class ReadDataWarehouseSchemaMCPTool(HogQLDatabaseMixin, MCPTool[ReadDataWarehou
     args_schema = ReadDataWarehouseSchemaMCPToolArgs
 
     async def execute(self, args: ReadDataWarehouseSchemaMCPToolArgs) -> str:
-        if args.query.table_names:
-            return await self._build_specific_tables(args.query.table_names)
-        return await self._build_tables_list()
+        match args.query:
+            case GetDataWarehouseTables():
+                return await self._build_specific_tables(args.query.table_names)
+            case ListDataWarehouseCatalog():
+                return await self._build_tables_list()
 
     @database_sync_to_async(thread_sensitive=False)
     def _build_tables_list(self) -> str:

--- a/ee/hogai/tools/read_data_warehouse_schema/mcp_tool.py
+++ b/ee/hogai/tools/read_data_warehouse_schema/mcp_tool.py
@@ -1,15 +1,26 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from posthog.sync import database_sync_to_async
 
 from ee.hogai.chat_agent.sql.mixins import HogQLDatabaseMixin
 from ee.hogai.mcp_tool import MCPTool, mcp_tool_registry
 
+_PERSONS_DB_TABLES = {"group_type_mappings", "groups"}
+_CORE_TABLE_NAMES = ["events", "groups", "persons", "sessions"]
+
 
 class ReadDataWarehouseSchemaQuery(BaseModel):
     kind: Literal["data_warehouse_schema"] = "data_warehouse_schema"
+    table_names: list[str] | None = Field(
+        default=None,
+        description=(
+            "Optional list of specific warehouse, system, view, or core table names. "
+            "If provided, returns schemas only for those tables (catalog sections are omitted). "
+            "If omitted, returns core tables plus the full catalog."
+        ),
+    )
 
 
 class ReadDataWarehouseSchemaMCPToolArgs(BaseModel):
@@ -28,6 +39,8 @@ class ReadDataWarehouseSchemaMCPTool(HogQLDatabaseMixin, MCPTool[ReadDataWarehou
     args_schema = ReadDataWarehouseSchemaMCPToolArgs
 
     async def execute(self, args: ReadDataWarehouseSchemaMCPToolArgs) -> str:
+        if args.query.table_names:
+            return await self._build_specific_tables(args.query.table_names)
         return await self._build_tables_list()
 
     @database_sync_to_async(thread_sensitive=False)
@@ -35,8 +48,7 @@ class ReadDataWarehouseSchemaMCPTool(HogQLDatabaseMixin, MCPTool[ReadDataWarehou
         database = self._get_database()
         hogql_context = self._get_default_hogql_context(database)
 
-        core_tables = {"events", "groups", "persons", "sessions"}
-        serialized = database.serialize(hogql_context, include_only=core_tables)
+        serialized = database.serialize(hogql_context, include_only=set(_CORE_TABLE_NAMES))
 
         lines: list[str] = ["# Core PostHog tables", ""]
 
@@ -48,8 +60,7 @@ class ReadDataWarehouseSchemaMCPTool(HogQLDatabaseMixin, MCPTool[ReadDataWarehou
 
         warehouse_tables = database.get_warehouse_table_names()
         # Filter out tables that live in the persons database and can't be queried via ClickHouse
-        persons_db_tables = {"group_type_mappings", "groups"}
-        system_tables = [t for t in database.get_system_table_names() if t not in persons_db_tables]
+        system_tables = [t for t in database.get_system_table_names() if t not in _PERSONS_DB_TABLES]
         views = database.get_view_names()
 
         def listify(items: list[str]) -> str:
@@ -65,3 +76,53 @@ class ReadDataWarehouseSchemaMCPTool(HogQLDatabaseMixin, MCPTool[ReadDataWarehou
         )
 
         return "\n".join(lines) + extra_sections
+
+    @database_sync_to_async(thread_sensitive=False)
+    def _build_specific_tables(self, table_names: list[str]) -> str:
+        database = self._get_database()
+        hogql_context = self._get_default_hogql_context(database)
+
+        # Order matters: the first source to claim a name wins the label.
+        sources: list[tuple[str, list[str]]] = [
+            ("data warehouse", database.get_warehouse_table_names()),
+            ("system", [t for t in database.get_system_table_names() if t not in _PERSONS_DB_TABLES]),
+            ("view", database.get_view_names()),
+            ("core", list(_CORE_TABLE_NAMES)),
+        ]
+        location_by_name: dict[str, str] = {}
+        all_names: set[str] = set()
+        for label, names in sources:
+            for n in names:
+                location_by_name.setdefault(n, label)
+                all_names.add(n)
+
+        seen: set[str] = set()
+        ordered_requested: list[str] = []
+        for n in table_names:
+            if n not in seen:
+                seen.add(n)
+                ordered_requested.append(n)
+
+        found = [n for n in ordered_requested if n in location_by_name]
+        missing = [n for n in ordered_requested if n not in location_by_name]
+
+        lines: list[str] = ["# Requested tables", ""]
+        if found:
+            serialized = database.serialize(hogql_context, include_only=set(found))
+            for name in ordered_requested:
+                if name not in serialized:
+                    continue
+                table = serialized[name]
+                lines.append(f"## Table `{name}` ({location_by_name[name]})")
+                for field in table.fields.values():
+                    lines.append(f"- {field.name} ({field.type})")
+                lines.append("")
+
+        if missing:
+            suggestions = ", ".join(sorted(all_names)[:10])
+            lines.append("## Not found")
+            for name in missing:
+                lines.append(f"- `{name}` — available tables include: {suggestions}")
+            lines.append("")
+
+        return "\n".join(lines).rstrip() + "\n"

--- a/ee/hogai/tools/read_data_warehouse_schema/mcp_tool.py
+++ b/ee/hogai/tools/read_data_warehouse_schema/mcp_tool.py
@@ -77,14 +77,31 @@ class ReadDataWarehouseSchemaMCPTool(HogQLDatabaseMixin, MCPTool[ReadDataWarehou
 
         return "\n".join(lines) + extra_sections
 
+    @staticmethod
+    def _resolve_warehouse_canonical(name: str, warehouse_names: set[str]) -> str | None:
+        # get_warehouse_table_names() returns both the canonical dotted form (e.g.
+        # "hubspot.companies") and an underscored alias ("hubspot_companies").
+        # database.serialize() only honors the dotted form, so if the agent asks
+        # for the alias we map it back before calling serialize.
+        if "." in name:
+            return None
+        parts = name.split("_")
+        for i in range(1, len(parts)):
+            candidate = ".".join(["_".join(parts[:i]), "_".join(parts[i:])])
+            if candidate in warehouse_names:
+                return candidate
+        return None
+
     @database_sync_to_async(thread_sensitive=False)
     def _build_specific_tables(self, table_names: list[str]) -> str:
         database = self._get_database()
         hogql_context = self._get_default_hogql_context(database)
 
+        warehouse_names = database.get_warehouse_table_names()
+
         # Order matters: the first source to claim a name wins the label.
         sources: list[tuple[str, list[str]]] = [
-            ("data warehouse", database.get_warehouse_table_names()),
+            ("data warehouse", warehouse_names),
             ("system", [t for t in database.get_system_table_names() if t not in _PERSONS_DB_TABLES]),
             ("view", database.get_view_names()),
             ("core", list(_CORE_TABLE_NAMES)),
@@ -103,20 +120,42 @@ class ReadDataWarehouseSchemaMCPTool(HogQLDatabaseMixin, MCPTool[ReadDataWarehou
                 seen.add(n)
                 ordered_requested.append(n)
 
+        warehouse_set = set(warehouse_names)
+        canonical_for: dict[str, str] = {}
+        for n in ordered_requested:
+            if n not in location_by_name:
+                continue
+            if location_by_name[n] == "data warehouse":
+                canonical_for[n] = self._resolve_warehouse_canonical(n, warehouse_set) or n
+            else:
+                canonical_for[n] = n
+
         found = [n for n in ordered_requested if n in location_by_name]
-        missing = [n for n in ordered_requested if n not in location_by_name]
+        unrecognized = [n for n in ordered_requested if n not in location_by_name]
+
+        serialized: dict[str, object] = {}
+        if found:
+            serialize_keys = {canonical_for[n] for n in found}
+            serialized = database.serialize(hogql_context, include_only=serialize_keys)
+
+        # Anything we marked found but serialize couldn't render falls back to
+        # missing — otherwise the response silently drops it with no signal.
+        unserialized = {n for n in found if canonical_for[n] not in serialized}
+        missing_set = set(unrecognized) | unserialized
+        missing = [n for n in ordered_requested if n in missing_set]
 
         lines: list[str] = ["# Requested tables", ""]
-        if found:
-            serialized = database.serialize(hogql_context, include_only=set(found))
-            for name in ordered_requested:
-                if name not in serialized:
-                    continue
-                table = serialized[name]
-                lines.append(f"## Table `{name}` ({location_by_name[name]})")
-                for field in table.fields.values():
-                    lines.append(f"- {field.name} ({field.type})")
-                lines.append("")
+        for name in ordered_requested:
+            if name not in location_by_name:
+                continue
+            canonical = canonical_for[name]
+            if canonical not in serialized:
+                continue
+            table = serialized[canonical]
+            lines.append(f"## Table `{name}` ({location_by_name[name]})")
+            for field in table.fields.values():
+                lines.append(f"- {field.name} ({field.type})")
+            lines.append("")
 
         if missing:
             suggestions = ", ".join(sorted(all_names)[:10])

--- a/ee/hogai/tools/read_data_warehouse_schema/test/test_mcp_tool.py
+++ b/ee/hogai/tools/read_data_warehouse_schema/test/test_mcp_tool.py
@@ -19,38 +19,38 @@ class TestReadDataWarehouseSchemaMCPTool(NonAtomicBaseTest):
     async def test_tool_has_correct_name(self):
         self.assertEqual(self.tool.name, "read_data_warehouse_schema")
 
-    async def test_returns_core_table_schemas(self):
+    async def test_catalog_returns_core_table_schemas(self):
         content = await self.tool.execute(
-            ReadDataWarehouseSchemaMCPToolArgs(query={"kind": "data_warehouse_schema"}),
+            ReadDataWarehouseSchemaMCPToolArgs(query={"kind": "data_warehouse_catalog"}),
         )
 
         self.assertIn("# Core PostHog tables", content)
         for table in ("events", "groups", "persons", "sessions"):
             self.assertIn(f"## Table `{table}`", content)
 
-    async def test_returns_string(self):
+    async def test_catalog_returns_string(self):
         content = await self.tool.execute(
-            ReadDataWarehouseSchemaMCPToolArgs(query={"kind": "data_warehouse_schema"}),
+            ReadDataWarehouseSchemaMCPToolArgs(query={"kind": "data_warehouse_catalog"}),
         )
 
         self.assertIsInstance(content, str)
 
-    async def test_lists_fields_for_core_tables(self):
+    async def test_catalog_lists_fields_for_core_tables(self):
         content = await self.tool.execute(
-            ReadDataWarehouseSchemaMCPToolArgs(query={"kind": "data_warehouse_schema"}),
+            ReadDataWarehouseSchemaMCPToolArgs(query={"kind": "data_warehouse_catalog"}),
         )
 
         self.assertIn("- event (", content)
         self.assertIn("- timestamp (", content)
 
-    async def test_schema_validates_query(self):
-        validated = self.tool.args_schema.model_validate({"query": {"kind": "data_warehouse_schema"}})
-        self.assertEqual(validated.query.kind, "data_warehouse_schema")
+    async def test_schema_validates_catalog_query(self):
+        validated = self.tool.args_schema.model_validate({"query": {"kind": "data_warehouse_catalog"}})
+        self.assertEqual(validated.query.kind, "data_warehouse_catalog")
 
-    async def test_returns_only_requested_table_when_table_names_provided(self):
+    async def test_tables_kind_returns_only_requested_table(self):
         content = await self.tool.execute(
             ReadDataWarehouseSchemaMCPToolArgs(
-                query={"kind": "data_warehouse_schema", "table_names": ["events"]},
+                query={"kind": "data_warehouse_tables", "table_names": ["events"]},
             ),
         )
 
@@ -61,10 +61,10 @@ class TestReadDataWarehouseSchemaMCPTool(NonAtomicBaseTest):
         self.assertNotIn("# PostHog Postgres tables", content)
         self.assertNotIn("# Data warehouse views", content)
 
-    async def test_returns_multiple_requested_tables(self):
+    async def test_tables_kind_returns_multiple_requested_tables(self):
         content = await self.tool.execute(
             ReadDataWarehouseSchemaMCPToolArgs(
-                query={"kind": "data_warehouse_schema", "table_names": ["events", "persons"]},
+                query={"kind": "data_warehouse_tables", "table_names": ["events", "persons"]},
             ),
         )
 
@@ -73,10 +73,10 @@ class TestReadDataWarehouseSchemaMCPTool(NonAtomicBaseTest):
         self.assertNotIn("# Core PostHog tables", content)
         self.assertNotIn("# Data warehouse tables", content)
 
-    async def test_unknown_table_returns_not_found_section(self):
+    async def test_tables_kind_unknown_table_returns_not_found_section(self):
         content = await self.tool.execute(
             ReadDataWarehouseSchemaMCPToolArgs(
-                query={"kind": "data_warehouse_schema", "table_names": ["does_not_exist"]},
+                query={"kind": "data_warehouse_tables", "table_names": ["does_not_exist"]},
             ),
         )
 
@@ -84,10 +84,10 @@ class TestReadDataWarehouseSchemaMCPTool(NonAtomicBaseTest):
         self.assertIn("`does_not_exist`", content)
         self.assertIn("available tables include:", content)
 
-    async def test_mixed_known_and_unknown_tables(self):
+    async def test_tables_kind_mixed_known_and_unknown_tables(self):
         content = await self.tool.execute(
             ReadDataWarehouseSchemaMCPToolArgs(
-                query={"kind": "data_warehouse_schema", "table_names": ["events", "does_not_exist"]},
+                query={"kind": "data_warehouse_tables", "table_names": ["events", "does_not_exist"]},
             ),
         )
 
@@ -95,50 +95,33 @@ class TestReadDataWarehouseSchemaMCPTool(NonAtomicBaseTest):
         self.assertIn("## Not found", content)
         self.assertIn("`does_not_exist`", content)
 
-    async def test_empty_table_names_falls_back_to_full_catalog(self):
-        content = await self.tool.execute(
-            ReadDataWarehouseSchemaMCPToolArgs(
-                query={"kind": "data_warehouse_schema", "table_names": []},
-            ),
-        )
+    async def test_tables_kind_rejects_empty_table_names(self):
+        # min_length=1 — the tables kind without any names would be ambiguous with
+        # the catalog kind, so Pydantic must reject it.
+        with self.assertRaises(Exception):
+            self.tool.args_schema.model_validate({"query": {"kind": "data_warehouse_tables", "table_names": []}})
 
-        self.assertIn("# Core PostHog tables", content)
-        for table in ("events", "groups", "persons", "sessions"):
-            self.assertIn(f"## Table `{table}`", content)
-        self.assertNotIn("# Requested tables", content)
-
-    async def test_omitted_table_names_unchanged_behavior(self):
-        with_default = await self.tool.execute(
-            ReadDataWarehouseSchemaMCPToolArgs(query={"kind": "data_warehouse_schema"}),
-        )
-        with_none = await self.tool.execute(
-            ReadDataWarehouseSchemaMCPToolArgs(
-                query={"kind": "data_warehouse_schema", "table_names": None},
-            ),
-        )
-
-        self.assertEqual(with_default, with_none)
-
-    async def test_schema_validates_query_with_table_names(self):
+    async def test_schema_validates_tables_query(self):
         validated = self.tool.args_schema.model_validate(
-            {"query": {"kind": "data_warehouse_schema", "table_names": ["events", "stripe_charges"]}}
+            {"query": {"kind": "data_warehouse_tables", "table_names": ["events", "stripe_charges"]}}
         )
+        self.assertEqual(validated.query.kind, "data_warehouse_tables")
         self.assertEqual(validated.query.table_names, ["events", "stripe_charges"])
 
-    async def test_persons_db_tables_excluded(self):
+    async def test_tables_kind_persons_db_tables_excluded(self):
         content = await self.tool.execute(
             ReadDataWarehouseSchemaMCPToolArgs(
-                query={"kind": "data_warehouse_schema", "table_names": ["group_type_mappings"]},
+                query={"kind": "data_warehouse_tables", "table_names": ["group_type_mappings"]},
             ),
         )
 
         self.assertIn("## Not found", content)
         self.assertIn("`group_type_mappings`", content)
 
-    async def test_deduplicates_requested_names(self):
+    async def test_tables_kind_deduplicates_requested_names(self):
         content = await self.tool.execute(
             ReadDataWarehouseSchemaMCPToolArgs(
-                query={"kind": "data_warehouse_schema", "table_names": ["events", "events"]},
+                query={"kind": "data_warehouse_tables", "table_names": ["events", "events"]},
             ),
         )
 
@@ -190,7 +173,7 @@ class TestReadDataWarehouseSchemaMCPTool(NonAtomicBaseTest):
         ):
             content = await self.tool.execute(
                 ReadDataWarehouseSchemaMCPToolArgs(
-                    query={"kind": "data_warehouse_schema", "table_names": ["hubspot_companies"]},
+                    query={"kind": "data_warehouse_tables", "table_names": ["hubspot_companies"]},
                 ),
             )
 
@@ -214,7 +197,7 @@ class TestReadDataWarehouseSchemaMCPTool(NonAtomicBaseTest):
         ):
             content = await self.tool.execute(
                 ReadDataWarehouseSchemaMCPToolArgs(
-                    query={"kind": "data_warehouse_schema", "table_names": ["orphan_table"]},
+                    query={"kind": "data_warehouse_tables", "table_names": ["orphan_table"]},
                 ),
             )
 

--- a/ee/hogai/tools/read_data_warehouse_schema/test/test_mcp_tool.py
+++ b/ee/hogai/tools/read_data_warehouse_schema/test/test_mcp_tool.py
@@ -1,4 +1,7 @@
+from types import SimpleNamespace
+
 from posthog.test.base import NonAtomicBaseTest
+from unittest.mock import patch
 
 from ee.hogai.tools.read_data_warehouse_schema.mcp_tool import (
     ReadDataWarehouseSchemaMCPTool,
@@ -140,3 +143,81 @@ class TestReadDataWarehouseSchemaMCPTool(NonAtomicBaseTest):
         )
 
         self.assertEqual(content.count("## Table `events` (core)"), 1)
+
+    def test_resolve_warehouse_canonical_maps_underscore_alias_to_dotted_form(self):
+        warehouse = {"hubspot.companies", "hubspot_companies"}
+        self.assertEqual(
+            ReadDataWarehouseSchemaMCPTool._resolve_warehouse_canonical("hubspot_companies", warehouse),
+            "hubspot.companies",
+        )
+
+    def test_resolve_warehouse_canonical_handles_multi_underscore_suffix(self):
+        warehouse = {"intercom.activity_logs", "intercom_activity_logs"}
+        self.assertEqual(
+            ReadDataWarehouseSchemaMCPTool._resolve_warehouse_canonical("intercom_activity_logs", warehouse),
+            "intercom.activity_logs",
+        )
+
+    def test_resolve_warehouse_canonical_returns_none_when_already_dotted(self):
+        warehouse = {"hubspot.companies"}
+        self.assertIsNone(ReadDataWarehouseSchemaMCPTool._resolve_warehouse_canonical("hubspot.companies", warehouse))
+
+    def test_resolve_warehouse_canonical_returns_none_when_no_match(self):
+        warehouse = {"hubspot.companies"}
+        self.assertIsNone(ReadDataWarehouseSchemaMCPTool._resolve_warehouse_canonical("unrelated_table", warehouse))
+
+    async def test_warehouse_underscore_alias_renders_via_canonical_form(self):
+        # Simulates the real catalog where get_warehouse_table_names() returns both
+        # the dotted canonical name and an underscored alias, but serialize() only
+        # honors the dotted form. Asking for the alias should still render columns.
+        fake_table = SimpleNamespace(
+            fields={
+                "id": SimpleNamespace(name="id", type="string"),
+                "name": SimpleNamespace(name="name", type="string"),
+            }
+        )
+        fake_database = SimpleNamespace(
+            get_warehouse_table_names=lambda: ["hubspot.companies", "hubspot_companies"],
+            get_system_table_names=lambda: [],
+            get_view_names=lambda: [],
+            serialize=lambda ctx, include_only: (
+                {"hubspot.companies": fake_table} if "hubspot.companies" in include_only else {}
+            ),
+        )
+        with (
+            patch.object(self.tool, "_get_database", return_value=fake_database),
+            patch.object(self.tool, "_get_default_hogql_context", return_value=object()),
+        ):
+            content = await self.tool.execute(
+                ReadDataWarehouseSchemaMCPToolArgs(
+                    query={"kind": "data_warehouse_schema", "table_names": ["hubspot_companies"]},
+                ),
+            )
+
+        self.assertIn("## Table `hubspot_companies` (data warehouse)", content)
+        self.assertIn("- id (string)", content)
+        self.assertNotIn("## Not found", content)
+
+    async def test_known_warehouse_name_falls_back_to_not_found_when_serialize_drops_it(self):
+        # If a name is in get_warehouse_table_names() but serialize() still doesn't
+        # return it (no resolvable canonical form), it must land in `## Not found`
+        # rather than disappearing silently from the response.
+        fake_database = SimpleNamespace(
+            get_warehouse_table_names=lambda: ["orphan_table"],
+            get_system_table_names=lambda: [],
+            get_view_names=lambda: [],
+            serialize=lambda ctx, include_only: {},
+        )
+        with (
+            patch.object(self.tool, "_get_database", return_value=fake_database),
+            patch.object(self.tool, "_get_default_hogql_context", return_value=object()),
+        ):
+            content = await self.tool.execute(
+                ReadDataWarehouseSchemaMCPToolArgs(
+                    query={"kind": "data_warehouse_schema", "table_names": ["orphan_table"]},
+                ),
+            )
+
+        self.assertIn("## Not found", content)
+        self.assertIn("`orphan_table`", content)
+        self.assertNotIn("## Table `orphan_table`", content)

--- a/ee/hogai/tools/read_data_warehouse_schema/test/test_mcp_tool.py
+++ b/ee/hogai/tools/read_data_warehouse_schema/test/test_mcp_tool.py
@@ -43,3 +43,100 @@ class TestReadDataWarehouseSchemaMCPTool(NonAtomicBaseTest):
     async def test_schema_validates_query(self):
         validated = self.tool.args_schema.model_validate({"query": {"kind": "data_warehouse_schema"}})
         self.assertEqual(validated.query.kind, "data_warehouse_schema")
+
+    async def test_returns_only_requested_table_when_table_names_provided(self):
+        content = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(
+                query={"kind": "data_warehouse_schema", "table_names": ["events"]},
+            ),
+        )
+
+        self.assertIn("# Requested tables", content)
+        self.assertIn("## Table `events` (core)", content)
+        self.assertNotIn("# Core PostHog tables", content)
+        self.assertNotIn("# Data warehouse tables", content)
+        self.assertNotIn("# PostHog Postgres tables", content)
+        self.assertNotIn("# Data warehouse views", content)
+
+    async def test_returns_multiple_requested_tables(self):
+        content = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(
+                query={"kind": "data_warehouse_schema", "table_names": ["events", "persons"]},
+            ),
+        )
+
+        self.assertIn("## Table `events` (core)", content)
+        self.assertIn("## Table `persons` (core)", content)
+        self.assertNotIn("# Core PostHog tables", content)
+        self.assertNotIn("# Data warehouse tables", content)
+
+    async def test_unknown_table_returns_not_found_section(self):
+        content = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(
+                query={"kind": "data_warehouse_schema", "table_names": ["does_not_exist"]},
+            ),
+        )
+
+        self.assertIn("## Not found", content)
+        self.assertIn("`does_not_exist`", content)
+        self.assertIn("available tables include:", content)
+
+    async def test_mixed_known_and_unknown_tables(self):
+        content = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(
+                query={"kind": "data_warehouse_schema", "table_names": ["events", "does_not_exist"]},
+            ),
+        )
+
+        self.assertIn("## Table `events` (core)", content)
+        self.assertIn("## Not found", content)
+        self.assertIn("`does_not_exist`", content)
+
+    async def test_empty_table_names_falls_back_to_full_catalog(self):
+        content = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(
+                query={"kind": "data_warehouse_schema", "table_names": []},
+            ),
+        )
+
+        self.assertIn("# Core PostHog tables", content)
+        for table in ("events", "groups", "persons", "sessions"):
+            self.assertIn(f"## Table `{table}`", content)
+        self.assertNotIn("# Requested tables", content)
+
+    async def test_omitted_table_names_unchanged_behavior(self):
+        with_default = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(query={"kind": "data_warehouse_schema"}),
+        )
+        with_none = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(
+                query={"kind": "data_warehouse_schema", "table_names": None},
+            ),
+        )
+
+        self.assertEqual(with_default, with_none)
+
+    async def test_schema_validates_query_with_table_names(self):
+        validated = self.tool.args_schema.model_validate(
+            {"query": {"kind": "data_warehouse_schema", "table_names": ["events", "stripe_charges"]}}
+        )
+        self.assertEqual(validated.query.table_names, ["events", "stripe_charges"])
+
+    async def test_persons_db_tables_excluded(self):
+        content = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(
+                query={"kind": "data_warehouse_schema", "table_names": ["group_type_mappings"]},
+            ),
+        )
+
+        self.assertIn("## Not found", content)
+        self.assertIn("`group_type_mappings`", content)
+
+    async def test_deduplicates_requested_names(self):
+        content = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(
+                query={"kind": "data_warehouse_schema", "table_names": ["events", "events"]},
+            ),
+        )
+
+        self.assertEqual(content.count("## Table `events` (core)"), 1)

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -4717,10 +4717,10 @@
         }
     },
     "read-data-warehouse-schema": {
-        "description": "Use this tool to retrieve the core data warehouse schemas for PostHog tables (events, groups, persons, sessions) and the available data warehouse tables, views, and system tables. Use this to understand the data model before writing HogQL queries.",
+        "description": "Use this tool to retrieve PostHog data warehouse schemas. Pass kind=`data_warehouse_catalog` to list core table schemas (events, groups, persons, sessions) plus a catalog of all available warehouse tables, system tables, and views. Pass kind=`data_warehouse_tables` with `table_names` to fetch full column schemas for specific tables. Use this to understand the data model before writing HogQL queries.",
         "category": "Data schema",
         "feature": "data_schema",
-        "summary": "Read core data warehouse schemas and table lists.",
+        "summary": "Read data warehouse schemas — full catalog or specific tables.",
         "title": "Read data warehouse schema",
         "required_scopes": ["warehouse_table:read", "warehouse_view:read"],
         "new_mcp": true,

--- a/services/mcp/schema/tool-definitions-v2.json
+++ b/services/mcp/schema/tool-definitions-v2.json
@@ -30,10 +30,10 @@
         }
     },
     "read-data-warehouse-schema": {
-        "description": "Use this tool to retrieve the core data warehouse schemas for PostHog tables (events, groups, persons, sessions) and the available data warehouse tables, views, and system tables. Use this to understand the data model before writing HogQL queries.",
+        "description": "Use this tool to retrieve PostHog data warehouse schemas. Pass kind=`data_warehouse_catalog` to list core table schemas (events, groups, persons, sessions) plus a catalog of all available warehouse tables, system tables, and views. Pass kind=`data_warehouse_tables` with `table_names` to fetch full column schemas for specific tables. Use this to understand the data model before writing HogQL queries.",
         "category": "Data schema",
         "feature": "data_schema",
-        "summary": "Read core data warehouse schemas and table lists.",
+        "summary": "Read data warehouse schemas — full catalog or specific tables.",
         "title": "Read data warehouse schema",
         "required_scopes": ["warehouse_table:read", "warehouse_view:read"],
         "new_mcp": true,

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -3140,16 +3140,37 @@
         "ReadDataWarehouseSchemaSchema": {
             "type": "object",
             "properties": {
-                "table_names": {
-                    "description": "Optional list of specific warehouse, system, view, or core table names to return schemas for. If omitted, returns the core table schemas plus a catalog of all available warehouse tables, system tables, and views. Use this when you already know which tables you want to inspect to avoid pulling the full catalog.",
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "minLength": 1
-                    }
+                "query": {
+                    "description": "The data warehouse schema query to execute.",
+                    "discriminator": { "propertyName": "kind" },
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "kind": { "type": "string", "const": "data_warehouse_catalog" }
+                            },
+                            "required": ["kind"],
+                            "description": "Returns core PostHog table schemas (events, groups, persons, sessions) plus a catalog listing of every available warehouse table, system table, and view by name. Call this first if you don't yet know which tables exist."
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "kind": { "type": "string", "const": "data_warehouse_tables" },
+                                "table_names": {
+                                    "description": "Specific warehouse, system, view, or core table names to fetch schemas for.",
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": { "type": "string", "minLength": 1 }
+                                }
+                            },
+                            "required": ["kind", "table_names"],
+                            "description": "Returns full column schemas for the named warehouse, system, view, or core tables. Use this after `data_warehouse_catalog` once you know which tables you need."
+                        }
+                    ]
                 }
             },
-            "description": "Returns PostHog data warehouse schemas. Without arguments, returns core table schemas plus a catalog of all warehouse tables, system tables, and views. With table_names, returns the full column list for each named table."
+            "required": ["query"],
+            "description": "Returns PostHog data warehouse schemas. Use kind=`data_warehouse_catalog` to list available tables, or kind=`data_warehouse_tables` with `table_names` to fetch full column schemas for specific tables."
         },
         "ScoreDefinitionConfigSchema": {
             "anyOf": [

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -3139,8 +3139,17 @@
         },
         "ReadDataWarehouseSchemaSchema": {
             "type": "object",
-            "properties": {},
-            "description": "No input required. Returns core data warehouse schemas."
+            "properties": {
+                "table_names": {
+                    "description": "Optional list of specific warehouse, system, view, or core table names to return schemas for. If omitted, returns the core table schemas plus a catalog of all available warehouse tables, system tables, and views. Use this when you already know which tables you want to inspect to avoid pulling the full catalog.",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            },
+            "description": "Returns PostHog data warehouse schemas. Without arguments, returns core table schemas plus a catalog of all warehouse tables, system tables, and views. With table_names, returns the full column list for each named table."
         },
         "ScoreDefinitionConfigSchema": {
             "anyOf": [

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -609,17 +609,34 @@ export const ExecuteSQLSchema = z.object({
         ),
 })
 
-export const ReadDataWarehouseSchemaSchema = z
+const ListDataWarehouseCatalogQuerySchema = z
     .object({
-        table_names: z
-            .array(z.string().min(1))
-            .optional()
-            .describe(
-                'Optional list of specific warehouse, system, view, or core table names to return schemas for. If omitted, returns the core table schemas plus a catalog of all available warehouse tables, system tables, and views. Use this when you already know which tables you want to inspect to avoid pulling the full catalog.'
-            ),
+        kind: z.literal('data_warehouse_catalog'),
     })
     .describe(
-        'Returns PostHog data warehouse schemas. Without arguments, returns core table schemas plus a catalog of all warehouse tables, system tables, and views. With table_names, returns the full column list for each named table.'
+        "Returns core PostHog table schemas (events, groups, persons, sessions) plus a catalog listing of every available warehouse table, system table, and view by name. Call this first if you don't yet know which tables exist."
+    )
+
+const GetDataWarehouseTablesQuerySchema = z
+    .object({
+        kind: z.literal('data_warehouse_tables'),
+        table_names: z
+            .array(z.string().min(1))
+            .min(1)
+            .describe('Specific warehouse, system, view, or core table names to fetch schemas for.'),
+    })
+    .describe(
+        'Returns full column schemas for the named warehouse, system, view, or core tables. Use this after `data_warehouse_catalog` once you know which tables you need.'
+    )
+
+export const ReadDataWarehouseSchemaSchema = z
+    .object({
+        query: z
+            .discriminatedUnion('kind', [ListDataWarehouseCatalogQuerySchema, GetDataWarehouseTablesQuerySchema])
+            .describe('The data warehouse schema query to execute.'),
+    })
+    .describe(
+        'Returns PostHog data warehouse schemas. Use kind=`data_warehouse_catalog` to list available tables, or kind=`data_warehouse_tables` with `table_names` to fetch full column schemas for specific tables.'
     )
 
 const ReadEventsQuerySchema = z.object({

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -610,8 +610,17 @@ export const ExecuteSQLSchema = z.object({
 })
 
 export const ReadDataWarehouseSchemaSchema = z
-    .object({})
-    .describe('No input required. Returns core data warehouse schemas.')
+    .object({
+        table_names: z
+            .array(z.string().min(1))
+            .optional()
+            .describe(
+                'Optional list of specific warehouse, system, view, or core table names to return schemas for. If omitted, returns the core table schemas plus a catalog of all available warehouse tables, system tables, and views. Use this when you already know which tables you want to inspect to avoid pulling the full catalog.'
+            ),
+    })
+    .describe(
+        'Returns PostHog data warehouse schemas. Without arguments, returns core table schemas plus a catalog of all warehouse tables, system tables, and views. With table_names, returns the full column list for each named table.'
+    )
 
 const ReadEventsQuerySchema = z.object({
     kind: z.literal('events'),

--- a/services/mcp/src/tools/posthogAiTools/readDataWarehouseSchema.ts
+++ b/services/mcp/src/tools/posthogAiTools/readDataWarehouseSchema.ts
@@ -11,15 +11,8 @@ type Params = z.infer<typeof schema>
 
 export const readDataWarehouseSchemaHandler: ToolBase<typeof schema, string>['handler'] = async (
     context: Context,
-    { table_names }: Params
+    { query }: Params
 ) => {
-    const query: { kind: 'data_warehouse_schema'; table_names?: string[] } = {
-        kind: 'data_warehouse_schema',
-    }
-    if (table_names && table_names.length > 0) {
-        query.table_names = table_names
-    }
-
     const result = await invokeMcpTool(context, 'read_data_warehouse_schema', { query })
 
     if (!result.success) {

--- a/services/mcp/src/tools/posthogAiTools/readDataWarehouseSchema.ts
+++ b/services/mcp/src/tools/posthogAiTools/readDataWarehouseSchema.ts
@@ -1,3 +1,5 @@
+import type { z } from 'zod'
+
 import { ReadDataWarehouseSchemaSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
 
@@ -5,10 +7,20 @@ import { invokeMcpTool } from './invokeTool'
 
 const schema = ReadDataWarehouseSchemaSchema
 
-export const readDataWarehouseSchemaHandler: ToolBase<typeof schema, string>['handler'] = async (context: Context) => {
-    const result = await invokeMcpTool(context, 'read_data_warehouse_schema', {
-        query: { kind: 'data_warehouse_schema' },
-    })
+type Params = z.infer<typeof schema>
+
+export const readDataWarehouseSchemaHandler: ToolBase<typeof schema, string>['handler'] = async (
+    context: Context,
+    { table_names }: Params
+) => {
+    const query: { kind: 'data_warehouse_schema'; table_names?: string[] } = {
+        kind: 'data_warehouse_schema',
+    }
+    if (table_names && table_names.length > 0) {
+        query.table_names = table_names
+    }
+
+    const result = await invokeMcpTool(context, 'read_data_warehouse_schema', { query })
 
     if (!result.success) {
         throw new Error(result.content)

--- a/services/mcp/tests/tools/dataWarehouseSchema.integration.test.ts
+++ b/services/mcp/tests/tools/dataWarehouseSchema.integration.test.ts
@@ -38,7 +38,7 @@ describe('read-data-warehouse-schema', { concurrent: false }, () => {
     const tool = readDataWarehouseSchemaTool()
 
     it('should return core PostHog table schemas', async () => {
-        const result = await tool.handler(context, {})
+        const result = await tool.handler(context, { query: { kind: 'data_warehouse_catalog' } })
 
         expect(typeof result).toBe('string')
         expect(result).toContain('# Core PostHog tables')
@@ -47,7 +47,7 @@ describe('read-data-warehouse-schema', { concurrent: false }, () => {
     })
 
     it('should include sessions and groups tables', async () => {
-        const result = await tool.handler(context, {})
+        const result = await tool.handler(context, { query: { kind: 'data_warehouse_catalog' } })
 
         expect(result).toContain('sessions')
         expect(result).toContain('groups')

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/read-data-warehouse-schema.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/read-data-warehouse-schema.json
@@ -1,15 +1,44 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "Returns PostHog data warehouse schemas. Without arguments, returns core table schemas plus a catalog of all warehouse tables, system tables, and views. With table_names, returns the full column list for each named table.",
+    "description": "Returns PostHog data warehouse schemas. Use kind=`data_warehouse_catalog` to list available tables, or kind=`data_warehouse_tables` with `table_names` to fetch full column schemas for specific tables.",
     "properties": {
-        "table_names": {
-            "description": "Optional list of specific warehouse, system, view, or core table names to return schemas for. If omitted, returns the core table schemas plus a catalog of all available warehouse tables, system tables, and views. Use this when you already know which tables you want to inspect to avoid pulling the full catalog.",
-            "items": {
-                "minLength": 1,
-                "type": "string"
-            },
-            "type": "array"
+        "query": {
+            "description": "The data warehouse schema query to execute.",
+            "oneOf": [
+                {
+                    "description": "Returns core PostHog table schemas (events, groups, persons, sessions) plus a catalog listing of every available warehouse table, system table, and view by name. Call this first if you don't yet know which tables exist.",
+                    "properties": {
+                        "kind": {
+                            "const": "data_warehouse_catalog",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["kind"],
+                    "type": "object"
+                },
+                {
+                    "description": "Returns full column schemas for the named warehouse, system, view, or core tables. Use this after `data_warehouse_catalog` once you know which tables you need.",
+                    "properties": {
+                        "kind": {
+                            "const": "data_warehouse_tables",
+                            "type": "string"
+                        },
+                        "table_names": {
+                            "description": "Specific warehouse, system, view, or core table names to fetch schemas for.",
+                            "items": {
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                        }
+                    },
+                    "required": ["kind", "table_names"],
+                    "type": "object"
+                }
+            ]
         }
     },
+    "required": ["query"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/read-data-warehouse-schema.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/read-data-warehouse-schema.json
@@ -1,6 +1,15 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "No input required. Returns core data warehouse schemas.",
-    "properties": {},
+    "description": "Returns PostHog data warehouse schemas. Without arguments, returns core table schemas plus a catalog of all warehouse tables, system tables, and views. With table_names, returns the full column list for each named table.",
+    "properties": {
+        "table_names": {
+            "description": "Optional list of specific warehouse, system, view, or core table names to return schemas for. If omitted, returns the core table schemas plus a catalog of all available warehouse tables, system tables, and views. Use this when you already know which tables you want to inspect to avoid pulling the full catalog.",
+            "items": {
+                "minLength": 1,
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
     "type": "object"
 }


### PR DESCRIPTION
## Problem

`read-data-warehouse-schema` always returned its full catalog: core table schemas (`events`, `groups`, `persons`, `sessions`) plus a name-only listing of every data warehouse table, every PostHog Postgres system table, and every user-created view. For projects with even modest warehouse setups the output is verbose enough to get truncated in MCP clients and is awkward when the actual question is "show me the columns of these specific tables."

There was no way to scope the response to a known set of tables.

## Changes

The tool now exposes two kinds in a discriminated union — matching the pattern that `read-data-schema` (the sibling `read_taxonomy` MCP tool) already uses across its seven kinds:

- `kind: "data_warehouse_catalog"` — no args, returns the full default catalog (core schemas + warehouse / system / view name lists). Byte-identical to the prior default response.
- `kind: "data_warehouse_tables"` — requires `table_names: list[str]` (min length 1), returns the full column list per requested table with each table's source labeled (`data warehouse` / `system` / `view` / `core`). Unknown names land in a `## Not found` section with up to 10 alphabetical suggestions; partial success is preserved across the rest of the list.

Required arguments now co-locate with the kind that needs them — Pydantic enforces it, the LLM can't pass `table_names: []` and silently fall through to the catalog mode.

**Name-resolution and defensive fallback** — `database.get_warehouse_table_names()` returns both the canonical dotted form (`hubspot.companies`) and an underscored alias (`hubspot_companies`), but `database.serialize()` only accepts the dotted form. The new `_resolve_warehouse_canonical` helper maps the alias back to the canonical form before serialize; anything that still doesn't survive serialize is routed to `## Not found` rather than dropped silently — so future drift between the catalog list and the serializer surfaces instead of vanishing.

**Files touched**:
- Python: `ee/hogai/tools/read_data_warehouse_schema/mcp_tool.py` (two-kinds union, alias resolver, defensive fallback) and the test module (20 tests covering both kinds plus the alias and fallback paths).
- TS: `services/mcp/src/schema/tool-inputs.ts` Zod schema rewritten as a discriminated union matching the Python shape; `services/mcp/schema/tool-inputs.json` mirrored; handler in `readDataWarehouseSchema.ts` simplified to a pass-through.
- Tool definitions in `services/mcp/schema/tool-definitions-v2.json` and `tool-definitions-all.json` updated with the new description and summary.
- Snapshot at `services/mcp/tests/unit/__snapshots__/tool-schemas/v2/read-data-warehouse-schema.json` regenerated.

## How did you test this code?

This PR is agent-authored end-to-end.

**Automated**:
- `hogli test ee/hogai/tools/read_data_warehouse_schema/test/test_mcp_tool.py` — 19 tests, all passing. Coverage: both kinds, schema validation (incl. rejection of empty `table_names`), alias resolution (single underscore, multi-underscore, already-dotted, no match), unknown-name fallback, mixed found/not-found, persons-DB exclusion, deduplication, and two mock-driven tests for the alias-resolution + serialize-miss paths using a stub Database.
- Vitest snapshot regenerated via `vitest -u` against the runtime Zod schema, then committed.

**Manual via posthog-local MCP** (local dev env with the new code wired through `services/mcp` → `/api/environments/{id}/mcp_tools/...`):
- `kind: "data_warehouse_catalog"` returns the full catalog layout.
- `kind: "data_warehouse_tables"` with the underscored alias `hubspot_companies` renders the full column schema labeled `(data warehouse)` — confirming the alias resolver works against a real warehouse table.
- Mix of warehouse + system + view names returns each section side by side with correct labels.
- Unknown name routes to `## Not found` with the suggestions list.

## Publish to changelog?

no

## Docs update

n/a — the only user-facing surface change is the input shape of an MCP tool, which is described by the tool's own schema.

## 🤖 Agent context

Authored by PostHog Code; refined in a follow-up Claude Code session.

**Decisions made along the way**:

- **Shape: discriminated union of two kinds, not a single kind with an optional `table_names`.** The original PR landed with an optional field on a single `data_warehouse_schema` kind. Code review against the sibling `read_taxonomy` tool (the closest neighbor in `ee/hogai/tools/`, also data-discovery, also returns markdown for LLM consumption) showed that pattern uses a discriminated union — each operation gets its own kind with its own required args. Migrated this PR to match before the new shape ships, since production has not yet seen any version of the new schema and there are no external callers to migrate.
- **Alias resolution is a name-mapping layer, not a custom warehouse serializer.** Discovered during manual MCP testing that warehouse tables silently disappeared when requested by their underscored form. Root cause: `get_warehouse_table_names()` returns both forms; `serialize()` only accepts dotted. The fix is purely about which key we hand to serialize — the existing serialize path works fine for warehouse tables when given the dotted name. Rejected a parallel "serialize warehouse tables ourselves" approach as unnecessary scope.
- **Defensive not-found fallback rather than raising on serialize misses.** If a future drift causes a warehouse name to still not survive serialize after alias resolution, the response now surfaces it as `## Not found` rather than dropping it silently. Raising would fail the whole batched request for one bad name and hurt the multi-name discovery UX the tool exists to enable.
- **Empty `table_names` rejected at schema time.** Pydantic `min_length=1` on the `data_warehouse_tables` kind. Previous behavior was to silently fall through to the catalog mode — that conflated two intents and was the surface where a category of LLM mistakes (building an empty list by accident) became invisible. With two explicit kinds, the agent has to pick one.

**Tools used**: Claude Code (Opus 4.7 1M context) over multiple sessions for the initial implementation, manual MCP testing against a local PostHog dev instance, and the follow-up refactor + alias bug fix.