### PR TITLE
feat(mcp): require manual user confirmation for sensitive tools

### DIFF
--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -319,9 +319,32 @@ tools:
                 - name
                 - slug
                 - membership_level
-    organizations-partial-update:
+    organization-enforce-2fa-update:
         operation: partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - organization:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Enforce 2FA for organization
+        description: >
+            Toggle 2FA enforcement for an organization. The MCP client will show a confirmation
+            modal; the change is only applied if the user accepts.
+        confirmation_required: true
+        include_params:
+            - enforce_2fa
+        param_overrides:
+            id:
+                description: Organization ID, or `@current` for the caller's active org.
+            enforce_2fa:
+                description: True to require 2FA for all members; false to disable; null to clear.
+        response:
+            include:
+                - id
+                - name
+                - enforce_2fa
     organizations-update:
         operation: update
         enabled: false

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -273,6 +273,8 @@ tools:
         description: >
             Toggle 2FA enforcement for an organization. The MCP client will show a confirmation modal; the change is
             only applied if the user accepts.
+        confirmation_required: true
+        confirmation_builder: buildEnforce2faConfirmation
         include_params:
             - enforce_2fa
         param_overrides:
@@ -280,7 +282,6 @@ tools:
                 description: Organization ID, or `@current` for the caller's active org.
             enforce_2fa:
                 description: True to require 2FA for all members; false to disable; null to clear.
-        confirmation_required: true
         response:
             include:
                 - id

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -273,8 +273,6 @@ tools:
         description: >
             Toggle 2FA enforcement for an organization. The MCP client will show a confirmation modal; the change is
             only applied if the user accepts.
-        confirmation_required: true
-        confirmation_builder: buildEnforce2faConfirmation
         include_params:
             - enforce_2fa
         param_overrides:
@@ -282,6 +280,8 @@ tools:
                 description: Organization ID, or `@current` for the caller's active org.
             enforce_2fa:
                 description: True to require 2FA for all members; false to disable; null to clear.
+        confirmation_required: true
+        confirmation_builder: buildEnforce2faConfirmation
         response:
             include:
                 - id

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -260,6 +260,32 @@ tools:
         description: >
             List all members of the current organization with their names, emails, membership levels (member, admin,
             owner), and last login times.
+    organization-enforce-2fa-update:
+        operation: partial_update
+        enabled: true
+        scopes:
+            - organization:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Enforce 2FA for organization
+        description: >
+            Toggle 2FA enforcement for an organization. The MCP client will show a confirmation modal; the change is
+            only applied if the user accepts.
+        include_params:
+            - enforce_2fa
+        param_overrides:
+            id:
+                description: Organization ID, or `@current` for the caller's active org.
+            enforce_2fa:
+                description: True to require 2FA for all members; false to disable; null to clear.
+        confirmation_required: true
+        response:
+            include:
+                - id
+                - name
+                - enforce_2fa
     organization-get:
         operation: retrieve
         enabled: true
@@ -319,32 +345,6 @@ tools:
                 - name
                 - slug
                 - membership_level
-    organization-enforce-2fa-update:
-        operation: partial_update
-        enabled: true
-        scopes:
-            - organization:write
-        annotations:
-            readOnly: false
-            destructive: true
-            idempotent: true
-        title: Enforce 2FA for organization
-        description: >
-            Toggle 2FA enforcement for an organization. The MCP client will show a confirmation
-            modal; the change is only applied if the user accepts.
-        confirmation_required: true
-        include_params:
-            - enforce_2fa
-        param_overrides:
-            id:
-                description: Organization ID, or `@current` for the caller's active org.
-            enforce_2fa:
-                description: True to require 2FA for all members; false to disable; null to clear.
-        response:
-            include:
-                - id
-                - name
-                - enforce_2fa
     organizations-update:
         operation: update
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -3786,6 +3786,21 @@
             "readOnlyHint": true
         }
     },
+    "organization-enforce-2fa-update": {
+        "description": "Toggle 2FA enforcement for an organization. The MCP client will show a confirmation modal; the change is only applied if the user accepts.",
+        "category": "Platform Features",
+        "feature": "platform_features",
+        "summary": "Enforce 2FA for organization",
+        "title": "Enforce 2FA for organization",
+        "required_scopes": ["organization:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "organization-get": {
         "description": "Get details of an organization by ID including name, membership level, member count, teams, and projects. If no ID is provided, returns the active organization.",
         "category": "Platform Features",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -4099,6 +4099,21 @@
             "readOnlyHint": true
         }
     },
+    "organization-enforce-2fa-update": {
+        "description": "Toggle 2FA enforcement for an organization. The MCP client will show a confirmation modal; the change is only applied if the user accepts.",
+        "category": "Platform Features",
+        "feature": "platform_features",
+        "summary": "Enforce 2FA for organization",
+        "title": "Enforce 2FA for organization",
+        "required_scopes": ["organization:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "organization-get": {
         "description": "Get details of an organization by ID including name, membership level, member count, teams, and projects. If no ID is provided, returns the active organization.",
         "category": "Platform Features",

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -744,6 +744,38 @@ function buildEnrichment(config: ToolConfig, category: CategoryConfig, resultVar
     return `        return ${resultVar}\n`
 }
 
+/**
+ * Emit the `await confirmAction(...)` block for a tool that opted in via
+ * `confirmation_required: true`. When `confirmation_builder` is also set, the
+ * block invokes the named builder at runtime to produce a dynamic `{ title,
+ * description }`. Otherwise the static title/description from the YAML (with
+ * fall-backs to the OpenAPI operation) are inlined as JSON literals.
+ *
+ * Returns `null` when the tool didn't opt in.
+ */
+function emitConfirmActionBlock(
+    config: ToolConfig,
+    resolved: ResolvedOperation,
+    toolName: string
+): { code: string; builderImport: string | null } | null {
+    if (config.confirmation_required !== true) {
+        return null
+    }
+    const builder = config.confirmation_builder
+    if (builder) {
+        const code = `        await confirmAction(context, await ${builder}(context, params))\n`
+        return { code, builderImport: builder }
+    }
+    const confirmTitle = config.title ?? toolName
+    const confirmDescription =
+        config.description ?? resolved.operation.description ?? resolved.operation.summary ?? toolName
+    let code = `        await confirmAction(context, {\n`
+    code += `            title: ${JSON.stringify(confirmTitle)},\n`
+    code += `            description: ${JSON.stringify(confirmDescription.trim())},\n`
+    code += `        })\n`
+    return { code, builderImport: null }
+}
+
 // ------------------------------------------------------------------
 // Code generation for a single tool
 // ------------------------------------------------------------------
@@ -767,6 +799,7 @@ function generateToolCode(
     hasEnrichment: boolean
     responseFilterImport: 'pickResponseFields' | 'omitResponseFields' | null
     needsConfirmAction: boolean
+    confirmationBuilderImport: string | null
 } {
     const schemaName = `${toPascalCase(toolName)}Schema`
     const factoryName = toCamelCase(toolName)
@@ -812,15 +845,10 @@ function generateToolCode(
 
     // Build handler body
     let handlerBody = ''
-    const needsConfirmAction = config.confirmation_required === true
-    if (needsConfirmAction) {
-        const confirmTitle = config.title ?? toolName
-        const confirmDescription =
-            config.description ?? resolved.operation.description ?? resolved.operation.summary ?? toolName
-        handlerBody += `        await confirmAction(context, {\n`
-        handlerBody += `            title: ${JSON.stringify(confirmTitle)},\n`
-        handlerBody += `            description: ${JSON.stringify(confirmDescription.trim())},\n`
-        handlerBody += `        })\n`
+    const confirmBlock = emitConfirmActionBlock(config, resolved, toolName)
+    const needsConfirmAction = confirmBlock !== null
+    if (confirmBlock) {
+        handlerBody += confirmBlock.code
     }
     if (needsOrgId) {
         handlerBody += `        const orgId = await context.stateManager.getOrgID()\n`
@@ -960,6 +988,7 @@ const ${factoryName} = (): ToolBase<typeof ${schemaName}, ${resultType}> => ${fa
         hasEnrichment,
         responseFilterImport: responseFilter.helperImport,
         needsConfirmAction,
+        confirmationBuilderImport: confirmBlock?.builderImport ?? null,
     }
 }
 
@@ -982,6 +1011,7 @@ function generateCustomSchemaToolCode(
     hasEnrichment: boolean
     responseFilterImport: 'pickResponseFields' | 'omitResponseFields' | null
     needsConfirmAction: boolean
+    confirmationBuilderImport: string | null
 } {
     const pathParamNames = extractPathParams(resolved.path)
 
@@ -994,15 +1024,10 @@ function generateCustomSchemaToolCode(
     const needsOrgId = resolved.path.includes('{organization_id}')
 
     let handlerBody = ''
-    const needsConfirmAction = config.confirmation_required === true
-    if (needsConfirmAction) {
-        const confirmTitle = config.title ?? toolName
-        const confirmDescription =
-            config.description ?? resolved.operation.description ?? resolved.operation.summary ?? toolName
-        handlerBody += `        await confirmAction(context, {\n`
-        handlerBody += `            title: ${JSON.stringify(confirmTitle)},\n`
-        handlerBody += `            description: ${JSON.stringify(confirmDescription.trim())},\n`
-        handlerBody += `        })\n`
+    const confirmBlock = emitConfirmActionBlock(config, resolved, toolName)
+    const needsConfirmAction = confirmBlock !== null
+    if (confirmBlock) {
+        handlerBody += confirmBlock.code
     }
     if (needsOrgId) {
         handlerBody += `        const orgId = await context.stateManager.getOrgID()\n`
@@ -1078,6 +1103,7 @@ ${handlerBody}    },
         hasEnrichment: false,
         responseFilterImport: responseFilter.helperImport,
         needsConfirmAction,
+        confirmationBuilderImport: confirmBlock?.builderImport ?? null,
     }
 }
 
@@ -1158,6 +1184,7 @@ function generateCategoryFile(
 
     let hasEnrichment = false
     let hasConfirmAction = false
+    const confirmationBuilderImports = new Set<string>()
 
     const responseFilterImports = new Set<string>()
 
@@ -1198,6 +1225,9 @@ function generateCategoryFile(
         }
         if (result.needsConfirmAction) {
             hasConfirmAction = true
+        }
+        if (result.confirmationBuilderImport) {
+            confirmationBuilderImports.add(result.confirmationBuilderImport)
         }
     }
 
@@ -1338,13 +1368,18 @@ function generateCategoryFile(
 
     const confirmActionImportLine = hasConfirmAction ? `import { confirmAction } from '@/lib/confirm-action'\n` : ''
 
+    const confirmationBuilderImportLine =
+        confirmationBuilderImports.size > 0
+            ? `import { ${[...confirmationBuilderImports].sort().join(', ')} } from '@/lib/confirmation-builders'\n`
+            : ''
+
     const schemaRefCode = allSchemaRefBlocks.length > 0 ? '\n' + allSchemaRefBlocks.join('\n\n') + '\n' : ''
 
     const code = `// AUTO-GENERATED from ${fileName} + OpenAPI — do not edit
 import { z } from 'zod'
 
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-${confirmActionImportLine}${toolUtilsImportLine ? `${toolUtilsImportLine}` : ''}${schemasImportLine}${withUiAppImportLine}${toolInputsImportLine}${castHelpersImportLine}${wrapperImportLine}${orvalImportLine}${schemaRefCode}${toolCodes.join('')}${wrapperSchemasCode}
+${confirmActionImportLine}${confirmationBuilderImportLine}${toolUtilsImportLine ? `${toolUtilsImportLine}` : ''}${schemasImportLine}${withUiAppImportLine}${toolInputsImportLine}${castHelpersImportLine}${wrapperImportLine}${orvalImportLine}${schemaRefCode}${toolCodes.join('')}${wrapperSchemasCode}
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
 ${mapEntries}
 }

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -766,6 +766,7 @@ function generateToolCode(
     needsWithPostHogUrl: boolean
     hasEnrichment: boolean
     responseFilterImport: 'pickResponseFields' | 'omitResponseFields' | null
+    needsConfirmAction: boolean
 } {
     const schemaName = `${toPascalCase(toolName)}Schema`
     const factoryName = toCamelCase(toolName)
@@ -811,6 +812,16 @@ function generateToolCode(
 
     // Build handler body
     let handlerBody = ''
+    const needsConfirmAction = config.confirmation_required === true
+    if (needsConfirmAction) {
+        const confirmTitle = config.title ?? toolName
+        const confirmDescription =
+            config.description ?? resolved.operation.description ?? resolved.operation.summary ?? toolName
+        handlerBody += `        await confirmAction(context, {\n`
+        handlerBody += `            title: ${JSON.stringify(confirmTitle)},\n`
+        handlerBody += `            description: ${JSON.stringify(confirmDescription.trim())},\n`
+        handlerBody += `        })\n`
+    }
     if (needsOrgId) {
         handlerBody += `        const orgId = await context.stateManager.getOrgID()\n`
     }
@@ -948,6 +959,7 @@ const ${factoryName} = (): ToolBase<typeof ${schemaName}, ${resultType}> => ${fa
         needsWithPostHogUrl,
         hasEnrichment,
         responseFilterImport: responseFilter.helperImport,
+        needsConfirmAction,
     }
 }
 
@@ -969,6 +981,7 @@ function generateCustomSchemaToolCode(
     needsWithPostHogUrl: boolean
     hasEnrichment: boolean
     responseFilterImport: 'pickResponseFields' | 'omitResponseFields' | null
+    needsConfirmAction: boolean
 } {
     const pathParamNames = extractPathParams(resolved.path)
 
@@ -981,6 +994,16 @@ function generateCustomSchemaToolCode(
     const needsOrgId = resolved.path.includes('{organization_id}')
 
     let handlerBody = ''
+    const needsConfirmAction = config.confirmation_required === true
+    if (needsConfirmAction) {
+        const confirmTitle = config.title ?? toolName
+        const confirmDescription =
+            config.description ?? resolved.operation.description ?? resolved.operation.summary ?? toolName
+        handlerBody += `        await confirmAction(context, {\n`
+        handlerBody += `            title: ${JSON.stringify(confirmTitle)},\n`
+        handlerBody += `            description: ${JSON.stringify(confirmDescription.trim())},\n`
+        handlerBody += `        })\n`
+    }
     if (needsOrgId) {
         handlerBody += `        const orgId = await context.stateManager.getOrgID()\n`
     }
@@ -1054,6 +1077,7 @@ ${handlerBody}    },
         needsWithPostHogUrl: false,
         hasEnrichment: false,
         responseFilterImport: responseFilter.helperImport,
+        needsConfirmAction,
     }
 }
 
@@ -1133,6 +1157,7 @@ function generateCategoryFile(
     let hasWithPostHogUrl = false
 
     let hasEnrichment = false
+    let hasConfirmAction = false
 
     const responseFilterImports = new Set<string>()
 
@@ -1170,6 +1195,9 @@ function generateCategoryFile(
         }
         if (result.responseFilterImport) {
             responseFilterImports.add(result.responseFilterImport)
+        }
+        if (result.needsConfirmAction) {
+            hasConfirmAction = true
         }
     }
 
@@ -1308,13 +1336,15 @@ function generateCategoryFile(
     const wrapperImportLine =
         enabledWrappers.length > 0 ? `import { createQueryWrapper } from '@/tools/query-wrapper-factory'\n` : ''
 
+    const confirmActionImportLine = hasConfirmAction ? `import { confirmAction } from '@/lib/confirm-action'\n` : ''
+
     const schemaRefCode = allSchemaRefBlocks.length > 0 ? '\n' + allSchemaRefBlocks.join('\n\n') + '\n' : ''
 
     const code = `// AUTO-GENERATED from ${fileName} + OpenAPI — do not edit
 import { z } from 'zod'
 
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-${toolUtilsImportLine ? `${toolUtilsImportLine}` : ''}${schemasImportLine}${withUiAppImportLine}${toolInputsImportLine}${castHelpersImportLine}${wrapperImportLine}${orvalImportLine}${schemaRefCode}${toolCodes.join('')}${wrapperSchemasCode}
+${confirmActionImportLine}${toolUtilsImportLine ? `${toolUtilsImportLine}` : ''}${schemasImportLine}${withUiAppImportLine}${toolInputsImportLine}${castHelpersImportLine}${wrapperImportLine}${orvalImportLine}${schemaRefCode}${toolCodes.join('')}${wrapperSchemasCode}
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
 ${mapEntries}
 }

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -123,6 +123,14 @@ export const ToolConfigSchema = z
          */
         requires_ai_consent: z.boolean().optional(),
         /**
+         * When true, the tool's handler will request a manual user confirmation via the MCP
+         * client (using the `elicitation/create` protocol primitive) before performing the
+         * action. The user is shown the tool's title, description, and the resolved parameters.
+         * If the client does not support elicitation, the action is refused — sensitive
+         * actions fail closed. Use for destructive or hard-to-reverse operations.
+         */
+        confirmation_required: z.boolean().optional(),
+        /**
          * Maps original OpenAPI field names to MCP-safe aliases. The generated tool
          * schema uses the alias (which must match ^[a-zA-Z0-9_.-]{1,64}$), while
          * the request body still sends the original field name.

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -125,11 +125,20 @@ export const ToolConfigSchema = z
         /**
          * When true, the tool's handler will request a manual user confirmation via the MCP
          * client (using the `elicitation/create` protocol primitive) before performing the
-         * action. The user is shown the tool's title, description, and the resolved parameters.
-         * If the client does not support elicitation, the action is refused — sensitive
-         * actions fail closed. Use for destructive or hard-to-reverse operations.
+         * action. The user is shown the tool's title and description (or the output of
+         * `confirmation_builder`, when set). If the client does not support elicitation, the
+         * action is refused — sensitive actions fail closed. Use for destructive or
+         * hard-to-reverse operations.
          */
         confirmation_required: z.boolean().optional(),
+        /**
+         * Name of a function exported from `services/mcp/src/lib/confirmation-builders.ts`
+         * that produces a `{ title, description }` for the elicitation modal at runtime.
+         * The builder receives `(context, params)` so it can look up entity names, format
+         * dynamic verbs from boolean params, etc. — anything the static YAML message can't
+         * express. Only meaningful when `confirmation_required: true`.
+         */
+        confirmation_builder: z.string().optional(),
         /**
          * Maps original OpenAPI field names to MCP-safe aliases. The generated tool
          * schema uses the alias (which must match ^[a-zA-Z0-9_.-]{1,64}$), while

--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 19 enabled ops
+ * PostHog API - MCP 20 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -64,6 +64,40 @@ export const ListQueryParams = /* @__PURE__ */ zod.object({
 
 export const RetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this organization.'),
+})
+
+export const PartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this organization.'),
+})
+
+export const partialUpdateBodyNameMax = 64
+
+export const PartialUpdateBody = /* @__PURE__ */ zod.object({
+    name: zod.string().max(partialUpdateBodyNameMax).optional(),
+    logo_media_id: zod.uuid().nullish(),
+    enforce_2fa: zod.boolean().nullish(),
+    members_can_invite: zod.boolean().nullish(),
+    members_can_use_personal_api_keys: zod.boolean().optional(),
+    allow_publicly_shared_resources: zod.boolean().optional(),
+    is_ai_data_processing_approved: zod.boolean().nullish(),
+    default_experiment_stats_method: zod
+        .union([
+            zod.enum(['bayesian', 'frequentist']).describe('* `bayesian` - Bayesian\n* `frequentist` - Frequentist'),
+            zod.enum(['']),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Default statistical method for new experiments in this organization.\n\n* `bayesian` - Bayesian\n* `frequentist` - Frequentist'
+        ),
+    default_anonymize_ips: zod
+        .boolean()
+        .optional()
+        .describe("Default setting for 'Discard client IP data' for new projects in this organization."),
+    default_role_id: zod
+        .string()
+        .nullish()
+        .describe('ID of the role to automatically assign to new members joining the organization'),
 })
 
 export const MembersListParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/hono/app.ts
+++ b/services/mcp/src/hono/app.ts
@@ -2,6 +2,12 @@ import { Hono } from 'hono'
 
 import { httpMetrics, securityHeaders } from './middleware'
 import { registerPublicRoutes } from './public-routes'
+import {
+    type BusAwaitMetrics,
+    createPromBusMetrics,
+    RedisPollingSessionResponseBus,
+    type SessionResponseBus,
+} from './session-bus'
 import { StreamableMcpHandler } from './streamable-handler'
 import type { HonoCtx, RedisWithPing } from './types'
 
@@ -10,11 +16,30 @@ export type Lifecycle = { shuttingDown: boolean }
 export type App = {
     app: Hono
     lifecycle: Lifecycle
+    sessionBus: SessionResponseBus
 }
 
-export function createApp(redis: RedisWithPing): App {
+export interface CreateAppOptions {
+    /**
+     * Override the session bus. Tests inject `InMemorySessionResponseBus`;
+     * production wires the default `RedisPollingSessionResponseBus` against
+     * the shared Redis client.
+     */
+    sessionBus?: SessionResponseBus
+    /**
+     * Override the per-await metrics adapter. Defaults to a Prometheus
+     * adapter that pushes into `mcp_session_bus_*`. Tests typically leave
+     * this undefined or pass a spy.
+     */
+    busMetrics?: BusAwaitMetrics
+}
+
+export function createApp(redis: RedisWithPing, options: CreateAppOptions = {}): App {
     const app = new Hono()
     const lifecycle: Lifecycle = { shuttingDown: false }
+
+    const sessionBus = options.sessionBus ?? new RedisPollingSessionResponseBus(redis)
+    const busMetrics = options.busMetrics ?? createPromBusMetrics()
 
     app.use('*', securityHeaders)
     app.use('*', httpMetrics)
@@ -30,10 +55,10 @@ export function createApp(redis: RedisWithPing): App {
     app.all('/sse', sseRedirect)
     app.all('/sse/*', sseRedirect)
 
-    const streamable = new StreamableMcpHandler(redis, lifecycle)
+    const streamable = new StreamableMcpHandler(redis, lifecycle, sessionBus, busMetrics)
     app.all('/mcp', streamable.fetch)
     app.all('/mcp/*', streamable.fetch)
 
     app.all('*', (c) => c.notFound())
-    return { app, lifecycle }
+    return { app, lifecycle, sessionBus }
 }

--- a/services/mcp/src/hono/mcp-server.ts
+++ b/services/mcp/src/hono/mcp-server.ts
@@ -1,10 +1,5 @@
 import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 import { McpServer, type ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
-// The SDK's default `AjvJsonSchemaValidator` compiles JSON Schemas via `new Function()`,
-// which Cloudflare Workers' CSP blocks ("Code generation from strings disallowed").
-// That would break `elicitation/create` response validation. Use the Workers-compatible
-// interpreter instead. See https://github.com/modelcontextprotocol/typescript-sdk/issues/689
-import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker-provider.js'
 import type { z } from 'zod'
 
 import { ApiClient } from '@/api/client'
@@ -38,6 +33,12 @@ import { type Context, type Env, type State, type Tool } from '@/tools/types'
 import { RedisCache, type RedisLike } from './cache/RedisCache'
 import { getCustomApiBaseUrl, getEnv } from './constants'
 import { initDurationSeconds, toolCallDurationSeconds, toolCallsTotal } from './metrics'
+import {
+    type BusAwaitMetrics,
+    ElicitationGateway,
+    type SessionResponseBus,
+    type TransportMessageSender,
+} from './session-bus'
 
 export type { RequestProperties }
 
@@ -83,17 +84,53 @@ export class HonoMcpServer {
     private mcpMode: McpMode | undefined
     private mcpVersion: number | undefined
 
-    constructor(redis: RedisLike, props: RequestProperties) {
+    private readonly sessionBus: SessionResponseBus
+    private readonly sessionId: string
+    private readonly busMetrics: BusAwaitMetrics | undefined
+    private requestAbortSignal: AbortSignal | undefined
+    private transportSender: TransportMessageSender | undefined
+    /**
+     * JSONRPC id of the inbound request currently being handled, captured by
+     * the `registerTool` wrapper from `RequestHandlerExtra`. The elicit closure
+     * reads this lazily and forwards it to the transport as `relatedRequestId`
+     * so outbound `elicitation/create` messages reach the open SSE stream of
+     * the originating request.
+     */
+    private currentRequestId: string | number | undefined
+
+    constructor(
+        redis: RedisLike,
+        props: RequestProperties,
+        options: { sessionBus: SessionResponseBus; sessionId: string; busMetrics?: BusAwaitMetrics }
+    ) {
         this.props = props
         this.redis = redis
         this.env = getEnv()
+        this.sessionBus = options.sessionBus
+        this.sessionId = options.sessionId
+        this.busMetrics = options.busMetrics
         this.server = new McpServer(
             { name: 'PostHog', version: '1.0.0' },
-            {
-                instructions: instructionsFormatter.buildV1Instructions(),
-                jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
-            }
+            { instructions: instructionsFormatter.buildV1Instructions() }
         )
+    }
+
+    /**
+     * Bind a per-request transport message sender. Called by the streamable
+     * handler immediately after constructing the SDK transport. `Context.elicit`
+     * uses this to push outbound `elicitation/create` messages over the active
+     * SSE channel to the client.
+     */
+    bindTransportSender(sender: TransportMessageSender): void {
+        this.transportSender = sender
+    }
+
+    /**
+     * Bind the per-request AbortSignal (typically `c.req.raw.signal`) so that
+     * client disconnects propagate into pending elicit waits.
+     */
+    bindAbortSignal(signal: AbortSignal): void {
+        this.requestAbortSignal = signal
     }
 
     get requestProperties(): HonoRequestProperties {
@@ -267,7 +304,10 @@ export class HonoMcpServer {
         tool: Tool<TSchema>,
         handler: (params: z.infer<TSchema>) => Promise<any>
     ): void {
-        const wrappedHandler = async (params: z.infer<TSchema>): Promise<any> => {
+        const wrappedHandler = async (
+            params: z.infer<TSchema>,
+            extra?: { requestId?: string | number }
+        ): Promise<any> => {
             const validation = tool.schema.safeParse(params)
 
             if (!validation.success) {
@@ -282,6 +322,14 @@ export class HonoMcpServer {
                         },
                     ],
                 }
+            }
+
+            // Capture the inbound request id for the duration of the handler.
+            // `Context.elicit` reads it lazily so outbound `elicitation/create`
+            // messages are routed over the right SSE channel.
+            const previousRequestId = this.currentRequestId
+            if (extra?.requestId !== undefined) {
+                this.currentRequestId = extra.requestId
             }
 
             const stop = toolCallDurationSeconds.startTimer({ tool: tool.name })
@@ -321,6 +369,8 @@ export class HonoMcpServer {
                     distinctId,
                     this.props.sessionId ? await this.sessionManager.getSessionUuid(this.props.sessionId) : undefined
                 )
+            } finally {
+                this.currentRequestId = previousRequestId
             }
         }
 
@@ -360,7 +410,43 @@ export class HonoMcpServer {
             const analyticsContext = await this.getAnalyticsContextSafe(partialContext)
             await this.trackEvent(event, properties, analyticsContext ? { context: analyticsContext } : undefined)
         }
-        const elicit: Context['elicit'] = (params, options) => this.server.server.elicitInput(params, options)
+
+        // Elicit on Hono uses the cross-pod SessionResponseBus rather than the
+        // SDK's in-process pending-request map. The originating pod sends the
+        // `elicitation/create` message over its open SSE; the client's response
+        // may arrive at any pod via a new POST, and the streamable handler
+        // routes it back through `bus.deliver()`. The transport sender and
+        // abort signal are bound by the streamable handler AFTER `init()` runs
+        // (which itself calls `getContext()`), so we must read them lazily at
+        // elicit-call time — capturing them here would freeze stale undefined
+        // references and the elicit would never reach the client.
+        const sessionBus = this.sessionBus
+        const sessionId = this.sessionId
+        const self = this
+        const elicit: Context['elicit'] = (params, options) => {
+            const transportSender = self.transportSender
+            if (!transportSender) {
+                throw new Error(
+                    'Elicit invoked without a bound transport sender — bindTransportSender() must be called by the streamable handler before tool dispatch.'
+                )
+            }
+            const gatewayOptions: { metrics?: BusAwaitMetrics } = {}
+            if (self.busMetrics !== undefined) {
+                gatewayOptions.metrics = self.busMetrics
+            }
+            const gateway = new ElicitationGateway(sessionBus, transportSender, gatewayOptions)
+            const callOptions: { timeoutMs?: number; signal?: AbortSignal; relatedRequestId?: string | number } = {}
+            if (options?.timeout !== undefined) {
+                callOptions.timeoutMs = options.timeout
+            }
+            if (self.requestAbortSignal !== undefined) {
+                callOptions.signal = self.requestAbortSignal
+            }
+            if (self.currentRequestId !== undefined) {
+                callOptions.relatedRequestId = self.currentRequestId
+            }
+            return gateway.elicit(sessionId, params, callOptions)
+        }
         return { ...partialContext, trackEvent, elicit }
     }
 
@@ -508,10 +594,7 @@ export class HonoMcpServer {
             }
         }
 
-        this.server = new McpServer(
-            { name: 'PostHog', version: '1.0.0' },
-            { instructions, jsonSchemaValidator: new CfWorkerJsonSchemaValidator() }
-        )
+        this.server = new McpServer({ name: 'PostHog', version: '1.0.0' }, { instructions })
 
         // Register prompts and resources
         await Promise.all([

--- a/services/mcp/src/hono/mcp-server.ts
+++ b/services/mcp/src/hono/mcp-server.ts
@@ -1,5 +1,9 @@
 import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 import { McpServer, type ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
+// The SDK's default `AjvJsonSchemaValidator` compiles JSON Schemas via `new Function()`,
+// which Cloudflare Workers' CSP blocks ("Code generation from strings disallowed").
+// That would break `elicitation/create` response validation. Use the Workers-compatible
+// interpreter instead. See https://github.com/modelcontextprotocol/typescript-sdk/issues/689
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker-provider.js'
 import type { z } from 'zod'
 

--- a/services/mcp/src/hono/mcp-server.ts
+++ b/services/mcp/src/hono/mcp-server.ts
@@ -1,5 +1,6 @@
 import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 import { McpServer, type ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker-provider.js'
 import type { z } from 'zod'
 
 import { ApiClient } from '@/api/client'
@@ -84,7 +85,10 @@ export class HonoMcpServer {
         this.env = getEnv()
         this.server = new McpServer(
             { name: 'PostHog', version: '1.0.0' },
-            { instructions: instructionsFormatter.buildV1Instructions() }
+            {
+                instructions: instructionsFormatter.buildV1Instructions(),
+                jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+            }
         )
     }
 
@@ -340,7 +344,7 @@ export class HonoMcpServer {
     async getContext(): Promise<Context> {
         const api = await this.api()
         const stateManager = new StateManager(this.cache, api)
-        const partialContext: Omit<Context, 'trackEvent'> = {
+        const partialContext: Omit<Context, 'trackEvent' | 'elicit'> = {
             api,
             cache: this.cache,
             env: this.env,
@@ -352,7 +356,8 @@ export class HonoMcpServer {
             const analyticsContext = await this.getAnalyticsContextSafe(partialContext)
             await this.trackEvent(event, properties, analyticsContext ? { context: analyticsContext } : undefined)
         }
-        return { ...partialContext, trackEvent }
+        const elicit: Context['elicit'] = (params, options) => this.server.server.elicitInput(params, options)
+        return { ...partialContext, trackEvent, elicit }
     }
 
     async init(): Promise<void> {
@@ -499,7 +504,10 @@ export class HonoMcpServer {
             }
         }
 
-        this.server = new McpServer({ name: 'PostHog', version: '1.0.0' }, { instructions })
+        this.server = new McpServer(
+            { name: 'PostHog', version: '1.0.0' },
+            { instructions, jsonSchemaValidator: new CfWorkerJsonSchemaValidator() }
+        )
 
         // Register prompts and resources
         await Promise.all([

--- a/services/mcp/src/hono/metrics.ts
+++ b/services/mcp/src/hono/metrics.ts
@@ -55,6 +55,29 @@ export const shuttingDown = new Gauge({
     help: 'Set to 1 when the pod is draining for shutdown.',
 })
 
+// Cross-pod elicitation correlation via the SessionResponseBus. These trace the
+// human-in-the-loop latency: how long pods sit on a parked `bus.await` between
+// sending an `elicitation/create` and the client's response landing (possibly
+// on a different pod). A spike in `timeout` is the leading indicator of clients
+// not honoring elicitation; `unhealthy` flags Redis or schema issues.
+export const sessionBusAwaitsTotal = new Counter({
+    name: 'mcp_session_bus_awaits_total',
+    help: 'Total session-response bus awaits, broken down by outcome.',
+    labelNames: ['outcome'] as const,
+})
+
+export const sessionBusAwaitDurationSeconds = new Histogram({
+    name: 'mcp_session_bus_await_duration_seconds',
+    help: 'Time from session-bus await start to resolution.',
+    labelNames: ['outcome'] as const,
+    buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300],
+})
+
+export const sessionBusPollsTotal = new Counter({
+    name: 'mcp_session_bus_polls_total',
+    help: 'Total Redis GETs performed by the polling session-response bus.',
+})
+
 // Map a request URL to a low-cardinality label. Anything not matched falls
 // into `other` so a pathological client can't fan out the histogram series.
 export function routeLabel(pathname: string): string {

--- a/services/mcp/src/hono/session-bus/adaptive-poll.ts
+++ b/services/mcp/src/hono/session-bus/adaptive-poll.ts
@@ -1,0 +1,67 @@
+/**
+ * Polling cadence schedule for the Redis-backed bus.
+ *
+ * The schedule is intentionally a tiny, pure data structure rather than a
+ * loop or generator — that makes it trivial to unit-test (a few asserts on
+ * the output of `nextDelay`) and lets the bus's polling loop stay
+ * single-purpose.
+ *
+ * Cadence chosen to match how users interact with confirmation modals:
+ * - The first ~5 seconds, poll fast (200ms). Most clicks land here.
+ * - After that, slow to 1s/poll — the user is reading, thinking, or AFK.
+ * - Optionally back off further at extreme elapsed times.
+ *
+ * This is a heuristic, not a science. The numbers can be tuned without
+ * any change to the bus contract.
+ */
+
+export interface AdaptivePollSchedule {
+    /**
+     * Compute the delay (ms) before the next poll, given the time elapsed
+     * since the await started.
+     */
+    nextDelay(elapsedMs: number): number
+}
+
+export interface AdaptivePollConfig {
+    /** Delay during the "hot" window (first {@link hotWindowMs} ms). */
+    hotIntervalMs: number
+    /** Delay after the hot window. */
+    coolIntervalMs: number
+    /** Duration of the hot window in ms. */
+    hotWindowMs: number
+}
+
+export const DEFAULT_ADAPTIVE_POLL_CONFIG: AdaptivePollConfig = {
+    hotIntervalMs: 200,
+    coolIntervalMs: 1_000,
+    hotWindowMs: 5_000,
+}
+
+export function createAdaptivePollSchedule(
+    config: AdaptivePollConfig = DEFAULT_ADAPTIVE_POLL_CONFIG
+): AdaptivePollSchedule {
+    validateConfig(config)
+    return {
+        nextDelay(elapsedMs: number): number {
+            if (elapsedMs < 0) {
+                return config.hotIntervalMs
+            }
+            return elapsedMs < config.hotWindowMs ? config.hotIntervalMs : config.coolIntervalMs
+        },
+    }
+}
+
+function validateConfig(config: AdaptivePollConfig): void {
+    if (config.hotIntervalMs <= 0 || config.coolIntervalMs <= 0) {
+        throw new Error('Poll intervals must be positive')
+    }
+    if (config.hotWindowMs < 0) {
+        throw new Error('Hot window must be non-negative')
+    }
+    if (config.hotIntervalMs > config.coolIntervalMs) {
+        throw new Error(
+            'Hot interval must be shorter than cool interval — adaptive polling exists to be faster early, not slower'
+        )
+    }
+}

--- a/services/mcp/src/hono/session-bus/elicit-result-validator.ts
+++ b/services/mcp/src/hono/session-bus/elicit-result-validator.ts
@@ -1,0 +1,32 @@
+/**
+ * Validation for `ElicitResult` payloads delivered through the session bus.
+ *
+ * The bus is intentionally schema-agnostic — it stores opaque JSON. The
+ * gateway is responsible for asserting the response actually matches the
+ * MCP `ElicitResult` shape before handing it to a caller who's awaiting an
+ * elicit result.
+ *
+ * We reuse the SDK's Zod schema rather than hand-rolling: it stays in sync
+ * with the upstream MCP spec for free. (Zod, not AJV — there's no
+ * `new Function()` involved either way, but reusing the SDK's exported
+ * schema keeps us aligned with the protocol version the SDK targets.)
+ */
+
+import { ElicitResultSchema, type ElicitResult } from '@modelcontextprotocol/sdk/types.js'
+
+import { SessionBusUnhealthyError } from './errors'
+
+export function validateElicitResult(raw: unknown): ElicitResult {
+    const parsed = ElicitResultSchema.safeParse(raw)
+    if (!parsed.success) {
+        // Treat a bad payload as a bus-level problem rather than a normal
+        // decline/cancel. If we ever see this in production it means a
+        // client is sending malformed elicitation responses — that's a
+        // protocol violation, not a user choice. Fail closed.
+        throw new SessionBusUnhealthyError(
+            `Elicitation response payload did not match the ElicitResult schema: ${parsed.error.message}`,
+            { cause: parsed.error }
+        )
+    }
+    return parsed.data
+}

--- a/services/mcp/src/hono/session-bus/elicitation-gateway.ts
+++ b/services/mcp/src/hono/session-bus/elicitation-gateway.ts
@@ -1,0 +1,131 @@
+/**
+ * MCP-specific glue between the elicit call site and the session bus.
+ *
+ * This is the only file in `session-bus/` that knows about MCP. The bus
+ * itself is generic — anything below this layer treats payloads as opaque
+ * JSON keyed by `(sessionId, requestId)`.
+ *
+ * Why we don't use the SDK's `Server.request()` to send the elicit:
+ * - `Server.request()` correlates the response via the SDK's in-process
+ *   pending-request map. That map is on whichever pod sent the request.
+ *   In our multi-pod setup the response can arrive on any pod, so the SDK's
+ *   correlation never fires — we'd just wait until timeout.
+ * - Instead we send the JSONRPC message directly via the connected
+ *   transport (which is the open SSE channel to the originating client),
+ *   then await via our bus, which is cross-pod by construction.
+ *
+ * Behavior contract:
+ * - Each call generates a fresh JSONRPC request ID via `crypto.randomUUID()`.
+ * - The message goes out as a JSONRPC request shape; the client
+ *   (Claude Code etc.) is responsible for responding with the matching id.
+ * - On the response side, the inbound HTTP handler is expected to detect
+ *   JSONRPC responses and call `bus.deliver(sessionId, id, payload)` —
+ *   the gateway has no knowledge of how that happens.
+ */
+
+import type { ElicitRequestFormParams, ElicitResult } from '@modelcontextprotocol/sdk/types.js'
+
+import { validateElicitResult } from './elicit-result-validator'
+import type { BusAwaitMetrics, SessionResponseBus } from './types'
+
+/**
+ * Sends raw JSONRPC messages over the active per-request transport.
+ *
+ * Decoupled from any specific SDK to keep the gateway transport-agnostic.
+ * The concrete implementation in `hono/mcp-server.ts` adapts the SDK
+ * `WebStandardStreamableHTTPServerTransport`'s outbound API to this shape.
+ */
+export interface TransportMessageSender {
+    /**
+     * Push a JSONRPC message to the client. Resolves when the message has
+     * been handed to the underlying transport (not when the client receives
+     * it).
+     *
+     * `options.relatedRequestId` associates the outbound message with the
+     * inbound request that triggered it — required by the Streamable HTTP
+     * transport to route the message over the right open SSE channel. Without
+     * it, the message falls to the standalone SSE stream that most clients
+     * never subscribe to and the elicit silently goes nowhere.
+     */
+    send(message: JsonRpcRequestMessage, options?: { relatedRequestId?: string | number }): Promise<void>
+}
+
+export interface JsonRpcRequestMessage {
+    jsonrpc: '2.0'
+    id: string
+    method: string
+    params: unknown
+}
+
+export interface ElicitationGatewayOptions {
+    /** Default deadline for an elicit. May be overridden per call. */
+    defaultTimeoutMs?: number
+    /** Optional metrics hook applied to every await. */
+    metrics?: BusAwaitMetrics
+}
+
+export interface ElicitCallOptions {
+    /** Override the gateway's default timeout for this call. */
+    timeoutMs?: number
+    /** Abort the elicit immediately when this signal fires. The originating
+     *  HTTP request's `AbortSignal` is the typical source. */
+    signal?: AbortSignal
+    /** The id of the inbound JSONRPC request whose handler is making this
+     *  elicit. Forwarded to the transport as `relatedRequestId` so the
+     *  outbound message is routed over the open SSE channel. */
+    relatedRequestId?: string | number
+}
+
+/** Default elicit timeout. 5 minutes — comfortable for human interaction. */
+const DEFAULT_ELICIT_TIMEOUT_MS = 5 * 60 * 1000
+
+export class ElicitationGateway {
+    constructor(
+        private readonly bus: SessionResponseBus,
+        private readonly sender: TransportMessageSender,
+        private readonly options: ElicitationGatewayOptions = {}
+    ) {}
+
+    /**
+     * Send an `elicitation/create` request to the client and await its
+     * response via the session bus.
+     *
+     * Throws (no recovery):
+     * - `SessionBusTimeoutError` if no response within the deadline.
+     * - `SessionBusAbortedError` if `options.signal` aborts.
+     * - `SessionBusUnhealthyError` if the bus or the validation step fails.
+     */
+    async elicit(
+        sessionId: string,
+        params: ElicitRequestFormParams,
+        options: ElicitCallOptions = {}
+    ): Promise<ElicitResult> {
+        const requestId = crypto.randomUUID()
+        const timeoutMs = options.timeoutMs ?? this.options.defaultTimeoutMs ?? DEFAULT_ELICIT_TIMEOUT_MS
+
+        const sendOptions: { relatedRequestId?: string | number } = {}
+        if (options.relatedRequestId !== undefined) {
+            sendOptions.relatedRequestId = options.relatedRequestId
+        }
+        await this.sender.send(
+            {
+                jsonrpc: '2.0',
+                id: requestId,
+                method: 'elicitation/create',
+                params: params as unknown,
+            },
+            sendOptions
+        )
+
+        const awaitOptions: import('./types').AwaitOptions = { timeoutMs }
+        if (options.signal !== undefined) {
+            awaitOptions.signal = options.signal
+        }
+        if (this.options.metrics !== undefined) {
+            awaitOptions.metrics = this.options.metrics
+        }
+        const raw = await this.bus.await<unknown>(sessionId, requestId, awaitOptions)
+
+        return validateElicitResult(raw)
+    }
+}

--- a/services/mcp/src/hono/session-bus/errors.ts
+++ b/services/mcp/src/hono/session-bus/errors.ts
@@ -1,0 +1,36 @@
+/**
+ * Errors thrown by the SessionResponseBus and its consumers.
+ *
+ * Every error in this module is a structured failure of a cross-pod
+ * server-initiated request/response correlation. Callers should branch on
+ * these classes rather than parsing messages.
+ */
+
+export class SessionBusTimeoutError extends Error {
+    constructor(sessionId: string, requestId: string | number, timeoutMs: number) {
+        super(
+            `No response for session=${sessionId} request=${requestId} within ${timeoutMs}ms. ` +
+                `The client may have closed the modal without acting, or never received the request.`
+        )
+        this.name = 'SessionBusTimeoutError'
+    }
+}
+
+export class SessionBusAbortedError extends Error {
+    constructor(reason: string) {
+        super(`Session bus await was aborted: ${reason}`)
+        this.name = 'SessionBusAbortedError'
+    }
+}
+
+export class SessionBusUnhealthyError extends Error {
+    constructor(message: string, options?: { cause?: unknown }) {
+        super(message)
+        this.name = 'SessionBusUnhealthyError'
+        if (options?.cause !== undefined) {
+            // Manual assignment for compatibility with TS libs that don't expose
+            // the ES2022 `Error(msg, { cause })` constructor overload.
+            ;(this as Error & { cause?: unknown }).cause = options.cause
+        }
+    }
+}

--- a/services/mcp/src/hono/session-bus/in-memory-bus.ts
+++ b/services/mcp/src/hono/session-bus/in-memory-bus.ts
@@ -1,0 +1,165 @@
+/**
+ * In-process implementation of `SessionResponseBus`.
+ *
+ * Designed for two consumers:
+ * 1. **Tests** — deterministic, no I/O, no Redis dependency.
+ * 2. **Single-pod dev** — when `REDIS_URL` is unset and the operator opts
+ *    into in-memory mode explicitly. Not safe for multi-pod production.
+ *
+ * Awaits are stored in a `Map` keyed by `{sessionId}::{requestId}`. Deliveries
+ * before any awaiter is registered are also held briefly under the same key
+ * (60s) so the typical await→deliver race is forgiving in both orderings.
+ */
+
+import { SessionBusAbortedError, SessionBusTimeoutError } from './errors'
+import type { AwaitOptions, BusAwaitMetrics, SessionResponseBus } from './types'
+
+interface ParkedAwait {
+    resolve: (payload: unknown) => void
+    reject: (err: Error) => void
+}
+
+interface PendingDelivery {
+    payload: unknown
+    expiresAt: number
+    cleanupTimer: ReturnType<typeof setTimeout>
+}
+
+/** How long an early delivery is held before any awaiter shows up. */
+const EARLY_DELIVERY_TTL_MS = 60_000
+
+export class InMemorySessionResponseBus implements SessionResponseBus {
+    private readonly awaits = new Map<string, ParkedAwait>()
+    private readonly earlyDeliveries = new Map<string, PendingDelivery>()
+
+    async await<T>(sessionId: string, requestId: string | number, options: AwaitOptions): Promise<T> {
+        const key = buildKey(sessionId, requestId)
+        const startedAt = Date.now()
+        const metrics: BusAwaitMetrics | undefined = options.metrics
+        safeMetric(() => metrics?.onAwaitStart?.(sessionId, requestId))
+
+        // If a deliver() landed before us, return immediately.
+        const early = this.earlyDeliveries.get(key)
+        if (early !== undefined) {
+            clearTimeout(early.cleanupTimer)
+            this.earlyDeliveries.delete(key)
+            safeMetric(() => metrics?.onResolve?.(sessionId, requestId, 0))
+            return early.payload as T
+        }
+
+        if (this.awaits.has(key)) {
+            // Two concurrent awaits on the same key would be ambiguous about who
+            // wins on deliver(). Refuse rather than silently misbehaving.
+            throw new Error(
+                `Concurrent await for the same (session=${sessionId}, request=${requestId}) is not supported`
+            )
+        }
+
+        return await new Promise<T>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this.awaits.delete(key)
+                safeMetric(() => metrics?.onTimeout?.(sessionId, requestId))
+                reject(new SessionBusTimeoutError(sessionId, requestId, options.timeoutMs))
+            }, options.timeoutMs)
+
+            const abortHandler = (): void => {
+                clearTimeout(timer)
+                this.awaits.delete(key)
+                const reason = describeAbortReason(options.signal)
+                safeMetric(() => metrics?.onAbort?.(sessionId, requestId, reason))
+                reject(new SessionBusAbortedError(reason))
+            }
+
+            if (options.signal !== undefined) {
+                if (options.signal.aborted) {
+                    abortHandler()
+                    return
+                }
+                options.signal.addEventListener('abort', abortHandler, { once: true })
+            }
+
+            this.awaits.set(key, {
+                resolve: (payload: unknown) => {
+                    clearTimeout(timer)
+                    options.signal?.removeEventListener('abort', abortHandler)
+                    safeMetric(() => metrics?.onResolve?.(sessionId, requestId, Date.now() - startedAt))
+                    resolve(payload as T)
+                },
+                reject: (err: Error) => {
+                    clearTimeout(timer)
+                    options.signal?.removeEventListener('abort', abortHandler)
+                    reject(err)
+                },
+            })
+        })
+    }
+
+    deliver(sessionId: string, requestId: string | number, payload: unknown): Promise<void> {
+        const key = buildKey(sessionId, requestId)
+        const parked = this.awaits.get(key)
+        if (parked !== undefined) {
+            this.awaits.delete(key)
+            parked.resolve(payload)
+            return Promise.resolve()
+        }
+        // No awaiter yet — hold the payload briefly so a slightly-late awaiter
+        // can still pick it up. Mirrors the Redis TTL on the writer side.
+        const existing = this.earlyDeliveries.get(key)
+        if (existing !== undefined) {
+            clearTimeout(existing.cleanupTimer)
+        }
+        const expiresAt = Date.now() + EARLY_DELIVERY_TTL_MS
+        const cleanupTimer = setTimeout(() => {
+            this.earlyDeliveries.delete(key)
+        }, EARLY_DELIVERY_TTL_MS)
+        // unref so tests don't hang on the timer
+        cleanupTimer.unref?.()
+        this.earlyDeliveries.set(key, { payload, expiresAt, cleanupTimer })
+        return Promise.resolve()
+    }
+
+    /** Drain all parked awaits with the given reason. Used in shutdown. */
+    abortAll(reason: string): void {
+        for (const [key, parked] of this.awaits.entries()) {
+            this.awaits.delete(key)
+            parked.reject(new SessionBusAbortedError(reason))
+        }
+        for (const [key, delivery] of this.earlyDeliveries.entries()) {
+            clearTimeout(delivery.cleanupTimer)
+            this.earlyDeliveries.delete(key)
+        }
+    }
+
+    /** Test helper — count parked awaits. Not part of the public interface. */
+    parkedCount(): number {
+        return this.awaits.size
+    }
+}
+
+function buildKey(_sessionId: string, requestId: string | number): string {
+    // Mirror the Redis impl — key by the JSONRPC request id alone. See the
+    // longer note in `redis-polling-bus.ts#buildKey`.
+    return `${requestId}`
+}
+
+function describeAbortReason(signal: AbortSignal | undefined): string {
+    if (signal === undefined) {
+        return 'unknown'
+    }
+    const reason = (signal as AbortSignal & { reason?: unknown }).reason
+    if (reason instanceof Error) {
+        return reason.message
+    }
+    if (typeof reason === 'string') {
+        return reason
+    }
+    return 'aborted'
+}
+
+function safeMetric(fn: () => void): void {
+    try {
+        fn()
+    } catch {
+        // Metrics hooks must never affect the bus.
+    }
+}

--- a/services/mcp/src/hono/session-bus/index.ts
+++ b/services/mcp/src/hono/session-bus/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Public API for the Hono session-response bus.
+ *
+ * Import from `@/hono/session-bus` rather than reaching into individual
+ * files — these exports are the supported surface; everything else is an
+ * implementation detail and can change.
+ */
+
+export { SessionBusAbortedError, SessionBusTimeoutError, SessionBusUnhealthyError } from './errors'
+
+export type { AwaitOptions, BusAwaitMetrics, SessionResponseBus } from './types'
+
+export { InMemorySessionResponseBus } from './in-memory-bus'
+
+export { RedisPollingSessionResponseBus, type RedisPollingSessionResponseBusOptions } from './redis-polling-bus'
+
+export {
+    DEFAULT_ADAPTIVE_POLL_CONFIG,
+    createAdaptivePollSchedule,
+    type AdaptivePollConfig,
+    type AdaptivePollSchedule,
+} from './adaptive-poll'
+
+export {
+    ElicitationGateway,
+    type ElicitationGatewayOptions,
+    type ElicitCallOptions,
+    type JsonRpcRequestMessage,
+    type TransportMessageSender,
+} from './elicitation-gateway'
+
+export { validateElicitResult } from './elicit-result-validator'
+
+export { createPromBusMetrics } from './prom-metrics'

--- a/services/mcp/src/hono/session-bus/prom-metrics.ts
+++ b/services/mcp/src/hono/session-bus/prom-metrics.ts
@@ -1,0 +1,33 @@
+/**
+ * Concrete `BusAwaitMetrics` implementation backed by the same `prom-client`
+ * registry the rest of the Hono server publishes to.
+ *
+ * Stays in this file (not in `metrics.ts`) so the bus stays a self-contained
+ * module — anyone importing from `@/hono/session-bus` only pulls in the
+ * abstraction, not the Prometheus dependency. Hono bootstrap wires this
+ * adapter explicitly.
+ */
+
+import { sessionBusAwaitDurationSeconds, sessionBusAwaitsTotal, sessionBusPollsTotal } from '../metrics'
+import type { BusAwaitMetrics } from './types'
+
+export function createPromBusMetrics(): BusAwaitMetrics {
+    return {
+        onPoll() {
+            sessionBusPollsTotal.inc()
+        },
+        onResolve(_sessionId, _requestId, latencyMs) {
+            sessionBusAwaitsTotal.inc({ outcome: 'resolved' })
+            sessionBusAwaitDurationSeconds.observe({ outcome: 'resolved' }, latencyMs / 1000)
+        },
+        onTimeout() {
+            sessionBusAwaitsTotal.inc({ outcome: 'timeout' })
+        },
+        onAbort() {
+            sessionBusAwaitsTotal.inc({ outcome: 'aborted' })
+        },
+        onUnhealthy() {
+            sessionBusAwaitsTotal.inc({ outcome: 'unhealthy' })
+        },
+    }
+}

--- a/services/mcp/src/hono/session-bus/redis-polling-bus.ts
+++ b/services/mcp/src/hono/session-bus/redis-polling-bus.ts
@@ -1,0 +1,228 @@
+/**
+ * Production `SessionResponseBus` for the Hono deployment.
+ *
+ * Uses two of the simplest Redis primitives — `SET … EX` and `GET`/`DEL` —
+ * to bridge a parked promise on one pod with a delivered response on (possibly)
+ * another. No pub/sub, no second client, no extension to `RedisLike`.
+ *
+ * Why polling and not pub/sub:
+ * 1. Polling only happens while a confirmation modal is open — a tiny,
+ *    bursty population. At our scale the steady-state Redis traffic is
+ *    indistinguishable from idle.
+ * 2. The `RedisLike` interface in this service is intentionally minimal
+ *    (`get`/`set`/`del`/`scan`). Adding pub/sub means a second connection
+ *    and a wider interface for a sub-100ms latency win that doesn't matter
+ *    here.
+ * 3. Polling fails open in a useful way: a Redis blip causes the next poll
+ *    to retry, not a dropped subscription requiring resubscribe-and-recover
+ *    bookkeeping.
+ *
+ * If the elicit-latency profile ever changes (e.g. high-frequency
+ * automated confirmations), swap to a `PubSubSessionResponseBus` behind
+ * the same interface — call sites won't change.
+ */
+
+import type { RedisLike } from '@/hono/cache/RedisCache'
+
+import { createAdaptivePollSchedule, type AdaptivePollSchedule, DEFAULT_ADAPTIVE_POLL_CONFIG } from './adaptive-poll'
+import { SessionBusAbortedError, SessionBusTimeoutError, SessionBusUnhealthyError } from './errors'
+import type { AwaitOptions, BusAwaitMetrics, SessionResponseBus } from './types'
+
+/** Default TTL on stored response payloads. Long enough to bridge the slowest
+ *  realistic awaiter cycle (1s polling + jitter), short enough to keep Redis
+ *  clean of abandoned responses. */
+const DEFAULT_RESPONSE_TTL_SECONDS = 60
+
+/** Maximum consecutive Redis errors before the await gives up with
+ *  `SessionBusUnhealthyError`. Lower than typical infra retry budgets — we'd
+ *  rather fail closed quickly than keep a human waiting on a broken bus. */
+const DEFAULT_MAX_CONSECUTIVE_ERRORS = 5
+
+/** Namespace for all session-response keys. Keep it greppable and
+ *  stable — `redis-cli --scan --pattern "mcp:session-response:*"` is a
+ *  load-bearing debugging tool. */
+const KEY_PREFIX = 'mcp:session-response'
+
+export interface RedisPollingSessionResponseBusOptions {
+    /** Polling cadence schedule. Defaults to the adaptive default. */
+    schedule?: AdaptivePollSchedule
+    /** TTL on each delivered response, in seconds. Defaults to 60s. */
+    responseTtlSeconds?: number
+    /** Maximum consecutive Redis errors tolerated before failing the await. */
+    maxConsecutiveErrors?: number
+}
+
+export class RedisPollingSessionResponseBus implements SessionResponseBus {
+    private readonly schedule: AdaptivePollSchedule
+    private readonly responseTtlSeconds: number
+    private readonly maxConsecutiveErrors: number
+
+    constructor(
+        private readonly redis: RedisLike,
+        options: RedisPollingSessionResponseBusOptions = {}
+    ) {
+        this.schedule = options.schedule ?? createAdaptivePollSchedule(DEFAULT_ADAPTIVE_POLL_CONFIG)
+        this.responseTtlSeconds = options.responseTtlSeconds ?? DEFAULT_RESPONSE_TTL_SECONDS
+        this.maxConsecutiveErrors = options.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS
+    }
+
+    async await<T>(sessionId: string, requestId: string | number, options: AwaitOptions): Promise<T> {
+        const key = buildKey(sessionId, requestId)
+        const startedAt = Date.now()
+        const deadline = startedAt + options.timeoutMs
+        const metrics: BusAwaitMetrics | undefined = options.metrics
+        safeMetric(() => metrics?.onAwaitStart?.(sessionId, requestId))
+
+        if (options.signal?.aborted === true) {
+            const reason = describeAbortReason(options.signal)
+            safeMetric(() => metrics?.onAbort?.(sessionId, requestId, reason))
+            throw new SessionBusAbortedError(reason)
+        }
+
+        let consecutiveErrors = 0
+
+        // Single poll loop — short, deliberately stateless between iterations.
+        // All early-exit conditions live in `checkExit`.
+        while (true) {
+            const exit = checkExit(deadline, options.signal)
+            if (exit !== null) {
+                if (exit.kind === 'timeout') {
+                    safeMetric(() => metrics?.onTimeout?.(sessionId, requestId))
+                    throw new SessionBusTimeoutError(sessionId, requestId, options.timeoutMs)
+                }
+                safeMetric(() => metrics?.onAbort?.(sessionId, requestId, exit.reason))
+                throw new SessionBusAbortedError(exit.reason)
+            }
+
+            safeMetric(() => metrics?.onPoll?.(sessionId, requestId))
+
+            let raw: string | null
+            try {
+                raw = await this.redis.get(key)
+                consecutiveErrors = 0
+            } catch (error) {
+                consecutiveErrors++
+                if (consecutiveErrors >= this.maxConsecutiveErrors) {
+                    safeMetric(() => metrics?.onUnhealthy?.(sessionId, requestId, error))
+                    throw new SessionBusUnhealthyError(
+                        `Redis GET failed ${consecutiveErrors} consecutive times for session=${sessionId} request=${requestId}`,
+                        { cause: error }
+                    )
+                }
+                // Fall through to sleep-and-retry — a transient Redis blip
+                // shouldn't break a 5-minute human-interactive await.
+                raw = null
+            }
+
+            if (raw !== null) {
+                // Deliver-then-DEL gives one-shot semantics. Best-effort: a
+                // failed DEL just lets the value linger until its TTL expires.
+                this.redis.del(key).catch(() => {
+                    /* swallow */
+                })
+                safeMetric(() => metrics?.onResolve?.(sessionId, requestId, Date.now() - startedAt))
+                return parsePayload<T>(raw)
+            }
+
+            const elapsedMs = Date.now() - startedAt
+            const remainingMs = deadline - Date.now()
+            const cadence = this.schedule.nextDelay(elapsedMs)
+            const sleepMs = Math.max(0, Math.min(cadence, remainingMs))
+            if (sleepMs > 0) {
+                await sleepWithAbort(sleepMs, options.signal)
+            }
+        }
+    }
+
+    async deliver(sessionId: string, requestId: string | number, payload: unknown): Promise<void> {
+        const key = buildKey(sessionId, requestId)
+        const value = JSON.stringify(payload)
+        // `SET key value EX seconds` — TTL guarantees abandoned responses
+        // self-clean. Last-writer-wins is fine; the await reads exactly once.
+        try {
+            await this.redis.set(key, value, 'EX', this.responseTtlSeconds)
+        } catch (error) {
+            throw new SessionBusUnhealthyError(`Redis SET failed for session=${sessionId} request=${requestId}`, {
+                cause: error,
+            })
+        }
+    }
+}
+
+interface ExitTimeout {
+    kind: 'timeout'
+}
+interface ExitAborted {
+    kind: 'aborted'
+    reason: string
+}
+
+function checkExit(deadline: number, signal: AbortSignal | undefined): ExitTimeout | ExitAborted | null {
+    if (signal?.aborted === true) {
+        return { kind: 'aborted', reason: describeAbortReason(signal) }
+    }
+    if (Date.now() >= deadline) {
+        return { kind: 'timeout' }
+    }
+    return null
+}
+
+function parsePayload<T>(raw: string): T {
+    try {
+        return JSON.parse(raw) as T
+    } catch (error) {
+        throw new SessionBusUnhealthyError(
+            `Stored response payload was not valid JSON. The bus contract requires JSON-serializable payloads.`,
+            { cause: error }
+        )
+    }
+}
+
+function buildKey(_sessionId: string, requestId: string | number): string {
+    // The JSONRPC request id is globally unique (UUID for server-initiated
+    // requests), so it alone suffices as the correlation key. The session id
+    // is accepted for API symmetry but intentionally not part of the key:
+    // clients (notably MCP Inspector) don't reliably echo `Mcp-Session-Id`
+    // across the request that triggered the elicit and the request that
+    // delivers its response, so requiring session-level correlation would
+    // strand legitimate replies.
+    return `${KEY_PREFIX}:${requestId}`
+}
+
+async function sleepWithAbort(ms: number, signal: AbortSignal | undefined): Promise<void> {
+    return await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+            signal?.removeEventListener('abort', onAbort)
+            resolve()
+        }, ms)
+        const onAbort = (): void => {
+            clearTimeout(timer)
+            resolve() // resolve, not reject — the outer loop checks `signal.aborted` next.
+        }
+        if (signal !== undefined) {
+            signal.addEventListener('abort', onAbort, { once: true })
+        }
+    })
+}
+
+function describeAbortReason(signal: AbortSignal | undefined): string {
+    if (signal === undefined) {
+        return 'unknown'
+    }
+    const reason = (signal as AbortSignal & { reason?: unknown }).reason
+    if (reason instanceof Error) {
+        return reason.message
+    }
+    if (typeof reason === 'string') {
+        return reason
+    }
+    return 'aborted'
+}
+
+function safeMetric(fn: () => void): void {
+    try {
+        fn()
+    } catch {
+        /* metrics must never affect bus behavior */
+    }
+}

--- a/services/mcp/src/hono/session-bus/types.ts
+++ b/services/mcp/src/hono/session-bus/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Session-keyed response bus — the abstraction over cross-pod delivery of
+ * server-initiated MCP request responses (elicitation, sampling, roots/list).
+ *
+ * The bus knows nothing about MCP itself. Its only job is to hold a parked
+ * promise on one process until some other process (possibly the same one)
+ * publishes a response keyed by `(sessionId, requestId)`. Higher layers map
+ * that primitive onto MCP-specific flows.
+ *
+ * Implementations:
+ * - `InMemorySessionResponseBus` — single-process, used in tests and as the
+ *   reference implementation.
+ * - `RedisPollingSessionResponseBus` — Redis-backed polling for multi-pod
+ *   Hono deployments. The default in production.
+ *
+ * The interface intentionally avoids exposing the transport (HTTP, SSE,
+ * pub/sub, polling, …). Swapping the implementation requires no changes at
+ * call sites; this is the load-bearing seam of the design.
+ */
+
+export interface SessionResponseBus {
+    /**
+     * Block until a response for `(sessionId, requestId)` is delivered, or
+     * until `options.timeoutMs` elapses, or `options.signal` is aborted.
+     *
+     * Resolves at most once. The bus deletes any underlying state once the
+     * promise resolves (one-shot semantics — replay attempts after resolution
+     * find nothing).
+     *
+     * Throws:
+     * - `SessionBusTimeoutError` when the deadline elapses with no response.
+     * - `SessionBusAbortedError` when `options.signal` aborts before a
+     *   response arrives.
+     * - `SessionBusUnhealthyError` when the underlying transport is failing
+     *   in a way the bus cannot recover from (e.g. Redis unreachable). Always
+     *   wraps the original cause via `.cause`.
+     */
+    await<T>(sessionId: string, requestId: string | number, options: AwaitOptions): Promise<T>
+
+    /**
+     * Make a response payload available to whichever process is awaiting it.
+     *
+     * Idempotent within the TTL window: calling twice with the same key
+     * overwrites the stored payload. The awaiting promise resolves on the
+     * first observation; subsequent deliveries are no-ops by virtue of the
+     * one-shot read semantics on the await side.
+     *
+     * `payload` is stored opaquely. Validation belongs to the caller of
+     * `await`, not the bus.
+     */
+    deliver(sessionId: string, requestId: string | number, payload: unknown): Promise<void>
+}
+
+export interface AwaitOptions {
+    /** Hard deadline in milliseconds. Required — there is no implicit default. */
+    timeoutMs: number
+    /** Optional abort signal — fires `SessionBusAbortedError` when triggered. */
+    signal?: AbortSignal
+    /** Optional metrics hook — see `BusAwaitMetrics`. */
+    metrics?: BusAwaitMetrics
+}
+
+/**
+ * Observation hooks for the await lifecycle. All methods are optional and
+ * synchronous; exceptions thrown from them are caught and logged but do not
+ * affect the bus's behavior.
+ *
+ * Provide a concrete implementation (Prometheus, statsd, PostHog analytics,
+ * etc.) when wiring the bus. The default in tests and dev is a no-op.
+ */
+export interface BusAwaitMetrics {
+    /** Called once at the start of each `await` invocation. */
+    onAwaitStart?(sessionId: string, requestId: string | number): void
+
+    /** Called on each underlying poll attempt (no-op in non-polling impls). */
+    onPoll?(sessionId: string, requestId: string | number): void
+
+    /** Called once when the await resolves with a payload. `latencyMs` is the
+     *  time from `await` invocation to resolution. */
+    onResolve?(sessionId: string, requestId: string | number, latencyMs: number): void
+
+    /** Called when the await deadline expires with no response. */
+    onTimeout?(sessionId: string, requestId: string | number): void
+
+    /** Called when an `AbortSignal` cuts the await short. */
+    onAbort?(sessionId: string, requestId: string | number, reason: string): void
+
+    /** Called when the underlying transport fails irrecoverably. */
+    onUnhealthy?(sessionId: string, requestId: string | number, cause: unknown): void
+}

--- a/services/mcp/src/hono/streamable-handler.ts
+++ b/services/mcp/src/hono/streamable-handler.ts
@@ -4,12 +4,37 @@ import type { Lifecycle } from './app'
 import type { RedisLike } from './cache/RedisCache'
 import { HonoMcpServer } from './mcp-server'
 import { authenticateAndParse, handleCatchError, passThrough } from './request-utils'
+import type { BusAwaitMetrics, JsonRpcRequestMessage, SessionResponseBus, TransportMessageSender } from './session-bus'
 import type { HonoCtx } from './types'
 
+/**
+ * Streamable-HTTP entry point for MCP requests.
+ *
+ * Responsibilities:
+ *
+ * 1. **Inbound request handling** — `tools/call`, `initialize`, etc. flow
+ *    through `transport.handleRequest()` as usual. Each request gets a
+ *    fresh `HonoMcpServer` + transport; that's the existing pattern and
+ *    is unchanged.
+ *
+ * 2. **Inbound response routing (new)** — when the client POSTs a
+ *    server-initiated request's response (today: an elicitation response),
+ *    the body is a JSONRPC response shape rather than a request. We detect
+ *    that, route the payload to whichever pod is awaiting it via the
+ *    {@link SessionResponseBus}, and short-circuit with 202 — the SDK
+ *    transport never sees these.
+ *
+ * The body is read once, classified, then re-supplied to the transport via
+ * a fresh `Request` if it turns out to be a request. The classification is
+ * cheap and avoids the alternative (multiple transports peeking at the
+ * stream or hacking the SDK's response correlation).
+ */
 export class StreamableMcpHandler {
     constructor(
         private readonly redis: RedisLike,
-        private readonly lifecycle: Lifecycle
+        private readonly lifecycle: Lifecycle,
+        private readonly sessionBus: SessionResponseBus,
+        private readonly busMetrics?: BusAwaitMetrics
     ) {}
 
     fetch = async (c: HonoCtx): Promise<Response> => {
@@ -25,14 +50,140 @@ export class StreamableMcpHandler {
             return auth.error
         }
 
+        // Read the body once. We need to classify it before we know whether to
+        // hand it to the SDK transport or to the session bus.
+        let bodyText: string
         try {
-            const mcpServer = new HonoMcpServer(this.redis, auth.props)
+            bodyText = await c.req.raw.clone().text()
+        } catch (error) {
+            return handleCatchError(error, auth.props)
+        }
+
+        const sessionId = extractOrCreateSessionId(c)
+        const classification = classifyBody(bodyText)
+
+        if (classification.kind === 'response') {
+            // Server-initiated request's response coming back from the client.
+            // Route it across pods via the bus; never touches the SDK.
+            try {
+                await this.sessionBus.deliver(sessionId, classification.id, classification.payload)
+            } catch (error) {
+                return handleCatchError(error, auth.props)
+            }
+            return new Response(null, { status: 202 })
+        }
+
+        try {
+            const serverOptions: {
+                sessionBus: SessionResponseBus
+                sessionId: string
+                busMetrics?: BusAwaitMetrics
+            } = {
+                sessionBus: this.sessionBus,
+                sessionId,
+            }
+            if (this.busMetrics !== undefined) {
+                serverOptions.busMetrics = this.busMetrics
+            }
+            const mcpServer = new HonoMcpServer(this.redis, auth.props, serverOptions)
+            mcpServer.bindAbortSignal(c.req.raw.signal)
             await mcpServer.init()
+
+            // We do NOT set `sessionIdGenerator` on the SDK transport — its
+            // session management is per-instance and we create a fresh
+            // transport per request, so it would treat every follow-up call
+            // as an uninitialized session. Our `sessionId` lives outside the
+            // SDK: clients echo it via `Mcp-Session-Id` and we use it
+            // strictly as a session-bus key.
             const transport = new WebStandardStreamableHTTPServerTransport({})
+            mcpServer.bindTransportSender(buildTransportSender(transport))
+
             await mcpServer.server.connect(transport)
-            return passThrough(await transport.handleRequest(c.req.raw))
+            const response = await passThrough(await transport.handleRequest(c.req.raw))
+            // Surface the session id to the client on its first response so it
+            // can echo it back via `Mcp-Session-Id` on subsequent requests.
+            response.headers.set('Mcp-Session-Id', sessionId)
+            return response
         } catch (error) {
             return handleCatchError(error, auth.props)
         }
     }
 }
+
+/**
+ * Build a {@link TransportMessageSender} that wraps the SDK transport's send
+ * method. Used by the elicitation gateway to push outbound JSONRPC messages
+ * over the active SSE channel without going through the SDK's request
+ * correlation (which is per-process and wouldn't survive a cross-pod
+ * response).
+ */
+function buildTransportSender(transport: WebStandardStreamableHTTPServerTransport): TransportMessageSender {
+    return {
+        async send(message: JsonRpcRequestMessage, options): Promise<void> {
+            // Streamable HTTP transports route server-initiated messages over
+            // the SSE channel of the related inbound request — `relatedRequestId`
+            // tells the SDK which channel to use. Omitting it causes the message
+            // to fall through to the (rarely-subscribed) standalone GET stream.
+            const sendOptions =
+                options?.relatedRequestId !== undefined ? { relatedRequestId: options.relatedRequestId } : undefined
+            await transport.send(message as never, sendOptions)
+        },
+    }
+}
+
+/**
+ * Read the `Mcp-Session-Id` request header. If absent, generate a new one.
+ *
+ * Echoing the freshly-generated id back on the response is the streamable
+ * handler's responsibility — see `fetch()`.
+ */
+function extractOrCreateSessionId(c: HonoCtx): string {
+    const fromHeader = c.req.header('Mcp-Session-Id') ?? c.req.header('mcp-session-id')
+    if (fromHeader && fromHeader.trim().length > 0) {
+        return fromHeader.trim()
+    }
+    return crypto.randomUUID()
+}
+
+type BodyClassification = { kind: 'request' } | { kind: 'response'; id: string | number; payload: unknown }
+
+/**
+ * Decide whether the inbound body is a JSONRPC **response** (server-initiated
+ * request's reply, e.g. an elicit result) or a **request** (everything else).
+ *
+ * Returns `{ kind: 'request' }` for anything ambiguous or malformed — the SDK
+ * transport already has rigorous JSONRPC validation, so we keep this peek
+ * intentionally conservative: only short-circuit when we're certain.
+ */
+function classifyBody(bodyText: string): BodyClassification {
+    if (bodyText.trim().length === 0) {
+        return { kind: 'request' }
+    }
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(bodyText)
+    } catch {
+        return { kind: 'request' }
+    }
+
+    // Streamable HTTP allows batching — handle the single-message common case
+    // here; batched arrays fall through to the SDK, which already supports them.
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { kind: 'request' }
+    }
+
+    const message = parsed as Record<string, unknown>
+    const id = message.id
+    const hasResult = 'result' in message
+    const hasError = 'error' in message
+    const hasMethod = 'method' in message
+
+    // JSONRPC response: id present, has result or error, no method.
+    const isResponse = !hasMethod && (hasResult || hasError) && (typeof id === 'string' || typeof id === 'number')
+    if (!isResponse) {
+        return { kind: 'request' }
+    }
+    const payload = hasError ? { error: message.error } : message.result
+    return { kind: 'response', id: id as string | number, payload }
+}
+// trigger rebuild 1779467266

--- a/services/mcp/src/lib/confirm-action.ts
+++ b/services/mcp/src/lib/confirm-action.ts
@@ -8,9 +8,14 @@ export class ConfirmationDeclinedError extends Error {
 }
 
 export class ConfirmationUnsupportedError extends Error {
-    constructor(message: string) {
+    constructor(message: string, options?: { cause?: unknown }) {
         super(message)
         this.name = 'ConfirmationUnsupportedError'
+        if (options?.cause !== undefined) {
+            // Assigned manually to stay compatible with TS libs that don't surface the
+            // ES2022 `Error(message, { cause })` constructor signature.
+            ;(this as Error & { cause?: unknown }).cause = options.cause
+        }
     }
 }
 
@@ -43,7 +48,8 @@ export async function confirmAction(context: Context, input: ConfirmActionInput)
     } catch (error) {
         const reason = error instanceof Error ? error.message : String(error)
         throw new ConfirmationUnsupportedError(
-            `This action requires manual user confirmation via the MCP client, but the client did not respond to an elicitation request (${reason}). Use the PostHog web UI to make this change instead.`
+            `This action requires manual user confirmation via the MCP client, but the elicitation request failed (${reason}). The client may not implement elicitation, or the request failed transiently. Use the PostHog web UI to make this change instead.`,
+            { cause: error }
         )
     }
 

--- a/services/mcp/src/lib/confirm-action.ts
+++ b/services/mcp/src/lib/confirm-action.ts
@@ -1,0 +1,53 @@
+import type { Context } from '@/tools/types'
+
+export class ConfirmationDeclinedError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'ConfirmationDeclinedError'
+    }
+}
+
+export class ConfirmationUnsupportedError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'ConfirmationUnsupportedError'
+    }
+}
+
+export interface ConfirmActionInput {
+    /** Short imperative title shown in the confirmation modal (e.g. "Enforce 2FA for organization"). */
+    title: string
+    /** Long-form description shown to the user — explain what changes and why it matters. */
+    description: string
+}
+
+/**
+ * Block a destructive action behind a manual user confirmation via MCP elicitation.
+ *
+ * Throws `ConfirmationDeclinedError` if the user declines or cancels.
+ * Throws `ConfirmationUnsupportedError` if the client does not implement elicitation —
+ * sensitive actions fail closed when the client cannot show a confirmation UI.
+ */
+export async function confirmAction(context: Context, input: ConfirmActionInput): Promise<void> {
+    const message = `${input.title}\n\n${input.description}`
+
+    let result
+    try {
+        result = await context.elicit({
+            message,
+            requestedSchema: {
+                type: 'object',
+                properties: {},
+            },
+        })
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error)
+        throw new ConfirmationUnsupportedError(
+            `This action requires manual user confirmation via the MCP client, but the client did not respond to an elicitation request (${reason}). Use the PostHog web UI to make this change instead.`
+        )
+    }
+
+    if (result.action !== 'accept') {
+        throw new ConfirmationDeclinedError(`User did not accept the action (${result.action}); no changes were made.`)
+    }
+}

--- a/services/mcp/src/lib/confirmation-builders.ts
+++ b/services/mcp/src/lib/confirmation-builders.ts
@@ -1,0 +1,47 @@
+/**
+ * Confirmation builders — per-tool functions that produce a `{ title, description }`
+ * for the elicitation modal at runtime, using resolved tool params (and optional
+ * server-side data, e.g. fetched entity names).
+ *
+ * Sensitive tools opt in via `confirmation_required: true` + `confirmation_builder: <name>`
+ * in their YAML. The codegen imports the named builder and calls it before invoking
+ * `confirmAction()`. Each builder must be a `(context, params) => Promise<ConfirmActionInput>`.
+ *
+ * Keep these functions narrow: don't perform side effects, don't throw on missing
+ * data — return the best human-readable message you can. The builder runs before
+ * the actual destructive request, so it must be safe to call even on declined paths.
+ */
+
+import type { Schemas } from '@/api/generated'
+import type { ConfirmActionInput } from '@/lib/confirm-action'
+import type { Context } from '@/tools/types'
+
+type Enforce2faParams = {
+    id: string
+    enforce_2fa?: boolean | null | undefined
+}
+
+export async function buildEnforce2faConfirmation(
+    context: Context,
+    params: Enforce2faParams
+): Promise<ConfirmActionInput> {
+    const verb = params.enforce_2fa === true ? 'Enable' : params.enforce_2fa === false ? 'Disable' : 'Clear'
+
+    let orgLabel = params.id
+    try {
+        const org = await context.api.request<Schemas.Organization>({
+            method: 'GET',
+            path: `/api/organizations/${encodeURIComponent(String(params.id))}/`,
+        })
+        if (org?.name && org?.id) {
+            orgLabel = `${org.name} (${org.id})`
+        }
+    } catch {
+        // Fall back to the raw id — surfacing the change is more important than the name lookup.
+    }
+
+    return {
+        title: `${verb} 2FA enforcement`,
+        description: `Action: ${verb} 2FA enforcement\nOrganization: ${orgLabel}`,
+    }
+}

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -1,5 +1,6 @@
 import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 import { McpServer, type ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker-provider.js'
 import guidelines from '@shared/guidelines.md'
 import { McpAgent } from 'agents/mcp'
 import type { z } from 'zod'
@@ -87,7 +88,10 @@ export type RequestProperties = {
 export class MCP extends McpAgent<Env> {
     server = new McpServer(
         { name: 'PostHog', version: '1.0.0' },
-        { instructions: instructionsFormatter.buildV1Instructions() }
+        {
+            instructions: instructionsFormatter.buildV1Instructions(),
+            jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+        }
     )
 
     initialState: State = {
@@ -531,7 +535,7 @@ export class MCP extends McpAgent<Env> {
     async getContext(): Promise<Context> {
         const api = await this.api()
         const stateManager = new StateManager(this.cache, api)
-        const partialContext: Omit<Context, 'trackEvent'> = {
+        const partialContext: Omit<Context, 'trackEvent' | 'elicit'> = {
             api,
             cache: this.cache,
             env: this.env,
@@ -543,7 +547,8 @@ export class MCP extends McpAgent<Env> {
             const analyticsContext = await this.getAnalyticsContextSafe(partialContext)
             await this.trackEvent(event, properties, analyticsContext ? { context: analyticsContext } : undefined)
         }
-        return { ...partialContext, trackEvent }
+        const elicit: Context['elicit'] = (params, options) => this.server.server.elicitInput(params, options)
+        return { ...partialContext, trackEvent, elicit }
     }
 
     async init(): Promise<void> {
@@ -706,7 +711,10 @@ export class MCP extends McpAgent<Env> {
             }
         }
 
-        this.server = new McpServer({ name: 'PostHog', version: '1.0.0' }, { instructions })
+        this.server = new McpServer(
+            { name: 'PostHog', version: '1.0.0' },
+            { instructions, jsonSchemaValidator: new CfWorkerJsonSchemaValidator() }
+        )
 
         // Register prompts and resources
         await Promise.all([

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -1,5 +1,9 @@
 import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 import { McpServer, type ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
+// The SDK's default `AjvJsonSchemaValidator` compiles JSON Schemas via `new Function()`,
+// which Cloudflare Workers' CSP blocks ("Code generation from strings disallowed").
+// That would break `elicitation/create` response validation. Use the Workers-compatible
+// interpreter instead. See https://github.com/modelcontextprotocol/typescript-sdk/issues/689
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker-provider.js'
 import guidelines from '@shared/guidelines.md'
 import { McpAgent } from 'agents/mcp'

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -26,6 +26,7 @@ import {
     UserHomeSettingsRetrieveParams,
 } from '@/generated/platform_features/api'
 import { confirmAction } from '@/lib/confirm-action'
+import { buildEnforce2faConfirmation } from '@/lib/confirmation-builders'
 import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
@@ -343,11 +344,7 @@ const organizationEnforce2faUpdate = (): ToolBase<typeof OrganizationEnforce2faU
     name: 'organization-enforce-2fa-update',
     schema: OrganizationEnforce2faUpdateSchema,
     handler: async (context: Context, params: z.infer<typeof OrganizationEnforce2faUpdateSchema>) => {
-        await confirmAction(context, {
-            title: 'Enforce 2FA for organization',
-            description:
-                'Toggle 2FA enforcement for an organization. The MCP client will show a confirmation modal; the change is only applied if the user accepts.',
-        })
+        await confirmAction(context, await buildEnforce2faConfirmation(context, params))
         const body: Record<string, unknown> = {}
         if (params.enforce_2fa !== undefined) {
             body['enforce_2fa'] = params.enforce_2fa

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -320,6 +320,48 @@ const orgMembersList = (): ToolBase<typeof OrgMembersListSchema, Schemas.Paginat
     },
 })
 
+const OrganizationEnforce2faUpdateSchema = PartialUpdateParams.extend(
+    PartialUpdateBody.omit({
+        name: true,
+        logo_media_id: true,
+        members_can_invite: true,
+        members_can_use_personal_api_keys: true,
+        allow_publicly_shared_resources: true,
+        is_ai_data_processing_approved: true,
+        default_experiment_stats_method: true,
+        default_anonymize_ips: true,
+        default_role_id: true,
+    }).shape
+).extend({
+    id: PartialUpdateParams.shape['id'].describe("Organization ID, or `@current` for the caller's active org."),
+    enforce_2fa: PartialUpdateBody.shape['enforce_2fa'].describe(
+        'True to require 2FA for all members; false to disable; null to clear.'
+    ),
+})
+
+const organizationEnforce2faUpdate = (): ToolBase<typeof OrganizationEnforce2faUpdateSchema, Schemas.Organization> => ({
+    name: 'organization-enforce-2fa-update',
+    schema: OrganizationEnforce2faUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof OrganizationEnforce2faUpdateSchema>) => {
+        await confirmAction(context, {
+            title: 'Enforce 2FA for organization',
+            description:
+                'Toggle 2FA enforcement for an organization. The MCP client will show a confirmation modal; the change is only applied if the user accepts.',
+        })
+        const body: Record<string, unknown> = {}
+        if (params.enforce_2fa !== undefined) {
+            body['enforce_2fa'] = params.enforce_2fa
+        }
+        const result = await context.api.request<Schemas.Organization>({
+            method: 'PATCH',
+            path: `/api/organizations/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        const filtered = pickResponseFields(result, ['id', 'name', 'enforce_2fa']) as typeof result
+        return filtered
+    },
+})
+
 const OrganizationGetSchema = RetrieveParams.extend({
     id: RetrieveParams.shape['id'].describe('Organization ID. If omitted, uses the active organization.').optional(),
 })
@@ -378,48 +420,6 @@ const organizationsList = (): ToolBase<
             ),
         } as typeof result
         return await withPostHogUrl(context, filtered, '/')
-    },
-})
-
-const OrganizationEnforce2faUpdateSchema = PartialUpdateParams.extend(
-    PartialUpdateBody.omit({
-        name: true,
-        logo_media_id: true,
-        members_can_invite: true,
-        members_can_use_personal_api_keys: true,
-        allow_publicly_shared_resources: true,
-        is_ai_data_processing_approved: true,
-        default_experiment_stats_method: true,
-        default_anonymize_ips: true,
-        default_role_id: true,
-    }).shape
-).extend({
-    id: PartialUpdateParams.shape['id'].describe("Organization ID, or `@current` for the caller's active org."),
-    enforce_2fa: PartialUpdateBody.shape['enforce_2fa'].describe(
-        'True to require 2FA for all members; false to disable; null to clear.'
-    ),
-})
-
-const organizationEnforce2faUpdate = (): ToolBase<typeof OrganizationEnforce2faUpdateSchema, Schemas.Organization> => ({
-    name: 'organization-enforce-2fa-update',
-    schema: OrganizationEnforce2faUpdateSchema,
-    handler: async (context: Context, params: z.infer<typeof OrganizationEnforce2faUpdateSchema>) => {
-        await confirmAction(context, {
-            title: 'Enforce 2FA for organization',
-            description:
-                'Toggle 2FA enforcement for an organization. The MCP client will show a confirmation modal; the change is only applied if the user accepts.',
-        })
-        const body: Record<string, unknown> = {}
-        if (params.enforce_2fa !== undefined) {
-            body['enforce_2fa'] = params.enforce_2fa
-        }
-        const result = await context.api.request<Schemas.Organization>({
-            method: 'PATCH',
-            path: `/api/organizations/${encodeURIComponent(String(params.id))}/`,
-            body,
-        })
-        const filtered = pickResponseFields(result, ['id', 'name', 'enforce_2fa']) as typeof result
-        return filtered
     },
 })
 
@@ -537,9 +537,9 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'comment-thread': commentThread,
     'comments-list': commentsList,
     'org-members-list': orgMembersList,
+    'organization-enforce-2fa-update': organizationEnforce2faUpdate,
     'organization-get': organizationGet,
     'organizations-list': organizationsList,
-    'organization-enforce-2fa-update': organizationEnforce2faUpdate,
     'role-get': roleGet,
     'role-members-list': roleMembersList,
     'roles-list': rolesList,

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -14,6 +14,8 @@ import {
     CommentsThreadRetrieveParams,
     ListQueryParams,
     MembersListQueryParams,
+    PartialUpdateBody,
+    PartialUpdateParams,
     RetrieveParams,
     RolesListQueryParams,
     RolesRetrieveParams,
@@ -23,6 +25,7 @@ import {
     UserHomeSettingsPartialUpdateParams,
     UserHomeSettingsRetrieveParams,
 } from '@/generated/platform_features/api'
+import { confirmAction } from '@/lib/confirm-action'
 import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
@@ -378,6 +381,48 @@ const organizationsList = (): ToolBase<
     },
 })
 
+const OrganizationEnforce2faUpdateSchema = PartialUpdateParams.extend(
+    PartialUpdateBody.omit({
+        name: true,
+        logo_media_id: true,
+        members_can_invite: true,
+        members_can_use_personal_api_keys: true,
+        allow_publicly_shared_resources: true,
+        is_ai_data_processing_approved: true,
+        default_experiment_stats_method: true,
+        default_anonymize_ips: true,
+        default_role_id: true,
+    }).shape
+).extend({
+    id: PartialUpdateParams.shape['id'].describe("Organization ID, or `@current` for the caller's active org."),
+    enforce_2fa: PartialUpdateBody.shape['enforce_2fa'].describe(
+        'True to require 2FA for all members; false to disable; null to clear.'
+    ),
+})
+
+const organizationEnforce2faUpdate = (): ToolBase<typeof OrganizationEnforce2faUpdateSchema, Schemas.Organization> => ({
+    name: 'organization-enforce-2fa-update',
+    schema: OrganizationEnforce2faUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof OrganizationEnforce2faUpdateSchema>) => {
+        await confirmAction(context, {
+            title: 'Enforce 2FA for organization',
+            description:
+                'Toggle 2FA enforcement for an organization. The MCP client will show a confirmation modal; the change is only applied if the user accepts.',
+        })
+        const body: Record<string, unknown> = {}
+        if (params.enforce_2fa !== undefined) {
+            body['enforce_2fa'] = params.enforce_2fa
+        }
+        const result = await context.api.request<Schemas.Organization>({
+            method: 'PATCH',
+            path: `/api/organizations/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        const filtered = pickResponseFields(result, ['id', 'name', 'enforce_2fa']) as typeof result
+        return filtered
+    },
+})
+
 const RoleGetSchema = RolesRetrieveParams.omit({ organization_id: true })
 
 const roleGet = (): ToolBase<typeof RoleGetSchema, Schemas.Role> => ({
@@ -494,6 +539,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'org-members-list': orgMembersList,
     'organization-get': organizationGet,
     'organizations-list': organizationsList,
+    'organization-enforce-2fa-update': organizationEnforce2faUpdate,
     'role-get': roleGet,
     'role-members-list': roleMembersList,
     'roles-list': rolesList,

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -1,3 +1,5 @@
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js'
+import type { ElicitRequestFormParams, ElicitResult } from '@modelcontextprotocol/sdk/types.js'
 import type { z } from 'zod'
 
 import type { ApiClient, GroupType } from '@/api/client'
@@ -92,6 +94,13 @@ export type Context = {
      * stateManager when not provided.
      */
     trackEvent: (event: AnalyticsEvent, properties?: Record<string, unknown>) => Promise<void>
+    /**
+     * Request structured input from the user via the MCP client (e.g. a confirmation modal).
+     * Returns the client's response, including the user's action (`accept`/`decline`/`cancel`)
+     * and any submitted form content. Used by `confirmAction()` to gate destructive operations
+     * behind manual user confirmation. Throws if the client does not implement elicitation.
+     */
+    elicit: (params: ElicitRequestFormParams, options?: RequestOptions) => Promise<ElicitResult>
 }
 
 export type Tool<TSchema extends z.ZodType = z.ZodType, TResult = unknown> = {

--- a/services/mcp/tests/hono/mcp-server.test.ts
+++ b/services/mcp/tests/hono/mcp-server.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { RedisLike } from '@/hono/cache/RedisCache'
 import { HonoMcpServer, type RequestProperties } from '@/hono/mcp-server'
+import { InMemorySessionResponseBus } from '@/hono/session-bus'
 
 interface MockRedis extends RedisLike {
     _store: Map<string, string>
@@ -41,12 +42,18 @@ describe('HonoMcpServer', () => {
 
     describe('constructor', () => {
         it('should create a server instance', () => {
-            const server = new HonoMcpServer(mockRedis, baseProps)
+            const server = new HonoMcpServer(mockRedis, baseProps, {
+                sessionBus: new InMemorySessionResponseBus(),
+                sessionId: 'test-session',
+            })
             expect(server.server).toBeTruthy()
         })
 
         it('should expose requestProperties', () => {
-            const server = new HonoMcpServer(mockRedis, baseProps)
+            const server = new HonoMcpServer(mockRedis, baseProps, {
+                sessionBus: new InMemorySessionResponseBus(),
+                sessionId: 'test-session',
+            })
             expect(server.requestProperties.userHash).toBe('test-hash')
             expect(server.requestProperties.apiToken).toBe('phx_test_token')
         })
@@ -55,14 +62,20 @@ describe('HonoMcpServer', () => {
     describe('getBaseUrl', () => {
         it('should return POSTHOG_API_BASE_URL from env', async () => {
             process.env.POSTHOG_API_BASE_URL = 'https://custom.posthog.com'
-            const server = new HonoMcpServer(mockRedis, baseProps)
+            const server = new HonoMcpServer(mockRedis, baseProps, {
+                sessionBus: new InMemorySessionResponseBus(),
+                sessionId: 'test-session',
+            })
             const url = await server.getBaseUrl()
             expect(url).toBe('https://custom.posthog.com')
         })
 
         it('should default to localhost:8010 in dev when not set', async () => {
             delete process.env.POSTHOG_API_BASE_URL
-            const server = new HonoMcpServer(mockRedis, baseProps)
+            const server = new HonoMcpServer(mockRedis, baseProps, {
+                sessionBus: new InMemorySessionResponseBus(),
+                sessionId: 'test-session',
+            })
             const url = await server.getBaseUrl()
             expect(url).toBe('http://localhost:8010')
         })
@@ -70,19 +83,28 @@ describe('HonoMcpServer', () => {
         it('should throw in production when not set', async () => {
             delete process.env.POSTHOG_API_BASE_URL
             process.env.NODE_ENV = 'production'
-            const server = new HonoMcpServer(mockRedis, baseProps)
+            const server = new HonoMcpServer(mockRedis, baseProps, {
+                sessionBus: new InMemorySessionResponseBus(),
+                sessionId: 'test-session',
+            })
             await expect(server.getBaseUrl()).rejects.toThrow('POSTHOG_API_BASE_URL must be set')
         })
     })
 
     describe('sessionManager', () => {
         it('should return a SessionManager instance', () => {
-            const server = new HonoMcpServer(mockRedis, baseProps)
+            const server = new HonoMcpServer(mockRedis, baseProps, {
+                sessionBus: new InMemorySessionResponseBus(),
+                sessionId: 'test-session',
+            })
             expect(server.sessionManager).toBeTruthy()
         })
 
         it('should return same instance on repeated access', () => {
-            const server = new HonoMcpServer(mockRedis, baseProps)
+            const server = new HonoMcpServer(mockRedis, baseProps, {
+                sessionBus: new InMemorySessionResponseBus(),
+                sessionId: 'test-session',
+            })
             const sm1 = server.sessionManager
             const sm2 = server.sessionManager
             expect(sm1).toBe(sm2)
@@ -91,7 +113,11 @@ describe('HonoMcpServer', () => {
 
     describe('getContext', () => {
         it('should return a context with all required fields', async () => {
-            const server = new HonoMcpServer(mockRedis, { ...baseProps, region: 'us' })
+            const server = new HonoMcpServer(
+                mockRedis,
+                { ...baseProps, region: 'us' },
+                { sessionBus: new InMemorySessionResponseBus(), sessionId: 'test-session' }
+            )
             vi.spyOn(server, 'getBaseUrl').mockResolvedValue('https://us.posthog.com')
             const ctx = await server.getContext()
             expect(ctx.api).toBeTruthy()
@@ -105,7 +131,10 @@ describe('HonoMcpServer', () => {
 
     describe('trackEvent', () => {
         it('should not throw on tracking errors', async () => {
-            const server = new HonoMcpServer(mockRedis, baseProps)
+            const server = new HonoMcpServer(mockRedis, baseProps, {
+                sessionBus: new InMemorySessionResponseBus(),
+                sessionId: 'test-session',
+            })
             vi.spyOn(server, 'getDistinctId').mockRejectedValue(new Error('fail'))
 
             const { AnalyticsEvent } = await import('@/lib/posthog/analytics')
@@ -116,7 +145,10 @@ describe('HonoMcpServer', () => {
     describe('api', () => {
         it('should cache the ApiClient instance', async () => {
             process.env.POSTHOG_API_BASE_URL = 'https://us.posthog.com'
-            const server = new HonoMcpServer(mockRedis, baseProps)
+            const server = new HonoMcpServer(mockRedis, baseProps, {
+                sessionBus: new InMemorySessionResponseBus(),
+                sessionId: 'test-session',
+            })
             const api1 = await server.api()
             const api2 = await server.api()
             expect(api1).toBe(api2)

--- a/services/mcp/tests/hono/session-bus/adaptive-poll.test.ts
+++ b/services/mcp/tests/hono/session-bus/adaptive-poll.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { createAdaptivePollSchedule, DEFAULT_ADAPTIVE_POLL_CONFIG } from '@/hono/session-bus/adaptive-poll'
+
+describe('createAdaptivePollSchedule', () => {
+    it('returns the hot interval during the hot window', () => {
+        const schedule = createAdaptivePollSchedule({
+            hotIntervalMs: 200,
+            coolIntervalMs: 1_000,
+            hotWindowMs: 5_000,
+        })
+        expect(schedule.nextDelay(0)).toBe(200)
+        expect(schedule.nextDelay(2_500)).toBe(200)
+        expect(schedule.nextDelay(4_999)).toBe(200)
+    })
+
+    it('returns the cool interval after the hot window', () => {
+        const schedule = createAdaptivePollSchedule({
+            hotIntervalMs: 200,
+            coolIntervalMs: 1_000,
+            hotWindowMs: 5_000,
+        })
+        expect(schedule.nextDelay(5_000)).toBe(1_000)
+        expect(schedule.nextDelay(60_000)).toBe(1_000)
+    })
+
+    it('treats negative elapsed times as hot (defensive)', () => {
+        const schedule = createAdaptivePollSchedule({
+            hotIntervalMs: 200,
+            coolIntervalMs: 1_000,
+            hotWindowMs: 5_000,
+        })
+        expect(schedule.nextDelay(-1)).toBe(200)
+    })
+
+    it('uses the documented defaults when no config is provided', () => {
+        const schedule = createAdaptivePollSchedule()
+        expect(schedule.nextDelay(0)).toBe(DEFAULT_ADAPTIVE_POLL_CONFIG.hotIntervalMs)
+        expect(schedule.nextDelay(DEFAULT_ADAPTIVE_POLL_CONFIG.hotWindowMs)).toBe(
+            DEFAULT_ADAPTIVE_POLL_CONFIG.coolIntervalMs
+        )
+    })
+
+    it('rejects non-positive intervals', () => {
+        expect(() =>
+            createAdaptivePollSchedule({ hotIntervalMs: 0, coolIntervalMs: 1_000, hotWindowMs: 5_000 })
+        ).toThrow(/positive/)
+        expect(() =>
+            createAdaptivePollSchedule({ hotIntervalMs: 200, coolIntervalMs: -1, hotWindowMs: 5_000 })
+        ).toThrow(/positive/)
+    })
+
+    it('rejects hot interval greater than cool interval', () => {
+        expect(() =>
+            createAdaptivePollSchedule({ hotIntervalMs: 2_000, coolIntervalMs: 1_000, hotWindowMs: 5_000 })
+        ).toThrow(/Hot interval/)
+    })
+})

--- a/services/mcp/tests/hono/session-bus/elicitation-gateway.test.ts
+++ b/services/mcp/tests/hono/session-bus/elicitation-gateway.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ElicitationGateway } from '@/hono/session-bus/elicitation-gateway'
+import type { TransportMessageSender } from '@/hono/session-bus/elicitation-gateway'
+import { SessionBusTimeoutError, SessionBusUnhealthyError } from '@/hono/session-bus/errors'
+import { InMemorySessionResponseBus } from '@/hono/session-bus/in-memory-bus'
+
+function createCapturingSender(): TransportMessageSender & { sent: unknown[] } {
+    const sent: unknown[] = []
+    return {
+        sent,
+        async send(message) {
+            sent.push(message)
+        },
+    }
+}
+
+describe('ElicitationGateway', () => {
+    it('sends a JSONRPC elicitation/create request, then resolves on a matching bus delivery', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const gateway = new ElicitationGateway(bus, sender)
+
+        const sessionId = 'sess-1'
+        const pending = gateway.elicit(sessionId, {
+            message: 'Confirm action',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+
+        // Wait for the gateway to dispatch the message.
+        await new Promise((resolve) => setImmediate(resolve))
+        expect(sender.sent).toHaveLength(1)
+        const sent = sender.sent[0] as { id: string; method: string; jsonrpc: string }
+        expect(sent.method).toBe('elicitation/create')
+        expect(sent.jsonrpc).toBe('2.0')
+        expect(typeof sent.id).toBe('string')
+
+        // Deliver a response on the same key.
+        await bus.deliver(sessionId, sent.id, { action: 'accept', content: {} })
+
+        await expect(pending).resolves.toEqual({ action: 'accept', content: {} })
+    })
+
+    it('passes through SessionBusTimeoutError on deadline', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const gateway = new ElicitationGateway(bus, sender, { defaultTimeoutMs: 25 })
+
+        await expect(
+            gateway.elicit('s', {
+                message: 'x',
+                requestedSchema: { type: 'object', properties: {} },
+            })
+        ).rejects.toBeInstanceOf(SessionBusTimeoutError)
+    })
+
+    it('rejects malformed elicit payloads with SessionBusUnhealthyError', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const gateway = new ElicitationGateway(bus, sender)
+
+        const pending = gateway.elicit('s', {
+            message: 'x',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+
+        await new Promise((resolve) => setImmediate(resolve))
+        const sent = sender.sent[0] as { id: string }
+        await bus.deliver('s', sent.id, { not: 'a valid ElicitResult' })
+
+        await expect(pending).rejects.toBeInstanceOf(SessionBusUnhealthyError)
+    })
+
+    it('forwards the AbortSignal to the bus', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const gateway = new ElicitationGateway(bus, sender)
+
+        const controller = new AbortController()
+        const pending = gateway.elicit(
+            's',
+            { message: 'x', requestedSchema: { type: 'object', properties: {} } },
+            { signal: controller.signal }
+        )
+
+        controller.abort()
+        await expect(pending).rejects.toThrow(/aborted/i)
+    })
+
+    it('emits await-start / resolve metrics via the configured hook', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const sender = createCapturingSender()
+        const startSpy = vi.fn()
+        const resolveSpy = vi.fn()
+        const gateway = new ElicitationGateway(bus, sender, {
+            metrics: { onAwaitStart: startSpy, onResolve: resolveSpy },
+        })
+
+        const pending = gateway.elicit('s', {
+            message: 'x',
+            requestedSchema: { type: 'object', properties: {} },
+        })
+
+        await new Promise((resolve) => setImmediate(resolve))
+        const sent = sender.sent[0] as { id: string }
+        await bus.deliver('s', sent.id, { action: 'cancel' })
+        await pending
+
+        expect(startSpy).toHaveBeenCalledTimes(1)
+        expect(resolveSpy).toHaveBeenCalledTimes(1)
+    })
+})

--- a/services/mcp/tests/hono/session-bus/in-memory-bus.test.ts
+++ b/services/mcp/tests/hono/session-bus/in-memory-bus.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+
+import { SessionBusAbortedError, SessionBusTimeoutError } from '@/hono/session-bus/errors'
+import { InMemorySessionResponseBus } from '@/hono/session-bus/in-memory-bus'
+
+describe('InMemorySessionResponseBus', () => {
+    it('resolves an awaiter when a matching deliver lands', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const pending = bus.await('session-a', 'req-1', { timeoutMs: 1_000 })
+        await bus.deliver('session-a', 'req-1', { action: 'accept' })
+        await expect(pending).resolves.toEqual({ action: 'accept' })
+    })
+
+    it('resolves an awaiter that registers AFTER an early delivery', async () => {
+        const bus = new InMemorySessionResponseBus()
+        await bus.deliver('session-a', 'req-1', { action: 'decline' })
+        await expect(bus.await('session-a', 'req-1', { timeoutMs: 1_000 })).resolves.toEqual({
+            action: 'decline',
+        })
+    })
+
+    it('does not cross deliveries between different request ids', async () => {
+        // The bus correlates by JSONRPC request id alone — sessionId is
+        // accepted for API symmetry but ignored in the key. Document the
+        // actual contract: same requestId resolves regardless of sessionId.
+        const bus = new InMemorySessionResponseBus()
+        const pending = bus.await('session-a', 'req-1', { timeoutMs: 100 })
+        await bus.deliver('session-a', 'req-2', { action: 'accept' })
+        await expect(pending).rejects.toBeInstanceOf(SessionBusTimeoutError)
+    })
+
+    it('resolves regardless of sessionId mismatch (request id is the correlation key)', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const pending = bus.await('session-a', 'req-1', { timeoutMs: 1_000 })
+        await bus.deliver('session-b', 'req-1', { action: 'accept' })
+        await expect(pending).resolves.toEqual({ action: 'accept' })
+    })
+
+    it('times out with SessionBusTimeoutError when no deliver arrives', async () => {
+        const bus = new InMemorySessionResponseBus()
+        await expect(bus.await('s', 'r', { timeoutMs: 25 })).rejects.toBeInstanceOf(SessionBusTimeoutError)
+    })
+
+    it('rejects with SessionBusAbortedError when the signal aborts during await', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const controller = new AbortController()
+        const pending = bus.await('s', 'r', { timeoutMs: 5_000, signal: controller.signal })
+        controller.abort()
+        await expect(pending).rejects.toBeInstanceOf(SessionBusAbortedError)
+    })
+
+    it('rejects immediately if the signal is already aborted before await', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const controller = new AbortController()
+        controller.abort()
+        await expect(bus.await('s', 'r', { timeoutMs: 5_000, signal: controller.signal })).rejects.toBeInstanceOf(
+            SessionBusAbortedError
+        )
+    })
+
+    it('refuses concurrent awaits on the same key', async () => {
+        const bus = new InMemorySessionResponseBus()
+        // Start the first await; intentionally don't await it so it stays parked.
+        void bus.await('s', 'r', { timeoutMs: 1_000 }).catch(() => undefined)
+        await expect(bus.await('s', 'r', { timeoutMs: 1_000 })).rejects.toThrow(/Concurrent await/)
+    })
+
+    it('invokes resolve metric with elapsed latency', async () => {
+        const bus = new InMemorySessionResponseBus()
+        let observedLatency: number | undefined
+        const pending = bus.await('s', 'r', {
+            timeoutMs: 1_000,
+            metrics: { onResolve: (_s, _r, ms) => (observedLatency = ms) },
+        })
+        await bus.deliver('s', 'r', { action: 'accept' })
+        await pending
+        expect(observedLatency).toBeGreaterThanOrEqual(0)
+        expect(observedLatency).toBeLessThan(50)
+    })
+
+    it('invokes timeout metric exactly once on deadline', async () => {
+        const bus = new InMemorySessionResponseBus()
+        let timeouts = 0
+        await expect(
+            bus.await('s', 'r', {
+                timeoutMs: 10,
+                metrics: { onTimeout: () => timeouts++ },
+            })
+        ).rejects.toBeInstanceOf(SessionBusTimeoutError)
+        expect(timeouts).toBe(1)
+    })
+
+    it('aborts all parked awaits on shutdown', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const a = bus.await('s', 'r1', { timeoutMs: 5_000 })
+        const b = bus.await('s', 'r2', { timeoutMs: 5_000 })
+        bus.abortAll('shutdown')
+        await expect(a).rejects.toBeInstanceOf(SessionBusAbortedError)
+        await expect(b).rejects.toBeInstanceOf(SessionBusAbortedError)
+        expect(bus.parkedCount()).toBe(0)
+    })
+
+    it('clears the parked entry after a one-shot deliver', async () => {
+        const bus = new InMemorySessionResponseBus()
+        const pending = bus.await('s', 'r', { timeoutMs: 1_000 })
+        await bus.deliver('s', 'r', { action: 'accept' })
+        await pending
+        expect(bus.parkedCount()).toBe(0)
+    })
+})

--- a/services/mcp/tests/hono/session-bus/redis-polling-bus.test.ts
+++ b/services/mcp/tests/hono/session-bus/redis-polling-bus.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RedisLike } from '@/hono/cache/RedisCache'
+import { createAdaptivePollSchedule } from '@/hono/session-bus/adaptive-poll'
+import { SessionBusAbortedError, SessionBusTimeoutError, SessionBusUnhealthyError } from '@/hono/session-bus/errors'
+import { RedisPollingSessionResponseBus } from '@/hono/session-bus/redis-polling-bus'
+
+interface MockRedis extends RedisLike {
+    _store: Map<string, string>
+    _failNextN: { get: number; set: number }
+}
+
+function createMockRedis(): MockRedis {
+    const store = new Map<string, string>()
+    const failNextN = { get: 0, set: 0 }
+    return {
+        get: vi.fn(async (key: string) => {
+            if (failNextN.get > 0) {
+                failNextN.get--
+                throw new Error('mock redis get failure')
+            }
+            return store.get(key) ?? null
+        }),
+        set: vi.fn(async (key: string, value: string) => {
+            if (failNextN.set > 0) {
+                failNextN.set--
+                throw new Error('mock redis set failure')
+            }
+            store.set(key, value)
+            return 'OK'
+        }),
+        del: vi.fn(async (...keys: string[]) => {
+            let count = 0
+            for (const key of keys) {
+                if (store.delete(key)) {
+                    count++
+                }
+            }
+            return count
+        }),
+        scan: vi.fn(async () => ['0', []] as [string, string[]]),
+        _store: store,
+        _failNextN: failNextN,
+    }
+}
+
+/** Schedule with very short delays so tests don't take seconds. */
+const FAST_SCHEDULE = createAdaptivePollSchedule({
+    hotIntervalMs: 5,
+    coolIntervalMs: 10,
+    hotWindowMs: 50,
+})
+
+describe('RedisPollingSessionResponseBus', () => {
+    let redis: MockRedis
+    let bus: RedisPollingSessionResponseBus
+
+    beforeEach(() => {
+        redis = createMockRedis()
+        bus = new RedisPollingSessionResponseBus(redis, {
+            schedule: FAST_SCHEDULE,
+            responseTtlSeconds: 60,
+        })
+    })
+
+    it('resolves when a deliver lands on the same instance', async () => {
+        const pending = bus.await('s', 'r', { timeoutMs: 1_000 })
+        await bus.deliver('s', 'r', { action: 'accept' })
+        await expect(pending).resolves.toEqual({ action: 'accept' })
+    })
+
+    it('resolves when a deliver writes the underlying key directly', async () => {
+        const pending = bus.await('s', 'r', { timeoutMs: 1_000 })
+        // Simulate a delivery from another pod sharing the same Redis.
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        redis._store.set('mcp:session-response:r', JSON.stringify({ action: 'decline' }))
+        await expect(pending).resolves.toEqual({ action: 'decline' })
+    })
+
+    it('DELs the key after a successful read (one-shot)', async () => {
+        const pending = bus.await('s', 'r', { timeoutMs: 1_000 })
+        await bus.deliver('s', 'r', { action: 'accept' })
+        await pending
+        // Allow the best-effort DEL to flush.
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        expect(redis._store.has('mcp:session-response:r')).toBe(false)
+    })
+
+    it('times out when no deliver arrives within the deadline', async () => {
+        await expect(bus.await('s', 'r', { timeoutMs: 30 })).rejects.toBeInstanceOf(SessionBusTimeoutError)
+    })
+
+    it('aborts immediately when signal is already aborted before await', async () => {
+        const controller = new AbortController()
+        controller.abort()
+        await expect(bus.await('s', 'r', { timeoutMs: 1_000, signal: controller.signal })).rejects.toBeInstanceOf(
+            SessionBusAbortedError
+        )
+    })
+
+    it('aborts mid-poll when signal fires later', async () => {
+        const controller = new AbortController()
+        const pending = bus.await('s', 'r', { timeoutMs: 5_000, signal: controller.signal })
+        setTimeout(() => controller.abort(), 20)
+        await expect(pending).rejects.toBeInstanceOf(SessionBusAbortedError)
+    })
+
+    it('tolerates transient redis errors and eventually resolves', async () => {
+        redis._failNextN.get = 3
+        const pending = bus.await('s', 'r', { timeoutMs: 1_000 })
+        // Deliver after the failing reads.
+        setTimeout(() => {
+            void bus.deliver('s', 'r', { action: 'accept' })
+        }, 60)
+        await expect(pending).resolves.toEqual({ action: 'accept' })
+    })
+
+    it('fails with SessionBusUnhealthyError after consecutive redis errors', async () => {
+        redis._failNextN.get = 99
+        const tightBus = new RedisPollingSessionResponseBus(redis, {
+            schedule: FAST_SCHEDULE,
+            maxConsecutiveErrors: 3,
+        })
+        await expect(tightBus.await('s', 'r', { timeoutMs: 5_000 })).rejects.toBeInstanceOf(SessionBusUnhealthyError)
+    })
+
+    it('treats invalid JSON in stored payload as bus unhealthy', async () => {
+        const pending = bus.await('s', 'r', { timeoutMs: 1_000 })
+        redis._store.set('mcp:session-response:r', '{not-json')
+        await expect(pending).rejects.toBeInstanceOf(SessionBusUnhealthyError)
+    })
+
+    it('translates SET failure into SessionBusUnhealthyError', async () => {
+        redis._failNextN.set = 1
+        await expect(bus.deliver('s', 'r', { action: 'accept' })).rejects.toBeInstanceOf(SessionBusUnhealthyError)
+    })
+
+    it('emits the documented metric signals on the happy path', async () => {
+        const events: string[] = []
+        const pending = bus.await('s', 'r', {
+            timeoutMs: 1_000,
+            metrics: {
+                onAwaitStart: () => events.push('start'),
+                onPoll: () => events.push('poll'),
+                onResolve: () => events.push('resolve'),
+            },
+        })
+        await bus.deliver('s', 'r', { action: 'accept' })
+        await pending
+        expect(events[0]).toBe('start')
+        expect(events).toContain('poll')
+        expect(events[events.length - 1]).toBe('resolve')
+    })
+
+    it('uses adaptive polling cadence (more polls early than late)', async () => {
+        const events: number[] = []
+        const start = Date.now()
+        const pending = bus.await('s', 'r', {
+            timeoutMs: 200,
+            metrics: { onPoll: () => events.push(Date.now() - start) },
+        })
+        await expect(pending).rejects.toBeInstanceOf(SessionBusTimeoutError)
+        expect(events.length).toBeGreaterThan(2)
+    })
+})

--- a/services/mcp/tests/integration/feature-routing.test.ts
+++ b/services/mcp/tests/integration/feature-routing.test.ts
@@ -22,6 +22,7 @@ const createMockContext = (): Context => ({
     sessionManager: new SessionManager({} as any),
     getDistinctId: async () => 'test-distinct-id',
     trackEvent: async () => {},
+    elicit: async () => ({ action: 'accept', content: { confirmed: true } }),
 })
 
 describe('Feature Routing Integration', () => {

--- a/services/mcp/tests/shared/test-utils.ts
+++ b/services/mcp/tests/shared/test-utils.ts
@@ -54,6 +54,7 @@ export function createTestContext(client: ApiClient): Context {
         sessionManager: new SessionManager(cache),
         getDistinctId: async () => 'test-distinct-id',
         trackEvent: async () => {},
+        elicit: async () => ({ action: 'accept', content: { confirmed: true } }),
     }
 
     return context

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/organization-enforce-2fa-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/organization-enforce-2fa-update.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "enforce_2fa": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "True to require 2FA for all members; false to disable; null to clear."
+        },
+        "id": {
+            "description": "Organization ID, or `@current` for the caller's active org.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/custom-tool-handlers.test.ts
+++ b/services/mcp/tests/unit/custom-tool-handlers.test.ts
@@ -13,6 +13,7 @@ function createMockContext(requestMock: ReturnType<typeof vi.fn>): Context {
         cache: {} as any,
         getDistinctId: async () => 'test-distinct-id',
         trackEvent: async () => {},
+        elicit: vi.fn().mockResolvedValue({ action: 'accept', content: { confirmed: true } }),
     }
 }
 

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -387,6 +387,7 @@ describe('exec tool', () => {
                 sessionManager: new SessionManager({} as any),
                 getDistinctId: async () => 'test-distinct-id',
                 trackEvent: async () => {},
+                elicit: async () => ({ action: 'accept', content: { confirmed: true } }),
             }
         }
 

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -256,6 +256,7 @@ const createMockContext = (scopes: string[]): Context => ({
     sessionManager: new SessionManager({} as any),
     getDistinctId: async () => 'test-distinct-id',
     trackEvent: async () => {},
+    elicit: async () => ({ action: 'accept', content: { confirmed: true } }),
 })
 
 describe('Tool Filtering - API Scopes', () => {
@@ -488,6 +489,7 @@ describe('Tool Filtering - AI Consent', () => {
             sessionManager: new SessionManager({} as any),
             getDistinctId: async () => 'test-distinct-id',
             trackEvent: async () => {},
+            elicit: async () => ({ action: 'accept', content: { confirmed: true } }),
         }
         const tools = await getToolsFromContext(context)
         const toolNames = tools.map((t) => t.name)
@@ -514,6 +516,7 @@ describe('Tool Filtering - AI Consent', () => {
             sessionManager: new SessionManager({} as any),
             getDistinctId: async () => 'test-distinct-id',
             trackEvent: async () => {},
+            elicit: async () => ({ action: 'accept', content: { confirmed: true } }),
         }
         const tools = await getToolsFromContext(context)
         const toolNames = tools.map((t) => t.name)

--- a/services/mcp/tests/unit/tool-schema-snapshots.test.ts
+++ b/services/mcp/tests/unit/tool-schema-snapshots.test.ts
@@ -28,6 +28,7 @@ function createMockContext(): Context {
         sessionManager: new SessionManager({} as any),
         getDistinctId: async () => 'test-distinct-id',
         trackEvent: async () => {},
+        elicit: async () => ({ action: 'accept', content: { confirmed: true } }),
     }
 }
 


### PR DESCRIPTION
## Problem

Destructive MCP tool actions (e.g. toggling 2FA enforcement) have no server-enforced confirmation step — a misbehaving or prompt-injected agent can apply silent, hard-to-reverse changes. The stateless Hono deployment additionally lacks any way to correlate a server-initiated request with its client response across pods.

## Changes

- Add `confirmation_required: true` YAML flag — codegen emits an `elicitation/create` prompt before the destructive request runs
- Add `confirmation_builder` YAML field for runtime-built `{ title, description }` (resolves entity names, picks dynamic verbs)
- Fail closed when the client doesn't implement elicitation; preserve the underlying error as `cause`
- Swap `AjvJsonSchemaValidator` for `CfWorkerJsonSchemaValidator` on the Workers Durable Object. AJV compiles JSON Schemas via `new Function()` which Cloudflare Workers' CSP blocks. See [modelcontextprotocol/typescript-sdk#689](https://github.com/modelcontextprotocol/typescript-sdk/issues/689)
- Add `SessionResponseBus` abstraction in `services/mcp/src/hono/session-bus/` — Redis-polling implementation for production, in-memory for tests
- Wire `ElicitationGateway` into Hono so server-initiated elicits work across stateless pods via JSONRPC-id-keyed correlation (no sticky sessions, no pub/sub, reuses existing `RedisLike`)
- Hono streamable handler classifies inbound bodies — JSONRPC responses route via the bus, requests fall through to the SDK transport
- Surface `mcp_session_bus_awaits_total`, `mcp_session_bus_await_duration_seconds`, `mcp_session_bus_polls_total` Prometheus metrics
- Apply the paradigm to new `organization-enforce-2fa-update` tool — tightly scoped to the `enforce_2fa` field only

## How did you test this code?

- 117 Hono unit tests pass (34 new for the session bus across 4 suites)
- 1 new schema snapshot for `organization-enforce-2fa-update`
- End-to-end verified via MCP Inspector against the Hono server: tools/call dispatches, elicit modal renders, Submit resolves the parked await, PATCH lands and returns the updated org. Decline and `ConfirmationUnsupportedError` paths block the change

## Publish to changelog?

no