### PR TITLE
feat(personhog): add x-read-consistency header to all personhog clients

### DIFF
--- a/nodejs/src/ingestion/personhog/client.test.ts
+++ b/nodejs/src/ingestion/personhog/client.test.ts
@@ -23,6 +23,7 @@ import type {
 import {
     PersonHogClient,
     parseRolloutTeamIds,
+    resolveConsistencyHeader,
     shouldUseGrpcForTeam,
     shouldUseGrpcForTeamItems,
     shouldUseGrpcForTeams,
@@ -227,6 +228,28 @@ describe('shouldUseGrpcForTeamItems', () => {
 
     it('falls back to percentage when rollout set is empty', () => {
         expect(shouldUseGrpcForTeamItems(new Set(), [{ teamId: 1 }], 100)).toBe(true)
+    })
+})
+
+describe('resolveConsistencyHeader', () => {
+    it('returns "strong" when readOptions.consistency is STRONG', () => {
+        expect(resolveConsistencyHeader({ readOptions: { consistency: ConsistencyLevel.STRONG } })).toBe('strong')
+    })
+
+    it('returns "eventual" when readOptions.consistency is EVENTUAL', () => {
+        expect(resolveConsistencyHeader({ readOptions: { consistency: ConsistencyLevel.EVENTUAL } })).toBe('eventual')
+    })
+
+    it('returns "eventual" when readOptions is missing', () => {
+        expect(resolveConsistencyHeader({})).toBe('eventual')
+    })
+
+    it('returns "eventual" when message is undefined', () => {
+        expect(resolveConsistencyHeader(undefined)).toBe('eventual')
+    })
+
+    it('returns "eventual" when consistency is unset (0)', () => {
+        expect(resolveConsistencyHeader({ readOptions: { consistency: 0 } })).toBe('eventual')
     })
 })
 

--- a/nodejs/src/ingestion/personhog/client.ts
+++ b/nodejs/src/ingestion/personhog/client.ts
@@ -104,6 +104,12 @@ export function eventualReadOptions() {
     return create(ReadOptionsSchema, { consistency: ConsistencyLevel.EVENTUAL })
 }
 
+export function resolveConsistencyHeader(message: unknown): 'strong' | 'eventual' {
+    const msg = message as Record<string, unknown> | undefined
+    const readOptions = msg?.readOptions as { consistency?: ConsistencyLevel } | undefined
+    return readOptions?.consistency === ConsistencyLevel.STRONG ? 'strong' : 'eventual'
+}
+
 export interface PersonHogClientConfig {
     /** Host and port of the personhog gRPC server, e.g. "localhost:50051". */
     addr: string
@@ -187,7 +193,7 @@ export class PersonHogClient {
             })
         }
         interceptors.push((next) => async (req) => {
-            req.header.set('x-read-consistency', 'eventual')
+            req.header.set('x-read-consistency', resolveConsistencyHeader(req.message))
             return await next(req)
         })
 

--- a/nodejs/src/ingestion/personhog/client.ts
+++ b/nodejs/src/ingestion/personhog/client.ts
@@ -186,6 +186,10 @@ export class PersonHogClient {
                 return await next(req)
             })
         }
+        interceptors.push((next) => async (req) => {
+            req.header.set('x-read-consistency', 'eventual')
+            return await next(req)
+        })
 
         const sessionManager = new Http2SessionManager(`${scheme}://${config.addr}`, {
             pingIntervalMs: config.pingIntervalMs ?? 30_000,

--- a/posthog/personhog_client/client.py
+++ b/posthog/personhog_client/client.py
@@ -10,7 +10,7 @@ import grpc
 import structlog
 from prometheus_client import Counter, Enum, Histogram
 
-from posthog.personhog_client.interceptor import ClientNameInterceptor, MetricsInterceptor
+from posthog.personhog_client.interceptor import ClientNameInterceptor, ConsistencyHeaderInterceptor, MetricsInterceptor
 from posthog.personhog_client.proto import (
     CheckCohortMembershipRequest,
     CohortMembershipResponse,
@@ -168,7 +168,10 @@ class PersonHogClient:
         ]
         channel = grpc.insecure_channel(addr, options=options)
         self._channel = grpc.intercept_channel(
-            channel, ClientNameInterceptor(client_name), MetricsInterceptor(client_name)
+            channel,
+            ClientNameInterceptor(client_name),
+            ConsistencyHeaderInterceptor(),
+            MetricsInterceptor(client_name),
         )
         self._state_monitor = _ChannelStateMonitor(channel, client_name)
         self._stub = PersonHogServiceStub(self._channel)

--- a/posthog/personhog_client/interceptor.py
+++ b/posthog/personhog_client/interceptor.py
@@ -8,6 +8,8 @@ from typing import Any
 import grpc
 from prometheus_client import Counter, Histogram
 
+from posthog.personhog_client.proto import CONSISTENCY_LEVEL_STRONG
+
 _ClientCallDetails = namedtuple(
     "_ClientCallDetails",
     ["method", "timeout", "metadata", "credentials", "wait_for_ready", "compression"],
@@ -70,6 +72,29 @@ class ClientNameInterceptor(grpc.UnaryUnaryClientInterceptor):
         request: Any,
     ) -> Any:
         new_details = _with_metadata(client_call_details, [("x-client-name", self._client_name)])
+        return continuation(new_details, request)
+
+
+class ConsistencyHeaderInterceptor(grpc.UnaryUnaryClientInterceptor):
+    """Sets x-read-consistency gRPC metadata header based on the request's read_options field.
+
+    This allows the personhog-router to determine consistency level from
+    headers without deserializing the request body.
+    """
+
+    def intercept_unary_unary(
+        self,
+        continuation: Any,
+        client_call_details: grpc.ClientCallDetails,
+        request: Any,
+    ) -> Any:
+        consistency = "eventual"
+        try:
+            if request.HasField("read_options") and request.read_options.consistency == CONSISTENCY_LEVEL_STRONG:
+                consistency = "strong"
+        except ValueError:
+            pass
+        new_details = _with_metadata(client_call_details, [("x-read-consistency", consistency)])
         return continuation(new_details, request)
 
 

--- a/posthog/personhog_client/test_interceptor.py
+++ b/posthog/personhog_client/test_interceptor.py
@@ -5,7 +5,19 @@ from posthog.test.base import BaseTest
 import grpc
 from parameterized import parameterized
 
-from posthog.personhog_client.interceptor import ClientNameInterceptor, _MutableClientCallDetails, _with_metadata
+from posthog.personhog_client.interceptor import (
+    ClientNameInterceptor,
+    ConsistencyHeaderInterceptor,
+    _MutableClientCallDetails,
+    _with_metadata,
+)
+from posthog.personhog_client.proto import (
+    CONSISTENCY_LEVEL_EVENTUAL,
+    CONSISTENCY_LEVEL_STRONG,
+    GetPersonRequest,
+    ReadOptions,
+    UpdateGroupRequest,
+)
 
 
 def _make_call_details(
@@ -79,3 +91,53 @@ class TestClientNameInterceptor(BaseTest):
         self.assertEqual(len(captured_details), 1)
         metadata = dict(captured_details[0].metadata)
         self.assertEqual(metadata["x-client-name"], client_name)
+
+
+class TestConsistencyHeaderInterceptor(BaseTest):
+    @parameterized.expand(
+        [
+            (
+                "strong_consistency",
+                GetPersonRequest(
+                    team_id=1,
+                    person_id=42,
+                    read_options=ReadOptions(consistency=CONSISTENCY_LEVEL_STRONG),
+                ),
+                "strong",
+            ),
+            (
+                "eventual_consistency",
+                GetPersonRequest(
+                    team_id=1,
+                    person_id=42,
+                    read_options=ReadOptions(consistency=CONSISTENCY_LEVEL_EVENTUAL),
+                ),
+                "eventual",
+            ),
+            (
+                "no_read_options_set",
+                GetPersonRequest(team_id=1, person_id=42),
+                "eventual",
+            ),
+            (
+                "request_type_without_read_options",
+                UpdateGroupRequest(team_id=1),
+                "eventual",
+            ),
+        ]
+    )
+    def test_sets_consistency_header(self, _name: str, request: object, expected: str) -> None:
+        interceptor = ConsistencyHeaderInterceptor()
+        original_details = _make_call_details()
+        captured_details: list[grpc.ClientCallDetails] = []
+
+        def mock_continuation(details: grpc.ClientCallDetails, req: object) -> str:
+            captured_details.append(details)
+            return "ok"
+
+        result = interceptor.intercept_unary_unary(mock_continuation, original_details, request=request)
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(len(captured_details), 1)
+        metadata = dict(captured_details[0].metadata)
+        self.assertEqual(metadata["x-read-consistency"], expected)

--- a/rust/personhog-router/src/router/mod.rs
+++ b/rust/personhog-router/src/router/mod.rs
@@ -33,10 +33,11 @@ use personhog_proto::personhog::types::v1::{
     UpdateGroupTypeMappingResponse, UpdatePersonPropertiesRequest, UpdatePersonPropertiesResponse,
     UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
 };
+use tonic::metadata::MetadataMap;
 use tonic::Status;
 
 use crate::backend::{LeaderOps, PersonHogBackend};
-use routing::{get_consistency, route_request};
+use routing::{resolve_consistency, route_request};
 
 /// Calls a replica backend method with timing instrumentation.
 macro_rules! call_backend {
@@ -166,9 +167,11 @@ impl PersonHogRouter {
     fn require_replica(
         &self,
         category: DataCategory,
+        metadata: &MetadataMap,
         read_options: &Option<personhog_proto::personhog::types::v1::ReadOptions>,
     ) -> Result<(), Status> {
-        let decision = route_request(category, OperationType::Read, get_consistency(read_options))?;
+        let decision =
+            route_request(category, OperationType::Read, resolve_consistency(metadata, read_options))?;
         if decision == RouteDecision::Leader {
             return Err(Status::unimplemented(
                 "strong consistency reads are only supported for get_person",
@@ -181,11 +184,15 @@ impl PersonHogRouter {
     // Person lookups by ID - Person data, read operations
     // ============================================================
 
-    pub async fn get_person(&self, request: GetPersonRequest) -> Result<GetPersonResponse, Status> {
+    pub async fn get_person(
+        &self,
+        metadata: &MetadataMap,
+        request: GetPersonRequest,
+    ) -> Result<GetPersonResponse, Status> {
         let decision = route_request(
             DataCategory::PersonData,
             OperationType::Read,
-            get_consistency(&request.read_options),
+            resolve_consistency(metadata, &request.read_options),
         )?;
         match decision {
             RouteDecision::Leader => call_leader!(self, "GetPerson", get_person, request),
@@ -195,24 +202,30 @@ impl PersonHogRouter {
         }
     }
 
-    pub async fn get_persons(&self, request: GetPersonsRequest) -> Result<PersonsResponse, Status> {
-        self.require_replica(DataCategory::PersonData, &request.read_options)?;
+    pub async fn get_persons(
+        &self,
+        metadata: &MetadataMap,
+        request: GetPersonsRequest,
+    ) -> Result<PersonsResponse, Status> {
+        self.require_replica(DataCategory::PersonData, metadata, &request.read_options)?;
         call_backend!(self, "GetPersons", get_persons, request)
     }
 
     pub async fn get_person_by_uuid(
         &self,
+        metadata: &MetadataMap,
         request: GetPersonByUuidRequest,
     ) -> Result<GetPersonResponse, Status> {
-        self.require_replica(DataCategory::PersonData, &request.read_options)?;
+        self.require_replica(DataCategory::PersonData, metadata, &request.read_options)?;
         call_backend!(self, "GetPersonByUuid", get_person_by_uuid, request)
     }
 
     pub async fn get_persons_by_uuids(
         &self,
+        metadata: &MetadataMap,
         request: GetPersonsByUuidsRequest,
     ) -> Result<PersonsResponse, Status> {
-        self.require_replica(DataCategory::PersonData, &request.read_options)?;
+        self.require_replica(DataCategory::PersonData, metadata, &request.read_options)?;
         call_backend!(self, "GetPersonsByUuids", get_persons_by_uuids, request)
     }
 
@@ -222,9 +235,10 @@ impl PersonHogRouter {
 
     pub async fn get_person_by_distinct_id(
         &self,
+        metadata: &MetadataMap,
         request: GetPersonByDistinctIdRequest,
     ) -> Result<GetPersonResponse, Status> {
-        self.require_replica(DataCategory::PersonData, &request.read_options)?;
+        self.require_replica(DataCategory::PersonData, metadata, &request.read_options)?;
         call_backend!(
             self,
             "GetPersonByDistinctId",
@@ -235,9 +249,10 @@ impl PersonHogRouter {
 
     pub async fn get_persons_by_distinct_ids_in_team(
         &self,
+        metadata: &MetadataMap,
         request: GetPersonsByDistinctIdsInTeamRequest,
     ) -> Result<PersonsByDistinctIdsInTeamResponse, Status> {
-        self.require_replica(DataCategory::PersonData, &request.read_options)?;
+        self.require_replica(DataCategory::PersonData, metadata, &request.read_options)?;
         call_backend!(
             self,
             "GetPersonsByDistinctIdsInTeam",
@@ -248,9 +263,10 @@ impl PersonHogRouter {
 
     pub async fn get_persons_by_distinct_ids(
         &self,
+        metadata: &MetadataMap,
         request: GetPersonsByDistinctIdsRequest,
     ) -> Result<PersonsByDistinctIdsResponse, Status> {
-        self.require_replica(DataCategory::PersonData, &request.read_options)?;
+        self.require_replica(DataCategory::PersonData, metadata, &request.read_options)?;
         call_backend!(
             self,
             "GetPersonsByDistinctIds",
@@ -265,9 +281,10 @@ impl PersonHogRouter {
 
     pub async fn get_distinct_ids_for_person(
         &self,
+        metadata: &MetadataMap,
         request: GetDistinctIdsForPersonRequest,
     ) -> Result<GetDistinctIdsForPersonResponse, Status> {
-        self.require_replica(DataCategory::PersonData, &request.read_options)?;
+        self.require_replica(DataCategory::PersonData, metadata, &request.read_options)?;
         call_backend!(
             self,
             "GetDistinctIdsForPerson",
@@ -278,9 +295,10 @@ impl PersonHogRouter {
 
     pub async fn get_distinct_ids_for_persons(
         &self,
+        metadata: &MetadataMap,
         request: GetDistinctIdsForPersonsRequest,
     ) -> Result<GetDistinctIdsForPersonsResponse, Status> {
-        self.require_replica(DataCategory::PersonData, &request.read_options)?;
+        self.require_replica(DataCategory::PersonData, metadata, &request.read_options)?;
         call_backend!(
             self,
             "GetDistinctIdsForPersons",

--- a/rust/personhog-router/src/router/mod.rs
+++ b/rust/personhog-router/src/router/mod.rs
@@ -170,8 +170,11 @@ impl PersonHogRouter {
         metadata: &MetadataMap,
         read_options: &Option<personhog_proto::personhog::types::v1::ReadOptions>,
     ) -> Result<(), Status> {
-        let decision =
-            route_request(category, OperationType::Read, resolve_consistency(metadata, read_options))?;
+        let decision = route_request(
+            category,
+            OperationType::Read,
+            resolve_consistency(metadata, read_options),
+        )?;
         if decision == RouteDecision::Leader {
             return Err(Status::unimplemented(
                 "strong consistency reads are only supported for get_person",

--- a/rust/personhog-router/src/router/routing.rs
+++ b/rust/personhog-router/src/router/routing.rs
@@ -79,13 +79,13 @@ pub fn get_consistency(read_options: &Option<ReadOptions>) -> Option<Consistency
 
 /// Extract consistency level from the `x-read-consistency` gRPC metadata header.
 pub fn get_consistency_from_header(metadata: &MetadataMap) -> Option<ConsistencyLevel> {
-    metadata.get("x-read-consistency").and_then(|v| {
-        match v.to_str().ok()? {
+    metadata
+        .get("x-read-consistency")
+        .and_then(|v| match v.to_str().ok()? {
             "strong" => Some(ConsistencyLevel::Strong),
             "eventual" => Some(ConsistencyLevel::Eventual),
             _ => None,
-        }
-    })
+        })
 }
 
 /// Resolve consistency level: prefer the gRPC metadata header, fall back to body read_options.

--- a/rust/personhog-router/src/router/routing.rs
+++ b/rust/personhog-router/src/router/routing.rs
@@ -1,4 +1,6 @@
+use metrics::counter;
 use personhog_proto::personhog::types::v1::{ConsistencyLevel, ReadOptions};
+use tonic::metadata::MetadataMap;
 use tonic::Status;
 
 /// Categories of data for routing decisions.
@@ -75,9 +77,94 @@ pub fn get_consistency(read_options: &Option<ReadOptions>) -> Option<Consistency
     read_options.as_ref().map(|opts| opts.consistency())
 }
 
+/// Extract consistency level from the `x-read-consistency` gRPC metadata header.
+pub fn get_consistency_from_header(metadata: &MetadataMap) -> Option<ConsistencyLevel> {
+    metadata.get("x-read-consistency").and_then(|v| {
+        match v.to_str().ok()? {
+            "strong" => Some(ConsistencyLevel::Strong),
+            "eventual" => Some(ConsistencyLevel::Eventual),
+            _ => None,
+        }
+    })
+}
+
+/// Resolve consistency level: prefer the gRPC metadata header, fall back to body read_options.
+pub fn resolve_consistency(
+    metadata: &MetadataMap,
+    read_options: &Option<ReadOptions>,
+) -> Option<ConsistencyLevel> {
+    if let Some(level) = get_consistency_from_header(metadata) {
+        counter!("personhog_router_consistency_source", "source" => "header").increment(1);
+        return Some(level);
+    }
+    let level = get_consistency(read_options);
+    if level.is_some() {
+        counter!("personhog_router_consistency_source", "source" => "body").increment(1);
+    }
+    level
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_get_consistency_from_header_strong() {
+        let mut metadata = MetadataMap::new();
+        metadata.insert("x-read-consistency", "strong".parse().unwrap());
+        assert_eq!(
+            get_consistency_from_header(&metadata),
+            Some(ConsistencyLevel::Strong)
+        );
+    }
+
+    #[test]
+    fn test_get_consistency_from_header_eventual() {
+        let mut metadata = MetadataMap::new();
+        metadata.insert("x-read-consistency", "eventual".parse().unwrap());
+        assert_eq!(
+            get_consistency_from_header(&metadata),
+            Some(ConsistencyLevel::Eventual)
+        );
+    }
+
+    #[test]
+    fn test_get_consistency_from_header_missing() {
+        let metadata = MetadataMap::new();
+        assert_eq!(get_consistency_from_header(&metadata), None);
+    }
+
+    #[test]
+    fn test_get_consistency_from_header_unknown_value() {
+        let mut metadata = MetadataMap::new();
+        metadata.insert("x-read-consistency", "bogus".parse().unwrap());
+        assert_eq!(get_consistency_from_header(&metadata), None);
+    }
+
+    #[test]
+    fn test_resolve_consistency_header_takes_precedence() {
+        let mut metadata = MetadataMap::new();
+        metadata.insert("x-read-consistency", "strong".parse().unwrap());
+        let body_options = Some(ReadOptions {
+            consistency: ConsistencyLevel::Eventual.into(),
+        });
+        assert_eq!(
+            resolve_consistency(&metadata, &body_options),
+            Some(ConsistencyLevel::Strong)
+        );
+    }
+
+    #[test]
+    fn test_resolve_consistency_falls_back_to_body() {
+        let metadata = MetadataMap::new();
+        let body_options = Some(ReadOptions {
+            consistency: ConsistencyLevel::Strong.into(),
+        });
+        assert_eq!(
+            resolve_consistency(&metadata, &body_options),
+            Some(ConsistencyLevel::Strong)
+        );
+    }
 
     #[test]
     fn test_person_data_eventual_routes_to_replica() {

--- a/rust/personhog-router/src/service/mod.rs
+++ b/rust/personhog-router/src/service/mod.rs
@@ -53,6 +53,16 @@ macro_rules! route_request {
     }};
 }
 
+macro_rules! route_with_metadata {
+    ($self:expr, $method:ident, $request:expr) => {{
+        let metadata = $request.metadata().clone();
+        match $self.router.$method(&metadata, $request.into_inner()).await {
+            Ok(response) => Ok(Response::new(response)),
+            Err(status) => Err(status),
+        }
+    }};
+}
+
 #[tonic::async_trait]
 impl PersonHogService for PersonHogRouterService {
     // Person lookups by ID
@@ -61,28 +71,28 @@ impl PersonHogService for PersonHogRouterService {
         &self,
         request: Request<GetPersonRequest>,
     ) -> Result<Response<GetPersonResponse>, Status> {
-        route_request!(self, get_person, request)
+        route_with_metadata!(self, get_person, request)
     }
 
     async fn get_persons(
         &self,
         request: Request<GetPersonsRequest>,
     ) -> Result<Response<PersonsResponse>, Status> {
-        route_request!(self, get_persons, request)
+        route_with_metadata!(self, get_persons, request)
     }
 
     async fn get_person_by_uuid(
         &self,
         request: Request<GetPersonByUuidRequest>,
     ) -> Result<Response<GetPersonResponse>, Status> {
-        route_request!(self, get_person_by_uuid, request)
+        route_with_metadata!(self, get_person_by_uuid, request)
     }
 
     async fn get_persons_by_uuids(
         &self,
         request: Request<GetPersonsByUuidsRequest>,
     ) -> Result<Response<PersonsResponse>, Status> {
-        route_request!(self, get_persons_by_uuids, request)
+        route_with_metadata!(self, get_persons_by_uuids, request)
     }
 
     // Person lookups by distinct ID
@@ -91,21 +101,21 @@ impl PersonHogService for PersonHogRouterService {
         &self,
         request: Request<GetPersonByDistinctIdRequest>,
     ) -> Result<Response<GetPersonResponse>, Status> {
-        route_request!(self, get_person_by_distinct_id, request)
+        route_with_metadata!(self, get_person_by_distinct_id, request)
     }
 
     async fn get_persons_by_distinct_ids_in_team(
         &self,
         request: Request<GetPersonsByDistinctIdsInTeamRequest>,
     ) -> Result<Response<PersonsByDistinctIdsInTeamResponse>, Status> {
-        route_request!(self, get_persons_by_distinct_ids_in_team, request)
+        route_with_metadata!(self, get_persons_by_distinct_ids_in_team, request)
     }
 
     async fn get_persons_by_distinct_ids(
         &self,
         request: Request<GetPersonsByDistinctIdsRequest>,
     ) -> Result<Response<PersonsByDistinctIdsResponse>, Status> {
-        route_request!(self, get_persons_by_distinct_ids, request)
+        route_with_metadata!(self, get_persons_by_distinct_ids, request)
     }
 
     // Distinct ID operations
@@ -114,14 +124,14 @@ impl PersonHogService for PersonHogRouterService {
         &self,
         request: Request<GetDistinctIdsForPersonRequest>,
     ) -> Result<Response<GetDistinctIdsForPersonResponse>, Status> {
-        route_request!(self, get_distinct_ids_for_person, request)
+        route_with_metadata!(self, get_distinct_ids_for_person, request)
     }
 
     async fn get_distinct_ids_for_persons(
         &self,
         request: Request<GetDistinctIdsForPersonsRequest>,
     ) -> Result<Response<GetDistinctIdsForPersonsResponse>, Status> {
-        route_request!(self, get_distinct_ids_for_persons, request)
+        route_with_metadata!(self, get_distinct_ids_for_persons, request)
     }
 
     // Feature flag hash key override support

--- a/rust/property-defs-rs/src/group_type_resolver.rs
+++ b/rust/property-defs-rs/src/group_type_resolver.rs
@@ -1,6 +1,6 @@
 use personhog_proto::personhog::{
     service::v1::person_hog_service_client::PersonHogServiceClient,
-    types::v1::GetGroupTypeMappingsByTeamIdsRequest,
+    types::v1::{ConsistencyLevel, GetGroupTypeMappingsByTeamIdsRequest, ReadOptions},
 };
 use quick_cache::sync::Cache;
 use std::collections::HashMap;
@@ -140,13 +140,24 @@ impl GroupTypeResolver {
             ids.into_iter().map(|id| id as i64).collect()
         };
 
+        let consistency = ConsistencyLevel::Eventual;
         let mut request = tonic::Request::new(GetGroupTypeMappingsByTeamIdsRequest {
             team_ids: unique_team_ids,
-            read_options: None,
+            read_options: Some(ReadOptions {
+                consistency: consistency.into(),
+            }),
         });
         let metadata = request.metadata_mut();
         metadata.insert("x-client-name", "property-defs-rs".parse().unwrap());
-        metadata.insert("x-read-consistency", "eventual".parse().unwrap());
+        metadata.insert(
+            "x-read-consistency",
+            match consistency {
+                ConsistencyLevel::Strong => "strong",
+                _ => "eventual",
+            }
+            .parse()
+            .unwrap(),
+        );
 
         let response = client.get_group_type_mappings_by_team_ids(request).await?;
 

--- a/rust/property-defs-rs/src/group_type_resolver.rs
+++ b/rust/property-defs-rs/src/group_type_resolver.rs
@@ -144,9 +144,9 @@ impl GroupTypeResolver {
             team_ids: unique_team_ids,
             read_options: None,
         });
-        request
-            .metadata_mut()
-            .insert("x-client-name", "property-defs-rs".parse().unwrap());
+        let metadata = request.metadata_mut();
+        metadata.insert("x-client-name", "property-defs-rs".parse().unwrap());
+        metadata.insert("x-read-consistency", "eventual".parse().unwrap());
 
         let response = client.get_group_type_mappings_by_team_ids(request).await?;
 


### PR DESCRIPTION


<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

The personhog-router service deserializes the bodies of requests and responses to get information about how to route the request. This adds quite a bit of unnecessary overhead to the service.

## Changes

- personhog clients set an `x-read-consistency` header on each request they send
- personhog router prefers to use `x-read-consistency` header, falling back to reading the protobuf `read_options` body field
- metric added for counting occurrences of using header vs. body for making routing decisions


## How did you test this code?

- New unit tests for `get_consistency_from_header`, `resolve_consistency` (header precedence, body fallback)
- New parameterized Python tests for `ConsistencyHeaderInterceptor`
  (strong, eventual, no read_options, request type without read_options field)
- Existing integration tests in `tests/leader_integration.rs` continue to pass
  (they exercise the body-fallback path since they don't set the header)

