### PR TITLE
feat(ingestion): emit per-service health gauge

### DIFF
--- a/nodejs/src/common/metrics.ts
+++ b/nodejs/src/common/metrics.ts
@@ -25,3 +25,28 @@ export const ingestionLagHistogram = new Histogram({
     labelNames: ['groupId', 'partition'],
     buckets: [1000, 2000, 5000, 10000, 30000, 60000, 120000, 300000, 600000, 900000],
 })
+
+export const PROCESS_HEALTH = {
+    OK: 'ok',
+    DEGRADED: 'degraded',
+    ERROR: 'error',
+} as const
+export type ProcessHealthStatus = (typeof PROCESS_HEALTH)[keyof typeof PROCESS_HEALTH]
+
+const PROCESS_HEALTH_STATUSES: readonly ProcessHealthStatus[] = Object.values(PROCESS_HEALTH)
+
+export const processHealthGauge = new Gauge({
+    name: 'ingestion_process_health',
+    help: 'Per-service process health: the active status label is 1 and stale ones are removed. Primed at startup so the series exists before the first healthcheck, making it safe for enumerating running pods regardless of traffic. ingestion_pipeline / ingestion_lane labels are attached via prom-client default labels.',
+    labelNames: ['service', 'status'],
+})
+
+export function setProcessHealth(service: string, status: ProcessHealthStatus): void {
+    for (const candidate of PROCESS_HEALTH_STATUSES) {
+        if (candidate === status) {
+            processHealthGauge.labels(service, candidate).set(1)
+        } else {
+            processHealthGauge.remove(service, candidate)
+        }
+    }
+}

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -3,6 +3,7 @@ import { Redis } from 'ioredis'
 import { Message } from 'node-rdkafka'
 import { Counter, Gauge } from 'prom-client'
 
+import { PROCESS_HEALTH, setProcessHealth } from '~/common/metrics'
 import { RedisV2, createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
 import { AppMetricsAggregator } from '~/common/services/app-metrics-aggregator'
 import { KeyedRateLimiterService } from '~/common/services/keyed-rate-limiter.service'
@@ -239,6 +240,8 @@ export class ErrorTrackingConsumer {
             })
         })
 
+        setProcessHealth(this.name, PROCESS_HEALTH.OK)
+
         logger.info('✅', `${this.name} - started`)
     }
 
@@ -373,7 +376,9 @@ export class ErrorTrackingConsumer {
     }
 
     public isHealthy(): HealthCheckResult {
-        return this.kafkaConsumer.isHealthy()
+        const result = this.kafkaConsumer.isHealthy()
+        setProcessHealth(this.name, result.status)
+        return result
     }
 
     public async handleKafkaBatch(messages: Message[]): Promise<void> {

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -1,6 +1,7 @@
 import { Message } from 'node-rdkafka'
 import { Gauge, Histogram } from 'prom-client'
 
+import { PROCESS_HEALTH, setProcessHealth } from '~/common/metrics'
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 
 import { HogTransformerService } from '../cdp/hog-transformations/hog-transformer.service'
@@ -300,6 +301,8 @@ export class IngestionConsumer {
                 async () => await this.handleKafkaBatch(messages)
             )
         })
+
+        setProcessHealth(this.name, PROCESS_HEALTH.OK)
     }
 
     public async stop(): Promise<void> {
@@ -317,6 +320,12 @@ export class IngestionConsumer {
     }
 
     public async isHealthy(): Promise<HealthCheckResult> {
+        const result = await this.computeHealth()
+        setProcessHealth(this.name, result.status)
+        return result
+    }
+
+    private async computeHealth(): Promise<HealthCheckResult> {
         if (!this.kafkaConsumer) {
             return new HealthCheckResultError('Kafka consumer not initialized', {})
         }

--- a/nodejs/src/session-recording/consumer.ts
+++ b/nodejs/src/session-recording/consumer.ts
@@ -1,6 +1,7 @@
 import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3'
 import { CODES, Message, TopicPartition, TopicPartitionOffset, features, librdkafkaVersion } from 'node-rdkafka'
 
+import { PROCESS_HEALTH, setProcessHealth } from '~/common/metrics'
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 
 import { buildIntegerMatcher } from '../config/config'
@@ -63,6 +64,8 @@ export type SessionRecordingIngesterConfig = SessionRecordingConfig &
     >
 
 export class SessionRecordingIngester {
+    private readonly name = 'session-recordings-blob-v2-overflow'
+
     kafkaConsumer: KafkaConsumer
     topic: string
     consumerGroupId: string
@@ -222,7 +225,7 @@ export class SessionRecordingIngester {
 
     public get service(): PluginServerService {
         return {
-            id: 'session-recordings-blob-v2-overflow',
+            id: this.name,
             onShutdown: async () => await this.stop(),
             healthcheck: () => this.isHealthy() ?? false,
         }
@@ -320,6 +323,8 @@ export class SessionRecordingIngester {
 
         // Start periodic flushing of TopHog metrics
         this.topHog.start()
+
+        setProcessHealth(this.name, PROCESS_HEALTH.OK)
     }
 
     public async stop(): Promise<PromiseSettledResult<any>[]> {
@@ -347,7 +352,9 @@ export class SessionRecordingIngester {
 
     public isHealthy(): HealthCheckResult {
         // TODO: Maybe extend this to check if we are shutting down so we don't get killed early.
-        return this.kafkaConsumer.isHealthy()
+        const result = this.kafkaConsumer.isHealthy()
+        setProcessHealth(this.name, result.status)
+        return result
     }
 
     private get assignedTopicPartitions(): TopicPartition[] {


### PR DESCRIPTION
## Problem

There is no metric that is reliably emitted by every ingestion pod regardless of traffic, which makes it hard to build Grafana dashboards that enumerate _all_ running pipelines and lanes (and especially the idle ones with no events flowing). Existing options either depend on Kafka activity (`latest_processed_timestamp_ms`) or are coincidentally always-on (`kafka_broker_rtt_ms`) — neither carries explicit health semantics.

## Changes

- Add `ingestion_process_health` gauge in `nodejs/src/common/metrics.ts` with labels `service` + `status` (`ok` / `degraded` / `error`). At any moment only the active status series exists for a given `service` — the rest are removed via `gauge.remove(...)` so queries don't double-count when health flips.
- Export `PROCESS_HEALTH` constants and a `setProcessHealth(service, status)` helper.
- Wire the gauge into three consumers:
  - `ingestion-consumer` — primed in `start()` after `kafkaConsumer.connect`, refreshed in `isHealthy()` (body extracted into `computeHealth()` so the metric update lives in one place).
  - `error-tracking-consumer` — primed in `start()` after `kafkaConsumer.connect`, refreshed in `isHealthy()`.
  - `session-recording` consumer — primed in `start()` after `topHog.start()`, refreshed in `isHealthy()`. Extracted the hard-coded `'session-recordings-blob-v2-overflow'` service id into a `private readonly name` field so the metric label and `service.id` share one source of truth.
- The Kubernetes liveness probe hits `/_health` frequently, so the gauge stays fresh as long as the pod is up. `ingestion_pipeline` / `ingestion_lane` are attached automatically as prom-client default labels.

Dashboard queries this enables:

```promql
# enumerate every running pipeline/lane regardless of traffic
count by (ingestion_pipeline, ingestion_lane) (ingestion_process_health)

# only the healthy ones
count by (ingestion_pipeline, ingestion_lane) (ingestion_process_health{status="ok"})

# anything currently unhealthy
ingestion_process_health{status="error"} == 1
```

## How did you test this code?

Authored by an agent — no manual end-to-end testing in a running cluster. Verified locally with `pnpm build` and `pnpm lint` in `nodejs/`; no new unit tests added (the helper is exercised through the existing `isHealthy()` paths). Reviewer should sanity-check that the gauge appears at `/metrics` after a consumer boots.

## Publish to changelog?

no

## Docs update

## 🤖 Agent context

Agent: Claude Code (Opus 4.7).

Considered three encodings for the health status before settling on the kube-style per-status series:
- single fractional gauge (1 / 0.5 / 0) — rejected, no fractions wanted
- 0/1 single gauge collapsing `degraded` into unhealthy — rejected, want to preserve the distinction
- per-status gauge with `.remove()` for stale labels — chosen, mirrors `kube_pod_status_phase` without leaving stale `0` series around

Refactored the `'ok'` literal call sites to use a `PROCESS_HEALTH` const object on request, so the only place the status strings appear is the source-of-truth constant and the `HealthCheckResult.status` union (kept compatible via `ProcessHealthStatus`).