### PR TITLE
fix(surveys): label survey response filters by question -- issue 52309

### DIFF
--- a/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
@@ -743,6 +743,7 @@ export function ControlledDefinitionPopover({
                         title={
                             <PropertyKeyInfo
                                 value={item.name ?? ''}
+                                displayText={'label' in item && typeof item.label === 'string' ? item.label : undefined}
                                 type={group.type}
                                 disablePopover
                                 disableIcon={!!icon}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -251,6 +251,7 @@ export function TaxonomicPropertyFilter({
                 : filter?.key && (
                       <PropertyKeyInfo
                           value={filter.key}
+                          displayText={filter.label}
                           disablePopover
                           ellipsis
                           type={PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE[filter.type]}

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -253,6 +253,7 @@ const renderItemContents = ({
                 {icon}
                 <PropertyKeyInfo
                     value={item.name ?? ''}
+                    displayText={'label' in item && typeof item.label === 'string' ? item.label : undefined}
                     disablePopover
                     disableIcon
                     className="w-full"

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -17,6 +17,7 @@ import {
     PropertyDefinition,
     PropertyFilterType,
     PropertyOperator,
+    PropertyType,
 } from '~/types'
 
 import { DataWarehouseTableForInsight } from 'products/data_warehouse/frontend/types'
@@ -24,10 +25,13 @@ import { DataWarehouseTableForInsight } from 'products/data_warehouse/frontend/t
 export interface SimpleOption {
     name: string
     propertyFilterType?: PropertyFilterType
+    property_type?: PropertyType
     /** When the search query matched a value rather than a key, this is set to 'value'. Otherwise 'key' or omitted. */
     matchedOn?: 'key' | 'value'
     /** Sample value that matched the search — only set when matchedOn === 'value'. */
     matchedValue?: string
+    label?: string
+    description?: string
 }
 
 export interface QuickFilterItem {

--- a/frontend/src/scenes/surveys/SurveyResponseFilters.tsx
+++ b/frontend/src/scenes/surveys/SurveyResponseFilters.tsx
@@ -12,7 +12,12 @@ import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { allOperatorsMapping } from 'lib/utils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { QUESTION_TYPE_ICON_MAP, SurveyQuestionLabel } from 'scenes/surveys/constants'
-import { getSurveyEndDateForQuery, getSurveyIdBasedResponseKey, getSurveyStartDateForQuery } from 'scenes/surveys/utils'
+import {
+    getSurveyEndDateForQuery,
+    getSurveyIdBasedResponseKey,
+    getSurveyStartDateForQuery,
+    getSurveyResponseFilterDisplayData,
+} from 'scenes/surveys/utils'
 
 import { groupsModel } from '~/models/groupsModel'
 import {
@@ -142,6 +147,9 @@ export const SurveyResponseFilters = React.memo(function SurveyResponseFilters()
         return Array.isArray(filter.value) ? filter.value.length > 0 : filter.value !== ''
     }).length
 
+    const { propertyFiltersWithSurveyLabels, taxonomicFilterOptionsFromProp, excludedProperties } =
+        getSurveyResponseFilterDisplayData(survey as Survey, propertyFilters)
+
     return (
         <div className="deprecated-space-y-2">
             <div className="flex justify-between items-center">
@@ -171,7 +179,7 @@ export const SurveyResponseFilters = React.memo(function SurveyResponseFilters()
                         </LemonButton>
                     )}
                     <PropertyFilters
-                        propertyFilters={propertyFilters}
+                        propertyFilters={propertyFiltersWithSurveyLabels}
                         onChange={setPropertyFilters}
                         pageKey="survey-results"
                         buttonText="Add filter"
@@ -183,6 +191,8 @@ export const SurveyResponseFilters = React.memo(function SurveyResponseFilters()
                             TaxonomicFilterGroupType.HogQLExpression,
                             ...groupsTaxonomicTypes,
                         ]}
+                        taxonomicFilterOptionsFromProp={taxonomicFilterOptionsFromProp}
+                        excludedProperties={excludedProperties}
                     />
                 </div>
                 <div className="flex gap-2 items-center">

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyFilters.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyFilters.tsx
@@ -13,7 +13,12 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { QUESTION_TYPE_ICON_MAP, SurveyQuestionLabel } from 'scenes/surveys/constants'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 import { OPERATOR_OPTIONS } from 'scenes/surveys/SurveyResponseFilters'
-import { getSurveyEndDateForQuery, getSurveyIdBasedResponseKey, getSurveyStartDateForQuery } from 'scenes/surveys/utils'
+import {
+    getSurveyEndDateForQuery,
+    getSurveyIdBasedResponseKey,
+    getSurveyResponseFilterDisplayData,
+    getSurveyStartDateForQuery,
+} from 'scenes/surveys/utils'
 
 import { groupsModel } from '~/models/groupsModel'
 import {
@@ -111,6 +116,9 @@ export function SurveyResultsFiltersBar(): JSX.Element {
         return Array.isArray(filter.value) ? filter.value.length > 0 : filter.value !== ''
     }).length
 
+    const { propertyFiltersWithSurveyLabels, taxonomicFilterOptionsFromProp, excludedProperties } =
+        getSurveyResponseFilterDisplayData(survey as Survey, propertyFilters)
+
     return (
         <div className="flex flex-col gap-2">
             <div className="flex flex-wrap gap-2 items-center justify-between">
@@ -134,7 +142,7 @@ export function SurveyResultsFiltersBar(): JSX.Element {
                         </LemonButton>
                     )}
                     <PropertyFilters
-                        propertyFilters={propertyFilters}
+                        propertyFilters={propertyFiltersWithSurveyLabels}
                         onChange={setPropertyFilters}
                         pageKey="survey-results"
                         buttonText="Add filter"
@@ -146,6 +154,8 @@ export function SurveyResultsFiltersBar(): JSX.Element {
                             TaxonomicFilterGroupType.HogQLExpression,
                             ...groupsTaxonomicTypes,
                         ]}
+                        taxonomicFilterOptionsFromProp={taxonomicFilterOptionsFromProp}
+                        excludedProperties={excludedProperties}
                     />
                 </div>
                 <div className="flex flex-wrap gap-2 items-center">

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -1,11 +1,14 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { getAppContext } from 'lib/utils/getAppContext'
 import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
 
 import {
+    AnyPropertyFilter,
     EventPropertyFilter,
     FeatureFlagFilters,
     PropertyOperator,
     PropertyFilterType,
+    PropertyType,
     Survey,
     SurveyAppearance,
     SurveyDisplayConditions,
@@ -30,6 +33,8 @@ import {
     getSurveyDisplayConditionsSummary,
     getSurveyEndDateForQuery,
     getSurveyResponse,
+    getSurveyResponseFilterDisplayData,
+    getSurveyResponsePropertyKeys,
     getSurveyStartDateForQuery,
     isSimpleSurveyAudienceTargeting,
     sanitizeColor,
@@ -304,6 +309,143 @@ describe('survey utils', () => {
             } as SurveyQuestion
 
             expect(getSurveyResponse(question, 1)).toBe("getSurveyResponse(1, 'question-456', true)")
+        })
+    })
+
+    describe('getSurveyResponsePropertyKeys', () => {
+        const makeSurvey = (questions: { question: string; type: SurveyQuestionType; id?: string }[]): Survey =>
+            ({
+                questions: questions.map((question, index) => ({
+                    ...question,
+                    id: question.id ?? `question-${index}`,
+                })),
+            }) as unknown as Survey
+
+        it('generates display labels, legacy keys, and UUID keys for survey response questions', () => {
+            const survey = makeSurvey([
+                { question: 'How likely are you to recommend us?', type: SurveyQuestionType.Rating, id: 'rating-id' },
+                { question: 'What can we improve?', type: SurveyQuestionType.Open, id: 'open-id' },
+            ])
+
+            expect(getSurveyResponsePropertyKeys(survey)).toEqual([
+                {
+                    key: '$survey_response',
+                    uuidKey: '$survey_response_rating-id',
+                    filterLabel: 'Survey response for 1st question',
+                    buttonLabel: 'How likely are you to recommend us?',
+                    question: 'How likely are you to recommend us?',
+                },
+                {
+                    key: '$survey_response_1',
+                    uuidKey: '$survey_response_open-id',
+                    filterLabel: 'Survey response for 2nd question',
+                    buttonLabel: 'What can we improve?',
+                    question: 'What can we improve?',
+                },
+            ])
+        })
+
+        it('skips link questions but preserves original question indices', () => {
+            const survey = makeSurvey([
+                { question: 'Rate us', type: SurveyQuestionType.Rating, id: 'rating-id' },
+                { question: 'Visit our site', type: SurveyQuestionType.Link, id: 'link-id' },
+                { question: 'Any feedback?', type: SurveyQuestionType.Open, id: 'open-id' },
+            ])
+
+            expect(getSurveyResponsePropertyKeys(survey)).toEqual([
+                {
+                    key: '$survey_response',
+                    uuidKey: '$survey_response_rating-id',
+                    filterLabel: 'Survey response for 1st question',
+                    buttonLabel: 'Rate us',
+                    question: 'Rate us',
+                },
+                {
+                    key: '$survey_response_2',
+                    uuidKey: '$survey_response_open-id',
+                    filterLabel: 'Survey response for 3rd question',
+                    buttonLabel: 'Any feedback?',
+                    question: 'Any feedback?',
+                },
+            ])
+        })
+
+        it('uses th for 11th, 12th, and 13th question labels', () => {
+            const survey = makeSurvey(
+                Array.from({ length: 13 }, (_, index) => ({
+                    question: `Question ${index + 1}`,
+                    type: SurveyQuestionType.Open,
+                }))
+            )
+
+            const result = getSurveyResponsePropertyKeys(survey)
+
+            expect(result[10].filterLabel).toBe('Survey response for 11th question')
+            expect(result[11].filterLabel).toBe('Survey response for 12th question')
+            expect(result[12].filterLabel).toBe('Survey response for 13th question')
+        })
+
+        it('truncates only the add-filter button label', () => {
+            const survey = makeSurvey([
+                {
+                    question: 'This is a very long question that should be truncated at forty characters',
+                    type: SurveyQuestionType.Open,
+                },
+            ])
+
+            const result = getSurveyResponsePropertyKeys(survey)
+
+            expect(result[0].buttonLabel).toBe('This is a very long question that shoul...')
+            expect(result[0].question).toBe('This is a very long question that should be truncated at forty characters')
+        })
+    })
+
+    describe('getSurveyResponseFilterDisplayData', () => {
+        it('adds display labels only to matching event property filters and returns UUID picker options', () => {
+            const survey = {
+                questions: [{ id: 'open-id', question: 'What can we improve?', type: SurveyQuestionType.Open }],
+            } as unknown as Survey
+            const filters: AnyPropertyFilter[] = [
+                {
+                    key: '$survey_response_open-id',
+                    value: 'pricing',
+                    operator: PropertyOperator.Exact,
+                    type: PropertyFilterType.Event,
+                },
+                {
+                    key: '$survey_response_open-id',
+                    value: 'pricing',
+                    operator: PropertyOperator.Exact,
+                    type: PropertyFilterType.Person,
+                },
+            ]
+
+            const {
+                propertyFiltersWithSurveyLabels,
+                surveyResponsePropertyOptions,
+                taxonomicFilterOptionsFromProp,
+                excludedProperties,
+            } = getSurveyResponseFilterDisplayData(survey, filters)
+
+            expect(propertyFiltersWithSurveyLabels[0]).toEqual({
+                ...filters[0],
+                label: 'Survey response for 1st question',
+            })
+            expect(propertyFiltersWithSurveyLabels[1]).toEqual(filters[1])
+            expect(surveyResponsePropertyOptions).toEqual([
+                {
+                    name: '$survey_response_open-id',
+                    label: 'Survey response for 1st question',
+                    description: 'What can we improve?',
+                    property_type: PropertyType.String,
+                },
+            ])
+            expect(taxonomicFilterOptionsFromProp).toEqual({
+                [TaxonomicFilterGroupType.EventProperties]: surveyResponsePropertyOptions,
+            })
+            expect(excludedProperties).toEqual({
+                [TaxonomicFilterGroupType.EventProperties]: ['$survey_response_open-id'],
+            })
         })
     })
 

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -2,13 +2,19 @@ import DOMPurify from 'dompurify'
 import { DeepPartialMap, ValidationErrorType } from 'kea-forms'
 import posthog from 'posthog-js'
 
+import {
+    type ExcludedProperties,
+    TaxonomicFilterGroupType,
+    type TaxonomicFilterProps,
+} from 'lib/components/TaxonomicFilter/types'
 import { dayjs } from 'lib/dayjs'
-import { dateStringToDayJs } from 'lib/utils'
+import { dateStringToDayJs, truncate } from 'lib/utils'
 import { getAppContext } from 'lib/utils/getAppContext'
 import { NEW_SURVEY, NewSurvey, SURVEY_CREATED_SOURCE, SURVEY_RATING_SCALE } from 'scenes/surveys/constants'
 import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
 
 import {
+    AnyPropertyFilter,
     BasicSurveyQuestion,
     CyclotronJobInvocationGlobals,
     CyclotronJobFiltersType,
@@ -18,6 +24,7 @@ import {
     MultipleSurveyQuestion,
     PropertyFilterType,
     PropertyOperator,
+    PropertyType,
     QuestionProcessedResponses,
     RatingSurveyQuestion,
     Survey,
@@ -107,6 +114,66 @@ export function getSurveyIdBasedResponseKey(questionId: string): string {
     return `${SurveyEventProperties.SURVEY_RESPONSE}_${questionId}`
 }
 
+export type SurveyResponsePropertyKey = {
+    key: string
+    uuidKey?: string
+    filterLabel: string
+    buttonLabel: string
+    question: string
+}
+
+export type SurveyResponsePropertyOption = {
+    name: string
+    label: string
+    description: string
+    property_type: PropertyType
+}
+
+export type SurveyResponseFilterDisplayData = {
+    surveyResponsePropertyKeys: SurveyResponsePropertyKey[]
+    propertyFiltersWithSurveyLabels: AnyPropertyFilter[]
+    surveyResponsePropertyOptions: SurveyResponsePropertyOption[]
+    taxonomicFilterOptionsFromProp?: TaxonomicFilterProps['optionsFromProp']
+    excludedProperties?: ExcludedProperties
+}
+
+function ordinal(value: number): string {
+    const remainder = value % 100
+    if (remainder >= 11 && remainder <= 13) {
+        return `${value}th`
+    }
+
+    switch (value % 10) {
+        case 1:
+            return `${value}st`
+        case 2:
+            return `${value}nd`
+        case 3:
+            return `${value}rd`
+        default:
+            return `${value}th`
+    }
+}
+
+export function getSurveyResponsePropertyKeys(survey: Survey): SurveyResponsePropertyKey[] {
+    return survey.questions
+        .map((question, index) => {
+            if (question.type === SurveyQuestionType.Link) {
+                return null
+            }
+            const questionOrdinal = ordinal(index + 1)
+
+            return {
+                key: getSurveyResponseKey(index),
+                uuidKey: question.id ? getSurveyIdBasedResponseKey(question.id) : undefined,
+                filterLabel: `Survey response for ${questionOrdinal} question`,
+                buttonLabel: truncate(question.question, 40),
+                question: question.question,
+            }
+        })
+        .filter(Boolean) as SurveyResponsePropertyKey[]
+}
+
 type SurveyExampleContext = Pick<Survey, 'id' | 'name' | 'questions'> | null | undefined
 
 function getExampleSurveyResponseValue(question: SurveyQuestion, index: number): string | string[] | undefined {
@@ -121,6 +188,69 @@ function getExampleSurveyResponseValue(question: SurveyQuestion, index: number):
             return question.choices.slice(0, Math.min(question.choices.length, 2))
         case SurveyQuestionType.Link:
             return undefined
+    }
+}
+
+export function getSurveyResponseFilterDisplayData(
+    survey: Survey | null | undefined,
+    propertyFilters: AnyPropertyFilter[]
+): SurveyResponseFilterDisplayData {
+    const surveyResponsePropertyKeys = survey ? getSurveyResponsePropertyKeys(survey) : []
+
+    const surveyResponsePropertyByKey = new Map<string, SurveyResponsePropertyKey>(
+        surveyResponsePropertyKeys.flatMap((property) =>
+            property.uuidKey
+                ? [[property.key, property] as const, [property.uuidKey, property] as const]
+                : [[property.key, property] as const]
+        )
+    )
+
+    const propertyFiltersWithSurveyLabels = propertyFilters.map((property) => {
+        if (property.type !== PropertyFilterType.Event || typeof property.key !== 'string') {
+            return property
+        }
+
+        const surveyResponseProperty = surveyResponsePropertyByKey.get(property.key)
+
+        return surveyResponseProperty
+            ? {
+                  ...property,
+                  label: surveyResponseProperty.filterLabel,
+              }
+            : property
+    })
+
+    const surveyResponsePropertyOptions = surveyResponsePropertyKeys.flatMap(({ uuidKey, filterLabel, question }) =>
+        uuidKey
+            ? [
+                  {
+                      name: uuidKey,
+                      label: filterLabel,
+                      description: question,
+                      property_type: PropertyType.String,
+                  },
+              ]
+            : []
+    )
+
+    const taxonomicFilterOptionsFromProp = surveyResponsePropertyOptions.length
+        ? {
+              [TaxonomicFilterGroupType.EventProperties]: surveyResponsePropertyOptions,
+          }
+        : undefined
+
+    const excludedProperties = surveyResponsePropertyOptions.length
+        ? {
+              [TaxonomicFilterGroupType.EventProperties]: surveyResponsePropertyOptions.map((option) => option.name),
+          }
+        : undefined
+
+    return {
+        surveyResponsePropertyKeys,
+        propertyFiltersWithSurveyLabels,
+        surveyResponsePropertyOptions,
+        taxonomicFilterOptionsFromProp,
+        excludedProperties,
     }
 }
 

--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { SimpleOption, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { isOperatorSemver } from 'lib/utils'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
@@ -44,6 +44,7 @@ export type HogFlowFiltersProps = {
     setFilters: (filters: HogFlowAction['filters']) => void
     typeKey?: string
     buttonCopy?: string
+    eventPropertyOptions?: SimpleOption[]
 }
 
 /**
@@ -102,7 +103,12 @@ export function HogFlowEventFilters({ filters, setFilters, typeKey, buttonCopy }
     )
 }
 
-export function HogFlowPropertyFilters({ filtersKey, filters, setFilters }: HogFlowFiltersProps): JSX.Element {
+export function HogFlowPropertyFilters({
+    filtersKey,
+    filters,
+    setFilters,
+    eventPropertyOptions = [],
+}: HogFlowFiltersProps): JSX.Element {
     const sampleGlobals = useSampleGlobals()
     const { groupsTaxonomicTypes } = useValues(groupsModel)
     const { workflow } = useValues(workflowLogic)
@@ -112,6 +118,11 @@ export function HogFlowPropertyFilters({ filtersKey, filters, setFilters }: HogF
         [TaxonomicFilterGroupType.WorkflowVariables]: (workflow?.variables ?? []).map((variable) => ({
             name: variable.key,
         })),
+        ...(eventPropertyOptions.length
+            ? {
+                  [TaxonomicFilterGroupType.EventProperties]: eventPropertyOptions,
+              }
+            : {}),
     }
     return (
         <PropertyFilters
@@ -130,6 +141,13 @@ export function HogFlowPropertyFilters({ filtersKey, filters, setFilters }: HogF
                 TaxonomicFilterGroupType.EventMetadata,
             ]}
             taxonomicFilterOptionsFromProp={taxonomicFilterOptionsFromProp}
+            excludedProperties={
+                eventPropertyOptions.length
+                    ? {
+                          [TaxonomicFilterGroupType.EventProperties]: eventPropertyOptions.map((option) => option.name),
+                      }
+                    : undefined
+            }
             metadataSource={{
                 kind: NodeKind.EventsQuery,
                 select: defaultDataTableColumns(NodeKind.EventsQuery),

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.test.ts
@@ -1,17 +1,7 @@
-import { Survey, SurveyEventName, SurveyQuestionType } from '~/types'
+import { SurveyEventName } from '~/types'
 
-import {
-    buildProperties,
-    getSelectedSurveyId,
-    getSurveyResponsePropertyKeys,
-    getUserProperties,
-    isSurveyTriggerConfig,
-} from './surveys'
+import { buildProperties, getSelectedSurveyId, getUserProperties, isSurveyTriggerConfig } from './surveys'
 import { getRegisteredTriggerTypes } from './triggerTypeRegistry'
-
-// Partial mock — getSurveyResponsePropertyKeys only accesses survey.questions
-const makeSurvey = (questions: { question: string; type: SurveyQuestionType }[]): Survey =>
-    ({ questions: questions.map((q) => ({ ...q, id: 'q-id' })) }) as unknown as Survey
 
 describe('surveys', () => {
     const getSurveyTriggerType = (): ReturnType<typeof getRegisteredTriggerTypes>[number] => {
@@ -230,49 +220,6 @@ describe('surveys', () => {
             },
         ])('$name', ({ surveyId, completedOnly, userProps, expected }) => {
             expect(buildProperties(surveyId, completedOnly, userProps)).toEqual(expected)
-        })
-    })
-
-    describe('getSurveyResponsePropertyKeys', () => {
-        it('generates correct keys for multiple questions', () => {
-            const survey = makeSurvey([
-                { question: 'How likely are you to recommend us?', type: SurveyQuestionType.Rating },
-                { question: 'What can we improve?', type: SurveyQuestionType.Open },
-            ])
-            const result = getSurveyResponsePropertyKeys(survey)
-            expect(result).toEqual([
-                {
-                    key: '$survey_response',
-                    buttonLabel: 'How likely are you to recommend us?',
-                    question: 'How likely are you to recommend us?',
-                },
-                { key: '$survey_response_1', buttonLabel: 'What can we improve?', question: 'What can we improve?' },
-            ])
-        })
-
-        it('skips link questions but preserves indices', () => {
-            const survey = makeSurvey([
-                { question: 'Rate us', type: SurveyQuestionType.Rating },
-                { question: 'Visit our site', type: SurveyQuestionType.Link },
-                { question: 'Any feedback?', type: SurveyQuestionType.Open },
-            ])
-            const result = getSurveyResponsePropertyKeys(survey)
-            expect(result).toEqual([
-                { key: '$survey_response', buttonLabel: 'Rate us', question: 'Rate us' },
-                { key: '$survey_response_2', buttonLabel: 'Any feedback?', question: 'Any feedback?' },
-            ])
-        })
-
-        it('truncates long question text', () => {
-            const survey = makeSurvey([
-                {
-                    question: 'This is a very long question that should be truncated at forty characters',
-                    type: SurveyQuestionType.Open,
-                },
-            ])
-            const result = getSurveyResponsePropertyKeys(survey)
-            expect(result[0].buttonLabel).toBe('This is a very long question that shoul...')
-            expect(result[0].question).toBe('This is a very long question that should be truncated at forty characters')
         })
     })
 })

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
@@ -7,11 +7,11 @@ import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { Link } from 'lib/lemon-ui/Link'
-import { truncate } from 'lib/utils'
 import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter/TestAccountFilter'
+import { getSurveyResponseFilterDisplayData } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 
-import { Survey, SurveyEventName, SurveyQuestionType } from '~/types'
+import { SurveyEventName } from '~/types'
 
 import { HogFlowPropertyFilters } from 'products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters'
 import {
@@ -48,20 +48,6 @@ export function getSelectedSurveyId(config: HogFlowAction['config']): string | n
 function getCompletedResponsesOnly(config: EventTriggerConfig): boolean {
     const completedProp = config.filters?.properties?.find((p: any) => p.key === '$survey_completed')
     return completedProp?.value === true
-}
-
-export function getSurveyResponsePropertyKeys(
-    survey: Survey
-): { key: string; buttonLabel: string; question: string }[] {
-    return survey.questions
-        .map((q, index) => {
-            if (q.type === SurveyQuestionType.Link) {
-                return null
-            }
-            const key = index === 0 ? '$survey_response' : `$survey_response_${index}`
-            return { key, buttonLabel: truncate(q.question, 40), question: q.question }
-        })
-        .filter(Boolean) as { key: string; buttonLabel: string; question: string }[]
 }
 
 const MANAGED_PROPERTY_KEYS = new Set(['$survey_id', '$survey_completed'])
@@ -124,6 +110,12 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
         selectedSurveyId && selectedSurveyId !== 'any' ? allSurveys.find((s) => s.id === selectedSurveyId) : null
     const selectedSurveyLabel =
         selectedSurvey?.name ?? (selectedSurveyId && selectedSurveyId !== 'any' ? 'Loading...' : null)
+
+    const {
+        surveyResponsePropertyKeys,
+        propertyFiltersWithSurveyLabels: userPropertiesWithSurveyLabels,
+        surveyResponsePropertyOptions,
+    } = getSurveyResponseFilterDisplayData(selectedSurvey, userProperties)
 
     const surveyOptions = [
         ...(selectedSurveyId && selectedSurveyLabel
@@ -310,8 +302,9 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
             <LemonField.Pure label="Only trigger for specific answers">
                 <div className="flex flex-col gap-2">
                     <HogFlowPropertyFilters
+                        filters={{ properties: userPropertiesWithSurveyLabels }}
+                        eventPropertyOptions={surveyResponsePropertyOptions}
                         filtersKey={`survey-trigger-${node.data.id}`}
-                        filters={{ properties: userProperties }}
                         setFilters={(filters) => {
                             updateTriggerConfig(selectedSurveyId, completedOnly, filters?.properties ?? [])
                         }}
@@ -320,7 +313,7 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
                         <div className="flex flex-col gap-1">
                             <span className="text-xs text-muted">Add filter for a question:</span>
                             <div className="flex flex-wrap gap-1">
-                                {getSurveyResponsePropertyKeys(selectedSurvey).map(({ key, buttonLabel, question }) => (
+                                {surveyResponsePropertyKeys.map(({ key, buttonLabel, question }) => (
                                     <LemonButton
                                         key={key}
                                         type="secondary"


### PR DESCRIPTION
## Problem

When filtering by survey response in workflows trigger config, the filter displays all multi-question survey response properties as "Survey response for NaNth question".

Closes #ISSUE_ID  52309 

## Changes

- Adds survey-aware display metadata for survey response properties.
- Shows labels like `Survey response for 1st question` instead of UUID-based property keys in survey response filters.
- Supports both legacy index-based keys and current question UUID-based keys.
- Applies the fix in Workflows and both survey results filter paths.
- Keeps generic fallback behavior from generating `NaNth` for UUID-based survey response keys.
- Preserves TaxonomicFilter option metadata so injected survey response options can show the question text and property type.

## How did you test this code?

- Ran app locally
- Created multi-question survey
- Responded to survey
- In workflow trigger step, select survey response

** Found same issue in viewing survey results. I applied fix here too.

<img width="1910" height="913" alt="WorkflowTrigger" src="https://github.com/user-attachments/assets/c514eed3-f1e7-4be0-9332-0f19247221db" />
<img width="1910" height="913" alt="SurveyResults" src="https://github.com/user-attachments/assets/9ca211df-999c-4481-a8de-186df097ebcf" />

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
hogli test frontend/src/scenes/surveys/utils.test.ts
hogli test frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
pnpm --filter=@posthog/frontend exec jest products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.test.ts

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no

## Docs update
skip-inkeep-docs
