### PR TITLE
fix(surveys): tailor launch UX for hosted surveys

### DIFF
--- a/frontend/src/scenes/surveys/CopySurveyLink.tsx
+++ b/frontend/src/scenes/surveys/CopySurveyLink.tsx
@@ -4,7 +4,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { IconLink } from 'lib/lemon-ui/icons'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
-function getSurveyUrl(surveyId: string): string {
+export function getSurveyUrl(surveyId: string): string {
     const url = new URL(window.location.origin)
     url.pathname = `/external_surveys/${surveyId}`
     return url.toString()

--- a/frontend/src/scenes/surveys/components/HostedSurveyRespondentHint.tsx
+++ b/frontend/src/scenes/surveys/components/HostedSurveyRespondentHint.tsx
@@ -2,15 +2,27 @@ import { Link } from '@posthog/lemon-ui'
 
 export function HostedSurveyRespondentHint({ className }: { className?: string }): JSX.Element {
     return (
-        <p className={className ?? 'text-xs text-muted'}>
-            Responses are anonymous by default. Append <code>?distinct_id=...</code> to the URL to tie responses to a
-            specific person.{' '}
+        <div className={`flex flex-col gap-1 text-muted ${className ?? 'text-xs'}`}>
+            <div className="font-medium text-secondary">Customize the URL with query parameters:</div>
+            <ul className="list-disc list-inside space-y-0.5 m-0">
+                <li>
+                    <code>?distinct_id=user_id</code> — tie the response to a specific person (use the same value as{' '}
+                    <code>posthog.identify()</code>)
+                </li>
+                <li>
+                    <code>?q0=2&amp;q1=8</code> — pre-fill answers for one-click surveys in emails (<code>q0</code> =
+                    first question, value = choice or rating)
+                </li>
+                <li>
+                    <code>?key=value</code> — any extra parameter is captured as an event property on the response
+                </li>
+            </ul>
             <Link
                 to="https://posthog.com/docs/surveys/creating-surveys#identifying-respondents-on-hosted-surveys"
                 target="_blank"
             >
-                Learn more
+                Learn more about hosted survey URLs
             </Link>
-        </p>
+        </div>
     )
 }

--- a/frontend/src/scenes/surveys/components/HostedSurveyRespondentHint.tsx
+++ b/frontend/src/scenes/surveys/components/HostedSurveyRespondentHint.tsx
@@ -1,0 +1,16 @@
+import { Link } from '@posthog/lemon-ui'
+
+export function HostedSurveyRespondentHint({ className }: { className?: string }): JSX.Element {
+    return (
+        <p className={className ?? 'text-xs text-muted'}>
+            Responses are anonymous by default. Append <code>?distinct_id=...</code> to the URL to tie responses to a
+            specific person.{' '}
+            <Link
+                to="https://posthog.com/docs/surveys/creating-surveys#identifying-respondents-on-hosted-surveys"
+                target="_blank"
+            >
+                Learn more
+            </Link>
+        </p>
+    )
+}

--- a/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
+++ b/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
@@ -41,10 +41,7 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                             <div className="flex flex-col gap-3">
                                 <SdkVersionWarnings warnings={surveyWarnings} />
                                 {isHostedSurvey ? (
-                                    <div className="flex flex-col gap-2 text-sm">
-                                        <div className="text-secondary">
-                                            Share this link with the people you want to answer the survey.
-                                        </div>
+                                    <div className="flex flex-col gap-3 text-sm">
                                         <div className="flex flex-col gap-1">
                                             <div className="text-muted text-xs">Share link</div>
                                             <CopySurveyLink

--- a/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
+++ b/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
@@ -4,10 +4,11 @@ import { ReactNode } from 'react'
 import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { HostedSurveyRespondentHint } from 'scenes/surveys/components/HostedSurveyRespondentHint'
 import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings'
 import { SurveyConditionsList } from 'scenes/surveys/components/SurveyConditions'
-import { CopySurveyLink } from 'scenes/surveys/CopySurveyLink'
+import { getSurveyUrl } from 'scenes/surveys/CopySurveyLink'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 import { getSurveyDisplayConditionsSummary } from 'scenes/surveys/utils'
 import { teamLogic } from 'scenes/teamLogic'
@@ -42,13 +43,10 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                                 <SdkVersionWarnings warnings={surveyWarnings} />
                                 {isHostedSurvey ? (
                                     <div className="flex flex-col gap-3 text-sm">
-                                        <div className="flex flex-col gap-1">
-                                            <div className="text-muted text-xs">Share link</div>
-                                            <CopySurveyLink
-                                                surveyId={survey.id}
-                                                enableIframeEmbedding={survey.enable_iframe_embedding ?? false}
-                                            />
-                                        </div>
+                                        <p className="text-secondary m-0">
+                                            Once launched, anyone with the link can answer the survey. We'll copy the
+                                            link to your clipboard so you can share it right away.
+                                        </p>
                                         <HostedSurveyRespondentHint />
                                     </div>
                                 ) : conditionsSummary.length > 0 ? (
@@ -69,11 +67,14 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                             </div>
                         ),
                         primaryButton: {
-                            children: 'Launch',
+                            children: isHostedSurvey ? 'Launch and copy link' : 'Launch',
                             type: 'primary',
                             onClick: () => {
                                 if (needsOptIn) {
                                     updateCurrentTeam({ surveys_opt_in: true })
+                                }
+                                if (isHostedSurvey) {
+                                    void copyToClipboard(getSurveyUrl(survey.id), 'survey link')
                                 }
                                 launchSurvey()
                             },

--- a/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
+++ b/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react'
 import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
-import { Link } from 'lib/lemon-ui/Link'
+import { HostedSurveyRespondentHint } from 'scenes/surveys/components/HostedSurveyRespondentHint'
 import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings'
 import { SurveyConditionsList } from 'scenes/surveys/components/SurveyConditions'
 import { CopySurveyLink } from 'scenes/surveys/CopySurveyLink'
@@ -52,16 +52,7 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                                                 enableIframeEmbedding={survey.enable_iframe_embedding ?? false}
                                             />
                                         </div>
-                                        <div className="text-xs text-muted">
-                                            Responses are anonymous by default. Append <code>?distinct_id=...</code> to
-                                            the URL to tie responses to a specific person.{' '}
-                                            <Link
-                                                to="https://posthog.com/docs/surveys/creating-surveys#identifying-respondents-on-hosted-surveys"
-                                                target="_blank"
-                                            >
-                                                Learn more
-                                            </Link>
-                                        </div>
+                                        <HostedSurveyRespondentHint />
                                     </div>
                                 ) : conditionsSummary.length > 0 ? (
                                     <div className="text-sm">

--- a/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
+++ b/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
@@ -4,13 +4,15 @@ import { ReactNode } from 'react'
 import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { Link } from 'lib/lemon-ui/Link'
 import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings'
 import { SurveyConditionsList } from 'scenes/surveys/components/SurveyConditions'
+import { CopySurveyLink } from 'scenes/surveys/CopySurveyLink'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 import { getSurveyDisplayConditionsSummary } from 'scenes/surveys/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
+import { AccessControlLevel, AccessControlResourceType, SurveyType } from '~/types'
 
 export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNode }): JSX.Element {
     const { survey, surveyWarnings } = useValues(surveyLogic)
@@ -19,7 +21,8 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
     const { updateCurrentTeam } = useActions(teamLogic)
 
     const needsOptIn = !currentTeam?.surveys_opt_in
-    const conditionsSummary = getSurveyDisplayConditionsSummary(survey)
+    const isHostedSurvey = survey.type === SurveyType.ExternalSurvey
+    const conditionsSummary = isHostedSurvey ? [] : getSurveyDisplayConditionsSummary(survey)
 
     return (
         <AccessControlAction
@@ -37,7 +40,30 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                         content: (
                             <div className="flex flex-col gap-3">
                                 <SdkVersionWarnings warnings={surveyWarnings} />
-                                {conditionsSummary.length > 0 ? (
+                                {isHostedSurvey ? (
+                                    <div className="flex flex-col gap-2 text-sm">
+                                        <div className="text-secondary">
+                                            Share this link with the people you want to answer the survey.
+                                        </div>
+                                        <div className="flex flex-col gap-1">
+                                            <div className="text-muted text-xs">Share link</div>
+                                            <CopySurveyLink
+                                                surveyId={survey.id}
+                                                enableIframeEmbedding={survey.enable_iframe_embedding ?? false}
+                                            />
+                                        </div>
+                                        <div className="text-xs text-muted">
+                                            Responses are anonymous by default. Append <code>?distinct_id=...</code> to
+                                            the URL to tie responses to a specific person.{' '}
+                                            <Link
+                                                to="https://posthog.com/docs/surveys/creating-surveys#identifying-respondents-on-hosted-surveys"
+                                                target="_blank"
+                                            >
+                                                Learn more
+                                            </Link>
+                                        </div>
+                                    </div>
+                                ) : conditionsSummary.length > 0 ? (
                                     <div className="text-sm">
                                         <div className="text-secondary mb-1">
                                             This survey will be shown to users who match:

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -5,7 +5,7 @@ import { getNextSurveyStep } from 'posthog-js/dist/surveys-preview'
 import { useEffect, useState } from 'react'
 
 import { IconArrowLeft, IconChevronLeft, IconChevronRight } from '@posthog/icons'
-import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog, Link } from '@posthog/lemon-ui'
 
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -17,10 +17,11 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-import { SurveyMatchType, SurveyQuestionBranchingType } from '~/types'
+import { SurveyMatchType, SurveyQuestionBranchingType, SurveyType } from '~/types'
 
 import { SdkVersionWarnings } from '../components/SdkVersionWarnings'
 import { NewSurvey } from '../constants'
+import { CopySurveyLink } from '../CopySurveyLink'
 import { SurveyAppearancePreview } from '../SurveyAppearancePreview'
 import { getEventPropertyFilterCount } from '../SurveyEventTrigger'
 import { surveyLogic } from '../surveyLogic'
@@ -130,6 +131,33 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         router.actions.push(target)
     }
 
+    const hostedEditorEnabled = !!featureFlags[FEATURE_FLAGS.SURVEYS_HOSTED_EDITOR]
+    const canConvertToHosted = hostedEditorEnabled && survey.type !== SurveyType.ExternalSurvey
+
+    const convertToHostedSurvey = (): void => {
+        LemonDialog.open({
+            title: 'Convert to hosted survey?',
+            description: (
+                <p className="py-2">
+                    This keeps the questions and style, then switches the editor to the hosted-survey setup. Display
+                    conditions and in-app placement settings won't apply.
+                </p>
+            ),
+            primaryButton: {
+                children: 'Convert',
+                onClick: () => {
+                    setSurveyValue('type', SurveyType.ExternalSurvey)
+                    // The wizard doesn't render hosted surveys — route to the dedicated editor.
+                    const target = isEditing ? `${urls.survey(id)}?edit=true` : urls.survey(id)
+                    router.actions.push(target)
+                },
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    }
+
     // Show loading state while loading existing survey
     if (isEditing && surveyLoading) {
         return (
@@ -215,8 +243,9 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     }
 
     const showLaunchConfirmation = (onConfirm: () => void): void => {
-        const hasConditions = doesSurveyHaveDisplayConditions(survey)
-        const conditionsSummary = getConditionsSummary()
+        const isHostedSurvey = survey.type === SurveyType.ExternalSurvey
+        const hasConditions = !isHostedSurvey && doesSurveyHaveDisplayConditions(survey)
+        const conditionsSummary = isHostedSurvey ? [] : getConditionsSummary()
         const hasAudienceConditions = conditionsSummary.length > 0
 
         LemonDialog.open({
@@ -224,7 +253,30 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
             content: (
                 <div className="space-y-2">
                     <SdkVersionWarnings warnings={surveyWarnings} />
-                    {hasConditions || hasAudienceConditions ? (
+                    {isHostedSurvey ? (
+                        <div className="flex flex-col gap-2">
+                            <p className="text-secondary">
+                                Share this link with the people you want to answer the survey.
+                            </p>
+                            <div className="flex flex-col gap-1">
+                                <span className="text-muted text-xs">Share link</span>
+                                <CopySurveyLink
+                                    surveyId={survey.id}
+                                    enableIframeEmbedding={survey.enable_iframe_embedding ?? false}
+                                />
+                            </div>
+                            <p className="text-xs text-muted">
+                                Responses are anonymous by default. Append <code>?distinct_id=...</code> to the URL to
+                                tie responses to a specific person.{' '}
+                                <Link
+                                    to="https://posthog.com/docs/surveys/creating-surveys#identifying-respondents-on-hosted-surveys"
+                                    target="_blank"
+                                >
+                                    Learn more
+                                </Link>
+                            </p>
+                        </div>
+                    ) : hasConditions || hasAudienceConditions ? (
                         <>
                             <p className="text-secondary">
                                 The survey will be shown to users who match these conditions:
@@ -315,9 +367,21 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
             <div className="space-y-1">
                 <div className="flex items-center justify-between">
                     {backButton}
-                    <LemonButton type="secondary" size="small" onClick={handleCustomizeMore}>
-                        Full editor
-                    </LemonButton>
+                    <div className="flex items-center gap-2">
+                        {canConvertToHosted && (
+                            <LemonButton
+                                data-attr="convert-to-hosted-survey"
+                                type="tertiary"
+                                size="small"
+                                onClick={convertToHostedSurvey}
+                            >
+                                Convert to hosted
+                            </LemonButton>
+                        )}
+                        <LemonButton type="secondary" size="small" onClick={handleCustomizeMore}>
+                            Full editor
+                        </LemonButton>
+                    </div>
                 </div>
                 <div>
                     <label htmlFor="survey-name" className="text-xs font-medium text-muted">

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -255,10 +255,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                 <div className="space-y-2">
                     <SdkVersionWarnings warnings={surveyWarnings} />
                     {isHostedSurvey ? (
-                        <div className="flex flex-col gap-2">
-                            <p className="text-secondary">
-                                Share this link with the people you want to answer the survey.
-                            </p>
+                        <div className="flex flex-col gap-3">
                             {survey.id && survey.id !== 'new' && (
                                 <div className="flex flex-col gap-1">
                                     <span className="text-muted text-xs">Share link</span>

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -22,7 +22,6 @@ import { SurveyMatchType, SurveyQuestionBranchingType, SurveyType } from '~/type
 import { HostedSurveyRespondentHint } from '../components/HostedSurveyRespondentHint'
 import { SdkVersionWarnings } from '../components/SdkVersionWarnings'
 import { NewSurvey } from '../constants'
-import { CopySurveyLink } from '../CopySurveyLink'
 import { SurveyAppearancePreview } from '../SurveyAppearancePreview'
 import { getEventPropertyFilterCount } from '../SurveyEventTrigger'
 import { surveyLogic } from '../surveyLogic'
@@ -256,15 +255,10 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                     <SdkVersionWarnings warnings={surveyWarnings} />
                     {isHostedSurvey ? (
                         <div className="flex flex-col gap-3">
-                            {survey.id && survey.id !== 'new' && (
-                                <div className="flex flex-col gap-1">
-                                    <span className="text-muted text-xs">Share link</span>
-                                    <CopySurveyLink
-                                        surveyId={survey.id}
-                                        enableIframeEmbedding={survey.enable_iframe_embedding ?? false}
-                                    />
-                                </div>
-                            )}
+                            <p className="text-secondary m-0">
+                                Once launched, anyone with the link can answer the survey. You'll get the share link on
+                                the next screen.
+                            </p>
                             <HostedSurveyRespondentHint />
                         </div>
                     ) : hasConditions || hasAudienceConditions ? (

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -5,7 +5,7 @@ import { getNextSurveyStep } from 'posthog-js/dist/surveys-preview'
 import { useEffect, useState } from 'react'
 
 import { IconArrowLeft, IconChevronLeft, IconChevronRight } from '@posthog/icons'
-import { LemonButton, LemonDialog, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -19,6 +19,7 @@ import { urls } from 'scenes/urls'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { SurveyMatchType, SurveyQuestionBranchingType, SurveyType } from '~/types'
 
+import { HostedSurveyRespondentHint } from '../components/HostedSurveyRespondentHint'
 import { SdkVersionWarnings } from '../components/SdkVersionWarnings'
 import { NewSurvey } from '../constants'
 import { CopySurveyLink } from '../CopySurveyLink'
@@ -258,23 +259,16 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                             <p className="text-secondary">
                                 Share this link with the people you want to answer the survey.
                             </p>
-                            <div className="flex flex-col gap-1">
-                                <span className="text-muted text-xs">Share link</span>
-                                <CopySurveyLink
-                                    surveyId={survey.id}
-                                    enableIframeEmbedding={survey.enable_iframe_embedding ?? false}
-                                />
-                            </div>
-                            <p className="text-xs text-muted">
-                                Responses are anonymous by default. Append <code>?distinct_id=...</code> to the URL to
-                                tie responses to a specific person.{' '}
-                                <Link
-                                    to="https://posthog.com/docs/surveys/creating-surveys#identifying-respondents-on-hosted-surveys"
-                                    target="_blank"
-                                >
-                                    Learn more
-                                </Link>
-                            </p>
+                            {survey.id && survey.id !== 'new' && (
+                                <div className="flex flex-col gap-1">
+                                    <span className="text-muted text-xs">Share link</span>
+                                    <CopySurveyLink
+                                        surveyId={survey.id}
+                                        enableIframeEmbedding={survey.enable_iframe_embedding ?? false}
+                                    />
+                                </div>
+                            )}
+                            <HostedSurveyRespondentHint />
                         </div>
                     ) : hasConditions || hasAudienceConditions ? (
                         <>

--- a/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
@@ -1,12 +1,13 @@
 import { router } from 'kea-router'
 import { useEffect, useState } from 'react'
 
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
-import { Survey, SurveySchedule } from '~/types'
+import { Survey, SurveySchedule, SurveyType } from '~/types'
 
+import { CopySurveyLink } from '../../CopySurveyLink'
 import { SurveyAppearancePreview } from '../../SurveyAppearancePreview'
 
 interface SuccessStepProps {
@@ -14,10 +15,11 @@ interface SuccessStepProps {
 }
 
 export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
+    const isHostedSurvey = survey.type === SurveyType.ExternalSurvey
     const [countdown, setCountdown] = useState(5)
 
     useEffect(() => {
-        if (!survey?.id) {
+        if (!survey?.id || isHostedSurvey) {
             return
         }
 
@@ -33,15 +35,44 @@ export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
             clearInterval(interval)
             clearTimeout(timer)
         }
-    }, [survey?.id])
+    }, [survey?.id, isHostedSurvey])
 
     return (
         <div className="text-center space-y-6">
             <div className="space-y-2">
                 <h1 className="text-2xl font-semibold">Your survey is live!</h1>
-                <p className="text-secondary">Responses will start coming in based on your targeting settings.</p>
-                <p className="text-muted text-sm">Redirecting to your survey in {countdown}...</p>
+                {isHostedSurvey ? (
+                    <>
+                        <p className="text-secondary">Share this link with the people you want to answer the survey.</p>
+                        <p className="text-muted text-sm">
+                            Responses are anonymous by default. Append <code>?distinct_id=...</code> to the URL to tie
+                            responses to a specific person.{' '}
+                            <Link
+                                to="https://posthog.com/docs/surveys/creating-surveys#identifying-respondents-on-hosted-surveys"
+                                target="_blank"
+                            >
+                                Learn more
+                            </Link>
+                        </p>
+                    </>
+                ) : (
+                    <>
+                        <p className="text-secondary">
+                            Responses will start coming in based on your targeting settings.
+                        </p>
+                        <p className="text-muted text-sm">Redirecting to your survey in {countdown}...</p>
+                    </>
+                )}
             </div>
+
+            {isHostedSurvey && (
+                <div className="flex justify-center">
+                    <CopySurveyLink
+                        surveyId={survey.id}
+                        enableIframeEmbedding={survey.enable_iframe_embedding ?? false}
+                    />
+                </div>
+            )}
 
             <div className="flex items-center justify-center gap-4">
                 <LemonButton type="primary" to={urls.survey(survey.id)}>
@@ -54,29 +85,31 @@ export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
                 <SurveyAppearancePreview survey={survey} previewPageIndex={0} />
             </div>
 
-            <div className="bg-bg-3000 rounded-lg p-4 text-left max-w-md mx-auto space-y-2">
-                <h3 className="font-medium">Summary</h3>
-                <dl className="space-y-1 text-sm">
-                    <div className="flex justify-between">
-                        <dt className="text-secondary">Showing on</dt>
-                        <dd>{survey.conditions?.url || 'All pages'}</dd>
-                    </div>
-                    <div className="flex justify-between">
-                        <dt className="text-secondary">Frequency</dt>
-                        <dd>
-                            {survey.schedule === SurveySchedule.Once || !survey.iteration_frequency_days
-                                ? 'Once ever'
-                                : `Up to ${survey.iteration_count ?? 10} times, every ${survey.iteration_frequency_days} days`}
-                        </dd>
-                    </div>
-                    {survey.conditions?.seenSurveyWaitPeriodInDays != null && (
+            {!isHostedSurvey && (
+                <div className="bg-bg-3000 rounded-lg p-4 text-left max-w-md mx-auto space-y-2">
+                    <h3 className="font-medium">Summary</h3>
+                    <dl className="space-y-1 text-sm">
                         <div className="flex justify-between">
-                            <dt className="text-secondary">Wait period across all surveys</dt>
-                            <dd>{survey.conditions.seenSurveyWaitPeriodInDays} days</dd>
+                            <dt className="text-secondary">Showing on</dt>
+                            <dd>{survey.conditions?.url || 'All pages'}</dd>
                         </div>
-                    )}
-                </dl>
-            </div>
+                        <div className="flex justify-between">
+                            <dt className="text-secondary">Frequency</dt>
+                            <dd>
+                                {survey.schedule === SurveySchedule.Once || !survey.iteration_frequency_days
+                                    ? 'Once ever'
+                                    : `Up to ${survey.iteration_count ?? 10} times, every ${survey.iteration_frequency_days} days`}
+                            </dd>
+                        </div>
+                        {survey.conditions?.seenSurveyWaitPeriodInDays != null && (
+                            <div className="flex justify-between">
+                                <dt className="text-secondary">Wait period across all surveys</dt>
+                                <dd>{survey.conditions.seenSurveyWaitPeriodInDays} days</dd>
+                            </div>
+                        )}
+                    </dl>
+                </div>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
@@ -43,10 +43,7 @@ export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
             <div className="space-y-2">
                 <h1 className="text-2xl font-semibold">Your survey is live!</h1>
                 {isHostedSurvey ? (
-                    <>
-                        <p className="text-secondary">Share this link with the people you want to answer the survey.</p>
-                        <HostedSurveyRespondentHint className="text-muted text-sm" />
-                    </>
+                    <p className="text-secondary">Copy the link below and share it to start collecting responses.</p>
                 ) : (
                     <>
                         <p className="text-secondary">
@@ -58,11 +55,14 @@ export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
             </div>
 
             {isHostedSurvey && (
-                <div className="flex justify-center">
+                <div className="flex flex-col items-center gap-4">
                     <CopySurveyLink
                         surveyId={survey.id}
                         enableIframeEmbedding={survey.enable_iframe_embedding ?? false}
                     />
+                    <div className="max-w-xl text-left">
+                        <HostedSurveyRespondentHint className="text-sm" />
+                    </div>
                 </div>
             )}
 

--- a/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
@@ -1,12 +1,13 @@
 import { router } from 'kea-router'
 import { useEffect, useState } from 'react'
 
-import { LemonButton, Link } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
 import { Survey, SurveySchedule, SurveyType } from '~/types'
 
+import { HostedSurveyRespondentHint } from '../../components/HostedSurveyRespondentHint'
 import { CopySurveyLink } from '../../CopySurveyLink'
 import { SurveyAppearancePreview } from '../../SurveyAppearancePreview'
 
@@ -44,16 +45,7 @@ export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
                 {isHostedSurvey ? (
                     <>
                         <p className="text-secondary">Share this link with the people you want to answer the survey.</p>
-                        <p className="text-muted text-sm">
-                            Responses are anonymous by default. Append <code>?distinct_id=...</code> to the URL to tie
-                            responses to a specific person.{' '}
-                            <Link
-                                to="https://posthog.com/docs/surveys/creating-surveys#identifying-respondents-on-hosted-surveys"
-                                target="_blank"
-                            >
-                                Learn more
-                            </Link>
-                        </p>
+                        <HostedSurveyRespondentHint className="text-muted text-sm" />
                     </>
                 ) : (
                     <>


### PR DESCRIPTION
## Problem

Launching a hosted survey (`SurveyType.ExternalSurvey`) showed the same in-app warning as a popover survey — _"This survey will be shown to all users"_ — even though hosted surveys are never shown automatically; they're only reachable via their shareable link. The shareable link itself was tucked away in the sidebar, so users had to hunt for it after launching.

The guided wizard also lacked the "Convert to hosted" affordance that already exists in the full editor (`SurveyEdit.tsx`), so users had to leave the wizard to switch a survey to a hosted one.

## Changes

- **Hosted-specific launch confirmation** (`LaunchSurveyButton.tsx` and `wizard/SurveyWizard.tsx`): when launching a hosted survey, the dialog now reads "Share this link with the people you want to answer the survey." and embeds the share link with the copy button right inline, plus a smaller hint about appending `?distinct_id=...` to identify respondents (linked to the existing `creating-surveys#identifying-respondents-on-hosted-surveys` docs anchor).
- **Wizard success screen** (`wizard/steps/SuccessStep.tsx`): for hosted surveys, the post-launch screen swaps the redirect-countdown / targeting-summary block for the share link and the same identifying-respondents hint. The countdown timer is skipped entirely so the user has time to grab the link.
- **"Convert to hosted" button in the wizard header** (`wizard/SurveyWizard.tsx`): mirrors the button already in `SurveyEdit.tsx`. Gated on the same `SURVEYS_HOSTED_EDITOR` feature flag and only visible when the survey isn't already hosted. On confirm, flips `type` to `ExternalSurvey` and routes to the regular editor (which already swaps to `HostedSurveyEdit`).

No copy changes outside hosted-survey paths; popover / API survey flows are unchanged.

## How did you test this code?

I'm an agent — I did not run the full test suite or perform manual QA. I ran:

- `pnpm exec oxlint` on the three modified files — 0 warnings, 0 errors.
- `pnpm exec oxfmt` on the three modified files — applied.

Reviewer should manually verify:
- Launching a hosted survey from the survey detail page → confirmation dialog shows the new copy + share link + identifying-respondents hint.
- Launching from the wizard → same confirmation dialog content, and the success step shows the share link prominently with no auto-redirect.
- Launching an in-app (popover) survey → unchanged from before.
- Wizard header → "Convert to hosted" appears only when `SURVEYS_HOSTED_EDITOR` flag is on and survey isn't already hosted; clicking it confirms then routes to the regular editor.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs change — links point at existing docs anchors.

## 🤖 Agent context

Authored by PostHog Code (Claude). Iterated on the launch-confirmation copy a couple of times based on author feedback: original draft had a defensive "won't be shown automatically to your users" framing, which was dropped in favor of the positive "share this link" framing plus the identifying-respondents hint. The "Convert to hosted" wizard button was added later in the same session to match the affordance already present in `SurveyEdit.tsx`.

One known dev-environment issue surfaced while testing: clicking Save in the regular editor right after the wizard's "Convert to hosted" redirect can hit `ApiConfig.getCurrentProjectId()` throwing "Project ID is not known." This appears to be local-env-specific (`projectLogic.loadCurrentProjectSuccess` not having fired yet on the new mount) rather than something introduced by this PR — the same code path exists on master. Flagging here so the reviewer is aware; not addressing it in this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*