### PR TITLE
fix(dashboard): scope selectednode styles to editable cards

### DIFF
--- a/frontend/src/lib/components/MarkdownEditor/shared/RichMarkdownEditor.scss
+++ b/frontend/src/lib/components/MarkdownEditor/shared/RichMarkdownEditor.scss
@@ -137,20 +137,20 @@
             border-top: 1px solid var(--color-border-primary);
         }
 
-        hr.ProseMirror-selectednode {
-            outline: 2px solid var(--color-accent);
-            outline-offset: 2px;
-        }
-
         img {
             display: block;
             max-width: 100%;
             height: auto;
             margin: 0.75rem 0;
+        }
 
-            &.ProseMirror-selectednode {
-                outline: 2px solid var(--color-accent);
-            }
+        &[contenteditable='true'] hr.ProseMirror-selectednode {
+            outline: 2px solid var(--color-accent);
+            outline-offset: 2px;
+        }
+
+        &[contenteditable='true'] img.ProseMirror-selectednode {
+            outline: 2px solid var(--color-accent);
         }
 
         [data-resize-container][data-node='image'] {


### PR DESCRIPTION
## Problem

Text card content can include image nodes that keep a `ProseMirror-selectednode` class from editor state.
Because selection styles were not restricted to editable contexts, readonly dashboard text cards could show an unintended red outline.

Closes #59036

## Changes

- Scoped `ProseMirror-selectednode` outline styles in `RichMarkdownEditor.scss` to editable editors only (`.ProseMirror[contenteditable='true']`).
- Kept readonly/rendered text card content unaffected, so dashboard cards no longer show the editor selection border.

## How did you test this code?

- Locally.
- Change is CSS-only and limited to selector scoping.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

Implemented with PostHog Code agent tooling in this session.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*