### PR TITLE
fix(experiments): fix admin experiment migration tool for shared metrics.

### DIFF
--- a/posthog/admin/admins/experiment_admin.py
+++ b/posthog/admin/admins/experiment_admin.py
@@ -195,16 +195,22 @@ class ExperimentAdmin(admin.ModelAdmin):
             return redirect("admin:experiments_experiment_changelist")
 
         all_metrics = (obj.metrics or []) + (obj.metrics_secondary or [])
-        extra_context["show_migration"] = has_legacy_metric(all_metrics)
         extra_context["show_fix_properties"] = has_malformed_properties(all_metrics)
 
         # Get all related ExperimentSavedMetric objects
         shared_metrics = obj.saved_metrics.all()
         shared_metrics_status = []
+        has_legacy_shared_metric = False
+        has_unmigrated_legacy_shared_metric = False
         for metric in shared_metrics:
             kind = metric.query.get("kind") if metric.query else None
             is_legacy = kind in ("ExperimentFunnelsQuery", "ExperimentTrendsQuery")
-            migrated = bool(metric.metadata and "migrated_to" in metric.metadata)
+            if is_legacy:
+                has_legacy_shared_metric = True
+            migrated_to_id = metric.metadata.get("migrated_to") if metric.metadata else None
+            migrated = migrated_to_id is not None
+            if is_legacy and not migrated:
+                has_unmigrated_legacy_shared_metric = True
             shared_metrics_status.append(
                 {
                     "id": metric.id,
@@ -212,9 +218,15 @@ class ExperimentAdmin(admin.ModelAdmin):
                     "is_legacy": is_legacy,
                     "migrated": migrated,
                     "migrate_url": reverse("admin:experiments_experimentsavedmetric_change", args=[metric.id]),
+                    "migrated_to_id": migrated_to_id,
+                    "migrated_to_url": reverse("admin:experiments_experimentsavedmetric_change", args=[migrated_to_id])
+                    if migrated_to_id
+                    else None,
                 }
             )
         extra_context["shared_metrics_status"] = shared_metrics_status
+        extra_context["show_migration"] = has_legacy_metric(all_metrics) or has_legacy_shared_metric
+        extra_context["can_migrate"] = not has_unmigrated_legacy_shared_metric
 
         return super().change_view(request, object_id, form_url, extra_context=extra_context)
 

--- a/posthog/templates/admin/posthog/experiment/change_form.html
+++ b/posthog/templates/admin/posthog/experiment/change_form.html
@@ -11,30 +11,58 @@
             </a>
         </div>
     {% endif %}
-    {% if show_migration %}
-        {% if shared_metrics_status %}
-            <div class="submit-row" style="margin-top: 20px; padding: 10px; border-radius: 5px; border: 1px solid #f7a501; color: #f7a501; display: flex; align-items: center; gap: 10px;">
-                <ul style="margin: 10px 0;">
+    {% if shared_metrics_status %}
+        <div class="module" style="margin-top: 20px;">
+            <h2>Shared metrics</h2>
+            <table style="width: 100%;">
+                <thead>
+                    <tr>
+                        <th scope="col">Name</th>
+                        <th scope="col">Engine</th>
+                        <th scope="col">Migrated to</th>
+                    </tr>
+                </thead>
+                <tbody>
                 {% for metric in shared_metrics_status %}
-                    <li>
-                        <a href="{{ metric.migrate_url }}" target="_blank">{{ metric.name }}</a>
-                        {% if metric.is_legacy %}
-                            {% if metric.migrated %}
-                                <span style="color: green;">&#10003;</span>
+                    <tr class="{% cycle 'row1' 'row2' %}">
+                        <td><a href="{{ metric.migrate_url }}" target="_blank">{{ metric.name }}</a></td>
+                        <td>
+                            {% if metric.is_legacy %}
+                                <span style="padding: 2px 6px; border-radius: 3px; background-color: #f7a501; color: white; font-size: 11px;">Legacy</span>
                             {% else %}
-                                <span style="color: red;">&#10007;</span>
+                                <span style="color: #6c757d;">Current</span>
                             {% endif %}
-                        {% endif %}
-                    </li>
+                        </td>
+                        <td>
+                            {% if metric.is_legacy %}
+                                {% if metric.migrated %}
+                                    <a href="{{ metric.migrated_to_url }}" target="_blank">#{{ metric.migrated_to_id }}</a>
+                                {% else %}
+                                    <span style="color: #dc3545;">Not migrated</span>
+                                {% endif %}
+                            {% else %}
+                                &mdash;
+                            {% endif %}
+                        </td>
+                    </tr>
                 {% endfor %}
-                </ul>
-            </div>
-        {% endif %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+    {% if show_migration %}
         <div class="submit-row" style="margin-top: 20px; padding: 20px; border-radius: 5px; border: 1px solid #f7a501; color: #f7a501; display: flex; align-items: center; gap: 10px;">
-            <div class="info">This experiment uses the legacy engine and can be migrated.</div>
-            <a class="button" style="padding:10px 15px;" href="{% url 'admin:experiment_migrate' object_id=original.pk %}">
-                Migrate Experiment
-            </a>
+            {% if can_migrate %}
+                <div class="info">This experiment uses the legacy engine and can be migrated.</div>
+                <a class="button" style="padding:10px 15px;" href="{% url 'admin:experiment_migrate' object_id=original.pk %}">
+                    Migrate Experiment
+                </a>
+            {% else %}
+                <div class="info">This experiment cannot be migrated yet. Migrate all legacy shared metrics first.</div>
+                <span class="button" style="padding:10px 15px; opacity: 0.5; cursor: not-allowed;" aria-disabled="true">
+                    Migrate Experiment
+                </span>
+            {% endif %}
         </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

The Django admin panel migration tool wasn't allowing for the migration of experiments with only shared metrics.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

| new shared metrics panel |
| - |
| <img width="1302" height="263" alt="image" src="https://github.com/user-attachments/assets/a18b1309-6161-4b4d-932b-99582344a509" /> |

Added a shared metrics table for all experiments, which was a missing relationship, while extending checks for shared metrics.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/7c4a4281-201b-4ad7-a0e9-5413b597617d)

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
