### PR TITLE
fix(data-warehouse): use cursor pagination for zendesk tickets import

### DIFF
--- a/posthog/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
+++ b/posthog/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
@@ -1,0 +1,98 @@
+import json
+from typing import Any
+
+from requests import Request, Response
+
+from posthog.temporal.data_imports.sources.zendesk.zendesk import ZendeskTicketsCursorIncrementalPaginator
+
+
+def _make_response(json_body: dict[str, Any] | None = None) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(json_body or {}).encode()
+    return resp
+
+
+class TestZendeskTicketsCursorIncrementalPaginator:
+    def test_advances_to_next_cursor(self) -> None:
+        p = ZendeskTicketsCursorIncrementalPaginator()
+        resp = _make_response({"tickets": [{"id": 1}], "after_cursor": "abc123", "end_of_stream": False})
+
+        p.update_state(resp)
+
+        assert p.has_next_page is True
+
+        req = Request(method="GET", url="https://x.zendesk.com/api/v2/incremental/tickets/cursor")
+        req.params = {"per_page": 1000, "start_time": 1591394586}
+        p.update_request(req)
+
+        assert req.params["cursor"] == "abc123"
+        # The seed start_time is dropped once we paginate by cursor.
+        assert "start_time" not in req.params
+        assert req.params["per_page"] == 1000
+
+    def test_first_request_keeps_seed_start_time(self) -> None:
+        p = ZendeskTicketsCursorIncrementalPaginator()
+
+        # Before any response, has_next_page is True and no cursor is set, so the
+        # first request must go out untouched (with its seed start_time).
+        assert p.has_next_page is True
+
+        req = Request(method="GET", url="https://x.zendesk.com/api/v2/incremental/tickets/cursor")
+        req.params = {"per_page": 1000, "start_time": 1591394586}
+        p.init_request(req)
+
+        assert req.params["start_time"] == 1591394586
+        assert "cursor" not in req.params
+
+    def test_stops_on_end_of_stream(self) -> None:
+        p = ZendeskTicketsCursorIncrementalPaginator()
+        resp = _make_response({"tickets": [], "after_cursor": "abc123", "end_of_stream": True})
+
+        p.update_state(resp)
+
+        assert p.has_next_page is False
+
+    def test_stops_when_after_cursor_missing(self) -> None:
+        p = ZendeskTicketsCursorIncrementalPaginator()
+        resp = _make_response({"tickets": [{"id": 1}], "after_cursor": None, "end_of_stream": False})
+
+        p.update_state(resp)
+
+        assert p.has_next_page is False
+
+    def test_stops_when_response_empty(self) -> None:
+        p = ZendeskTicketsCursorIncrementalPaginator()
+
+        p.update_state(_make_response({}))
+
+        assert p.has_next_page is False
+
+    def test_stops_when_cursor_does_not_advance(self) -> None:
+        """The time-based export's failure mode (a cursor that never moves) must
+        terminate rather than loop forever re-fetching the same page."""
+        p = ZendeskTicketsCursorIncrementalPaginator()
+
+        first = _make_response({"tickets": [{"id": 1}], "after_cursor": "abc123", "end_of_stream": False})
+        p.update_state(first)
+        assert p.has_next_page is True
+
+        repeated = _make_response({"tickets": [{"id": 1}], "after_cursor": "abc123", "end_of_stream": False})
+        p.update_state(repeated)
+        assert p.has_next_page is False
+
+    def test_paginates_across_multiple_pages(self) -> None:
+        p = ZendeskTicketsCursorIncrementalPaginator()
+        req = Request(method="GET", url="https://x.zendesk.com/api/v2/incremental/tickets/cursor")
+        req.params = {"per_page": 1000, "start_time": 1591394586}
+
+        p.update_state(_make_response({"tickets": [{"id": 1}], "after_cursor": "cursor_1", "end_of_stream": False}))
+        p.update_request(req)
+        assert req.params["cursor"] == "cursor_1"
+
+        p.update_state(_make_response({"tickets": [{"id": 2}], "after_cursor": "cursor_2", "end_of_stream": False}))
+        p.update_request(req)
+        assert req.params["cursor"] == "cursor_2"
+
+        p.update_state(_make_response({"tickets": [{"id": 3}], "after_cursor": "cursor_3", "end_of_stream": True}))
+        assert p.has_next_page is False

--- a/posthog/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
+++ b/posthog/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
@@ -1,6 +1,8 @@
 import json
 from typing import Any
 
+import pytest
+
 from requests import Request, Response
 
 from posthog.temporal.data_imports.sources.zendesk.zendesk import ZendeskTicketsCursorIncrementalPaginator
@@ -9,6 +11,7 @@ from posthog.temporal.data_imports.sources.zendesk.zendesk import ZendeskTickets
 def _make_response(json_body: dict[str, Any] | None = None) -> Response:
     resp = Response()
     resp.status_code = 200
+    resp.headers["Content-Type"] = "application/json"
     resp._content = json.dumps(json_body or {}).encode()
     return resp
 
@@ -45,32 +48,37 @@ class TestZendeskTicketsCursorIncrementalPaginator:
         assert req.params["start_time"] == 1591394586
         assert "cursor" not in req.params
 
-    def test_stops_on_end_of_stream(self) -> None:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param({"tickets": [], "after_cursor": "abc123", "end_of_stream": True}, id="end_of_stream"),
+            pytest.param({}, id="empty_response"),
+        ],
+    )
+    def test_stops_pagination(self, body: dict[str, Any]) -> None:
         p = ZendeskTicketsCursorIncrementalPaginator()
-        resp = _make_response({"tickets": [], "after_cursor": "abc123", "end_of_stream": True})
 
-        p.update_state(resp)
+        p.update_state(_make_response(body))
 
         assert p.has_next_page is False
 
-    def test_stops_when_after_cursor_missing(self) -> None:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param({"tickets": [{"id": 1}], "after_cursor": None, "end_of_stream": False}, id="missing_cursor"),
+            pytest.param({"tickets": [{"id": 1}], "after_cursor": "abc123"}, id="missing_end_of_stream"),
+        ],
+    )
+    def test_raises_on_invalid_response(self, body: dict[str, Any]) -> None:
         p = ZendeskTicketsCursorIncrementalPaginator()
-        resp = _make_response({"tickets": [{"id": 1}], "after_cursor": None, "end_of_stream": False})
 
-        p.update_state(resp)
+        with pytest.raises(ValueError):
+            p.update_state(_make_response(body))
 
-        assert p.has_next_page is False
-
-    def test_stops_when_response_empty(self) -> None:
-        p = ZendeskTicketsCursorIncrementalPaginator()
-
-        p.update_state(_make_response({}))
-
-        assert p.has_next_page is False
-
-    def test_stops_when_cursor_does_not_advance(self) -> None:
-        """The time-based export's failure mode (a cursor that never moves) must
-        terminate rather than loop forever re-fetching the same page."""
+    def test_raises_when_cursor_does_not_advance(self) -> None:
+        """A cursor that never moves while end_of_stream is False is the time-based
+        export's failure mode; fail loud so the activity retries instead of
+        silently truncating data."""
         p = ZendeskTicketsCursorIncrementalPaginator()
 
         first = _make_response({"tickets": [{"id": 1}], "after_cursor": "abc123", "end_of_stream": False})
@@ -78,8 +86,8 @@ class TestZendeskTicketsCursorIncrementalPaginator:
         assert p.has_next_page is True
 
         repeated = _make_response({"tickets": [{"id": 1}], "after_cursor": "abc123", "end_of_stream": False})
-        p.update_state(repeated)
-        assert p.has_next_page is False
+        with pytest.raises(ValueError):
+            p.update_state(repeated)
 
     def test_paginates_across_multiple_pages(self) -> None:
         p = ZendeskTicketsCursorIncrementalPaginator()

--- a/posthog/temporal/data_imports/sources/zendesk/zendesk.py
+++ b/posthog/temporal/data_imports/sources/zendesk/zendesk.py
@@ -248,17 +248,24 @@ class ZendeskTicketsCursorIncrementalPaginator(BasePaginator):
     def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         res = response.json()
 
-        if not res or res.get("end_of_stream", True):
+        if not res:
             self._has_next_page = False
             return
 
+        if "end_of_stream" not in res:
+            raise ValueError("Zendesk cursor export response is missing 'end_of_stream'")
+
+        if res["end_of_stream"]:
+            self._has_next_page = False
+            return
+
+        # `end_of_stream` is False, so the stream continues and a valid, advancing
+        # `after_cursor` must be present. A missing or non-advancing cursor is an
+        # invalid/partial response — raise so the activity retries instead of
+        # committing truncated data as a successful sync.
         after_cursor = res.get("after_cursor")
-
-        # No cursor advance means there's nothing further to fetch. Stop rather
-        # than re-request the same page — defends against a stuck cursor.
         if not after_cursor or after_cursor == self._after_cursor:
-            self._has_next_page = False
-            return
+            raise ValueError("Zendesk cursor export returned end_of_stream=False without an advancing after_cursor")
 
         self._after_cursor = after_cursor
         self._has_next_page = True

--- a/posthog/temporal/data_imports/sources/zendesk/zendesk.py
+++ b/posthog/temporal/data_imports/sources/zendesk/zendesk.py
@@ -180,8 +180,13 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
             "columns": get_dlt_mapping_for_external_table("zendesk_tickets"),
             "endpoint": {
                 "data_selector": "tickets",
-                "path": "/api/v2/incremental/tickets",
-                "paginator": ZendeskTicketsIncrementalEndpointPaginator(),
+                # Cursor-based incremental export. The time-based export
+                # (`/api/v2/incremental/tickets`) deadlocks when >1000 tickets
+                # share a `generated_timestamp`: the page never advances past
+                # that timestamp, so pagination loops forever re-fetching the
+                # same boundary page. Cursor pagination is immune to this.
+                "path": "/api/v2/incremental/tickets/cursor",
+                "paginator": ZendeskTicketsCursorIncrementalPaginator(),
                 "params": {
                     "per_page": 1000,
                     "start_time": {
@@ -226,29 +231,46 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
     return resources[name]
 
 
-class ZendeskTicketsIncrementalEndpointPaginator(BasePaginator):
+class ZendeskTicketsCursorIncrementalPaginator(BasePaginator):
+    """Cursor-based pagination for Zendesk's incremental tickets export.
+
+    The first request is seeded with `start_time` (resolved from the incremental
+    cursor); every subsequent request follows the opaque `after_cursor` token.
+    Unlike the time-based export, the cursor encodes the stream position rather
+    than a timestamp, so it can't get pinned when many tickets share a
+    `generated_timestamp`.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._after_cursor: Optional[str] = None
+
     def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         res = response.json()
 
-        self._next_start_time = None
-
-        if not res:
+        if not res or res.get("end_of_stream", True):
             self._has_next_page = False
             return
 
-        if not res["end_of_stream"]:
-            self._has_next_page = True
+        after_cursor = res.get("after_cursor")
 
-            last_value_in_response = res["tickets"][-1]["generated_timestamp"]
-            self._next_start_time = last_value_in_response
-        else:
+        # No cursor advance means there's nothing further to fetch. Stop rather
+        # than re-request the same page — defends against a stuck cursor.
+        if not after_cursor or after_cursor == self._after_cursor:
             self._has_next_page = False
+            return
+
+        self._after_cursor = after_cursor
+        self._has_next_page = True
 
     def update_request(self, request: Request) -> None:
         if request.params is None:
             request.params = {}
 
-        request.params["start_time"] = self._next_start_time
+        # After the first page we paginate purely by cursor; drop the seed
+        # `start_time` so it doesn't conflict with the `cursor` param.
+        request.params.pop("start_time", None)
+        request.params["cursor"] = self._after_cursor
 
 
 class ZendeskIncrementalEndpointPaginator(BasePaginator):


### PR DESCRIPTION
## Problem

The Zendesk tickets import uses the **time-based** incremental export (`/api/v2/incremental/tickets`). This endpoint has a documented failure mode: when more than one page of tickets share the same `generated_timestamp` (common when a bulk update or migration stamps thousands of older tickets at once), the cursor can never advance past that timestamp. Pagination then loops forever re-fetching the same boundary page.

The downstream effects compound:

- The sync never reaches `end_of_stream`, so it never commits its incremental cursor.
- Every worker restart resumes from the same uncommitted `start_time` and replays the full fetch-and-merge.
- The repeated re-merges fragment the affected Delta partitions into many small files and the worker eventually OOMs, so the import never completes.

## Changes

Switch the tickets resource to Zendesk's **cursor-based** incremental export (`/api/v2/incremental/tickets/cursor`), which Zendesk recommends specifically to avoid the same-timestamp loop — the cursor encodes stream position rather than a timestamp, so it can't get pinned.

- New `ZendeskTicketsCursorIncrementalPaginator`: the first request keeps the `start_time` seed (resolved from the incremental cursor); subsequent requests drop it and follow the opaque `after_cursor` token. It also terminates if the cursor ever fails to advance, as a defensive guard against any future stuck-cursor scenario.
- The `generated_timestamp` incremental cursor config is unchanged, so cross-run resumption and committed-cursor behavior are preserved.
- Removed the old `ZendeskTicketsIncrementalEndpointPaginator` (only used by tickets).

The existing Delta merge logic is untouched — the small-file fragmentation was a symptom of the replay loop and stops accreting once imports stop replaying.

## How did you test this code?

I'm an agent (Claude Code). I added and ran unit tests for the new paginator covering cursor advance, first-request seed preservation, `end_of_stream` termination, missing/stuck cursor, empty response, and multi-page traversal — all 7 pass locally. I did not run a live import against the Zendesk API.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code. Investigation started from worker OOM logs showing the same `start_time` request repeating indefinitely on a tickets import. Confirmed via Zendesk's incremental export docs that the time-based endpoint cannot make progress when >1000 records share a timestamp, and that cursor-based export is the recommended fix.

Considered and rejected: bumping `start_time` by +1s to force progress (would skip the remaining boundary tickets beyond the first page → silent data loss); following the response `next_page`/`end_time` instead of the last record's timestamp (still loops when `end_time == start_time`). Cursor-based pagination is the only approach immune to the failure mode.

Out of scope (noted for follow-up): `ticket_events` / `ticket_metric_events` still use the time-based paginator and carry the same theoretical risk, though their incrementality is currently disabled.
