### PR TITLE
fix(analytics-platform): disable INSERT quorum in local dev so lazy precompute does not hang

### DIFF
--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -28,7 +28,7 @@ from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.preaggregation.sql import DISTRIBUTED_PREAGGREGATION_RESULTS_TABLE
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.models.team import Team
-from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME, TEST
+from posthog.settings import DEBUG, HOGQL_INCREASED_MAX_EXECUTION_TIME, TEST
 from posthog.utils import relative_date_parse_with_delta_mapping
 
 from products.analytics_platform.backend.lazy_computation.computation_notifications import (
@@ -67,9 +67,10 @@ DEFAULT_CH_START_GRACE_PERIOD_SECONDS = 60  # 1 minute
 # Quorum for INSERT queries. "auto" = majority of replicas must acknowledge writes before
 # the INSERT returns. This ensures data is replicated before the subsequent SELECT reads it,
 # preventing stale reads from hitting a replica that hasn't received the data yet.
-# Disabled in tests to avoid quorum behavior (tests usually run against a single-node or simplified
-# ClickHouse setup and we want them to remain fast and deterministic).
-PREAGGREGATION_INSERT_QUORUM: str | int = 0 if TEST else "auto"
+# Disabled in tests AND local dev (DEBUG) — both run against a single-node ClickHouse
+# where `insert_quorum=auto` waits 600s for an acknowledgement that never comes (the local
+# replica writes immediately but ClickHouse still blocks on the quorum protocol).
+PREAGGREGATION_INSERT_QUORUM: str | int = 0 if TEST or DEBUG else "auto"
 
 
 def _get_insert_settings(team_id: int) -> dict:


### PR DESCRIPTION
## Problem

Local dev runs against a single-replica ClickHouse, but the lazy computation framework hardcodes `insert_quorum: \"auto\"` on every INSERT. On a single-node setup, ClickHouse writes immediately but still blocks on the quorum protocol — the INSERT then hits the 600s `max_execution_time` and dies with:

```
Code: 319. Unknown quorum status. The data was inserted in the local replica
  but we could not verify quorum. Reason: Timeout while waiting for quorum:
  Insertion status: Wrote 1 blocks and N rows on shard 0 replica 0
```

Every fresh lazy precompute request hangs for 10 minutes locally, fails, and falls through to the live path. Tests already had a special case for this (`PREAGGREGATION_INSERT_QUORUM = 0 if TEST else "auto"`), but `DEBUG` mode didn't.

## Changes

Extend the existing TEST exemption to also cover `DEBUG=True`. Prod (`DEBUG=False`, `TEST=False`) behavior is unchanged — `auto` still waits for majority quorum on multi-replica clusters.

## How did you test this code?

I'm an agent — no manual UI testing claimed.

- Locally: WebOverview lazy precompute request went from hanging 600s → completing in ~1.1s. INSERT succeeds with `usedLazyPrecompute=True` in the response. Surfaced while debugging [#59075](https://github.com/PostHog/posthog/pull/59075).
- `hogli test products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py` → 110 passed.

## Publish to changelog?

no

## 🤖 Agent context

Agent-authored. Found by following the chain "INSERT hangs" → log says "Unknown quorum status" → single-node CH can't satisfy quorum → existing exemption already exists for `TEST`, just needs to also apply to `DEBUG`. Same shape and justification as the original `TEST` guard.