### PR TITLE
fix(llma): guard against null generation_id in eval runs table

### DIFF
--- a/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
@@ -29,21 +29,26 @@ export function EvaluationRunsTable(): JSX.Element {
         {
             title: 'Generation ID',
             key: 'generation_id',
-            render: (_, run) => (
-                <div className="font-mono text-sm">
-                    <Link
-                        to={
-                            combineUrl(urls.llmAnalyticsTrace(run.trace_id), {
-                                ...traceSearchParams,
-                                event: run.generation_id,
-                            }).url
-                        }
-                        className="text-primary"
-                    >
-                        {run.generation_id.slice(0, 12)}...
-                    </Link>
-                </div>
-            ),
+            render: (_, run) => {
+                if (!run.generation_id) {
+                    return <span className="font-mono text-sm text-muted">—</span>
+                }
+                return (
+                    <div className="font-mono text-sm">
+                        <Link
+                            to={
+                                combineUrl(urls.llmAnalyticsTrace(run.trace_id), {
+                                    ...traceSearchParams,
+                                    event: run.generation_id,
+                                }).url
+                            }
+                            className="text-primary"
+                        >
+                            {run.generation_id.slice(0, 12)}...
+                        </Link>
+                    </div>
+                )
+            },
         },
         {
             title: 'Result',

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -689,7 +689,9 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             (runs): Record<string, EvaluationRun> => {
                 const lookup: Record<string, EvaluationRun> = {}
                 for (const run of runs) {
-                    lookup[run.generation_id] = run
+                    if (run.generation_id) {
+                        lookup[run.generation_id] = run
+                    }
                 }
                 return lookup
             },

--- a/products/llm_analytics/frontend/evaluations/types.ts
+++ b/products/llm_analytics/frontend/evaluations/types.ts
@@ -71,7 +71,7 @@ export interface EvaluationRun {
     id: string
     evaluation_id: string
     evaluation_name: string
-    generation_id: string
+    generation_id: string | null
     trace_id: string
     timestamp: string
     result: boolean | null


### PR DESCRIPTION
## Problem

We assumed that all evaluations had `$ai_target_event_id` set, but this stopped being true with offline, manually emitted evals. When missing, it crashes the eval run table.

## Changes

Make it not crash

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude via PostHog Code. Diagnosis traced the stack frame `Object.render` inside `LemonTable` `flatMap`/`map` to the single `.slice` call in the LLM analytics scene that operates on a value sourced from a possibly-missing event property. Chose to keep the row visible (timestamp / result / reasoning are still useful) and degrade only the link cell rather than filter out runs without a generation_id, since filtering would hide data the user is investigating.