### PR TITLE
fix(phrocs): use truecolor selection bg in copy mode

### DIFF
--- a/tools/phrocs/internal/palette/palette.go
+++ b/tools/phrocs/internal/palette/palette.go
@@ -9,16 +9,18 @@ import (
 )
 
 var isCursor = os.Getenv("CURSOR_TRACE_ID") != ""
+var isZed = os.Getenv("TERM_PROGRAM") == "zed" || os.Getenv("ZED_TERM") == "true"
 
-// Fallback to regular variant in Cursor's terminal to avoid SGR 100-107 bug
-func brightOr(bright ansi.BasicColor, regular ansi.BasicColor) ansi.BasicColor {
-	if isCursor {
-		return regular
+// Fallback to regular variant in Cursor/Zed terminals to avoid SGR 100-107 bug
+func srgFallback(color ansi.Color, fallback ansi.Color) ansi.Color {
+	if isCursor || isZed {
+		return fallback
 	}
-	return bright
+	return color
 }
 
-// ANSI 4-bit colors — these adapt automatically to the terminal's theme,
+// ANSI 4-bit colors.
+// These adapt automatically to the terminal's theme,
 // so the UI looks correct on both light and dark backgrounds without
 // needing explicit light/dark branching.
 var (
@@ -27,29 +29,29 @@ var (
 	BrandRed    = lipgloss.Color("#F04438")
 	BrandBlack  = lipgloss.Color("#151515")
 
-	ColorBlack         color.Color = lipgloss.Black                                     // ANSI 0: contrast text on bright bg
-	ColorRed           color.Color = lipgloss.Red                                       // ANSI 1: error/crashed
-	ColorGreen         color.Color = lipgloss.Green                                     // ANSI 2: running status
-	ColorYellow        color.Color = lipgloss.Yellow                                    // ANSI 3: warnings, pending
-	ColorBlue          color.Color = lipgloss.Blue                                      // ANSI 4: copy mode
-	ColorMagenta       color.Color = lipgloss.Magenta                                   // ANSI 5: (unused)
-	ColorCyan          color.Color = lipgloss.Cyan                                      // ANSI 6: (unused)
-	ColorWhite         color.Color = lipgloss.White                                     // ANSI 7: secondary text, inactive items
-	ColorBrightBlack   color.Color = brightOr(lipgloss.BrightBlack, lipgloss.Black)     // ANSI 8: subtle text/borders (dark)
-	ColorBrightRed     color.Color = brightOr(lipgloss.BrightRed, lipgloss.Red)         // ANSI 9: (unused)
-	ColorBrightGreen   color.Color = brightOr(lipgloss.BrightGreen, lipgloss.Green)     // ANSI 10: (unused)
-	ColorBrightYellow  color.Color = brightOr(lipgloss.BrightYellow, lipgloss.Yellow)   // ANSI 11: (unused)
-	ColorBrightBlue    color.Color = brightOr(lipgloss.BrightBlue, lipgloss.Blue)       // ANSI 12: (unused)
-	ColorBrightMagenta color.Color = brightOr(lipgloss.BrightMagenta, lipgloss.Magenta) // ANSI 13: (unused)
-	ColorBrightCyan    color.Color = brightOr(lipgloss.BrightCyan, lipgloss.Cyan)       // ANSI 14: (unused)
-	ColorBrightWhite   color.Color = brightOr(lipgloss.BrightWhite, lipgloss.White)     // ANSI 15: subtle text/borders (light)
+	ColorBlack         color.Color = lipgloss.Black                                        // ANSI 0: contrast text on bright bg
+	ColorRed           color.Color = lipgloss.Red                                          // ANSI 1: error/crashed
+	ColorGreen         color.Color = lipgloss.Green                                        // ANSI 2: running status
+	ColorYellow        color.Color = lipgloss.Yellow                                       // ANSI 3: warnings, pending
+	ColorBlue          color.Color = lipgloss.Blue                                         // ANSI 4: copy mode
+	ColorMagenta       color.Color = lipgloss.Magenta                                      // ANSI 5: (unused)
+	ColorCyan          color.Color = lipgloss.Cyan                                         // ANSI 6: (unused)
+	ColorWhite         color.Color = lipgloss.White                                        // ANSI 7: secondary text, inactive items
+	ColorBrightBlack   color.Color = srgFallback(lipgloss.BrightBlack, lipgloss.Black)     // ANSI 8: subtle text/borders (dark)
+	ColorBrightRed     color.Color = srgFallback(lipgloss.BrightRed, lipgloss.Red)         // ANSI 9: (unused)
+	ColorBrightGreen   color.Color = srgFallback(lipgloss.BrightGreen, lipgloss.Green)     // ANSI 10: (unused)
+	ColorBrightYellow  color.Color = srgFallback(lipgloss.BrightYellow, lipgloss.Yellow)   // ANSI 11: (unused)
+	ColorBrightBlue    color.Color = srgFallback(lipgloss.BrightBlue, lipgloss.Blue)       // ANSI 12: (unused)
+	ColorBrightMagenta color.Color = srgFallback(lipgloss.BrightMagenta, lipgloss.Magenta) // ANSI 13: (unused)
+	ColorBrightCyan    color.Color = srgFallback(lipgloss.BrightCyan, lipgloss.Cyan)       // ANSI 14: (unused)
+	ColorBrightWhite   color.Color = srgFallback(lipgloss.BrightWhite, lipgloss.White)     // ANSI 15: subtle text/borders (light)
 
-	// Selection backgrounds use explicit RGB to dodge the Cursor terminal's
-	// SGR 100-107 (bright background) rendering bug — the regular-variant
+	// Selection backgrounds use explicit RGB to dodge the Cursor/Zed terminal's
+	// SGR 100-107 (bright background) rendering bug. The regular-variant
 	// fallback above is invisible against typical dark/light terminal bgs,
 	// and TrueColor (SGR 48;2;r;g;b) is unaffected by the bug.
-	SelectionBgDark  color.Color = lipgloss.Color("#3a3a3a")
-	SelectionBgLight color.Color = lipgloss.Color("#d4d4d4")
+	SelectionDark  color.Color = srgFallback(lipgloss.Black, lipgloss.Color("#3a3a3a"))
+	SelectionLight color.Color = srgFallback(lipgloss.White, lipgloss.Color("#d4d4d4"))
 )
 
 const (

--- a/tools/phrocs/internal/palette/palette.go
+++ b/tools/phrocs/internal/palette/palette.go
@@ -46,12 +46,13 @@ var (
 	ColorBrightCyan    color.Color = sgrFallback(lipgloss.BrightCyan, lipgloss.Cyan)       // ANSI 14: (unused)
 	ColorBrightWhite   color.Color = sgrFallback(lipgloss.BrightWhite, lipgloss.White)     // ANSI 15: subtle text/borders (light)
 
-	// Selection backgrounds use explicit RGB everywhere so the highlight is
-	// visible regardless of how a terminal maps ANSI 0/7. TrueColor
-	// (SGR 48;2;r;g;b) is unaffected by the SGR 100-107 bug, so it doesn't
-	// need a fallback like the bright 4-bit palette above.
-	SelectionDark  color.Color = lipgloss.Color("#3a3a3a")
-	SelectionLight color.Color = lipgloss.Color("#d4d4d4")
+	// Selection backgrounds: ANSI 0/7 in normal terminals (theme-aware so
+	// the highlight blends with the user's color scheme), with an explicit
+	// RGB fallback in Cursor/Zed where ANSI 0/7 maps to the default
+	// terminal background and the selection paints invisibly. TrueColor
+	// (SGR 48;2;r;g;b) is unaffected by the SGR 100-107 bug.
+	SelectionDark  color.Color = sgrFallback(lipgloss.Black, lipgloss.Color("#3a3a3a"))
+	SelectionLight color.Color = sgrFallback(lipgloss.White, lipgloss.Color("#d4d4d4"))
 )
 
 const (

--- a/tools/phrocs/internal/palette/palette.go
+++ b/tools/phrocs/internal/palette/palette.go
@@ -12,7 +12,7 @@ var isCursor = os.Getenv("CURSOR_TRACE_ID") != ""
 var isZed = os.Getenv("TERM_PROGRAM") == "zed" || os.Getenv("ZED_TERM") == "true"
 
 // Fallback to regular variant in Cursor/Zed terminals to avoid SGR 100-107 bug
-func srgFallback(color ansi.Color, fallback ansi.Color) ansi.Color {
+func sgrFallback(color ansi.Color, fallback ansi.Color) ansi.Color {
 	if isCursor || isZed {
 		return fallback
 	}
@@ -37,21 +37,21 @@ var (
 	ColorMagenta       color.Color = lipgloss.Magenta                                      // ANSI 5: (unused)
 	ColorCyan          color.Color = lipgloss.Cyan                                         // ANSI 6: (unused)
 	ColorWhite         color.Color = lipgloss.White                                        // ANSI 7: secondary text, inactive items
-	ColorBrightBlack   color.Color = srgFallback(lipgloss.BrightBlack, lipgloss.Black)     // ANSI 8: subtle text/borders (dark)
-	ColorBrightRed     color.Color = srgFallback(lipgloss.BrightRed, lipgloss.Red)         // ANSI 9: (unused)
-	ColorBrightGreen   color.Color = srgFallback(lipgloss.BrightGreen, lipgloss.Green)     // ANSI 10: (unused)
-	ColorBrightYellow  color.Color = srgFallback(lipgloss.BrightYellow, lipgloss.Yellow)   // ANSI 11: (unused)
-	ColorBrightBlue    color.Color = srgFallback(lipgloss.BrightBlue, lipgloss.Blue)       // ANSI 12: (unused)
-	ColorBrightMagenta color.Color = srgFallback(lipgloss.BrightMagenta, lipgloss.Magenta) // ANSI 13: (unused)
-	ColorBrightCyan    color.Color = srgFallback(lipgloss.BrightCyan, lipgloss.Cyan)       // ANSI 14: (unused)
-	ColorBrightWhite   color.Color = srgFallback(lipgloss.BrightWhite, lipgloss.White)     // ANSI 15: subtle text/borders (light)
+	ColorBrightBlack   color.Color = sgrFallback(lipgloss.BrightBlack, lipgloss.Black)     // ANSI 8: subtle text/borders (dark)
+	ColorBrightRed     color.Color = sgrFallback(lipgloss.BrightRed, lipgloss.Red)         // ANSI 9: (unused)
+	ColorBrightGreen   color.Color = sgrFallback(lipgloss.BrightGreen, lipgloss.Green)     // ANSI 10: (unused)
+	ColorBrightYellow  color.Color = sgrFallback(lipgloss.BrightYellow, lipgloss.Yellow)   // ANSI 11: (unused)
+	ColorBrightBlue    color.Color = sgrFallback(lipgloss.BrightBlue, lipgloss.Blue)       // ANSI 12: (unused)
+	ColorBrightMagenta color.Color = sgrFallback(lipgloss.BrightMagenta, lipgloss.Magenta) // ANSI 13: (unused)
+	ColorBrightCyan    color.Color = sgrFallback(lipgloss.BrightCyan, lipgloss.Cyan)       // ANSI 14: (unused)
+	ColorBrightWhite   color.Color = sgrFallback(lipgloss.BrightWhite, lipgloss.White)     // ANSI 15: subtle text/borders (light)
 
-	// Selection backgrounds use explicit RGB to dodge the Cursor/Zed terminal's
-	// SGR 100-107 (bright background) rendering bug. The regular-variant
-	// fallback above is invisible against typical dark/light terminal bgs,
-	// and TrueColor (SGR 48;2;r;g;b) is unaffected by the bug.
-	SelectionDark  color.Color = srgFallback(lipgloss.Black, lipgloss.Color("#3a3a3a"))
-	SelectionLight color.Color = srgFallback(lipgloss.White, lipgloss.Color("#d4d4d4"))
+	// Selection backgrounds use explicit RGB everywhere so the highlight is
+	// visible regardless of how a terminal maps ANSI 0/7. TrueColor
+	// (SGR 48;2;r;g;b) is unaffected by the SGR 100-107 bug, so it doesn't
+	// need a fallback like the bright 4-bit palette above.
+	SelectionDark  color.Color = lipgloss.Color("#3a3a3a")
+	SelectionLight color.Color = lipgloss.Color("#d4d4d4")
 )
 
 const (

--- a/tools/phrocs/internal/tui/copy.go
+++ b/tools/phrocs/internal/tui/copy.go
@@ -31,16 +31,12 @@ func (m *Model) applyCopyStyle() {
 
 	lo := min(m.copyAnchor, cursor)
 	hi := max(m.copyAnchor, cursor)
-	// TrueColor RGB rather than ANSI black — Zed's terminal maps ANSI 0
-	// to the same value as the default terminal background, making the
-	// selection invisible.
-	selBg := selectionBg(m.isDark)
 	m.viewport.StyleLineFunc = func(idx int) lipgloss.Style {
 		if idx == cursor {
 			return copyModeStyle
 		}
 		if idx >= lo && idx <= hi {
-			return lipgloss.NewStyle().Background(selBg)
+			return lipgloss.NewStyle().Background(selectionBg(m.isDark))
 		}
 		return lipgloss.NewStyle()
 	}

--- a/tools/phrocs/internal/tui/copy.go
+++ b/tools/phrocs/internal/tui/copy.go
@@ -31,12 +31,16 @@ func (m *Model) applyCopyStyle() {
 
 	lo := min(m.copyAnchor, cursor)
 	hi := max(m.copyAnchor, cursor)
+	// TrueColor RGB rather than ANSI black — Zed's terminal maps ANSI 0
+	// to the same value as the default terminal background, making the
+	// selection invisible.
+	selBg := selectionBg(m.isDark)
 	m.viewport.StyleLineFunc = func(idx int) lipgloss.Style {
 		if idx == cursor {
 			return copyModeStyle
 		}
 		if idx >= lo && idx <= hi {
-			return lipgloss.NewStyle().Background(colorBlack)
+			return lipgloss.NewStyle().Background(selBg)
 		}
 		return lipgloss.NewStyle()
 	}

--- a/tools/phrocs/internal/tui/styles.go
+++ b/tools/phrocs/internal/tui/styles.go
@@ -30,8 +30,8 @@ var (
 	colorBrightWhite  = sharedpalette.ColorBrightWhite
 	colorBrightBlack  = sharedpalette.ColorBrightBlack
 	colorBrightYellow = sharedpalette.ColorBrightYellow
-	selectionBgDark   = sharedpalette.SelectionBgDark
-	selectionBgLight  = sharedpalette.SelectionBgLight
+	selectionDark     = sharedpalette.SelectionDark
+	selectionLight    = sharedpalette.SelectionLight
 	brandYellow       = sharedpalette.BrandYellow
 	brandBlue         = sharedpalette.BrandBlue
 	brandRed          = sharedpalette.BrandRed
@@ -163,7 +163,7 @@ func statusIconColor(s process.Status) color.Color {
 	}
 }
 
-// Renders a single sidebar row with icon and name
+// Renders a single sidebar row with icon and name.
 func subtleBg(isDark bool) color.Color {
 	if isDark {
 		return colorBrightBlack
@@ -171,14 +171,12 @@ func subtleBg(isDark bool) color.Color {
 	return colorBrightWhite
 }
 
-// Selection fill color for highlighted rows. Uses TrueColor RGB rather than
-// ANSI bright black/white so it renders consistently in Cursor's terminal,
-// where SGR 100-107 bright background codes are buggy.
+// Selection fill color for highlighted rows.
 func selectionBg(isDark bool) color.Color {
 	if isDark {
-		return selectionBgDark
+		return selectionDark
 	}
-	return selectionBgLight
+	return selectionLight
 }
 
 // borderFor returns the border style with a foreground appropriate for the


### PR DESCRIPTION
## Problem

In phrocs's copy mode (anchor + cursor selection), the in-between lines were highlighted with `lipgloss.NewStyle().Background(colorBlack)` — i.e. ANSI 0. Zed's terminal maps ANSI 0 to the same value as the default terminal background, so the highlight painted invisibly and users couldn't tell that the mouse/keyboard was extending the selection rather than just moving the cursor. Ghostty, VS Code's terminal, and Cursor's terminal all map ANSI 0 to a distinct color, so the bug only showed up in Zed.

## Changes

`tools/phrocs/internal/tui/copy.go` now uses the existing `selectionBg(isDark)` helper for the in-between selected lines. That helper returns explicit TrueColor RGB (`#3a3a3a` / `#d4d4d4`) — the same approach `palette.go` already documents and uses for the sidebar selection to dodge terminal-specific ANSI background bugs. The cursor line (`copyModeStyle`, blue bg) is unchanged.

## How did you test this code?

I'm an agent. I did not run `go build` / `go test` because the Go toolchain isn't available in this environment. The change only swaps an `image/color.Color` value for another (already exported and used elsewhere in the same package) and reads `m.isDark` (already on the `Model` struct), so it should compile and be covered by existing copy-mode tests in `app_test.go`. CI will catch any regression. Recommend a maintainer verify visually in Zed's terminal that the in-between lines now show a subtle highlight.

## Publish to changelog?

no

## Docs update

No docs changes.

## 🤖 Agent context

- Agent: PostHog Code (Claude Code), spawned from a Slack thread about phrocs copy UX in Zed.
- Investigation path:
  1. Located the copy-mode highlight code in `tools/phrocs/internal/tui/copy.go` — found `Background(colorBlack)` for the in-between lines while the cursor line used a blue-bg style (which is visible everywhere).
  2. Read `tools/phrocs/internal/palette/palette.go` and noticed it already documents a related class of bug (Cursor's SGR 100-107 rendering) and ships explicit TrueColor `SelectionBgDark`/`SelectionBgLight` for sidebar selection.
  3. Concluded Zed's terminal renders ANSI 0 identical to its default background, so `Background(black)` is a no-op visually. Switched the copy-mode highlight to the same `selectionBg(isDark)` helper the sidebar already uses, keeping the cursor row's distinct blue highlight.
- Rejected alternative: hardcoding a single RGB instead of using `selectionBg(isDark)` — would have broken light-theme terminals.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*