### PR TITLE
chore(semgrep): anchor path patterns to silence v2 deprecation warnings

### DIFF
--- a/.semgrep/rules/admin-modeladmin-needs-register-decorator.yaml
+++ b/.semgrep/rules/admin-modeladmin-needs-register-decorator.yaml
@@ -29,8 +29,8 @@ rules:
           # Only enforce inside admin modules. Other places might subclass
           # `ModelAdmin` for testing or as abstract scaffolding.
           include:
-              - 'posthog/admin/admins/*.py'
-              - 'products/*/backend/admin.py'
+              - '/posthog/admin/admins/*.py'
+              - '/products/*/backend/admin.py'
       metadata:
           category: correctness
           technology:

--- a/.semgrep/rules/hogql-no-string-table-chain.yaml
+++ b/.semgrep/rules/hogql-no-string-table-chain.yaml
@@ -22,10 +22,10 @@ rules:
           and POE virtual-table paths working.
       paths:
           include:
-              - 'posthog/hogql/**/*.py'
-              - 'posthog/hogql_queries/**/*.py'
-              - 'products/**/*.py'
-              - 'ee/**/*.py'
+              - '/posthog/hogql/**/*.py'
+              - '/posthog/hogql_queries/**/*.py'
+              - '/products/**/*.py'
+              - '/ee/**/*.py'
           exclude:
               - '**/test/**'
               - '**/tests/**'

--- a/.semgrep/rules/logs-alert-state-must-go-through-state-machine.yaml
+++ b/.semgrep/rules/logs-alert-state-must-go-through-state-machine.yaml
@@ -43,10 +43,10 @@ rules:
           confidence: HIGH
       paths:
           include:
-              - 'products/logs/backend/**/*.py'
+              - '/products/logs/backend/**/*.py'
           exclude:
               # The state machine itself — apply_outcome is the one legal mutator.
-              - 'products/logs/backend/alert_state_machine.py'
+              - '/products/logs/backend/alert_state_machine.py'
               # Test files — fixtures and parametrized snapshots set state directly.
-              - 'products/logs/backend/test/**'
-              - 'products/logs/backend/**/test_*.py'
+              - '/products/logs/backend/test/**'
+              - '/products/logs/backend/**/test_*.py'

--- a/.semgrep/rules/no-direct-fuse-instantiation.yaml
+++ b/.semgrep/rules/no-direct-fuse-instantiation.yaml
@@ -12,4 +12,4 @@ rules:
                 regex: ^(Fuse|FuseClass|_Fuse)$
       paths:
           exclude:
-              - frontend/src/lib/utils/fuseSearch.ts
+              - /frontend/src/lib/utils/fuseSearch.ts

--- a/.semgrep/rules/no-direct-kafka-producer.yaml
+++ b/.semgrep/rules/no-direct-kafka-producer.yaml
@@ -17,22 +17,22 @@ rules:
       paths:
           exclude:
               # Routing module is the only allowed constructor of the primitives.
-              - posthog/kafka_client/routing.py
+              - /posthog/kafka_client/routing.py
               # The primitives live here.
-              - posthog/kafka_client/client.py
+              - /posthog/kafka_client/client.py
               # Tests for the primitives themselves.
-              - posthog/kafka_client/test/test_client.py
+              - /posthog/kafka_client/test/test_client.py
               # Existing integration tests that explicitly opt out of the test stub
               # to exercise a real broker. These are gated behind KAFKA_ROUNDTRIP_TESTS.
-              - posthog/dags/tests/test_person_property_reconciliation.py
-              - posthog/temporal/tests/dlq_replay/test_activities.py
-              - posthog/temporal/tests/common/test_logger.py
+              - /posthog/dags/tests/test_person_property_reconciliation.py
+              - /posthog/temporal/tests/dlq_replay/test_activities.py
+              - /posthog/temporal/tests/common/test_logger.py
               # DLQ replay needs per-message header passthrough, which confluent's
               # AIOProducer refuses in batch mode. Uses raw aiokafka with cluster
               # config resolved via get_profile_settings().
-              - posthog/temporal/dlq_replay/activities.py
+              - /posthog/temporal/dlq_replay/activities.py
               # Batch export metrics path — tests assert metrics land in ClickHouse
               # via the kafka→CH ingest pipeline, and the confluent AIOProducer
               # behaves differently in that test environment. Left on raw aiokafka
               # to keep existing tests passing; migrate in a follow-up PR.
-              - products/batch_exports/backend/temporal/batch_exports.py
+              - /products/batch_exports/backend/temporal/batch_exports.py


### PR DESCRIPTION
## Problem

Every Semgrep run in CI (e.g. [this job](https://github.com/PostHog/posthog/actions/runs/26187622639/job/77051245135?pr=59128)) prints dozens of deprecation warnings of the form:

> Rule semgrep.rules.X contains an [include/exclude] pattern 'foo/bar.py' that will soon be interpreted as '/foo/bar.py' to comply with the Semgrepignore v2 and Gitignore specifications.

Semgrep is migrating to Gitignore-style anchoring: bare paths in `paths.include` / `paths.exclude` will soon be treated as anchored to the repo root rather than matching anywhere in the tree. Each unprefixed pattern emits a warning per scan, drowning out actual findings and adding noise to the CI logs across `semgrep-python`, `semgrep-js`, and friends.

## Changes

Prefixed the affected `paths.include` / `paths.exclude` entries with `/` in 5 rule files to opt into the future-default anchored behavior:

- `.semgrep/rules/no-direct-kafka-producer.yaml` (8 exclude entries)
- `.semgrep/rules/no-direct-fuse-instantiation.yaml` (1 exclude entry)
- `.semgrep/rules/hogql-no-string-table-chain.yaml` (4 include entries)
- `.semgrep/rules/admin-modeladmin-needs-register-decorator.yaml` (2 include entries)
- `.semgrep/rules/logs-alert-state-must-go-through-state-machine.yaml` (1 include + 3 exclude entries)

All affected patterns reference repo-rooted paths, so anchoring (`/`) matches the existing intent exactly. The `**/test/**`-style globs in `hogql-no-string-table-chain` are intentionally left as-is — they're meant to match `test/` directories anywhere in the tree, and the leading `**/` already satisfies the v2 rules.

## How did you test this code?

I'm an agent (Claude Code). I did not run manual UI tests. Verification was automated:

- Ran the 5 modified rules against the relevant source dirs (`posthog/kafka_client/`, `frontend/src/lib/utils/`, `posthog/hogql/`, `posthog/admin/admins/`, `products/logs/backend/`) using the upstream `semgrep/semgrep` Docker image — **zero deprecation warnings emitted** (vs. 30+ before).
- Spot-checked that excluded files are still skipped: scanning `posthog/kafka_client/client.py` directly with `no-direct-kafka-producer.yaml` reports `Targets scanned: 0`, confirming the exclude still fires.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). The agent inspected the failing CI run's logs to enumerate every warning, identified the 5 affected rule files, and chose `/` (anchored) over `**/` (preserve-unanchored) because every pattern in question is a repo-rooted path — anchoring matches the existing intent and aligns with the new v2 default rather than perpetuating the legacy unanchored shape. Verified locally with the upstream `semgrep/semgrep` image before opening the PR.