### PR TITLE
fix(InsightViz): remove trailing period from validation error messages

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/utils.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.ts
@@ -186,9 +186,12 @@ export const extractValidationError = (error: Error | Record<string, any> | null
     if (error instanceof ApiError || (error && typeof error === 'object' && 'status' in error)) {
         // We use 512 for query timeouts
         // Async queries put the error message on data.error_message, while synchronous ones use detail
-        return error?.status === 400 || error?.status === 512
-            ? (error.detail || error.data?.error_message)?.replace('Try ', 'Try\u00A0') // Add unbreakable space for better line breaking
-            : null
+        const validationError =
+            error?.status === 400 || error?.status === 512 ? error.detail || error.data?.error_message : null
+
+        return validationError
+            ?.replace('Try ', 'Try\u00A0') // Add unbreakable space for better line breaking
+            .replace(/\?\.$/, '?')
     }
 
     return null


### PR DESCRIPTION
## Problem

Dashboard card validation errors could render awkward trailing punctuation when the upstream message ended with `?.`, for example when suggesting an alternative table name.
This made the error state look sloppy even though the underlying message was otherwise correct.

## Changes

- Normalized validation error strings in `extractValidationError` so messages ending in `?.` render as `?`
- Added a focused unit test for the formatter behavior, including unchanged messages and nullish inputs

<img width="447" height="454" alt="image" src="https://github.com/user-attachments/assets/ad204c68-a743-42b8-a45d-4f0f4937f3eb" />

## How did you test this code?

Agent-authored change.

Automated tests run:
- `pnpm --filter=@posthog/frontend test -- --runInBand frontend/src/queries/nodes/InsightViz/utils.test.ts`

## Publish to changelog?

no

## Docs update

No documentation update needed for this formatting fix.

## 🤖 Agent context

This PR was updated with PostHog Code after identifying that the dashboard card error formatter was preserving an extra trailing period after a question mark in some backend validation messages.
The change was kept intentionally small by fixing the shared validation error formatting path rather than adjusting individual UI components.
After review feedback, a dedicated unit test was added to lock in the punctuation normalization behavior and cover unchanged and nullish cases.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
