### PR TITLE
feat(billing): route enterprise add-on through sales

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4827,9 +4827,9 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.414326f685dca45885b93d728ae8a75c7d8b600af35d76c9512a74a27e453006.IyZ8qHUwOv6qsBYvdUR1ZsK1Md_GNFCftDGvNZj78BQ
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
-        hash: v1.k794b7964.c47bdb853ef9b6becfb675e2ca0bdbdb0c1b4385cf2442d50dd92752d90f7906.gaL7vRk-pWoOUkiPi-NGCd1W72x-M5l9jk5Qu-UcjwI
+        hash: v1.k794b7964.293297b83994468984576e5c15fa2cbbb2c4c0a7a8234959b9deba539efa383b.xupnP9sdcp25xPBOMzrhSHwtRpKPLKHaqLDBncapvQA
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
-        hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.dtIb8VK_HAoAvzi8YbVjGpt2Y8yONsVV7mEiD9DrclQ
+        hash: v1.k794b7964.c63132bb5b13cbe97938ebdb2e59e320ebc338bd12b2d3bfd6af81e56270650a.3gc3UBg-8GVo4HkNBH7UrogK2q1uh9pXPDjTdYGT8nc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:
         hash: v1.k794b7964.8887db0213a228a0f958496f8de814bd30d4735f99f8dcd886fbc9740a703afd.U7j0SBm9JuPzdVQVGChjxt-Iw1svrkRV06tAv9pg-mM
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--light:
@@ -5963,9 +5963,9 @@ snapshots:
     scenes-app-web-analytics--web-analytics-dashboard-loading--light:
         hash: v1.k794b7964.14c98d2be2e0a815929fe4571e09f268fb5e334c7317df6bfbc0530197843186.pU-pE_UnnowEjnHyJo2e4OhFMJB672Krvmo7jyBT2-M
     scenes-other-billing--billing--dark:
-        hash: v1.k794b7964.0fbd211a7ee299a4abb1afb6d3d1e0589eb349c82c59bd5997b16e434356ee18.HyWfDl8iMD41jnar9y2uxNCx2MJJ6DuHch0n18cCWBA
+        hash: v1.k794b7964.4915bd031af89b1ee6a155b5889fa7bd5754b8d0f1a6a94dc323229b540df234.gh3QiniHy0PGoZEERCN8SsJPx5gfQgTQeMYtkLUlFfE
     scenes-other-billing--billing--light:
-        hash: v1.k794b7964.ec333a1128280653920054bbfa7758909259b4ff6b80179ad465afc763a029bf.NneoMyLu4B49A0zcyNsQthEJxuswloZjIh8A-2JlKDQ
+        hash: v1.k794b7964.50ab945fccfc7839f092829b0c11d948d32743916a84b6692d2ff64f0802dc35.kUQ7v-S8ANgYS99Xyi4mLb0oYTlDa7zqQkEr8q-298w
     scenes-other-billing--billing-purchase-credits-modal--dark:
         hash: v1.k794b7964.dc9b77730db0685138240858a0c550db9765c172321e54304e9f297d0bd00adc.v7awXXbWH1-_a9mzHgVKs99YvwpmU6dHZQgLI_OW9k4
     scenes-other-billing--billing-purchase-credits-modal--light:
@@ -5975,9 +5975,9 @@ snapshots:
     scenes-other-billing--billing-unsubscribe-modal--light:
         hash: v1.k794b7964.b676dda14727516b10f340ebb626babaee98152329868ac8aa8c5a3a90ee26d1.MxyCnRf692V5gtPnmOsCTnxMCAAt__URa4rJQJENBZw
     scenes-other-billing--billing-with-credit-cta--dark:
-        hash: v1.k794b7964.53893ebd7f73563e2e83b32f6c0d819eca291be67e480af696f2d77ee71f113a.OcFNrsOVcSzBB0oBvAK-0_Yu1XeQmfQhtBNcY_s24_s
+        hash: v1.k794b7964.facbcfe5d375b41994873fcf6a7611c452c070363524076c811e32a3dd3de0b9.LORm3kYgtVjl8dlNp766_klLlyeiiMzOSkR7ac6CZxE
     scenes-other-billing--billing-with-credit-cta--light:
-        hash: v1.k794b7964.f4bcaf25e2cce65f109b1dcffdd98ee7e990a8d63f4142c8b46c84485247f120.VkO7gG_OVPe8LKTqjT8PhVZUm7kpjvO5JMbV7fwqolM
+        hash: v1.k794b7964.cdaa59ea0ee6daec15aad76bd42b17a0336557f928b8f60922a889afe5fd9078.v916EatJIuK_lqABP7bG_9OKEUn1hzrI3Bx2SmPZPlU
     scenes-other-billing--billing-with-credits--dark:
         hash: v1.k794b7964.457257072f4ee70056be2e1a4551fc098644ce363246c8ce4727a636d6231a06.RvIsfP2a2yPEOYspq28VMp3DZx-mY_nAbnb5OsRGHVU
     scenes-other-billing--billing-with-credits--light:
@@ -5991,29 +5991,29 @@ snapshots:
     scenes-other-billing--billing-with-limit-and-100-percent-discount--light:
         hash: v1.k794b7964.c60133947fb5ef34eaf37fa21bb0390bccff77b1b5fe49e01e9f5a7b239a7c04.oIDvDkc41HCJUBwamg0ahQQYn3NNsIX7cLFMOTjk4VE
     scenes-other-billing--billing-without-icon-keys--dark:
-        hash: v1.k794b7964.4374b8349aeb5ce08fadf66ecc0cde2cc5056eedc320baebf51809097ded6e52.6klYYV8rDqtNN1k6qBdXLtl3k9fohykw9SzD0D-xSuc
+        hash: v1.k794b7964.e0fcc55b627ad32f7291950fcf7a849e67abed7345069914cdacdaca5694bf84.KSOhHtIaxGpMfpAcweJxdqyZcx3g4odqrFPsNMeqmfY
     scenes-other-billing--billing-without-icon-keys--light:
-        hash: v1.k794b7964.0391c94a0f84dd417ee07c588a191aa2412d03aabb3c10966b9dbd7f5386bd99.PUyPkHTOACQB34E8e4CJU4hpcRfGwShmnj0Url8YIfo
+        hash: v1.k794b7964.2cb9ec40b586321cdf938f7b81ee9f8e02150b8ea22d210ad564fcc9943c89bf.4wnhJJr-IdlW6Zf93k3TxFlb3YXJaoEk4LpSM85kHqA
     scenes-other-billing-product--billing-product-inclusion-only-with-addon--dark:
-        hash: v1.k794b7964.64ccfd0de013c474a9ac6fa2706aa85ae741306312d5b5b5fb3045bff60b9901.BMvWfPso4WjTHMAmPD7zddxGstkpvZEL89vmOB5hcJg
+        hash: v1.k794b7964.f3987a2a3cb620a01d9d15bdc25382734ed26e4491e0d556931b79036aedb3b6.yeNhB6d3Ip7Xxc28hXCSsZx6fOPZI7EHQjU-f-5dn5I
     scenes-other-billing-product--billing-product-inclusion-only-with-addon--light:
-        hash: v1.k794b7964.b27a399bdb0861ce79f7d2b5fb3f86343789462f6a3ba862147c79eeca5b9b5a.OJngiZnIIx8jrT-MY_eK1zE7pI-J9DHil3nC4JCsmio
+        hash: v1.k794b7964.acaa8f4ed8cb5d6846cfa8bbb918aa691d452a5618a2f83c4ac1adc8e18f8755.b0IharphQq76FoKkETUjqAvNbsN1kYsrAUf1gtpBTSw
     scenes-other-billing-product--billing-product-platform-addons-on-legacy-teams--dark:
-        hash: v1.k794b7964.e922ba9818de410151d0b633554fd279e2711b42d03cd4f6d80ea4951127b279.qORTw7PIZtpP2bdTMZpebJ43oIi1YgKuSZfa8LQeiEY
+        hash: v1.k794b7964.9efe1a28355eaf77ffadb98c3abdcfd7193d18312e140d2d39d1e0d8c0829e8a.VKuvXT3II-350aVzYfnwvtnUQ28utVHVbeX3SA1bS5o
     scenes-other-billing-product--billing-product-platform-addons-on-legacy-teams--light:
-        hash: v1.k794b7964.9e7da6dcb6b7703cd0b344a1b5a234bf3e094ed955fc93dc9209a5ef739f38b6.7byC6-7Q1xlUUYFaSp2WMKgOL6gFS5zCC2YvkheSFCc
+        hash: v1.k794b7964.f8bd770834e4a0403daeaca137f656e4ba0355fda6e42f80039bd2555b96dc8f.8v5IG2YENZ2AwrJ_eF1dotJ6y5Qx4jrC9E6mOK2PUlw
     scenes-other-billing-product--billing-product-platform-addons-on-scale--dark:
-        hash: v1.k794b7964.646170e02093f0d750a126daec494440719c9c1aa1050f02c058c6b82fc3fb6e.ue7TJgQfvgh0ca9zBQW8PJbwZvsTcC7xph-AA50mfpk
+        hash: v1.k794b7964.44a68a6c75b765c2dbae2bf5d7597b2b9b95655cb475882e8ceded5815039c00.R_hJ9T6g5_HgjenXAxJ6WCnm6BzJauTfDsjCVjLi-Tw
     scenes-other-billing-product--billing-product-platform-addons-on-scale--light:
-        hash: v1.k794b7964.dec22348aae29dc20122b9a3091df25dbeb823b43fed0b6d75b1e840ca7b04b7.Wc2SDEOixDvWeDXWIs-Fm_d8UqIZq8kbzE2W4xqgUPg
+        hash: v1.k794b7964.00482255eba591196c0bb6d87f15de9a10c66e82e7ccca5a8b085c30964f14a5.scivrCHgVWLJJ9gNtJO5UowLuVOfL3JDntc8g8kFIqM
     scenes-other-billing-product--billing-product-platform-addons-trial-available--dark:
-        hash: v1.k794b7964.64ccfd0de013c474a9ac6fa2706aa85ae741306312d5b5b5fb3045bff60b9901.YjX5hkBczEhEk5yij5sJKh3OiO_XM9d0q7bnY83l1uM
+        hash: v1.k794b7964.f3987a2a3cb620a01d9d15bdc25382734ed26e4491e0d556931b79036aedb3b6.IzzOUHKpgdGNegpdKEq3YOzGo6oKwjTAvQm8zDnwH8A
     scenes-other-billing-product--billing-product-platform-addons-trial-available--light:
-        hash: v1.k794b7964.b27a399bdb0861ce79f7d2b5fb3f86343789462f6a3ba862147c79eeca5b9b5a.P0gZfwTACrxR5OwIrhsiF-EafmuFW53w_l84PVU8MOo
+        hash: v1.k794b7964.acaa8f4ed8cb5d6846cfa8bbb918aa691d452a5618a2f83c4ac1adc8e18f8755.PIma2mX1J74PNMlZUoc0C4Z7MKoW72CbI7nNWMBqCYg
     scenes-other-billing-product--billing-product-platform-addons-trial-used--dark:
-        hash: v1.k794b7964.c182e6e4a167c2c0b1a0509685313e4fef9544cc72ad6b2fc8baeae386938bd6.FlNMKKoDb8d11W1V7qssIpBbQlMK5ekEy8VgFJj7_Oo
+        hash: v1.k794b7964.9076b31e5209a171bfc996061ed04ccaf0150b27017f6b5d108f88a8a145c9f5.aQ40FCFUiGNFpHEKtzNw6gkX5u887Hr7PLu9fXOua94
     scenes-other-billing-product--billing-product-platform-addons-trial-used--light:
-        hash: v1.k794b7964.ec00e43af4951307e829dc14e7f4e9e126849dc2a4ef5f4f434cbb64122e57e8.QegssiorS1CNn5gM1woV2qdWh8XjjHBPeAbdZYuGGcg
+        hash: v1.k794b7964.420c0a4d31667f912684d75a211ab0e001f6fd401e45b4da125bbbaf02f77251.KwDNnvTIQQWeRUn8rdMwuL4CAeQIDyB7ncV-i-lXfUs
     scenes-other-billing-product--billing-product-temporarily-free--dark:
         hash: v1.k794b7964.793c583d893543c9f4ccd111450b803d1966cf2f2d89b9e5e4d34144c41fde7e.7u2bxJwsxrwUWutogyzX9FtdlGxd7mPZkYgglNhgsSs
     scenes-other-billing-product--billing-product-temporarily-free--light:

--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -271,6 +271,12 @@ export const BillingProductAddonActions = ({
     } else if (billing?.trial && billing?.trial?.target === addon.type) {
         // Current trial on this addon
         content = renderTrialActions()
+    } else if (addon.type === 'enterprise') {
+        content = (
+            <LemonButton type="primary" to="https://posthog.com/talk-to-a-human" targetBlank>
+                Contact us
+            </LemonButton>
+        )
     } else if (addon.contact_support) {
         content = (
             <LemonButton type="secondary" to="https://posthog.com/talk-to-a-human">

--- a/frontend/src/scenes/billing/PlatformAddonComparison.tsx
+++ b/frontend/src/scenes/billing/PlatformAddonComparison.tsx
@@ -151,7 +151,7 @@ const PlanCard = ({
                     </Link>
                 </div>
             )}
-            {pricedPlan?.flat_rate && (
+            {pricedPlan?.flat_rate && addon.type !== BillingPlan.Enterprise && (
                 <PlanPrice addon={addon} unit_amount_usd={pricedPlan.unit_amount_usd} unit_label={pricedPlan.unit} />
             )}
             <div className="-mt-2">

--- a/frontend/src/scenes/billing/PlatformAddonComparison.tsx
+++ b/frontend/src/scenes/billing/PlatformAddonComparison.tsx
@@ -154,7 +154,7 @@ const PlanCard = ({
             {pricedPlan?.flat_rate && addon.type !== BillingPlan.Enterprise && (
                 <PlanPrice addon={addon} unit_amount_usd={pricedPlan.unit_amount_usd} unit_label={pricedPlan.unit} />
             )}
-            <div className="-mt-2">
+            <div className="mt-auto">
                 <BillingProductAddonActions addon={addon} buttonSize="small" align="left" hidePricingNote />
             </div>
         </div>


### PR DESCRIPTION
## Problem

The billing settings page lets any customer self-serve subscribe to the **Enterprise** platform add-on at \$2,000/month with one click. Enterprise pricing should be a sales-led conversation — the self-serve path skips contract terms, SCIM/SSO rollout discussion, dedicated account management, and the rest of the things that make Enterprise actually Enterprise.

This change replaces the self-serve action on the Enterprise plan card with a **Contact us** button and hides the headline price. Boost and Scale remain fully self-serve.

## Changes

- `frontend/src/scenes/billing/BillingProductAddonActions.tsx` — new branch in the action decision tree: when `addon.type === 'enterprise'` and the user isn't already subscribed or on a trial for it, render a `LemonButton` linking to `https://posthog.com/talk-to-a-human` labeled "Contact us". This replaces both the self-serve "Add" button (`renderPurchaseActions`) and the "Upgrade" button (`renderUpgradeActions`) — so customers on Boost or Scale also hit the contact path when looking at Enterprise.
- `frontend/src/scenes/billing/PlatformAddonComparison.tsx` — added `addon.type !== BillingPlan.Enterprise` guard on the `<PlanPrice>` render so the \$2,000 headline price no longer shows on the Enterprise card.

Preserved behavior:
- Already-subscribed Enterprise customers still see the "Remove add-on" menu (unchanged).
- Customers on an Enterprise trial still see "Cancel trial" for autosubscribe trials; sales-managed trials remain action-less as before.
- The feature comparison table below the cards is untouched.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I ran:

- `npx tsc --noEmit` — no new TypeScript errors introduced; the only failures reported are pre-existing in `products/workflows/` and unrelated to this change.
- `oxlint` and `oxfmt` on both edited files — clean.
- The repo's lint-staged pre-commit hook (`bin/hogli format:js`) passed.

I did not run the dev server or click through the UI. Manual verification suggestions for the reviewer:
1. Visit `/organization/billing` on a free org → Enterprise card shows "Contact us" only, no \$2,000 label.
2. Same view as an org subscribed to Boost or Scale → Enterprise card shows "Contact us" instead of "Upgrade".
3. Same view as an org already subscribed to Enterprise → unchanged ("Remove add-on" in the kebab menu).
4. Click the new button → opens `https://posthog.com/talk-to-a-human` in a new tab.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Approach considered and rejected: flipping the existing `addon.contact_support` server flag to `true` for the Enterprise add-on. That would require a billing-service change and couples release timing; a frontend-only special-case keeps the change atomic and uses the same `posthog.com/talk-to-a-human` URL that the existing `contact_support` branch already uses, so URL surface area doesn't grow.

The decision-tree branch is intentionally placed after the trial-on-this-addon check and before the `contact_support` / purchase / upgrade branches, so trial-cancellation and already-subscribed paths remain intact.

Requires a human reviewer — do not self-merge.