### PR TITLE
fix(proxy): show managed proxy setup to impersonating staff

### DIFF
--- a/frontend/src/scenes/settings/environment/ManagedReverseProxy.tsx
+++ b/frontend/src/scenes/settings/environment/ManagedReverseProxy.tsx
@@ -39,7 +39,7 @@ const statusText = {
 
 export function ManagedReverseProxy(): JSX.Element {
     const {
-        cloudflareOptInAcknowledged,
+        shouldShowCloudflareOptIn,
         formState,
         proxyRecords,
         proxyRecordsLoading,
@@ -183,7 +183,7 @@ export function ManagedReverseProxy(): JSX.Element {
     ]
 
     // Show opt-in banner if Cloudflare proxy is enabled but not yet acknowledged
-    if (cloudflareProxyEnabled && !cloudflareOptInAcknowledged) {
+    if (cloudflareProxyEnabled && shouldShowCloudflareOptIn) {
         return (
             <CloudflareOptInBanner onAcknowledge={acknowledgeCloudflareOptIn} restrictionReason={restrictionReason} />
         )

--- a/frontend/src/scenes/settings/environment/proxyLogic.test.ts
+++ b/frontend/src/scenes/settings/environment/proxyLogic.test.ts
@@ -1,0 +1,107 @@
+import { MOCK_DEFAULT_USER, MOCK_ORGANIZATION_ID } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { organizationLogic } from 'scenes/organizationLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { UserType } from '~/types'
+
+import { ProxyRecord, proxyLogic } from './proxyLogic'
+
+const MOCK_IMPERSONATED_USER: UserType = {
+    ...MOCK_DEFAULT_USER,
+    is_impersonated: true,
+}
+
+const mockProxyRecord = (overrides: Partial<ProxyRecord> = {}): ProxyRecord => ({
+    id: 'record-1',
+    domain: 't.example.com',
+    status: 'valid',
+    target_cname: 'proxy.posthog.com',
+    ...overrides,
+})
+
+const proxyRecordsResponse = (records: ProxyRecord[]): { results: ProxyRecord[]; max_proxy_records: number } => ({
+    results: records,
+    max_proxy_records: 2,
+})
+
+describe('proxyLogic — shouldShowCloudflareOptIn', () => {
+    let logic: ReturnType<typeof proxyLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                [`/api/organizations/${MOCK_ORGANIZATION_ID}/proxy_records`]: proxyRecordsResponse([]),
+            },
+        })
+        initKeaTests()
+        organizationLogic.mount()
+        userLogic.mount()
+        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    async function mountLogic(): Promise<void> {
+        logic = proxyLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+    }
+
+    it('returns false when the user is impersonating, even with no records and no acknowledgment', async () => {
+        userLogic.actions.loadUserSuccess(MOCK_IMPERSONATED_USER)
+        await mountLogic()
+
+        await expectLogic(logic).toMatchValues({
+            cloudflareOptInAcknowledged: false,
+            proxyRecords: [],
+            shouldShowCloudflareOptIn: false,
+        })
+    })
+
+    it('returns false when the organization already has proxy records, regardless of acknowledgment', async () => {
+        useMocks({
+            get: {
+                [`/api/organizations/${MOCK_ORGANIZATION_ID}/proxy_records`]: proxyRecordsResponse([mockProxyRecord()]),
+            },
+        })
+        await mountLogic()
+
+        await expectLogic(logic).toMatchValues({
+            cloudflareOptInAcknowledged: false,
+            shouldShowCloudflareOptIn: false,
+        })
+        expect(logic.values.proxyRecords.length).toBeGreaterThan(0)
+    })
+
+    it('returns true for a first-time non-impersonating user with no records and no acknowledgment', async () => {
+        await mountLogic()
+
+        await expectLogic(logic).toMatchValues({
+            cloudflareOptInAcknowledged: false,
+            proxyRecords: [],
+            shouldShowCloudflareOptIn: true,
+        })
+    })
+
+    it('returns false once acknowledgeCloudflareOptIn has been dispatched', async () => {
+        await mountLogic()
+
+        await expectLogic(logic).toMatchValues({
+            shouldShowCloudflareOptIn: true,
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.acknowledgeCloudflareOptIn()
+        }).toMatchValues({
+            cloudflareOptInAcknowledged: true,
+            shouldShowCloudflareOptIn: false,
+        })
+    })
+})

--- a/frontend/src/scenes/settings/environment/proxyLogic.ts
+++ b/frontend/src/scenes/settings/environment/proxyLogic.ts
@@ -232,6 +232,21 @@ export const proxyLogic = kea<proxyLogicType>([
                 return proxyRecords.some((r) => ['waiting', 'issuing', 'deleting'].includes(r.status))
             },
         ],
+        shouldShowCloudflareOptIn: [
+            (s) => [s.cloudflareOptInAcknowledged, s.proxyRecords, s.user],
+            (acknowledged: boolean, records: ProxyRecord[], user: UserType | null): boolean => {
+                if (acknowledged) {
+                    return false
+                }
+                if (user?.is_impersonated) {
+                    return false
+                }
+                if (records.length > 0) {
+                    return false
+                }
+                return true
+            },
+        ],
     })),
     listeners(({ actions, values }) => ({
         collapseForm: () => actions.loadRecords(),


### PR DESCRIPTION
## Problem

When a PostHog staff member impersonates a customer and opens **Settings → Project → Managed reverse proxy**, the page renders the "Enable Managed Proxy (Beta)" opt-in banner instead of the customer's actual proxy records, CNAME instructions, and SDK snippet. To support, it looks like the customer has no managed proxy at all — which is misleading and has already caused a wrong-call on a real support ticket.

Root cause: `cloudflareOptInAcknowledged` is a kea reducer with `{ persist: true }`, so the value lives in the impersonator's own `localStorage`. The customer org may have acknowledged years ago and have valid proxy records, but the staffer impersonating them on a fresh browser starts at `false`, and `ManagedReverseProxy.tsx` early-returns the banner — hiding the entire records table and setup details behind it.

## Changes

- `proxyLogic.ts` — add a `shouldShowCloudflareOptIn` selector. It returns `false` whenever the user has acknowledged, the user is impersonating, or the org already has proxy records (proxy records can only be created after acknowledgment, so they are proof of past consent).
- `ManagedReverseProxy.tsx` — swap the early-return condition from `!cloudflareOptInAcknowledged` to `shouldShowCloudflareOptIn`. Once the gate is open, the existing render path (records table, expandable CNAME details, diagnose actions, `<WaitingRecords />`, `<ProxySDKSetup />`) shows automatically — no UI work needed.
- The existing `cloudflareOptInAcknowledged` reducer is untouched so the banner still gates first-time non-impersonating users with no records.

This is a small frontend-only fix. The proper long-term solution — moving the acknowledgment to an organization field — is filed as a follow-up since it needs a Django migration, serializer change, `hogli build:openapi`, and a backfill.

## How did you test this code?

I'm an agent. Automated only:

- `hogli test frontend/src/scenes/settings/environment/proxyLogic.test.ts` — 4 new cases pass:
  - returns `false` when impersonating, with no records and no acknowledgment
  - returns `false` when the org already has proxy records
  - returns `true` for a first-time non-impersonating user with no records and no acknowledgment
  - returns `false` after `acknowledgeCloudflareOptIn` is dispatched
- `tsc --noEmit` clean for `proxyLogic.ts` and `ManagedReverseProxy.tsx` (pre-existing unrelated errors elsewhere on master).

Manual smoke test still needs a human: impersonate a customer who has proxy records, navigate to **Settings → Project → Managed reverse proxy**, confirm the records table renders directly (not the opt-in banner).

## Publish to changelog?

no

## Docs update

No docs changes.

## 🤖 Agent context

Authored by PostHog Code (Opus 4.7) from a handoff doc describing the bug and proposed fix. Decisions worth flagging for review:

- **Selector vs. backend field.** Considered moving `cloudflareOptInAcknowledged` to `Organization.cloudflare_proxy_opt_in_acknowledged_at`. Rejected for this PR — the selector guard is ~10 lines, no migration, and unblocks the immediate support need. Backend move filed as a follow-up.
- **Whether to keep the explicit `is_impersonated` short-circuit in the selector.** Discussed with the requester: it's belt-and-suspenders on top of the records-based check. It diverges slightly from "exactly what the real user sees" in the rare "acknowledged + zero records" case, but covers the support workflow safely. Kept it in.
- **Tests file location.** The handoff claimed `proxyLogic.test.ts` already existed alongside `proxyLogic.ts`; it did not. Created from scratch following the kea testing pattern used in `impersonationNoticeLogic.test.ts` (mocked `userLogic`, `useMocks` for the proxy_records API).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*