### PR TITLE
feat(max): tag llm analytics events by ui surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,10 @@ DEBUG=1
 # GITHUB_APP_CLIENT_SECRET=
 # GITHUB_APP_SLUG=
 # GITHUB_APP_PRIVATE_KEY=
+
+# Max hands-free mode (ElevenLabs Scribe for STT + ElevenLabs TTS for voice playback)
+ELEVENLABS_API_KEY=
+# ELEVENLABS_API_BASE_URL=https://api.elevenlabs.io
+# ELEVENLABS_STT_MODEL_ID=scribe_v1
+# ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
+# ELEVENLABS_TTS_MODEL_ID=eleven_turbo_v2_5

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -106,6 +106,10 @@ class MessageSerializer(MessageMinimalSerializer):
     agent_mode = serializers.ChoiceField(required=False, choices=[mode.value for mode in AgentMode])
     is_sandbox = serializers.BooleanField(required=False, default=False)
     resume_payload = serializers.JSONField(required=False, allow_null=True)
+    # Which UI surface produced this turn — tags LLM analytics generations so cost,
+    # latency, model-mix can be filtered per surface. Free-form so new surfaces don't
+    # require an enum migration; validated only for shape (short string).
+    surface = serializers.CharField(required=False, allow_blank=True, max_length=32)
 
     def validate(self, attrs):
         data = attrs
@@ -438,6 +442,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
                 is_agent_billable=is_agent_billable,
                 is_impersonated=is_impersonated,
                 resume_payload=serializer.validated_data.get("resume_payload"),
+                surface=serializer.validated_data.get("surface") or None,
             )
             workflow_class = ChatAgentWorkflow
             timeout = CHAT_AGENT_WORKFLOW_TIMEOUT

--- a/ee/api/hands_free.py
+++ b/ee/api/hands_free.py
@@ -1,0 +1,190 @@
+"""Backend support for Max's hands-free mode.
+
+Hands-free mode lets a user talk to Max with their hands and eyes off the screen — built
+for mobile-web (gym, walking, driving). Speech-to-text runs via ElevenLabs Scribe directly
+from the browser; this module's only job is to mint single-use Scribe tokens so the
+ElevenLabs API key never reaches the client. TTS is handled by the browser's native
+speechSynthesis API and needs no backend at all.
+"""
+
+from typing import Any
+
+from django.conf import settings
+from django.http import StreamingHttpResponse
+
+import requests
+import structlog
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema
+from prometheus_client import Counter
+from rest_framework import serializers, status
+from rest_framework.decorators import action
+from rest_framework.exceptions import APIException
+from rest_framework.parsers import JSONParser
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.rate_limit import MaxHandsFreeBurstRateThrottle, MaxHandsFreeSustainedRateThrottle
+
+from ee.models.assistant import Conversation
+
+logger = structlog.get_logger(__name__)
+
+ELEVENLABS_TIMEOUT_SECONDS = (5, 10)
+# Generous enough for any Max summary, tight enough that an attacker minting at the
+# throttle ceiling can't ramp Scribe cost into the stratosphere.
+TTS_MAX_INPUT_CHARS = 2000
+
+# One counter, partitioned by outcome — lets us track abuse signal (provider rejection
+# spikes, repeated empty tokens) and steady-state cost (ok counts ≈ Scribe spend) without
+# blowing up cardinality via per-team labels.
+HANDS_FREE_TOKEN_COUNTER = Counter(
+    "max_hands_free_token_total",
+    "Outcomes for ElevenLabs Scribe single-use token mints from the hands-free endpoint.",
+    labelnames=["outcome"],
+)
+HANDS_FREE_SYNTHESIZE_COUNTER = Counter(
+    "max_hands_free_synthesize_total",
+    "Outcomes for ElevenLabs TTS proxy requests from the hands-free endpoint.",
+    labelnames=["outcome"],
+)
+HANDS_FREE_SYNTHESIZE_CHARS_COUNTER = Counter(
+    "max_hands_free_synthesize_chars_total",
+    "Total characters submitted for ElevenLabs TTS — proxy for Scribe spend.",
+)
+
+
+class HandsFreeNotConfigured(APIException):
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = "Hands-free mode is not configured on this PostHog instance."
+    default_code = "hands_free_not_configured"
+
+
+class HandsFreeProviderError(APIException):
+    status_code = status.HTTP_502_BAD_GATEWAY
+    default_detail = "The hands-free provider rejected the request."
+    default_code = "hands_free_provider_error"
+
+
+class SynthesizeSerializer(serializers.Serializer):
+    text = serializers.CharField(
+        required=True,
+        max_length=TTS_MAX_INPUT_CHARS,
+        help_text="The text the assistant should speak aloud.",
+    )
+
+
+def _require_api_key() -> str:
+    api_key = settings.ELEVENLABS_API_KEY
+    if not api_key:
+        HANDS_FREE_TOKEN_COUNTER.labels(outcome="missing_key").inc()
+        logger.warning("max_hands_free_api_key_missing")
+        raise HandsFreeNotConfigured()
+    return api_key
+
+
+class MaxHandsFreeViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
+    scope_object = "INTERNAL"
+    # Hands-free actions are list-level and don't operate on any model — DRF's GenericViewSet
+    # needs a queryset attribute for the routing scaffolding but it is never read.
+    queryset = Conversation.objects.none()
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [MaxHandsFreeBurstRateThrottle, MaxHandsFreeSustainedRateThrottle]
+
+    @extend_schema(responses={200: OpenApiTypes.OBJECT})
+    @action(detail=False, methods=["POST"], url_path="token")
+    def token(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Mint a single-use ElevenLabs Scribe realtime token.
+
+        The browser uses the token to open a WebSocket directly to ElevenLabs — audio never
+        transits PostHog infrastructure. Tokens are time-bound (15 min) and single-use; the
+        per-team rate limit on this endpoint caps how often a user can mint new ones.
+
+        Never logs the upstream response body — provider error responses can echo PII back and
+        we don't want any of that landing in structured logs.
+        """
+        api_key = _require_api_key()
+        try:
+            upstream = requests.post(
+                f"{settings.ELEVENLABS_API_BASE_URL}/v1/single-use-token/realtime_scribe",
+                headers={"xi-api-key": api_key},
+                timeout=ELEVENLABS_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException:
+            HANDS_FREE_TOKEN_COUNTER.labels(outcome="provider_unreachable").inc()
+            logger.exception("max_hands_free_token_failed")
+            raise HandsFreeProviderError("Failed to reach the hands-free provider.")
+
+        if upstream.status_code != status.HTTP_200_OK:
+            HANDS_FREE_TOKEN_COUNTER.labels(outcome="provider_rejected").inc()
+            logger.warning("max_hands_free_token_rejected", status_code=upstream.status_code)
+            raise HandsFreeProviderError(f"Hands-free provider returned {upstream.status_code}.")
+
+        token: str = upstream.json().get("token", "")
+        if not token:
+            HANDS_FREE_TOKEN_COUNTER.labels(outcome="empty_token").inc()
+            logger.warning("max_hands_free_token_empty")
+            raise HandsFreeProviderError("Hands-free provider returned an empty token.")
+        HANDS_FREE_TOKEN_COUNTER.labels(outcome="ok").inc()
+        return Response({"token": token})
+
+    @extend_schema(request=SynthesizeSerializer, responses={200: OpenApiTypes.BINARY})
+    @action(detail=False, methods=["POST"], url_path="synthesize", parser_classes=[JSONParser])
+    def synthesize(self, request: Request, *args: Any, **kwargs: Any) -> StreamingHttpResponse:
+        """Proxy text-to-speech to ElevenLabs, streaming mp3 audio back to the browser.
+
+        The viewset has no per-action `parser_classes` other than this one because the
+        token endpoint takes no body. Putting JSONParser here keeps the rest of the
+        viewset parser-free.
+        """
+        serializer = SynthesizeSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        text = serializer.validated_data["text"]
+
+        api_key = _require_api_key()
+        HANDS_FREE_SYNTHESIZE_CHARS_COUNTER.inc(len(text))
+        voice_id = settings.ELEVENLABS_VOICE_ID
+        try:
+            upstream = requests.post(
+                f"{settings.ELEVENLABS_API_BASE_URL}/v1/text-to-speech/{voice_id}",
+                headers={
+                    "xi-api-key": api_key,
+                    "Accept": "audio/mpeg",
+                    "Content-Type": "application/json",
+                },
+                json={"text": text, "model_id": settings.ELEVENLABS_TTS_MODEL_ID},
+                timeout=ELEVENLABS_TIMEOUT_SECONDS,
+                stream=True,
+            )
+        except requests.RequestException:
+            HANDS_FREE_SYNTHESIZE_COUNTER.labels(outcome="provider_unreachable").inc()
+            logger.exception("max_hands_free_synthesize_failed")
+            raise HandsFreeProviderError("Failed to reach the hands-free provider.")
+
+        if upstream.status_code != status.HTTP_200_OK:
+            HANDS_FREE_SYNTHESIZE_COUNTER.labels(outcome="provider_rejected").inc()
+            # ElevenLabs 4xx responses are JSON describing the account/quota state — not the
+            # user's input. Safe to log a snippet so devs can see "quota_exceeded" vs
+            # "voice_not_found" without hitting the dashboard.
+            body_preview = ""
+            try:
+                body_preview = upstream.text[:300].replace("\n", " ")
+            except Exception:
+                pass
+            logger.warning(
+                "max_hands_free_synthesize_rejected",
+                status_code=upstream.status_code,
+                body_preview=body_preview,
+            )
+            raise HandsFreeProviderError(f"Hands-free provider returned {upstream.status_code}.")
+
+        HANDS_FREE_SYNTHESIZE_COUNTER.labels(outcome="ok").inc()
+        response = StreamingHttpResponse(
+            upstream.iter_content(chunk_size=4096),
+            content_type="audio/mpeg",
+        )
+        response["Cache-Control"] = "no-store"
+        return response

--- a/ee/api/test/test_hands_free.py
+++ b/ee/api/test/test_hands_free.py
@@ -1,0 +1,63 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+
+@override_settings(
+    ELEVENLABS_API_KEY="test-key",
+    ELEVENLABS_API_BASE_URL="https://api.elevenlabs.example",
+)
+class TestMaxHandsFreeAPI(APIBaseTest):
+    def _token_url(self) -> str:
+        return f"/api/environments/{self.team.id}/max_hands_free/token/"
+
+    @patch("ee.api.hands_free.requests.post")
+    def test_token_returns_signed_token_from_elevenlabs(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"token": "single-use-token-abc"}),
+        )
+
+        response = self.client.post(self._token_url(), format="json")
+
+        assert response.status_code == 200
+        assert response.json() == {"token": "single-use-token-abc"}
+        assert mock_post.call_args.args[0].endswith("/v1/single-use-token/realtime_scribe")
+        assert mock_post.call_args.kwargs["headers"]["xi-api-key"] == "test-key"
+
+    @override_settings(ELEVENLABS_API_KEY="")
+    def test_returns_503_when_api_key_missing(self) -> None:
+        response = self.client.post(self._token_url(), format="json")
+        assert response.status_code == 503
+
+    @patch("ee.api.hands_free.requests.post")
+    def test_returns_502_when_provider_errors(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = MagicMock(status_code=429, text="rate limited")
+        response = self.client.post(self._token_url(), format="json")
+        assert response.status_code == 502
+
+    @patch("ee.api.hands_free.requests.post")
+    def test_returns_502_when_provider_returns_empty_token(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = MagicMock(status_code=200, json=MagicMock(return_value={"token": ""}))
+        response = self.client.post(self._token_url(), format="json")
+        assert response.status_code == 502
+
+    @patch("ee.api.hands_free.requests.post")
+    def test_provider_error_does_not_log_response_body(self, mock_post: MagicMock) -> None:
+        upstream = MagicMock(status_code=500, text="ECHOED API KEY OR PII")
+        mock_post.return_value = upstream
+
+        with patch("ee.api.hands_free.logger") as mock_logger:
+            response = self.client.post(self._token_url(), format="json")
+
+        assert response.status_code == 502
+        log_calls = mock_logger.warning.call_args_list + mock_logger.exception.call_args_list
+        for call in log_calls:
+            for value in list(call.args) + list(call.kwargs.values()):
+                assert "ECHOED API KEY OR PII" not in str(value)
+
+    def test_requires_authentication(self) -> None:
+        self.client.logout()
+        response = self.client.post(self._token_url(), format="json")
+        assert response.status_code in (401, 403)

--- a/ee/hogai/chat_agent/runner.py
+++ b/ee/hogai/chat_agent/runner.py
@@ -57,6 +57,7 @@ class ChatAgentRunner(BaseAgentRunner):
     _state: Optional[AssistantState]
     _initial_state: Optional[AssistantState | PartialAssistantState]
     _selected_agent_mode: AgentMode | None
+    _selected_surface: Optional[str]
 
     def __init__(
         self,
@@ -78,6 +79,7 @@ class ChatAgentRunner(BaseAgentRunner):
         is_agent_billable: bool = True,
         is_impersonated: bool = False,
         resume_payload: Optional[dict[str, Any]] = None,
+        surface: Optional[str] = None,
     ):
         super().__init__(
             team,
@@ -108,6 +110,7 @@ class ChatAgentRunner(BaseAgentRunner):
             resume_payload=resume_payload,
         )
         self._selected_agent_mode = agent_mode
+        self._selected_surface = surface
 
     def get_initial_state(self) -> AssistantState:
         if self._latest_message:
@@ -117,6 +120,7 @@ class ChatAgentRunner(BaseAgentRunner):
                 query_generation_retry_count=0,
                 graph_status=None,
                 rag_context=None,
+                surface=self._selected_surface,
             )
             # Only set the agent mode if it was explicitly set.
             if self._selected_agent_mode:

--- a/ee/hogai/core/agent_modes/executables.py
+++ b/ee/hogai/core/agent_modes/executables.py
@@ -268,6 +268,7 @@ class AgentExecutable(BaseAgentLoopRootExecutable):
         return {
             "agent_mode": state.agent_mode_or_default.value,
             "supermode": supermode_value,
+            "surface": state.surface,
         }
 
     def _get_model(self, state: AssistantState, tools: list["MaxTool"]):

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -325,6 +325,12 @@ class BaseStateWithMessages(BaseState):
     The supermode of the agent (e.g., PLAN, RESEARCH).
     Use CLEAR_SUPERMODE string to explicitly clear the supermode.
     """
+    surface: str | None = Field(default=None)
+    """
+    Which UI surface produced this turn (e.g. "hands_free", "text"). Tagged on every
+    LLM analytics generation so cost / latency / model-mix can be scoped to a specific
+    surface. Set per-turn from the request payload; not persisted across turns.
+    """
 
     @field_validator("messages", mode="after")
     @classmethod

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -46,7 +46,7 @@ def extend_api_router() -> None:
         router as root_router,
     )
 
-    from ee.api import max_tools, session_summaries
+    from ee.api import hands_free, max_tools, session_summaries
 
     root_router.register(r"billing", billing.BillingViewset, "billing")
     root_router.register(r"license", license.LicenseViewSet)
@@ -97,6 +97,10 @@ def extend_api_router() -> None:
     )
 
     environments_router.register(r"max_tools", max_tools.MaxToolsViewSet, "environment_max_tools", ["team_id"])
+
+    environments_router.register(
+        r"max_hands_free", hands_free.MaxHandsFreeViewSet, "environment_max_hands_free", ["team_id"]
+    )
 
     environments_router.register(
         r"session_summaries", session_summaries.SessionSummariesViewSet, "environment_session_summaries", ["team_id"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
+        "@elevenlabs/client": "^1.4.0",
         "@floating-ui/react": "^0.27.19",
         "@marsidev/react-turnstile": "^1.4.2",
         "@mathjax/src": "^4.1.1",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1709,6 +1709,11 @@ export class ApiRequest {
         return this.environmentsDetail(teamId).addPathComponent('conversations').addPathComponent(id)
     }
 
+    // Max hands-free mode (ElevenLabs Scribe token proxy)
+    public maxHandsFree(teamId?: TeamType['id']): ApiRequest {
+        return this.environmentsDetail(teamId).addPathComponent('max_hands_free')
+    }
+
     // Conversations (Support product)
     public conversationsTickets(teamId?: TeamType['id']): ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('conversations').addPathComponent('tickets')
@@ -6357,6 +6362,23 @@ const api = {
     schema: {
         async queryUpgrade(data: { query: Node }): Promise<{ query: Node }> {
             return await new ApiRequest().queryUpgrade().create({ data })
+        },
+    },
+
+    maxHandsFree: {
+        async token(options?: ApiMethodOptions): Promise<{ token: string }> {
+            return await api.create(
+                new ApiRequest().maxHandsFree().withAction('token').assembleFullUrl(),
+                undefined,
+                options
+            )
+        },
+        async synthesize(text: string, options?: ApiMethodOptions): Promise<Response> {
+            return await api.createResponse(
+                new ApiRequest().maxHandsFree().withAction('synthesize').assembleFullUrl(),
+                { text },
+                options
+            )
         },
     },
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6398,6 +6398,9 @@ const api = {
                     proposal_id: string
                     feedback?: string
                 } | null
+                /** UI surface that triggered this turn (e.g. 'hands_free'). Tagged on backend
+                 *  LLM analytics events so cost / latency / model-mix can be filtered per surface. */
+                surface?: string
             },
             options?: ApiMethodOptions
         ): Promise<Response> {

--- a/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
+++ b/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
@@ -178,8 +178,8 @@ export const appShortcutLogic = kea<appShortcutLogicType>([
                 return
             }
 
-            // Handle sequence shortcuts (no modifier keys, not in editable elements)
-            if (isEditableElement(event) || event.altKey) {
+            // Handle sequence shortcuts (no modifier keys, not in editable elements, not mid-IME-composition)
+            if (isEditableElement(event) || event.altKey || event.isComposing) {
                 return
             }
 

--- a/frontend/src/lib/components/AppShortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/AppShortcuts/shortcuts.ts
@@ -38,6 +38,7 @@ export const keyBinds: Record<string, string[]> = {
     tab9: [...baseModifier, '9'],
     zenMode: [...baseModifier, 'z'],
     newChat: ['g', 'then', 'n'],
+    maxHandsFree: ['h', 'then', 'f'],
     allChats: ['g', 'then', '1'],
     allApps: ['g', 'then', '2'],
     theme: ['g', 'then', 't'],

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -369,6 +369,7 @@ export const FEATURE_FLAGS = {
     MAX_AI_INSIGHT_SEARCH: 'max-ai-insight-search', // owner: #team-posthog-ai
     MAX_BILLING_CONTEXT: 'max-billing-context', // owner: @pawel-cebula #team-billing
     MAX_DEEP_RESEARCH: 'max-deep-research', // owner: @kappa90 #team-posthog-ai
+    MAX_HANDS_FREE: 'max-hands-free', // owner: #team-posthog-ai
     MCP_SERVERS: 'mcp-servers', // owner: #team-posthog-ai
     MESSAGING_SES: 'messaging-ses', // owner #team-workflows
     METRICS: 'metrics', // owner: #team-apm (@jonmcwest, @frankh)

--- a/frontend/src/scenes/max/components/HandsFreeButton.scss
+++ b/frontend/src/scenes/max/components/HandsFreeButton.scss
@@ -1,0 +1,48 @@
+@keyframes HandsFreeButton__pulse {
+    0%,
+    100% {
+        filter: drop-shadow(0 0 0 rgb(255 87 87 / 0%));
+        opacity: 1;
+        transform: scale(1);
+    }
+
+    50% {
+        filter: drop-shadow(0 0 6px rgb(255 87 87 / 55%));
+        opacity: 0.85;
+        transform: scale(1.12);
+    }
+}
+
+@keyframes HandsFreeButton__pulseCool {
+    0%,
+    100% {
+        filter: drop-shadow(0 0 0 rgb(96 165 250 / 0%));
+        opacity: 1;
+        transform: scale(1);
+    }
+
+    50% {
+        filter: drop-shadow(0 0 6px rgb(96 165 250 / 55%));
+        opacity: 0.85;
+        transform: scale(1.08);
+    }
+}
+
+.hands-free-mic-icon {
+    transition: color 200ms ease;
+
+    &--listening {
+        color: rgb(239 68 68);
+        animation: HandsFreeButton__pulse 1.4s ease-in-out infinite;
+    }
+
+    &--thinking {
+        color: rgb(59 130 246);
+        animation: HandsFreeButton__pulseCool 1.6s ease-in-out infinite;
+    }
+
+    &--speaking {
+        color: rgb(34 197 94);
+        animation: HandsFreeButton__pulseCool 1.6s ease-in-out infinite;
+    }
+}

--- a/frontend/src/scenes/max/components/HandsFreeButton.tsx
+++ b/frontend/src/scenes/max/components/HandsFreeButton.tsx
@@ -1,0 +1,52 @@
+import './HandsFreeButton.scss'
+
+import clsx from 'clsx'
+import { useActions, useValues } from 'kea'
+
+import { IconMicrophone } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
+import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+
+import { handsFreeLogic } from '../handsFreeLogic'
+
+interface HandsFreeButtonProps {
+    tabId: string
+}
+
+export function HandsFreeButton({ tabId }: HandsFreeButtonProps): JSX.Element | null {
+    const flagEnabled = useFeatureFlag('MAX_HANDS_FREE')
+    const { status, canUseHandsFree } = useValues(handsFreeLogic({ tabId }))
+    const { toggleHandsFree } = useActions(handsFreeLogic({ tabId }))
+
+    if (!flagEnabled || !canUseHandsFree) {
+        return null
+    }
+    // When hands-free is active, the big mic inside HandsFreeSurface is the exit affordance.
+    // The composer-corner button only renders for the "enter hands-free" path.
+    if (status !== 'off') {
+        return null
+    }
+
+    return (
+        <AppShortcut
+            name="maxHandsFree"
+            keybind={[keyBinds.maxHandsFree]}
+            intent="Enter hands-free"
+            interaction="click"
+        >
+            <LemonButton
+                data-attr="max-hands-free-toggle"
+                data-status={status}
+                size="small"
+                type="tertiary"
+                icon={<IconMicrophone className={clsx('hands-free-mic-icon')} />}
+                onClick={toggleHandsFree}
+                tooltip="Enter hands-free"
+                aria-label="Enter hands-free"
+            />
+        </AppShortcut>
+    )
+}

--- a/frontend/src/scenes/max/components/HandsFreeSurface.scss
+++ b/frontend/src/scenes/max/components/HandsFreeSurface.scss
@@ -1,0 +1,177 @@
+.hands-free-surface {
+    display: grid;
+    grid-template-rows: minmax(2.5rem, auto) auto minmax(1.5rem, auto);
+    gap: 1rem;
+    place-items: center center;
+    width: 100%;
+    min-height: 11rem;
+    padding: 1.25rem 1rem;
+    text-align: center;
+}
+
+.hands-free-surface__top {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 2.5rem;
+}
+
+.hands-free-surface__partial {
+    max-width: 32rem;
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.4;
+    color: var(--color-text-primary);
+    word-wrap: break-word;
+}
+
+.hands-free-surface__hint {
+    max-width: 32rem;
+    margin: 0;
+    font-size: 0.8125rem;
+    font-style: italic;
+    color: var(--color-text-secondary);
+}
+
+.hands-free-surface__error {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-danger);
+}
+
+.hands-free-surface__mic {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    color: var(--color-text-primary);
+    appearance: none;
+    cursor: pointer;
+    background: var(--color-bg-fill-secondary);
+    border: none;
+    border-radius: 50%;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 20%);
+    transition:
+        transform 120ms ease,
+        background 120ms ease;
+
+    svg {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    &:hover {
+        transform: scale(1.04);
+    }
+
+    &:active {
+        transform: scale(0.97);
+    }
+}
+
+.hands-free-surface__mic--listening {
+    color: var(--color-text-on-fill);
+    background: var(--color-success);
+}
+
+.hands-free-surface__mic--speaking {
+    color: var(--color-text-on-fill);
+    background: var(--color-ai);
+}
+
+.hands-free-surface__mic--thinking,
+.hands-free-surface__mic--starting {
+    color: var(--color-text-on-fill);
+    background: var(--color-warning);
+}
+
+// Pulse applied only when status === 'listening' (your turn to talk).
+.hands-free-surface__mic--pulsing {
+    animation: HandsFreeSurface__micPulse 1.6s ease-in-out infinite;
+}
+
+// Spinner ring around the mic when thinking/starting — keeps the mic icon visible
+// so the user still knows the button is tappable to exit.
+.hands-free-surface__mic--thinking::after,
+.hands-free-surface__mic--starting::after {
+    position: absolute;
+    inset: -4px;
+    content: '';
+    border: 2px solid transparent;
+    border-top-color: currentColor;
+    border-radius: 50%;
+    animation: HandsFreeSurface__micSpin 1s linear infinite;
+}
+
+@keyframes HandsFreeSurface__micSpin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes HandsFreeSurface__micPulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 rgb(0 0 0 / 0%);
+    }
+
+    50% {
+        box-shadow: 0 0 0 0.75rem rgb(255 255 255 / 8%);
+    }
+}
+
+.hands-free-surface__bottom {
+    display: inline-flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.hands-free-surface__dot {
+    display: inline-block;
+    flex-shrink: 0;
+    width: 0.5rem;
+    height: 0.5rem;
+    background: var(--color-bg-fill-tertiary);
+    border-radius: 50%;
+}
+
+.hands-free-surface__dot--listening {
+    background: var(--color-success);
+}
+
+.hands-free-surface__dot--speaking {
+    background: var(--color-ai);
+}
+
+.hands-free-surface__dot--thinking,
+.hands-free-surface__dot--starting {
+    background: var(--color-warning);
+}
+
+.hands-free-surface__dot--pulsing {
+    animation: HandsFreeSurface__pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes HandsFreeSurface__pulse {
+    0%,
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+
+    50% {
+        opacity: 0.5;
+        transform: scale(1.4);
+    }
+}
+
+.hands-free-surface__label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+}

--- a/frontend/src/scenes/max/components/HandsFreeSurface.tsx
+++ b/frontend/src/scenes/max/components/HandsFreeSurface.tsx
@@ -1,0 +1,99 @@
+import './HandsFreeSurface.scss'
+
+import clsx from 'clsx'
+import { useActions, useValues } from 'kea'
+
+import { IconMicrophone } from '@posthog/icons'
+
+import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
+import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
+
+import { HandsFreeStatus, handsFreeLogic } from '../handsFreeLogic'
+
+interface HandsFreeSurfaceProps {
+    tabId: string
+}
+
+const STATUS_LABEL: Record<HandsFreeStatus, string> = {
+    off: '',
+    starting: 'Connecting',
+    listening: 'Listening',
+    thinking: 'Thinking',
+    speaking: 'Speaking',
+}
+
+const STATUS_HINT: Record<HandsFreeStatus, string> = {
+    off: '',
+    starting: 'One moment, getting microphone ready',
+    listening: 'I will send your question when you pause speaking',
+    thinking: 'Working on your answer',
+    speaking: 'Start talking to interrupt',
+}
+
+export function HandsFreeSurface({ tabId }: HandsFreeSurfaceProps): JSX.Element | null {
+    const { status, partialTranscript, error } = useValues(handsFreeLogic({ tabId }))
+    const { toggleHandsFree, interruptSpeaking } = useActions(handsFreeLogic({ tabId }))
+
+    // Register the v-then-m exit shortcut while the surface is mounted.
+    // HandsFreeButton owns the same shortcut for the "enter" path; same-name
+    // re-registration in appShortcutLogic handles the handover cleanly.
+    useAppShortcut({
+        name: 'maxHandsFree',
+        keybind: [keyBinds.maxHandsFree],
+        intent: 'Exit hands-free',
+        interaction: 'function',
+        callback: toggleHandsFree,
+    })
+
+    if (status === 'off') {
+        return null
+    }
+
+    // Listening pulses (your turn), thinking spins a ring around the icon (working on it).
+    // Both keep the mic icon visible so the user knows the button is still tap-to-exit.
+    const isListening = status === 'listening'
+    const isSpeaking = status === 'speaking'
+    // Tapping the mic while Max is talking interrupts the TTS and returns to listening so
+    // you can ask the next question. Tapping in any other state exits hands-free entirely.
+    const onMicClick = isSpeaking ? interruptSpeaking : toggleHandsFree
+    const ariaLabel = isSpeaking ? 'Stop speaking and listen' : 'Exit hands-free'
+
+    return (
+        <div className="hands-free-surface" data-attr="max-hands-free-surface" data-status={status}>
+            <div className="hands-free-surface__top">
+                {partialTranscript ? (
+                    <p className="hands-free-surface__partial">{partialTranscript}</p>
+                ) : (
+                    <p className="hands-free-surface__hint">{STATUS_HINT[status]}</p>
+                )}
+                {error && <p className="hands-free-surface__error">{error}</p>}
+            </div>
+
+            <button
+                type="button"
+                onClick={onMicClick}
+                aria-label={ariaLabel}
+                data-attr={isSpeaking ? 'max-hands-free-interrupt' : 'max-hands-free-exit'}
+                className={clsx(
+                    'hands-free-surface__mic',
+                    `hands-free-surface__mic--${status}`,
+                    isListening && 'hands-free-surface__mic--pulsing'
+                )}
+            >
+                <IconMicrophone />
+            </button>
+
+            <div className="hands-free-surface__bottom">
+                <span
+                    className={clsx(
+                        'hands-free-surface__dot',
+                        `hands-free-surface__dot--${status}`,
+                        isListening && 'hands-free-surface__dot--pulsing'
+                    )}
+                    aria-hidden
+                />
+                <span className="hands-free-surface__label">{STATUS_LABEL[status]}</span>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -17,10 +17,13 @@ import { AgentMode } from '~/queries/schema/schema-assistant-messages'
 import { ConversationQueueMessage } from '~/types'
 
 import { ContextDisplay } from '../Context'
+import { handsFreeLogic } from '../handsFreeLogic'
 import { maxGlobalLogic } from '../maxGlobalLogic'
 import { maxLogic } from '../maxLogic'
 import { maxThreadLogic } from '../maxThreadLogic'
 import { MAX_SLASH_COMMANDS } from '../slash-commands'
+import { HandsFreeButton } from './HandsFreeButton'
+import { HandsFreeSurface } from './HandsFreeSurface'
 import { SlashCommandAutocomplete } from './SlashCommandAutocomplete'
 
 interface QuestionInputProps {
@@ -140,7 +143,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
     ref
 ) {
     const { dataProcessingAccepted, dataProcessingApprovalDisabledReason } = useValues(maxGlobalLogic)
-    const { question } = useValues(maxLogic)
+    const { question, tabId: maxTabId } = useValues(maxLogic)
     const { setQuestion } = useActions(maxLogic)
     const { user } = useValues(userLogic)
     const {
@@ -162,6 +165,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
     } = useValues(maxThreadLogic)
     const { askMax, stopGeneration, completeThreadGeneration, setSupportOverrideEnabled, updateQueuedMessage } =
         useActions(maxThreadLogic)
+    const { isActive: handsFreeActive } = useValues(handsFreeLogic({ tabId: maxTabId }))
     // Show info banner for conversations created during impersonation (marked as internal)
     const isImpersonatedInternalConversation = user?.is_impersonated && conversation?.is_internal
 
@@ -262,87 +266,98 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                             !streamingActive && '[--input-ring-color:var(--color-ai)]'
                         )}
                     >
-                        <SlashCommandAutocomplete visible={showAutocomplete} onClose={() => setShowAutocomplete(false)}>
-                            <div className="relative w-full">
-                                {!question && (
-                                    <div
-                                        id="textarea-hint"
-                                        className="text-secondary absolute top-4 left-4 text-sm pointer-events-none"
-                                    >
-                                        {conversation && isSharedThread ? (
-                                            `This thread was shared with you by ${conversation.user.first_name} ${conversation.user.last_name}`
-                                        ) : threadLoading ? (
-                                            'Thinking…'
-                                        ) : isThreadVisible ? (
-                                            placeholder || (
+                        {handsFreeActive ? (
+                            <HandsFreeSurface tabId={maxTabId} />
+                        ) : (
+                            <SlashCommandAutocomplete
+                                visible={showAutocomplete}
+                                onClose={() => setShowAutocomplete(false)}
+                            >
+                                <div className="relative w-full">
+                                    {!question && (
+                                        <div
+                                            id="textarea-hint"
+                                            className="text-secondary absolute top-4 left-4 text-sm pointer-events-none"
+                                        >
+                                            {conversation && isSharedThread ? (
+                                                `This thread was shared with you by ${conversation.user.first_name} ${conversation.user.last_name}`
+                                            ) : threadLoading ? (
+                                                'Thinking…'
+                                            ) : isThreadVisible ? (
+                                                placeholder || (
+                                                    <>
+                                                        Ask follow-up{' '}
+                                                        <span className="text-tertiary opacity-80 contrast-more:opacity-100">
+                                                            or / for commands
+                                                        </span>
+                                                    </>
+                                                )
+                                            ) : (
                                                 <>
-                                                    Ask follow-up{' '}
+                                                    Ask a question{' '}
                                                     <span className="text-tertiary opacity-80 contrast-more:opacity-100">
                                                         or / for commands
                                                     </span>
                                                 </>
-                                            )
-                                        ) : (
-                                            <>
-                                                Ask a question{' '}
-                                                <span className="text-tertiary opacity-80 contrast-more:opacity-100">
-                                                    or / for commands
-                                                </span>
-                                            </>
-                                        )}
-                                    </div>
-                                )}
-                                <LemonTextArea
-                                    aria-describedby={!question ? 'textarea-hint' : undefined}
-                                    id="question-input"
-                                    data-attr="max-chat-input"
-                                    ref={textAreaRef}
-                                    value={isSharedThread ? '' : question}
-                                    onChange={(value) => setQuestion(value)}
-                                    onPressEnter={() => {
-                                        if (
-                                            hasQuestion &&
-                                            !submissionDisabledReason &&
-                                            (!threadLoading || queueingEnabled)
-                                        ) {
-                                            onSubmit?.()
-                                            askMax(question)
-                                        }
-                                    }}
-                                    onKeyDown={(event) => {
-                                        if (
-                                            event.key === 'ArrowUp' &&
-                                            !question.trim() &&
-                                            queuedMessages.length > 0 &&
-                                            !editingQueueId
-                                        ) {
-                                            const target = event.currentTarget
-                                            const atStart = target.selectionStart === 0 && target.selectionEnd === 0
-                                            const isSingleLine = target.value.split('\n').length <= 1
-                                            if (!atStart || !isSingleLine) {
-                                                return
+                                            )}
+                                        </div>
+                                    )}
+                                    <LemonTextArea
+                                        aria-describedby={!question ? 'textarea-hint' : undefined}
+                                        id="question-input"
+                                        data-attr="max-chat-input"
+                                        ref={textAreaRef}
+                                        value={isSharedThread ? '' : question}
+                                        onChange={(value) => setQuestion(value)}
+                                        onPressEnter={() => {
+                                            if (
+                                                hasQuestion &&
+                                                !submissionDisabledReason &&
+                                                (!threadLoading || queueingEnabled)
+                                            ) {
+                                                onSubmit?.()
+                                                askMax(question)
                                             }
-                                            const nextMessageId = queuedMessages[0]?.id
-                                            if (!nextMessageId) {
-                                                return
+                                        }}
+                                        onKeyDown={(event) => {
+                                            if (
+                                                event.key === 'ArrowUp' &&
+                                                !question.trim() &&
+                                                queuedMessages.length > 0 &&
+                                                !editingQueueId
+                                            ) {
+                                                const target = event.currentTarget
+                                                const atStart = target.selectionStart === 0 && target.selectionEnd === 0
+                                                const isSingleLine = target.value.split('\n').length <= 1
+                                                if (!atStart || !isSingleLine) {
+                                                    return
+                                                }
+                                                const nextMessageId = queuedMessages[0]?.id
+                                                if (!nextMessageId) {
+                                                    return
+                                                }
+                                                event.preventDefault()
+                                                setEditingQueueId(nextMessageId)
                                             }
-                                            event.preventDefault()
-                                            setEditingQueueId(nextMessageId)
-                                        }
-                                    }}
-                                    disabled={inputDisabled}
-                                    minRows={1}
-                                    maxRows={10}
-                                    className="!border-none !bg-transparent min-h-16 py-2 pl-2 pr-12 resize-none"
-                                    hideFocus
-                                />
-                            </div>
-                        </SlashCommandAutocomplete>
+                                        }}
+                                        disabled={inputDisabled}
+                                        minRows={1}
+                                        maxRows={10}
+                                        className="!border-none !bg-transparent min-h-16 py-2 pl-2 pr-20 resize-none"
+                                        hideFocus
+                                    />
+                                </div>
+                            </SlashCommandAutocomplete>
+                        )}
 
-                        {!isSharedThread && (
-                            <div className="pb-2 pr-12">
+                        {!isSharedThread && !handsFreeActive && (
+                            // pr-20 reserves ~80px on the right for the absolutely-positioned
+                            // mic + send buttons. The smaller pr-12 fit when only send was there,
+                            // but mic + gap + send + right-offset now totals ~75px and the chip
+                            // row would otherwise wrap UNDER the buttons.
+                            <div className="pb-2 pr-20">
                                 {!isThreadVisible ? (
-                                    <div className="flex items-start justify-between">
+                                    <div className="flex items-start justify-between flex-wrap gap-1">
                                         <ContextDisplay size={contextDisplaySize} />
 
                                         <div className="flex items-start gap-1 h-full mt-1 mr-1">{topActions}</div>
@@ -355,77 +370,80 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                     </label>
                     <div
                         className={clsx(
-                            'absolute flex items-center',
+                            'absolute flex items-center gap-1',
                             isSharedThread && 'hidden',
                             isThreadVisible ? 'bottom-[9px] right-[9px]' : 'bottom-[7px] right-[7px]'
                         )}
                     >
-                        <AIConsentPopoverWrapper
-                            placement="bottom-end"
-                            showArrow
-                            ignoreDismissal
-                            onApprove={() => askMax(pendingPrompt || question)}
-                            onDismiss={() => completeThreadGeneration()}
-                            middleware={[
-                                offset((state) => ({
-                                    mainAxis: state.placement.includes('top') ? 30 : 1,
-                                })),
-                            ]}
-                            hidden={!isAdmin || (!threadLoading && !pendingPrompt)}
-                        >
-                            <LemonButton
-                                data-attr={showStopButton ? 'max-stop-generation' : 'max-send-message'}
-                                type={(isThreadVisible && !hasQuestion) || showStopButton ? 'secondary' : 'primary'}
-                                onClick={() => {
-                                    if (threadLoading) {
-                                        if (isQueueingSubmission) {
-                                            if (submissionDisabledReason) {
-                                                textAreaRef?.current?.focus()
+                        <HandsFreeButton tabId={maxTabId} />
+                        {!handsFreeActive && (
+                            <AIConsentPopoverWrapper
+                                placement="bottom-end"
+                                showArrow
+                                ignoreDismissal
+                                onApprove={() => askMax(pendingPrompt || question)}
+                                onDismiss={() => completeThreadGeneration()}
+                                middleware={[
+                                    offset((state) => ({
+                                        mainAxis: state.placement.includes('top') ? 30 : 1,
+                                    })),
+                                ]}
+                                hidden={!isAdmin || (!threadLoading && !pendingPrompt)}
+                            >
+                                <LemonButton
+                                    data-attr={showStopButton ? 'max-stop-generation' : 'max-send-message'}
+                                    type={(isThreadVisible && !hasQuestion) || showStopButton ? 'secondary' : 'primary'}
+                                    onClick={() => {
+                                        if (threadLoading) {
+                                            if (isQueueingSubmission) {
+                                                if (submissionDisabledReason) {
+                                                    textAreaRef?.current?.focus()
+                                                    return
+                                                }
+                                                askMax(question)
                                                 return
                                             }
-                                            askMax(question)
+                                            stopGeneration()
                                             return
                                         }
-                                        stopGeneration()
-                                        return
+                                        if (submissionDisabledReason) {
+                                            textAreaRef?.current?.focus()
+                                            return
+                                        }
+                                        askMax(question)
+                                    }}
+                                    tooltip={
+                                        disabledReason ? (
+                                            disabledReason
+                                        ) : showStopButton ? (
+                                            <>
+                                                Let's bail <KeyboardShortcut enter />
+                                            </>
+                                        ) : isQueueingSubmission ? (
+                                            <>
+                                                Queue message <KeyboardShortcut enter />
+                                            </>
+                                        ) : (
+                                            <>
+                                                Let's go! <KeyboardShortcut enter />
+                                            </>
+                                        )
                                     }
-                                    if (submissionDisabledReason) {
-                                        textAreaRef?.current?.focus()
-                                        return
+                                    loading={threadLoading && !dataProcessingAccepted}
+                                    disabledReason={disabledReason}
+                                    className={disabledReason ? 'opacity-[0.5]' : ''}
+                                    size="small"
+                                    icon={
+                                        showStopButton ? (
+                                            <IconStopFilled />
+                                        ) : (
+                                            MAX_SLASH_COMMANDS.find((cmd) => cmd.name === question.split(' ', 1)[0])
+                                                ?.icon || <IconArrowRight />
+                                        )
                                     }
-                                    askMax(question)
-                                }}
-                                tooltip={
-                                    disabledReason ? (
-                                        disabledReason
-                                    ) : showStopButton ? (
-                                        <>
-                                            Let's bail <KeyboardShortcut enter />
-                                        </>
-                                    ) : isQueueingSubmission ? (
-                                        <>
-                                            Queue message <KeyboardShortcut enter />
-                                        </>
-                                    ) : (
-                                        <>
-                                            Let's go! <KeyboardShortcut enter />
-                                        </>
-                                    )
-                                }
-                                loading={threadLoading && !dataProcessingAccepted}
-                                disabledReason={disabledReason}
-                                className={disabledReason ? 'opacity-[0.5]' : ''}
-                                size="small"
-                                icon={
-                                    showStopButton ? (
-                                        <IconStopFilled />
-                                    ) : (
-                                        MAX_SLASH_COMMANDS.find((cmd) => cmd.name === question.split(' ', 1)[0])
-                                            ?.icon || <IconArrowRight />
-                                    )
-                                }
-                            />
-                        </AIConsentPopoverWrapper>
+                                />
+                            </AIConsentPopoverWrapper>
+                        )}
                     </div>
                 </div>
                 {/* Info banner for conversations created during impersonation (marked as internal) */}

--- a/frontend/src/scenes/max/handsFreeLogic.test.ts
+++ b/frontend/src/scenes/max/handsFreeLogic.test.ts
@@ -1,0 +1,86 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { handsFreeLogic } from './handsFreeLogic'
+import { maxLogic } from './maxLogic'
+import { maxMocks } from './testUtils'
+
+describe('handsFreeLogic state machine', () => {
+    let logic: ReturnType<typeof handsFreeLogic.build>
+    let parent: ReturnType<typeof maxLogic.build>
+
+    beforeEach(() => {
+        useMocks(maxMocks)
+        initKeaTests()
+        parent = maxLogic({ tabId: 'hands-free-test-tab' })
+        parent.mount()
+        logic = handsFreeLogic({ tabId: 'hands-free-test-tab' })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        parent.unmount()
+    })
+
+    it('starts off with idle connection and exposes isActive=false', async () => {
+        await expectLogic(logic).toMatchValues({ status: 'off', connection: 'idle', isActive: false })
+    })
+
+    it('exitHandsFree from off keeps status off (defensive)', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.exitHandsFree('test')
+        }).toMatchValues({ status: 'off', connection: 'idle' })
+    })
+
+    it('setStatus("listening") then exitHandsFree resets back to off + connection idle', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setStatus('listening')
+            logic.actions.setConnection('connected')
+        }).toMatchValues({ status: 'listening', connection: 'connected', isActive: true })
+
+        await expectLogic(logic, () => {
+            logic.actions.exitHandsFree('test')
+        }).toMatchValues({ status: 'off', connection: 'idle', isActive: false })
+    })
+
+    it('setError stores the error string; entering hands-free clears it', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setError('something broke')
+        }).toMatchValues({ error: 'something broke' })
+
+        await expectLogic(logic, () => {
+            logic.actions.setError(null)
+        }).toMatchValues({ error: null })
+    })
+
+    it('setPartialTranscript stores the in-flight transcript; commitTranscript clears it', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setPartialTranscript('how is the prod')
+        }).toMatchValues({ partialTranscript: 'how is the prod' })
+
+        // commit triggers askMax via the listener; thread isn't mounted here so it'll error out,
+        // but the reducer for partialTranscript clears regardless
+        await expectLogic(logic, () => {
+            logic.actions.commitTranscript('how is the product doing today')
+        }).toMatchValues({ partialTranscript: '' })
+    })
+
+    it('exitHandsFree clears any in-flight partial transcript', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setPartialTranscript('mid sentence')
+        }).toMatchValues({ partialTranscript: 'mid sentence' })
+
+        await expectLogic(logic, () => {
+            logic.actions.exitHandsFree('test')
+        }).toMatchValues({ partialTranscript: '' })
+    })
+
+    it('speakAssistantResponse with empty summary while off is a no-op', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.speakAssistantResponse({ text: '', vizCount: 0 })
+        }).toMatchValues({ status: 'off' })
+    })
+})

--- a/frontend/src/scenes/max/handsFreeLogic.ts
+++ b/frontend/src/scenes/max/handsFreeLogic.ts
@@ -341,7 +341,9 @@ export const handsFreeLogic = kea<handsFreeLogicType>([
             actions.setStatus('thinking')
             cache.userTurnCount = (cache.userTurnCount ?? 0) + 1
             posthog.capture('max hands-free user spoke', { transcript_chars: text.length })
-            threadLogic.actions.askMax(text)
+            // Tag the turn with surface='hands_free' so every downstream $ai_generation event
+            // is scoped to hands-free, queryable in PostHog LLM analytics.
+            threadLogic.actions.askMax(text, true, undefined, 'hands_free')
         },
 
         speakAssistantResponse: async ({ summary }) => {

--- a/frontend/src/scenes/max/handsFreeLogic.ts
+++ b/frontend/src/scenes/max/handsFreeLogic.ts
@@ -1,0 +1,512 @@
+// Hands-free conversational mode for Max — STT via ElevenLabs Scribe (browser → WS direct),
+// TTS via the browser's native speechSynthesis. Built for mobile-web use (gym, walking).
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import posthog from 'posthog-js'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+
+import type { handsFreeLogicType } from './handsFreeLogicType'
+import { AssistantSummary, buildSpokenText } from './handsFreeUtils'
+import { maxLogic } from './maxLogic'
+import { maxThreadLogic } from './maxThreadLogic'
+
+export type HandsFreeStatus = 'off' | 'starting' | 'listening' | 'thinking' | 'speaking'
+export type HandsFreeConnection = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'closed'
+
+const SCRIBE_REALTIME_MODEL_ID = 'scribe_v2_realtime'
+
+export interface HandsFreeLogicProps {
+    tabId: string
+}
+
+interface ScribeConnection {
+    close: () => void
+    on: (event: string, listener: (payload: any) => void) => void
+    off: (event: string, listener: (payload: any) => void) => void
+}
+
+interface ScribeNamespace {
+    connect: (options: {
+        token: string
+        modelId: string
+        commitStrategy?: string
+        microphone?: { echoCancellation?: boolean; noiseSuppression?: boolean }
+    }) => ScribeConnection
+}
+
+type RealtimeEventsEnum = Record<string, string>
+type CommitStrategyEnum = { MANUAL: string; VAD: string }
+
+let cachedSdkPromise: Promise<{
+    Scribe: ScribeNamespace
+    RealtimeEvents: RealtimeEventsEnum
+    CommitStrategy: CommitStrategyEnum
+}> | null = null
+
+async function loadScribeSdk(): Promise<{
+    Scribe: ScribeNamespace
+    RealtimeEvents: RealtimeEventsEnum
+    CommitStrategy: CommitStrategyEnum
+}> {
+    if (!cachedSdkPromise) {
+        cachedSdkPromise = import(/* webpackChunkName: "elevenlabs-client" */ '@elevenlabs/client').then((mod) => ({
+            Scribe: (mod as unknown as { Scribe: ScribeNamespace }).Scribe,
+            RealtimeEvents: (mod as unknown as { RealtimeEvents: RealtimeEventsEnum }).RealtimeEvents,
+            CommitStrategy: (mod as unknown as { CommitStrategy: CommitStrategyEnum }).CommitStrategy,
+        }))
+    }
+    return cachedSdkPromise
+}
+
+export const handsFreeLogic = kea<handsFreeLogicType>([
+    props({} as HandsFreeLogicProps),
+    key((props) => props.tabId),
+    path((key) => ['scenes', 'max', 'handsFreeLogic', key]),
+
+    connect(({ tabId }: HandsFreeLogicProps) => ({
+        values: [maxLogic({ tabId }), ['threadLogicKey']],
+    })),
+
+    actions({
+        enterHandsFree: true,
+        exitHandsFree: (reason?: string) => ({ reason: reason ?? 'user' }),
+        toggleHandsFree: true,
+        setStatus: (status: HandsFreeStatus) => ({ status }),
+        setConnection: (connection: HandsFreeConnection) => ({ connection }),
+        setError: (error: string | null) => ({ error }),
+        setPartialTranscript: (text: string) => ({ text }),
+        commitTranscript: (text: string) => ({ text }),
+        speakAssistantResponse: (summary: AssistantSummary) => ({ summary }),
+        cancelSpeaking: true,
+        // Stop TTS playback and go back to listening — used by the surface's tap-to-interrupt
+        // affordance while Max is talking. Distinct from cancelSpeaking (which only tears down
+        // playback) and exitHandsFree (which leaves hands-free entirely). Trigger lets analytics
+        // distinguish "user tapped the mic" from "user talked over Max" (voice barge-in).
+        interruptSpeaking: (trigger: 'tap' | 'voice' = 'tap') => ({ trigger }),
+        setSdkAvailable: (available: boolean) => ({ available }),
+    }),
+
+    reducers({
+        status: [
+            'off' as HandsFreeStatus,
+            {
+                setStatus: (_, { status }) => status,
+            },
+        ],
+        connection: [
+            'idle' as HandsFreeConnection,
+            {
+                setConnection: (_, { connection }) => connection,
+                exitHandsFree: () => 'idle' as HandsFreeConnection,
+            },
+        ],
+        error: [
+            null as string | null,
+            {
+                setError: (_, { error }) => error,
+                enterHandsFree: () => null,
+                exitHandsFree: () => null,
+            },
+        ],
+        partialTranscript: [
+            '' as string,
+            {
+                setPartialTranscript: (_, { text }) => text,
+                commitTranscript: () => '',
+                exitHandsFree: () => '',
+            },
+        ],
+        // null = probe not yet finished, true = Scribe present, false = SDK missing or load failed
+        sdkAvailable: [
+            null as boolean | null,
+            {
+                setSdkAvailable: (_, { available }) => available,
+            },
+        ],
+    }),
+
+    selectors({
+        isActive: [(s) => [s.status], (status) => status !== 'off'],
+        // Render the mic button when the probe hasn't completed yet (null) or has succeeded (true).
+        // Hide it only once we've confirmed the SDK can't be used.
+        canUseHandsFree: [(s) => [s.sdkAvailable], (sdkAvailable) => sdkAvailable !== false],
+    }),
+
+    listeners(({ actions, values, cache, props }) => ({
+        toggleHandsFree: () => {
+            if (values.status === 'off') {
+                actions.enterHandsFree()
+            } else {
+                actions.exitHandsFree()
+            }
+        },
+
+        enterHandsFree: async () => {
+            if (values.status !== 'off') {
+                return
+            }
+            actions.setStatus('starting')
+            actions.setConnection('connecting')
+
+            // Per-session analytics counters, captured at exit so a single PostHog query can
+            // build session-length and turn-count distributions without re-aggregating events.
+            cache.sessionStartedAt = Date.now()
+            cache.userTurnCount = 0
+            cache.assistantTurnCount = 0
+            cache.interruptedCount = 0
+
+            // iOS Safari requires the first audio playback (HTMLAudioElement.play()) to be
+            // initiated from a user-gesture handler. The mic-button click IS that gesture, so
+            // we prime a silent Audio element here. Subsequent .play() calls (driven by Max
+            // responses arriving over the network) then succeed without re-prompting.
+            try {
+                const primer = new Audio()
+                primer.muted = true
+                primer.src =
+                    'data:audio/mpeg;base64,SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4LjI5LjEwMAAAAAAAAAAAAAAA//tQxAADB8AhSmxhhgAAAAAAAAAAAExBTUUzLjEwMACqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq//tSxAADB8AhSmxhhgAAAAAAAAAAAExBTUUzLjEwMKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq'
+                void primer.play().catch(() => undefined)
+            } catch {
+                // best-effort
+            }
+
+            let token: string
+            try {
+                const response = await api.maxHandsFree.token()
+                token = response.token
+            } catch (err) {
+                posthog.captureException(err)
+                actions.setError('Could not start hands-free session.')
+                lemonToast.error('Hands-free could not start. Please try again.')
+                actions.exitHandsFree('token_failed')
+                return
+            }
+            if (values.status === 'off') {
+                return
+            }
+
+            let sdk
+            try {
+                sdk = await loadScribeSdk()
+            } catch (err) {
+                posthog.captureException(err)
+                actions.setError('Could not load the hands-free SDK.')
+                lemonToast.error('Hands-free could not load. Please try again.')
+                actions.exitHandsFree('sdk_load_failed')
+                return
+            }
+            if (values.status === 'off') {
+                return
+            }
+
+            const { Scribe, RealtimeEvents, CommitStrategy } = sdk
+            if (!Scribe || typeof Scribe.connect !== 'function') {
+                // Should be unreachable — the mount-time probe should have already hidden the
+                // button when the SDK doesn't expose Scribe. If we get here, capture so we can
+                // see it in PostHog and bail without confusing the user.
+                posthog.captureException(new Error('handsFree: Scribe namespace missing from @elevenlabs/client'))
+                actions.setSdkAvailable(false)
+                actions.exitHandsFree('sdk_missing_scribe')
+                return
+            }
+            let connection: ScribeConnection
+            try {
+                connection = Scribe.connect({
+                    token,
+                    modelId: SCRIBE_REALTIME_MODEL_ID,
+                    // SDK defaults to MANUAL — we need VAD so silence on the mic auto-commits
+                    // the speech segment and triggers askMax. Without this it isn't hands-free.
+                    commitStrategy: CommitStrategy?.VAD ?? 'vad',
+                    microphone: { echoCancellation: true, noiseSuppression: true },
+                })
+            } catch (err) {
+                posthog.captureException(err)
+                const message = (err as Error)?.message ?? ''
+                const isPermissionError =
+                    /permission|notallowed|denied/i.test(message) ||
+                    (err as { name?: string })?.name === 'NotAllowedError'
+                if (isPermissionError) {
+                    actions.setError('Microphone access was denied.')
+                    lemonToast.error('Microphone access was denied. Hands-free disabled.')
+                    actions.exitHandsFree('mic_permission_denied')
+                } else {
+                    actions.setError(`Hands-free connection failed: ${message || 'unknown error'}`)
+                    lemonToast.error('Hands-free failed to start. See console for details.')
+                    actions.exitHandsFree('connection_failed')
+                }
+                return
+            }
+            cache.connection = connection
+
+            const onOpen = (): void => actions.setConnection('connected')
+            const onSessionStarted = (): void => {
+                if (values.status === 'starting') {
+                    actions.setStatus('listening')
+                }
+                posthog.capture('max hands-free entered')
+            }
+            // While 'speaking', the Scribe mic stream stays open (we can't cheaply pause it)
+            // and the speakers' TTS audio bleeds back into the mic — Scribe transcribes its
+            // own voice. To support real barge-in (user talks over Max -> Max shuts up and
+            // listens) without self-triggering, we compare incoming partials to what Max is
+            // currently saying. If the partial is a substring of the spoken text, it's
+            // self-transcription bleed; otherwise the user is talking over Max.
+            const onPartial = (payload: any): void => {
+                const text: string = payload?.text ?? payload?.transcript ?? ''
+                if (values.status === 'speaking') {
+                    const partialLower = normaliseForBargeInMatch(text)
+                    const spokenLower: string = cache.spokenTextLower ?? ''
+                    if (looksLikeSelfTranscription(spokenLower, partialLower)) {
+                        return
+                    }
+                    // User is talking over Max — barge in: stop TTS, flip to listening, then
+                    // let the partial-transcript reducer below pick up the user's words.
+                    actions.interruptSpeaking('voice')
+                }
+                if (values.status === 'listening') {
+                    actions.setPartialTranscript(text)
+                }
+            }
+            const onCommitted = (payload: any): void => {
+                const text: string = (payload?.text ?? payload?.transcript ?? '').trim()
+                if (!text) {
+                    return
+                }
+                if (values.status === 'speaking') {
+                    const committedLower = normaliseForBargeInMatch(text)
+                    const spokenLower: string = cache.spokenTextLower ?? ''
+                    if (looksLikeSelfTranscription(spokenLower, committedLower)) {
+                        return
+                    }
+                    actions.interruptSpeaking('voice')
+                }
+                if (values.status !== 'listening') {
+                    return
+                }
+                actions.commitTranscript(text)
+            }
+            const onClose = (): void => {
+                actions.setConnection('closed')
+                if (values.status !== 'off') {
+                    actions.exitHandsFree('connection_closed')
+                }
+            }
+            const onError = (payload: any): void => {
+                posthog.captureException(new Error(`scribe error: ${JSON.stringify(payload ?? {})}`))
+                actions.setError('Hands-free connection error.')
+                actions.exitHandsFree('scribe_error')
+            }
+
+            connection.on(RealtimeEvents.OPEN, onOpen)
+            connection.on(RealtimeEvents.SESSION_STARTED, onSessionStarted)
+            connection.on(RealtimeEvents.PARTIAL_TRANSCRIPT, onPartial)
+            connection.on(RealtimeEvents.COMMITTED_TRANSCRIPT, onCommitted)
+            connection.on(RealtimeEvents.CLOSE, onClose)
+            connection.on(RealtimeEvents.ERROR, onError)
+            cache.connectionListeners = { onOpen, onSessionStarted, onPartial, onCommitted, onClose, onError }
+        },
+
+        exitHandsFree: ({ reason }) => {
+            posthog.capture('max hands-free exited', {
+                reason,
+                duration_ms: cache.sessionStartedAt ? Date.now() - cache.sessionStartedAt : null,
+                user_turns: cache.userTurnCount ?? 0,
+                assistant_turns: cache.assistantTurnCount ?? 0,
+                interruptions: cache.interruptedCount ?? 0,
+            })
+            actions.cancelSpeaking()
+            const connection = cache.connection as ScribeConnection | undefined
+            if (connection) {
+                try {
+                    connection.close()
+                } catch {
+                    // best-effort
+                }
+                cache.connection = undefined
+                cache.connectionListeners = undefined
+            }
+            actions.setStatus('off')
+        },
+
+        commitTranscript: ({ text }) => {
+            const threadKey = values.threadLogicKey
+            const threadLogic = threadKey
+                ? maxThreadLogic.findMounted({ tabId: props.tabId, conversationId: threadKey })
+                : null
+            if (!threadLogic) {
+                actions.setError('Could not find an active conversation to send the message to.')
+                actions.exitHandsFree('no_thread')
+                return
+            }
+            actions.setStatus('thinking')
+            cache.userTurnCount = (cache.userTurnCount ?? 0) + 1
+            posthog.capture('max hands-free user spoke', { transcript_chars: text.length })
+            threadLogic.actions.askMax(text)
+        },
+
+        speakAssistantResponse: async ({ summary }) => {
+            if (values.status === 'off') {
+                return
+            }
+            // guard re-entry — if two assistant turns complete back-to-back, tear down the
+            // previous playback (revokes blob URL, aborts inflight request) before queuing a
+            // new one. Otherwise the previous audio leaks and overlaps.
+            teardownSpeaking(cache)
+
+            const spokenText = buildSpokenText(summary)
+            if (!spokenText) {
+                actions.setStatus('listening')
+                return
+            }
+            actions.setStatus('speaking')
+
+            // Store what we're saying so onPartial can match incoming transcripts against it
+            // and tell self-transcription bleed apart from real user barge-in.
+            cache.spokenTextLower = normaliseForBargeInMatch(spokenText)
+
+            const controller = new AbortController()
+            cache.speakAbortController = controller
+
+            try {
+                const response = await api.maxHandsFree.synthesize(spokenText, { signal: controller.signal })
+                if (!response.ok) {
+                    throw new Error(`TTS returned ${response.status}`)
+                }
+                const audioBlob = await response.blob()
+                if (controller.signal.aborted || values.status !== 'speaking') {
+                    return
+                }
+                const url = URL.createObjectURL(audioBlob)
+                const audioElement = new Audio(url)
+                cache.speakAudioElement = audioElement
+                cache.speakAudioUrl = url
+
+                const finished = new Promise<void>((resolve, reject) => {
+                    audioElement.onended = () => resolve()
+                    audioElement.onerror = () => reject(new Error('audio playback failed'))
+                })
+
+                await audioElement.play()
+                // Capture once playback has actually started — distinguishes "Max attempted to
+                // speak" from "Max successfully voiced a response." Counted per session via
+                // assistant_turns on the exit event.
+                cache.assistantTurnCount = (cache.assistantTurnCount ?? 0) + 1
+                posthog.capture('max hands-free assistant spoke', {
+                    text_chars: spokenText.length,
+                    viz_count: summary.vizCount,
+                })
+                await finished
+            } catch (err) {
+                if ((err as { name?: string }).name !== 'AbortError') {
+                    posthog.captureException(err)
+                }
+            } finally {
+                if (cache.speakAbortController === controller) {
+                    teardownSpeaking(cache)
+                    if (values.status === 'speaking') {
+                        actions.setStatus('listening')
+                    }
+                }
+            }
+        },
+
+        cancelSpeaking: () => {
+            teardownSpeaking(cache)
+        },
+
+        interruptSpeaking: ({ trigger }) => {
+            // Only meaningful while we're actually playing audio — guard so a stray tap during
+            // listening or thinking doesn't accidentally jolt us through state transitions.
+            if (values.status !== 'speaking') {
+                return
+            }
+            teardownSpeaking(cache)
+            actions.setStatus('listening')
+            cache.interruptedCount = (cache.interruptedCount ?? 0) + 1
+            posthog.capture('max hands-free tts interrupted', { trigger })
+        },
+    })),
+
+    afterMount(({ actions, cache }) => {
+        // Probe the SDK once on mount so the mic button can decide whether to render itself.
+        // We capture failures to PostHog instead of surfacing dev-facing errors to end users.
+        cache.disposables.add(() => {
+            let cancelled = false
+            void loadScribeSdk()
+                .then((sdk) => {
+                    if (cancelled) {
+                        return
+                    }
+                    const available = !!sdk?.Scribe && typeof sdk.Scribe.connect === 'function'
+                    if (!available) {
+                        posthog.captureException(
+                            new Error('handsFree: @elevenlabs/client loaded but Scribe is missing')
+                        )
+                    }
+                    actions.setSdkAvailable(available)
+                })
+                .catch((err) => {
+                    if (cancelled) {
+                        return
+                    }
+                    posthog.captureException(err)
+                    actions.setSdkAvailable(false)
+                })
+            return () => {
+                cancelled = true
+            }
+        }, 'sdkProbe')
+    }),
+])
+
+// Normalises a string to lowercase letters and digits separated by single spaces. Used to
+// match an incoming Scribe partial against the TTS content for self-transcription detection.
+function normaliseForBargeInMatch(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim()
+}
+
+// True when the partial transcript looks like a chunk of what Max is currently speaking
+// (i.e. TTS audio bleeding through the mic and getting re-transcribed). When false, the
+// user is talking over Max and we should barge in.
+function looksLikeSelfTranscription(spokenLower: string, partialLower: string): boolean {
+    if (!partialLower || partialLower.length < 4) {
+        // ignore noise-level micro-partials of 1-3 chars — both bleed-back AND legitimate
+        // user blips are usually too short to act on either way
+        return true
+    }
+    return spokenLower.includes(partialLower)
+}
+
+function teardownSpeaking(cache: Record<string, any>): void {
+    const controller = cache.speakAbortController as AbortController | undefined
+    if (controller) {
+        try {
+            controller.abort()
+        } catch {
+            // best-effort
+        }
+        cache.speakAbortController = undefined
+    }
+    const audio = cache.speakAudioElement as HTMLAudioElement | undefined
+    if (audio) {
+        try {
+            audio.pause()
+            audio.src = ''
+        } catch {
+            // best-effort
+        }
+        cache.speakAudioElement = undefined
+    }
+    if (cache.speakAudioUrl) {
+        try {
+            URL.revokeObjectURL(cache.speakAudioUrl)
+        } catch {
+            // best-effort
+        }
+        cache.speakAudioUrl = undefined
+    }
+    cache.spokenTextLower = undefined
+}

--- a/frontend/src/scenes/max/handsFreeUtils.test.ts
+++ b/frontend/src/scenes/max/handsFreeUtils.test.ts
@@ -1,0 +1,120 @@
+import { AssistantMessageType } from '~/queries/schema/schema-assistant-messages'
+
+import { buildSpokenText, stripMarkdown, summariseAssistantThread } from './handsFreeUtils'
+
+type StubMessage = Parameters<typeof summariseAssistantThread>[0][number]
+
+const human = (content = 'hi'): StubMessage => ({ type: AssistantMessageType.Human, content })
+const ai = (content: string): StubMessage => ({ type: AssistantMessageType.Assistant, content })
+const viz = (): StubMessage => ({ type: AssistantMessageType.Visualization })
+const multiViz = (): StubMessage => ({ type: AssistantMessageType.MultiVisualization })
+const artifact = (): StubMessage => ({ type: AssistantMessageType.Artifact })
+
+describe('handsFreeUtils', () => {
+    describe('summariseAssistantThread()', () => {
+        it('returns the assistant prose message and no viz suffix when none present', () => {
+            const result = summariseAssistantThread([human(), ai('here is the answer')])
+            expect(result).toEqual({ text: 'here is the answer', vizCount: 0 })
+        })
+
+        it.each([
+            ['Visualization', [ai('see chart'), viz()], 1],
+            ['MultiVisualization', [ai('see charts'), multiViz()], 1],
+            ['Artifact', [ai('see notebook'), artifact()], 1],
+            ['mix of viz types', [ai('see charts'), viz(), multiViz(), artifact()], 3],
+        ] as const)('counts %s blocks since the last human message', (_label, tail, expectedCount) => {
+            const result = summariseAssistantThread([human(), ...tail])
+            expect(result.vizCount).toBe(expectedCount)
+        })
+
+        it('only counts messages produced after the most recent human message', () => {
+            const result = summariseAssistantThread([
+                human('first ask'),
+                ai('old answer'),
+                viz(),
+                human('second ask'),
+                ai('new answer'),
+                viz(),
+            ])
+            expect(result).toEqual({ text: 'new answer', vizCount: 1 })
+        })
+
+        it('returns the LATEST prose message when the assistant emits several in one turn', () => {
+            const result = summariseAssistantThread([
+                human(),
+                ai('first part of the answer'),
+                ai('second part of the answer'),
+                ai('final summary'),
+            ])
+            expect(result).toEqual({ text: 'final summary', vizCount: 0 })
+        })
+
+        it('returns empty text when only viz messages followed the human turn', () => {
+            const result = summariseAssistantThread([human(), viz(), multiViz()])
+            expect(result).toEqual({ text: '', vizCount: 2 })
+        })
+
+        it('returns empty text and zero count when thread has no assistant turn', () => {
+            const result = summariseAssistantThread([human()])
+            expect(result).toEqual({ text: '', vizCount: 0 })
+        })
+
+        it('handles a thread that never had a human turn (e.g. agent-initiated)', () => {
+            const result = summariseAssistantThread([ai('hello there'), viz()])
+            expect(result).toEqual({ text: 'hello there', vizCount: 1 })
+        })
+    })
+
+    describe('buildSpokenText()', () => {
+        it.each([
+            [{ text: 'just words', vizCount: 0 }, 'just words'],
+            [{ text: 'words', vizCount: 1 }, "words I've added 1 chart to the chat."],
+            [{ text: 'words', vizCount: 3 }, "words I've added 3 charts to the chat."],
+            [{ text: '', vizCount: 2 }, "I've added 2 charts to the chat."],
+            [{ text: '', vizCount: 0 }, ''],
+        ])('builds %p -> %p', (summary, expected) => {
+            expect(buildSpokenText(summary)).toBe(expected)
+        })
+    })
+
+    describe('stripMarkdown()', () => {
+        it.each([
+            ['# Heading', 'Heading'],
+            ['**bold text**', 'bold text'],
+            ['_italic_', 'italic'],
+            ['*emphasised*', 'emphasised'],
+            ['~~struck~~', 'struck'],
+            ['`inline code`', 'inline code'],
+            ['1. first item\n2. second item', 'first item second item'],
+            ['- bullet\n- bullet', 'bullet bullet'],
+            ['[link text](https://example.com)', 'link text'],
+            ['![alt](https://example.com/x.png) caption', ' caption'],
+            ['> quoted line', 'quoted line'],
+        ])('strips %p -> %p', (input, expected) => {
+            expect(stripMarkdown(input)).toBe(expected)
+        })
+
+        it('leaves identifiers like foo_bar_baz alone (bold underscore guard)', () => {
+            expect(stripMarkdown('the var is foo_bar_baz here')).toBe('the var is foo_bar_baz here')
+        })
+
+        it('omits fenced code blocks rather than reading them verbatim', () => {
+            const input = 'before\n```ts\nconst x = 1\n```\nafter'
+            expect(stripMarkdown(input)).toContain('code block omitted')
+            expect(stripMarkdown(input)).not.toContain('const x')
+        })
+
+        it('strips table separator rows and pipes', () => {
+            const input = '| col a | col b |\n| --- | --- |\n| one | two |'
+            const result = stripMarkdown(input)
+            expect(result).not.toContain('---')
+            expect(result).not.toContain('|')
+            expect(result).toContain('col a')
+            expect(result).toContain('one')
+        })
+
+        it('collapses runs of whitespace so TTS does not over-pause', () => {
+            expect(stripMarkdown('one\n\n\ntwo')).toBe('one two')
+        })
+    })
+})

--- a/frontend/src/scenes/max/handsFreeUtils.ts
+++ b/frontend/src/scenes/max/handsFreeUtils.ts
@@ -1,0 +1,85 @@
+import { AssistantMessageType } from '~/queries/schema/schema-assistant-messages'
+
+const VIZ_TYPES = new Set<AssistantMessageType>([
+    AssistantMessageType.Visualization,
+    AssistantMessageType.MultiVisualization,
+    AssistantMessageType.Artifact,
+])
+
+export interface AssistantSummary {
+    text: string
+    vizCount: number
+}
+
+export function summariseAssistantThread(
+    messages: { type: AssistantMessageType; content?: unknown }[]
+): AssistantSummary {
+    let humanCutoff = -1
+    for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i].type === AssistantMessageType.Human) {
+            humanCutoff = i
+            break
+        }
+    }
+
+    let latestProse = ''
+    let vizCount = 0
+    for (let i = humanCutoff + 1; i < messages.length; i++) {
+        const msg = messages[i]
+        if (VIZ_TYPES.has(msg.type)) {
+            vizCount += 1
+            continue
+        }
+        if (msg.type === AssistantMessageType.Assistant && typeof msg.content === 'string' && msg.content) {
+            latestProse = msg.content
+        }
+    }
+    return { text: latestProse, vizCount }
+}
+
+export function buildSpokenText(summary: AssistantSummary): string {
+    const stripped = stripMarkdown(summary.text).trim()
+    if (summary.vizCount === 0) {
+        return stripped
+    }
+    const suffix =
+        summary.vizCount === 1
+            ? "I've added 1 chart to the chat."
+            : `I've added ${summary.vizCount} charts to the chat.`
+    return stripped ? `${stripped} ${suffix}` : suffix
+}
+
+export function stripMarkdown(text: string): string {
+    return (
+        text
+            // fenced code blocks - replaced wholesale; never spoken
+            .replace(/```[\s\S]*?```/g, ' (code block omitted) ')
+            // inline code
+            .replace(/`([^`]+)`/g, '$1')
+            // images
+            .replace(/!\[[^\]]*\]\([^)]+\)/g, '')
+            // links - keep link text
+            .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+            // tables - drop row-separator lines (| --- |) and pipe characters elsewhere
+            .replace(/^\s*\|?\s*:?-{2,}:?(\s*\|\s*:?-{2,}:?)*\s*\|?\s*$/gm, '')
+            .replace(/\|/g, ' ')
+            // headings
+            .replace(/^#+\s*/gm, '')
+            // bold - **foo** or __foo__ - run twice to safely handle nested markers
+            .replace(/\*\*([^*]+?)\*\*/g, '$1')
+            .replace(/__([^_]+?)__/g, '$1')
+            // italic - *foo* or _foo_ - but only when the marker is at a word boundary so
+            // identifiers like foo_bar_baz aren't mangled
+            .replace(/(^|[^A-Za-z0-9_])[*_]([^*_\n]+?)[*_](?=$|[^A-Za-z0-9_])/g, '$1$2')
+            // strikethrough
+            .replace(/~~([^~]+?)~~/g, '$1')
+            // blockquotes
+            .replace(/^\s*>\s?/gm, '')
+            // bulleted lists
+            .replace(/^\s*[-*+]\s+/gm, '')
+            // ordered lists
+            .replace(/^\s*\d+[.)]\s+/gm, '')
+            // collapse runs of whitespace - TTS reads runs of "\n\n" as awkward pauses
+            .replace(/\s+/g, ' ')
+    )
+}

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -168,10 +168,19 @@ export const maxLogic = kea<maxLogicType>([
 
     actions({
         setQuestion: (question: string) => ({ question }), // update the form input
-        askMax: (prompt: string | null, addToThread: boolean = true, uiContext?: Partial<MaxUIContext>) => ({
+        askMax: (
+            prompt: string | null,
+            addToThread: boolean = true,
+            uiContext?: Partial<MaxUIContext>,
+            // Optional UI surface that triggered this turn (e.g. 'hands_free'). Tagged on
+            // backend LLM analytics events so cost / latency / model-mix can be filtered
+            // per surface. Omit for default text-composer asks.
+            surface?: string
+        ) => ({
             prompt,
             addToThread,
             uiContext,
+            surface,
         }), // used by maxThreadLogic to start a conversation
         scrollThreadToBottom: (behavior?: 'instant' | 'smooth') => ({ behavior }),
         openConversation: (conversationId: string) => ({ conversationId }),

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -66,6 +66,8 @@ import {
 
 import { LogEntry, parseLogEvent } from 'products/tasks/frontend/lib/parse-logs'
 
+import { handsFreeLogic } from './handsFreeLogic'
+import { summariseAssistantThread } from './handsFreeUtils'
 import { MODE_DEFINITIONS, ToolRegistration } from './max-constants'
 import { MaxBillingContext, MaxBillingContextSubscriptionLevel, maxBillingContextLogic } from './maxBillingContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
@@ -1164,6 +1166,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         },
 
         completeThreadGeneration: () => {
+            const handsFree = handsFreeLogic.findMounted({ tabId: props.tabId })
+            if (handsFree?.values.isActive) {
+                handsFree.actions.speakAssistantResponse(summariseAssistantThread(values.threadRaw))
+            }
+
             // Update the conversation history to include the new conversation
             actions.loadConversationHistory({ doNotUpdateCurrentThread: true })
 

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -191,6 +191,9 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 contextual_tools?: Record<string, any>
                 ui_context?: any
                 resume_payload?: ResumePayload | null
+                // UI surface that triggered this turn. Forwarded to the backend so LLM
+                // analytics events get tagged with it.
+                surface?: string
             },
             generationAttempt: number,
             addToThread: boolean = true
@@ -996,7 +999,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.clearQueuedMessages()
             }
         },
-        askMax: async ({ prompt, addToThread = true, uiContext }) => {
+        askMax: async ({ prompt, addToThread = true, uiContext, surface }) => {
             // Only process if this thread is the currently active one
             if (values.conversationId !== values.activeThreadKey) {
                 return
@@ -1109,6 +1112,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     conversation: values.conversation?.id || values.conversationId,
                     // Include auto-rejection payload if there was a pending approval
                     resume_payload: autoRejectPayload,
+                    surface,
                 },
                 0,
                 addToThread

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,7 +275,7 @@ importers:
         version: 3.12.1
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
       oxfmt:
         specifier: 'catalog:'
         version: 0.35.0
@@ -448,7 +448,7 @@ importers:
         version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/test-runner':
         specifier: ^0.16.0
-        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
+        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)
       '@storybook/theming':
         specifier: ^7.6.4
         version: 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -556,6 +556,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.1
         version: 3.2.1(react@18.3.1)
+      '@elevenlabs/client':
+        specifier: ^1.4.0
+        version: 1.7.0(@types/dom-mediacapture-record@1.0.22)
       '@floating-ui/react':
         specifier: ^0.27.19
         version: 0.27.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1306,7 +1309,7 @@ importers:
         version: 29.7.0
       jest-image-snapshot:
         specifier: ^6.1.0
-        version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@22.18.8))
       kea-typegen:
         specifier: 3.6.2-leakfix.5
         version: 3.6.2-leakfix.5(typescript@5.9.3)
@@ -1801,7 +1804,7 @@ importers:
         version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.52.4)(typescript@5.9.3)(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
       '@storybook/test-runner':
         specifier: ^0.16.0
-        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
+        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)
       '@storybook/theming':
         specifier: ^7.6.20
         version: 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1819,10 +1822,10 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
+        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@22.18.8))
       storybook:
         specifier: ^7.6.4
         version: 7.6.4(encoding@0.1.13)
@@ -3556,7 +3559,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
+        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -5112,8 +5115,8 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
-  '@bufbuild/protobuf@1.7.2':
-    resolution: {integrity: sha512-i5GE2Dk5ekdlK1TR7SugY4LWRrKSfb5T1Qn4unpIMbfxoeGKERKQ59HG3iYewacGD10SR7UzevfPnh6my4tNmQ==}
+  '@bufbuild/protobuf@1.10.1':
+    resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
 
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
@@ -5589,6 +5592,12 @@ packages:
     resolution: {integrity: sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==}
     peerDependencies:
       react: 18.3.1
+
+  '@elevenlabs/client@1.7.0':
+    resolution: {integrity: sha512-uLlR2GHM3lBAVZ+0zyACBYQ3hTJ5kcRh3H6fj/EMy8+N6pO43ru7hJhorMQbda19eY2sHwivjD5Vys0O0vR1Og==}
+
+  '@elevenlabs/types@0.13.0':
+    resolution: {integrity: sha512-4FdEv9YYR1EHl1KJwUFNqJcm9e1zuHi92Ky3wQgCM4UkzCiWNA24SyhLGchbXxv/Hc4w4arqBObQQ6SMj3jsKA==}
 
   '@emnapi/core@1.3.1':
     resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
@@ -7261,6 +7270,12 @@ packages:
 
   '@lezer/lr@1.4.2':
     resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
+
+  '@livekit/mutex@1.1.1':
+    resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
+
+  '@livekit/protocol@1.45.8':
+    resolution: {integrity: sha512-Q+l57E7w/xxOBFVWzdX5rkAZO7ffyF+rlDzNUYq2SU114+5aTyCq+PK4unaEVDNd4952Af7wteKr3sOgasGuaA==}
 
   '@lmdb/lmdb-darwin-arm64@2.8.5':
     resolution: {integrity: sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==}
@@ -12033,6 +12048,9 @@ packages:
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
+
+  '@types/dom-mediacapture-record@1.0.22':
+    resolution: {integrity: sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==}
 
   '@types/dompurify@3.0.3':
     resolution: {integrity: sha512-odiGr/9/qMqjcBOe5UhcNLOFHSYmKFOyr+bJ/Xu3Qp4k1pNPAlNLUVNNLcLfjQI7+W7ObX58EdD3H+3p3voOvA==}
@@ -18031,6 +18049,11 @@ packages:
     resolution: {integrity: sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==}
     engines: {node: '>=18.0.0'}
 
+  livekit-client@2.19.0:
+    resolution: {integrity: sha512-aolY1XDAtx0nHKBNm29W9OhzBnSz1CP5kq3phvRhFfi1NbvMXs8tcACjAkZTnIKgihkp+BiJScZZ3tZv0Gz8sA==}
+    peerDependencies:
+      '@types/dom-mediacapture-record': ^1
+
   lmdb@2.8.5:
     resolution: {integrity: sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==}
     hasBin: true
@@ -18164,6 +18187,10 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   long-timeout@0.1.1:
     resolution: {integrity: sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==}
@@ -21424,6 +21451,13 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  sdp-transform@2.15.0:
+    resolution: {integrity: sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==}
+    hasBin: true
+
+  sdp@3.2.2:
+    resolution: {integrity: sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==}
+
   secure-compare@3.0.1:
     resolution: {integrity: sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==}
 
@@ -22681,6 +22715,9 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typed-emitter@2.1.0:
+    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
+
   typed-query-selector@2.12.1:
     resolution: {integrity: sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==}
 
@@ -23406,6 +23443,10 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  webrtc-adapter@9.0.5:
+    resolution: {integrity: sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==}
+    engines: {node: '>=6.0.0', npm: '>=3.10.0'}
 
   webworkify@1.5.0:
     resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
@@ -27887,7 +27928,7 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
-  '@bufbuild/protobuf@1.7.2': {}
+  '@bufbuild/protobuf@1.10.1': {}
 
   '@bufbuild/protobuf@2.11.0': {}
 
@@ -28329,6 +28370,15 @@ snapshots:
     dependencies:
       react: 18.3.1
       tslib: 2.8.1
+
+  '@elevenlabs/client@1.7.0(@types/dom-mediacapture-record@1.0.22)':
+    dependencies:
+      '@elevenlabs/types': 0.13.0
+      livekit-client: 2.19.0(@types/dom-mediacapture-record@1.0.22)
+    transitivePeerDependencies:
+      - '@types/dom-mediacapture-record'
+
+  '@elevenlabs/types@0.13.0': {}
 
   '@emnapi/core@1.3.1':
     dependencies:
@@ -29212,41 +29262,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.18.8
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -29895,6 +29910,12 @@ snapshots:
   '@lezer/lr@1.4.2':
     dependencies:
       '@lezer/common': 1.2.3
+
+  '@livekit/mutex@1.1.1': {}
+
+  '@livekit/protocol@1.45.8':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
 
   '@lmdb/lmdb-darwin-arm64@2.8.5':
     optional: true
@@ -34682,7 +34703,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/test-runner@0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))':
+  '@storybook/test-runner@0.16.0(@types/node@22.18.8)(encoding@0.1.13)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -35946,6 +35967,8 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
+  '@types/dom-mediacapture-record@1.0.22': {}
+
   '@types/dompurify@3.0.3':
     dependencies:
       '@types/trusted-types': 2.0.4
@@ -36681,7 +36704,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -38663,21 +38686,6 @@ snapshots:
       ripemd160: 2.0.2
       safe-buffer: 5.2.1
       sha.js: 2.4.12
-
-  create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)):
     dependencies:
@@ -42143,25 +42151,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
@@ -42233,37 +42222,6 @@ snapshots:
       - canvas
       - supports-color
       - utf-8-validate
-
-  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)):
     dependencies:
@@ -42515,7 +42473,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))):
+  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@22.18.8)):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -43171,18 +43129,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
@@ -43779,6 +43725,19 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
+  livekit-client@2.19.0(@types/dom-mediacapture-record@1.0.22):
+    dependencies:
+      '@livekit/mutex': 1.1.1
+      '@livekit/protocol': 1.45.8
+      '@types/dom-mediacapture-record': 1.0.22
+      events: 3.3.0
+      jose: 6.1.3
+      loglevel: 1.9.2
+      sdp-transform: 2.15.0
+      tslib: 2.8.1
+      typed-emitter: 2.1.0
+      webrtc-adapter: 9.0.5
+
   lmdb@2.8.5:
     dependencies:
       msgpackr: 1.11.2
@@ -43906,6 +43865,8 @@ snapshots:
       slice-ansi: 7.1.0
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  loglevel@1.9.2: {}
 
   long-timeout@0.1.1: {}
 
@@ -48138,7 +48099,7 @@ snapshots:
 
   sass-embedded@1.70.0:
     dependencies:
-      '@bufbuild/protobuf': 1.7.2
+      '@bufbuild/protobuf': 1.10.1
       buffer-builder: 0.2.0
       immutable: 4.1.0
       rxjs: 7.8.1
@@ -48224,6 +48185,10 @@ snapshots:
   scroll-into-view-if-needed@3.1.0:
     dependencies:
       compute-scroll-into-view: 3.1.1
+
+  sdp-transform@2.15.0: {}
+
+  sdp@3.2.2: {}
 
   secure-compare@3.0.1: {}
 
@@ -49532,27 +49497,6 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
 
-  ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 22.18.8
-      acorn: 8.15.0
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.11.4
-    optional: true
-
   ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -49722,6 +49666,10 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.0.0
       reflect.getprototypeof: 1.0.10
+
+  typed-emitter@2.1.0:
+    optionalDependencies:
+      rxjs: 7.8.1
 
   typed-query-selector@2.12.1: {}
 
@@ -50582,6 +50530,10 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  webrtc-adapter@9.0.5:
+    dependencies:
+      sdp: 3.2.2
 
   webworkify@1.5.0: {}
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -424,6 +424,26 @@ class AIResearchBurstRateThrottle(_AIThrottleBase):
     action_name = "ai research burst rate limited"
 
 
+class MaxHandsFreeBurstRateThrottle(_AIThrottleBase):
+    # In prod: 10/min covers normal reconnects (network blip, tab refocus) and stays
+    # well below any plausible legitimate flow. In dev (settings.DEBUG): a much larger
+    # ceiling so rapid iteration doesn't trip the throttle and ruin the dev loop.
+    scope = "max_hands_free_burst"
+    rate = "1000/minute" if settings.DEBUG else "10/minute"
+    action_name = "max hands-free burst rate limited"
+
+
+class MaxHandsFreeSustainedRateThrottle(_AIThrottleBase):
+    # Each token grants ~15 min of Scribe usage. A 2-hour gym session is ~8 tokens at
+    # minimum plus reconnects, call it 15. Prod 60/day covers several long sessions a
+    # day with headroom — a 10x reduction on the prior 600/day ceiling that bounds
+    # worst-case Scribe spend per compromised account. Dev gets a much larger ceiling
+    # so testing all day doesn't lock out the developer.
+    scope = "max_hands_free_sustained"
+    rate = "10000/day" if settings.DEBUG else "60/day"
+    action_name = "max hands-free sustained rate limited"
+
+
 class AIResearchSustainedRateThrottle(_AIThrottleBase):
     scope = "ai_research_sustained"
     rate = "10/day"

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -98,6 +98,20 @@ CLOUDFLARE_TURNSTILE_SITE_KEY = get_from_env("CLOUDFLARE_TURNSTILE_SITE_KEY", ""
 RECALL_AI_API_KEY = get_from_env("RECALL_AI_API_KEY", "")
 RECALL_AI_API_URL = get_from_env("RECALL_AI_API_URL", "https://us-west-2.recall.ai")
 
+# ElevenLabs (Max hands-free mode)
+# STT goes browser ↔ ElevenLabs over a single-use Scribe WebSocket token (backend just mints).
+# TTS goes browser → PostHog → ElevenLabs → audio stream (backend proxies the key to ElevenLabs).
+ELEVENLABS_API_KEY = get_from_env("ELEVENLABS_API_KEY", "")
+ELEVENLABS_API_BASE_URL = get_from_env("ELEVENLABS_API_BASE_URL", "https://api.elevenlabs.io")
+# Rachel is ElevenLabs' default voice — neutral, clear at gym pace. Override if you want a
+# different feel without redeploying.
+ELEVENLABS_VOICE_ID = get_from_env("ELEVENLABS_VOICE_ID", "21m00Tcm4TlvDq8ikWAM")
+# Turbo v2.5 has ~300ms TTFB latency, sits in the free tier, and sounds clean enough for
+# gym-pace narration. Flash v2.5 is marginally faster but requires Creator ($22/mo) or above
+# on the ElevenLabs side, so devs running on free quota hit a 402 from the TTS proxy.
+# Override at the env level if you're on a paid tier and want the extra polish.
+ELEVENLABS_TTS_MODEL_ID = get_from_env("ELEVENLABS_TTS_MODEL_ID", "eleven_turbo_v2_5")
+
 # PandaDoc (for legal documents: BAA/DPA). One template per document variant.
 # Each call needs the matching template id, so we keep them as separate env vars —
 # rotating one (e.g., when Legal updates the DPA copy) doesn't touch the others.

--- a/posthog/temporal/ai/chat_agent.py
+++ b/posthog/temporal/ai/chat_agent.py
@@ -123,6 +123,9 @@ class ChatAgentWorkflowInputs:
     is_agent_billable: bool = True
     is_impersonated: bool = False
     resume_payload: Optional[dict[str, Any]] = None
+    # Which UI surface produced this turn (e.g. "hands_free", "text"). Tags LLM analytics
+    # events so we can scope cost / latency / model-mix dashboards to a specific surface.
+    surface: Optional[str] = None
 
 
 @workflow.defn(name="chat-agent")
@@ -201,6 +204,7 @@ async def process_chat_agent_activity(inputs: ChatAgentWorkflowInputs) -> None:
             is_agent_billable=inputs.is_agent_billable,
             is_impersonated=inputs.is_impersonated,
             resume_payload=inputs.resume_payload,
+            surface=inputs.surface,
         )
 
         async for chunk in stream_runner(assistant):


### PR DESCRIPTION
## Problem

Stacked on top of #59188 (hands-free voice mode).

Once hands-free ships, we'll want to know its LLM cost shape: cost per turn, latency per turn, model mix, tool-call rate — and how it compares to text-composer turns. Today every `$ai_generation` event in PostHog LLM analytics carries `agent_mode` + `supermode` but not which **UI surface** triggered the turn. Without that we can't filter LLM analytics dashboards to hands-free.

## Changes

Threads a `surface` field (free-form, max 32 chars) through the streaming-chat request path. Every `MaxChatAnthropic` / `MaxChatOpenAI` call made on behalf of a turn ends up tagged with `surface=hands_free` (or `surface=text` etc. in future) on its `$ai_generation` event.

**Backend** (`ee/api/conversation.py`, `posthog/temporal/ai/chat_agent.py`, `ee/hogai/chat_agent/runner.py`, `ee/hogai/utils/types/base.py`, `ee/hogai/core/agent_modes/executables.py`):

- `StreamSerializer` accepts optional `surface` field
- `ChatAgentWorkflowInputs` + `ChatAgentRunner` forward it
- `AssistantState.surface` (per-turn field, not persisted across resumes)
- `_get_agent_mode_posthog_properties` returns `surface` alongside the existing `agent_mode` + `supermode` tags — uses the same channel that gets attached to LLM gateway calls

**Frontend** (`frontend/src/lib/api.ts`, `frontend/src/scenes/max/maxLogic.tsx`, `frontend/src/scenes/max/maxThreadLogic.tsx`, `frontend/src/scenes/max/handsFreeLogic.ts`):

- `askMax(prompt, addToThread, uiContext, surface?)` — optional surface arg
- Plumbed through `streamConversation` → `api.conversations.stream` body
- `handsFreeLogic.commitTranscript` passes `surface='hands_free'`
- Text-composer asks omit it (backend treats as `None`)

## How did you test this code?

I'm an agent (PostHog Code). Automated coverage:

- Existing `handsFreeUtils` tests still pass (30/30)
- Backend tests for the conversation streaming endpoint cover the serializer path the new field flows through; new field is optional + default-null so existing tests should be unchanged
- Backend lint + format clean
- Frontend typecheck + kea typegen clean

No new tests added in this PR — it's mechanical plumbing of an optional field. The downstream effect (LLM analytics events being tagged) is observable in PostHog itself once data flows.

## Publish to changelog?

Do not publish to changelog — this is internal analytics plumbing with no user-facing change.

## 🤖 Agent context

Stacked follow-up to #59188 (PostHog Code). The decision to put this in its own PR instead of folding it into the hands-free PR:

- The hands-free PR is already chunky (~1.7k lines). Adding 7 more files in two languages would muddy the diff for reviewers focused on the feature shell.
- This change touches the main streaming API which gets careful review on its own; better to surface that as a separate diff.
- The `surface` field is independently useful even before hands-free ships — any future UI surface (mobile chat, embedded Slack, etc.) can opt in.

Considered + rejected:

- **Joining via `trace_id`** rather than adding `surface` — workable but forces every LLM analytics query to be a join across `$ai_generation` + `max hands-free entered` events. Filter-on-property is dramatically simpler to use in PostHog UI.
- **Stuffing surface into `ui_context`** rather than a top-level field — `ui_context` is taxonomic-context-for-Max, mixing UI-surface metadata in there is concept-creep.
- **Adding to AssistantState only at runner-init time vs threading from the request** — would lose surface on workflow resumes. Threading from the request via workflow inputs is more durable.

Future tags worth considering (not in this PR):

- `turn_number` per conversation — degradation analysis on long sessions
- `is_mobile` (derived from User-Agent server-side)
- `viz_count` returned by the assistant — cost-per-chart correlation

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*