### PR TITLE
feat(logs): add ios and react native to logs onboarding

### DIFF
--- a/docs/onboarding/logs/index.ts
+++ b/docs/onboarding/logs/index.ts
@@ -1,6 +1,8 @@
 export { GoInstallation } from './go'
+export { IOSInstallation } from './ios'
 export { JavaInstallation } from './java'
 export { NextJSInstallation } from './nextjs'
 export { NodeJSInstallation } from './nodejs'
 export { OpenTelemetryInstallation } from './opentelemetry'
 export { PythonInstallation } from './python'
+export { ReactNativeInstallation } from './react-native'

--- a/docs/onboarding/logs/ios.tsx
+++ b/docs/onboarding/logs/ios.tsx
@@ -17,8 +17,8 @@ export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
         content: (
             <>
                 <Markdown>
-                    Capture a structured log record using the logger facade. Records are batched and shipped to
-                    PostHog's logs product.
+                    Capture a structured log record with `captureLog`. Records are batched and shipped to PostHog's logs
+                    product.
                 </Markdown>
                 <CodeBlock
                     blocks={[
@@ -28,7 +28,7 @@ export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                             code: dedent`
                                 import PostHog
 
-                                PostHogSDK.shared.logger.info("Server started", attributes: [
+                                PostHogSDK.shared.captureLog("Server started", level: .info, attributes: [
                                     "server.port": 3000,
                                     "server.env": "production"
                                 ])

--- a/docs/onboarding/logs/ios.tsx
+++ b/docs/onboarding/logs/ios.tsx
@@ -1,0 +1,52 @@
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { getIOSSteps as getIOSStepsPA } from '../product-analytics/ios'
+import { StepDefinition } from '../steps'
+
+export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    const installSteps = getIOSStepsPA(ctx, {
+        minVersionPod: '3.58',
+        minVersionSPM: '3.58.0',
+    })
+
+    const sendLogStep: StepDefinition = {
+        title: 'Send a log',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>
+                    Capture a structured log record using the logger facade. Records are batched and shipped to
+                    PostHog's logs product.
+                </Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'swift',
+                            file: 'Swift',
+                            code: dedent`
+                                import PostHog
+
+                                PostHogSDK.shared.logger.info("Server started", attributes: [
+                                    "server.port": 3000,
+                                    "server.env": "production"
+                                ])
+                            `,
+                        },
+                    ]}
+                />
+                <Markdown>
+                    {dedent`
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter
+                        by service name, severity, or any attribute you attach.
+                    `}
+                </Markdown>
+            </>
+        ),
+    }
+
+    return [...installSteps, sendLogStep]
+}
+
+export const IOSInstallation = createInstallation(getIOSSteps)

--- a/docs/onboarding/logs/react-native.tsx
+++ b/docs/onboarding/logs/react-native.tsx
@@ -6,7 +6,7 @@ import { StepDefinition } from '../steps'
 export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
-    const installSteps = getReactNativeStepsPA(ctx)
+    const installSteps = getReactNativeStepsPA(ctx, { minVersion: '4.44.0' })
 
     const sendLogStep: StepDefinition = {
         title: 'Send a log',

--- a/docs/onboarding/logs/react-native.tsx
+++ b/docs/onboarding/logs/react-native.tsx
@@ -1,0 +1,56 @@
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { getReactNativeSteps as getReactNativeStepsPA } from '../product-analytics/react-native'
+import { StepDefinition } from '../steps'
+
+export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    const installSteps = getReactNativeStepsPA(ctx)
+
+    const sendLogStep: StepDefinition = {
+        title: 'Send a log',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>
+                    Capture a structured log record using the logger facade. Requires `posthog-react-native` 4.44.0 or
+                    later. Records are batched and shipped to PostHog's logs product.
+                </Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'tsx',
+                            file: 'Component.tsx',
+                            code: dedent`
+                                import { usePostHog } from 'posthog-react-native'
+
+                                function MyComponent() {
+                                    const posthog = usePostHog()
+
+                                    const handlePress = () => {
+                                        posthog.logger.info('checkout completed', {
+                                            order_id: 'ord_789'
+                                        })
+                                    }
+
+                                    return <Button onPress={handlePress} title="Check out" />
+                                }
+                            `,
+                        },
+                    ]}
+                />
+                <Markdown>
+                    {dedent`
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter
+                        by service name, severity, or any attribute you attach.
+                    `}
+                </Markdown>
+            </>
+        ),
+    }
+
+    return [...installSteps, sendLogStep]
+}
+
+export const ReactNativeInstallation = createInstallation(getReactNativeSteps)

--- a/docs/onboarding/product-analytics/react-native.tsx
+++ b/docs/onboarding/product-analytics/react-native.tsx
@@ -2,8 +2,15 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 
 import { StepDefinition } from '../steps'
 
-export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+export const getReactNativeSteps = (
+    ctx: OnboardingComponentsContext,
+    options?: {
+        minVersion?: string
+    }
+): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
+
+    const pkg = options?.minVersion ? `posthog-react-native@^${options.minVersion}` : 'posthog-react-native'
 
     return [
         {
@@ -18,14 +25,14 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'Expo',
                                 code: dedent`
-                                    npx expo install posthog-react-native expo-file-system expo-application expo-device expo-localization
+                                    npx expo install ${pkg} expo-file-system expo-application expo-device expo-localization
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'yarn',
                                 code: dedent`
-                                    yarn add posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize
+                                    yarn add ${pkg} @react-native-async-storage/async-storage react-native-device-info react-native-localize
 
                                     # for iOS
                                     cd ios && pod install
@@ -35,7 +42,7 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'npm',
                                 code: dedent`
-                                    npm i -s posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize
+                                    npm i -s ${pkg} @react-native-async-storage/async-storage react-native-device-info react-native-localize
 
                                     # for iOS
                                     cd ios && pod install

--- a/frontend/src/scenes/onboarding/sdks/logs/LogsSDKInstructions.tsx
+++ b/frontend/src/scenes/onboarding/sdks/logs/LogsSDKInstructions.tsx
@@ -1,10 +1,12 @@
 import {
     GoInstallation,
+    IOSInstallation,
     JavaInstallation,
     NextJSInstallation,
     NodeJSInstallation,
     OpenTelemetryInstallation,
     PythonInstallation,
+    ReactNativeInstallation,
 } from '@posthog/shared-onboarding/logs'
 
 import { SDKInstructionsMap, SDKKey } from '~/types'
@@ -38,6 +40,14 @@ const LogsOpenTelemetryInstructionsWrapper = withOnboardingDocsWrapper({
     Installation: OpenTelemetryInstallation,
 })
 
+const LogsIOSInstructionsWrapper = withOnboardingDocsWrapper({
+    Installation: IOSInstallation,
+})
+
+const LogsReactNativeInstructionsWrapper = withOnboardingDocsWrapper({
+    Installation: ReactNativeInstallation,
+})
+
 export const LogsSDKInstructions: SDKInstructionsMap = {
     [SDKKey.NODE_JS]: LogsNodeJSInstructionsWrapper,
     [SDKKey.NEXT_JS]: LogsNextJSInstructionsWrapper,
@@ -45,4 +55,6 @@ export const LogsSDKInstructions: SDKInstructionsMap = {
     [SDKKey.GO]: LogsGoInstructionsWrapper,
     [SDKKey.JAVA]: LogsJavaInstructionsWrapper,
     [SDKKey.OPENTELEMETRY]: LogsOpenTelemetryInstructionsWrapper,
+    [SDKKey.IOS]: LogsIOSInstructionsWrapper,
+    [SDKKey.REACT_NATIVE]: LogsReactNativeInstructionsWrapper,
 }


### PR DESCRIPTION
## Problem

The Logs install onboarding picker did not list iOS or React Native, even though both SDKs support manual log capture (posthog-ios 3.58.0+, posthog-react-native 4.44.0+). Mobile developers had no in-product path to wire up Logs.

## Changes

Adds iOS and React Native tiles to the Logs SDK picker. Each reuses the product-analytics install + configure steps, then appends a Logs-specific "Send a log" step using the SDK native capture API.

## How did you test this code?

I am an agent. I ran `pnpm exec tsc --noEmit` (no errors in touched files), lint-staged on commit, plannotator review (no findings), and manually drove the local dev stack to load the onboarding picker, click into both tiles, and verify the rendered snippets matched the SDK APIs.

## Publish to changelog?

no

## Docs update

Not needed.