### PR TITLE
feat(mcp): evaluate feature flags using groups

### DIFF
--- a/services/mcp/src/hono/mcp-server.ts
+++ b/services/mcp/src/hono/mcp-server.ts
@@ -17,7 +17,7 @@ import {
     initMcpAnalytics,
     type MCPAnalyticsContext,
 } from '@/lib/posthog/analytics'
-import { evaluateFeatureFlags, isFeatureFlagEnabled } from '@/lib/posthog/flags'
+import { evaluateFeatureFlags, type FlagGroups, isFeatureFlagEnabled } from '@/lib/posthog/flags'
 import { type RequestProperties } from '@/lib/request-properties'
 import { SessionManager } from '@/lib/SessionManager'
 import { StateManager } from '@/lib/StateManager'
@@ -369,9 +369,9 @@ export class HonoMcpServer {
 
         await this.resolveClientInfo()
 
-        // Start feature flag resolution in parallel with cache seeding
+        // User-level flags resolve in parallel with cache seeding. Tool flags are
+        // deferred until orgId/projectUuid are known so group-scoped rollouts evaluate correctly.
         const flagPromise = this.resolveVersionFlag()
-        const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion)
         const singleExecPromise = this.resolveSingleExecFlag()
 
         // Seed cache with header-provided IDs before any fetches
@@ -393,6 +393,12 @@ export class HonoMcpServer {
         if (!cachedProjectId) {
             await context.stateManager.setDefaultOrganizationAndProject()
         }
+
+        // Flag-eval groups mirror analytics `$groups` so per-organization and per-project
+        // rollouts evaluate against the same entities — see `buildMCPAnalyticsGroups`.
+        const flagAnalyticsContext = await this.getAnalyticsContextSafe(context)
+        const flagGroups = flagAnalyticsContext ? buildMCPAnalyticsGroups(flagAnalyticsContext) : undefined
+        const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion, flagGroups)
 
         const [flagVersion, toolFeatureFlags, singleExecFlagOn, _apiKey] = await Promise.all([
             flagPromise,
@@ -682,7 +688,10 @@ export class HonoMcpServer {
         }
     }
 
-    private async resolveToolFeatureFlags(version?: number): Promise<Record<string, boolean> | undefined> {
+    private async resolveToolFeatureFlags(
+        version?: number,
+        groups?: FlagGroups
+    ): Promise<Record<string, boolean> | undefined> {
         try {
             const { getRequiredFeatureFlags } = await import('@/tools/toolDefinitions')
             const flagKeys = getRequiredFeatureFlags(version)
@@ -690,7 +699,7 @@ export class HonoMcpServer {
                 return undefined
             }
             const distinctId = await this.getDistinctId()
-            return await evaluateFeatureFlags(flagKeys, distinctId)
+            return await evaluateFeatureFlags(flagKeys, distinctId, groups)
         } catch {
             return undefined
         }

--- a/services/mcp/src/lib/posthog/flags.ts
+++ b/services/mcp/src/lib/posthog/flags.ts
@@ -1,13 +1,6 @@
 import { getPostHogClient } from './client'
 
-/**
- * Group context for posthog-node flag evaluation. The keys are PostHog group
- * types (e.g. `organization`, `project`) and the values are the group keys —
- * same shape we already use for `$groups` on analytics events
- * (`buildMCPAnalyticsGroups`). Lets per-organization (and per-project) feature
- * flags resolve correctly when the rollout is keyed off a group instead of the
- * user.
- */
+// Group type → group key, matching the `$groups` shape from `buildMCPAnalyticsGroups`.
 export type FlagGroups = Record<string, string>
 
 export async function isFeatureFlagEnabled(flagKey: string, distinctId: string, groups?: FlagGroups): Promise<boolean> {
@@ -25,11 +18,8 @@ export async function isFeatureFlagEnabled(flagKey: string, distinctId: string, 
 
 /**
  * Evaluate multiple feature flags in parallel for the given user.
- * Returns a map of flag key → boolean.
- *
- * `groups` is forwarded to posthog-node so flags rolled out at a group level
- * (e.g. per-organization) evaluate against the resolved workspace context
- * rather than the user alone.
+ * Returns a map of flag key → boolean. `groups` is forwarded to posthog-node
+ * so group-scoped rollouts (e.g. per-organization) evaluate correctly.
  */
 export async function evaluateFeatureFlags(
     flagKeys: string[],

--- a/services/mcp/src/lib/posthog/flags.ts
+++ b/services/mcp/src/lib/posthog/flags.ts
@@ -6,7 +6,8 @@ export type FlagGroups = Record<string, string>
 export async function isFeatureFlagEnabled(flagKey: string, distinctId: string, groups?: FlagGroups): Promise<boolean> {
     try {
         const client = getPostHogClient()
-        const result = await client.isFeatureEnabled(flagKey, distinctId, groups ? { groups } : undefined)
+        const hasGroups = groups && Object.keys(groups).length > 0
+        const result = await client.isFeatureEnabled(flagKey, distinctId, hasGroups ? { groups } : undefined)
         return result === true
     } catch {
         return false

--- a/services/mcp/src/lib/posthog/flags.ts
+++ b/services/mcp/src/lib/posthog/flags.ts
@@ -6,10 +6,7 @@ export type FlagGroups = Record<string, string>
 export async function isFeatureFlagEnabled(flagKey: string, distinctId: string, groups?: FlagGroups): Promise<boolean> {
     try {
         const client = getPostHogClient()
-        const hasGroups = groups && Object.keys(groups).length > 0
-        const result = hasGroups
-            ? await client.isFeatureEnabled(flagKey, distinctId, { groups })
-            : await client.isFeatureEnabled(flagKey, distinctId)
+        const result = await client.isFeatureEnabled(flagKey, distinctId, groups ? { groups } : undefined)
         return result === true
     } catch {
         return false

--- a/services/mcp/src/lib/posthog/flags.ts
+++ b/services/mcp/src/lib/posthog/flags.ts
@@ -1,9 +1,22 @@
 import { getPostHogClient } from './client'
 
-export async function isFeatureFlagEnabled(flagKey: string, distinctId: string): Promise<boolean> {
+/**
+ * Group context for posthog-node flag evaluation. The keys are PostHog group
+ * types (e.g. `organization`, `project`) and the values are the group keys —
+ * same shape we already use for `$groups` on analytics events
+ * (`buildMCPAnalyticsGroups`). Lets per-organization (and per-project) feature
+ * flags resolve correctly when the rollout is keyed off a group instead of the
+ * user.
+ */
+export type FlagGroups = Record<string, string>
+
+export async function isFeatureFlagEnabled(flagKey: string, distinctId: string, groups?: FlagGroups): Promise<boolean> {
     try {
         const client = getPostHogClient()
-        const result = await client.isFeatureEnabled(flagKey, distinctId)
+        const hasGroups = groups && Object.keys(groups).length > 0
+        const result = hasGroups
+            ? await client.isFeatureEnabled(flagKey, distinctId, { groups })
+            : await client.isFeatureEnabled(flagKey, distinctId)
         return result === true
     } catch {
         return false
@@ -13,15 +26,23 @@ export async function isFeatureFlagEnabled(flagKey: string, distinctId: string):
 /**
  * Evaluate multiple feature flags in parallel for the given user.
  * Returns a map of flag key → boolean.
+ *
+ * `groups` is forwarded to posthog-node so flags rolled out at a group level
+ * (e.g. per-organization) evaluate against the resolved workspace context
+ * rather than the user alone.
  */
-export async function evaluateFeatureFlags(flagKeys: string[], distinctId: string): Promise<Record<string, boolean>> {
+export async function evaluateFeatureFlags(
+    flagKeys: string[],
+    distinctId: string,
+    groups?: FlagGroups
+): Promise<Record<string, boolean>> {
     if (flagKeys.length === 0) {
         return {}
     }
 
     const results = await Promise.all(
         flagKeys.map(async (key) => {
-            const enabled = await isFeatureFlagEnabled(key, distinctId)
+            const enabled = await isFeatureFlagEnabled(key, distinctId, groups)
             return [key, enabled] as const
         })
     )

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -564,9 +564,8 @@ export class MCP extends McpAgent<Env> {
         // `resolveClientInfo` is only reachable post-init.
         await this.resolveClientInfo()
 
-        // Start user-level feature flag resolution in parallel with cache seeding.
-        // Tool-level flags are deferred until orgId is known so per-organization
-        // gating can evaluate against the right group context.
+        // User-level flags resolve in parallel with cache seeding. Tool flags are
+        // deferred until orgId is known so org-group rollouts evaluate correctly.
         const flagPromise = this.resolveVersionFlag()
         const singleExecPromise = this.resolveSingleExecFlag()
 
@@ -597,11 +596,8 @@ export class MCP extends McpAgent<Env> {
             await context.stateManager.setDefaultOrganizationAndProject()
         }
 
-        // Resolve the active organization id (header → cache → default resolution
-        // above) and use it as the `organization` group when evaluating
-        // tool-gating feature flags. This makes per-organization rollouts
-        // (e.g. `notebooks-collaboration`) consistent across every user in
-        // that org instead of being keyed off the individual distinct_id.
+        // Header → cache → default resolution above. Passed as the `organization`
+        // group so per-org tool flag rollouts evaluate consistently across the org.
         const resolvedOrgId = organizationId || (await this.cache.get('orgId')) || undefined
         const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion, resolvedOrgId)
 
@@ -932,9 +928,6 @@ export class MCP extends McpAgent<Env> {
                 return undefined
             }
             const distinctId = await this.getDistinctId()
-            // Tool-gating flags are sometimes scoped to an organization (e.g.
-            // `notebooks-collaboration`). Forward the `organization` group so
-            // posthog-node matches the rollout against the right entity.
             const groups = orgId ? { organization: orgId } : undefined
             return await evaluateFeatureFlags(flagKeys, distinctId, groups)
         } catch {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -28,7 +28,7 @@ import {
     McpAnalyticsInitResult,
     type MCPAnalyticsContext,
 } from '@/lib/posthog/analytics'
-import { evaluateFeatureFlags, isFeatureFlagEnabled } from '@/lib/posthog/flags'
+import { evaluateFeatureFlags, type FlagGroups, isFeatureFlagEnabled } from '@/lib/posthog/flags'
 import { SessionManager } from '@/lib/SessionManager'
 import { StateManager } from '@/lib/StateManager'
 import { formatPrompt, type McpMode, sanitizeHeaderValue } from '@/lib/utils'
@@ -596,10 +596,11 @@ export class MCP extends McpAgent<Env> {
             await context.stateManager.setDefaultOrganizationAndProject()
         }
 
-        // Header → cache → default resolution above. Passed as the `organization`
-        // group so per-org tool flag rollouts evaluate consistently across the org.
-        const resolvedOrgId = organizationId || (await this.cache.get('orgId')) || undefined
-        const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion, resolvedOrgId)
+        // Flag-eval groups mirror analytics `$groups` so per-organization and per-project
+        // rollouts evaluate against the same entities — see `buildMCPAnalyticsGroups`.
+        const flagAnalyticsContext = await this.getAnalyticsContextSafe(context)
+        const flagGroups = flagAnalyticsContext ? buildMCPAnalyticsGroups(flagAnalyticsContext) : undefined
+        const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion, flagGroups)
 
         const [flagVersion, toolFeatureFlags, singleExecFlagOn, _apiKey] = await Promise.all([
             flagPromise,
@@ -919,7 +920,7 @@ export class MCP extends McpAgent<Env> {
 
     private async resolveToolFeatureFlags(
         version?: number,
-        orgId?: string
+        groups?: FlagGroups
     ): Promise<Record<string, boolean> | undefined> {
         try {
             const { getRequiredFeatureFlags } = await import('@/tools/toolDefinitions')
@@ -928,7 +929,6 @@ export class MCP extends McpAgent<Env> {
                 return undefined
             }
             const distinctId = await this.getDistinctId()
-            const groups = orgId ? { organization: orgId } : undefined
             return await evaluateFeatureFlags(flagKeys, distinctId, groups)
         } catch {
             return undefined

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -564,9 +564,10 @@ export class MCP extends McpAgent<Env> {
         // `resolveClientInfo` is only reachable post-init.
         await this.resolveClientInfo()
 
-        // Start feature flag resolution in parallel with cache seeding
+        // Start user-level feature flag resolution in parallel with cache seeding.
+        // Tool-level flags are deferred until orgId is known so per-organization
+        // gating can evaluate against the right group context.
         const flagPromise = this.resolveVersionFlag()
-        const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion)
         const singleExecPromise = this.resolveSingleExecFlag()
 
         // Seed cache with header-provided IDs before any fetches
@@ -595,6 +596,14 @@ export class MCP extends McpAgent<Env> {
         if (!cachedProjectId) {
             await context.stateManager.setDefaultOrganizationAndProject()
         }
+
+        // Resolve the active organization id (header → cache → default resolution
+        // above) and use it as the `organization` group when evaluating
+        // tool-gating feature flags. This makes per-organization rollouts
+        // (e.g. `notebooks-collaboration`) consistent across every user in
+        // that org instead of being keyed off the individual distinct_id.
+        const resolvedOrgId = organizationId || (await this.cache.get('orgId')) || undefined
+        const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion, resolvedOrgId)
 
         const [flagVersion, toolFeatureFlags, singleExecFlagOn, _apiKey] = await Promise.all([
             flagPromise,
@@ -912,7 +921,10 @@ export class MCP extends McpAgent<Env> {
         }
     }
 
-    private async resolveToolFeatureFlags(version?: number): Promise<Record<string, boolean> | undefined> {
+    private async resolveToolFeatureFlags(
+        version?: number,
+        orgId?: string
+    ): Promise<Record<string, boolean> | undefined> {
         try {
             const { getRequiredFeatureFlags } = await import('@/tools/toolDefinitions')
             const flagKeys = getRequiredFeatureFlags(version)
@@ -920,7 +932,11 @@ export class MCP extends McpAgent<Env> {
                 return undefined
             }
             const distinctId = await this.getDistinctId()
-            return await evaluateFeatureFlags(flagKeys, distinctId)
+            // Tool-gating flags are sometimes scoped to an organization (e.g.
+            // `notebooks-collaboration`). Forward the `organization` group so
+            // posthog-node matches the rollout against the right entity.
+            const groups = orgId ? { organization: orgId } : undefined
+            return await evaluateFeatureFlags(flagKeys, distinctId, groups)
         } catch {
             return undefined
         }

--- a/services/mcp/tests/unit/feature-flag-version.test.ts
+++ b/services/mcp/tests/unit/feature-flag-version.test.ts
@@ -20,7 +20,7 @@ describe('isFeatureFlagEnabled', () => {
 
         const result = await isFeatureFlagEnabled('mcp-version-2', 'user-123')
         expect(result).toBe(true)
-        expect(mockIsFeatureEnabled).toHaveBeenCalledWith('mcp-version-2', 'user-123')
+        expect(mockIsFeatureEnabled).toHaveBeenCalledWith('mcp-version-2', 'user-123', undefined)
     })
 
     it('should return false when the flag is disabled', async () => {
@@ -52,14 +52,6 @@ describe('isFeatureFlagEnabled', () => {
         expect(mockIsFeatureEnabled).toHaveBeenCalledWith('notebooks-collaboration', 'user-123', {
             groups: { organization: 'org-abc' },
         })
-    })
-
-    it('should omit the options arg when groups is empty', async () => {
-        mockIsFeatureEnabled.mockResolvedValue(true)
-
-        await isFeatureFlagEnabled('flag-x', 'user-123', {})
-
-        expect(mockIsFeatureEnabled).toHaveBeenCalledWith('flag-x', 'user-123')
     })
 })
 

--- a/services/mcp/tests/unit/feature-flag-version.test.ts
+++ b/services/mcp/tests/unit/feature-flag-version.test.ts
@@ -53,6 +53,14 @@ describe('isFeatureFlagEnabled', () => {
             groups: { organization: 'org-abc' },
         })
     })
+
+    it('should omit the options arg when groups is an empty object', async () => {
+        mockIsFeatureEnabled.mockResolvedValue(true)
+
+        await isFeatureFlagEnabled('flag-x', 'user-123', {})
+
+        expect(mockIsFeatureEnabled).toHaveBeenCalledWith('flag-x', 'user-123', undefined)
+    })
 })
 
 describe('evaluateFeatureFlags', () => {

--- a/services/mcp/tests/unit/feature-flag-version.test.ts
+++ b/services/mcp/tests/unit/feature-flag-version.test.ts
@@ -44,20 +44,17 @@ describe('isFeatureFlagEnabled', () => {
         expect(result).toBe(false)
     })
 
-    it('should forward groups when provided so per-organization rollouts evaluate correctly', async () => {
+    it('should forward groups as options when provided', async () => {
         mockIsFeatureEnabled.mockResolvedValue(true)
 
-        const result = await isFeatureFlagEnabled('notebooks-collaboration', 'user-123', {
-            organization: 'org-abc',
-        })
+        await isFeatureFlagEnabled('notebooks-collaboration', 'user-123', { organization: 'org-abc' })
 
-        expect(result).toBe(true)
         expect(mockIsFeatureEnabled).toHaveBeenCalledWith('notebooks-collaboration', 'user-123', {
             groups: { organization: 'org-abc' },
         })
     })
 
-    it('should omit the options arg when groups is empty so user-level eval is unchanged', async () => {
+    it('should omit the options arg when groups is empty', async () => {
         mockIsFeatureEnabled.mockResolvedValue(true)
 
         await isFeatureFlagEnabled('flag-x', 'user-123', {})
@@ -72,13 +69,9 @@ describe('evaluateFeatureFlags', () => {
     })
 
     it('should evaluate multiple flags and forward groups on each call', async () => {
-        mockIsFeatureEnabled.mockImplementation((flagKey: string) => {
-            return Promise.resolve(flagKey === 'flag-on')
-        })
+        mockIsFeatureEnabled.mockImplementation((flagKey: string) => Promise.resolve(flagKey === 'flag-on'))
 
-        const result = await evaluateFeatureFlags(['flag-on', 'flag-off'], 'user-123', {
-            organization: 'org-abc',
-        })
+        const result = await evaluateFeatureFlags(['flag-on', 'flag-off'], 'user-123', { organization: 'org-abc' })
 
         expect(result).toEqual({ 'flag-on': true, 'flag-off': false })
         expect(mockIsFeatureEnabled).toHaveBeenCalledWith('flag-on', 'user-123', {

--- a/services/mcp/tests/unit/feature-flag-version.test.ts
+++ b/services/mcp/tests/unit/feature-flag-version.test.ts
@@ -8,7 +8,7 @@ vi.mock('posthog-node', () => ({
 }))
 
 // Must import after vi.mock
-import { isFeatureFlagEnabled } from '@/lib/posthog/flags'
+import { evaluateFeatureFlags, isFeatureFlagEnabled } from '@/lib/posthog/flags'
 
 describe('isFeatureFlagEnabled', () => {
     beforeEach(() => {
@@ -42,5 +42,57 @@ describe('isFeatureFlagEnabled', () => {
 
         const result = await isFeatureFlagEnabled('mcp-version-2', 'user-123')
         expect(result).toBe(false)
+    })
+
+    it('should forward groups when provided so per-organization rollouts evaluate correctly', async () => {
+        mockIsFeatureEnabled.mockResolvedValue(true)
+
+        const result = await isFeatureFlagEnabled('notebooks-collaboration', 'user-123', {
+            organization: 'org-abc',
+        })
+
+        expect(result).toBe(true)
+        expect(mockIsFeatureEnabled).toHaveBeenCalledWith('notebooks-collaboration', 'user-123', {
+            groups: { organization: 'org-abc' },
+        })
+    })
+
+    it('should omit the options arg when groups is empty so user-level eval is unchanged', async () => {
+        mockIsFeatureEnabled.mockResolvedValue(true)
+
+        await isFeatureFlagEnabled('flag-x', 'user-123', {})
+
+        expect(mockIsFeatureEnabled).toHaveBeenCalledWith('flag-x', 'user-123')
+    })
+})
+
+describe('evaluateFeatureFlags', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('should evaluate multiple flags and forward groups on each call', async () => {
+        mockIsFeatureEnabled.mockImplementation((flagKey: string) => {
+            return Promise.resolve(flagKey === 'flag-on')
+        })
+
+        const result = await evaluateFeatureFlags(['flag-on', 'flag-off'], 'user-123', {
+            organization: 'org-abc',
+        })
+
+        expect(result).toEqual({ 'flag-on': true, 'flag-off': false })
+        expect(mockIsFeatureEnabled).toHaveBeenCalledWith('flag-on', 'user-123', {
+            groups: { organization: 'org-abc' },
+        })
+        expect(mockIsFeatureEnabled).toHaveBeenCalledWith('flag-off', 'user-123', {
+            groups: { organization: 'org-abc' },
+        })
+    })
+
+    it('should short-circuit when no flag keys are requested', async () => {
+        const result = await evaluateFeatureFlags([], 'user-123', { organization: 'org-abc' })
+
+        expect(result).toEqual({})
+        expect(mockIsFeatureEnabled).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
## Problem

MCP feature flags are evaluated per user today. But some flags only make sense per organization — e.g. `notebooks-collaboration` (gates the [upcoming](https://github.com/PostHog/posthog/pull/58678) `notebook-edit` tool), because the old and new collab versions can't coexist in the same team. 

## Changes

- Evaluate tool-gating flags after the org id is resolved, and pass it to posthog-node as the `organization` group. 
- User-level flags (`mcp-version-2`, `mcp-single-exec-tool`) still resolve in parallel with cache seeding. 
- Group key matches the analytics convention in `buildMCPAnalyticsGroups`.

## How did you test this code?
Verified locally that an org-scoped feature flag evaluates correctly for MCP tools
`pnpm exec vitest run tests/unit/feature-flag-version.test.ts`

## Publish to changelog?

no