### PR TITLE
feat(cdp): add cdp-cyclotron-worker-hogflow-legacy-pg server mode

### DIFF
--- a/nodejs/src/capabilities.ts
+++ b/nodejs/src/capabilities.ts
@@ -124,6 +124,10 @@ export function getPluginServerCapabilities(
             return {
                 cdpCyclotronWorkerHogFlow: true,
             }
+        case PluginServerMode.cdp_cyclotron_worker_hogflow_legacy_pg:
+            return {
+                cdpCyclotronWorkerHogFlowLegacyPg: true,
+            }
         case PluginServerMode.cdp_precalculated_filters:
             return {
                 cdpPrecalculatedFilters: true,

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -25,6 +25,7 @@ export enum PluginServerMode {
     cdp_precalculated_filters = 'cdp-precalculated-filters',
     cdp_cohort_membership = 'cdp-cohort-membership',
     cdp_cyclotron_worker_hogflow = 'cdp-cyclotron-worker-hogflow',
+    cdp_cyclotron_worker_hogflow_legacy_pg = 'cdp-cyclotron-worker-hogflow-legacy-pg',
     cdp_api = 'cdp-api',
     cdp_legacy_on_event = 'cdp-legacy-on-event',
     evaluation_scheduler = 'evaluation-scheduler',

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -86,6 +86,7 @@ export class PluginServer implements NodeServer {
             capabilities.cdpApi ||
             capabilities.cdpCyclotronWorker ||
             capabilities.cdpCyclotronWorkerHogFlow ||
+            capabilities.cdpCyclotronWorkerHogFlowLegacyPg ||
             capabilities.cdpPrecalculatedFilters ||
             capabilities.cdpCohortMembership ||
             capabilities.cdpBatchHogFlow
@@ -220,6 +221,18 @@ export class PluginServer implements NodeServer {
         if (capabilities.cdpCyclotronWorkerHogFlow) {
             serviceLoaders.push(async () => {
                 const worker = new CdpCyclotronWorkerHogFlow(this.config, cdpDeps!)
+                await worker.start()
+                return worker.service
+            })
+        }
+
+        // Legacy postgres v1 drain for hogflow jobs — delete once cdp-cyclotron-worker-hogflows-pg-legacy is shut down
+        if (capabilities.cdpCyclotronWorkerHogFlowLegacyPg) {
+            serviceLoaders.push(async () => {
+                const worker = new CdpCyclotronWorkerHogFlow(
+                    { ...this.config, CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: 'postgres' },
+                    cdpDeps!
+                )
                 await worker.start()
                 return worker.service
             })

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -166,6 +166,7 @@ export interface PluginServerCapabilities {
     cdpBatchHogFlow?: boolean
     cdpCyclotronWorker?: boolean
     cdpCyclotronWorkerHogFlow?: boolean
+    cdpCyclotronWorkerHogFlowLegacyPg?: boolean
     cdpPrecalculatedFilters?: boolean
     cdpCohortMembership?: boolean
     cdpApi?: boolean


### PR DESCRIPTION
## Problem

The legacy hogflow postgres v1 drain deployment (`cdp-cyclotron-worker-hogflows-pg-legacy`) currently uses `PLUGIN_SERVER_MODE: cdp-cyclotron-worker-hogflow` with `CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: postgres` to override the queue backend at runtime. This indirection makes it easy to misconfigure.

## Changes

Add a dedicated `cdp-cyclotron-worker-hogflow-legacy-pg` server mode that always uses the postgres v1 queue — no consumer mode config needed.

- New `PluginServerMode` enum entry
- New `cdpCyclotronWorkerHogFlowLegacyPg` capability
- `server.ts` wires it to `CdpCyclotronWorkerHogFlow` with `CONSUMER_MODE: postgres`

This is additive only — nothing existing changes. The charts deployment can switch from `cdp-cyclotron-worker-hogflow` to `cdp-cyclotron-worker-hogflow-legacy-pg` and remove the `CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE` env var.

Delete this mode once the legacy drain deployment is shut down.

## How did you test this code?

- TypeScript build clean
- Additive only — no existing behavior changes

## Publish to changelog?

No

## 🤖 Agent context

- **Tool:** Claude Code (Opus 4.6)
- Cherry-picked from the larger job queue refactor PR (#58997) to allow safe incremental rollout