### PR TITLE
chore: add friendly mention of rafa to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+p.s. Rafa is nice. 💖


### PR DESCRIPTION
## Problem

Adds a small, friendly p.s. note to the bottom of the README mentioning Rafa.

## Changes

Appended a one-line p.s. at the very end of `README.md`, after the existing "We're hiring!" section. No other content was touched.

## How did you test this code?

I'm an agent (PostHog Code). No automated tests were run — this is a docs-only change to `README.md`. Verified locally that the diff is a single appended line.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code on request from Rafael.
- The user asked for "a small mention on the README that Rafa is nice". I picked the end of the file (after the "dedicated README reader" / hiring section) as the least intrusive spot rather than touching the intro or product sections.
- No sensitive data involved; change is cosmetic.