### PR TITLE
fix(hogql): coerce LHS to numeric for lt/lte/gt/gte/between on json props

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -568,27 +568,29 @@ def _expr_to_compare_op(
     elif operator == PropertyOperator.BETWEEN:
         _validate_between_values(value, operator)
         assert isinstance(value, list)
-        # _validate_between_values already enforces numeric bounds, so the LHS
-        # always needs numeric coercion here.
-        left_low = _force_numeric(expr) if _is_numeric_value(value[0]) else expr
-        left_high = _force_numeric(expr) if _is_numeric_value(value[1]) else expr
+        # `_validate_between_values` accepts string-numerics like "5" via float(), so
+        # the two bounds can arrive with different Python types (e.g. [1, "5"]). Decide
+        # coercion once per BETWEEN to keep both comparisons in the same regime — if
+        # either bound looks numeric, treat the LHS as numeric for both halves so we
+        # don't end up comparing one bound numerically and the other lexicographically.
+        needs_coercion = _is_numeric_value(value[0]) or _is_numeric_value(value[1])
+        left = _force_numeric(expr) if needs_coercion else expr
         return ast.And(
             exprs=[
-                ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=left_low, right=ast.Constant(value=value[0])),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.LtEq, left=left_high, right=ast.Constant(value=value[1])
-                ),
+                ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=left, right=ast.Constant(value=value[0])),
+                ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=left, right=ast.Constant(value=value[1])),
             ]
         )
     elif operator == PropertyOperator.NOT_BETWEEN:
         _validate_between_values(value, operator)
         assert isinstance(value, list)
-        left_low = _force_numeric(expr) if _is_numeric_value(value[0]) else expr
-        left_high = _force_numeric(expr) if _is_numeric_value(value[1]) else expr
+        # See BETWEEN above — same one-decision-per-bound-pair rationale.
+        needs_coercion = _is_numeric_value(value[0]) or _is_numeric_value(value[1])
+        left = _force_numeric(expr) if needs_coercion else expr
         return ast.Or(
             exprs=[
-                ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=left_low, right=ast.Constant(value=value[0])),
-                ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=left_high, right=ast.Constant(value=value[1])),
+                ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=left, right=ast.Constant(value=value[0])),
+                ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=left, right=ast.Constant(value=value[1])),
             ]
         )
     elif operator == PropertyOperator.IS_CLEANED_PATH_EXACT:

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -355,6 +355,32 @@ def _resolve_date_value(value: ValueT, team: Team) -> ValueT:
     return value
 
 
+def _is_numeric_value(value: ValueT) -> bool:
+    """Check whether ``value`` should drive numeric coercion of the LHS.
+
+    Booleans subclass int in Python, so ``isinstance(True, int)`` is ``True`` —
+    exclude them explicitly so boolean comparisons stay literal.
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _force_numeric(expr: ast.Expr) -> ast.Expr:
+    """Coerce ``expr`` to Float64 for numeric comparison.
+
+    Event JSON properties live as strings (``JSONExtractRaw`` returns a String),
+    so a String-vs-Int comparison like ``properties.rating <= 3`` is rejected by
+    ClickHouse with "no supertype for types String, Float64". The hog VM that
+    evaluates filters at delivery time auto-coerces strings to numbers via
+    ``unifyComparisonTypes``; this helper makes the ClickHouse path match.
+
+    Wrapping in ``toFloat`` (which maps to ``accurateCastOrNull(..., 'Float64')``)
+    lets a row through only when the property parses cleanly as a number;
+    non-numeric strings become NULL and the comparison drops them — same as the
+    runtime VM rejects them.
+    """
+    return ast.Call(name="toFloat", args=[expr])
+
+
 def _force_datetime(expr: ast.Expr) -> ast.Expr:
     """Coerce ``expr`` to DateTime for chronological IS_DATE_* comparison.
 
@@ -514,7 +540,8 @@ def _expr_to_compare_op(
             right=ast.Constant(value=_handle_bool_values(value, expr, property, team)),
         )
     elif operator == PropertyOperator.LT:
-        return ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=expr, right=ast.Constant(value=value))
+        left = _force_numeric(expr) if _is_numeric_value(value) else expr
+        return ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=left, right=ast.Constant(value=value))
     elif operator == PropertyOperator.IS_DATE_BEFORE:
         assert isinstance(value, str)
         return ast.CompareOperation(
@@ -523,7 +550,8 @@ def _expr_to_compare_op(
             right=_force_datetime(ast.Constant(value=_resolve_date_value(value, team))),
         )
     elif operator == PropertyOperator.GT:
-        return ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=expr, right=ast.Constant(value=value))
+        left = _force_numeric(expr) if _is_numeric_value(value) else expr
+        return ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=left, right=ast.Constant(value=value))
     elif operator == PropertyOperator.IS_DATE_AFTER:
         assert isinstance(value, str)
         return ast.CompareOperation(
@@ -532,25 +560,35 @@ def _expr_to_compare_op(
             right=_force_datetime(ast.Constant(value=_resolve_date_value(value, team))),
         )
     elif operator == PropertyOperator.LTE or operator == PropertyOperator.MAX:
-        return ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=expr, right=ast.Constant(value=value))
+        left = _force_numeric(expr) if _is_numeric_value(value) else expr
+        return ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=left, right=ast.Constant(value=value))
     elif operator == PropertyOperator.GTE or operator == PropertyOperator.MIN:
-        return ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=expr, right=ast.Constant(value=value))
+        left = _force_numeric(expr) if _is_numeric_value(value) else expr
+        return ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=left, right=ast.Constant(value=value))
     elif operator == PropertyOperator.BETWEEN:
         _validate_between_values(value, operator)
         assert isinstance(value, list)
+        # _validate_between_values already enforces numeric bounds, so the LHS
+        # always needs numeric coercion here.
+        left_low = _force_numeric(expr) if _is_numeric_value(value[0]) else expr
+        left_high = _force_numeric(expr) if _is_numeric_value(value[1]) else expr
         return ast.And(
             exprs=[
-                ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=expr, right=ast.Constant(value=value[0])),
-                ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=expr, right=ast.Constant(value=value[1])),
+                ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=left_low, right=ast.Constant(value=value[0])),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.LtEq, left=left_high, right=ast.Constant(value=value[1])
+                ),
             ]
         )
     elif operator == PropertyOperator.NOT_BETWEEN:
         _validate_between_values(value, operator)
         assert isinstance(value, list)
+        left_low = _force_numeric(expr) if _is_numeric_value(value[0]) else expr
+        left_high = _force_numeric(expr) if _is_numeric_value(value[1]) else expr
         return ast.Or(
             exprs=[
-                ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=expr, right=ast.Constant(value=value[0])),
-                ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=expr, right=ast.Constant(value=value[1])),
+                ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=left_low, right=ast.Constant(value=value[0])),
+                ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=left_high, right=ast.Constant(value=value[1])),
             ]
         )
     elif operator == PropertyOperator.IS_CLEANED_PATH_EXACT:

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -132,7 +132,7 @@ class TestProperty(BaseTest):
             self._property_to_expr(
                 Property(type="group", group_type_index=0, key="arr", operator="gt", value=100), scope="group"
             ),
-            self._parse_expr("properties.arr > 100"),
+            self._parse_expr("toFloat(properties.arr) > 100"),
         )
 
     def test_property_to_expr_group_booleans(self):
@@ -1334,17 +1334,17 @@ class TestProperty(BaseTest):
     def test_property_to_expr_between_operator(self):
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "age", "operator": "between", "value": [18, 65]}),
-            self._parse_expr("(properties.age >= 18 AND properties.age <= 65)"),
+            self._parse_expr("(toFloat(properties.age) >= 18 AND toFloat(properties.age) <= 65)"),
         )
 
         self.assertEqual(
             self._property_to_expr({"type": "person", "key": "age", "operator": "between", "value": [25, 50]}),
-            self._parse_expr("(person.properties.age >= 25 AND person.properties.age <= 50)"),
+            self._parse_expr("(toFloat(person.properties.age) >= 25 AND toFloat(person.properties.age) <= 50)"),
         )
 
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "score", "operator": "not_between", "value": [0, 100]}),
-            self._parse_expr("(properties.score < 0 OR properties.score > 100)"),
+            self._parse_expr("(toFloat(properties.score) < 0 OR toFloat(properties.score) > 100)"),
         )
 
     def test_property_to_expr_between_operator_validation(self):
@@ -1383,26 +1383,56 @@ class TestProperty(BaseTest):
         # Test MIN operator (alias for GTE)
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "age", "operator": "min", "value": 18}),
-            self._parse_expr("properties.age >= 18"),
+            self._parse_expr("toFloat(properties.age) >= 18"),
         )
 
         # Test MAX operator (alias for LTE)
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "age", "operator": "max", "value": 65}),
-            self._parse_expr("properties.age <= 65"),
+            self._parse_expr("toFloat(properties.age) <= 65"),
         )
 
         # Test MIN with person properties
         self.assertEqual(
             self._property_to_expr({"type": "person", "key": "age", "operator": "min", "value": 25}),
-            self._parse_expr("person.properties.age >= 25"),
+            self._parse_expr("toFloat(person.properties.age) >= 25"),
         )
 
         # Test MAX with person properties
         self.assertEqual(
             self._property_to_expr({"type": "person", "key": "score", "operator": "max", "value": 100}),
-            self._parse_expr("person.properties.score <= 100"),
+            self._parse_expr("toFloat(person.properties.score) <= 100"),
         )
+
+    def test_property_to_expr_numeric_coercion_for_comparison_operators(self):
+        """LT/LTE/GT/GTE on event JSON properties must coerce the LHS to a number.
+
+        Event ``properties`` are stored as JSON-extracted strings in ClickHouse.
+        Comparing String <= Float64 has no supertype and the query errors out
+        with "There is no supertype for types String, Float64". The hog VM that
+        evaluates the same filter at delivery time auto-coerces via
+        unifyComparisonTypes, so the ClickHouse path needs to match.
+        """
+        for operator, op_sql in [("lt", "<"), ("lte", "<="), ("gt", ">"), ("gte", ">=")]:
+            self.assertEqual(
+                self._property_to_expr({"type": "event", "key": "rating", "value": 3, "operator": operator}),
+                self._parse_expr(f"toFloat(properties.rating) {op_sql} 3"),
+            )
+            # Float values also trigger coercion.
+            self.assertEqual(
+                self._property_to_expr({"type": "event", "key": "rating", "value": 3.5, "operator": operator}),
+                self._parse_expr(f"toFloat(properties.rating) {op_sql} 3.5"),
+            )
+            # String values keep lexicographic comparison (existing behavior).
+            self.assertEqual(
+                self._property_to_expr({"type": "event", "key": "rating", "value": "3", "operator": operator}),
+                self._parse_expr(f"properties.rating {op_sql} '3'"),
+            )
+            # Booleans are not numeric in this context.
+            self.assertEqual(
+                self._property_to_expr({"type": "event", "key": "flag", "value": True, "operator": operator}),
+                self._parse_expr(f"properties.flag {op_sql} true"),
+            )
 
     def test_property_to_expr_semver_operators(self):
         # Test semver_eq

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -2060,10 +2060,11 @@ class TestPropertyNumericOperatorsWithData(APIBaseTest):
     comparing a String with an Int constant has no supertype in ClickHouse.
     """
 
+    event_name = "survey_response"
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.event_name = "survey_response"
 
         # The ``"five"`` and missing-rating rows are the contract-defining ones: the
         # numeric coercion must drop them silently (accurateCastOrNull returns NULL,

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -1472,19 +1472,44 @@ class TestProperty(BaseTest):
         )
 
     def test_property_to_expr_numeric_coercion_in_between_validation(self):
-        """BETWEEN already enforces numeric bounds via _validate_between_values, so the LHS
-        is always coerced. Confirm both bounds wrap independently — there's no scenario
-        where one bound is numeric and the other isn't.
+        """BETWEEN bounds may arrive with mixed Python types because
+        ``_validate_between_values`` accepts string-numerics like ``"5"`` via ``float()``.
+        Coercion must be decided once per BETWEEN so both halves stay in the same
+        comparison regime — never one numeric and one lexicographic.
         """
-        # Float bounds.
+        # Float bounds: both numeric → both halves coerced.
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": [0.5, 99.5]}),
             self._parse_expr("(toFloat(properties.score) >= 0.5 AND toFloat(properties.score) <= 99.5)"),
         )
-        # Mixed int/float.
+        # Mixed int/float: both numeric → both halves coerced.
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": [0, 99.5]}),
             self._parse_expr("(toFloat(properties.score) >= 0 AND toFloat(properties.score) <= 99.5)"),
+        )
+        # Mixed int/string-numeric: one side is numeric, so both halves must coerce —
+        # otherwise we'd produce ``toFloat(x) >= 1 AND x <= '5'`` (numeric on one side,
+        # lexicographic on the other), which gives subtly wrong results.
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": [1, "5"]}),
+            self._parse_expr("(toFloat(properties.score) >= 1 AND toFloat(properties.score) <= '5')"),
+        )
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": ["1", 5]}),
+            self._parse_expr("(toFloat(properties.score) >= '1' AND toFloat(properties.score) <= 5)"),
+        )
+        # Both bounds are string-numerics: neither is _is_numeric_value, so we keep
+        # the legacy lexicographic comparison — matches the single-value LT/LTE
+        # behavior for string operands.
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": ["1", "5"]}),
+            self._parse_expr("(properties.score >= '1' AND properties.score <= '5')"),
+        )
+
+        # Same one-decision-per-pair rule for NOT_BETWEEN.
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "score", "operator": "not_between", "value": [1, "5"]}),
+            self._parse_expr("(toFloat(properties.score) < 1 OR toFloat(properties.score) > '5')"),
         )
 
     def test_property_to_expr_numeric_coercion_does_not_affect_other_operators(self):

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -1423,6 +1423,19 @@ class TestProperty(BaseTest):
                 self._property_to_expr({"type": "event", "key": "rating", "value": 3.5, "operator": operator}),
                 self._parse_expr(f"toFloat(properties.rating) {op_sql} 3.5"),
             )
+            # Negative numbers, zero, and large numbers all coerce too.
+            self.assertEqual(
+                self._property_to_expr({"type": "event", "key": "rating", "value": -1, "operator": operator}),
+                self._parse_expr(f"toFloat(properties.rating) {op_sql} -1"),
+            )
+            self.assertEqual(
+                self._property_to_expr({"type": "event", "key": "rating", "value": 0, "operator": operator}),
+                self._parse_expr(f"toFloat(properties.rating) {op_sql} 0"),
+            )
+            self.assertEqual(
+                self._property_to_expr({"type": "event", "key": "rating", "value": 1_000_000, "operator": operator}),
+                self._parse_expr(f"toFloat(properties.rating) {op_sql} 1000000"),
+            )
             # String values keep lexicographic comparison (existing behavior).
             self.assertEqual(
                 self._property_to_expr({"type": "event", "key": "rating", "value": "3", "operator": operator}),
@@ -1433,6 +1446,71 @@ class TestProperty(BaseTest):
                 self._property_to_expr({"type": "event", "key": "flag", "value": True, "operator": operator}),
                 self._parse_expr(f"properties.flag {op_sql} true"),
             )
+
+    def test_property_to_expr_numeric_coercion_across_scopes(self):
+        """Numeric coercion must apply to all property scopes (event, person, group, session)."""
+        # Person property
+        self.assertEqual(
+            self._property_to_expr({"type": "person", "key": "age", "value": 25, "operator": "lte"}),
+            self._parse_expr("toFloat(person.properties.age) <= 25"),
+        )
+        # Group property
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "group", "group_type_index": 0, "key": "size", "value": 100, "operator": "gte"},
+                scope="event",
+            ),
+            self._parse_expr("toFloat(group_0.properties.size) >= 100"),
+        )
+        # Session property (typed column, but coercion is a no-op cast and still safe to apply).
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "session", "key": "$session_duration", "value": 60, "operator": "lte"},
+                scope="event",
+            ),
+            self._parse_expr("toFloat(session.$session_duration) <= 60"),
+        )
+
+    def test_property_to_expr_numeric_coercion_in_between_validation(self):
+        """BETWEEN already enforces numeric bounds via _validate_between_values, so the LHS
+        is always coerced. Confirm both bounds wrap independently — there's no scenario
+        where one bound is numeric and the other isn't.
+        """
+        # Float bounds.
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": [0.5, 99.5]}),
+            self._parse_expr("(toFloat(properties.score) >= 0.5 AND toFloat(properties.score) <= 99.5)"),
+        )
+        # Mixed int/float.
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": [0, 99.5]}),
+            self._parse_expr("(toFloat(properties.score) >= 0 AND toFloat(properties.score) <= 99.5)"),
+        )
+
+    def test_property_to_expr_numeric_coercion_does_not_affect_other_operators(self):
+        """Equality, contains, regex, IS_SET etc. must NOT be coerced — they need
+        string/literal semantics. A regression here would break any filter relying on those.
+        """
+        # exact / EQ — keeps literal comparison, no toFloat wrap.
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "rating", "value": 3, "operator": "exact"}),
+            self._parse_expr("properties.rating = 3"),
+        )
+        # is_not — keeps literal NotEq comparison.
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "rating", "value": 3, "operator": "is_not"}),
+            self._parse_expr("properties.rating != 3"),
+        )
+        # icontains — uses toString, never toFloat.
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "rating", "value": 3, "operator": "icontains"}),
+            self._parse_expr("toString(properties.rating) ilike '%3%'"),
+        )
+        # is_set — NotEq null, no coercion involved.
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "rating", "operator": "is_set"}),
+            self._parse_expr("properties.rating != null"),
+        )
 
     def test_property_to_expr_semver_operators(self):
         # Test semver_eq
@@ -1953,3 +2031,149 @@ class TestPropertyDateOperatorsWithData(APIBaseTest):
 
         count = self._run({"type": "event", "key": "signup_dt", "value": value, "operator": operator})
         assert count == expected_count
+
+
+class TestPropertyNumericOperatorsWithData(APIBaseTest):
+    """End-to-end tests for LT/LTE/GT/GTE/BETWEEN/NOT_BETWEEN on JSON properties that
+    actually execute the generated SQL against ClickHouse.
+
+    Unit tests only assert AST shape and can't catch ClickHouse-level type errors. The
+    real bug we fixed surfaced as "There is no supertype for types String, Float64"
+    because event JSON property values come out of ``JSONExtractRaw`` as String, and
+    comparing a String with an Int constant has no supertype in ClickHouse.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.event_name = "survey_response"
+
+        # Six "numeric" responses spanning the typical survey scale.
+        for distinct_id, rating, comment in [
+            ("u1", 1, "ok"),
+            ("u2", 2, "ok"),
+            ("u3", 3, "ok"),
+            ("u4", 4, "ok"),
+            ("u5", 5, "ok"),
+            # A non-numeric rating like "five" must be dropped silently by toFloat
+            # (accurateCastOrNull returns NULL, comparison is NULL, filter excludes).
+            ("u6", "five", "ok"),
+            # Missing rating — same expectation: row excluded.
+            ("u7", None, "ok"),
+        ]:
+            properties: dict[str, Any] = {"comment": comment}
+            if rating is not None:
+                properties["rating"] = rating
+            _create_event(
+                team=cls.team,
+                event=cls.event_name,
+                distinct_id=distinct_id,
+                properties=properties,
+            )
+
+    def _run(self, filter: dict) -> int:
+        expr = property_to_expr(filter, team=self.team, scope="event")
+        query_ast = ast.SelectQuery(
+            select=[ast.Call(name="count", args=[])],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.And(
+                exprs=[
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=ast.Field(chain=["event"]),
+                        right=ast.Constant(value=self.event_name),
+                    ),
+                    expr,
+                ]
+            ),
+        )
+        result = execute_hogql_query(team=self.team, query=query_ast)
+        return result.results[0][0]
+
+    @parameterized.expand(
+        [
+            # (operator, value, expected_count, description)
+            ("lte", 3, 3, "lte 3 matches ratings 1,2,3"),
+            ("lt", 3, 2, "lt 3 matches ratings 1,2"),
+            ("gte", 3, 3, "gte 3 matches ratings 3,4,5"),
+            ("gt", 3, 2, "gt 3 matches ratings 4,5"),
+            ("lte", 5, 5, "lte 5 matches all numeric ratings"),
+            ("gte", 1, 5, "gte 1 matches all numeric ratings"),
+            ("lte", 0, 0, "lte 0 matches no rating"),
+            ("gte", 6, 0, "gte 6 matches no rating"),
+            ("lte", -1, 0, "negative threshold matches nothing"),
+        ]
+    )
+    def test_numeric_comparison_filters_events_correctly(
+        self,
+        operator: str,
+        value: int,
+        expected_count: int,
+        _description: str,
+    ):
+        """The actual filter delivered to ClickHouse must run cleanly AND return the right rows.
+
+        This is the precise scenario that triggered the survey notification incident:
+        a ``rating <= 3`` filter on an event JSON property. Before the fix the query
+        errored out; we now also assert that we filter to exactly the rows we expect.
+        """
+        count = self._run({"type": "event", "key": "rating", "value": value, "operator": operator})
+        assert count == expected_count, f"{operator} {value}: expected {expected_count}, got {count}"
+
+    @parameterized.expand(
+        [
+            ("between_1_3", [1, 3], 3, "between [1,3] matches 1,2,3"),
+            ("between_2_4", [2, 4], 3, "between [2,4] matches 2,3,4"),
+            ("between_3_3", [3, 3], 1, "between [3,3] matches 3 only"),
+            ("between_6_9", [6, 9], 0, "between [6,9] outside range"),
+        ]
+    )
+    def test_between_filter_returns_expected_rows(
+        self,
+        _name: str,
+        value: list[int],
+        expected_count: int,
+        _description: str,
+    ):
+        count = self._run({"type": "event", "key": "rating", "value": value, "operator": "between"})
+        assert count == expected_count
+
+    @parameterized.expand(
+        [
+            ("not_between_1_3", [1, 3], 2, "not_between [1,3] excludes 1,2,3 and non-numeric"),
+            ("not_between_2_4", [2, 4], 2, "not_between [2,4] excludes 2,3,4 and non-numeric"),
+        ]
+    )
+    def test_not_between_filter_returns_expected_rows(
+        self,
+        _name: str,
+        value: list[int],
+        expected_count: int,
+        _description: str,
+    ):
+        count = self._run({"type": "event", "key": "rating", "value": value, "operator": "not_between"})
+        assert count == expected_count
+
+    def test_string_comparison_still_uses_lexicographic_semantics(self):
+        """A numeric coercion regression here would silently change string filter results.
+
+        With ``value="3"`` (string), the LHS must NOT be wrapped in ``toFloat`` —
+        the comparison stays lexicographic so existing filters keep working.
+        """
+        # `comment` is the literal string "ok" for every event. "ok" <= "z" lexically.
+        count = self._run({"type": "event", "key": "comment", "value": "z", "operator": "lte"})
+        # All 7 events match — "ok" is lexically <= "z".
+        assert count == 7
+
+    @parameterized.expand([("not_materialized", False), ("materialized", True)])
+    def test_lte_works_against_materialized_column(self, _name: str, is_materialized: bool):
+        """Materialized columns store the property in a typed column. The toFloat wrap
+        should remain valid (toFloat on a numeric column is a no-op cast) and the query
+        should still return the right rows whether or not the column is materialized.
+        """
+        if is_materialized:
+            self.addCleanup(cleanup_materialized_columns)
+            materialize("events", "rating")
+
+        count = self._run({"type": "event", "key": "rating", "value": 3, "operator": "lte"})
+        assert count == 3, f"materialized={is_materialized}: expected 3, got {count}"

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -1418,12 +1418,10 @@ class TestProperty(BaseTest):
                 self._property_to_expr({"type": "event", "key": "rating", "value": 3, "operator": operator}),
                 self._parse_expr(f"toFloat(properties.rating) {op_sql} 3"),
             )
-            # Float values also trigger coercion.
             self.assertEqual(
                 self._property_to_expr({"type": "event", "key": "rating", "value": 3.5, "operator": operator}),
                 self._parse_expr(f"toFloat(properties.rating) {op_sql} 3.5"),
             )
-            # Negative numbers, zero, and large numbers all coerce too.
             self.assertEqual(
                 self._property_to_expr({"type": "event", "key": "rating", "value": -1, "operator": operator}),
                 self._parse_expr(f"toFloat(properties.rating) {op_sql} -1"),
@@ -1436,12 +1434,14 @@ class TestProperty(BaseTest):
                 self._property_to_expr({"type": "event", "key": "rating", "value": 1_000_000, "operator": operator}),
                 self._parse_expr(f"toFloat(properties.rating) {op_sql} 1000000"),
             )
-            # String values keep lexicographic comparison (existing behavior).
+            # String value must stay lexicographic — users explicitly opt out of numeric
+            # comparison by passing a string, and existing filters rely on that.
             self.assertEqual(
                 self._property_to_expr({"type": "event", "key": "rating", "value": "3", "operator": operator}),
                 self._parse_expr(f"properties.rating {op_sql} '3'"),
             )
-            # Booleans are not numeric in this context.
+            # Booleans subclass int in Python; without the explicit guard they would
+            # silently get coerced and break boolean property filters.
             self.assertEqual(
                 self._property_to_expr({"type": "event", "key": "flag", "value": True, "operator": operator}),
                 self._parse_expr(f"properties.flag {op_sql} true"),
@@ -1449,12 +1449,10 @@ class TestProperty(BaseTest):
 
     def test_property_to_expr_numeric_coercion_across_scopes(self):
         """Numeric coercion must apply to all property scopes (event, person, group, session)."""
-        # Person property
         self.assertEqual(
             self._property_to_expr({"type": "person", "key": "age", "value": 25, "operator": "lte"}),
             self._parse_expr("toFloat(person.properties.age) <= 25"),
         )
-        # Group property
         self.assertEqual(
             self._property_to_expr(
                 {"type": "group", "group_type_index": 0, "key": "size", "value": 100, "operator": "gte"},
@@ -1462,7 +1460,9 @@ class TestProperty(BaseTest):
             ),
             self._parse_expr("toFloat(group_0.properties.size) >= 100"),
         )
-        # Session property (typed column, but coercion is a no-op cast and still safe to apply).
+        # `$session_duration` is already numerically typed; the toFloat wrap is a no-op
+        # cast, exercised here so a future "skip coercion for typed columns" optimization
+        # doesn't accidentally diverge between session and event scopes.
         self.assertEqual(
             self._property_to_expr(
                 {"type": "session", "key": "$session_duration", "value": 60, "operator": "lte"},
@@ -1477,19 +1477,17 @@ class TestProperty(BaseTest):
         Coercion must be decided once per BETWEEN so both halves stay in the same
         comparison regime — never one numeric and one lexicographic.
         """
-        # Float bounds: both numeric → both halves coerced.
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": [0.5, 99.5]}),
             self._parse_expr("(toFloat(properties.score) >= 0.5 AND toFloat(properties.score) <= 99.5)"),
         )
-        # Mixed int/float: both numeric → both halves coerced.
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": [0, 99.5]}),
             self._parse_expr("(toFloat(properties.score) >= 0 AND toFloat(properties.score) <= 99.5)"),
         )
-        # Mixed int/string-numeric: one side is numeric, so both halves must coerce —
-        # otherwise we'd produce ``toFloat(x) >= 1 AND x <= '5'`` (numeric on one side,
-        # lexicographic on the other), which gives subtly wrong results.
+        # Mixed int + string-numeric — locks in the one-decision-per-pair behavior so
+        # we can't regress to ``toFloat(x) >= 1 AND x <= '5'`` (lexicographic high bound
+        # would silently exclude ``"10"`` even when the user meant ``<= 5``).
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": [1, "5"]}),
             self._parse_expr("(toFloat(properties.score) >= 1 AND toFloat(properties.score) <= '5')"),
@@ -1498,15 +1496,13 @@ class TestProperty(BaseTest):
             self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": ["1", 5]}),
             self._parse_expr("(toFloat(properties.score) >= '1' AND toFloat(properties.score) <= 5)"),
         )
-        # Both bounds are string-numerics: neither is _is_numeric_value, so we keep
-        # the legacy lexicographic comparison — matches the single-value LT/LTE
-        # behavior for string operands.
+        # Both bounds string: stay lexicographic to match single-value LT/LTE semantics
+        # for string operands — the user explicitly opted out of numeric comparison.
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "score", "operator": "between", "value": ["1", "5"]}),
             self._parse_expr("(properties.score >= '1' AND properties.score <= '5')"),
         )
 
-        # Same one-decision-per-pair rule for NOT_BETWEEN.
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "score", "operator": "not_between", "value": [1, "5"]}),
             self._parse_expr("(toFloat(properties.score) < 1 OR toFloat(properties.score) > '5')"),
@@ -1516,22 +1512,18 @@ class TestProperty(BaseTest):
         """Equality, contains, regex, IS_SET etc. must NOT be coerced — they need
         string/literal semantics. A regression here would break any filter relying on those.
         """
-        # exact / EQ — keeps literal comparison, no toFloat wrap.
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "rating", "value": 3, "operator": "exact"}),
             self._parse_expr("properties.rating = 3"),
         )
-        # is_not — keeps literal NotEq comparison.
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "rating", "value": 3, "operator": "is_not"}),
             self._parse_expr("properties.rating != 3"),
         )
-        # icontains — uses toString, never toFloat.
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "rating", "value": 3, "operator": "icontains"}),
             self._parse_expr("toString(properties.rating) ilike '%3%'"),
         )
-        # is_set — NotEq null, no coercion involved.
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "rating", "operator": "is_set"}),
             self._parse_expr("properties.rating != null"),
@@ -2073,17 +2065,17 @@ class TestPropertyNumericOperatorsWithData(APIBaseTest):
         super().setUpTestData()
         cls.event_name = "survey_response"
 
-        # Six "numeric" responses spanning the typical survey scale.
+        # The ``"five"`` and missing-rating rows are the contract-defining ones: the
+        # numeric coercion must drop them silently (accurateCastOrNull returns NULL,
+        # the comparison is NULL, the row is excluded) so non-numeric or absent values
+        # never accidentally satisfy a numeric filter.
         for distinct_id, rating, comment in [
             ("u1", 1, "ok"),
             ("u2", 2, "ok"),
             ("u3", 3, "ok"),
             ("u4", 4, "ok"),
             ("u5", 5, "ok"),
-            # A non-numeric rating like "five" must be dropped silently by toFloat
-            # (accurateCastOrNull returns NULL, comparison is NULL, filter excludes).
             ("u6", "five", "ok"),
-            # Missing rating — same expectation: row excluded.
             ("u7", None, "ok"),
         ]:
             properties: dict[str, Any] = {"comment": comment}
@@ -2117,16 +2109,15 @@ class TestPropertyNumericOperatorsWithData(APIBaseTest):
 
     @parameterized.expand(
         [
-            # (operator, value, expected_count, description)
-            ("lte", 3, 3, "lte 3 matches ratings 1,2,3"),
-            ("lt", 3, 2, "lt 3 matches ratings 1,2"),
-            ("gte", 3, 3, "gte 3 matches ratings 3,4,5"),
-            ("gt", 3, 2, "gt 3 matches ratings 4,5"),
-            ("lte", 5, 5, "lte 5 matches all numeric ratings"),
-            ("gte", 1, 5, "gte 1 matches all numeric ratings"),
-            ("lte", 0, 0, "lte 0 matches no rating"),
-            ("gte", 6, 0, "gte 6 matches no rating"),
-            ("lte", -1, 0, "negative threshold matches nothing"),
+            ("lte", 3, 3),
+            ("lt", 3, 2),
+            ("gte", 3, 3),
+            ("gt", 3, 2),
+            ("lte", 5, 5),
+            ("gte", 1, 5),
+            ("lte", 0, 0),
+            ("gte", 6, 0),
+            ("lte", -1, 0),
         ]
     )
     def test_numeric_comparison_filters_events_correctly(
@@ -2134,23 +2125,20 @@ class TestPropertyNumericOperatorsWithData(APIBaseTest):
         operator: str,
         value: int,
         expected_count: int,
-        _description: str,
     ):
-        """The actual filter delivered to ClickHouse must run cleanly AND return the right rows.
-
-        This is the precise scenario that triggered the survey notification incident:
-        a ``rating <= 3`` filter on an event JSON property. Before the fix the query
-        errored out; we now also assert that we filter to exactly the rows we expect.
+        """Reproduces the survey-notification incident: a ``rating <= 3`` filter on an
+        event JSON property used to error out at the ClickHouse layer. This test holds
+        the line — the query must compile *and* match exactly the rows the user intends.
         """
         count = self._run({"type": "event", "key": "rating", "value": value, "operator": operator})
         assert count == expected_count, f"{operator} {value}: expected {expected_count}, got {count}"
 
     @parameterized.expand(
         [
-            ("between_1_3", [1, 3], 3, "between [1,3] matches 1,2,3"),
-            ("between_2_4", [2, 4], 3, "between [2,4] matches 2,3,4"),
-            ("between_3_3", [3, 3], 1, "between [3,3] matches 3 only"),
-            ("between_6_9", [6, 9], 0, "between [6,9] outside range"),
+            ("between_1_3", [1, 3], 3),
+            ("between_2_4", [2, 4], 3),
+            ("between_3_3", [3, 3], 1),
+            ("between_6_9", [6, 9], 0),
         ]
     )
     def test_between_filter_returns_expected_rows(
@@ -2158,15 +2146,14 @@ class TestPropertyNumericOperatorsWithData(APIBaseTest):
         _name: str,
         value: list[int],
         expected_count: int,
-        _description: str,
     ):
         count = self._run({"type": "event", "key": "rating", "value": value, "operator": "between"})
         assert count == expected_count
 
     @parameterized.expand(
         [
-            ("not_between_1_3", [1, 3], 2, "not_between [1,3] excludes 1,2,3 and non-numeric"),
-            ("not_between_2_4", [2, 4], 2, "not_between [2,4] excludes 2,3,4 and non-numeric"),
+            ("not_between_1_3", [1, 3], 2),
+            ("not_between_2_4", [2, 4], 2),
         ]
     )
     def test_not_between_filter_returns_expected_rows(
@@ -2174,7 +2161,6 @@ class TestPropertyNumericOperatorsWithData(APIBaseTest):
         _name: str,
         value: list[int],
         expected_count: int,
-        _description: str,
     ):
         count = self._run({"type": "event", "key": "rating", "value": value, "operator": "not_between"})
         assert count == expected_count
@@ -2185,9 +2171,11 @@ class TestPropertyNumericOperatorsWithData(APIBaseTest):
         With ``value="3"`` (string), the LHS must NOT be wrapped in ``toFloat`` —
         the comparison stays lexicographic so existing filters keep working.
         """
-        # `comment` is the literal string "ok" for every event. "ok" <= "z" lexically.
         count = self._run({"type": "event", "key": "comment", "value": "z", "operator": "lte"})
-        # All 7 events match — "ok" is lexically <= "z".
+        # All 7 events match: every seeded ``comment`` is the literal "ok", and
+        # "ok" <= "z" lexically. A numeric-coercion bleed-through would turn "ok"
+        # into NULL via accurateCastOrNull and the count would drop to 0 — the
+        # specific failure mode this test guards against.
         assert count == 7
 
     @parameterized.expand([("not_materialized", False), ("materialized", True)])

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_data_warehouse_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_data_warehouse_metric.ambr
@@ -568,7 +568,7 @@
             posthog_test_usage.ds AS timestamp,
             coalesce(accurateCastOrNull(posthog_test_usage.usage, 'Float64'), 0) AS value
      FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql.experiments.queryrunner/posthog_test_usage/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`ds` Date, `id` String, `plan` String, `usage` Float64, `region` String, `userid` String') AS posthog_test_usage
-     WHERE and(greaterOrEquals(posthog_test_usage.ds, assumeNotNull(toDateTime('2023-01-01 00:00:00', 'UTC'))), less(posthog_test_usage.ds, plus(assumeNotNull(toDateTime('2023-01-31 00:00:00', 'UTC')), toIntervalSecond(0))), greater(posthog_test_usage.usage, 100.0))),
+     WHERE and(greaterOrEquals(posthog_test_usage.ds, assumeNotNull(toDateTime('2023-01-01 00:00:00', 'UTC'))), less(posthog_test_usage.ds, plus(assumeNotNull(toDateTime('2023-01-31 00:00:00', 'UTC')), toIntervalSecond(0))), ifNull(greater(accurateCastOrNull(posthog_test_usage.usage, 'Float64'), 100.0), 0))),
        entity_metrics AS
     (SELECT exposures.entity_id AS entity_id,
             exposures.variant AS variant,
@@ -624,7 +624,7 @@
             posthog_test_usage.ds AS timestamp,
             coalesce(accurateCastOrNull(posthog_test_usage.usage, 'Float64'), 0) AS value
      FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql.experiments.queryrunner/posthog_test_usage/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`ds` Date, `id` String, `plan` String, `usage` Float64, `region` String, `userid` String') AS posthog_test_usage
-     WHERE and(greaterOrEquals(posthog_test_usage.ds, assumeNotNull(toDateTime('2023-01-01 00:00:00', 'UTC'))), less(posthog_test_usage.ds, plus(assumeNotNull(toDateTime('2023-01-31 00:00:00', 'UTC')), toIntervalSecond(0))), and(equals(posthog_test_usage.plan, 'premium'), greater(posthog_test_usage.usage, 50.0)))),
+     WHERE and(greaterOrEquals(posthog_test_usage.ds, assumeNotNull(toDateTime('2023-01-01 00:00:00', 'UTC'))), less(posthog_test_usage.ds, plus(assumeNotNull(toDateTime('2023-01-31 00:00:00', 'UTC')), toIntervalSecond(0))), and(equals(posthog_test_usage.plan, 'premium'), ifNull(greater(accurateCastOrNull(posthog_test_usage.usage, 'Float64'), 50.0), 0)))),
        entity_metrics AS
     (SELECT exposures.entity_id AS entity_id,
             exposures.variant AS variant,

--- a/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
+++ b/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
@@ -98,7 +98,7 @@
      WHERE equals(groups.team_id, 99999)
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
-  WHERE and(ifNull(equals(groups.index, 0), 0), ifNull(greater(accurateCastOrNull(groups.properties___arr, 'Float64'), 100.0), 0))
+  WHERE and(ifNull(equals(groups.index, 0), 0), ifNull(greater(accurateCastOrNull(accurateCastOrNull(groups.properties___arr, 'Float64'), 'Float64'), 100.0), 0))
   ORDER BY groups.created_at DESC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_formula.ambr
@@ -1008,7 +1008,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(toStartOfInterval(assumeNotNull(toDateTime('2019-12-28 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2020-01-04 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS e__session ON equals(e.`$session_id_uuid`, e__session.session_id_v7)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2019-12-28 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2020-01-04 23:59:59', 'UTC'))), equals(e.event, 'session start'), ifNull(greater(e__session.`$session_duration`, 12.0), 0))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2019-12-28 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2020-01-04 23:59:59', 'UTC'))), equals(e.event, 'session start'), ifNull(greater(accurateCastOrNull(e__session.`$session_duration`, 'Float64'), 12.0), 0))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -1072,7 +1072,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(toStartOfInterval(assumeNotNull(toDateTime('2019-12-28 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2020-01-04 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS e__session ON equals(e.`$session_id_uuid`, e__session.session_id_v7)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2019-12-28 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2020-01-04 23:59:59', 'UTC'))), equals(e.event, '$autocapture'), ifNull(less(e__session.`$session_duration`, 30.0), 0))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2019-12-28 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2020-01-04 23:59:59', 'UTC'))), equals(e.event, '$autocapture'), ifNull(less(accurateCastOrNull(e__session.`$session_duration`, 'Float64'), 30.0), 0))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -1107,7 +1107,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(toStartOfInterval(assumeNotNull(toDateTime('2019-12-28 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2020-01-04 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS e__session ON equals(e.`$session_id_uuid`, e__session.session_id_v7)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2019-12-28 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2020-01-04 23:59:59', 'UTC'))), equals(e.event, 'session start'), ifNull(greater(e__session.`$session_duration`, 500.0), 0))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2019-12-28 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2020-01-04 23:59:59', 'UTC'))), equals(e.event, 'session start'), ifNull(greater(accurateCastOrNull(e__session.`$session_duration`, 'Float64'), 500.0), 0))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/posthog/hogql_queries/test/__snapshots__/test_sessions_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_sessions_query_runner.ambr
@@ -499,7 +499,7 @@
      FROM raw_sessions
      WHERE and(equals(raw_sessions.team_id, 99999), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(toDateTime64('2024-01-01 14:00:05.000000', 6, 'UTC'), toIntervalDay(3))), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(3))))
      GROUP BY raw_sessions.session_id_v7) AS sessions
-  WHERE and(ifNull(greaterOrEquals(sessions.`$session_duration`, 0.0), 0), ifNull(less(sessions.`$start_timestamp`, toDateTime64('2024-01-01 14:00:05.000000', 6, 'UTC')), 0), ifNull(greater(sessions.`$start_timestamp`, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(ifNull(greaterOrEquals(accurateCastOrNull(sessions.`$session_duration`, 'Float64'), 0.0), 0), ifNull(less(sessions.`$start_timestamp`, toDateTime64('2024-01-01 14:00:05.000000', 6, 'UTC')), 0), ifNull(greater(sessions.`$start_timestamp`, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), 0))
   ORDER BY sessions.session_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recording_list_from_query.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recording_list_from_query.ambr
@@ -2117,7 +2117,7 @@
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        LIMIT 1000000))))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -2479,7 +2479,7 @@
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(s.min_first_timestamp, toDateTime64('2020-12-29 00:00:00.000000', 6, 'UTC')), lessOrEquals(s.min_first_timestamp, toDateTime64('today', 6, 'UTC')))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -3125,7 +3125,7 @@
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(s.min_first_timestamp, toDateTime64('2020-12-29 00:00:00.000000', 6, 'UTC')), lessOrEquals(s.min_first_timestamp, toDateTime64('today', 6, 'UTC')))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -3165,7 +3165,7 @@
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(s.min_first_timestamp, toDateTime64('2020-12-29 00:00:00.000000', 6, 'UTC')), lessOrEquals(s.min_first_timestamp, toDateTime64('today', 6, 'UTC')))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(less(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(less(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -3393,7 +3393,7 @@
                                                                                                                                                                                                                       ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
                                                                                                                                                                                                                       LIMIT 1000000)))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -3440,7 +3440,7 @@
                                                                                                                                                                                                                       ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
                                                                                                                                                                                                                       LIMIT 1000000)))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(active_seconds, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(active_seconds, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -8094,7 +8094,7 @@
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(s.min_first_timestamp, toDateTime64('2020-12-29 00:00:00.000000', 6, 'UTC')), lessOrEquals(s.min_first_timestamp, toDateTime64('today', 6, 'UTC')))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -9583,7 +9583,7 @@
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        LIMIT 1000000))))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -9945,7 +9945,7 @@
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(s.min_first_timestamp, toDateTime64('2020-12-29 00:00:00.000000', 6, 'UTC')), lessOrEquals(s.min_first_timestamp, toDateTime64('today', 6, 'UTC')))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -10591,7 +10591,7 @@
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(s.min_first_timestamp, toDateTime64('2020-12-29 00:00:00.000000', 6, 'UTC')), lessOrEquals(s.min_first_timestamp, toDateTime64('today', 6, 'UTC')))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -10631,7 +10631,7 @@
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(s.min_first_timestamp, toDateTime64('2020-12-29 00:00:00.000000', 6, 'UTC')), lessOrEquals(s.min_first_timestamp, toDateTime64('today', 6, 'UTC')))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(less(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(less(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -10859,7 +10859,7 @@
                                                                                                                                                                                                                       ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
                                                                                                                                                                                                                       LIMIT 1000000)))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -10906,7 +10906,7 @@
                                                                                                                                                                                                                       ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
                                                                                                                                                                                                                       LIMIT 1000000)))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(active_seconds, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(active_seconds, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,
@@ -15560,7 +15560,7 @@
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(s.min_first_timestamp, toDateTime64('2020-12-29 00:00:00.000000', 6, 'UTC')), lessOrEquals(s.min_first_timestamp, toDateTime64('today', 6, 'UTC')))
   GROUP BY s.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(duration, 60.0), 0))
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(s.is_deleted), 0), 0), ifNull(greater(accurateCastOrNull(duration, 'Float64'), 60.0), 0))
   ORDER BY start_time DESC,
            s.session_id DESC
   LIMIT 51 SETTINGS readonly=2,


### PR DESCRIPTION
## Problem

Numeric property filters like `properties.rating <= 3` on event JSON properties failed at the ClickHouse layer with `There is no supertype for types String, Float64` — the LHS came out of `JSONExtractRaw` as a String and the compiler emitted no coercion. The hog VM that evaluates the same filter at delivery time already coerced via `unifyComparisonTypes`, so deliveries silently worked while every preview surface (notably the sparkline on the survey notification config page) errored out. This divergence between the two evaluators was the actual bug.

Affected surfaces: hog function sparkline preview, cohort previews, insight builders, precalculated filter checks — anywhere `_expr_to_compare_op` runs against a JSON-stored property.

## Changes

- `_force_numeric(expr)` helper wraps LHS in `toFloat(...)` (lowers to `accurateCastOrNull(..., 'Float64')`) so non-numeric values become NULL and drop out — same semantics as the runtime hog VM.
- `_is_numeric_value(value)` decides when to coerce; excludes booleans explicitly because `isinstance(True, int) is True` in Python.
- Applied across `LT`, `LTE`/`MAX`, `GT`, `GTE`/`MIN`, `BETWEEN`, `NOT_BETWEEN`. `BETWEEN`/`NOT_BETWEEN` decide coercion once per bound pair so a `[1, "5"]` filter can't produce one numeric and one lexicographic half.
- Booleans, strings, and lists keep their existing literal/lexicographic comparison.

Fixing this in `_expr_to_compare_op` rather than at the survey notification call site closes the same divergence for every product surface that uses property filters.

## How did you test this code?

I'm an agent (Claude); below is only what I actually ran locally — no manual UI testing.

- 21 new tests in `posthog/hogql/test/test_property.py` (148 total pass, up from 127) covering: edge values (negative/zero/large/float), all scopes (event/person/group/session), mixed-type BETWEEN bounds, guardrail that `exact`/`is_not`/`icontains`/`is_set` aren't coerced, and a `TestPropertyNumericOperatorsWithData` integration class that round-trips real queries against ClickHouse on seeded events including non-numeric and missing values, plus a materialized-column variant.
- Regression sweeps clean: HogQL printer + filters (636 + 182 snapshots), trends (160 + 107 snapshots), CDP (80 + 6 snapshots), cohort suites.
- Verified pre-existing broader-suite failures (test_mapping, test_metadata, feature-flag survey exclusion, funnel data-warehouse breakdowns) reproduce on `master` — environmental, not from this change.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (PostHog Code harness).

Three fix levels considered: (1) cast at the survey notification call site, (2) coerce in `_expr_to_compare_op` so every numeric comparison aligns with the hog VM, (3) unify the two evaluators entirely. Chose (2) — (1) leaves the trap in cohort/insight surfaces, (3) is multi-quarter scope.

Used `toFloat` → `accurateCastOrNull(..., 'Float64')` over `toFloatOrZero` because `accurateCastOrNull` returns NULL for non-numeric values, matching how the hog VM rejects them via `unifyComparisonTypes`. `toFloatOrZero` would silently start matching non-numeric strings against `<= 0` filters.

Greptile flagged a real edge case in `BETWEEN`/`NOT_BETWEEN`: `_validate_between_values` accepts string-numerics like `"5"` through `float()`, so `[1, "5"]` previously produced asymmetric output (`toFloat(x) >= 1 AND x <= '5'` — numeric low, lexicographic high). Fixed in 11d94d74d11 by deciding coercion once per bound pair.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*