### PR TITLE
fix(hogli): load .env.services for all subcommands, not just hogli run

### DIFF
--- a/tools/hogli/src/hogli/cli.py
+++ b/tools/hogli/src/hogli/cli.py
@@ -171,6 +171,7 @@ def _auto_update_manifest() -> None:
 @click.pass_context
 def cli(ctx: click.Context) -> None:
     """hogli - YAML-driven developer CLI."""
+    _load_default_env_files()
     # Auto-update manifest on every invocation (but skip for meta:check and git hooks)
     # Skip during git hooks to prevent manifest modifications during lint-staged execution
     in_git_hook = os.environ.get("GIT_DIR") is not None or os.environ.get("HUSKY") is not None
@@ -281,6 +282,20 @@ def _load_env_file(path: os.PathLike[str], only_if_unset: bool = True) -> None:
         if only_if_unset and name in os.environ:
             continue
         os.environ[name] = value
+
+
+def _load_default_env_files() -> None:
+    """Load .env.development and .env.services for every hogli subcommand.
+
+    Mirrors bin/start so commands that shell out to manage.py / bin scripts
+    (dev:reset, migrations:run, etc.) see the same service connection defaults
+    the dev stack uses. Shell vars win; we never overwrite.
+
+    .env.local is intentionally NOT loaded here — it can contain 1Password
+    op:// refs that only `hogli run` knows how to resolve via `op run`.
+    """
+    _load_env_file(REPO_ROOT / ".env.development", only_if_unset=True)
+    _load_env_file(REPO_ROOT / ".env.services", only_if_unset=True)
 
 
 @cli.command(name="run", help="Run a command with resolved environment (1Password + defaults)")


### PR DESCRIPTION
## Problem

`hogli dev:reset` and `hogli migrations:run` were silently writing ClickHouse tables into the wrong database (`default` instead of `posthog`).

The chain:

1. Only the `hogli run <cmd>` subcommand loaded `.env.development` + `.env.services`. Every other hogli subcommand inherited whatever env it got from the user's shell.
2. `hogli dev:reset` / `hogli migrations:run` shell out to `bin/migrate`, which calls `python manage.py migrate_clickhouse`. Without `.env.services` loaded, `CLICKHOUSE_DATABASE` was unset.
3. Django fell back to the literal `"default"` in [posthog/settings/data_stores.py:279](posthog/settings/data_stores.py#L279), so migrations created tables in the `default` ClickHouse database.
4. Meanwhile the running app — started via `bin/start`, which *does* source `.env.services` for its child processes — read from `posthog`. Result: `Table posthog.events does not exist. Maybe you meant default.events?`

This is a systemic gap, not bad luck: anyone running `hogli dev:reset` from a shell that doesn't have `CLICKHOUSE_DATABASE` exported (i.e. most fresh terminals — `.envrc` doesn't set it, flox doesn't set it, and `bin/start`'s `export`s don't leak back to the parent shell) hits it.

## Changes

- New `_load_default_env_files()` helper in [tools/hogli/src/hogli/cli.py](tools/hogli/src/hogli/cli.py) — calls the existing `_load_env_file()` on `.env.development` + `.env.services`.
- Invoked once at the top of the `cli()` group function so every hogli subcommand inherits the same defaults that `bin/start` already gives to child processes.
- `.env.local` is intentionally *not* loaded here — it can contain 1Password `op://` refs that only `hogli run` knows how to resolve via `op run`.
- Shell vars still win (`only_if_unset=True`), matching `bin/start`'s precedence: `shell env > .env.local > .env.development > .env.services`.

## How did you test this code?

I'm an agent. Automated only — no manual UI testing.

- All 192 existing `tools/hogli/tests/` unit tests pass.
- Wiped and recreated the local clickhouse + zookeeper docker volumes, then ran `hogli migrations:run --scope=clickhouse` from a shell with `CLICKHOUSE_DATABASE` unset. Result: ClickHouse migrations now land all 218 tables in the `posthog` database; the `default` database stays empty apart from ClickHouse's own 9 system tables. Before the fix, the same flow created 227 application tables in `default` and produced the `is_deleted` ZK-conflict error trying to also create them in `posthog`.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). The bug surfaced while debugging a `Table posthog.events does not exist` error on a working tree where `.env.services` had `CLICKHOUSE_DATABASE=posthog` but `hogli dev:reset` was creating tables in `default`. Tried two alternative fixes first — (a) bumping the Python fallback in `settings/data_stores.py` from `"default"` to `"posthog"`, (b) sourcing `.env.services` inside `bin/migrate` — and rejected both: the Python fallback only fixes this one var, and `bin/migrate` only fixes migrations. Lifting env loading into hogli's top-level `cli()` group fixes the whole class of "hogli subcommand silently disagrees with the running app" problems, mirrors what `bin/start` already does, and keeps `hogli run`'s 1Password handling untouched.