### PR TITLE
feat(dashboards): add minimal view behind feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -263,6 +263,7 @@ export const FEATURE_FLAGS = {
     CUSTOMER_PROFILE_CONFIG_BUTTON: 'customer-profile-config-button', // owner: @arthurdedeus #team-customer-analytics
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
     DASHBOARD_LAYOUT_DISCARD_PROMPT: 'dashboard-layout-discard-prompt', // owner: @cory.s #team-analytics-platform
+    DASHBOARD_MINIMAL_VIEW: 'dashboard-minimal-view', // owner: #team-product-analytics
     DASHBOARD_QUICK_FILTERS_EXPERIMENT: 'dashboard-quick-filters-experiment', // owner: @vdekrijger #team-product-analytics multivariate=control,test
     DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT: 'dashboard-template-chooser-experiment', // owner: @mattp #team-analytics-platform multivariate=control,simple,new
     DATA_MODELING_BACKEND_V2: 'data-modeling-backend-v2', // owner: #team-data-modeling

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -263,7 +263,7 @@ export const FEATURE_FLAGS = {
     CUSTOMER_PROFILE_CONFIG_BUTTON: 'customer-profile-config-button', // owner: @arthurdedeus #team-customer-analytics
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
     DASHBOARD_LAYOUT_DISCARD_PROMPT: 'dashboard-layout-discard-prompt', // owner: @cory.s #team-analytics-platform
-    DASHBOARD_MINIMAL_VIEW: 'dashboard-minimal-view', // owner: #team-product-analytics
+    DASHBOARD_MINIMAL_VIEW: 'dashboard-minimal-view', // owner: @mattp #team-product-analytics
     DASHBOARD_QUICK_FILTERS_EXPERIMENT: 'dashboard-quick-filters-experiment', // owner: @vdekrijger #team-product-analytics multivariate=control,test
     DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT: 'dashboard-template-chooser-experiment', // owner: @mattp #team-analytics-platform multivariate=control,simple,new
     DATA_MODELING_BACKEND_V2: 'data-modeling-backend-v2', // owner: #team-data-modeling

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { NotFound } from 'lib/components/NotFound'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { cn } from 'lib/utils/css-classes'
@@ -77,8 +78,10 @@ function DashboardScene({ backTo }: { backTo?: { url: string; name: string } }):
         accessDeniedToDashboard,
         refreshAnalysisResult,
         analysisRating,
+        minimalViewEnabled,
     } = useValues(dashboardLogic)
     const { layoutZoom } = useValues(dashboardLogic)
+    const isMinimalViewActive = useFeatureFlag('DASHBOARD_MINIMAL_VIEW') && minimalViewEnabled
     const { currentTeamId } = useValues(teamLogic)
     const { reportDashboardViewed, abortAnyRunningQuery, setRefreshAnalysisResult, setAnalysisRating, setLayoutZoom } =
         useActions(dashboardLogic)
@@ -154,18 +157,20 @@ function DashboardScene({ backTo }: { backTo?: { url: string; name: string } }):
                         </LemonBanner>
                     )}
 
-                    <SceneStickyBar showBorderBottom={false} className="flex gap-2 space-y-0">
-                        <DashboardFilterBar backTo={backTo} />
-                        {dashboardMode === DashboardMode.Edit &&
-                            canEditDashboard &&
-                            [
-                                DashboardPlacement.Dashboard,
-                                DashboardPlacement.ProjectHomepage,
-                                DashboardPlacement.Builtin,
-                            ].includes(placement) && (
-                                <DashboardZoomControl layoutZoom={layoutZoom} setLayoutZoom={setLayoutZoom} />
-                            )}
-                    </SceneStickyBar>
+                    {!isMinimalViewActive && (
+                        <SceneStickyBar showBorderBottom={false} className="flex gap-2 space-y-0">
+                            <DashboardFilterBar backTo={backTo} />
+                            {dashboardMode === DashboardMode.Edit &&
+                                canEditDashboard &&
+                                [
+                                    DashboardPlacement.Dashboard,
+                                    DashboardPlacement.ProjectHomepage,
+                                    DashboardPlacement.Builtin,
+                                ].includes(placement) && (
+                                    <DashboardZoomControl layoutZoom={layoutZoom} setLayoutZoom={setLayoutZoom} />
+                                )}
+                        </SceneStickyBar>
+                    )}
 
                     <DashboardItems />
                 </div>

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -7,7 +7,6 @@ import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { NotFound } from 'lib/components/NotFound'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { cn } from 'lib/utils/css-classes'
@@ -78,10 +77,9 @@ function DashboardScene({ backTo }: { backTo?: { url: string; name: string } }):
         accessDeniedToDashboard,
         refreshAnalysisResult,
         analysisRating,
-        minimalViewEnabled,
+        shouldHideDashboardFilterBar,
     } = useValues(dashboardLogic)
     const { layoutZoom } = useValues(dashboardLogic)
-    const isMinimalViewActive = useFeatureFlag('DASHBOARD_MINIMAL_VIEW') && minimalViewEnabled
     const { currentTeamId } = useValues(teamLogic)
     const { reportDashboardViewed, abortAnyRunningQuery, setRefreshAnalysisResult, setAnalysisRating, setLayoutZoom } =
         useActions(dashboardLogic)
@@ -157,7 +155,7 @@ function DashboardScene({ backTo }: { backTo?: { url: string; name: string } }):
                         </LemonBanner>
                     )}
 
-                    {!isMinimalViewActive && (
+                    {!shouldHideDashboardFilterBar && (
                         <SceneStickyBar showBorderBottom={false} className="flex gap-2 space-y-0">
                             <DashboardFilterBar backTo={backTo} />
                             {dashboardMode === DashboardMode.Edit &&

--- a/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
@@ -3,7 +3,6 @@ import '@testing-library/jest-dom'
 import { cleanup, render } from '@testing-library/react'
 import { BindLogic } from 'kea'
 
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 
 import { useMocks } from '~/mocks/jest'
@@ -18,6 +17,21 @@ jest.mock('lib/components/FullScreen', () => ({
 }))
 jest.mock('scenes/max/MaxTool', () => ({
     MaxTool: ({ children }: any) => <>{children}</>,
+}))
+
+let dashboardMinimalViewFlagEnabled = false
+let sceneMenuBarFlagEnabled = false
+
+jest.mock('lib/hooks/useFeatureFlag', () => ({
+    useFeatureFlag: (flag: string) => {
+        if (flag === 'DASHBOARD_MINIMAL_VIEW') {
+            return dashboardMinimalViewFlagEnabled
+        }
+        if (flag === 'SCENE_MENU_BAR') {
+            return sceneMenuBarFlagEnabled
+        }
+        return false
+    },
 }))
 
 const MOCK_DASHBOARD: DashboardType<QueryBasedInsightModel> = {
@@ -65,7 +79,8 @@ describe('DashboardHeader', () => {
             },
         })
         initKeaTests()
-        featureFlagLogic.mount()
+        dashboardMinimalViewFlagEnabled = false
+        sceneMenuBarFlagEnabled = false
     })
 
     afterEach(() => {
@@ -75,11 +90,18 @@ describe('DashboardHeader', () => {
     function renderHeader(opts: {
         dashboard?: DashboardType<QueryBasedInsightModel>
         dashboardMode?: DashboardMode | null
+        minimalView?: boolean
     }): { logic: ReturnType<typeof dashboardLogic.build> } {
-        const { dashboard = MOCK_DASHBOARD, dashboardMode = null } = opts
+        const { dashboard = MOCK_DASHBOARD, dashboardMode = null, minimalView = false } = opts
 
         const logic = dashboardLogic({ id: dashboard.id, dashboard })
         logic.mount()
+
+        if (minimalView) {
+            dashboardMinimalViewFlagEnabled = true
+            sceneMenuBarFlagEnabled = true
+            logic.actions.setMinimalViewEnabled(true)
+        }
 
         if (dashboardMode) {
             logic.actions.setDashboardMode(dashboardMode, DashboardEventSource.Browser)
@@ -100,14 +122,33 @@ describe('DashboardHeader', () => {
             dashboardMode: null as DashboardMode | null,
             canEdit: true,
             visible: ['dashboard-share-button', 'dashboard-add-tile', 'dashboard-edit-mode-button'],
-            notVisible: ['dashboard-edit-mode-discard', 'dashboard-edit-mode-save'],
+            notVisible: ['dashboard-edit-mode-discard', 'dashboard-edit-mode-save', 'dashboard-menubar-minimal-view'],
+        },
+        {
+            scenario: 'Minimal view, can edit',
+            dashboardMode: null as DashboardMode | null,
+            canEdit: true,
+            minimalView: true,
+            visible: ['dashboard-menubar-view'],
+            notVisible: [
+                'dashboard-add-tile',
+                'dashboard-share-button',
+                'dashboard-edit-mode-button',
+                'dashboard-edit-mode-discard',
+                'dashboard-edit-mode-save',
+            ],
         },
         {
             scenario: 'View mode, cannot edit',
             dashboardMode: null as DashboardMode | null,
             canEdit: false,
-            visible: ['dashboard-share-button', 'dashboard-add-tile'],
-            notVisible: ['dashboard-edit-mode-discard', 'dashboard-edit-mode-save', 'dashboard-edit-mode-button'],
+            visible: ['dashboard-share-button'],
+            notVisible: [
+                'dashboard-edit-mode-discard',
+                'dashboard-edit-mode-save',
+                'dashboard-edit-mode-button',
+                'dashboard-add-tile',
+            ],
         },
         {
             scenario: 'Edit mode',
@@ -123,11 +164,11 @@ describe('DashboardHeader', () => {
             visible: ['dashboard-exit-presentation-mode'],
             notVisible: ['dashboard-share-button', 'dashboard-edit-mode-save'],
         },
-    ])('$scenario shows correct action buttons', ({ dashboardMode, canEdit, visible, notVisible }) => {
+    ])('$scenario shows correct action buttons', ({ dashboardMode, canEdit, minimalView, visible, notVisible }) => {
         const dashboard = makeDashboard({
             user_access_level: canEdit ? AccessControlLevel.Editor : AccessControlLevel.Viewer,
         })
-        const { logic } = renderHeader({ dashboard, dashboardMode })
+        const { logic } = renderHeader({ dashboard, dashboardMode, minimalView })
 
         for (const attr of visible) {
             expect(document.querySelector(`[data-attr="${attr}"]`)).toBeInTheDocument()

--- a/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
@@ -3,6 +3,8 @@ import '@testing-library/jest-dom'
 import { cleanup, render } from '@testing-library/react'
 import { BindLogic } from 'kea'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 
 import { useMocks } from '~/mocks/jest'
@@ -17,21 +19,6 @@ jest.mock('lib/components/FullScreen', () => ({
 }))
 jest.mock('scenes/max/MaxTool', () => ({
     MaxTool: ({ children }: any) => <>{children}</>,
-}))
-
-let dashboardMinimalViewFlagEnabled = false
-let sceneMenuBarFlagEnabled = false
-
-jest.mock('lib/hooks/useFeatureFlag', () => ({
-    useFeatureFlag: (flag: string) => {
-        if (flag === 'DASHBOARD_MINIMAL_VIEW') {
-            return dashboardMinimalViewFlagEnabled
-        }
-        if (flag === 'SCENE_MENU_BAR') {
-            return sceneMenuBarFlagEnabled
-        }
-        return false
-    },
 }))
 
 const MOCK_DASHBOARD: DashboardType<QueryBasedInsightModel> = {
@@ -63,6 +50,26 @@ function makeDashboard(overrides: Record<string, any> = {}): DashboardType<Query
     return { ...MOCK_DASHBOARD, ...overrides }
 }
 
+function setDashboardHeaderFeatureFlags({
+    minimalViewFlag = false,
+    sceneMenuBar = false,
+}: {
+    minimalViewFlag?: boolean
+    sceneMenuBar?: boolean
+}): void {
+    const flags: string[] = []
+    const variants: Record<string, boolean> = {}
+    if (sceneMenuBar) {
+        flags.push(FEATURE_FLAGS.SCENE_MENU_BAR)
+        variants[FEATURE_FLAGS.SCENE_MENU_BAR] = true
+    }
+    if (minimalViewFlag) {
+        flags.push(FEATURE_FLAGS.DASHBOARD_MINIMAL_VIEW)
+        variants[FEATURE_FLAGS.DASHBOARD_MINIMAL_VIEW] = true
+    }
+    featureFlagLogic.actions.setFeatureFlags(flags, variants)
+}
+
 beforeAll(() => {
     const root = document.createElement('div')
     root.id = 'root'
@@ -79,8 +86,8 @@ describe('DashboardHeader', () => {
             },
         })
         initKeaTests()
-        dashboardMinimalViewFlagEnabled = false
-        sceneMenuBarFlagEnabled = false
+        featureFlagLogic.mount()
+        setDashboardHeaderFeatureFlags({})
     })
 
     afterEach(() => {
@@ -90,16 +97,20 @@ describe('DashboardHeader', () => {
     function renderHeader(opts: {
         dashboard?: DashboardType<QueryBasedInsightModel>
         dashboardMode?: DashboardMode | null
+        minimalViewFlag?: boolean
         minimalView?: boolean
     }): { logic: ReturnType<typeof dashboardLogic.build> } {
-        const { dashboard = MOCK_DASHBOARD, dashboardMode = null, minimalView = false } = opts
+        const { dashboard = MOCK_DASHBOARD, dashboardMode = null, minimalViewFlag = false, minimalView = false } = opts
+
+        setDashboardHeaderFeatureFlags({
+            minimalViewFlag,
+            sceneMenuBar: minimalViewFlag,
+        })
 
         const logic = dashboardLogic({ id: dashboard.id, dashboard })
         logic.mount()
 
         if (minimalView) {
-            dashboardMinimalViewFlagEnabled = true
-            sceneMenuBarFlagEnabled = true
             logic.actions.setMinimalViewEnabled(true)
         }
 
@@ -125,9 +136,23 @@ describe('DashboardHeader', () => {
             notVisible: ['dashboard-edit-mode-discard', 'dashboard-edit-mode-save', 'dashboard-menubar-minimal-view'],
         },
         {
+            scenario: 'Minimal view flag on, toggle off',
+            dashboardMode: null as DashboardMode | null,
+            canEdit: true,
+            minimalViewFlag: true,
+            visible: [
+                'dashboard-menubar-view',
+                'dashboard-share-button',
+                'dashboard-add-tile',
+                'dashboard-edit-mode-button',
+            ],
+            notVisible: ['dashboard-edit-mode-discard', 'dashboard-edit-mode-save', 'dashboard-menubar-minimal-view'],
+        },
+        {
             scenario: 'Minimal view, can edit',
             dashboardMode: null as DashboardMode | null,
             canEdit: true,
+            minimalViewFlag: true,
             minimalView: true,
             visible: ['dashboard-menubar-view'],
             notVisible: [
@@ -142,13 +167,8 @@ describe('DashboardHeader', () => {
             scenario: 'View mode, cannot edit',
             dashboardMode: null as DashboardMode | null,
             canEdit: false,
-            visible: ['dashboard-share-button'],
-            notVisible: [
-                'dashboard-edit-mode-discard',
-                'dashboard-edit-mode-save',
-                'dashboard-edit-mode-button',
-                'dashboard-add-tile',
-            ],
+            visible: ['dashboard-share-button', 'dashboard-add-tile'],
+            notVisible: ['dashboard-edit-mode-discard', 'dashboard-edit-mode-save', 'dashboard-edit-mode-button'],
         },
         {
             scenario: 'Edit mode',
@@ -164,19 +184,22 @@ describe('DashboardHeader', () => {
             visible: ['dashboard-exit-presentation-mode'],
             notVisible: ['dashboard-share-button', 'dashboard-edit-mode-save'],
         },
-    ])('$scenario shows correct action buttons', ({ dashboardMode, canEdit, minimalView, visible, notVisible }) => {
-        const dashboard = makeDashboard({
-            user_access_level: canEdit ? AccessControlLevel.Editor : AccessControlLevel.Viewer,
-        })
-        const { logic } = renderHeader({ dashboard, dashboardMode, minimalView })
+    ])(
+        '$scenario shows correct action buttons',
+        ({ dashboardMode, canEdit, minimalViewFlag, minimalView, visible, notVisible }) => {
+            const dashboard = makeDashboard({
+                user_access_level: canEdit ? AccessControlLevel.Editor : AccessControlLevel.Viewer,
+            })
+            const { logic } = renderHeader({ dashboard, dashboardMode, minimalViewFlag, minimalView })
 
-        for (const attr of visible) {
-            expect(document.querySelector(`[data-attr="${attr}"]`)).toBeInTheDocument()
-        }
-        for (const attr of notVisible) {
-            expect(document.querySelector(`[data-attr="${attr}"]`)).not.toBeInTheDocument()
-        }
+            for (const attr of visible) {
+                expect(document.querySelector(`[data-attr="${attr}"]`)).toBeInTheDocument()
+            }
+            for (const attr of notVisible) {
+                expect(document.querySelector(`[data-attr="${attr}"]`)).not.toBeInTheDocument()
+            }
 
-        logic.unmount()
-    })
+            logic.unmount()
+        }
+    )
 })

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -1,7 +1,6 @@
 import { useActions, useValues } from 'kea'
 
 import { FullScreen } from 'lib/components/FullScreen'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
@@ -21,11 +20,10 @@ export const DASHBOARD_CANNOT_EDIT_MESSAGE =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."
 
 export function DashboardHeader(): JSX.Element | null {
-    const { dashboard, dashboardLoading, dashboardMode, canEditDashboard, minimalViewEnabled } =
+    const { dashboard, dashboardLoading, dashboardMode, canEditDashboard, isMinimalViewActive } =
         useValues(dashboardLogic)
     const { setDashboardMode, loadDashboard } = useActions(dashboardLogic)
     const { updateDashboard } = useActions(dashboardsModel)
-    const isMinimalViewActive = useFeatureFlag('DASHBOARD_MINIMAL_VIEW') && minimalViewEnabled
 
     if (!dashboard && !dashboardLoading) {
         return null

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -1,6 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { FullScreen } from 'lib/components/FullScreen'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
@@ -20,9 +21,11 @@ export const DASHBOARD_CANNOT_EDIT_MESSAGE =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."
 
 export function DashboardHeader(): JSX.Element | null {
-    const { dashboard, dashboardLoading, dashboardMode, canEditDashboard } = useValues(dashboardLogic)
+    const { dashboard, dashboardLoading, dashboardMode, canEditDashboard, minimalViewEnabled } =
+        useValues(dashboardLogic)
     const { setDashboardMode, loadDashboard } = useActions(dashboardLogic)
     const { updateDashboard } = useActions(dashboardsModel)
+    const isMinimalViewActive = useFeatureFlag('DASHBOARD_MINIMAL_VIEW') && minimalViewEnabled
 
     if (!dashboard && !dashboardLoading) {
         return null
@@ -41,7 +44,7 @@ export function DashboardHeader(): JSX.Element | null {
 
             <SceneTitleSection
                 name={dashboard?.name}
-                description={dashboard?.description}
+                description={isMinimalViewActive ? null : dashboard?.description}
                 resourceType={{
                     type: sceneConfigurations[Scene.Dashboard].iconType || 'default_icon_type',
                 }}

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -6,6 +6,7 @@ import { IconGridMasonry, IconPlusSmall, IconShare } from '@posthog/icons'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
@@ -90,8 +91,10 @@ export function FullscreenModeActions(): JSX.Element {
 }
 
 export function ViewModeActions(): JSX.Element {
-    const { dashboard, canEditDashboard, tiles } = useValues(dashboardLogic)
+    const { dashboard, canEditDashboard, tiles, minimalViewEnabled } = useValues(dashboardLogic)
     const { setDashboardMode, loadDashboard } = useActions(dashboardLogic)
+    const isMinimalViewFeatureEnabled = useFeatureFlag('DASHBOARD_MINIMAL_VIEW')
+    const isMinimalViewActive = isMinimalViewFeatureEnabled && minimalViewEnabled
     const { showAddInsightToDashboardModal } = useActions(addInsightToDashboardLogic)
     const { push } = useActions(router)
     if (!dashboard) {
@@ -100,92 +103,102 @@ export function ViewModeActions(): JSX.Element {
 
     return (
         <>
-            <LemonButton
-                type="secondary"
-                data-attr="dashboard-share-button"
-                onClick={() => push(urls.dashboardSharing(dashboard.id))}
-                size="small"
-                icon={<IconShare fontSize="16" />}
-                disabledReason={tiles.length === 0 ? 'Add at least one tile before sharing this dashboard' : undefined}
-            >
-                Share
-            </LemonButton>
-            {canEditDashboard && (
-                <AppShortcut
-                    name="EnterEditMode"
-                    scope={Scene.Dashboard}
-                    keybind={[keyBinds.edit]}
-                    intent="Enter edit mode"
-                    interaction="click"
-                    disabled={tiles.length === 0}
-                >
+            {!isMinimalViewActive && (
+                <>
                     <LemonButton
                         type="secondary"
-                        data-attr="dashboard-edit-mode-button"
-                        onClick={() => setDashboardMode(DashboardMode.Edit, DashboardEventSource.SceneCommonButtons)}
+                        data-attr="dashboard-share-button"
+                        onClick={() => push(urls.dashboardSharing(dashboard.id))}
                         size="small"
-                        icon={<IconGridMasonry fontSize="16" />}
-                        tooltip="Edit layout"
-                        tooltipPlacement="top"
-                        disabledReason={tiles.length === 0 ? 'Add at least one tile to edit layout' : undefined}
+                        icon={<IconShare fontSize="16" />}
+                        disabledReason={
+                            tiles.length === 0 ? 'Add at least one tile before sharing this dashboard' : undefined
+                        }
                     >
-                        Edit layout
+                        Share
                     </LemonButton>
-                </AppShortcut>
-            )}
-            <MaxTool
-                identifier="upsert_dashboard"
-                context={{
-                    current_dashboard: {
-                        id: dashboard.id,
-                        name: dashboard.name,
-                        description: dashboard.description,
-                        tags: dashboard.tags,
-                    },
-                }}
-                contextDescription={{
-                    text: dashboard.name,
-                    icon: iconForType('dashboard'),
-                }}
-                active={false}
-                callback={() => loadDashboard({ action: DashboardLoadAction.Update })}
-                position="top-right"
-            >
-                <AccessControlAction
-                    resourceType={AccessControlResourceType.Dashboard}
-                    minAccessLevel={AccessControlLevel.Editor}
-                    userAccessLevel={dashboard.user_access_level}
-                >
-                    <LemonMenu
-                        items={[
-                            {
-                                label: 'Insight',
-                                onClick: showAddInsightToDashboardModal,
-                                'data-attr': 'dashboard-add-insight',
-                            },
-                            {
-                                label: 'Text card',
-                                onClick: () => push(urls.dashboardTextTile(dashboard.id, 'new')),
-                                'data-attr': 'dashboard-add-text-tile',
-                            },
-                            {
-                                label: 'Button',
-                                onClick: () => push(urls.dashboardButtonTile(dashboard.id, 'new')),
-                                'data-attr': 'dashboard-add-button-tile',
-                            },
-                        ]}
-                    >
-                        <LemonButton
-                            type="primary"
-                            data-attr="dashboard-add-tile"
-                            size="small"
-                            icon={<IconPlusSmall />}
+                    {canEditDashboard && (
+                        <AppShortcut
+                            name="EnterEditMode"
+                            scope={Scene.Dashboard}
+                            keybind={[keyBinds.edit]}
+                            intent="Enter edit mode"
+                            interaction="click"
+                            disabled={tiles.length === 0}
                         >
-                            Add
-                        </LemonButton>
-                    </LemonMenu>
-                </AccessControlAction>
-            </MaxTool>
+                            <LemonButton
+                                type="secondary"
+                                data-attr="dashboard-edit-mode-button"
+                                onClick={() =>
+                                    setDashboardMode(DashboardMode.Edit, DashboardEventSource.SceneCommonButtons)
+                                }
+                                size="small"
+                                icon={<IconGridMasonry fontSize="16" />}
+                                tooltip="Edit layout"
+                                tooltipPlacement="top"
+                                disabledReason={tiles.length === 0 ? 'Add at least one tile to edit layout' : undefined}
+                            >
+                                Edit layout
+                            </LemonButton>
+                        </AppShortcut>
+                    )}
+                    {canEditDashboard && (
+                        <MaxTool
+                            identifier="upsert_dashboard"
+                            context={{
+                                current_dashboard: {
+                                    id: dashboard.id,
+                                    name: dashboard.name,
+                                    description: dashboard.description,
+                                    tags: dashboard.tags,
+                                },
+                            }}
+                            contextDescription={{
+                                text: dashboard.name,
+                                icon: iconForType('dashboard'),
+                            }}
+                            active={false}
+                            callback={() => loadDashboard({ action: DashboardLoadAction.Update })}
+                            position="top-right"
+                        >
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.Dashboard}
+                                minAccessLevel={AccessControlLevel.Editor}
+                                userAccessLevel={dashboard.user_access_level}
+                            >
+                                <LemonMenu
+                                    items={[
+                                        {
+                                            label: 'Insight',
+                                            onClick: showAddInsightToDashboardModal,
+                                            'data-attr': 'dashboard-add-insight',
+                                        },
+                                        {
+                                            label: 'Text card',
+                                            onClick: () => push(urls.dashboardTextTile(dashboard.id, 'new')),
+                                            'data-attr': 'dashboard-add-text-tile',
+                                        },
+                                        {
+                                            label: 'Button',
+                                            onClick: () => push(urls.dashboardButtonTile(dashboard.id, 'new')),
+                                            'data-attr': 'dashboard-add-button-tile',
+                                        },
+                                    ]}
+                                >
+                                    <LemonButton
+                                        type="primary"
+                                        data-attr="dashboard-add-tile"
+                                        size="small"
+                                        icon={<IconPlusSmall />}
+                                    >
+                                        Add
+                                    </LemonButton>
+                                </LemonMenu>
+                            </AccessControlAction>
+                        </MaxTool>
+                    )}
+                </>
+            )}
         </>
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -6,7 +6,6 @@ import { IconGridMasonry, IconPlusSmall, IconShare } from '@posthog/icons'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
@@ -91,10 +90,8 @@ export function FullscreenModeActions(): JSX.Element {
 }
 
 export function ViewModeActions(): JSX.Element {
-    const { dashboard, canEditDashboard, tiles, minimalViewEnabled } = useValues(dashboardLogic)
+    const { dashboard, canEditDashboard, tiles, isMinimalViewActive } = useValues(dashboardLogic)
     const { setDashboardMode, loadDashboard } = useActions(dashboardLogic)
-    const isMinimalViewFeatureEnabled = useFeatureFlag('DASHBOARD_MINIMAL_VIEW')
-    const isMinimalViewActive = isMinimalViewFeatureEnabled && minimalViewEnabled
     const { showAddInsightToDashboardModal } = useActions(addInsightToDashboardLogic)
     const { push } = useActions(router)
     if (!dashboard) {
@@ -142,61 +139,59 @@ export function ViewModeActions(): JSX.Element {
                             </LemonButton>
                         </AppShortcut>
                     )}
-                    {canEditDashboard && (
-                        <MaxTool
-                            identifier="upsert_dashboard"
-                            context={{
-                                current_dashboard: {
-                                    id: dashboard.id,
-                                    name: dashboard.name,
-                                    description: dashboard.description,
-                                    tags: dashboard.tags,
-                                },
-                            }}
-                            contextDescription={{
-                                text: dashboard.name,
-                                icon: iconForType('dashboard'),
-                            }}
-                            active={false}
-                            callback={() => loadDashboard({ action: DashboardLoadAction.Update })}
-                            position="top-right"
+                    <MaxTool
+                        identifier="upsert_dashboard"
+                        context={{
+                            current_dashboard: {
+                                id: dashboard.id,
+                                name: dashboard.name,
+                                description: dashboard.description,
+                                tags: dashboard.tags,
+                            },
+                        }}
+                        contextDescription={{
+                            text: dashboard.name,
+                            icon: iconForType('dashboard'),
+                        }}
+                        active={false}
+                        callback={() => loadDashboard({ action: DashboardLoadAction.Update })}
+                        position="top-right"
+                    >
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.Dashboard}
+                            minAccessLevel={AccessControlLevel.Editor}
+                            userAccessLevel={dashboard.user_access_level}
                         >
-                            <AccessControlAction
-                                resourceType={AccessControlResourceType.Dashboard}
-                                minAccessLevel={AccessControlLevel.Editor}
-                                userAccessLevel={dashboard.user_access_level}
+                            <LemonMenu
+                                items={[
+                                    {
+                                        label: 'Insight',
+                                        onClick: showAddInsightToDashboardModal,
+                                        'data-attr': 'dashboard-add-insight',
+                                    },
+                                    {
+                                        label: 'Text card',
+                                        onClick: () => push(urls.dashboardTextTile(dashboard.id, 'new')),
+                                        'data-attr': 'dashboard-add-text-tile',
+                                    },
+                                    {
+                                        label: 'Button',
+                                        onClick: () => push(urls.dashboardButtonTile(dashboard.id, 'new')),
+                                        'data-attr': 'dashboard-add-button-tile',
+                                    },
+                                ]}
                             >
-                                <LemonMenu
-                                    items={[
-                                        {
-                                            label: 'Insight',
-                                            onClick: showAddInsightToDashboardModal,
-                                            'data-attr': 'dashboard-add-insight',
-                                        },
-                                        {
-                                            label: 'Text card',
-                                            onClick: () => push(urls.dashboardTextTile(dashboard.id, 'new')),
-                                            'data-attr': 'dashboard-add-text-tile',
-                                        },
-                                        {
-                                            label: 'Button',
-                                            onClick: () => push(urls.dashboardButtonTile(dashboard.id, 'new')),
-                                            'data-attr': 'dashboard-add-button-tile',
-                                        },
-                                    ]}
+                                <LemonButton
+                                    type="primary"
+                                    data-attr="dashboard-add-tile"
+                                    size="small"
+                                    icon={<IconPlusSmall />}
                                 >
-                                    <LemonButton
-                                        type="primary"
-                                        data-attr="dashboard-add-tile"
-                                        size="small"
-                                        icon={<IconPlusSmall />}
-                                    >
-                                        Add
-                                    </LemonButton>
-                                </LemonMenu>
-                            </AccessControlAction>
-                        </MaxTool>
-                    )}
+                                    Add
+                                </LemonButton>
+                            </LemonMenu>
+                        </AccessControlAction>
+                    </MaxTool>
                 </>
             )}
         </>

--- a/frontend/src/scenes/dashboard/DashboardSceneMenuBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSceneMenuBar.tsx
@@ -130,7 +130,7 @@ function DashboardSceneMenuBarInner(): JSX.Element | null {
     const showCreateMenu = canEditDashboard // notebook + subscribe both gated on canEdit
     const showEditMenu = true // duplicate always
     const showFileMenu = true
-    const showViewMenu = isMinimalViewFeatureEnabled
+    const showViewMenu = true
     const showMetadataMenu = true
 
     return (
@@ -308,6 +308,19 @@ function DashboardSceneMenuBarInner(): JSX.Element | null {
                     >
                         Pinned
                     </SceneMenuBarCheckboxItem>
+                </SceneMenuBarMenu>
+            )}
+            {showViewMenu && (
+                <SceneMenuBarMenu label="View" dataAttr={`${RESOURCE_TYPE}-menubar-view`}>
+                    {isMinimalViewFeatureEnabled && (
+                        <SceneMenuBarCheckboxItem
+                            checked={minimalViewEnabled}
+                            onCheckedChange={(checked) => setMinimalViewEnabled(checked)}
+                            data-attr={`${RESOURCE_TYPE}-menubar-minimal-view`}
+                        >
+                            Minimal view
+                        </SceneMenuBarCheckboxItem>
+                    )}
                     <SceneMenuBarCheckboxItem
                         checked={dashboardMode === DashboardMode.Fullscreen}
                         onCheckedChange={(checked) => {
@@ -319,17 +332,6 @@ function DashboardSceneMenuBarInner(): JSX.Element | null {
                         data-attr={`${RESOURCE_TYPE}-menubar-fullscreen`}
                     >
                         Fullscreen
-                    </SceneMenuBarCheckboxItem>
-                </SceneMenuBarMenu>
-            )}
-            {showViewMenu && (
-                <SceneMenuBarMenu label="View" dataAttr={`${RESOURCE_TYPE}-menubar-view`}>
-                    <SceneMenuBarCheckboxItem
-                        checked={minimalViewEnabled}
-                        onCheckedChange={(checked) => setMinimalViewEnabled(checked)}
-                        data-attr={`${RESOURCE_TYPE}-menubar-minimal-view`}
-                    >
-                        Minimal view
                     </SceneMenuBarCheckboxItem>
                 </SceneMenuBarMenu>
             )}

--- a/frontend/src/scenes/dashboard/DashboardSceneMenuBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSceneMenuBar.tsx
@@ -23,6 +23,7 @@ import { SceneTagsCombobox } from 'lib/components/Scenes/SceneTagsCombobox'
 import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
 import { urlForSubscriptions } from 'lib/components/Subscriptions/utils'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { slugify } from 'lib/utils'
 import { getAccessControlDisabledReason, userHasAccess } from 'lib/utils/accessControlUtils'
@@ -56,8 +57,8 @@ import { dashboardTemplateModalLogic } from './dashboards/templates/dashboardTem
 const RESOURCE_TYPE = 'dashboard'
 
 export function DashboardSceneMenuBar(): JSX.Element | null {
-    const { featureFlags } = useValues(featureFlagLogic)
-    if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
+    const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
+    if (!sceneMenuBarEnabled) {
         return null
     }
     return <DashboardSceneMenuBarInner />
@@ -76,8 +77,11 @@ function DashboardSceneMenuBarInner(): JSX.Element | null {
         effectiveDashboardVariableOverrides,
         tiles,
         apiUrl,
+        minimalViewEnabled,
     } = useValues(dashboardLogic)
-    const { setDashboardMode, updateDashboardTags, togglePinned, setTerraformModalOpen } = useActions(dashboardLogic)
+    const { setDashboardMode, updateDashboardTags, togglePinned, setTerraformModalOpen, setMinimalViewEnabled } =
+        useActions(dashboardLogic)
+    const isMinimalViewFeatureEnabled = useFeatureFlag('DASHBOARD_MINIMAL_VIEW')
     const { startExport } = useActions(exportsLogic)
     const { createNotebookFromDashboard } = useActions(notebooksModel)
     const { showInsightColorsModal } = useActions(dashboardInsightColorsModalLogic)
@@ -127,6 +131,7 @@ function DashboardSceneMenuBarInner(): JSX.Element | null {
     const showCreateMenu = canEditDashboard // notebook + subscribe both gated on canEdit
     const showEditMenu = true // duplicate always
     const showFileMenu = true
+    const showViewMenu = isMinimalViewFeatureEnabled
     const showMetadataMenu = true
 
     return (
@@ -315,6 +320,17 @@ function DashboardSceneMenuBarInner(): JSX.Element | null {
                         data-attr={`${RESOURCE_TYPE}-menubar-fullscreen`}
                     >
                         Fullscreen
+                    </SceneMenuBarCheckboxItem>
+                </SceneMenuBarMenu>
+            )}
+            {showViewMenu && (
+                <SceneMenuBarMenu label="View" dataAttr={`${RESOURCE_TYPE}-menubar-view`}>
+                    <SceneMenuBarCheckboxItem
+                        checked={minimalViewEnabled}
+                        onCheckedChange={(checked) => setMinimalViewEnabled(checked)}
+                        data-attr={`${RESOURCE_TYPE}-menubar-minimal-view`}
+                    >
+                        Minimal view
                     </SceneMenuBarCheckboxItem>
                 </SceneMenuBarMenu>
             )}

--- a/frontend/src/scenes/dashboard/DashboardSceneMenuBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSceneMenuBar.tsx
@@ -23,7 +23,6 @@ import { SceneTagsCombobox } from 'lib/components/Scenes/SceneTagsCombobox'
 import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
 import { urlForSubscriptions } from 'lib/components/Subscriptions/utils'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { slugify } from 'lib/utils'
 import { getAccessControlDisabledReason, userHasAccess } from 'lib/utils/accessControlUtils'
@@ -57,8 +56,8 @@ import { dashboardTemplateModalLogic } from './dashboards/templates/dashboardTem
 const RESOURCE_TYPE = 'dashboard'
 
 export function DashboardSceneMenuBar(): JSX.Element | null {
-    const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
-    if (!sceneMenuBarEnabled) {
+    const { featureFlags } = useValues(featureFlagLogic)
+    if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
         return null
     }
     return <DashboardSceneMenuBarInner />
@@ -78,10 +77,10 @@ function DashboardSceneMenuBarInner(): JSX.Element | null {
         tiles,
         apiUrl,
         minimalViewEnabled,
+        isMinimalViewFeatureEnabled,
     } = useValues(dashboardLogic)
     const { setDashboardMode, updateDashboardTags, togglePinned, setTerraformModalOpen, setMinimalViewEnabled } =
         useActions(dashboardLogic)
-    const isMinimalViewFeatureEnabled = useFeatureFlag('DASHBOARD_MINIMAL_VIEW')
     const { startExport } = useActions(exportsLogic)
     const { createNotebookFromDashboard } = useActions(notebooksModel)
     const { showInsightColorsModal } = useActions(dashboardInsightColorsModalLogic)

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1161,6 +1161,20 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return hasFeatureFlag && hasSSESupport
             },
         ],
+        isMinimalViewFeatureEnabled: [
+            (s) => [s.featureFlags],
+            (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.DASHBOARD_MINIMAL_VIEW],
+        ],
+        isMinimalViewActive: [
+            (s) => [s.isMinimalViewFeatureEnabled, s.minimalViewEnabled],
+            (isMinimalViewFeatureEnabled, minimalViewEnabled): boolean =>
+                isMinimalViewFeatureEnabled && minimalViewEnabled,
+        ],
+        shouldHideDashboardFilterBar: [
+            (s) => [s.isMinimalViewActive, s.placement],
+            (isMinimalViewActive, placement): boolean =>
+                isMinimalViewActive && placement === DashboardPlacement.Dashboard,
+        ],
         canAutoPreview: [
             (s) => [s.dashboard],
             (dashboard) => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -249,6 +249,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
          **/
         setAutoRefresh: (enabled: boolean, interval: number) => ({ enabled, interval }),
         resetInterval: true,
+        setMinimalViewEnabled: (enabled: boolean) => ({ enabled }),
 
         /*
          * Dashboard filters & variables.
@@ -964,6 +965,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
             { persist: true, prefix: '2_' },
             {
                 setAutoRefresh: (_, { enabled, interval }) => ({ enabled, interval }),
+            },
+        ],
+        minimalViewEnabled: [
+            false,
+            { persist: true },
+            {
+                setMinimalViewEnabled: (_, { enabled }) => enabled,
             },
         ],
         shouldReportOnAPILoad: [


### PR DESCRIPTION
## Problem

Dashboard power users want a cleaner presentation mode that hides chrome (filters, header actions) without leaving the dashboard scene. This should ship behind a feature flag with a per-user toggle so rollout is controlled.

## Changes

- Add `DASHBOARD_MINIMAL_VIEW` (`dashboard-minimal-view`) and a persisted per-dashboard `minimalViewEnabled` toggle in the scene menu bar **View** menu
- When minimal view is active on the main dashboard placement: hide filter sticky bar, share/edit/add header actions, and dashboard description in the title section
- Centralize `isMinimalViewActive` / `shouldHideDashboardFilterBar` in `dashboardLogic` selectors (flag + toggle, placement-scoped filter bar hide)
- Move **Fullscreen** from Edit → View; View menu always visible when scene menu bar is on, minimal view checkbox only when flag is enrolled
- Restore Add tile `AccessControlAction` behavior for viewers (disabled + tooltip, not hidden)
- Expand `DashboardHeader` tests for flag-on/toggle-off and menubar visibility

## How did you test this code?

Agent-assisted PR. Automated: `hogli test frontend/src/scenes/dashboard/DashboardHeader.test.tsx` (6 tests passed).

## Publish to changelog?

no

## Docs update

No docs update — gated behind `dashboard-minimal-view` feature flag.

## 🤖 Agent context

- Cursor agent implemented the minimal view UI and follow-up review fixes on branch `mattp/minimial-dashboard`
- Chose two-stage gating: feature flag exposes the View menu item; user toggle controls behavior; preference persisted per dashboard id in localStorage
- Scoped filter bar hiding to `DashboardPlacement.Dashboard` so embedded/homepage placements keep filters when the same dashboard id is reused
- Moved fullscreen under View so presentation controls live together; fullscreen still emits existing `dashboard mode toggled` with `scene_common_buttons`
- Minimal view toggle has no dedicated product analytics event yet (only fullscreen/pin use existing dashboard events)


Made with [Cursor](https://cursor.com)