### PR TITLE
fix(funnels): show date in historical trends tooltip header

### DIFF
--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -19,6 +19,16 @@ import { BreakdownKeyType, ChartParams, GraphDataset, GraphType } from '~/types'
 import { funnelDataLogic } from './funnelDataLogic'
 import { funnelPersonsModalLogic } from './funnelPersonsModalLogic'
 
+// The funnel backend uses the literal "Baseline" (or `['Baseline', ...]` for multi-breakdowns)
+// to mark the overall series, which is not a breakdown the user picked.
+function hasBreakdown(breakdownValue: BreakdownKeyType | undefined): boolean {
+    return (
+        breakdownValue !== undefined &&
+        breakdownValue !== 'Baseline' &&
+        !(Array.isArray(breakdownValue) && breakdownValue[0] === 'Baseline')
+    )
+}
+
 const LineGraphWrapper = ({ inCardView, children }: { inCardView?: boolean; children: JSX.Element }): JSX.Element => {
     if (inCardView) {
         return <>{children}</>
@@ -72,7 +82,7 @@ export function FunnelLineGraph({
                 goalLines={goalLines ?? []}
                 tooltip={{
                     renderSeries: (_, datum) => {
-                        if (datum.breakdown_value !== undefined && !!datum.breakdown_value) {
+                        if (hasBreakdown(datum.breakdown_value)) {
                             return <div className="datum-label-column">{getDatumTitle(datum, breakdownFilter)}</div>
                         }
                         return <div className="datum-label-column">Conversion</div>
@@ -95,11 +105,7 @@ export function FunnelLineGraph({
                               const day = dataset?.days?.[index] ?? ''
                               const breakdownValue = (dataset as { breakdown_value?: BreakdownKeyType })
                                   ?.breakdown_value
-                              const hasBreakdown =
-                                  breakdownValue !== undefined &&
-                                  breakdownValue !== 'Baseline' &&
-                                  !(Array.isArray(breakdownValue) && breakdownValue[0] === 'Baseline')
-                              const breakdownLabel = hasBreakdown
+                              const breakdownLabel = hasBreakdown(breakdownValue)
                                   ? formatBreakdownLabel(
                                         breakdownValue,
                                         breakdownFilter,
@@ -128,7 +134,7 @@ export function FunnelLineGraph({
                                   funnelTrendsDropOff: false,
                                   includeRecordings: true,
                                   funnelTrendsEntrancePeriodStart: dayjs(day).format('YYYY-MM-DD HH:mm:ss'),
-                                  ...(hasBreakdown ? { funnelStepBreakdown: breakdownValue } : {}),
+                                  ...(hasBreakdown(breakdownValue) ? { funnelStepBreakdown: breakdownValue } : {}),
                               }
                               openPersonsModal({
                                   title,

--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -18,16 +18,7 @@ import { BreakdownKeyType, ChartParams, GraphDataset, GraphType } from '~/types'
 
 import { funnelDataLogic } from './funnelDataLogic'
 import { funnelPersonsModalLogic } from './funnelPersonsModalLogic'
-
-// The funnel backend uses the literal "Baseline" (or `['Baseline', ...]` for multi-breakdowns)
-// to mark the overall series, which is not a breakdown the user picked.
-function hasBreakdown(breakdownValue: BreakdownKeyType | undefined): boolean {
-    return (
-        breakdownValue !== undefined &&
-        breakdownValue !== 'Baseline' &&
-        !(Array.isArray(breakdownValue) && breakdownValue[0] === 'Baseline')
-    )
-}
+import { hasBreakdown } from './funnelUtils'
 
 const LineGraphWrapper = ({ inCardView, children }: { inCardView?: boolean; children: JSX.Element }): JSX.Element => {
     if (inCardView) {

--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -2,9 +2,9 @@ import { useValues } from 'kea'
 
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { dayjs } from 'lib/dayjs'
-import { capitalizeFirstLetter, shortTimeZone } from 'lib/utils'
+import { capitalizeFirstLetter } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { getFormattedDate } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+import { getDatumTitle } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { LineGraph } from 'scenes/insights/views/LineGraph/LineGraph'
 import { teamLogic } from 'scenes/teamLogic'
@@ -71,22 +71,11 @@ export function FunnelLineGraph({
                 showTrendLines={funnelsFilter?.showTrendLines ?? false}
                 goalLines={goalLines ?? []}
                 tooltip={{
-                    showHeader: false,
-                    hideColorCol: true,
                     renderSeries: (_, datum) => {
-                        if (!indexedSteps?.[0]?.days) {
-                            return 'Trend'
+                        if (datum.breakdown_value !== undefined && !!datum.breakdown_value) {
+                            return <div className="datum-label-column">{getDatumTitle(datum, breakdownFilter)}</div>
                         }
-                        return (
-                            getFormattedDate(indexedSteps[0].days?.[datum.dataIndex], {
-                                interval,
-                                dateRange: insightData?.resolved_date_range,
-                                timezone: insightData?.timezone,
-                                weekStartDay,
-                            }) +
-                            ' ' +
-                            (insightData?.timezone ? shortTimeZone(insightData.timezone) : 'UTC')
-                        )
+                        return <div className="datum-label-column">Conversion</div>
                     },
                     renderCount: (count) => {
                         return `${count}%`

--- a/frontend/src/scenes/funnels/funnelUtils.test.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.test.ts
@@ -22,6 +22,7 @@ import {
     getReferenceStep,
     getStepBreakdownSeries,
     getVisibilityKey,
+    hasBreakdown,
     isFunnelWithEnoughSteps,
     isFunnelWithIncompleteDataWarehouseStep,
     parseDisplayNameForCorrelation,
@@ -832,5 +833,30 @@ describe('isFunnelWithIncompleteDataWarehouseStep', () => {
         },
     ])('returns $expected for $scenario', ({ series, expected }) => {
         expect(isFunnelWithIncompleteDataWarehouseStep(series as FunnelsQuery['series'])).toBe(expected)
+    })
+})
+
+describe('hasBreakdown', () => {
+    it.each([
+        { scenario: 'undefined value', breakdownValue: undefined, expected: false },
+        { scenario: '"Baseline" string', breakdownValue: 'Baseline', expected: false },
+        { scenario: '["Baseline"] array', breakdownValue: ['Baseline'], expected: false },
+        {
+            scenario: '["Baseline", "mobile"] multi-breakdown array',
+            breakdownValue: ['Baseline', 'mobile'],
+            expected: false,
+        },
+        { scenario: 'numeric zero (regression: 0 must count as a real breakdown)', breakdownValue: 0, expected: true },
+        {
+            scenario: 'empty string (regression: "" must count as a real breakdown)',
+            breakdownValue: '',
+            expected: true,
+        },
+        { scenario: 'non-baseline string', breakdownValue: 'Chrome', expected: true },
+        { scenario: 'non-baseline number', breakdownValue: 42, expected: true },
+        { scenario: 'non-baseline array', breakdownValue: ['Chrome', 'mobile'], expected: true },
+        { scenario: 'null', breakdownValue: null, expected: true },
+    ])('returns $expected for $scenario', ({ breakdownValue, expected }) => {
+        expect(hasBreakdown(breakdownValue as Parameters<typeof hasBreakdown>[0])).toBe(expected)
     })
 })

--- a/frontend/src/scenes/funnels/funnelUtils.tsx
+++ b/frontend/src/scenes/funnels/funnelUtils.tsx
@@ -192,6 +192,19 @@ export function hasBreakdownFilterParameter(
     )
 }
 
+/**
+ * Whether a series's `breakdown_value` represents an actual user-picked breakdown.
+ * The funnel backend uses the literal "Baseline" (or `['Baseline', ...]` for
+ * multi-breakdowns) to mark the overall, non-broken-down series.
+ */
+export function hasBreakdown(breakdownValue: BreakdownKeyType | undefined): boolean {
+    return (
+        breakdownValue !== undefined &&
+        breakdownValue !== 'Baseline' &&
+        !(Array.isArray(breakdownValue) && breakdownValue[0] === 'Baseline')
+    )
+}
+
 /** String identifier for breakdowns used when determining visibility. */
 export function getVisibilityKey(breakdownValue?: BreakdownKeyType): string {
     const breakdownValues = getBreakdownStepValues(


### PR DESCRIPTION
## Problem

The historical trends tooltip was hiding the column header (`showHeader: false`) and stuffing the formatted date into each row's label as a workaround. With a breakdown, the tooltip switches to the inverted/columnized layout where the `renderSeries` override has no effect, so the date wasn't surfaced anywhere — leaving the user with no indication of which week (or other interval) they were hovering.

https://posthoghelp.zendesk.com/agent/tickets/58554 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/59377)

<img width="1207" height="681" alt="Screenshot 2026-05-20 at 16 36 57" src="https://github.com/user-attachments/assets/5db7e13b-d6f0-4d6c-8a85-79309313d711" />


## Changes

Let the column header render the date the same way trends insights do, and use `renderSeries` to label rows with the breakdown value (or "Conversion" when there's no breakdown) instead.

<img width="1201" height="661" alt="Screenshot 2026-05-20 at 16 36 04" src="https://github.com/user-attachments/assets/4247450c-3ecd-4889-9b8c-586f71f27a4e" />


## How did you test this code?

Manually

## Publish to changelog?

No

## Docs update

No