### PR TITLE
chore(flags): log when surveys/EAF mutate flags without feature_flag:write

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.db import transaction
 from django.db.models import Count, Prefetch, Q, QuerySet, deletion
 
+import structlog
 import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, OpenApiResponse
@@ -106,6 +107,11 @@ from products.product_tours.backend.models import ProductTour
 from products.surveys.backend.models import Survey
 
 logger = logging.getLogger(__name__)
+# Dedicated logger name (not `__name__`) so the underlying stdlib logger is created
+# *after* Django applies `disable_existing_loggers: True`. Using `__name__` here
+# results in a disabled logger because `posthog.api.feature_flag` is loaded during
+# Django startup. Remove this logger together with the helper once the scope is enforced.
+scope_audit_logger = structlog.get_logger("posthog.feature_flag_scope_audit")
 
 BEHAVIOURAL_COHORT_FOUND_ERROR_CODE = "behavioral_cohort_found"
 
@@ -158,18 +164,16 @@ def warn_if_missing_feature_flag_write_scope(
     if "*" in scopes or "feature_flag:write" in scopes:
         return
 
-    logger.warning(
+    scope_audit_logger.warning(
         "feature_flag_write_via_other_scope",
-        extra={
-            "action": action,
-            "team_id": team_id,
-            "feature_flag_id": feature_flag_id,
-            "scopes": scopes,
-            "auth_kind": auth_kind,
-            "auth_id": auth_id,
-            "auth_label": auth_label,
-            "user_id": getattr(getattr(request, "user", None), "id", None),
-        },
+        action=action,
+        team_id=team_id,
+        feature_flag_id=feature_flag_id,
+        scopes=scopes,
+        auth_kind=auth_kind,
+        auth_id=auth_id,
+        auth_label=auth_label,
+        user_id=getattr(getattr(request, "user", None), "id", None),
     )
 
 

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -126,6 +126,53 @@ RUST_FLAG_FIELDS = (
 )
 
 
+def warn_if_missing_feature_flag_write_scope(
+    request,
+    *,
+    action: str,
+    team_id: int | None = None,
+    feature_flag_id: int | None = None,
+) -> None:
+    # Temporary observability for a cross-resource scope bypass: SurveyViewSet and
+    # EarlyAccessFeatureViewSet mutate FeatureFlag rows under their own scope
+    # (`survey:write` / `early_access_feature:write`). Before enforcing
+    # `feature_flag:write` on these paths we want to know which customers rely on
+    # the transitive access so we can notify them. Remove this helper and its
+    # call sites once the scope is enforced.
+    authenticator = getattr(request, "successful_authenticator", None)
+    if isinstance(authenticator, PersonalAPIKeyAuthentication):
+        scopes = list(authenticator.personal_api_key.scopes or [])
+        auth_kind = "personal_api_key"
+        auth_id: str | None = authenticator.personal_api_key.id
+        auth_label: str | None = authenticator.personal_api_key.label
+    elif isinstance(authenticator, OAuthAccessTokenAuthentication):
+        scope_string = authenticator.access_token.scope or ""
+        scopes = scope_string.split()
+        auth_kind = "oauth_access_token"
+        raw_id = getattr(authenticator.access_token, "id", None)
+        auth_id = str(raw_id) if raw_id is not None else None
+        auth_label = None
+    else:
+        return
+
+    if "*" in scopes or "feature_flag:write" in scopes:
+        return
+
+    logger.warning(
+        "feature_flag_write_via_other_scope",
+        extra={
+            "action": action,
+            "team_id": team_id,
+            "feature_flag_id": feature_flag_id,
+            "scopes": scopes,
+            "auth_kind": auth_kind,
+            "auth_id": auth_id,
+            "auth_label": auth_label,
+            "user_id": getattr(getattr(request, "user", None), "id", None),
+        },
+    )
+
+
 def _is_realtime_cohort_flag_targeting_enabled(request) -> bool:
     """Check whether the realtime cohort flag targeting feature is enabled for this request."""
     try:

--- a/products/early_access_features/backend/api.py
+++ b/products/early_access_features/backend/api.py
@@ -12,7 +12,11 @@ from rest_framework.response import Response
 
 from posthog.schema import ProductKey
 
-from posthog.api.feature_flag import FeatureFlagSerializer, MinimalFeatureFlagSerializer
+from posthog.api.feature_flag import (
+    FeatureFlagSerializer,
+    MinimalFeatureFlagSerializer,
+    warn_if_missing_feature_flag_write_scope,
+)
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import get_token
@@ -109,6 +113,17 @@ class EarlyAccessFeatureSerializer(serializers.ModelSerializer):
         request = self.context["request"]
         user_data = UserBasicSerializer(request.user).data if request.user else None
         serialized_previous = MinimalEarlyAccessFeatureSerializer(instance).data
+
+        stage_will_change = (
+            "stage" in self.initial_data and instance.stage != stage and instance.feature_flag is not None
+        )
+        if stage_will_change:
+            warn_if_missing_feature_flag_write_scope(
+                request,
+                action="early_access_feature.stage_change",
+                team_id=instance.team_id,
+                feature_flag_id=instance.feature_flag.id,
+            )
 
         if instance.stage != stage:
             send_events_for_early_access_feature_stage_change.delay(str(instance.id), instance.stage, stage)
@@ -265,6 +280,13 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
     def create(self, validated_data):
         validated_data["team_id"] = self.context["team_id"]
 
+        warn_if_missing_feature_flag_write_scope(
+            self.context["request"],
+            action="early_access_feature.create",
+            team_id=self.context["team_id"],
+            feature_flag_id=validated_data.get("feature_flag_id"),
+        )
+
         feature_flag_id = validated_data.get("feature_flag_id", None)
 
         default_condition = [
@@ -349,6 +371,12 @@ class EarlyAccessFeatureViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         related_feature_flag = instance.feature_flag
 
         if related_feature_flag:
+            warn_if_missing_feature_flag_write_scope(
+                request,
+                action="early_access_feature.destroy",
+                team_id=instance.team_id,
+                feature_flag_id=related_feature_flag.id,
+            )
             related_feature_flag.filters = {
                 **related_feature_flag.filters,
                 "super_groups": None,

--- a/products/early_access_features/backend/api.py
+++ b/products/early_access_features/backend/api.py
@@ -114,18 +114,14 @@ class EarlyAccessFeatureSerializer(serializers.ModelSerializer):
         user_data = UserBasicSerializer(request.user).data if request.user else None
         serialized_previous = MinimalEarlyAccessFeatureSerializer(instance).data
 
-        stage_will_change = (
-            "stage" in self.initial_data and instance.stage != stage and instance.feature_flag is not None
-        )
-        if stage_will_change:
-            warn_if_missing_feature_flag_write_scope(
-                request,
-                action="early_access_feature.stage_change",
-                team_id=instance.team_id,
-                feature_flag_id=instance.feature_flag.id,
-            )
-
         if instance.stage != stage:
+            if "stage" in self.initial_data and instance.feature_flag is not None:
+                warn_if_missing_feature_flag_write_scope(
+                    request,
+                    action="early_access_feature.stage_change",
+                    team_id=instance.team_id,
+                    feature_flag_id=instance.feature_flag.id,
+                )
             send_events_for_early_access_feature_stage_change.delay(str(instance.id), instance.stage, stage)
 
         if instance.stage != stage and stage == EarlyAccessFeature.Stage.GENERAL_AVAILABILITY and rollout_to_all:

--- a/products/early_access_features/backend/test/test_early_access_feature.py
+++ b/products/early_access_features/backend/test/test_early_access_feature.py
@@ -1253,12 +1253,12 @@ class TestEarlyAccessFeatureScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         )
 
     def test_create_with_early_access_feature_write_only_logs_warning(self):
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self._create_feature()
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         events = self._warning_events(mock_logger)
         assert len(events) == 1
-        extra = events[0].kwargs["extra"]
+        extra = events[0].kwargs
         assert extra["action"] == "early_access_feature.create"
         assert extra["team_id"] == self.team.id
         assert extra["scopes"] == ["early_access_feature:write"]
@@ -1268,7 +1268,7 @@ class TestEarlyAccessFeatureScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
     def test_create_with_feature_flag_write_does_not_log(self):
         self.key.scopes = ["early_access_feature:write", "feature_flag:write"]
         self.key.save()
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self._create_feature()
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         assert self._warning_events(mock_logger) == []
@@ -1276,7 +1276,7 @@ class TestEarlyAccessFeatureScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
     def test_create_with_wildcard_scope_does_not_log(self):
         self.key.scopes = ["*"]
         self.key.save()
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self._create_feature()
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         assert self._warning_events(mock_logger) == []
@@ -1288,7 +1288,7 @@ class TestEarlyAccessFeatureScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         self.key.scopes = ["early_access_feature:write"]
         self.key.save()
 
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self.client.patch(
                 f"/api/projects/{self.team.id}/early_access_feature/{feature_id}/",
                 data={"stage": "beta"},
@@ -1298,7 +1298,7 @@ class TestEarlyAccessFeatureScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         assert response.status_code == status.HTTP_200_OK, response.json()
         events = self._warning_events(mock_logger)
         assert len(events) == 1
-        assert events[0].kwargs["extra"]["action"] == "early_access_feature.stage_change"
+        assert events[0].kwargs["action"] == "early_access_feature.stage_change"
 
     def test_update_without_stage_change_does_not_log(self):
         self.key.scopes = ["*"]
@@ -1307,7 +1307,7 @@ class TestEarlyAccessFeatureScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         self.key.scopes = ["early_access_feature:write"]
         self.key.save()
 
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self.client.patch(
                 f"/api/projects/{self.team.id}/early_access_feature/{feature_id}/",
                 data={"description": "updated"},
@@ -1324,7 +1324,7 @@ class TestEarlyAccessFeatureScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         self.key.scopes = ["early_access_feature:write"]
         self.key.save()
 
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self.client.delete(
                 f"/api/projects/{self.team.id}/early_access_feature/{feature_id}/",
                 headers=self.auth_headers,
@@ -1332,11 +1332,11 @@ class TestEarlyAccessFeatureScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         assert response.status_code == status.HTTP_204_NO_CONTENT
         events = self._warning_events(mock_logger)
         assert len(events) == 1
-        assert events[0].kwargs["extra"]["action"] == "early_access_feature.destroy"
+        assert events[0].kwargs["action"] == "early_access_feature.destroy"
 
     def test_session_auth_does_not_log(self):
         self.client.force_login(self.user)
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self.client.post(
                 f"/api/projects/{self.team.id}/early_access_feature/",
                 data=self.CREATE_PAYLOAD,

--- a/products/early_access_features/backend/test/test_early_access_feature.py
+++ b/products/early_access_features/backend/test/test_early_access_feature.py
@@ -10,6 +10,7 @@ from django.test.client import Client
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.api.test.test_personal_api_keys import PersonalAPIKeysBaseTest
 from posthog.models import FeatureFlag, Person
 from posthog.models.team.team_caching import set_team_in_cache
 
@@ -1221,3 +1222,125 @@ class TestPreviewList(BaseTest, QueryMatchingTest):
                     }
                 ],
             )
+
+
+class TestEarlyAccessFeatureScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
+    CREATE_PAYLOAD = {
+        "name": "Scope warning feature",
+        "description": "x",
+        "stage": "concept",
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.key.scopes = ["early_access_feature:write"]
+        self.key.save()
+        self.auth_headers = {"authorization": f"Bearer {self.value}"}
+
+    def _warning_events(self, mock_logger):
+        return [
+            call
+            for call in mock_logger.warning.call_args_list
+            if call.args and call.args[0] == "feature_flag_write_via_other_scope"
+        ]
+
+    def _create_feature(self, **extra):
+        return self.client.post(
+            f"/api/projects/{self.team.id}/early_access_feature/",
+            data={**self.CREATE_PAYLOAD, **extra},
+            format="json",
+            headers=self.auth_headers,
+        )
+
+    def test_create_with_early_access_feature_write_only_logs_warning(self):
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self._create_feature()
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        events = self._warning_events(mock_logger)
+        assert len(events) == 1
+        extra = events[0].kwargs["extra"]
+        assert extra["action"] == "early_access_feature.create"
+        assert extra["team_id"] == self.team.id
+        assert extra["scopes"] == ["early_access_feature:write"]
+        assert extra["auth_kind"] == "personal_api_key"
+        assert extra["auth_id"] == self.key.id
+
+    def test_create_with_feature_flag_write_does_not_log(self):
+        self.key.scopes = ["early_access_feature:write", "feature_flag:write"]
+        self.key.save()
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self._create_feature()
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert self._warning_events(mock_logger) == []
+
+    def test_create_with_wildcard_scope_does_not_log(self):
+        self.key.scopes = ["*"]
+        self.key.save()
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self._create_feature()
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert self._warning_events(mock_logger) == []
+
+    def test_update_with_stage_change_logs_warning(self):
+        self.key.scopes = ["*"]
+        self.key.save()
+        feature_id = self._create_feature().json()["id"]
+        self.key.scopes = ["early_access_feature:write"]
+        self.key.save()
+
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/early_access_feature/{feature_id}/",
+                data={"stage": "beta"},
+                format="json",
+                headers=self.auth_headers,
+            )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        events = self._warning_events(mock_logger)
+        assert len(events) == 1
+        assert events[0].kwargs["extra"]["action"] == "early_access_feature.stage_change"
+
+    def test_update_without_stage_change_does_not_log(self):
+        self.key.scopes = ["*"]
+        self.key.save()
+        feature_id = self._create_feature().json()["id"]
+        self.key.scopes = ["early_access_feature:write"]
+        self.key.save()
+
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/early_access_feature/{feature_id}/",
+                data={"description": "updated"},
+                format="json",
+                headers=self.auth_headers,
+            )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert self._warning_events(mock_logger) == []
+
+    def test_destroy_logs_warning(self):
+        self.key.scopes = ["*"]
+        self.key.save()
+        feature_id = self._create_feature().json()["id"]
+        self.key.scopes = ["early_access_feature:write"]
+        self.key.save()
+
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self.client.delete(
+                f"/api/projects/{self.team.id}/early_access_feature/{feature_id}/",
+                headers=self.auth_headers,
+            )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        events = self._warning_events(mock_logger)
+        assert len(events) == 1
+        assert events[0].kwargs["extra"]["action"] == "early_access_feature.destroy"
+
+    def test_session_auth_does_not_log(self):
+        self.client.force_login(self.user)
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/early_access_feature/",
+                data=self.CREATE_PAYLOAD,
+                format="json",
+            )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert self._warning_events(mock_logger) == []

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -1745,19 +1745,16 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         instance = self.get_object()
         related_targeting_flag = instance.targeting_flag
-        related_internal_targeting_flag = instance.internal_targeting_flag
-
-        if related_targeting_flag or related_internal_targeting_flag:
+        if related_targeting_flag:
             warn_if_missing_feature_flag_write_scope(
                 request,
                 action="survey.destroy",
                 team_id=self.team_id,
-                feature_flag_id=related_targeting_flag.id if related_targeting_flag else None,
+                feature_flag_id=related_targeting_flag.id,
             )
-
-        if related_targeting_flag:
             related_targeting_flag.delete()
 
+        related_internal_targeting_flag = instance.internal_targeting_flag
         if related_internal_targeting_flag:
             related_internal_targeting_flag.delete()
 

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -47,6 +47,7 @@ from posthog.api.feature_flag import (
     BEHAVIOURAL_COHORT_FOUND_ERROR_CODE,
     FeatureFlagSerializer,
     MinimalFeatureFlagSerializer,
+    warn_if_missing_feature_flag_write_scope,
 )
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
@@ -1215,6 +1216,11 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
             validated_data.pop("remove_targeting_flag")
 
         validated_data["team_id"] = self.context["team_id"]
+        warn_if_missing_feature_flag_write_scope(
+            self.context["request"],
+            action="survey.create",
+            team_id=self.context["team_id"],
+        )
         if validated_data.get("targeting_flag_filters"):
             targeting_feature_flag = self._create_or_update_targeting_flag(
                 None, validated_data["targeting_flag_filters"], validated_data["name"]
@@ -1249,6 +1255,13 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
         before_update = Survey.objects.get(pk=instance.pk)
         user = self.context["request"].user
         changes = []
+
+        warn_if_missing_feature_flag_write_scope(
+            self.context["request"],
+            action="survey.update",
+            team_id=self.context["team_id"],
+            feature_flag_id=instance.targeting_flag_id,
+        )
 
         if validated_data.get("remove_targeting_flag"):
             if instance.targeting_flag:
@@ -1732,10 +1745,19 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         instance = self.get_object()
         related_targeting_flag = instance.targeting_flag
+        related_internal_targeting_flag = instance.internal_targeting_flag
+
+        if related_targeting_flag or related_internal_targeting_flag:
+            warn_if_missing_feature_flag_write_scope(
+                request,
+                action="survey.destroy",
+                team_id=self.team_id,
+                feature_flag_id=related_targeting_flag.id if related_targeting_flag else None,
+            )
+
         if related_targeting_flag:
             related_targeting_flag.delete()
 
-        related_internal_targeting_flag = instance.internal_targeting_flag
         if related_internal_targeting_flag:
             related_internal_targeting_flag.delete()
 

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -1256,15 +1256,14 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
         user = self.context["request"].user
         changes = []
 
-        warn_if_missing_feature_flag_write_scope(
-            self.context["request"],
-            action="survey.update",
-            team_id=self.context["team_id"],
-            feature_flag_id=instance.targeting_flag_id,
-        )
-
         if validated_data.get("remove_targeting_flag"):
             if instance.targeting_flag:
+                warn_if_missing_feature_flag_write_scope(
+                    self.context["request"],
+                    action="survey.update.remove_targeting_flag",
+                    team_id=self.context["team_id"],
+                    feature_flag_id=instance.targeting_flag_id,
+                )
                 # Manually delete the flag and log the change
                 # The `changes_between` method won't catch this because the flag (and underlying ForeignKey relationship)
                 # will have been deleted by the time the `changes_between` method is called, so we need to log the change manually
@@ -1280,6 +1279,12 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
 
         # if the target flag filters come back with data, update the targeting feature flag if there is one, otherwise create a new one
         if validated_data.get("targeting_flag_filters"):
+            warn_if_missing_feature_flag_write_scope(
+                self.context["request"],
+                action="survey.update.targeting_flag_filters",
+                team_id=self.context["team_id"],
+                feature_flag_id=instance.targeting_flag_id,
+            )
             new_filters = validated_data["targeting_flag_filters"]
             if instance.targeting_flag:
                 existing_targeting_flag = instance.targeting_flag

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -1745,16 +1745,16 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         instance = self.get_object()
         related_targeting_flag = instance.targeting_flag
-        if related_targeting_flag:
+        related_internal_targeting_flag = instance.internal_targeting_flag
+        if related_targeting_flag or related_internal_targeting_flag:
             warn_if_missing_feature_flag_write_scope(
                 request,
                 action="survey.destroy",
                 team_id=self.team_id,
-                feature_flag_id=related_targeting_flag.id,
+                feature_flag_id=(related_targeting_flag or related_internal_targeting_flag).id,
             )
+        if related_targeting_flag:
             related_targeting_flag.delete()
-
-        related_internal_targeting_flag = instance.internal_targeting_flag
         if related_internal_targeting_flag:
             related_internal_targeting_flag.delete()
 

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -6294,6 +6294,23 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         assert len(events) == 1
         assert events[0].kwargs["action"] == "survey.destroy"
 
+    def test_destroy_with_only_internal_targeting_flag_logs_warning(self):
+        survey_id = self._create_survey().json()["id"]
+        survey = Survey.objects.get(pk=survey_id)
+        assert survey.targeting_flag_id is None
+        assert survey.internal_targeting_flag_id is not None
+
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
+            response = self.client.delete(
+                f"/api/projects/{self.team.id}/surveys/{survey_id}/",
+                headers=self.auth_headers,
+            )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        events = self._warning_events(mock_logger)
+        assert len(events) == 1
+        assert events[0].kwargs["action"] == "survey.destroy"
+        assert events[0].kwargs["feature_flag_id"] == survey.internal_targeting_flag_id
+
     def test_destroy_without_any_flag_does_not_log(self):
         survey = Survey.objects.create(
             team=self.team,

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -6224,12 +6224,12 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         )
 
     def test_create_with_survey_write_only_logs_warning(self):
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self._create_survey()
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         events = self._warning_events(mock_logger)
         assert len(events) == 1
-        extra = events[0].kwargs["extra"]
+        extra = events[0].kwargs
         assert extra["action"] == "survey.create"
         assert extra["team_id"] == self.team.id
         assert extra["scopes"] == ["survey:write"]
@@ -6240,7 +6240,7 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
     def test_create_with_feature_flag_write_does_not_log(self):
         self.key.scopes = ["survey:write", "feature_flag:write"]
         self.key.save()
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self._create_survey()
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         assert self._warning_events(mock_logger) == []
@@ -6248,7 +6248,7 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
     def test_create_with_wildcard_scope_does_not_log(self):
         self.key.scopes = ["*"]
         self.key.save()
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self._create_survey()
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         assert self._warning_events(mock_logger) == []
@@ -6260,7 +6260,7 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         self.key.scopes = ["survey:write"]
         self.key.save()
 
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self.client.patch(
                 f"/api/projects/{self.team.id}/surveys/{survey_id}/",
                 data={"name": "renamed"},
@@ -6270,7 +6270,7 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         assert response.status_code == status.HTTP_200_OK, response.json()
         events = self._warning_events(mock_logger)
         assert len(events) == 1
-        assert events[0].kwargs["extra"]["action"] == "survey.update"
+        assert events[0].kwargs["action"] == "survey.update"
 
     def test_destroy_with_targeting_flag_logs_warning(self):
         self.key.scopes = ["*"]
@@ -6284,7 +6284,7 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         self.key.scopes = ["survey:write"]
         self.key.save()
 
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self.client.delete(
                 f"/api/projects/{self.team.id}/surveys/{survey_id}/",
                 headers=self.auth_headers,
@@ -6292,7 +6292,7 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         assert response.status_code == status.HTTP_204_NO_CONTENT
         events = self._warning_events(mock_logger)
         assert len(events) == 1
-        assert events[0].kwargs["extra"]["action"] == "survey.destroy"
+        assert events[0].kwargs["action"] == "survey.destroy"
 
     def test_destroy_without_any_flag_does_not_log(self):
         survey = Survey.objects.create(
@@ -6301,7 +6301,7 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
             type="popover",
             questions=[{"type": "open", "question": "Q?"}],
         )
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self.client.delete(
                 f"/api/projects/{self.team.id}/surveys/{survey.id}/",
                 headers=self.auth_headers,
@@ -6311,7 +6311,7 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
 
     def test_session_auth_does_not_log(self):
         self.client.force_login(self.user)
-        with patch("posthog.api.feature_flag.logger") as mock_logger:
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
             response = self.client.post(
                 f"/api/projects/{self.team.id}/surveys/",
                 data=self.SURVEY_PAYLOAD,

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -6253,7 +6253,7 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         assert self._warning_events(mock_logger) == []
 
-    def test_update_with_survey_write_only_logs_warning(self):
+    def test_update_payload_only_does_not_log(self):
         self.key.scopes = ["*"]
         self.key.save()
         survey_id = self._create_survey().json()["id"]
@@ -6268,9 +6268,48 @@ class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
                 headers=self.auth_headers,
             )
         assert response.status_code == status.HTTP_200_OK, response.json()
+        assert self._warning_events(mock_logger) == []
+
+    def test_update_targeting_flag_filters_logs_warning(self):
+        self.key.scopes = ["*"]
+        self.key.save()
+        survey_id = self._create_survey().json()["id"]
+        self.key.scopes = ["survey:write"]
+        self.key.save()
+
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/surveys/{survey_id}/",
+                data={"targeting_flag_filters": {"groups": [{"properties": [], "rollout_percentage": 75}]}},
+                format="json",
+                headers=self.auth_headers,
+            )
+        assert response.status_code == status.HTTP_200_OK, response.json()
         events = self._warning_events(mock_logger)
         assert len(events) == 1
-        assert events[0].kwargs["action"] == "survey.update"
+        assert events[0].kwargs["action"] == "survey.update.targeting_flag_filters"
+
+    def test_update_remove_targeting_flag_logs_warning(self):
+        self.key.scopes = ["*"]
+        self.key.save()
+        survey_id = self._create_survey(
+            targeting_flag_filters={"groups": [{"properties": [], "rollout_percentage": 50}]},
+        ).json()["id"]
+        assert Survey.objects.get(pk=survey_id).targeting_flag_id is not None
+        self.key.scopes = ["survey:write"]
+        self.key.save()
+
+        with patch("posthog.api.feature_flag.scope_audit_logger") as mock_logger:
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/surveys/{survey_id}/",
+                data={"remove_targeting_flag": True},
+                format="json",
+                headers=self.auth_headers,
+            )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        events = self._warning_events(mock_logger)
+        assert len(events) == 1
+        assert events[0].kwargs["action"] == "survey.update.remove_targeting_flag"
 
     def test_destroy_with_targeting_flag_logs_warning(self):
         self.key.scopes = ["*"]

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -6193,3 +6193,129 @@ class TestSurveyResponseArchive(ClickhouseTestMixin, APIBaseTest):
         self.assertIn(uuid1, uuids)
         self.assertIn(uuid2, uuids)
         self.assertNotIn(uuid3, uuids)
+
+
+class TestSurveyFeatureFlagScopeWarning(PersonalAPIKeysBaseTest, APIBaseTest):
+    SURVEY_PAYLOAD = {
+        "name": "Scope warning survey",
+        "type": "popover",
+        "questions": [{"type": "open", "question": "Q?"}],
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.key.scopes = ["survey:write"]
+        self.key.save()
+        self.auth_headers = {"authorization": f"Bearer {self.value}"}
+
+    def _warning_events(self, mock_logger):
+        return [
+            call
+            for call in mock_logger.warning.call_args_list
+            if call.args and call.args[0] == "feature_flag_write_via_other_scope"
+        ]
+
+    def _create_survey(self, **extra):
+        return self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={**self.SURVEY_PAYLOAD, **extra},
+            format="json",
+            headers=self.auth_headers,
+        )
+
+    def test_create_with_survey_write_only_logs_warning(self):
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self._create_survey()
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        events = self._warning_events(mock_logger)
+        assert len(events) == 1
+        extra = events[0].kwargs["extra"]
+        assert extra["action"] == "survey.create"
+        assert extra["team_id"] == self.team.id
+        assert extra["scopes"] == ["survey:write"]
+        assert extra["auth_kind"] == "personal_api_key"
+        assert extra["auth_id"] == self.key.id
+        assert extra["user_id"] == self.user.id
+
+    def test_create_with_feature_flag_write_does_not_log(self):
+        self.key.scopes = ["survey:write", "feature_flag:write"]
+        self.key.save()
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self._create_survey()
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert self._warning_events(mock_logger) == []
+
+    def test_create_with_wildcard_scope_does_not_log(self):
+        self.key.scopes = ["*"]
+        self.key.save()
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self._create_survey()
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert self._warning_events(mock_logger) == []
+
+    def test_update_with_survey_write_only_logs_warning(self):
+        self.key.scopes = ["*"]
+        self.key.save()
+        survey_id = self._create_survey().json()["id"]
+        self.key.scopes = ["survey:write"]
+        self.key.save()
+
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/surveys/{survey_id}/",
+                data={"name": "renamed"},
+                format="json",
+                headers=self.auth_headers,
+            )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        events = self._warning_events(mock_logger)
+        assert len(events) == 1
+        assert events[0].kwargs["extra"]["action"] == "survey.update"
+
+    def test_destroy_with_targeting_flag_logs_warning(self):
+        self.key.scopes = ["*"]
+        self.key.save()
+        create_response = self._create_survey(
+            targeting_flag_filters={"groups": [{"properties": [], "rollout_percentage": 50}]},
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.json()
+        survey_id = create_response.json()["id"]
+        assert Survey.objects.get(pk=survey_id).targeting_flag_id is not None
+        self.key.scopes = ["survey:write"]
+        self.key.save()
+
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self.client.delete(
+                f"/api/projects/{self.team.id}/surveys/{survey_id}/",
+                headers=self.auth_headers,
+            )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        events = self._warning_events(mock_logger)
+        assert len(events) == 1
+        assert events[0].kwargs["extra"]["action"] == "survey.destroy"
+
+    def test_destroy_without_any_flag_does_not_log(self):
+        survey = Survey.objects.create(
+            team=self.team,
+            name="No flag",
+            type="popover",
+            questions=[{"type": "open", "question": "Q?"}],
+        )
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self.client.delete(
+                f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+                headers=self.auth_headers,
+            )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert self._warning_events(mock_logger) == []
+
+    def test_session_auth_does_not_log(self):
+        self.client.force_login(self.user)
+        with patch("posthog.api.feature_flag.logger") as mock_logger:
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/surveys/",
+                data=self.SURVEY_PAYLOAD,
+                format="json",
+            )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert self._warning_events(mock_logger) == []


### PR DESCRIPTION
## Problem

`SurveyViewSet` and `EarlyAccessFeatureViewSet` mutate `FeatureFlag` rows under their own scopes (`survey:write`, `early_access_feature:write`) without requiring `feature_flag:write`. Before enforcing the stricter scope, we need observability on which customers rely on this transitive access so we can notify them.

## Changes

Adds a temporary `warn_if_missing_feature_flag_write_scope` helper that logs a warning when a personal API key or OAuth token mutates a feature flag via the survey or early access feature endpoints without holding `feature_flag:write` (or `*`). Call sites are added on the relevant create/update/destroy paths in both viewsets. To be removed once the scope is enforced.

## How did you test this code?

Agent-authored. Added unit tests in `test_survey.py` and `test_early_access_feature.py` covering both presence and absence of `feature_flag:write` for personal API keys. No manual testing performed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code. Helper deliberately scoped to personal API key and OAuth authenticators since session-authenticated requests aren't the concern here. Logged context is structured for downstream querying so we can identify affected keys/tokens before flipping the scope requirement.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*