### PR TITLE
chore(hogli): adopt implicit namespace packages for backend subdirs

### DIFF
--- a/tools/hogli-commands/hogli_commands/product/checks.py
+++ b/tools/hogli-commands/hogli_commands/product/checks.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from .paths import TACH_TOML, get_tach_block
-from .scaffold import flatten_structure
 
 # ---------------------------------------------------------------------------
 # Utilities
@@ -531,17 +530,17 @@ class FileFolderConflictsCheck(ProductCheck):
 
         # Collect "<name>" stems that may be expressed as either a file or a
         # package, from two structure shapes:
-        #   - "<name>.py" with `can_be_folder: true` (e.g. models.py)
-        #   - "<name>/__init__.py"                   (e.g. logic/__init__.py)
-        # Any package init file in the canonical structure (facade, presentation,
-        # tasks, tests, ...) qualifies; this also catches a stray `tasks.py`
-        # next to `tasks/`, which is always a mistake.
+        #   - "<name>.py" with `can_be_folder: true`        (e.g. models.py)
+        #   - "<name>/" as a top-level backend_files entry  (e.g. logic/, facade/)
+        # Subdirectories qualify whether or not they declare an `__init__.py`
+        # in the structure — namespace packages are fine, and this also catches
+        # a stray `tasks.py` next to `tasks/`, which is always a mistake.
         stems: set[str] = set()
-        for path, config in flatten_structure(ctx.structure.get("backend_files", {})).items():
-            if config.get("can_be_folder", False) and path.endswith(".py"):
-                stems.add(path[: -len(".py")])
-            elif path.endswith("/__init__.py"):
-                stems.add(path[: -len("/__init__.py")])
+        for name, config in ctx.structure.get("backend_files", {}).items():
+            if name.endswith("/"):
+                stems.add(name.rstrip("/"))
+            elif name.endswith(".py") and isinstance(config, dict) and config.get("can_be_folder", False):
+                stems.add(name[: -len(".py")])
 
         # Conflict if both `<stem>.py` and `<stem>/` directory exist on disk.
         # Check the directory itself (not `__init__.py`) so a half-migrated state

--- a/tools/hogli-commands/hogli_commands/product_structure.yaml
+++ b/tools/hogli-commands/hogli_commands/product_structure.yaml
@@ -85,11 +85,16 @@ root_files:
             }}
 
 # Backend files (in backend/)
+#
+# We deliberately do not scaffold `__init__.py` files for `backend/`,
+# `backend/facade/`, `backend/presentation/`, or `backend/tasks/`. Python 3.3+
+# implicit namespace packages handle imports without them, and the convention
+# under products/ is to keep package surfaces intentional — either populate
+# `__init__.py` with explicit exports (rare) or omit it.
+# `tests/__init__.py` is the one exception: pytest's default `prepend` import
+# mode would collide on duplicate test filenames across products (11×
+# `test_models.py`, 11× `test_api.py`, etc.) without it.
 backend_files:
-    __init__.py:
-        required: true
-        template: ''
-
     apps.py:
         required: true
         template: |
@@ -166,10 +171,6 @@ backend_files:
                     return list(SplineReticulator.objects.all())
 
     tasks/:
-        __init__.py:
-            required: false
-            template: ''
-
         tasks.py:
             required: false
             template: |
@@ -189,10 +190,6 @@ backend_files:
                 # Define periodic task schedules here
 
     facade/:
-        __init__.py:
-            required: true
-            template: ''
-
         api.py:
             required: true
             template: |
@@ -284,10 +281,6 @@ backend_files:
                     RETICULATED = "reticulated"
 
     presentation/:
-        __init__.py:
-            required: true
-            template: ''
-
         serializers.py:
             required: true
             template: |

--- a/tools/hogli-commands/hogli_commands/tests/test_checks.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_checks.py
@@ -588,13 +588,15 @@ class TestProductYamlOwnersCheck:
 # FileFolderConflictsCheck — file vs package twin detection
 # ---------------------------------------------------------------------------
 
-# Structure mirrors product_structure.yaml: logic is a package, models can be
-# either a file or folder. Tests exercise both shapes plus a stray-twin case.
+# Structure mirrors product_structure.yaml: subdirs (logic/, tasks/, facade/)
+# are packages regardless of whether they declare an __init__.py in the
+# structure; models can be either a file or folder via can_be_folder.
 _CONFLICT_STRUCTURE = {
     "backend_files": {
         "models.py": {"can_be_folder": True},
         "logic/": {"__init__.py": {}},
-        "tasks/": {"__init__.py": {}},
+        "tasks/": {"tasks.py": {}},  # no __init__.py declared — namespace package
+        "facade/": {"api.py": {}, "contracts.py": {}},
     },
 }
 
@@ -653,6 +655,9 @@ class TestFileFolderConflictsCheck:
             # Pattern B also covers other canonical packages — stray tasks.py is a mistake
             (["tasks/__init__.py"], []),
             (["tasks.py", "tasks/__init__.py"], ["tasks.py"]),
+            # Namespace-package subdir (no __init__.py declared in structure) — stem still detected
+            (["facade/api.py"], []),
+            (["facade.py", "facade/api.py"], ["facade.py"]),
             # Multiple conflicts at once
             (["logic.py", "logic/", "models.py", "models/"], ["logic.py", "models.py"]),
         ],


### PR DESCRIPTION
## Problem

The product scaffolding structure currently requires explicit `__init__.py` files in backend subdirectories (`backend/`, `backend/facade/`, `backend/presentation/`, `backend/tasks/`), but Python 3.3+ supports implicit namespace packages that don't need them. This change aligns the scaffolding with the actual convention used in products: keeping package surfaces intentional by either populating `__init__.py` with explicit exports or omitting it entirely.

The only exception is `tests/__init__.py`, which must be present because pytest's default `prepend` import mode would collide on duplicate test filenames across products without it (e.g., 11 products each with `test_models.py`).

## Changes

- **product_structure.yaml**: Removed `__init__.py` scaffolding declarations from `backend/`, `backend/facade/`, `backend/presentation/`, and `backend/tasks/`. Added explanatory comment documenting the namespace package convention and the `tests/__init__.py` exception.
- **checks.py**: Updated `FileFolderConflictsCheck` to detect package subdirectories by their trailing slash in the structure definition (e.g., `facade/`) rather than by the presence of `__init__.py` entries. This correctly identifies stems whether or not they declare an init file, and removes the now-unused `flatten_structure` import.
- **test_checks.py**: Updated test structure and cases to reflect namespace packages (e.g., `tasks/` without `__init__.py` declared) and added test cases verifying that namespace-package subdirs are still correctly detected for conflict checking.

## How did you test this code?

Existing unit tests in `test_checks.py` were updated to cover the new behavior:
- Tests verify that subdirectories with trailing slashes are detected as stems regardless of whether they declare `__init__.py`
- Tests confirm that file/folder conflicts are still caught (e.g., `facade.py` alongside `facade/`)
- Tests exercise both explicit init files and namespace packages in the same structure

The changes are backward-compatible: the conflict detection logic still catches the same mistakes (stray `tasks.py` next to `tasks/`, etc.), just via a simpler mechanism that doesn't depend on `__init__.py` presence in the structure definition.

## Publish to changelog?

no

https://claude.ai/code/session_01634RWR9wimZNyLox8QLWtm