### PR TITLE
chore(logs): move capture-logs management port off 8081

### DIFF
--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -94,7 +94,7 @@ case "$RS_SVC" in
     export RUST_BACKTRACE=1
     export BIND_HOST=0.0.0.0
     export BIND_PORT=4320 # Offset from 4318 to avoid conflict with otel-collector host port mapping
-    export MANAGEMENT_BIND_PORT=8081 # Avoid clash with other Rust services on 8080
+    export MANAGEMENT_BIND_PORT=3304 # Park alongside the other Rust services (3301-3309); 8080/8081 clash with local infra (temporal-ui)
     export KAFKA_HOSTS=localhost:9092
     export KAFKA_TOPIC=logs_ingestion
     export KAFKA_METRICS_TOPIC=metrics_ingestion


### PR DESCRIPTION
## Problem

The `capture-logs` Rust service started by `bin/start-rust-service` exports `MANAGEMENT_BIND_PORT=8081`, which collides with the local `temporal-ui` container. When both run together, the temporal UI is unreachable on `localhost:8081` (or the management endpoint fails to bind, depending on start order).

The 8081 binding landed alongside an unrelated larger change and was never intended to be sticky — it can move freely.

## Changes

- `bin/start-rust-service`: set `MANAGEMENT_BIND_PORT=3304` for `capture-logs`, parking it next to the other Rust dev services (3301 batch-import-worker, 3302 cymbal, 3303 cyclotron-janitor, 3305 embedding-worker, 3306–3309 capture variants). 3304 was the only unused slot in that adjacent range.
- The HTTP `BIND_PORT=4320` for actual log ingestion is unchanged.

## How did you test this code?

I'm an agent — I did not run the dev stack to verify. Confirmed by inspection that:

- 3304 is not assigned to any other service in `bin/start-rust-service` or any Rust service `config.rs` default,
- The change is purely a local-dev env var; production deployments override `MANAGEMENT_BIND_PORT` separately.

Recommend a reviewer brings up `hogli start` (or `./bin/start`) with `capture-logs` enabled and confirms `localhost:8081` returns the temporal UI while `capture-logs` health/metrics respond on `localhost:3304`.

## Publish to changelog?

no

## Docs update

No docs reference this port.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7) from a Slack thread where the original author confirmed the 8081 binding wasn't intentional and could move anywhere. Chose 3304 over higher ports (3310+) to keep the Rust dev services contiguous; verified by grepping `bin/start-rust-service` and the per-service `config.rs` defaults that no other service claims 3304.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*