### PR TITLE
feat(mcp): scope warehouse-schema + wizard tools for agent use

### DIFF
--- a/ee/hogai/tools/read_data_warehouse_schema/mcp_tool.py
+++ b/ee/hogai/tools/read_data_warehouse_schema/mcp_tool.py
@@ -1,15 +1,40 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from posthog.sync import database_sync_to_async
 
 from ee.hogai.chat_agent.sql.mixins import HogQLDatabaseMixin
 from ee.hogai.mcp_tool import MCPTool, mcp_tool_registry
 
+Section = Literal["core", "warehouse", "views", "system"]
+ALL_SECTIONS: tuple[Section, ...] = ("core", "warehouse", "views", "system")
+
+# Cap how much of a failed view's `latest_error` we surface — full ClickHouse errors
+# can be many KB and would defeat the purpose of the filters.
+_LATEST_ERROR_PREVIEW_CHARS = 200
+
 
 class ReadDataWarehouseSchemaQuery(BaseModel):
     kind: Literal["data_warehouse_schema"] = "data_warehouse_schema"
+    table_names: list[str] | None = Field(
+        default=None,
+        description=(
+            "Optional list of exact table or view names to include in the output. "
+            "Applied to all sections (core, warehouse, system, views). "
+            "If omitted, every name in the included sections is listed."
+        ),
+    )
+    include: list[Section] | None = Field(
+        default=None,
+        description=(
+            "Optional list of sections to include in the output. Choose from: "
+            "'core' (events/groups/persons/sessions with full column lists), "
+            "'warehouse' (data warehouse tables), 'views' (saved query views), "
+            "'system' (PostHog Postgres tables exposed as `system.*`). "
+            "Defaults to all sections."
+        ),
+    )
 
 
 class ReadDataWarehouseSchemaMCPToolArgs(BaseModel):
@@ -19,49 +44,102 @@ class ReadDataWarehouseSchemaMCPToolArgs(BaseModel):
 @mcp_tool_registry.register(scopes=["warehouse_table:read", "warehouse_view:read"])
 class ReadDataWarehouseSchemaMCPTool(HogQLDatabaseMixin, MCPTool[ReadDataWarehouseSchemaMCPToolArgs]):
     """
-    MCP tool that returns core PostHog table schemas (events, groups, persons, sessions).
+    MCP tool that returns core PostHog table schemas (events, groups, persons, sessions)
+    plus the names of warehouse tables, system tables, and views available for HogQL queries.
 
-    This provides the data model information needed for writing HogQL queries.
+    Pass `query.table_names` to scope the output to specific tables, and `query.include`
+    to limit which sections (core/warehouse/views/system) appear. Views also surface
+    their last-run `status` and any `latest_error` so callers can skip broken ones
+    before issuing `execute-sql`.
     """
 
     name = "read_data_warehouse_schema"
     args_schema = ReadDataWarehouseSchemaMCPToolArgs
 
     async def execute(self, args: ReadDataWarehouseSchemaMCPToolArgs) -> str:
-        return await self._build_tables_list()
+        sections = tuple(args.query.include) if args.query.include else ALL_SECTIONS
+        return await self._build_tables_list(
+            table_names=args.query.table_names,
+            sections=sections,
+        )
 
     @database_sync_to_async(thread_sensitive=False)
-    def _build_tables_list(self) -> str:
+    def _build_tables_list(self, table_names: list[str] | None, sections: tuple[Section, ...]) -> str:
+        from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+
         database = self._get_database()
         hogql_context = self._get_default_hogql_context(database)
 
-        core_tables = {"events", "groups", "persons", "sessions"}
-        serialized = database.serialize(hogql_context, include_only=core_tables)
+        wanted: set[str] | None = set(table_names) if table_names else None
 
-        lines: list[str] = ["# Core PostHog tables", ""]
-
-        for table_name, table in serialized.items():
-            lines.append(f"## Table `{table_name}`")
-            for field in table.fields.values():
-                lines.append(f"- {field.name} ({field.type})")
-            lines.append("")
-
-        warehouse_tables = database.get_warehouse_table_names()
-        # Filter out tables that live in the persons database and can't be queried via ClickHouse
-        persons_db_tables = {"group_type_mappings", "groups"}
-        system_tables = [t for t in database.get_system_table_names() if t not in persons_db_tables]
-        views = database.get_view_names()
+        def in_filter(name: str) -> bool:
+            return wanted is None or name in wanted
 
         def listify(items: list[str]) -> str:
             return "\n".join(f"- {item}" for item in sorted(items))
 
-        def section(title: str, items: list[str]) -> str:
-            return f"# {title}\n{listify(items)}\n" if items else ""
+        out: list[str] = []
 
-        extra_sections = (
-            f"{section('Data warehouse tables', warehouse_tables)}"
-            f"{section('PostHog Postgres tables', system_tables)}"
-            f"{section('Data warehouse views', views)}"
-        )
+        if "core" in sections:
+            core_tables = {"events", "groups", "persons", "sessions"}
+            if wanted is not None:
+                core_tables = core_tables & wanted
+            if core_tables:
+                serialized = database.serialize(hogql_context, include_only=core_tables)
+                out.append("# Core PostHog tables")
+                out.append("")
+                for table_name, table in serialized.items():
+                    out.append(f"## Table `{table_name}`")
+                    for field in table.fields.values():
+                        out.append(f"- {field.name} ({field.type})")
+                    out.append("")
 
-        return "\n".join(lines) + extra_sections
+        if "warehouse" in sections:
+            warehouse_tables = [t for t in database.get_warehouse_table_names() if in_filter(t)]
+            if warehouse_tables:
+                out.append("# Data warehouse tables")
+                out.append(listify(warehouse_tables))
+                out.append("")
+
+        if "system" in sections:
+            persons_db_tables = {"group_type_mappings", "groups"}
+            system_tables = [
+                t for t in database.get_system_table_names() if t not in persons_db_tables and in_filter(t)
+            ]
+            if system_tables:
+                out.append("# PostHog Postgres tables")
+                out.append(listify(system_tables))
+                out.append("")
+
+        if "views" in sections:
+            view_names = [v for v in database.get_view_names() if in_filter(v)]
+            if view_names:
+                saved_queries = {
+                    sq.name: sq
+                    for sq in DataWarehouseSavedQuery.objects.filter(
+                        team_id=self._team.pk, name__in=view_names, deleted=False
+                    ).only("name", "status", "latest_error", "last_run_at")
+                }
+                out.append("# Data warehouse views")
+                out.append(
+                    "Listed with last-run status when known. Views with status=Failed or a `latest_error` "
+                    "may fail when queried with `execute-sql` — verify before relying on them."
+                )
+                for view_name in sorted(view_names):
+                    sq = saved_queries.get(view_name)
+                    annotations: list[str] = []
+                    if sq is not None:
+                        if sq.status:
+                            annotations.append(f"status={sq.status}")
+                        if sq.latest_error:
+                            err_preview = sq.latest_error[:_LATEST_ERROR_PREVIEW_CHARS].replace("\n", " ").strip()
+                            if len(sq.latest_error) > _LATEST_ERROR_PREVIEW_CHARS:
+                                err_preview += "…"
+                            annotations.append(f"latest_error={err_preview!r}")
+                    if annotations:
+                        out.append(f"- {view_name} ({', '.join(annotations)})")
+                    else:
+                        out.append(f"- {view_name}")
+                out.append("")
+
+        return "\n".join(out).rstrip() + "\n"

--- a/ee/hogai/tools/read_data_warehouse_schema/test/test_mcp_tool.py
+++ b/ee/hogai/tools/read_data_warehouse_schema/test/test_mcp_tool.py
@@ -1,5 +1,7 @@
 from posthog.test.base import NonAtomicBaseTest
 
+from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+
 from ee.hogai.tools.read_data_warehouse_schema.mcp_tool import (
     ReadDataWarehouseSchemaMCPTool,
     ReadDataWarehouseSchemaMCPToolArgs,
@@ -43,3 +45,51 @@ class TestReadDataWarehouseSchemaMCPTool(NonAtomicBaseTest):
     async def test_schema_validates_query(self):
         validated = self.tool.args_schema.model_validate({"query": {"kind": "data_warehouse_schema"}})
         self.assertEqual(validated.query.kind, "data_warehouse_schema")
+        self.assertIsNone(validated.query.table_names)
+        self.assertIsNone(validated.query.include)
+
+    async def test_include_filters_sections(self):
+        content = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(query={"kind": "data_warehouse_schema", "include": ["core"]}),
+        )
+
+        self.assertIn("# Core PostHog tables", content)
+        self.assertNotIn("# Data warehouse tables", content)
+        self.assertNotIn("# PostHog Postgres tables", content)
+        self.assertNotIn("# Data warehouse views", content)
+
+    async def test_table_names_filters_core_tables(self):
+        content = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(
+                query={"kind": "data_warehouse_schema", "table_names": ["events"], "include": ["core"]},
+            ),
+        )
+
+        self.assertIn("## Table `events`", content)
+        self.assertNotIn("## Table `persons`", content)
+        self.assertNotIn("## Table `sessions`", content)
+
+    async def test_views_show_status_and_error(self):
+        from posthog.sync import database_sync_to_async
+
+        @database_sync_to_async
+        def make_saved_query():
+            return DataWarehouseSavedQuery.objects.create(
+                team=self.team,
+                name="failing_view",
+                query={"kind": "HogQLQuery", "query": "SELECT 1 FROM does_not_exist"},
+                status=DataWarehouseSavedQuery.Status.FAILED,
+                latest_error="Unknown table 'does_not_exist'",
+            )
+
+        await make_saved_query()
+
+        content = await self.tool.execute(
+            ReadDataWarehouseSchemaMCPToolArgs(
+                query={"kind": "data_warehouse_schema", "table_names": ["failing_view"], "include": ["views"]},
+            ),
+        )
+
+        self.assertIn("failing_view", content)
+        self.assertIn("status=Failed", content)
+        self.assertIn("Unknown table", content)

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -41,6 +41,7 @@ from posthog.models.activity_logging.external_data_utils import (
     get_external_data_source_detail_name,
 )
 from posthog.models.hog_functions.hog_function import HogFunction
+from posthog.models.integration import Integration
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.user import User
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
@@ -1762,15 +1763,76 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             ).data,
         )
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="source_type",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description=(
+                    "Return only the config for the given source type "
+                    "(e.g. 'GoogleAds', 'GoogleSheets'). Case-sensitive. "
+                    "When set, the response additionally includes `_available_integrations` "
+                    "and `_oauth_hint` for any OAuth fields. Omit to return the full catalog."
+                ),
+            ),
+            OpenApiParameter(
+                name="released_only",
+                type=bool,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description=(
+                    "If true, exclude sources marked `unreleasedSource: true` (scaffolded sources "
+                    "with no working sync logic). Defaults to false to preserve previous behaviour."
+                ),
+            ),
+        ]
+    )
     @action(methods=["GET"], detail=False)
     def wizard(self, request: Request, *arg: Any, **kwargs: Any):
+        source_type_filter = request.query_params.get("source_type")
+        released_only = request.query_params.get("released_only", "").lower() in ("true", "1", "yes")
+
         sources = SourceRegistry.get_all_sources()
+        if source_type_filter:
+            sources = {k: v for k, v in sources.items() if str(k) == source_type_filter}
+
         configs = {name: source.get_source_config for name, source in sources.items()}
 
-        return Response(
-            status=status.HTTP_200_OK,
-            data={str(key): value.model_dump() for key, value in configs.items()},
-        )
+        if released_only:
+            configs = {k: v for k, v in configs.items() if not v.unreleasedSource}
+
+        response_data = {str(key): value.model_dump() for key, value in configs.items()}
+
+        # When scoped to a single source, enrich any OAuth fields with the existing
+        # integrations in this project so callers (UI / agents) don't have to guess
+        # how to populate `*_integration_id`.
+        if source_type_filter and len(response_data) == 1:
+            source_data = next(iter(response_data.values()))
+            oauth_kinds: set[str] = {
+                field["kind"]
+                for field in source_data.get("fields") or []
+                if isinstance(field, dict) and field.get("type") == "oauth" and field.get("kind")
+            }
+            if oauth_kinds:
+                integrations = Integration.objects.filter(team_id=self.team_id, kind__in=oauth_kinds)
+                source_data["_available_integrations"] = [
+                    {
+                        "id": integration.id,
+                        "kind": integration.kind,
+                        "display_name": integration.display_name,
+                    }
+                    for integration in integrations
+                ]
+                source_data["_oauth_hint"] = (
+                    "Each `fields[*]` entry with type='oauth' must be populated with the integer `id` "
+                    "of an existing OAuth integration in this project. Pick one from "
+                    "`_available_integrations` (match by `kind`), or list more via the "
+                    "`integrations-list` endpoint with the same `kind`."
+                )
+
+        return Response(status=status.HTTP_200_OK, data=response_data)
 
     @extend_schema(responses=ExternalDataSourceConnectionOptionSerializer(many=True))
     @action(methods=["GET"], detail=False)

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -4466,6 +4466,58 @@ class TestExternalDataSource(APIBaseTest):
         assert response.status_code == 200
         assert payload is not None
 
+    def test_get_wizard_sources_with_source_type_filter(self):
+        response = self.client.get(
+            f"/api/environments/{self.team.pk}/external_data_sources/wizard?source_type=GoogleAds"
+        )
+        payload = response.json()
+        assert response.status_code == 200
+        assert list(payload.keys()) == ["GoogleAds"]
+
+    def test_get_wizard_sources_with_unknown_source_type(self):
+        response = self.client.get(
+            f"/api/environments/{self.team.pk}/external_data_sources/wizard?source_type=NotASource"
+        )
+        payload = response.json()
+        assert response.status_code == 200
+        assert payload == {}
+
+    def test_get_wizard_sources_released_only_drops_unreleased(self):
+        all_response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/wizard")
+        released_response = self.client.get(
+            f"/api/environments/{self.team.pk}/external_data_sources/wizard?released_only=true"
+        )
+
+        all_payload = all_response.json()
+        released_payload = released_response.json()
+
+        unreleased_keys = {k for k, v in all_payload.items() if v.get("unreleasedSource")}
+        assert unreleased_keys, (
+            "expected at least one unreleased source in the full catalog for this assertion to be meaningful"
+        )
+        assert not (unreleased_keys & released_payload.keys())
+        assert released_payload.keys() <= all_payload.keys()
+
+    def test_get_wizard_sources_oauth_hint_for_scoped_source(self):
+        from posthog.models.integration import Integration
+
+        Integration.objects.create(
+            team=self.team,
+            kind="google-ads",
+            integration_id="customer-1",
+            config={"name": "Test Google Ads"},
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.pk}/external_data_sources/wizard?source_type=GoogleAds"
+        )
+        payload = response.json()
+        assert response.status_code == 200
+        google_ads = payload["GoogleAds"]
+        assert "_oauth_hint" in google_ads
+        assert "_available_integrations" in google_ads
+        assert any(integration["kind"] == "google-ads" for integration in google_ads["_available_integrations"])
+
     def test_revenue_analytics_config_created_automatically(self):
         """Test that revenue analytics config is created automatically when external data source is created."""
         source = self._create_external_data_source()

--- a/products/data_warehouse/frontend/generated/api.schemas.ts
+++ b/products/data_warehouse/frontend/generated/api.schemas.ts
@@ -1987,6 +1987,17 @@ export type ExternalDataSourcesConnectionsListParams = {
     search?: string
 }
 
+export type ExternalDataSourcesWizardRetrieveParams = {
+    /**
+     * If true, exclude sources marked `unreleasedSource: true` (scaffolded sources with no working sync logic). Defaults to false to preserve previous behaviour.
+     */
+    released_only?: boolean
+    /**
+     * Return only the config for the given source type (e.g. 'GoogleAds', 'GoogleSheets'). Case-sensitive. When set, the response additionally includes `_available_integrations` and `_oauth_hint` for any OAuth fields. Omit to return the full catalog.
+     */
+    source_type?: string
+}
+
 export type InsightVariablesListParams = {
     /**
      * A page number within the paginated result set.

--- a/products/data_warehouse/frontend/generated/api.ts
+++ b/products/data_warehouse/frontend/generated/api.ts
@@ -26,6 +26,7 @@ import type {
     ExternalDataSourcesCheckCdcPrerequisitesCreate200,
     ExternalDataSourcesConnectionsListParams,
     ExternalDataSourcesListParams,
+    ExternalDataSourcesWizardRetrieveParams,
     FixHogqlListParams,
     InsightVariableApi,
     InsightVariablesListParams,
@@ -1210,15 +1211,34 @@ export const externalDataSourcesSourcePrefixCreate = async (
     })
 }
 
-export const getExternalDataSourcesWizardRetrieveUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/external_data_sources/wizard/`
+export const getExternalDataSourcesWizardRetrieveUrl = (
+    projectId: string,
+    params?: ExternalDataSourcesWizardRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/external_data_sources/wizard/?${stringifiedParams}`
+        : `/api/projects/${projectId}/external_data_sources/wizard/`
 }
 
 /**
  * Create, Read, Update and Delete External data Sources.
  */
-export const externalDataSourcesWizardRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getExternalDataSourcesWizardRetrieveUrl(projectId), {
+export const externalDataSourcesWizardRetrieve = async (
+    projectId: string,
+    params?: ExternalDataSourcesWizardRetrieveParams,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getExternalDataSourcesWizardRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
     })

--- a/products/data_warehouse/mcp/tools.yaml
+++ b/products/data_warehouse/mcp/tools.yaml
@@ -431,9 +431,14 @@ tools:
             idempotent: true
         title: Get source type configurations
         description: >
-            Return the configuration metadata for all supported data warehouse source types. Each entry describes the
-            required fields (host, port, database, credentials, etc.), field types, and OAuth flows. Use this to
-            discover what source types are available and what parameters are needed to create a new source.
+            Return the configuration metadata for supported data warehouse source types. Each entry describes the
+            required fields (host, port, database, credentials, etc.), field types, and OAuth flows. Pass
+            `source_type=<Name>` (case-sensitive, e.g. `GoogleAds`, `GoogleSheets`) to scope the response to a
+            single source — strongly preferred when the target source is known, as the full catalog is large.
+            Pass `released_only=true` to drop sources marked `unreleasedSource: true` (scaffolded sources with no
+            working sync logic). When scoped to one source, the response also includes `_available_integrations`
+            (existing OAuth integrations of the matching `kind` in this project) and `_oauth_hint` explaining how
+            to populate `*_integration_id` fields.
         response:
             include:
                 - '*.name'
@@ -442,6 +447,8 @@ tools:
                 - '*.featured'
                 - '*.unreleasedSource'
                 - '*.fields'
+                - '*._available_integrations'
+                - '*._oauth_hint'
     fix-hogql-create:
         operation: fix_hogql_create
         enabled: false

--- a/products/data_warehouse/mcp/tools.yaml
+++ b/products/data_warehouse/mcp/tools.yaml
@@ -433,12 +433,12 @@ tools:
         description: >
             Return the configuration metadata for supported data warehouse source types. Each entry describes the
             required fields (host, port, database, credentials, etc.), field types, and OAuth flows. Pass
-            `source_type=<Name>` (case-sensitive, e.g. `GoogleAds`, `GoogleSheets`) to scope the response to a
-            single source — strongly preferred when the target source is known, as the full catalog is large.
-            Pass `released_only=true` to drop sources marked `unreleasedSource: true` (scaffolded sources with no
-            working sync logic). When scoped to one source, the response also includes `_available_integrations`
-            (existing OAuth integrations of the matching `kind` in this project) and `_oauth_hint` explaining how
-            to populate `*_integration_id` fields.
+            `source_type=<Name>` (case-sensitive, e.g. `GoogleAds`, `GoogleSheets`) to scope the response to a single
+            source — strongly preferred when the target source is known, as the full catalog is large. Pass
+            `released_only=true` to drop sources marked `unreleasedSource: true` (scaffolded sources with no working
+            sync logic). When scoped to one source, the response also includes `_available_integrations` (existing OAuth
+            integrations of the matching `kind` in this project) and `_oauth_hint` explaining how to populate
+            `*_integration_id` fields.
         response:
             include:
                 - '*.name'

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2046,7 +2046,7 @@
         }
     },
     "external-data-sources-wizard": {
-        "description": "Return the configuration metadata for all supported data warehouse source types. Each entry describes the required fields (host, port, database, credentials, etc.), field types, and OAuth flows. Use this to discover what source types are available and what parameters are needed to create a new source.",
+        "description": "Return the configuration metadata for supported data warehouse source types. Each entry describes the required fields (host, port, database, credentials, etc.), field types, and OAuth flows. Pass `source_type=<Name>` (case-sensitive, e.g. `GoogleAds`, `GoogleSheets`) to scope the response to a single source — strongly preferred when the target source is known, as the full catalog is large. Pass `released_only=true` to drop sources marked `unreleasedSource: true` (scaffolded sources with no working sync logic). When scoped to one source, the response also includes `_available_integrations` (existing OAuth integrations of the matching `kind` in this project) and `_oauth_hint` explaining how to populate `*_integration_id` fields.",
         "category": "Data warehouse",
         "feature": "data_warehouse",
         "summary": "Get source type configurations",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2300,7 +2300,7 @@
         }
     },
     "external-data-sources-wizard": {
-        "description": "Return the configuration metadata for all supported data warehouse source types. Each entry describes the required fields (host, port, database, credentials, etc.), field types, and OAuth flows. Use this to discover what source types are available and what parameters are needed to create a new source.",
+        "description": "Return the configuration metadata for supported data warehouse source types. Each entry describes the required fields (host, port, database, credentials, etc.), field types, and OAuth flows. Pass `source_type=<Name>` (case-sensitive, e.g. `GoogleAds`, `GoogleSheets`) to scope the response to a single source — strongly preferred when the target source is known, as the full catalog is large. Pass `released_only=true` to drop sources marked `unreleasedSource: true` (scaffolded sources with no working sync logic). When scoped to one source, the response also includes `_available_integrations` (existing OAuth integrations of the matching `kind` in this project) and `_oauth_hint` explaining how to populate `*_integration_id` fields.",
         "category": "Data warehouse",
         "feature": "data_warehouse",
         "summary": "Get source type configurations",

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -3139,8 +3139,24 @@
         },
         "ReadDataWarehouseSchemaSchema": {
             "type": "object",
-            "properties": {},
-            "description": "No input required. Returns core data warehouse schemas."
+            "properties": {
+                "table_names": {
+                    "description": "Optional list of exact table or view names to include. Applied to all sections (core, warehouse, system, views). Omit to list every name.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "include": {
+                    "description": "Optional list of sections to include. 'core' returns full column lists for events/groups/persons/sessions; 'warehouse' lists data warehouse tables; 'views' lists saved query views with their last-run status; 'system' lists PostHog Postgres tables exposed as system.*. Defaults to all sections — prefer narrowing this when the catalog is large.",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["core", "warehouse", "views", "system"]
+                    }
+                }
+            },
+            "description": "Returns core PostHog table schemas plus warehouse/view/system table names. Pass table_names and/or include to scope the output when the full catalog is too large."
         },
         "ScoreDefinitionConfigSchema": {
             "anyOf": [

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37235,6 +37235,17 @@ export namespace Schemas {
     search?: string;
     };
 
+    export type EnvironmentsExternalDataSourcesWizardRetrieveParams = {
+    /**
+     * If true, exclude sources marked `unreleasedSource: true` (scaffolded sources with no working sync logic). Defaults to false to preserve previous behaviour.
+     */
+    released_only?: boolean;
+    /**
+     * Return only the config for the given source type (e.g. 'GoogleAds', 'GoogleSheets'). Case-sensitive. When set, the response additionally includes `_available_integrations` and `_oauth_hint` for any OAuth fields. Omit to return the full catalog.
+     */
+    source_type?: string;
+    };
+
     export type EnvironmentsFileSystemListParams = {
     /**
      * Number of results to return per page.
@@ -42155,6 +42166,17 @@ export namespace Schemas {
      * A search term.
      */
     search?: string;
+    };
+
+    export type ExternalDataSourcesWizardRetrieveParams = {
+    /**
+     * If true, exclude sources marked `unreleasedSource: true` (scaffolded sources with no working sync logic). Defaults to false to preserve previous behaviour.
+     */
+    released_only?: boolean;
+    /**
+     * Return only the config for the given source type (e.g. 'GoogleAds', 'GoogleSheets'). Case-sensitive. When set, the response additionally includes `_available_integrations` and `_oauth_hint` for any OAuth fields. Omit to return the full catalog.
+     */
+    source_type?: string;
     };
 
     export type FeatureFlagsListParams = {

--- a/services/mcp/src/generated/data_warehouse/api.ts
+++ b/services/mcp/src/generated/data_warehouse/api.ts
@@ -901,6 +901,21 @@ export const ExternalDataSourcesWizardRetrieveParams = /* @__PURE__ */ zod.objec
         ),
 })
 
+export const ExternalDataSourcesWizardRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    released_only: zod
+        .boolean()
+        .optional()
+        .describe(
+            'If true, exclude sources marked `unreleasedSource: true` (scaffolded sources with no working sync logic). Defaults to false to preserve previous behaviour.'
+        ),
+    source_type: zod
+        .string()
+        .optional()
+        .describe(
+            "Return only the config for the given source type (e.g. 'GoogleAds', 'GoogleSheets'). Case-sensitive. When set, the response additionally includes `_available_integrations` and `_oauth_hint` for any OAuth fields. Omit to return the full catalog."
+        ),
+})
+
 export const InsightVariablesCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -610,8 +610,23 @@ export const ExecuteSQLSchema = z.object({
 })
 
 export const ReadDataWarehouseSchemaSchema = z
-    .object({})
-    .describe('No input required. Returns core data warehouse schemas.')
+    .object({
+        table_names: z
+            .array(z.string())
+            .optional()
+            .describe(
+                'Optional list of exact table or view names to include. Applied to all sections (core, warehouse, system, views). Omit to list every name.'
+            ),
+        include: z
+            .array(z.enum(['core', 'warehouse', 'views', 'system']))
+            .optional()
+            .describe(
+                "Optional list of sections to include. 'core' returns full column lists for events/groups/persons/sessions; 'warehouse' lists data warehouse tables; 'views' lists saved query views with their last-run status; 'system' lists PostHog Postgres tables exposed as system.*. Defaults to all sections — prefer narrowing this when the catalog is large."
+            ),
+    })
+    .describe(
+        'Returns core PostHog table schemas plus warehouse/view/system table names. Pass table_names and/or include to scope the output when the full catalog is too large.'
+    )
 
 const ReadEventsQuerySchema = z.object({
     kind: z.literal('events'),

--- a/services/mcp/src/tools/generated/data_warehouse.ts
+++ b/services/mcp/src/tools/generated/data_warehouse.ts
@@ -33,6 +33,7 @@ import {
     ExternalDataSourcesUpdateWebhookInputsCreateBody,
     ExternalDataSourcesUpdateWebhookInputsCreateParams,
     ExternalDataSourcesWebhookInfoRetrieveParams,
+    ExternalDataSourcesWizardRetrieveQueryParams,
     InsightVariablesCreateBody,
     InsightVariablesDestroyParams,
     InsightVariablesPartialUpdateBody,
@@ -695,17 +696,20 @@ const externalDataSourcesWebhookInfoRetrieve = (): ToolBase<
     },
 })
 
-const ExternalDataSourcesWizardSchema = z.object({})
+const ExternalDataSourcesWizardSchema = ExternalDataSourcesWizardRetrieveQueryParams
 
 const externalDataSourcesWizard = (): ToolBase<typeof ExternalDataSourcesWizardSchema, unknown> => ({
     name: 'external-data-sources-wizard',
     schema: ExternalDataSourcesWizardSchema,
-    // eslint-disable-next-line no-unused-vars
     handler: async (context: Context, params: z.infer<typeof ExternalDataSourcesWizardSchema>) => {
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<unknown>({
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/external_data_sources/wizard/`,
+            query: {
+                released_only: params.released_only,
+                source_type: params.source_type,
+            },
         })
         const filtered = pickResponseFields(result, [
             '*.name',
@@ -714,6 +718,8 @@ const externalDataSourcesWizard = (): ToolBase<typeof ExternalDataSourcesWizardS
             '*.featured',
             '*.unreleasedSource',
             '*.fields',
+            '*._available_integrations',
+            '*._oauth_hint',
         ]) as typeof result
         return filtered
     },

--- a/services/mcp/src/tools/posthogAiTools/readDataWarehouseSchema.ts
+++ b/services/mcp/src/tools/posthogAiTools/readDataWarehouseSchema.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod'
+
 import { ReadDataWarehouseSchemaSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
 
@@ -5,10 +7,21 @@ import { invokeMcpTool } from './invokeTool'
 
 const schema = ReadDataWarehouseSchemaSchema
 
-export const readDataWarehouseSchemaHandler: ToolBase<typeof schema, string>['handler'] = async (context: Context) => {
-    const result = await invokeMcpTool(context, 'read_data_warehouse_schema', {
-        query: { kind: 'data_warehouse_schema' },
-    })
+type Params = z.infer<typeof schema>
+
+export const readDataWarehouseSchemaHandler: ToolBase<typeof schema, string>['handler'] = async (
+    context: Context,
+    params: Params
+) => {
+    const query: Record<string, unknown> = { kind: 'data_warehouse_schema' }
+    if (params?.table_names && params.table_names.length > 0) {
+        query.table_names = params.table_names
+    }
+    if (params?.include && params.include.length > 0) {
+        query.include = params.include
+    }
+
+    const result = await invokeMcpTool(context, 'read_data_warehouse_schema', { query })
 
     if (!result.success) {
         throw new Error(result.content)

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/read-data-warehouse-schema.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/read-data-warehouse-schema.json
@@ -1,6 +1,22 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "No input required. Returns core data warehouse schemas.",
-    "properties": {},
+    "description": "Returns core PostHog table schemas plus warehouse/view/system table names. Pass table_names and/or include to scope the output when the full catalog is too large.",
+    "properties": {
+        "include": {
+            "description": "Optional list of sections to include. 'core' returns full column lists for events/groups/persons/sessions; 'warehouse' lists data warehouse tables; 'views' lists saved query views with their last-run status; 'system' lists PostHog Postgres tables exposed as system.*. Defaults to all sections — prefer narrowing this when the catalog is large.",
+            "items": {
+                "enum": ["core", "warehouse", "views", "system"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "table_names": {
+            "description": "Optional list of exact table or view names to include. Applied to all sections (core, warehouse, system, views). Omit to list every name.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
     "type": "object"
 }


### PR DESCRIPTION
## Problem

Three MCP agent feedback reports flagged the same theme on these two tools — they're shaped for a UI consumer, not an agent that already knows what it wants:

- `read-data-warehouse-schema` accepts no input and always returns the full project catalog (core + warehouse + system + views). On a real project that's many kilobytes for a question that may only need to confirm one table or one view. Listed views also have no validity status — agents can pick a view from the list and then watch `execute-sql` fail with `Unknown table …` from a broken upstream dependency.
- `external-data-sources-wizard` returned ~52 KB of YAML covering ~150 registered sources every call, the bulk of which are scaffolded stubs marked `unreleasedSource: true`. There's no way to ask "give me just GoogleSheets".
- OAuth-backed sources expose a `*_integration_id` field whose `kind` matches the `kind` enum of `integrations-list`, but neither tool description nor field schema told agents to look there. They had to discover the linkage by hand.

## Changes

- `read-data-warehouse-schema`: optional `table_names` and `include` (`core` / `warehouse` / `views` / `system`) filters. Views also surface `status` and a truncated `latest_error` pulled from `DataWarehouseSavedQuery` so callers can skip broken views before issuing SQL.
- `external-data-sources-wizard`: optional `source_type` and `released_only` query params. When scoped to a single source, the response inlines `_available_integrations` (matching `Integration` rows for any OAuth field's `kind`) plus an `_oauth_hint` explaining how to populate `*_integration_id` fields.
- Updated the wizard MCP tool description in `products/data_warehouse/mcp/tools.yaml` to mention the new params and the OAuth/integrations linkage.

Default behaviour is preserved for all consumers — the frontend wizard call and prior MCP invocations get the same shape as before.

The dedup case (warehouse table names appearing as both `attio.companies` and `attio_companies`) is split into its own investigation — root cause sits in how `_warehouse_table_names` is populated, not in the schema tool.

## How did you test this code?

I'm an agent — no manual UI testing.

Automated tests run locally and passing:

- `hogli test ee/hogai/tools/read_data_warehouse_schema/test/test_mcp_tool.py` — 8 tests, including new coverage for `table_names` / `include` filters and view validity surfacing.
- `hogli test products/data_warehouse/backend/api/test/test_external_data_source.py::TestExternalDataSource::test_get_wizard_sources*` — 5 tests, including the existing backward-compat case and new tests for `source_type`, unknown source, `released_only`, and the OAuth hint.
- `pnpm --filter @posthog/mcp vitest run tests/unit/schema.ajv.test.ts` — passes after `hogli build:schema-mcp` regenerated `tool-inputs.json`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (claude-opus-4-7) at Marcus's request after validating four pieces of MCP agent feedback against the code:

1. read-data-warehouse-schema listing un-queryable views (valid)
2. wizard returning 52 KB with no filter (valid)
3. wizard `*_integration_id` field unlinked from integrations-list (valid)
4. read-data-warehouse-schema huge for targeted checks (valid — same tool, no input params at all)

Scope choices:
- Surfaced view validity inline rather than adding a new tool — keeps the agent's discovery flow as one call instead of two.
- The wizard response stays a flat dict; OAuth metadata goes under `_`-prefixed keys so the frontend (which only reads named source fields) ignores it.
- The wizard's `_available_integrations` lookup runs only when `source_type` is provided, so the no-arg call (used by the frontend) doesn't take a per-source DB hit.
- Dedup investigation split off — the duplicate table names look like two different paths populating `_warehouse_table_names` (e.g. a `schema.table` entry and a flattened `schema_table` alias), needs deeper digging than this PR's scope.

Not run locally:
- Full `hogli build:openapi` pipeline. The wizard `@extend_schema` change and `tools.yaml` description need the OpenAPI regeneration to flow into `services/mcp/schema/tool-definitions-*.json` and the Orval-generated MCP zod schemas. The repo's `ci-mcp` auto-commit workflow regenerates and commits those on the PR — flagged here so a human reviewer can confirm the auto-commit lands or run `hogli build:openapi` manually.