### PR TITLE
fix(llma): apply cluster event filters inside generation argMaxIf

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -124,6 +124,12 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
             trace_filter_expr = ast.And(exprs=filter_exprs) if len(filter_exprs) > 1 else filter_exprs[0]
 
         if analysis_level == "generation":
+            # Sample generations directly: get the last generation per trace
+            # with the trace's first_timestamp for navigation.
+            # We query all AI event types to get accurate trace_first_timestamp,
+            # but use argMaxIf to only pick generation UUIDs.
+            # Also filters by event count and total properties size to prevent
+            # oversized traces from reaching the CPU-intensive formatting activity.
             generations_query = parse_select(
                 """
                 SELECT

--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -124,17 +124,11 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
             trace_filter_expr = ast.And(exprs=filter_exprs) if len(filter_exprs) > 1 else filter_exprs[0]
 
         if analysis_level == "generation":
-            # Sample generations directly: get the last generation per trace
-            # with the trace's first_timestamp for navigation.
-            # We query all AI event types to get accurate trace_first_timestamp,
-            # but use argMaxIf to only pick generation UUIDs.
-            # Also filters by event count and total properties size to prevent
-            # oversized traces from reaching the CPU-intensive formatting activity.
             generations_query = parse_select(
                 """
                 SELECT
                     properties.$ai_trace_id as trace_id,
-                    argMaxIf(uuid, timestamp, event = '$ai_generation') as last_generation_id,
+                    argMaxIf(uuid, timestamp, event = '$ai_generation' AND {trace_filter}) as last_generation_id,
                     min(timestamp) as trace_first_timestamp,
                     count() as event_count,
                     sum(length(properties)) as total_properties_size
@@ -144,10 +138,10 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                     AND timestamp < toDateTime({end_ts}, 'UTC')
                     AND properties.$ai_trace_id != ''
                 GROUP BY trace_id
-                HAVING last_generation_id IS NOT NULL
+                -- argMaxIf returns the zero UUID (not NULL) when no rows match
+                HAVING last_generation_id != toUUIDOrZero('')
                     AND event_count <= {max_events}
                     AND total_properties_size <= {max_properties_size}
-                    AND countIf({trace_filter}) > 0
                 ORDER BY trace_first_timestamp DESC
                 LIMIT {limit}
                 """

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -134,6 +134,86 @@ class TestSampleItemsInWindowActivity:
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio
+    async def test_generation_filter_is_applied_inside_argmaxif(self, mock_team):
+        from posthog.hogql import ast
+        from posthog.hogql.visitor import TraversingVisitor
+
+        inputs = BatchSummarizationInputs(
+            team_id=mock_team.id,
+            max_items=10,
+            analysis_level="generation",
+            window_minutes=60,
+            window_start="2025-01-15T11:00:00",
+            window_end="2025-01-15T12:00:00",
+            event_filters=[{"key": "is_background_task", "type": "event", "value": ["false"], "operator": "exact"}],
+        )
+
+        with patch("posthog.temporal.llm_analytics.trace_summarization.sampling.execute_hogql_query") as mock_execute:
+            mock_execute.return_value.results = []
+            await sample_items_in_window_activity(inputs)
+
+            query: ast.SelectQuery = mock_execute.call_args.kwargs["query"]
+
+            class CallCollector(TraversingVisitor):
+                def __init__(self, name: str) -> None:
+                    self.name = name
+                    self.found: list[ast.Call] = []
+
+                def visit_call(self, node: ast.Call) -> None:
+                    if node.name == self.name:
+                        self.found.append(node)
+                    super().visit_call(node)
+
+            class KeyReferenced(TraversingVisitor):
+                def __init__(self, key: str) -> None:
+                    self.key = key
+                    self.found = False
+
+                def visit_field(self, node: ast.Field) -> None:
+                    if node.chain and node.chain[-1] == self.key:
+                        self.found = True
+
+            argmaxif = CallCollector("argMaxIf")
+            for item in query.select:
+                argmaxif.visit(item)
+            assert len(argmaxif.found) == 1
+
+            class PlaceholderFinder(TraversingVisitor):
+                def __init__(self, name: str) -> None:
+                    self.name = name
+                    self.found = False
+
+                def visit_placeholder(self, node: ast.Placeholder) -> None:
+                    if node.chain and node.chain[-1] == self.name:
+                        self.found = True
+
+            trace_filter_in_argmaxif = PlaceholderFinder("trace_filter")
+            trace_filter_in_argmaxif.visit(argmaxif.found[0].args[2])
+            assert trace_filter_in_argmaxif.found, (
+                "Filter placeholder must be inside argMaxIf so the picked generation itself satisfies it"
+            )
+
+            trace_filter_expr = mock_execute.call_args.kwargs["placeholders"]["trace_filter"]
+            key_ref = KeyReferenced("is_background_task")
+            key_ref.visit(trace_filter_expr)
+            assert key_ref.found, "trace_filter placeholder must reference the configured event property"
+
+            # The trace-level countIf gate is redundant once the filter is in argMaxIf —
+            # HAVING drops traces whose argMaxIf returned the zero UUID (no matching generation).
+            countif = CallCollector("countIf")
+            if query.having is not None:
+                countif.visit(query.having)
+            assert countif.found == []
+
+            # argMaxIf with no matching rows returns the zero UUID (not NULL), so
+            # HAVING must explicitly compare against it — IS NOT NULL doesn't catch it.
+            zero_uuid_guard = CallCollector("toUUIDOrZero")
+            assert query.having is not None
+            zero_uuid_guard.visit(query.having)
+            assert zero_uuid_guard.found, "HAVING must guard against zero-UUID phantom generations"
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
     async def test_sample_items_empty(self, mock_team):
         inputs = BatchSummarizationInputs(
             team_id=mock_team.id,


### PR DESCRIPTION
## Problem

Filters for generation clustering were not being applied properly since the sampling process first fetched the trace, and then matched a random generation, which oftentimes in multi-generation traces could be a different one and not match the filters.

## Changes

Ensure we pick a generation that matches the filters.

## How did you test this code?

I'm an agent. Automated:

- Added `test_generation_filter_is_applied_inside_argmaxif` in `posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py`, asserting (a) `argMaxIf` carries the `trace_filter` placeholder in its predicate, (b) the placeholder expression references the configured event property, and (c) the now-redundant `countIf` is no longer in the `HAVING`.
- Re-ran the full `TestSampleItemsInWindowActivity` suite — 9 passed.

Not tested manually end-to-end against ClickHouse; the existing real-data ratios on a representative team (~90% background bg=true in sampled embeddings) are what prompted the fix.

## Publish to changelog?

no

## 🤖 Agent context

Authored with PostHog Code. The investigation started from a support ticket about clusters being dominated by background tasks despite a saved `is_background_task = false` filter on the clustering job. Walked the filter through Postgres (`llm_analytics_clusteringjob.event_filters`) → workflow inputs → sampling SQL, cross-checked sampled `document_id`s against the source events to confirm 90% bg=true, then traced the over-inclusion to the trace-vs-generation grain mismatch in `sampling.py`'s `argMaxIf`. Considered also tightening the trace-level path but kept that out of scope — the trace-level `countIf > 0` semantics are arguably load-bearing for traces that legitimately mix event kinds.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
