### PR TITLE
fix(quill): floor guard for prev chevron, lastSet sync in Now

### DIFF
--- a/packages/quill/packages/blocks/package.json
+++ b/packages/quill/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-blocks",
-    "version": "0.3.0-beta.9",
+    "version": "0.3.0-beta.10",
     "private": true,
     "description": "Internal workspace package (private, not published). The highest layer of the quill design system — product-level patterns made of components + primitives (e.g. a PageHeader with title + breadcrumb + action slot, an EmptyState with icon + copy + CTA, a CommandPalette, a user-menu dropdown). Opinionated and shape-stable across products so they feel consistent. Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/components/package.json
+++ b/packages/quill/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-components",
-    "version": "0.3.0-beta.9",
+    "version": "0.3.0-beta.10",
     "private": true,
     "description": "Internal workspace package (private, not published). The middle layer of the quill design system — higher-level compositions of primitives that wire several of them together with sensible defaults (e.g. a FormField that composes Label + Input + validation state, or a ConfirmDialog that composes Dialog + Button + destructive variant). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -19,7 +19,7 @@ import {
 import { ArrowRight, ChevronLeft, ChevronRight, SettingsIcon } from 'lucide-react'
 import * as React from 'react'
 
-import { Badge, Button, InputGroup, InputGroupNumberInput, ScrollArea, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Separator, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, cn } from '@posthog/quill-primitives'
+import { Badge, Button, InputGroup, InputGroupNumberInput, ScrollArea, Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue, Separator, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, cn } from '@posthog/quill-primitives'
 
 import { CUSTOM_RANGE, type DateTimeRange, quickRanges } from './date-time-ranges'
 import { Day, useCalendar } from './use-calendar'
@@ -253,11 +253,13 @@ function Calendar({
                         </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
-                        {monthOptions.map(({ key, year, month }) => (
-                            <SelectItem key={key} value={key} disabled={key === siblingKey}>
-                                {MONTH_NAMES[month]} {year}
-                            </SelectItem>
-                        ))}
+                        <SelectGroup>
+                            {monthOptions.map(({ key, year, month }) => (
+                                <SelectItem key={key} value={key} disabled={key === siblingKey}>
+                                    {MONTH_NAMES[month]} {year}
+                                </SelectItem>
+                            ))}
+                        </SelectGroup>
                     </SelectContent>
                 </Select>
                 <Button

--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -186,6 +186,12 @@ function Calendar({
         onViewChange(addMonths(viewing, 1))
     }
 
+    const floorDate = minDate && minDate.getTime() > POSTHOG_START_DATE.getTime() ? minDate : POSTHOG_START_DATE
+    const minYearVal = getYear(floorDate)
+    const minMonthAtMinYear = getMonth(floorDate)
+    const floorKey = minYearVal * 12 + minMonthAtMinYear
+    const viewingKey = getYear(viewing) * 12 + getMonth(viewing)
+
     const disableNext =
         (getMonth(viewing) === getMonth(new Date()) && getYear(viewing) === getYear(new Date())) ||
         (!!siblingViewing &&
@@ -193,13 +199,10 @@ function Calendar({
             getYear(siblingViewing) === getYear(addMonths(viewing, 1)))
 
     const disablePrev =
-        !!siblingViewing &&
-        getMonth(siblingViewing) === getMonth(subMonths(viewing, 1)) &&
-        getYear(siblingViewing) === getYear(subMonths(viewing, 1))
-
-    const floorDate = minDate && minDate.getTime() > POSTHOG_START_DATE.getTime() ? minDate : POSTHOG_START_DATE
-    const minYearVal = getYear(floorDate)
-    const minMonthAtMinYear = getMonth(floorDate)
+        viewingKey <= floorKey ||
+        (!!siblingViewing &&
+            getMonth(siblingViewing) === getMonth(subMonths(viewing, 1)) &&
+            getYear(siblingViewing) === getYear(subMonths(viewing, 1)))
     const maxYearVal = getYear(maxDate)
     const maxMonthAtMaxYear = getMonth(maxDate)
     const currentYear = getYear(viewing)
@@ -536,6 +539,7 @@ export function DateTimePicker({
             setStart(now)
         }
         setEnd(now)
+        setLastSet('end')
     }
 
     const handleQuickRange = (next: DateTimeRange): void => {

--- a/packages/quill/packages/primitives/package.json
+++ b/packages/quill/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-primitives",
-    "version": "0.3.0-beta.9",
+    "version": "0.3.0-beta.10",
     "private": true,
     "description": "Internal workspace package (private, not published). The lowest layer of the quill design system — unstyled Base UI primitives wrapped with quill's Tailwind classes (Button, Card, Dialog, Input, Popover, Combobox, etc.). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill",
-    "version": "0.3.0-beta.9",
+    "version": "0.3.0-beta.10",
     "description": "PostHog's unified design system — primitives, components, and blocks designed to be compiled by the consumer's Tailwind v4.",
     "license": "MIT",
     "repository": {

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-tokens",
-    "version": "0.3.0-beta.9",
+    "version": "0.3.0-beta.10",
     "license": "MIT",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Problem

Two bugs called out in code review on #59279:

1. **`disablePrev` ignores `floorDate`.** In compact mode (single calendar, no sibling) the prev chevron has no lower-bound check, so it can navigate before `POSTHOG_START_DATE`. Once `viewing` is below `floorDate`, `currentKey` no longer matches any entry in `monthOptions` and the month/year Select renders blank.
2. **`handleNow` doesn't update `lastSet`.** Clicking "Now" writes `end` but leaves `lastSet` carrying whatever the previous interaction left behind. The next inside-range calendar click then misinterprets which edge was just set and pulls the wrong side inward.

## Changes

- Add `floorKey` / `viewingKey` helpers and OR `viewingKey <= floorKey` into `disablePrev`
- `handleNow` now calls `setLastSet('end')` to match what it actually did

Bumps `@posthog/quill{,-blocks,-components,-primitives,-tokens}` to `0.3.0-beta.10`.

## How did you test this code?

I'm an agent — built the components package (`pnpm build` in `packages/quill/packages/components`) and confirmed type/build success. No automated tests for these flows yet.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (`claude-opus-4-7[1m]`). Greptile also flagged a third issue suggesting the `SelectValue` function-as-children was dead code — I rejected that one because Quill's `Select` wraps `@base-ui/react/select`, which does support a render-function child (we verified empirically: without it the trigger renders the raw `year*12+month` integer).

Stacked on #59279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)