### PR TITLE
feat(modeling): dag per sync frequency interval

### DIFF
--- a/products/data_modeling/backend/management/commands/migrate_teams_to_dag_schedules.py
+++ b/products/data_modeling/backend/management/commands/migrate_teams_to_dag_schedules.py
@@ -1,7 +1,7 @@
 import time
+from collections import defaultdict
 from dataclasses import asdict
 from datetime import timedelta
-from typing import cast
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
@@ -17,14 +17,18 @@ from temporalio.client import (
 )
 from temporalio.common import RetryPolicy, SearchAttributePair, TypedSearchAttributes
 
+from posthog.hogql.database.database import Database
+
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import create_schedule, delete_schedule, schedule_exists
 from posthog.temporal.common.search_attributes import POSTHOG_DAG_ID_KEY, POSTHOG_ORG_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.data_modeling.workflows.execute_dag import ExecuteDAGInputs
 
-from products.data_modeling.backend.models import DAG, Node
+from products.data_modeling.backend.models import DAG, Edge, Node
 from products.data_modeling.backend.schedule import build_schedule_spec
+from products.data_modeling.backend.services.saved_query_dag_sync import resolve_dependency_to_node
 from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+from products.data_warehouse.backend.models.modeling import UnknownParentError, get_parents_from_model_query
 
 logger = structlog.get_logger(__name__)
 
@@ -32,7 +36,7 @@ BATCH_DELAY_SECONDS = 0.5
 
 
 class Command(BaseCommand):
-    help = "Migrate teams from per-node v1 schedules to a single per-DAG v2 schedule"
+    help = "Migrate teams from per-node v1 schedules to per-frequency v2 DAG schedules"
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -88,142 +92,229 @@ class Command(BaseCommand):
             logger.info(f"Done! Migrated: {migrated}, Skipped: {skipped}, Failed: {failed}")
 
     def _migrate_dag(self, dag: DAG, *, dry_run: bool) -> bool:
-        """Migrate a single DAG to a v2 schedule.
+        """Migrate a single DAG to one or more v2 cohort schedules.
+
+        Each distinct sync_frequency_interval across the source DAG's scheduled
+        nodes becomes its own cohort DAG (e.g., 'Default (1h)', 'Default (6h)')
+        with its own Temporal schedule. Cross-cohort edges are dropped — the
+        underlying HogQL dependency still resolves at query time, but the v2
+        orchestrator stops enforcing freshness between cohorts.
 
         Returns True if migrated, False if skipped.
         """
         team = dag.team
-        # find all materialized nodes in this DAG that have saved queries with sync schedules
-        scheduled_nodes = Node.objects.filter(
-            dag=dag,
-            saved_query__isnull=False,
-            saved_query__sync_frequency_interval__isnull=False,
-            saved_query__deleted=False,
-        ).select_related("saved_query")
-        if not scheduled_nodes.exists():
+        scheduled_nodes = list(
+            Node.objects.filter(
+                dag=dag,
+                saved_query__isnull=False,
+                saved_query__sync_frequency_interval__isnull=False,
+                saved_query__deleted=False,
+            ).select_related("saved_query")
+        )
+        if not scheduled_nodes:
             logger.info("No scheduled nodes found, skipping", dag_id=str(dag.id), team_id=team.pk)
             return False
-        # check that all scheduled saved queries share the same sync frequency
-        distinct_intervals = scheduled_nodes.values_list("saved_query__sync_frequency_interval", flat=True).distinct()
-        intervals = list(distinct_intervals)
-        if len(intervals) != 1:
-            logger.warning(
-                "DAG has multiple sync frequencies, skipping",
-                dag_id=str(dag.id),
-                team_id=team.pk,
-                intervals=[str(i) for i in intervals],
-            )
-            return False
-        interval = cast(timedelta, intervals[0])
+
+        nodes_by_interval: dict[timedelta, list[Node]] = defaultdict(list)
+        for node in scheduled_nodes:
+            assert node.saved_query is not None  # filter above guarantees this
+            nodes_by_interval[node.saved_query.sync_frequency_interval].append(node)
+
         if dry_run:
             logger.info(
                 "Would migrate DAG",
                 dag_id=str(dag.id),
                 dag_name=dag.name,
                 team_id=team.pk,
-                interval=str(interval),
-                scheduled_nodes=scheduled_nodes.count(),
+                cohorts={str(i): len(ns) for i, ns in nodes_by_interval.items()},
             )
             return True
-        # create the v2 DAG schedule
+
         temporal = sync_connect()
-        schedule_id = str(dag.id)
-        if schedule_exists(temporal, schedule_id=schedule_id):
-            logger.info("V2 schedule already exists, skipping creation", dag_id=str(dag.id), team_id=team.pk)
-        else:
-            inputs = ExecuteDAGInputs(
-                team_id=team.pk,
-                dag_id=str(dag.id),
-                node_ids=None,
-                duckgres_only=False,
-            )
-            spec = build_schedule_spec(
-                entity_id=dag.id,
-                interval=interval,
-                team_timezone=team.timezone,
-            )
-            schedule = Schedule(
-                action=ScheduleActionStartWorkflow(
-                    "data-modeling-execute-dag",
-                    asdict(inputs),
-                    id=f"execute-dag-{dag.id}",
-                    task_queue=str(settings.DATA_MODELING_TASK_QUEUE),
-                    retry_policy=RetryPolicy(
-                        initial_interval=timedelta(seconds=10),
-                        maximum_interval=timedelta(seconds=60),
-                        maximum_attempts=3,
-                        non_retryable_error_types=["NondeterminismError", "CancelledError"],
-                    ),
-                ),
-                spec=spec,
-                state=ScheduleState(note=f"DAG schedule for team {team.pk}"),
-                policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
-            )
-            search_attributes = TypedSearchAttributes(
-                search_attributes=[
-                    SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=team.pk),
-                    SearchAttributePair(key=POSTHOG_ORG_ID_KEY, value=str(team.organization_id)),
-                    SearchAttributePair(key=POSTHOG_DAG_ID_KEY, value=str(dag.id)),
-                ]
-            )
-            create_schedule(
-                temporal,
-                id=schedule_id,
-                schedule=schedule,
-                trigger_immediately=False,
-                search_attributes=search_attributes,
-            )
-            logger.info("Created v2 DAG schedule", dag_id=str(dag.id), team_id=team.pk, interval=str(interval))
-            # update the DAG only after schedule creation succeeded
-            dag.name = "Default"
-            dag.sync_frequency_interval = interval
-            dag.save(update_fields=["name", "sync_frequency_interval"])
-            logger.info("Renamed DAG", dag_id=str(dag.id), team_id=team.pk)
-            # delete old per-node schedules
-            deleted_count = 0
-            failed_schedule_ids: list[str] = []
-            for node in scheduled_nodes:
-                saved_query = node.saved_query
-                if saved_query is None:
-                    continue
-                try:
-                    delete_schedule(temporal, schedule_id=str(saved_query.id))
-                    deleted_count += 1
-                except temporalio.service.RPCError as e:
-                    if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
-                        logger.warning(
-                            "Old schedule not found (already deleted?)",
-                            saved_query_id=str(saved_query.id),
-                            team_id=team.pk,
-                        )
-                    else:
-                        failed_schedule_ids.append(str(saved_query.id))
-                        logger.exception(
-                            "Failed to delete old schedule",
-                            saved_query_id=str(saved_query.id),
-                            team_id=team.pk,
-                        )
-            if failed_schedule_ids:
-                logger.warning(
-                    "Some old schedules could not be deleted",
-                    dag_id=str(dag.id),
-                    team_id=team.pk,
-                    failed_schedule_ids=failed_schedule_ids,
-                )
-            logger.info(
-                "Deleted old per-node schedules",
-                dag_id=str(dag.id),
-                team_id=team.pk,
-                deleted=deleted_count,
-                total=scheduled_nodes.count(),
-            )
-            # null out sync_frequency_interval on migrated saved queries so v1 schedules are not re-created
-            migrated_sq_ids = [node.saved_query_id for node in scheduled_nodes if node.saved_query_id is not None]
-            DataWarehouseSavedQuery.objects.filter(id__in=migrated_sq_ids).update(sync_frequency_interval=None)
-            logger.info(
-                "Cleared sync_frequency_interval on saved queries",
-                dag_id=str(dag.id),
-                team_id=team.pk,
-                count=len(migrated_sq_ids),
-            )
+        for interval, cohort_nodes in nodes_by_interval.items():
+            self._migrate_cohort(temporal, team, interval, cohort_nodes)
+
+        self._delete_v1_schedules(temporal, team, scheduled_nodes)
+        self._clear_saved_query_intervals(scheduled_nodes)
         return True
+
+    def _migrate_cohort(
+        self,
+        temporal,
+        team,
+        interval: timedelta,
+        cohort_nodes: list[Node],
+    ) -> None:
+        """Move a frequency cohort into its own DAG and ensure its v2 schedule exists."""
+        cohort_dag = DAG.get_or_create_for_frequency(team, interval)
+        schedule_id = str(cohort_dag.id)
+
+        node_ids = [n.id for n in cohort_nodes]
+        Node.objects.filter(id__in=node_ids).exclude(dag=cohort_dag).update(dag=cohort_dag)
+        # refresh in-memory dag_id so callers downstream don't see stale FKs
+        for node in cohort_nodes:
+            node.dag = cohort_dag
+            node.dag_id = cohort_dag.id
+
+        self._rebuild_cohort_edges(team, cohort_nodes, cohort_dag)
+
+        if schedule_exists(temporal, schedule_id=schedule_id):
+            logger.info(
+                "Cohort v2 schedule already exists, skipping creation",
+                dag_id=str(cohort_dag.id),
+                team_id=team.pk,
+                interval=str(interval),
+            )
+            return
+
+        self._create_cohort_schedule(temporal, team, cohort_dag, interval)
+
+    def _rebuild_cohort_edges(self, team, cohort_nodes: list[Node], cohort_dag: DAG) -> None:
+        """Rebuild incoming edges for each cohort node inside the cohort DAG.
+
+        Cross-cohort dependencies (a node in this cohort that depended on a node
+        now living in a different cohort DAG) are dropped — `resolve_dependency_to_node`
+        raises Node.DoesNotExist when the source's dag != cohort_dag, and we
+        log+skip rather than fail the migration.
+        """
+        database = Database.create_for(team=team)
+        for node in cohort_nodes:
+            Edge.objects.filter(team=team, target=node).delete()
+            saved_query = node.saved_query
+            if saved_query is None:
+                continue
+            query_text = saved_query.query.get("query") if saved_query.query else None
+            if not query_text:
+                continue
+            try:
+                deps = get_parents_from_model_query(team, saved_query.name, query_text)
+            except Exception:
+                logger.exception(
+                    "Failed to parse saved query during cohort migration",
+                    saved_query_id=str(saved_query.id),
+                    team_id=team.pk,
+                )
+                continue
+            for dep_name in deps:
+                self._create_cohort_edge(team, cohort_dag, node, dep_name, database)
+
+    def _create_cohort_edge(self, team, cohort_dag: DAG, target: Node, dep_name: str, database: Database) -> None:
+        try:
+            source = resolve_dependency_to_node(dep_name, team, database, cohort_dag)
+        except (Node.DoesNotExist, DataWarehouseSavedQuery.DoesNotExist, UnknownParentError):
+            logger.info(
+                "Dropping cross-cohort dependency",
+                team_id=team.pk,
+                cohort_dag_id=str(cohort_dag.id),
+                target_node_id=str(target.id),
+                dependency_name=dep_name,
+            )
+            return
+        try:
+            Edge.objects.create(team=team, dag=cohort_dag, source=source, target=target)
+        except Exception:
+            logger.exception(
+                "Failed to create cohort edge",
+                team_id=team.pk,
+                cohort_dag_id=str(cohort_dag.id),
+                source_node_id=str(source.id),
+                target_node_id=str(target.id),
+            )
+
+    def _create_cohort_schedule(self, temporal, team, cohort_dag: DAG, interval: timedelta) -> None:
+        inputs = ExecuteDAGInputs(
+            team_id=team.pk,
+            dag_id=str(cohort_dag.id),
+            node_ids=None,
+            duckgres_only=False,
+        )
+        spec = build_schedule_spec(
+            entity_id=cohort_dag.id,
+            interval=interval,
+            team_timezone=team.timezone,
+        )
+        schedule = Schedule(
+            action=ScheduleActionStartWorkflow(
+                "data-modeling-execute-dag",
+                asdict(inputs),
+                id=f"execute-dag-{cohort_dag.id}",
+                task_queue=str(settings.DATA_MODELING_TASK_QUEUE),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=10),
+                    maximum_interval=timedelta(seconds=60),
+                    maximum_attempts=3,
+                    non_retryable_error_types=["NondeterminismError", "CancelledError"],
+                ),
+            ),
+            spec=spec,
+            state=ScheduleState(note=f"DAG schedule for team {team.pk} cohort {interval}"),
+            policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+        )
+        search_attributes = TypedSearchAttributes(
+            search_attributes=[
+                SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=team.pk),
+                SearchAttributePair(key=POSTHOG_ORG_ID_KEY, value=str(team.organization_id)),
+                SearchAttributePair(key=POSTHOG_DAG_ID_KEY, value=str(cohort_dag.id)),
+            ]
+        )
+        create_schedule(
+            temporal,
+            id=str(cohort_dag.id),
+            schedule=schedule,
+            trigger_immediately=False,
+            search_attributes=search_attributes,
+        )
+        # ensure the DAG's stored frequency matches the schedule's frequency
+        if cohort_dag.sync_frequency_interval != interval:
+            cohort_dag.sync_frequency_interval = interval
+            cohort_dag.save(update_fields=["sync_frequency_interval"])
+        logger.info(
+            "Created v2 cohort schedule",
+            dag_id=str(cohort_dag.id),
+            team_id=team.pk,
+            interval=str(interval),
+        )
+
+    def _delete_v1_schedules(self, temporal, team, scheduled_nodes: list[Node]) -> None:
+        deleted = 0
+        failed: list[str] = []
+        for node in scheduled_nodes:
+            saved_query = node.saved_query
+            if saved_query is None:
+                continue
+            try:
+                delete_schedule(temporal, schedule_id=str(saved_query.id))
+                deleted += 1
+            except temporalio.service.RPCError as e:
+                if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
+                    logger.warning(
+                        "Old schedule not found (already deleted?)",
+                        saved_query_id=str(saved_query.id),
+                        team_id=team.pk,
+                    )
+                else:
+                    failed.append(str(saved_query.id))
+                    logger.exception(
+                        "Failed to delete old schedule",
+                        saved_query_id=str(saved_query.id),
+                        team_id=team.pk,
+                    )
+        if failed:
+            logger.warning(
+                "Some old schedules could not be deleted",
+                team_id=team.pk,
+                failed_schedule_ids=failed,
+            )
+        logger.info(
+            "Deleted old per-node schedules",
+            team_id=team.pk,
+            deleted=deleted,
+            total=len(scheduled_nodes),
+        )
+
+    def _clear_saved_query_intervals(self, scheduled_nodes: list[Node]) -> None:
+        sq_ids = [n.saved_query_id for n in scheduled_nodes if n.saved_query_id is not None]
+        if not sq_ids:
+            return
+        DataWarehouseSavedQuery.objects.filter(id__in=sq_ids).update(sync_frequency_interval=None)
+        logger.info("Cleared sync_frequency_interval on saved queries", count=len(sq_ids))

--- a/products/data_modeling/backend/models/dag.py
+++ b/products/data_modeling/backend/models/dag.py
@@ -7,10 +7,17 @@ from django.db import models
 
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDModel
 
+from products.data_modeling.backend.schedule import sync_frequency_interval_to_short_name
+
 if TYPE_CHECKING:
     from posthog.models import Team
 
 DEFAULT_DAG_NAME = "Default"
+
+
+def build_cohort_dag_name(base_name: str, interval: timedelta) -> str:
+    """Compose a cohort DAG name like 'Default (1h)' for a given base + frequency."""
+    return f"{base_name} ({sync_frequency_interval_to_short_name(interval)})"
 
 
 class DAG(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
@@ -27,6 +34,17 @@ class DAG(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
     @classmethod
     def get_or_create_default(cls, team: Team) -> DAG:
         dag, _ = cls.objects.get_or_create(team=team, name=DEFAULT_DAG_NAME)
+        return dag
+
+    @classmethod
+    def get_or_create_for_frequency(cls, team: Team, interval: timedelta, *, base_name: str = DEFAULT_DAG_NAME) -> DAG:
+        """Return the cohort DAG for `team` at `interval`, creating it if missing.
+
+        Sets sync_frequency_interval on creation so downstream schedule-building
+        code can read it directly from the DAG.
+        """
+        name = build_cohort_dag_name(base_name, interval)
+        dag, _ = cls.objects.get_or_create(team=team, name=name, defaults={"sync_frequency_interval": interval})
         return dag
 
     @property

--- a/products/data_modeling/backend/schedule.py
+++ b/products/data_modeling/backend/schedule.py
@@ -16,6 +16,32 @@ from datetime import timedelta
 
 from temporalio.client import ScheduleCalendarSpec, ScheduleRange, ScheduleSpec
 
+from products.data_warehouse.backend.models.external_data_schema import sync_frequency_interval_to_sync_frequency
+
+_SYNC_FREQUENCY_TO_SHORT_NAME: dict[str, str] = {
+    "15min": "15m",
+    "30min": "30m",
+    "1hour": "1h",
+    "6hour": "6h",
+    "12hour": "12h",
+    "24hour": "1d",
+    "7day": "7d",
+    "30day": "30d",
+}
+
+
+def sync_frequency_interval_to_short_name(interval: timedelta) -> str:
+    """Render a sync-frequency interval as a short suffix (e.g. '15m', '1h', '1d', '7d').
+
+    Used to name frequency-cohort DAGs. Delegates to data_warehouse's
+    `sync_frequency_interval_to_sync_frequency` for the canonical long-form name,
+    then maps to the short form. Raises ValueError for unsupported intervals.
+    """
+    long_name = sync_frequency_interval_to_sync_frequency(interval)
+    if long_name is None or long_name not in _SYNC_FREQUENCY_TO_SHORT_NAME:
+        raise ValueError(f"Frequency interval {interval} has no short-name mapping")
+    return _SYNC_FREQUENCY_TO_SHORT_NAME[long_name]
+
 
 def _deterministic_int(entity_id: uuid.UUID, salt: str) -> int:
     """SHA-256 based deterministic integer from entity_id + salt."""

--- a/products/data_modeling/backend/services/saved_query_dag_sync.py
+++ b/products/data_modeling/backend/services/saved_query_dag_sync.py
@@ -124,7 +124,13 @@ def sync_saved_query_to_dag(
     extra_properties = extra_properties or {}
     team = saved_query.team
     if dag is None:
-        dag = DAG.get_or_create_default(team)
+        # Route by the saved query's sync frequency so multi-frequency teams keep
+        # each cohort in its own DAG. Unscheduled saved queries fall back to the
+        # team's Default DAG.
+        if saved_query.sync_frequency_interval is not None:
+            dag = DAG.get_or_create_for_frequency(team, saved_query.sync_frequency_interval)
+        else:
+            dag = DAG.get_or_create_default(team)
     model_query = saved_query.query.get("query") if saved_query.query else None
     if not model_query:
         raise ValueError(f"DataWarehouseSavedQuery has no query: saved_query_id={saved_query.id}")

--- a/products/data_modeling/backend/test/test_migrate_teams_to_dag_schedules.py
+++ b/products/data_modeling/backend/test/test_migrate_teams_to_dag_schedules.py
@@ -1,0 +1,237 @@
+from datetime import timedelta
+
+import pytest
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.core.management import call_command
+
+from parameterized import parameterized
+
+from products.data_modeling.backend.models import DAG, Edge, Node
+from products.data_modeling.backend.models.dag import DEFAULT_DAG_NAME, build_cohort_dag_name
+from products.data_modeling.backend.models.node import NodeType
+from products.data_modeling.backend.services.saved_query_dag_sync import sync_saved_query_to_dag
+from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+
+
+def _patch_temporal(test_method):
+    """Wrap a test method with the mocks every migrate-command test needs.
+
+    The command talks to Temporal in three places — sync_connect, create_schedule,
+    schedule_exists, delete_schedule. None of those have side effects we want in
+    tests, so we replace them with no-op MagicMocks and pass the mocks through to
+    the test so it can assert against them.
+    """
+
+    @patch("products.data_modeling.backend.management.commands.migrate_teams_to_dag_schedules.delete_schedule")
+    @patch("products.data_modeling.backend.management.commands.migrate_teams_to_dag_schedules.create_schedule")
+    @patch(
+        "products.data_modeling.backend.management.commands.migrate_teams_to_dag_schedules.schedule_exists",
+        return_value=False,
+    )
+    @patch(
+        "products.data_modeling.backend.management.commands.migrate_teams_to_dag_schedules.sync_connect",
+        return_value=MagicMock(),
+    )
+    def wrapper(self, *args, **kwargs):
+        return test_method(self, *args, **kwargs)
+
+    wrapper.__name__ = test_method.__name__
+    return wrapper
+
+
+@pytest.mark.django_db
+class TestMigrateTeamsToDagSchedules(BaseTest):
+    def _make_saved_query(self, name: str, sync_frequency_interval: timedelta | None) -> DataWarehouseSavedQuery:
+        return DataWarehouseSavedQuery.objects.create(
+            name=name,
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+            sync_frequency_interval=sync_frequency_interval,
+        )
+
+    def _seed_node(self, sq: DataWarehouseSavedQuery, dag: DAG) -> Node:
+        # sync_saved_query_to_dag would route a freshly-created SQ to its
+        # frequency-cohort DAG via our new logic, so for migration tests we
+        # need to force everything into a single source DAG (the team's
+        # pre-migration Default) and let _migrate_dag split it.
+        node, _ = Node.objects.get_or_create(
+            team=self.team,
+            saved_query=sq,
+            dag=dag,
+            defaults={"name": sq.name, "type": NodeType.VIEW},
+        )
+        return node
+
+    def _run(self) -> None:
+        call_command("migrate_teams_to_dag_schedules", "--team-ids", str(self.team.pk))
+
+    @_patch_temporal
+    def test_skips_dag_with_no_scheduled_nodes(self, _sc, _exists, mock_create, _del):
+        DAG.get_or_create_default(self.team)
+        self._run()
+        mock_create.assert_not_called()
+
+    @_patch_temporal
+    def test_single_frequency_creates_single_cohort_dag(self, _sc, _exists, mock_create, _del):
+        source_dag = DAG.get_or_create_default(self.team)
+        sq = self._make_saved_query("view_a", sync_frequency_interval=timedelta(hours=1))
+        self._seed_node(sq, source_dag)
+
+        self._run()
+
+        cohort_dag = DAG.objects.get(team=self.team, name=build_cohort_dag_name(DEFAULT_DAG_NAME, timedelta(hours=1)))
+        assert cohort_dag.sync_frequency_interval == timedelta(hours=1)
+        assert Node.objects.filter(saved_query=sq).get().dag_id == cohort_dag.id
+        mock_create.assert_called_once()
+        sq.refresh_from_db()
+        assert sq.sync_frequency_interval is None
+
+    @parameterized.expand(
+        [
+            ("two_freq", [timedelta(hours=1), timedelta(hours=6)]),
+            ("three_freq", [timedelta(hours=1), timedelta(hours=6), timedelta(days=1)]),
+        ]
+    )
+    @_patch_temporal
+    def test_multi_frequency_splits_into_one_cohort_dag_per_frequency(
+        self, _sc, _exists, mock_create, _del, _name, intervals
+    ):
+        source_dag = DAG.get_or_create_default(self.team)
+        sqs_by_interval = {}
+        for i, interval in enumerate(intervals):
+            sq = self._make_saved_query(f"view_{i}", sync_frequency_interval=interval)
+            self._seed_node(sq, source_dag)
+            sqs_by_interval[interval] = sq
+
+        self._run()
+
+        for interval, sq in sqs_by_interval.items():
+            cohort_name = build_cohort_dag_name(DEFAULT_DAG_NAME, interval)
+            cohort_dag = DAG.objects.get(team=self.team, name=cohort_name)
+            assert cohort_dag.sync_frequency_interval == interval
+            node = Node.objects.get(saved_query=sq)
+            assert node.dag_id == cohort_dag.id
+            sq.refresh_from_db()
+            assert sq.sync_frequency_interval is None
+        assert mock_create.call_count == len(intervals)
+
+    @_patch_temporal
+    def test_idempotent_rerun_after_intervals_cleared(self, _sc, _exists, mock_create, _del):
+        source_dag = DAG.get_or_create_default(self.team)
+        sq = self._make_saved_query("view_a", sync_frequency_interval=timedelta(hours=1))
+        self._seed_node(sq, source_dag)
+
+        self._run()
+        first_call_count = mock_create.call_count
+        # second run: SQ.sync_frequency_interval is now None so the source DAG
+        # has no scheduled nodes; the command should short-circuit and create no
+        # additional schedules.
+        self._run()
+        assert mock_create.call_count == first_call_count
+
+    @_patch_temporal
+    def test_cross_cohort_edges_are_dropped(self, _sc, _exists, mock_create, _del):
+        source_dag = DAG.get_or_create_default(self.team)
+        upstream_sq = DataWarehouseSavedQuery.objects.create(
+            name="upstream_view",
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+            sync_frequency_interval=timedelta(hours=1),
+        )
+        # downstream references upstream by name, creating a real intra-DAG edge
+        downstream_sq = DataWarehouseSavedQuery.objects.create(
+            name="downstream_view",
+            team=self.team,
+            query={"query": "SELECT * FROM upstream_view", "kind": "HogQLQuery"},
+            sync_frequency_interval=timedelta(hours=6),
+        )
+        sync_saved_query_to_dag(upstream_sq, dag=source_dag)
+        sync_saved_query_to_dag(downstream_sq, dag=source_dag)
+        upstream_node = Node.objects.get(saved_query=upstream_sq)
+        downstream_node = Node.objects.get(saved_query=downstream_sq)
+        # sanity: edge exists pre-migration
+        assert Edge.objects.filter(source=upstream_node, target=downstream_node).exists()
+
+        self._run()
+
+        upstream_node.refresh_from_db()
+        downstream_node.refresh_from_db()
+        assert upstream_node.dag.name == build_cohort_dag_name(DEFAULT_DAG_NAME, timedelta(hours=1))
+        assert downstream_node.dag.name == build_cohort_dag_name(DEFAULT_DAG_NAME, timedelta(hours=6))
+        # cross-cohort edge must be gone — orchestrator no longer ties cohorts together
+        assert not Edge.objects.filter(source=upstream_node, target=downstream_node).exists()
+
+    @_patch_temporal
+    def test_dry_run_makes_no_changes(self, _sc, _exists, mock_create, _del):
+        source_dag = DAG.get_or_create_default(self.team)
+        sq = self._make_saved_query("view_a", sync_frequency_interval=timedelta(hours=1))
+        node = self._seed_node(sq, source_dag)
+
+        call_command("migrate_teams_to_dag_schedules", "--team-ids", str(self.team.pk), "--dry-run")
+
+        node.refresh_from_db()
+        assert node.dag_id == source_dag.id
+        sq.refresh_from_db()
+        assert sq.sync_frequency_interval == timedelta(hours=1)
+        mock_create.assert_not_called()
+        assert not DAG.objects.filter(
+            team=self.team, name=build_cohort_dag_name(DEFAULT_DAG_NAME, timedelta(hours=1))
+        ).exists()
+
+
+@pytest.mark.django_db
+class TestSyncSavedQueryToDagFrequencyRouting(BaseTest):
+    """Behavior we added to sync_saved_query_to_dag: route by SQ.sync_frequency_interval."""
+
+    def test_unscheduled_saved_query_lands_in_default_dag(self):
+        sq = DataWarehouseSavedQuery.objects.create(
+            name="unscheduled",
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+        )
+
+        node = sync_saved_query_to_dag(sq)
+
+        assert node is not None
+        assert node.dag.name == DEFAULT_DAG_NAME
+        assert node.dag.sync_frequency_interval == timedelta(days=1)  # the DAG model default
+
+    @parameterized.expand(
+        [
+            (timedelta(minutes=15),),
+            (timedelta(hours=1),),
+            (timedelta(hours=6),),
+            (timedelta(days=1),),
+            (timedelta(days=7),),
+        ]
+    )
+    def test_scheduled_saved_query_lands_in_frequency_cohort_dag(self, interval):
+        sq = DataWarehouseSavedQuery.objects.create(
+            name=f"scheduled_{int(interval.total_seconds())}",
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+            sync_frequency_interval=interval,
+        )
+
+        node = sync_saved_query_to_dag(sq)
+
+        assert node is not None
+        expected_name = build_cohort_dag_name(DEFAULT_DAG_NAME, interval)
+        assert node.dag.name == expected_name
+        assert node.dag.sync_frequency_interval == interval
+
+    def test_explicit_dag_argument_overrides_routing(self):
+        explicit_dag = DAG.objects.create(team=self.team, name="explicit-target")
+        sq = DataWarehouseSavedQuery.objects.create(
+            name="ignores_routing",
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+            sync_frequency_interval=timedelta(hours=1),
+        )
+
+        node = sync_saved_query_to_dag(sq, dag=explicit_dag)
+
+        assert node is not None
+        assert node.dag_id == explicit_dag.id


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

we have moved into the stage where a dag can only have one sync frequency interval. but we are still creating only one default DAG per team.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

this would make the migration of a team with multiple sync frequencies look like the following

Default DAG - all unscheduled views
Default DAG 15min - all 15 min schedules
...
Default DAG 30d - all 30 day schedules
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

ran local and unit tests

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->

<!-- gg:stack-start -->
## gg stack

- **#59243 `andrew/multi-frequency-dag-migration` 👈 this PR**
<!-- gg:stack-end -->
