### PR TITLE
fix(alerts): attach langchain callback so alert investigation agent emits LLM analytics

### DIFF
--- a/posthog/temporal/ai/anomaly_investigation/runner.py
+++ b/posthog/temporal/ai/anomaly_investigation/runner.py
@@ -12,12 +12,17 @@ message with no tool calls, or on budget exhaustion.
 from __future__ import annotations
 
 import json
+import uuid
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
+import posthoganalytics
+from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
+from langchain_core.runnables import RunnableConfig
+from posthoganalytics.ai.langchain.callbacks import CallbackHandler
 from pydantic import BaseModel, ValidationError
 
 from posthog.models import Team, User
@@ -153,6 +158,13 @@ async def run_investigation(
     )
     llm_with_final_report = llm.bind_tools([final_report_tool], tool_choice=FINAL_REPORT_TOOL_NAME)
 
+    # Without a langchain CallbackHandler attached, MaxChatAnthropic's posthog_properties
+    # never reach LLM analytics — langchain-anthropic itself doesn't emit $ai_* events.
+    # Attach one here so every generation/span this agent makes shows up under
+    # ai_product=alert_investigation_agent, matching the convention used by other
+    # Temporal-driven agents (see llma_eval_reports/report_agent/graph.py).
+    config: RunnableConfig = {"callbacks": _build_callbacks(team=team, alert=alert)}
+
     messages: list[Any] = [
         SystemMessage(content=SYSTEM_PROMPT),
         HumanMessage(content=anomaly_context),
@@ -178,7 +190,7 @@ async def run_investigation(
             if heartbeat is not None:
                 heartbeat()
             try:
-                final = await llm_with_final_report.ainvoke(messages)
+                final = await llm_with_final_report.ainvoke(messages, config=config)
             except Exception as err:
                 # Swallow final-turn failures and return an inconclusive report rather than
                 # bouncing off Temporal retries — MaxChatAnthropic already exhausted its
@@ -197,7 +209,7 @@ async def run_investigation(
             break
 
         try:
-            response = await llm_with_tools.ainvoke(messages)
+            response = await llm_with_tools.ainvoke(messages, config=config)
         except Exception as err:
             logger.warning("anomaly_investigation.llm_invoke_error", extra={"error": str(err)})
             return InvestigationRunResult(
@@ -247,6 +259,28 @@ async def run_investigation(
     report = _parse_report(getattr(final_message, "content", ""))
     report.tool_calls_used = tool_calls_used
     return InvestigationRunResult(report=report, tool_calls_used=tool_calls_used, model=AGENT_MODEL)
+
+
+def _build_callbacks(*, team: Team, alert: AlertConfiguration | None) -> list[BaseCallbackHandler]:
+    callbacks: list[BaseCallbackHandler] = []
+    client = posthoganalytics.default_client
+    if client is None:
+        return callbacks
+    properties: dict[str, Any] = {
+        "ai_product": "alert_investigation_agent",
+        "team_id": team.id,
+    }
+    if alert is not None:
+        properties["alert_id"] = str(alert.id)
+    callbacks.append(
+        CallbackHandler(
+            client,
+            distinct_id=str(team.id),
+            trace_id=f"alert-investigation-{uuid.uuid4()}",
+            properties=properties,
+        )
+    )
+    return callbacks
 
 
 def _parse_report_message(message: Any) -> InvestigationReport | None:

--- a/posthog/temporal/tests/ai/test_anomaly_investigation_runner.py
+++ b/posthog/temporal/tests/ai/test_anomaly_investigation_runner.py
@@ -1,5 +1,8 @@
+from unittest.mock import MagicMock, patch
+
 from posthog.temporal.ai.anomaly_investigation.runner import (
     FINAL_REPORT_TOOL_NAME,
+    _build_callbacks,
     _parse_report,
     _report_from_tool_calls,
 )
@@ -56,3 +59,56 @@ def test_parse_report_keeps_plain_json_fallback() -> None:
 
     assert report.verdict == "inconclusive"
     assert report.summary == "Need manual review."
+
+
+def test_build_callbacks_tags_ai_product_for_llm_analytics() -> None:
+    team = MagicMock(id=314)
+    alert = MagicMock(id="alert-uuid")
+    sentinel_client = MagicMock(name="default_client")
+
+    with (
+        patch("posthog.temporal.ai.anomaly_investigation.runner.posthoganalytics") as mock_module,
+        patch("posthog.temporal.ai.anomaly_investigation.runner.CallbackHandler") as mock_handler,
+    ):
+        mock_module.default_client = sentinel_client
+
+        callbacks = _build_callbacks(team=team, alert=alert)
+
+    assert callbacks == [mock_handler.return_value]
+    mock_handler.assert_called_once()
+    args, kwargs = mock_handler.call_args
+    assert args[0] is sentinel_client
+    assert kwargs["distinct_id"] == "314"
+    assert kwargs["trace_id"].startswith("alert-investigation-")
+    assert kwargs["properties"] == {
+        "ai_product": "alert_investigation_agent",
+        "team_id": 314,
+        "alert_id": "alert-uuid",
+    }
+
+
+def test_build_callbacks_skips_when_default_client_missing() -> None:
+    team = MagicMock(id=1)
+
+    with patch("posthog.temporal.ai.anomaly_investigation.runner.posthoganalytics") as mock_module:
+        mock_module.default_client = None
+        callbacks = _build_callbacks(team=team, alert=None)
+
+    assert callbacks == []
+
+
+def test_build_callbacks_omits_alert_id_when_alert_missing() -> None:
+    team = MagicMock(id=42)
+    sentinel_client = MagicMock(name="default_client")
+
+    with (
+        patch("posthog.temporal.ai.anomaly_investigation.runner.posthoganalytics") as mock_module,
+        patch("posthog.temporal.ai.anomaly_investigation.runner.CallbackHandler") as mock_handler,
+    ):
+        mock_module.default_client = sentinel_client
+
+        _build_callbacks(team=team, alert=None)
+
+    _args, kwargs = mock_handler.call_args
+    assert "alert_id" not in kwargs["properties"]
+    assert kwargs["properties"]["ai_product"] == "alert_investigation_agent"

--- a/posthog/temporal/tests/ai/test_anomaly_investigation_runner.py
+++ b/posthog/temporal/tests/ai/test_anomaly_investigation_runner.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import MagicMock, patch
 
 from posthog.temporal.ai.anomaly_investigation.runner import (
@@ -61,9 +62,24 @@ def test_parse_report_keeps_plain_json_fallback() -> None:
     assert report.summary == "Need manual review."
 
 
-def test_build_callbacks_tags_ai_product_for_llm_analytics() -> None:
+@pytest.mark.parametrize(
+    "alert_id,expected_properties",
+    [
+        pytest.param(
+            "alert-uuid",
+            {"ai_product": "alert_investigation_agent", "team_id": 314, "alert_id": "alert-uuid"},
+            id="with_alert",
+        ),
+        pytest.param(
+            None,
+            {"ai_product": "alert_investigation_agent", "team_id": 314},
+            id="without_alert",
+        ),
+    ],
+)
+def test_build_callbacks_tags_ai_product_for_llm_analytics(alert_id, expected_properties) -> None:
     team = MagicMock(id=314)
-    alert = MagicMock(id="alert-uuid")
+    alert = MagicMock(id=alert_id) if alert_id is not None else None
     sentinel_client = MagicMock(name="default_client")
 
     with (
@@ -80,11 +96,7 @@ def test_build_callbacks_tags_ai_product_for_llm_analytics() -> None:
     assert args[0] is sentinel_client
     assert kwargs["distinct_id"] == "314"
     assert kwargs["trace_id"].startswith("alert-investigation-")
-    assert kwargs["properties"] == {
-        "ai_product": "alert_investigation_agent",
-        "team_id": 314,
-        "alert_id": "alert-uuid",
-    }
+    assert kwargs["properties"] == expected_properties
 
 
 def test_build_callbacks_skips_when_default_client_missing() -> None:
@@ -95,20 +107,3 @@ def test_build_callbacks_skips_when_default_client_missing() -> None:
         callbacks = _build_callbacks(team=team, alert=None)
 
     assert callbacks == []
-
-
-def test_build_callbacks_omits_alert_id_when_alert_missing() -> None:
-    team = MagicMock(id=42)
-    sentinel_client = MagicMock(name="default_client")
-
-    with (
-        patch("posthog.temporal.ai.anomaly_investigation.runner.posthoganalytics") as mock_module,
-        patch("posthog.temporal.ai.anomaly_investigation.runner.CallbackHandler") as mock_handler,
-    ):
-        mock_module.default_client = sentinel_client
-
-        _build_callbacks(team=team, alert=None)
-
-    _args, kwargs = mock_handler.call_args
-    assert "alert_id" not in kwargs["properties"]
-    assert kwargs["properties"]["ai_product"] == "alert_investigation_agent"


### PR DESCRIPTION
## Problem

PR #59099 set `posthog_properties={"ai_product": "alert_investigation_agent"}` on the agent's `MaxChatAnthropic` instance, but that property never reaches LLM analytics. `MaxChatMixin._with_posthog_properties` only stuffs the props into `kwargs["metadata"]["posthog_properties"]` — there is no `posthoganalytics.ai.langchain.callbacks.CallbackHandler` attached to the runnable, and `langchain-anthropic` itself doesn't emit `$ai_*` events. Confirmed empirically against project 2: zero `$ai_generation` events in the last 36h whose system prompt contains the agent's signature, even though alerts fired this morning and produced investigation verdicts plus notebooks.

This means the agent has never appeared in PostHog's own LLM analytics — neither under the intended `alert_investigation_agent` tag nor under the previously assumed `posthog_ai` fallback.

## Changes

- Build a `CallbackHandler` from `posthoganalytics.default_client` with `properties={"ai_product": "alert_investigation_agent", "team_id": team.id, "alert_id": …}` and `distinct_id=str(team.id)` (so traces group by project, matching the `llma_eval_reports` agent's convention).
- Pass it through `RunnableConfig.callbacks` on both `ainvoke` call sites — the tool-calling loop and the forced finalize turn — so generations from either path are captured.
- Left the existing `posthog_properties=` kwarg on the `MaxChatAnthropic` constructor in place: it's redundant once the callback is attached, but harmless, and removing it would expand scope beyond the bug.

## How did you test this code?

Agent-authored change. No manual testing performed — couldn't trigger the alert investigation agent end-to-end from the dev box.

Automated coverage added in `posthog/temporal/tests/ai/test_anomaly_investigation_runner.py`:
- `test_build_callbacks_tags_ai_product_for_llm_analytics` — asserts the constructed `CallbackHandler` receives `properties["ai_product"] == "alert_investigation_agent"`, plus `team_id` and `alert_id`, and uses `str(team.id)` as the distinct id and an `alert-investigation-*` trace id.
- `test_build_callbacks_skips_when_default_client_missing` — returns an empty list when `posthoganalytics.default_client` is unset (hobby / not-yet-initialized environments).
- `test_build_callbacks_omits_alert_id_when_alert_missing` — `alert` is optional on `run_investigation`; the property must be dropped rather than serialized as "None".

`ruff check` and `ruff format --check` pass on the changed files. Pytest was not runnable in the agent's sandbox (no flox / venv); CI will execute the new tests.

Refs #59099

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7).
- Diagnosed by checking project 2 LLM analytics via MCP after the user noticed PR #59099's traces weren't appearing. Listed every `ai_product` value on `$ai_*` events for the last 7 days (no `alert_investigation_agent`, no `anomaly_investigation`), then searched generations by system-prompt signature (0 matches), which ruled out the fallback-tag hypothesis from PR #59099's body.
- Compared against `posthog/temporal/llm_analytics/eval_reports/report_agent/graph.py`, which uses the same `MaxChatAnthropic`-style stack and *does* emit traces — the difference is that it constructs a `CallbackHandler` and passes it through `RunnableConfig.callbacks`. Adopted that pattern verbatim, including `distinct_id=str(team.id)` so traces group by project.
- Decided to leave the existing `posthog_properties=` kwarg from PR #59099 alone: removing it would technically clean up dead metadata, but it's a no-op rather than a hazard, and keeping the diff small makes the fix easier to review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*