### PR TITLE
feat(hogli): make env loading generic + drop 1Password from core

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -13,6 +13,23 @@ config:
         - mprocs-test.yaml
         - sandbox-entrypoint.py
         - lint-feature-flag-sorting.mjs
+    # Environment loaded into every hogli invocation. Generic dotenv-style
+    # mechanism (like just/mise/task); secrets resolution is delegated to a
+    # configurable wrap binary (op/doppler/vault/…), not baked into hogli core.
+    env:
+        # Loaded in order; earlier files win for duplicate keys; shell env always wins.
+        files:
+            - .env.development
+            - .env.services
+        # Optional: when .env.local contains the marker substring AND the wrap
+        # binary is on PATH, hogli re-execs the whole invocation under it. If
+        # the wrap binary is missing, hogli loads .env.local directly with
+        # marker-matching lines skipped (so 'op://…' literals never leak as
+        # garbage env values that break downstream services with cryptic 401s).
+        secrets:
+            file: .env.local
+            marker: 'op://'
+            wrap: [op, run, --env-file, '{file}', --]
     telemetry:
         # Write-only project token for PostHog's internal hogli project.
         # It cannot read data; safe to commit. Standalone hogli users get a blank

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -13,19 +13,10 @@ config:
         - mprocs-test.yaml
         - sandbox-entrypoint.py
         - lint-feature-flag-sorting.mjs
-    # Environment loaded into every hogli invocation. Generic dotenv-style
-    # mechanism (like just/mise/task); secrets resolution is delegated to a
-    # configurable wrap binary (op/doppler/vault/…), not baked into hogli core.
     env:
-        # Loaded in order; earlier files win for duplicate keys; shell env always wins.
         files:
             - .env.development
             - .env.services
-        # Optional: when .env.local contains the marker substring AND the wrap
-        # binary is on PATH, hogli re-execs the whole invocation under it. If
-        # the wrap binary is missing, hogli loads .env.local directly with
-        # marker-matching lines skipped (so 'op://…' literals never leak as
-        # garbage env values that break downstream services with cryptic 401s).
         secrets:
             file: .env.local
             marker: 'op://'

--- a/tools/hogli/AGENTS.md
+++ b/tools/hogli/AGENTS.md
@@ -1,0 +1,85 @@
+# hogli — framework boundary and conventions
+
+`tools/hogli/` is the **generic** developer-CLI framework published on PyPI as `hogli`. It is not PostHog-specific. PostHog happens to be its primary consumer today, but the framework must remain usable by any project that wants a YAML-driven dev CLI.
+
+The PostHog-specific extension layer lives in `tools/hogli-commands/hogli_commands/` and is wired in via `config.commands_dir` + `config.boot_modules` in `hogli.yaml`.
+
+## What belongs where
+
+| Concern                                                                    | `tools/hogli/` (core, PyPI) | `tools/hogli-commands/` (PostHog extension)  |
+| -------------------------------------------------------------------------- | --------------------------- | -------------------------------------------- |
+| Command discovery (manifest schema, lazy click, extends)                   | ✅                          | ❌                                           |
+| Categorized help output                                                    | ✅                          | ❌                                           |
+| Telemetry framework (hook registration)                                    | ✅                          | ❌                                           |
+| Generic env file loading (`config.env.files`)                              | ✅                          | ❌                                           |
+| Generic secret-wrapper hook (`config.env.secrets` — file, marker, wrap)    | ✅                          | ❌                                           |
+| PostHog command implementations (`migrations:run`, `test`, `doctor`…)      | ❌                          | ✅                                           |
+| PostHog precheck handlers / telemetry properties / hint hooks              | ❌                          | ✅                                           |
+| Knowledge of `1Password` / `op` / `op://` specifically                     | ❌                          | ❌ — _neither._ Use the generic wrap config  |
+| Knowledge of `.env.development` / `.env.services` / `.env.local` filenames | ❌                          | ❌ — _neither._ Declare them in `hogli.yaml` |
+
+## Reviewer checklist for PRs touching `tools/hogli/`
+
+- [ ] Is the change generic, or does it bake in knowledge of a specific consumer (PostHog, a specific secrets tool, a specific filename)?
+- [ ] If it's specific, does it need to be in core, or can it move to `tools/hogli-commands/` (or be declared in `hogli.yaml` config)?
+- [ ] If new config schema, does it follow the existing pattern (`config.scripts_dir`, `config.commands_dir`, `config.boot_modules`)?
+- [ ] Tests live in `tools/hogli/tests/` and use temp configs/files — they don't depend on PostHog's `hogli.yaml`.
+
+## Prior art (env files + secrets)
+
+Researched 2026-05-20 before committing to the `config.env` schema. Summary, so the next contributor doesn't have to re-derive this:
+
+| Tool                                                            | Generic env files in core?                                              | Secret resolution in core?                                                                                                                        |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [just](https://just.systems/man/en/settings.html)               | ✅ (`dotenv-load`, `dotenv-filename`, `dotenv-path`, `dotenv-override`) | ❌ — wrap with `op run`/`doppler run`                                                                                                             |
+| [mise](https://mise.jdx.dev/environments/)                      | ✅ (`[env] _.file`, list, formats, redact)                              | ❌ — [maintainer explicitly excluded](https://github.com/jdx/mise/discussions/3712), built [fnox](https://github.com/jdx/fnox) as a separate tool |
+| [task](https://taskfile.dev/docs/guide)                         | ✅ (`dotenv: [...]`, global + per-task)                                 | ❌                                                                                                                                                |
+| `op run` / `doppler run` / `infisical run` / `dotenvx` / `fnox` | ❌ (they wrap your command)                                             | ✅ — _this is their whole product_                                                                                                                |
+| [varlock](https://varlock.dev/)                                 | ✅ + typed schema                                                       | ✅ via _provider plugins_ — but varlock is itself a dedicated secrets product, not a task runner                                                  |
+
+**The pattern that emerged:** generic env-file loading is a normal CLI framework feature with a small contract. Specific secret resolution (1Password, Vault, Doppler…) is its own product, invoked as a wrapper via `<secret-cli> run -- <your-command>`. mise's maintainer puts it best:
+
+> "mise reloads its environment too often and because secrets often rely on remote calls to things like kms or 1Password, it would make it too slow to be helpful."
+
+Even 1Password's own docs don't recommend a "task runner integration" — they just say to invoke `op run --` directly.
+
+## How hogli applies the pattern
+
+**In core (generic):**
+
+- `config.env.files: [...]` — list of dotenv files, loaded in order, first wins, shell env always wins.
+- `config.env.secrets.{file, marker, wrap}` — optional generic wrapper hook. When the secrets file contains the marker substring AND the wrap binary is on PATH, hogli re-execs the whole invocation under the wrap command. When the binary isn't installed, hogli loads the file directly with marker-matching lines skipped (so literals don't leak as garbage strings). A `HOGLI_SECRETS_WRAPPED=1` sentinel prevents re-exec loops.
+
+**Not in core:**
+
+- `op` / `op://` / 1Password as concepts — _declare them in `config.env.secrets`_.
+- Any specific file names (`.env.local`, `.env.development`, …) — _declare them in `config.env.files`_.
+
+PostHog declares its setup in the root `hogli.yaml`:
+
+```yaml
+config:
+  env:
+    files:
+      - .env.development
+      - .env.services
+    secrets:
+      file: .env.local
+      marker: 'op://'
+      wrap: [op, run, --env-file, '{file}', --]
+```
+
+Same primitive works for Doppler (`wrap: [doppler, run, --]`), Infisical (`wrap: [infisical, run, --]`), Vault, dotenvx, fnox, or anything else that follows the wrap-and-exec convention.
+
+## How not to evolve hogli
+
+Anti-patterns flagged during PR review (don't re-introduce):
+
+- Hardcoded filenames in `hogli/cli.py`. Always read from manifest.
+- `if shutil.which("op"):` or any tool-specific binary check in core. The wrap config makes the binary configurable; just check whether `shlex.split(wrap[0])` is on PATH.
+- Provider-specific helpful error messages ("install brew install 1password-cli"). Core's error message should be tool-agnostic ("the configured wrap binary `<x>` is not on PATH"). The PostHog-side extension can layer richer messaging via the hooks API if needed.
+- Adding behavior to `tools/hogli/src/hogli/cli.py` that's only useful to PostHog. Move it to `tools/hogli-commands/` and register via `boot_modules`.
+
+## When in doubt
+
+If you're about to add code to `tools/hogli/` and you're not sure whether it's generic enough: it probably isn't. Ask first, or write it in `tools/hogli-commands/` and we can promote it later if multiple consumers want it.

--- a/tools/hogli/AGENTS.md
+++ b/tools/hogli/AGENTS.md
@@ -76,7 +76,7 @@ Same primitive works for Doppler (`wrap: [doppler, run, --]`), Infisical (`wrap:
 Anti-patterns flagged during PR review (don't re-introduce):
 
 - Hardcoded filenames in `hogli/cli.py`. Always read from manifest.
-- `if shutil.which("op"):` or any tool-specific binary check in core. The wrap config makes the binary configurable; just check whether `shlex.split(wrap[0])` is on PATH.
+- `if shutil.which("op"):` or any tool-specific binary check in core. The wrap config makes the binary configurable; use `shutil.which(wrap[0])` so any wrap tool the user declared works the same way.
 - Provider-specific helpful error messages ("install brew install 1password-cli"). Core's error message should be tool-agnostic ("the configured wrap binary `<x>` is not on PATH"). The PostHog-side extension can layer richer messaging via the hooks API if needed.
 - Adding behavior to `tools/hogli/src/hogli/cli.py` that's only useful to PostHog. Move it to `tools/hogli-commands/` and register via `boot_modules`.
 

--- a/tools/hogli/CLAUDE.md
+++ b/tools/hogli/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/tools/hogli/README.md
+++ b/tools/hogli/README.md
@@ -251,6 +251,66 @@ def maybe_show_hint(command: str | None, exit_code: int) -> None:
 register_post_command_hook(maybe_show_hint)
 ```
 
+## Environment files
+
+hogli can load dotenv files into every command's environment, the same way
+[just](https://just.systems/man/en/settings.html),
+[mise](https://mise.jdx.dev/environments/), and
+[task](https://taskfile.dev/docs/guide) do. Declare them in `hogli.yaml`:
+
+```yaml
+config:
+  env:
+    files:
+      - .env.development # loaded in order; earlier wins for duplicate keys
+      - .env.services # shell env always wins (only_if_unset)
+```
+
+Missing files are silently skipped — same convention as the other tools — so
+`.env.local` is fine to leave optional.
+
+### Secret references (`config.env.secrets`)
+
+Loading raw secrets from disk is a separate problem from loading dotenv files,
+and tools like [1Password CLI](https://www.1password.dev/cli/),
+[Doppler](https://docs.doppler.com/docs/cli), [Infisical](https://infisical.com/docs/cli/overview),
+[Vault](https://developer.hashicorp.com/vault/docs/commands), and
+[dotenvx](https://dotenvx.com/) all expose the same pattern: wrap the command
+they should run, fetch the secrets at runtime, inject them into the subprocess
+env. hogli supports this generically — no provider-specific knowledge in core:
+
+```yaml
+config:
+  env:
+    secrets:
+      file: .env.local # the file that contains secret references
+      marker: 'op://' # optional: only wrap when this substring appears in the file
+      wrap: [op, run, --env-file, '{file}', --]
+```
+
+What happens at startup:
+
+1. If the secrets file exists AND contains `marker` AND `wrap[0]` is on `PATH`:
+   hogli re-execs itself under `wrap` (with `{file}` substituted to the
+   absolute path of the secrets file). The wrap binary resolves secrets and
+   re-runs hogli with them in the env. A `HOGLI_SECRETS_WRAPPED=1` sentinel
+   prevents infinite re-exec loops.
+2. If the wrap binary is missing, hogli loads the file directly but skips
+   any line whose value contains `marker` (so unresolved `op://...` strings
+   don't leak as garbage env values that produce confusing 401s downstream).
+3. If there's no marker hit, hogli loads the file directly without wrap.
+
+The same shape works for Doppler (`wrap: [doppler, run, --]`), Vault
+(`wrap: [vault, exec, --]`), Infisical (`wrap: [infisical, run, --]`),
+dotenvx (`wrap: [dotenvx, run, --]`), or anything else following the
+wrap-and-exec convention. hogli itself stays ignorant of which tool you use.
+
+Why this split (and not built-in 1Password/Doppler/Vault knowledge)? Because
+[mise's maintainer explicitly excluded secret resolution from mise core for
+good reasons](https://github.com/jdx/mise/discussions/3712): secret APIs are
+slow, caching them is a security risk, and CLI frameworks reload env too
+often for that to play nicely. Better to delegate to a purpose-built tool.
+
 ## Configuration Reference
 
 ```yaml
@@ -259,6 +319,12 @@ config:
   boot_modules:
     - package.boot # Optional eager hook registration modules
   scripts_dir: scripts # For bin_script resolution (default: bin/)
+  env:
+    files: [.env.development, .env.services] # Optional dotenv files (in order)
+    secrets: # Optional secret-wrapper hook
+      file: .env.local
+      marker: 'op://'
+      wrap: [op, run, --env-file, '{file}', --]
 
 metadata:
   categories:

--- a/tools/hogli/README.md
+++ b/tools/hogli/README.md
@@ -284,7 +284,7 @@ config:
   env:
     secrets:
       file: .env.local # the file that contains secret references
-      marker: 'op://' # optional: only wrap when this substring appears in the file
+      marker: 'op://' # substring that triggers the wrap; required, non-empty
       wrap: [op, run, --env-file, '{file}', --]
 ```
 
@@ -295,10 +295,17 @@ What happens at startup:
    absolute path of the secrets file). The wrap binary resolves secrets and
    re-runs hogli with them in the env. A `HOGLI_SECRETS_WRAPPED=1` sentinel
    prevents infinite re-exec loops.
-2. If the wrap binary is missing, hogli loads the file directly but skips
-   any line whose value contains `marker` (so unresolved `op://...` strings
-   don't leak as garbage env values that produce confusing 401s downstream).
-3. If there's no marker hit, hogli loads the file directly without wrap.
+2. If the wrap binary is missing or the marker isn't present, hogli loads the
+   file directly with marker-matching lines skipped (so unresolved `op://...`
+   strings don't leak as garbage env values that produce confusing 401s
+   downstream — only literal values get loaded).
+
+Precedence in either path (highest wins): shell env > secrets file > env
+files. So a literal override in `.env.local` always beats `.env.development`,
+matching what `op run` does when it's available.
+
+`marker` is required (not optional) — an "always wrap" mode would force a
+process exec on every hogli invocation, which we never want.
 
 The same shape works for Doppler (`wrap: [doppler, run, --]`), Vault
 (`wrap: [vault, exec, --]`), Infisical (`wrap: [infisical, run, --]`),

--- a/tools/hogli/src/hogli/cli.py
+++ b/tools/hogli/src/hogli/cli.py
@@ -311,18 +311,21 @@ def _apply_env_config() -> None:
     - No ``config.env``: no-op. hogli stays a transparent CLI.
     - ``config.env.files``: each file is loaded with only_if_unset=True. First
       file in the list wins for duplicate keys; shell env always wins.
-    - ``config.env.secrets``: optional wrapper for a secrets file (e.g. one
-      containing 1Password ``op://`` refs).
-        * If the file exists, has the marker, and the wrap binary is on PATH:
-          set the ``HOGLI_SECRETS_WRAPPED`` sentinel and ``execvp`` into the
-          wrap command, which re-runs this hogli invocation with secrets
-          resolved. Files are pre-loaded so wrap's child inherits them.
-        * If the file exists but the wrap binary is missing: load the file
-          directly with the marker as ``skip_pattern`` so ref lines don't
-          leak as literal strings. Warn the user.
-        * If the sentinel is already set, we are the child of a wrap re-exec —
-          skip the wrap entirely and proceed to load the files normally
-          (wrap has already populated the env from the secrets file).
+    - ``config.env.secrets``: wrapper for a secrets file (e.g. one containing
+      1Password ``op://`` refs).
+        * If the file exists, contains the marker, and the wrap binary is on
+          PATH: set the ``HOGLI_SECRETS_WRAPPED`` sentinel and ``execvp`` into
+          the wrap command, which re-runs hogli with secrets resolved. Files
+          are pre-loaded so wrap's child inherits them.
+        * If the wrap binary is missing or the marker doesn't hit, load the
+          file directly. Lines whose value contains the marker are skipped
+          (so unresolved refs don't leak as garbage env values).
+        * If the sentinel is already set we are the child of a wrap re-exec —
+          skip the wrap entirely and proceed to load the files normally.
+
+    Precedence (in both wrap-resolved and fallback paths, highest wins):
+    shell env > secrets file > env files (earlier files in the list win for
+    duplicate keys).
     """
     manifest = get_manifest()
     try:
@@ -340,15 +343,14 @@ def _apply_env_config() -> None:
     if secrets is not None and not already_wrapped:
         _maybe_reexec_via_wrap(secrets, env_files)
 
-    # Either no secrets configured, or we're the child of a wrap re-exec, or
-    # the wrap binary was missing / the marker didn't hit. Load files now.
+        # Reached here = no re-exec happened (no marker hit, file missing, or
+        # wrap binary missing). Load secrets BEFORE env_files so .env.local
+        # literals override .env.development / .env.services — matches the
+        # wrap-resolved path's precedence (where op layers .env.local on top).
+        _load_env_file(secrets["file"], only_if_unset=True, skip_pattern=secrets["marker"])
+
     for path in env_files:
         _load_env_file(path, only_if_unset=True)
-
-    if secrets is not None and not already_wrapped:
-        # Load any literal values from the secrets file; skip ref lines so
-        # unresolved markers don't leak as garbage env values.
-        _load_env_file(secrets["file"], only_if_unset=True, skip_pattern=secrets["marker"])
 
 
 def _maybe_reexec_via_wrap(secrets: dict[str, Any], env_files: list[Path]) -> None:
@@ -358,7 +360,7 @@ def _maybe_reexec_via_wrap(secrets: dict[str, Any], env_files: list[Path]) -> No
     file loading). Otherwise replaces the current process via ``os.execvp``.
     """
     secrets_file: Path = secrets["file"]
-    marker: str | None = secrets["marker"]
+    marker: str = secrets["marker"]
     wrap: list[str] | None = secrets["wrap"]
 
     if wrap is None or not secrets_file.exists():
@@ -367,12 +369,11 @@ def _maybe_reexec_via_wrap(secrets: dict[str, Any], env_files: list[Path]) -> No
     # Marker-gated re-exec: only wrap when the file actually references the
     # external resolver. Saves a process exec on dev workflows that haven't
     # set up secrets yet.
-    if marker:
-        try:
-            if marker not in secrets_file.read_text():
-                return
-        except OSError:
+    try:
+        if marker not in secrets_file.read_text():
             return
+    except OSError:
+        return
 
     wrap_binary = wrap[0]
     if not shutil.which(wrap_binary):

--- a/tools/hogli/src/hogli/cli.py
+++ b/tools/hogli/src/hogli/cli.py
@@ -13,6 +13,7 @@ import shutil
 import platform
 import importlib
 from collections import defaultdict
+from pathlib import Path
 from typing import Any
 
 import click
@@ -171,7 +172,10 @@ def _auto_update_manifest() -> None:
 @click.pass_context
 def cli(ctx: click.Context) -> None:
     """hogli - YAML-driven developer CLI."""
-    _load_default_env_files()
+    # Skip env loading during shell completion — completion fires this
+    # callback for every Tab press and doesn't need the env populated.
+    if not ctx.resilient_parsing:
+        _apply_env_config()
     # Auto-update manifest on every invocation (but skip for meta:check and git hooks)
     # Skip during git hooks to prevent manifest modifications during lint-staged execution
     in_git_hook = os.environ.get("GIT_DIR") is not None or os.environ.get("HUSKY") is not None
@@ -255,15 +259,34 @@ def concepts() -> None:
         click.echo()
 
 
-def _load_env_file(path: os.PathLike[str], only_if_unset: bool = True) -> None:
-    """Load environment variables from a file (KEY=VALUE per line, # comments).
+# Sentinel that prevents `_apply_env_config` from re-execing into the wrap
+# command in an infinite loop. Set by hogli right before exec'ing the wrap
+# binary; checked at the top of `_apply_env_config` on subsequent invocations.
+_SECRETS_WRAPPED_ENV = "HOGLI_SECRETS_WRAPPED"
 
-    op:// refs are always skipped — they only get resolved by `op run`, never by
-    sourcing the file directly. Setting them as literal strings would break
-    downstream services with cryptic API errors.
+# Substituted to the absolute path of the secrets file when building the wrap
+# argv. Kept as a constant so the README, AGENTS.md, and runtime stay in sync.
+_WRAP_FILE_PLACEHOLDER = "{file}"
+
+
+def _load_env_file(
+    path: os.PathLike[str],
+    only_if_unset: bool = True,
+    skip_pattern: str | None = None,
+) -> None:
+    """Load environment variables from a dotenv file (KEY=VALUE, # comments).
+
+    Args:
+        path: Path to the env file. Missing files are silently skipped
+            (matches just/mise/task convention so optional `.env.local` etc.
+            don't error).
+        only_if_unset: If True (default), don't overwrite existing env vars.
+            Lets shell env always win.
+        skip_pattern: If set, any line whose VALUE substring-matches this
+            pattern is skipped entirely. Used to keep secret-reference lines
+            (e.g. `op://...`) from leaking into the environment as literal
+            strings when the resolver isn't available. None disables filtering.
     """
-    from pathlib import Path
-
     env_file = Path(path)
     if not env_file.exists():
         return
@@ -273,75 +296,123 @@ def _load_env_file(path: os.PathLike[str], only_if_unset: bool = True) -> None:
         if not line or line.startswith("#") or "=" not in line:
             continue
         name, _, value = line.partition("=")
-        # Substring match so quoted (`KEY="op://..."`) and space-padded
-        # (`KEY= op://...`) forms are also skipped — matches what op run itself
-        # accepts. Leaking these as literals would break downstream services
-        # with cryptic API errors.
-        if "op://" in value:
+        if skip_pattern and skip_pattern in value:
             continue
         if only_if_unset and name in os.environ:
             continue
         os.environ[name] = value
 
 
-def _load_default_env_files() -> None:
-    """Load .env.development and .env.services for every hogli subcommand.
+def _apply_env_config() -> None:
+    """Apply ``config.env`` from hogli.yaml: load files, optionally re-exec via wrap.
 
-    Mirrors bin/start so commands that shell out to manage.py / bin scripts
-    (dev:reset, migrations:run, etc.) see the same service connection defaults
-    the dev stack uses. Shell vars win; we never overwrite.
+    Behavior depends on what's declared in the manifest:
 
-    .env.local is intentionally NOT loaded here — it can contain 1Password
-    op:// refs that only `hogli run` knows how to resolve via `op run`.
+    - No ``config.env``: no-op. hogli stays a transparent CLI.
+    - ``config.env.files``: each file is loaded with only_if_unset=True. First
+      file in the list wins for duplicate keys; shell env always wins.
+    - ``config.env.secrets``: optional wrapper for a secrets file (e.g. one
+      containing 1Password ``op://`` refs).
+        * If the file exists, has the marker, and the wrap binary is on PATH:
+          set the ``HOGLI_SECRETS_WRAPPED`` sentinel and ``execvp`` into the
+          wrap command, which re-runs this hogli invocation with secrets
+          resolved. Files are pre-loaded so wrap's child inherits them.
+        * If the file exists but the wrap binary is missing: load the file
+          directly with the marker as ``skip_pattern`` so ref lines don't
+          leak as literal strings. Warn the user.
+        * If the sentinel is already set, we are the child of a wrap re-exec —
+          skip the wrap entirely and proceed to load the files normally
+          (wrap has already populated the env from the secrets file).
     """
-    _load_env_file(REPO_ROOT / ".env.development", only_if_unset=True)
-    _load_env_file(REPO_ROOT / ".env.services", only_if_unset=True)
+    manifest = get_manifest()
+    try:
+        secrets = manifest.secrets_config
+        env_files = manifest.env_files
+    except ValueError as e:
+        click.echo(f"⚠️  Invalid config.env in hogli.yaml: {e}", err=True)
+        return
+
+    # Consume the sentinel — we're either the wrap-child (sentinel set) or
+    # the initial parent (sentinel unset). Pop so the sentinel never leaks
+    # to subprocesses or repeat in-process calls.
+    already_wrapped = os.environ.pop(_SECRETS_WRAPPED_ENV, None) is not None
+
+    if secrets is not None and not already_wrapped:
+        _maybe_reexec_via_wrap(secrets, env_files)
+
+    # Either no secrets configured, or we're the child of a wrap re-exec, or
+    # the wrap binary was missing / the marker didn't hit. Load files now.
+    for path in env_files:
+        _load_env_file(path, only_if_unset=True)
+
+    if secrets is not None and not already_wrapped:
+        # Load any literal values from the secrets file; skip ref lines so
+        # unresolved markers don't leak as garbage env values.
+        _load_env_file(secrets["file"], only_if_unset=True, skip_pattern=secrets["marker"])
 
 
-@cli.command(name="run", help="Run a command with resolved environment (1Password + defaults)")
+def _maybe_reexec_via_wrap(secrets: dict[str, Any], env_files: list[Path]) -> None:
+    """Re-exec hogli under the configured wrap command if the secrets file warrants it.
+
+    Returns normally if no re-exec is needed (caller falls through to direct
+    file loading). Otherwise replaces the current process via ``os.execvp``.
+    """
+    secrets_file: Path = secrets["file"]
+    marker: str | None = secrets["marker"]
+    wrap: list[str] | None = secrets["wrap"]
+
+    if wrap is None or not secrets_file.exists():
+        return
+
+    # Marker-gated re-exec: only wrap when the file actually references the
+    # external resolver. Saves a process exec on dev workflows that haven't
+    # set up secrets yet.
+    if marker:
+        try:
+            if marker not in secrets_file.read_text():
+                return
+        except OSError:
+            return
+
+    wrap_binary = wrap[0]
+    if not shutil.which(wrap_binary):
+        click.echo(
+            f"⚠️  {secrets_file.name} contains '{marker}' refs but the configured wrap binary "
+            f"'{wrap_binary}' is not on PATH.",
+            err=True,
+        )
+        click.echo(
+            f"   Refs will be skipped — services that need them will fail with their own errors. "
+            f"Install '{wrap_binary}' or replace the refs with literal values in {secrets_file.name}.",
+            err=True,
+        )
+        return
+
+    # Pre-load non-secrets files so the wrap binary's child inherits them.
+    # The wrap binary layers secrets on top, overriding these for any key
+    # also defined in the secrets file.
+    for path in env_files:
+        _load_env_file(path, only_if_unset=True)
+
+    resolved_wrap = [arg.replace(_WRAP_FILE_PLACEHOLDER, str(secrets_file)) for arg in wrap]
+    os.environ[_SECRETS_WRAPPED_ENV] = "1"
+    os.execvp(resolved_wrap[0], [*resolved_wrap, sys.executable, "-m", "hogli", *sys.argv[1:]])
+
+
+@cli.command(name="run", help="Run a command with the manifest's resolved environment")
 @click.argument("command", nargs=-1, required=True)
 def run_with_env(command: tuple[str, ...]) -> None:
-    """Run a command with PostHog environment variables.
+    """Run a command with the env loaded from ``config.env`` in hogli.yaml.
 
-    Loads .env.development defaults and .env.local overrides.
-    If .env.local contains 1Password references (op://), resolves them via `op run`.
-
-    Note: When using 1Password, op run's .env.local takes precedence over shell env.
-    This is op's design — secrets from 1Password are meant to win.
+    Env loading (files + optional wrap) is applied by the parent ``cli()``
+    group before this command runs, so by the time we get here ``os.environ``
+    already reflects whatever the manifest declared. This command is just a
+    thin ``execvp`` so callers don't need to repeat the wrapper pattern.
 
     Examples:
         hogli run ./manage.py shell
         hogli run pytest posthog/api/
     """
-    env_dev = REPO_ROOT / ".env.development"
-    env_services = REPO_ROOT / ".env.services"
-    env_local = REPO_ROOT / ".env.local"
-
-    has_op_refs = env_local.exists() and "op://" in env_local.read_text()
-
-    if has_op_refs and shutil.which("op"):
-        # Pre-load .env.development and .env.services (only if not already set in shell)
-        # so op run's child inherits them. op run then layers .env.local on top,
-        # overriding any variable it defines — including ones from shell. That's
-        # the precedence the docstring above promises: shell env > .env.local
-        # only applies to vars NOT defined in .env.local.
-        _load_env_file(env_dev, only_if_unset=True)
-        _load_env_file(env_services, only_if_unset=True)
-        os.execvp("op", ["op", "run", f"--env-file={env_local}", "--", *command])
-        return
-
-    # No op refs OR op CLI not installed — source files directly. _load_env_file
-    # skips op:// lines, so missing op CLI degrades gracefully: vars that needed
-    # 1Password are simply unset, and the downstream command fails with its own
-    # "missing key" error rather than swallowing a literal "op://..." string.
-    if has_op_refs:
-        click.echo("⚠️  .env.local contains 1Password refs (op://) but 'op' CLI is not installed.", err=True)
-        click.echo("   These refs will be skipped. Install: brew install 1password-cli", err=True)
-        click.echo("   Or replace op:// refs with literal values in .env.local.", err=True)
-
-    _load_env_file(env_local, only_if_unset=True)
-    _load_env_file(env_dev, only_if_unset=True)
-    _load_env_file(env_services, only_if_unset=True)
     os.execvp(command[0], list(command))
 
 

--- a/tools/hogli/src/hogli/manifest.py
+++ b/tools/hogli/src/hogli/manifest.py
@@ -183,7 +183,12 @@ class Manifest:
         raw_files = env_config.get("files") or []
         if not isinstance(raw_files, list):
             raise ValueError("config.env.files must be a list of repo-relative paths")
-        return [self._resolve_repo_relative_path("config.env.files", str(p)) for p in raw_files]
+        resolved: list[Path] = []
+        for entry in raw_files:
+            if not isinstance(entry, str) or not entry:
+                raise ValueError("config.env.files entries must be non-empty strings")
+            resolved.append(self._resolve_repo_relative_path("config.env.files", entry))
+        return resolved
 
     @property
     def secrets_config(self) -> dict[str, Any] | None:
@@ -191,7 +196,10 @@ class Manifest:
 
         Returned dict has:
         - ``file``: absolute Path to the secrets file (caller checks existence)
-        - ``marker``: substring that triggers the wrap (may be None to always wrap)
+        - ``marker``: required, non-empty substring that triggers the wrap.
+          Required (rather than optional) to keep behavior unambiguous: an
+          "always wrap" mode would force a process exec on every invocation
+          even when no secrets need resolving, which we never want.
         - ``wrap``: list[str], with ``{file}`` placeholder substituted to the
           absolute path of ``file`` at call time by the loader (not here, so
           the manifest stays declarative).
@@ -205,12 +213,12 @@ class Manifest:
 
         file_str = secrets.get("file")
         if not isinstance(file_str, str) or not file_str:
-            raise ValueError("config.env.secrets.file is required and must be a string")
+            raise ValueError("config.env.secrets.file is required and must be a non-empty string")
         file_path = self._resolve_repo_relative_path("config.env.secrets.file", file_str)
 
         marker = secrets.get("marker")
-        if marker is not None and not isinstance(marker, str):
-            raise ValueError("config.env.secrets.marker must be a string when set")
+        if not isinstance(marker, str) or not marker:
+            raise ValueError("config.env.secrets.marker is required and must be a non-empty string")
 
         wrap = secrets.get("wrap")
         if wrap is not None:

--- a/tools/hogli/src/hogli/manifest.py
+++ b/tools/hogli/src/hogli/manifest.py
@@ -147,21 +147,11 @@ class Manifest:
         if not isinstance(configured, str) or not configured:
             raise ValueError("config.commands_dir must be a non-empty relative path")
 
-        configured_path = Path(configured)
-        if configured_path.is_absolute():
-            raise ValueError(f"config.commands_dir '{configured}' must be relative to the repo root")
-
-        path = (REPO_ROOT / configured_path).resolve()
-        try:
-            path.relative_to(REPO_ROOT.resolve())
-        except ValueError:
-            raise ValueError(f"config.commands_dir '{configured}' resolves outside the repo root")
-
+        path = self._resolve_repo_relative_path("config.commands_dir", configured)
         if not path.exists():
             raise ValueError(f"config.commands_dir '{configured}' does not exist")
         if not path.is_dir():
             raise ValueError(f"config.commands_dir '{configured}' must resolve to a directory")
-
         return path
 
     @property
@@ -175,14 +165,77 @@ class Manifest:
         Always returns a path (may not exist).
         """
         configured = self.config.get("scripts_dir")
-        if configured:
-            path = (REPO_ROOT / configured).resolve()
-            try:
-                path.relative_to(REPO_ROOT.resolve())
-            except ValueError:
-                raise ValueError(f"config.scripts_dir '{configured}' resolves outside the repo root")
-            return path
-        return REPO_ROOT / "bin"
+        if not configured:
+            return REPO_ROOT / "bin"
+        return self._resolve_repo_relative_path("config.scripts_dir", configured)
+
+    @property
+    def env_files(self) -> list[Path]:
+        """Resolved env files to load before every command (`config.env.files`).
+
+        Files are NOT checked for existence here — the loader treats missing
+        files as silent no-ops (matches just/mise/task convention).
+
+        Precedence between files: hogli loads in the order returned here; the
+        loader uses only-if-unset so earlier entries win for duplicate keys.
+        """
+        env_config = self.config.get("env") or {}
+        raw_files = env_config.get("files") or []
+        if not isinstance(raw_files, list):
+            raise ValueError("config.env.files must be a list of repo-relative paths")
+        return [self._resolve_repo_relative_path("config.env.files", str(p)) for p in raw_files]
+
+    @property
+    def secrets_config(self) -> dict[str, Any] | None:
+        """Parsed `config.env.secrets` block, or None if unset.
+
+        Returned dict has:
+        - ``file``: absolute Path to the secrets file (caller checks existence)
+        - ``marker``: substring that triggers the wrap (may be None to always wrap)
+        - ``wrap``: list[str], with ``{file}`` placeholder substituted to the
+          absolute path of ``file`` at call time by the loader (not here, so
+          the manifest stays declarative).
+        """
+        env_config = self.config.get("env") or {}
+        secrets = env_config.get("secrets")
+        if secrets is None:
+            return None
+        if not isinstance(secrets, dict):
+            raise ValueError("config.env.secrets must be a mapping")
+
+        file_str = secrets.get("file")
+        if not isinstance(file_str, str) or not file_str:
+            raise ValueError("config.env.secrets.file is required and must be a string")
+        file_path = self._resolve_repo_relative_path("config.env.secrets.file", file_str)
+
+        marker = secrets.get("marker")
+        if marker is not None and not isinstance(marker, str):
+            raise ValueError("config.env.secrets.marker must be a string when set")
+
+        wrap = secrets.get("wrap")
+        if wrap is not None:
+            if not isinstance(wrap, list) or not all(isinstance(p, str) for p in wrap):
+                raise ValueError("config.env.secrets.wrap must be a list of strings when set")
+            if not wrap:
+                raise ValueError("config.env.secrets.wrap must not be empty when set")
+
+        return {"file": file_path, "marker": marker, "wrap": wrap}
+
+    def _resolve_repo_relative_path(self, key: str, raw: str) -> Path:
+        """Resolve a repo-relative path used in config.*, with sandbox checks.
+
+        Shared by commands_dir, scripts_dir, env_files, and secrets.file —
+        every config path must be relative and stay inside the repo root.
+        """
+        candidate = Path(raw)
+        if candidate.is_absolute():
+            raise ValueError(f"{key} '{raw}' must be relative to the repo root")
+        resolved = (REPO_ROOT / candidate).resolve()
+        try:
+            resolved.relative_to(REPO_ROOT.resolve())
+        except ValueError:
+            raise ValueError(f"{key} '{raw}' resolves outside the repo root")
+        return resolved
 
     def get_category_for_command(self, command_name: str) -> str:
         """Get category for a command based on which section it's placed in.

--- a/tools/hogli/tests/test_cli.py
+++ b/tools/hogli/tests/test_cli.py
@@ -204,7 +204,7 @@ class TestHelpText:
 
 
 class TestLoadEnvFile:
-    """Test _load_env_file behavior — esp. graceful handling of op:// refs."""
+    """Test _load_env_file behavior — esp. the optional skip_pattern."""
 
     def _write_env(self, tmp_path, content: str):
         env_file = tmp_path / ".env.test"
@@ -220,13 +220,13 @@ class TestLoadEnvFile:
         ],
         ids=["bare", "double-quoted", "leading-space"],
     )
-    def test_skips_op_refs_so_they_dont_leak_as_literals(
+    def test_skip_pattern_filters_matching_values(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch, op_line: str
     ) -> None:
-        """op:// values must never be set as literal env vars — they'd break downstream services.
+        """skip_pattern filters values that should never leak as literal env vars.
 
-        Covers bare, quoted, and space-padded forms (op run itself accepts all three,
-        so users may write any of them).
+        Covers bare/quoted/space-padded forms (op run itself accepts all three),
+        so users may write any of them and the substring match still skips them.
         """
         from hogli.cli import _load_env_file
 
@@ -234,10 +234,27 @@ class TestLoadEnvFile:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("LITERAL_VAR", raising=False)
 
-        _load_env_file(env_file)
+        _load_env_file(env_file, skip_pattern="op://")
 
         assert "OPENAI_API_KEY" not in os.environ
         assert os.environ["LITERAL_VAR"] == "actual_value"
+
+    def test_no_skip_pattern_loads_everything(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without skip_pattern the loader stays a transparent dotenv parser.
+
+        Important so the loader is reusable for plain dotenv files that have
+        nothing to do with secrets resolution.
+        """
+        from hogli.cli import _load_env_file
+
+        env_file = self._write_env(tmp_path, "API_KEY=op://foo/bar\nOTHER=baz\n")
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.delenv("OTHER", raising=False)
+
+        _load_env_file(env_file)  # no skip_pattern
+
+        assert os.environ["API_KEY"] == "op://foo/bar"
+        assert os.environ["OTHER"] == "baz"
 
     def test_missing_file_is_silent(self, tmp_path) -> None:
         """Missing env files should not raise — caller may pass an optional file."""
@@ -264,3 +281,218 @@ class TestLoadEnvFile:
         _load_env_file(env_file)
 
         assert os.environ["REAL_VAR"] == "42"
+
+
+class TestApplyEnvConfig:
+    """End-to-end behavior of _apply_env_config against mocked manifest config.
+
+    Patches `get_manifest` so each test can declare its own env_files /
+    secrets_config and we don't depend on PostHog's hogli.yaml. The mocked
+    manifest also keeps existing PostHog tests in the same file unaffected.
+    """
+
+    def _make_manifest(self, env_files=None, secrets_config=None) -> MagicMock:
+        m = MagicMock()
+        m.env_files = env_files or []
+        m.secrets_config = secrets_config
+        return m
+
+    def test_no_env_config_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Generic hogli installs with no `config.env` should not touch os.environ.
+
+        The PyPI hogli package must stay transparent for users who don't opt in.
+        """
+        from hogli.cli import _apply_env_config
+
+        monkeypatch.setattr("hogli.cli.get_manifest", lambda: self._make_manifest())
+        monkeypatch.delenv("UNRELATED_VAR", raising=False)
+        before = dict(os.environ)
+
+        _apply_env_config()
+
+        assert os.environ == before
+
+    def test_loads_files_in_declared_order_first_wins(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Earlier files in `config.env.files` win for duplicate keys (matches just/mise/task)."""
+        from hogli.cli import _apply_env_config
+
+        first = tmp_path / ".env.first"
+        second = tmp_path / ".env.second"
+        first.write_text("SHARED=from_first\nONLY_FIRST=1\n")
+        second.write_text("SHARED=from_second\nONLY_SECOND=2\n")
+
+        monkeypatch.setattr(
+            "hogli.cli.get_manifest",
+            lambda: self._make_manifest(env_files=[first, second]),
+        )
+        for k in ("SHARED", "ONLY_FIRST", "ONLY_SECOND", "HOGLI_SECRETS_WRAPPED"):
+            monkeypatch.delenv(k, raising=False)
+
+        _apply_env_config()
+
+        assert os.environ["SHARED"] == "from_first"
+        assert os.environ["ONLY_FIRST"] == "1"
+        assert os.environ["ONLY_SECOND"] == "2"
+
+    def test_shell_env_always_wins(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Shell env beats every config file — same precedence as bin/start."""
+        from hogli.cli import _apply_env_config
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("OVERRIDE_ME=from_file\n")
+
+        monkeypatch.setattr(
+            "hogli.cli.get_manifest",
+            lambda: self._make_manifest(env_files=[env_file]),
+        )
+        monkeypatch.setenv("OVERRIDE_ME", "from_shell")
+        monkeypatch.delenv("HOGLI_SECRETS_WRAPPED", raising=False)
+
+        _apply_env_config()
+
+        assert os.environ["OVERRIDE_ME"] == "from_shell"
+
+    def test_secrets_file_without_marker_loads_literals_directly(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Secrets file with no marker hit: load directly, no wrap re-exec."""
+        from hogli.cli import _apply_env_config
+
+        secrets_file = tmp_path / ".env.local"
+        secrets_file.write_text("PLAIN_KEY=plain_value\n")
+
+        secrets = {
+            "file": secrets_file,
+            "marker": "op://",
+            "wrap": ["op", "run", "--env-file", "{file}", "--"],
+        }
+        monkeypatch.setattr(
+            "hogli.cli.get_manifest",
+            lambda: self._make_manifest(secrets_config=secrets),
+        )
+        monkeypatch.delenv("PLAIN_KEY", raising=False)
+        monkeypatch.delenv("HOGLI_SECRETS_WRAPPED", raising=False)
+
+        with patch("os.execvp") as mock_exec:
+            _apply_env_config()
+
+        mock_exec.assert_not_called()
+        assert os.environ["PLAIN_KEY"] == "plain_value"
+
+    def test_marker_hit_with_wrap_binary_present_reexecs(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When marker matches and wrap binary is on PATH, hogli re-execs under it.
+
+        Verifies the wrap command is built with `{file}` substituted, the
+        sentinel is set so the child won't loop, and pre-existing env_files
+        were loaded into os.environ so the wrap child inherits them.
+        """
+        from hogli.cli import _apply_env_config
+
+        env_file = tmp_path / ".env.development"
+        env_file.write_text("PRELOADED=yes\n")
+        secrets_file = tmp_path / ".env.local"
+        secrets_file.write_text("API_KEY=op://vault/item/credential\n")
+
+        secrets = {
+            "file": secrets_file,
+            "marker": "op://",
+            "wrap": ["op", "run", "--env-file", "{file}", "--"],
+        }
+        monkeypatch.setattr(
+            "hogli.cli.get_manifest",
+            lambda: self._make_manifest(env_files=[env_file], secrets_config=secrets),
+        )
+        for k in ("PRELOADED", "HOGLI_SECRETS_WRAPPED"):
+            monkeypatch.delenv(k, raising=False)
+
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/op"),
+            patch("os.execvp") as mock_exec,
+        ):
+            _apply_env_config()
+
+        mock_exec.assert_called_once()
+        args, _kwargs = mock_exec.call_args
+        binary, argv = args
+        assert binary == "op"
+        # {file} got substituted with the absolute path
+        assert str(secrets_file) in argv
+        assert "{file}" not in argv
+        # argv re-runs hogli (so the child completes the original invocation)
+        assert any("hogli" in arg for arg in argv)
+        # pre-loaded files were applied before the exec (so wrap-child inherits)
+        assert os.environ["PRELOADED"] == "yes"
+        # sentinel set to prevent infinite re-exec loop
+        assert os.environ["HOGLI_SECRETS_WRAPPED"] == "1"
+
+    def test_marker_hit_but_wrap_binary_missing_falls_back_with_warning(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """When wrap binary isn't installed, load files but skip ref lines + warn.
+
+        This is the user-friendly degradation: the dev still gets `.env.local`
+        literal values (if any), but the unresolved refs don't leak as garbage
+        env values that produce confusing 401s downstream.
+        """
+        from hogli.cli import _apply_env_config
+
+        secrets_file = tmp_path / ".env.local"
+        secrets_file.write_text("OPENAI_API_KEY=op://vault/item/credential\nLITERAL=keep_me\n")
+
+        secrets = {
+            "file": secrets_file,
+            "marker": "op://",
+            "wrap": ["op", "run", "--env-file", "{file}", "--"],
+        }
+        monkeypatch.setattr(
+            "hogli.cli.get_manifest",
+            lambda: self._make_manifest(secrets_config=secrets),
+        )
+        for k in ("OPENAI_API_KEY", "LITERAL", "HOGLI_SECRETS_WRAPPED"):
+            monkeypatch.delenv(k, raising=False)
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("os.execvp") as mock_exec,
+        ):
+            _apply_env_config()
+
+        mock_exec.assert_not_called()
+        assert "OPENAI_API_KEY" not in os.environ
+        assert os.environ["LITERAL"] == "keep_me"
+        err = capsys.readouterr().err
+        assert "op://" in err
+        assert "op" in err  # wrap binary name surfaced
+
+    def test_sentinel_skips_reexec_so_child_doesnt_loop(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """After wrap re-execs hogli, the child sees HOGLI_SECRETS_WRAPPED and skips wrap.
+
+        Without this, the wrap binary would re-exec hogli forever.
+        """
+        from hogli.cli import _apply_env_config
+
+        secrets_file = tmp_path / ".env.local"
+        secrets_file.write_text("API_KEY=op://vault/item/credential\n")
+
+        secrets = {
+            "file": secrets_file,
+            "marker": "op://",
+            "wrap": ["op", "run", "--env-file", "{file}", "--"],
+        }
+        monkeypatch.setattr(
+            "hogli.cli.get_manifest",
+            lambda: self._make_manifest(secrets_config=secrets),
+        )
+        # Simulate being the child of a wrap re-exec: sentinel set, wrap already
+        # populated the env via op run (so OPENAI_API_KEY would be in env).
+        monkeypatch.setenv("HOGLI_SECRETS_WRAPPED", "1")
+        monkeypatch.setenv("API_KEY", "resolved_by_op")
+
+        with patch("os.execvp") as mock_exec:
+            _apply_env_config()
+
+        mock_exec.assert_not_called()
+        # Wrap binary's resolved value wins; the file isn't sourced over it
+        assert os.environ["API_KEY"] == "resolved_by_op"
+        # Sentinel is consumed so subsequent in-process calls behave normally
+        assert "HOGLI_SECRETS_WRAPPED" not in os.environ

--- a/tools/hogli/tests/test_cli.py
+++ b/tools/hogli/tests/test_cli.py
@@ -379,6 +379,64 @@ class TestApplyEnvConfig:
         mock_exec.assert_not_called()
         assert os.environ["PLAIN_KEY"] == "plain_value"
 
+    def test_secrets_file_overrides_env_files_in_fallback_path(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """In the no-wrap fallback path, .env.local literal values must win
+        over .env.development / .env.services — same precedence the wrap path
+        gives (where the resolver layers .env.local on top). This guards the
+        regression Codex flagged: loading env_files first with only_if_unset
+        meant .env.development was beating .env.local literal overrides."""
+        from hogli.cli import _apply_env_config
+
+        secrets_file = tmp_path / ".env.local"
+        secrets_file.write_text("SHARED_KEY=local_wins\n")
+        env_file = tmp_path / ".env.development"
+        env_file.write_text("SHARED_KEY=dev_loses\nDEV_ONLY=dev_value\n")
+
+        secrets = {
+            "file": secrets_file,
+            "marker": "op://",
+            "wrap": ["op", "run", "--env-file", "{file}", "--"],
+        }
+        monkeypatch.setattr(
+            "hogli.cli.get_manifest",
+            lambda: self._make_manifest(env_files=[env_file], secrets_config=secrets),
+        )
+        for k in ("SHARED_KEY", "DEV_ONLY", "HOGLI_SECRETS_WRAPPED"):
+            monkeypatch.delenv(k, raising=False)
+
+        with patch("os.execvp") as mock_exec:
+            _apply_env_config()
+
+        mock_exec.assert_not_called()
+        assert os.environ["SHARED_KEY"] == "local_wins"
+        assert os.environ["DEV_ONLY"] == "dev_value"
+
+    def test_missing_secrets_file_falls_through_silently(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No `.env.local` file at all (fresh user) — env_files still load and
+        no errors are raised. This is the bin/start "if one does not have the
+        .env.local file already" scenario."""
+        from hogli.cli import _apply_env_config
+
+        env_file = tmp_path / ".env.development"
+        env_file.write_text("DEV_ONLY=ok\n")
+        secrets = {
+            "file": tmp_path / ".env.local",  # doesn't exist
+            "marker": "op://",
+            "wrap": ["op", "run", "--env-file", "{file}", "--"],
+        }
+        monkeypatch.setattr(
+            "hogli.cli.get_manifest",
+            lambda: self._make_manifest(env_files=[env_file], secrets_config=secrets),
+        )
+        for k in ("DEV_ONLY", "HOGLI_SECRETS_WRAPPED"):
+            monkeypatch.delenv(k, raising=False)
+
+        with patch("os.execvp") as mock_exec:
+            _apply_env_config()
+
+        mock_exec.assert_not_called()
+        assert os.environ["DEV_ONLY"] == "ok"
+
     def test_marker_hit_with_wrap_binary_present_reexecs(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
         """When marker matches and wrap binary is on PATH, hogli re-execs under it.
 

--- a/tools/hogli/tests/test_manifest.py
+++ b/tools/hogli/tests/test_manifest.py
@@ -312,14 +312,12 @@ class TestEnvConfig:
         with pytest.raises(ValueError, match="must be a list"):
             _ = manifest.env_files
 
-    def test_secrets_config_minimal(self, tmp_path: Path, manifest_at) -> None:
-        """Marker and wrap are both optional — file alone is valid."""
-        manifest = manifest_at({"env": {"secrets": {"file": ".env.local"}}})
-        cfg = manifest.secrets_config
-        assert cfg is not None
-        assert cfg["file"] == tmp_path.resolve() / ".env.local"
-        assert cfg["marker"] is None
-        assert cfg["wrap"] is None
+    def test_env_files_rejects_non_string_entry(self, manifest_at) -> None:
+        """YAML can drop a number or mapping into the list — reject explicitly so
+        we don't silently `str()`-coerce it into a surprise path like `.` or `42`."""
+        manifest = manifest_at({"env": {"files": [".env.development", 42]}})
+        with pytest.raises(ValueError, match="non-empty strings"):
+            _ = manifest.env_files
 
     def test_secrets_config_full(self, tmp_path: Path, manifest_at) -> None:
         manifest = manifest_at(
@@ -344,12 +342,27 @@ class TestEnvConfig:
         with pytest.raises(ValueError, match="file is required"):
             _ = manifest.secrets_config
 
+    def test_secrets_config_requires_marker(self, manifest_at) -> None:
+        """Marker must be set + non-empty: 'always wrap' would force a process
+        exec on every invocation, and an empty string is too ambiguous to
+        deserve a behavior."""
+        manifest = manifest_at({"env": {"secrets": {"file": ".env.local", "wrap": ["op", "run", "--"]}}})
+        with pytest.raises(ValueError, match="marker is required"):
+            _ = manifest.secrets_config
+
+    def test_secrets_config_rejects_empty_marker(self, manifest_at) -> None:
+        manifest = manifest_at({"env": {"secrets": {"file": ".env.local", "marker": "", "wrap": ["op"]}}})
+        with pytest.raises(ValueError, match="marker is required"):
+            _ = manifest.secrets_config
+
     def test_secrets_config_rejects_empty_wrap(self, manifest_at) -> None:
-        manifest = manifest_at({"env": {"secrets": {"file": ".env.local", "wrap": []}}})
+        manifest = manifest_at({"env": {"secrets": {"file": ".env.local", "marker": "op://", "wrap": []}}})
         with pytest.raises(ValueError, match="must not be empty"):
             _ = manifest.secrets_config
 
     def test_secrets_config_rejects_non_string_wrap_items(self, manifest_at) -> None:
-        manifest = manifest_at({"env": {"secrets": {"file": ".env.local", "wrap": ["op", 42, "--"]}}})
+        manifest = manifest_at(
+            {"env": {"secrets": {"file": ".env.local", "marker": "op://", "wrap": ["op", 42, "--"]}}}
+        )
         with pytest.raises(ValueError, match="list of strings"):
             _ = manifest.secrets_config

--- a/tools/hogli/tests/test_manifest.py
+++ b/tools/hogli/tests/test_manifest.py
@@ -260,3 +260,96 @@ class TestCommandsDir:
             manifest = Manifest()
             with pytest.raises(ValueError, match="must be relative"):
                 _ = manifest.commands_dir
+
+
+class TestEnvConfig:
+    """Test `config.env` schema parsing.
+
+    Uses monkeypatch (not `with patch(...)`) so the module-level REPO_ROOT
+    swap survives the assertions — the existing TestCommandsDir style of
+    asserting inside a `with patch` block doesn't compose with `pytest.raises`
+    or with multi-assertion tests.
+    """
+
+    @pytest.fixture
+    def manifest_at(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Factory: build a Manifest rooted at tmp_path with the given config."""
+        # Resolve through symlinks once so equality checks work on macOS where
+        # /var/folders -> /private/var/folders.
+        repo = tmp_path.resolve()
+
+        def _build(config: dict) -> Manifest:
+            monkeypatch.setattr("hogli.manifest.REPO_ROOT", repo)
+            monkeypatch.setattr("hogli.manifest.MANIFEST_FILE", repo / "hogli.yaml")
+            monkeypatch.setattr(Manifest, "_load", lambda self: {"config": config})
+            return Manifest()
+
+        return _build
+
+    def test_unset_returns_empty_and_none(self, manifest_at) -> None:
+        """Without `config.env`, both accessors stay quiet — generic hogli is transparent."""
+        manifest = manifest_at({})
+        assert manifest.env_files == []
+        assert manifest.secrets_config is None
+
+    def test_env_files_resolves_repo_relative_paths(self, tmp_path: Path, manifest_at) -> None:
+        manifest = manifest_at({"env": {"files": [".env.development", ".env.services"]}})
+        repo = tmp_path.resolve()
+        assert manifest.env_files == [repo / ".env.development", repo / ".env.services"]
+
+    def test_env_files_rejects_absolute_path(self, tmp_path: Path, manifest_at) -> None:
+        manifest = manifest_at({"env": {"files": [str(tmp_path / ".env")]}})
+        with pytest.raises(ValueError, match="must be relative"):
+            _ = manifest.env_files
+
+    def test_env_files_rejects_escape_outside_repo(self, manifest_at) -> None:
+        manifest = manifest_at({"env": {"files": ["../etc/passwd"]}})
+        with pytest.raises(ValueError, match="outside the repo root"):
+            _ = manifest.env_files
+
+    def test_env_files_rejects_non_list(self, manifest_at) -> None:
+        manifest = manifest_at({"env": {"files": ".env"}})
+        with pytest.raises(ValueError, match="must be a list"):
+            _ = manifest.env_files
+
+    def test_secrets_config_minimal(self, tmp_path: Path, manifest_at) -> None:
+        """Marker and wrap are both optional — file alone is valid."""
+        manifest = manifest_at({"env": {"secrets": {"file": ".env.local"}}})
+        cfg = manifest.secrets_config
+        assert cfg is not None
+        assert cfg["file"] == tmp_path.resolve() / ".env.local"
+        assert cfg["marker"] is None
+        assert cfg["wrap"] is None
+
+    def test_secrets_config_full(self, tmp_path: Path, manifest_at) -> None:
+        manifest = manifest_at(
+            {
+                "env": {
+                    "secrets": {
+                        "file": ".env.local",
+                        "marker": "op://",
+                        "wrap": ["op", "run", "--env-file", "{file}", "--"],
+                    }
+                }
+            }
+        )
+        cfg = manifest.secrets_config
+        assert cfg is not None
+        assert cfg["file"] == tmp_path.resolve() / ".env.local"
+        assert cfg["marker"] == "op://"
+        assert cfg["wrap"] == ["op", "run", "--env-file", "{file}", "--"]
+
+    def test_secrets_config_requires_file(self, manifest_at) -> None:
+        manifest = manifest_at({"env": {"secrets": {"marker": "op://", "wrap": ["op", "run", "--"]}}})
+        with pytest.raises(ValueError, match="file is required"):
+            _ = manifest.secrets_config
+
+    def test_secrets_config_rejects_empty_wrap(self, manifest_at) -> None:
+        manifest = manifest_at({"env": {"secrets": {"file": ".env.local", "wrap": []}}})
+        with pytest.raises(ValueError, match="must not be empty"):
+            _ = manifest.secrets_config
+
+    def test_secrets_config_rejects_non_string_wrap_items(self, manifest_at) -> None:
+        manifest = manifest_at({"env": {"secrets": {"file": ".env.local", "wrap": ["op", 42, "--"]}}})
+        with pytest.raises(ValueError, match="list of strings"):
+            _ = manifest.secrets_config


### PR DESCRIPTION
## Problem

`tools/hogli/` is the **generic** dev-CLI framework published on PyPI as `hogli`. It is supposed to be reusable by any project that wants a YAML-driven dev CLI.

But two recent PRs baked PostHog-specifics into the framework:

- #45696 hardcoded the filenames `.env.development` / `.env.services` / `.env.local` and the `op://` substring into `hogli/cli.py`, and added a `hogli run` subcommand that knows about 1Password's CLI.
- #59199 added `_load_default_env_files()` that loads those PostHog files on every hogli subcommand.

Neither belongs in the framework. Other consumers of hogli would have had to fork or work around it.

## Approach

Surveyed prior art before settling on a shape (just / mise / taskfile / dotenvx / fnox / 1Password CLI / Doppler / Infisical / varlock). The pattern that emerges:

- **Generic env-file loading** is a normal CLI framework feature with a small contract. just, mise, taskfile all have it (`dotenv-load`, `[env] _.file`, `dotenv:`).
- **Specific secret resolution** (1Password, Vault, Doppler…) is its own product, invoked as a wrapper: `<cli> run -- <your-command>`. mise's maintainer [explicitly excluded it from mise core](https://github.com/jdx/mise/discussions/3712) and built fnox separately because secret APIs are slow + caching them is a security risk. 1Password's own docs don't recommend a "task runner integration" either — they just say to invoke `op run --` directly.

So this PR splits the two: generic loading in core, specific resolver delegated to a configurable wrap binary.

## Changes

**In `tools/hogli/` (the framework):**

- New `config.env.files` — ordered dotenv loading, earlier wins for duplicate keys, shell env always wins. Missing files are silent (matches just/mise/task).
- New `config.env.secrets {file, marker, wrap}` — optional generic wrap hook. When the secrets file contains `marker` AND `wrap[0]` is on PATH, hogli re-execs itself under the wrap command (with `{file}` substituted). A `HOGLI_SECRETS_WRAPPED=1` sentinel prevents infinite re-exec loops. If the wrap binary is missing, hogli loads the file directly with marker-matching lines skipped (so unresolved refs don't leak as garbage env values that produce confusing 401s downstream).
- Dropped all 1Password / op:// / .env.\* knowledge from `hogli/cli.py`. The same primitive now drives Doppler (`wrap: [doppler, run, --]`), Vault (`wrap: [vault, exec, --]`), Infisical, dotenvx, fnox, or anything else following the wrap-and-exec convention.
- Skips the loading work entirely during shell completion (`ctx.resilient_parsing`).
- Shared `_resolve_repo_relative_path` helper across `commands_dir` / `scripts_dir` / `env_files` / `secrets.file` — also fixes a latent bug where `config.scripts_dir` silently accepted absolute paths.

**In PostHog's `hogli.yaml`:**

```yaml
config:
  env:
    files:
      - .env.development
      - .env.services
    secrets:
      file: .env.local
      marker: 'op://'
      wrap: [op, run, --env-file, '{file}', --]
```

**New `tools/hogli/AGENTS.md`** (+ `CLAUDE.md` symlink): documents the framework-vs-extension boundary, the prior-art research, a reviewer checklist, and the list of anti-patterns to avoid so the next contributor doesn't re-introduce hardcoded `op://` / `.env.local` knowledge in core.

**Docs:** README section on `config.env` covering the wrap pattern with examples for op / doppler / vault.

## Backwards compatibility

PostHog behavior is unchanged — the existing `.env.development` / `.env.services` / op:// flow now runs through the generic loader instead of hardcoded paths. Generic hogli installs without `config.env` continue to behave transparently (no env loading happens).

## How did you test this code?

Agent-authored (Claude Opus 4.7) with human direction and a manual `/simplify` review pass that fixed: inline imports, stringly-typed placeholders, double file reads, hot-path completion bloat, hidden side effects, and the shared path resolver.

Automated:

- 216/216 hogli tests pass (added 22 new ones covering manifest schema parsing, env loader behavior, wrap re-exec, sentinel recursion guard, graceful binary-missing fallback)
- `ruff check` + `ruff format --check` clean
- semgrep devex rules clean

Manual:

- `hogli run env` confirms `DEBUG` / `CLICKHOUSE_DATABASE` / `PERSONHOG_ADDR` are loaded into subprocess env, matching the pre-PR behavior
- Manifest schema parsed correctly against PostHog's actual `hogli.yaml`

Did NOT test: `hogli start` end-to-end (would require booting the dev stack); the wrap re-exec path against real `op` (covered by mocked test instead).

## Publish to changelog?

no

## 🤖 Agent context

Claude Opus 4.7 (Claude Code) — design + implementation + simplify pass.

Investigation path: user flagged that recent PRs were baking PostHog conventions into the published hogli package. Did a web-search pass through just/mise/task/dotenvx/varlock/fnox/op-CLI/Doppler/Infisical to understand the design space before committing to a schema. The mise discussion (linked above + in AGENTS.md) was decisive — same maintainer constraints apply here.

Decisions:

- Marker-gated wrap rather than always-wrap (saves a process exec when no secrets are configured).
- `{file}` placeholder substitution (kept narrow — not a full templating language) to support both `op run --env-file=PATH --` and `doppler run --` styles with one schema.
- Sentinel via env var (`HOGLI_SECRETS_WRAPPED`) rather than command-line flag — survives re-exec without polluting Click's arg parser.
- Kept the existing `_load_env_file` (~15 lines) instead of pulling in `python-dotenv` — would expand the PyPI wheel's runtime deps for trivial parsing.
