### PR TITLE
fix(data-warehouse): hide columns panel for non-postgres sources

### DIFF
--- a/products/data_warehouse/frontend/scenes/SchemaScene/SchemaScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/SchemaScene.tsx
@@ -19,6 +19,7 @@ import { sourceSettingsLogic } from '../SourceScene/tabs/sourceSettingsLogic'
 import { ConfigurationTab } from './ConfigurationTab'
 import { MetricsTab } from './MetricsTab'
 import {
+    DEFAULT_SCHEMA_CONFIGURATION_SECTION,
     SCHEMA_CONFIGURATION_SECTIONS,
     SchemaConfigurationSection,
     SchemaSceneProps,
@@ -87,20 +88,25 @@ function SchemaSceneContent({ sourceId, schemaId }: SchemaSceneProps): JSX.Eleme
         return <NotFound object="Data warehouse schema" />
     }
 
+    const isPostgres = source?.source_type === 'Postgres'
+    const visibleSections = SCHEMA_CONFIGURATION_SECTIONS.filter((key) => key !== 'columns' || isPostgres)
+    const effectiveSection = visibleSections.includes(currentSection) ? currentSection : DEFAULT_SCHEMA_CONFIGURATION_SECTION
+
     const tabs: LemonTab<SchemaSceneTab>[] = [
         {
             label: 'Configuration',
             key: 'configuration',
             content: (
                 <ConfigurationSectionLayout
-                    section={currentSection}
+                    section={effectiveSection}
+                    sections={visibleSections}
                     onSectionChange={setCurrentSection}
                     body={
                         <ConfigurationTab
                             sourceId={cleanedSourceId}
                             schema={schema}
                             source={source}
-                            section={currentSection}
+                            section={effectiveSection}
                         />
                     }
                 />
@@ -132,10 +138,12 @@ function SchemaSceneContent({ sourceId, schemaId }: SchemaSceneProps): JSX.Eleme
 
 function ConfigurationSectionLayout({
     section,
+    sections,
     onSectionChange,
     body,
 }: {
     section: SchemaConfigurationSection
+    sections: readonly SchemaConfigurationSection[]
     onSectionChange: (section: SchemaConfigurationSection) => void
     body: JSX.Element
 }): JSX.Element {
@@ -143,7 +151,7 @@ function ConfigurationSectionLayout({
         <div className="flex items-start gap-6">
             <nav className="sticky top-[var(--scene-title-section-height,50px)] flex flex-col w-56 flex-shrink-0">
                 <ul className="flex flex-col gap-y-px">
-                    {SCHEMA_CONFIGURATION_SECTIONS.map((key) => (
+                    {sections.map((key) => (
                         <li key={key}>
                             <LemonButton
                                 fullWidth

--- a/products/data_warehouse/frontend/scenes/SchemaScene/SchemaScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/SchemaScene.tsx
@@ -75,6 +75,18 @@ function SchemaSceneContent({ sourceId, schemaId }: SchemaSceneProps): JSX.Eleme
         }
     }, [showMetrics, currentTab, setCurrentTab])
 
+    const isPostgres = source?.source_type === 'Postgres'
+    const visibleSections = SCHEMA_CONFIGURATION_SECTIONS.filter((key) => key !== 'columns' || isPostgres)
+    const effectiveSection = visibleSections.includes(currentSection)
+        ? currentSection
+        : DEFAULT_SCHEMA_CONFIGURATION_SECTION
+
+    useEffect(() => {
+        if (source && effectiveSection !== currentSection) {
+            setCurrentSection(effectiveSection)
+        }
+    }, [source, effectiveSection, currentSection, setCurrentSection])
+
     if (sourceLoading && !source) {
         return (
             <SceneContent>
@@ -87,10 +99,6 @@ function SchemaSceneContent({ sourceId, schemaId }: SchemaSceneProps): JSX.Eleme
     if (!schema) {
         return <NotFound object="Data warehouse schema" />
     }
-
-    const isPostgres = source?.source_type === 'Postgres'
-    const visibleSections = SCHEMA_CONFIGURATION_SECTIONS.filter((key) => key !== 'columns' || isPostgres)
-    const effectiveSection = visibleSections.includes(currentSection) ? currentSection : DEFAULT_SCHEMA_CONFIGURATION_SECTION
 
     const tabs: LemonTab<SchemaSceneTab>[] = [
         {


### PR DESCRIPTION
## Problem

The schema configuration sidebar in the data warehouse Schema scene always renders a `Columns` nav entry, but per-column selection is only supported for Postgres sources today. For every other source type (Stripe, Hubspot, MySQL, BigQuery, etc.) the panel just showed the placeholder copy "Per-column selection is currently available for Postgres sources only." — a dead-end click with nothing to do.

## Changes

- In `SchemaScene.tsx`, filter `SCHEMA_CONFIGURATION_SECTIONS` to omit `columns` unless `source.source_type === 'Postgres'` before passing it to `ConfigurationSectionLayout`.
- If a non-Postgres user happens to land on `/configuration/columns` via a stale URL, the rendered section falls back to the default (`details`) so they don't see an empty page.
- Pass the filtered sections list into `ConfigurationSectionLayout` instead of having it read the full list from the module constant.

The existing `isPostgres` guard inside `ColumnsSection` itself is left intact as a defense-in-depth fallback.

## How did you test this code?

I'm an agent (PostHog Code) — no manual UI testing performed. The change is a presentational filter over a constant array driving a `LemonButton` list; the existing `ColumnsSection` already had a non-Postgres branch, so this only suppresses the nav entry that fronts it.

Reviewer steps:

- [ ] Open a non-Postgres source schema (e.g. Stripe) and confirm the `Columns` entry is gone from the configuration sidebar.
- [ ] Open a Postgres source schema and confirm `Columns` still appears and works.
- [ ] Visit `/data-warehouse/source/.../schema/.../configuration/columns` for a non-Postgres source and confirm the page renders the `Details` section instead of a broken/empty state.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code. The user asked to hide the `columns` panel in the configurations section for existing non-postgres sources. I located the schema scene's sidebar in `products/data_warehouse/frontend/scenes/SchemaScene/SchemaScene.tsx` and the existing Postgres-only guard at `ConfigurationTab.tsx:424` (`isPostgres = source?.source_type === 'Postgres'`). Rather than reach into the section component, I filtered the nav list at the layout level and added a URL fallback so deep links to `columns` on non-Postgres sources don't render a stranded section.

Considered (and rejected): leaving the nav entry visible and just disabling the button. The current behavior was already a dead-end placeholder, so hiding it entirely is cleaner than showing a disabled affordance.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*