### PR TITLE
chore(code): add reset_posthog_code_usage command

### DIFF
--- a/services/llm-gateway/pyproject.toml
+++ b/services/llm-gateway/pyproject.toml
@@ -43,6 +43,9 @@ dev = [
     "types-cachetools>=5.5.0",
 ]
 
+[project.scripts]
+reset-posthog-code-usage = "llm_gateway.cli.reset_posthog_code_usage:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/services/llm-gateway/src/llm_gateway/cli/__init__.py
+++ b/services/llm-gateway/src/llm_gateway/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Operational CLIs for the LLM gateway service."""

--- a/services/llm-gateway/src/llm_gateway/cli/reset_posthog_code_usage.py
+++ b/services/llm-gateway/src/llm_gateway/cli/reset_posthog_code_usage.py
@@ -1,0 +1,81 @@
+"""Reset PostHog Code usage counters for every user in Redis."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+import structlog
+from redis.asyncio import Redis
+
+from llm_gateway.config import get_settings
+from llm_gateway.services.plan_resolver import POSTHOG_CODE_PRODUCT
+
+logger = structlog.get_logger(__name__)
+
+# Mirrors the cache key built by _UserCostThrottleBase._get_cache_key in
+# rate_limiting/cost_throttles.py (with the outer "ratelimit:" added by
+# redis_limiter). Update both ends if the key shape changes.
+PATTERNS = (
+    f"ratelimit:cost:user:user_cost_burst:{POSTHOG_CODE_PRODUCT}:*",
+    f"ratelimit:cost:user:user_cost_sustained:{POSTHOG_CODE_PRODUCT}:*",
+)
+
+SCAN_COUNT = 500
+UNLINK_BATCH = 500
+
+
+async def reset_usage(redis: Redis, *, dry_run: bool) -> int:
+    deleted = 0
+    for pattern in PATTERNS:
+        batch: list[str] = []
+        cursor = 0
+        while True:
+            cursor, keys = await redis.scan(cursor=cursor, match=pattern, count=SCAN_COUNT)
+            for k in keys:
+                batch.append(k.decode() if isinstance(k, bytes) else k)
+                if len(batch) >= UNLINK_BATCH:
+                    deleted += await _flush(redis, batch, dry_run=dry_run)
+            if cursor == 0:
+                break
+        if batch:
+            deleted += await _flush(redis, batch, dry_run=dry_run)
+    return deleted
+
+
+async def _flush(redis: Redis, batch: list[str], *, dry_run: bool) -> int:
+    n = len(batch)
+    if not dry_run:
+        await redis.unlink(*batch)
+    batch.clear()
+    return n
+
+
+async def _amain(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="reset-posthog-code-usage",
+        description="Reset PostHog Code usage counters in the LLM gateway Redis for every user.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Count keys without deleting.")
+    args = parser.parse_args(argv)
+
+    settings = get_settings()
+    if not settings.redis_url:
+        logger.error("redis_url_not_configured")
+        return 1
+
+    redis: Redis = Redis.from_url(settings.redis_url)
+    deleted = await reset_usage(redis, dry_run=args.dry_run)
+
+    mode = "DRY RUN" if args.dry_run else "EXECUTED"
+    print(f"[{mode}] reset posthog_code usage: {deleted} keys")
+    return 0
+
+
+def main() -> None:
+    sys.exit(asyncio.run(_amain(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/llm-gateway/tests/cli/__init__.py
+++ b/services/llm-gateway/tests/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for llm_gateway.cli scripts."""

--- a/services/llm-gateway/tests/cli/test_reset_posthog_code_usage.py
+++ b/services/llm-gateway/tests/cli/test_reset_posthog_code_usage.py
@@ -1,0 +1,64 @@
+from collections.abc import AsyncGenerator
+
+import pytest
+from fakeredis import aioredis as fakeredis
+
+from llm_gateway.cli.reset_posthog_code_usage import reset_usage
+
+
+@pytest.fixture
+async def redis() -> AsyncGenerator[fakeredis.FakeRedis, None]:
+    yield fakeredis.FakeRedis()
+
+
+class TestResetUsage:
+    async def test_resets_every_user_regardless_of_plan(self, redis: fakeredis.FakeRedis) -> None:
+        # Free, pro, and unknown-plan users — all should be reset.
+        keys = [
+            "ratelimit:cost:user:user_cost_burst:posthog_code:100",
+            "ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0",
+            "ratelimit:cost:user:user_cost_burst:posthog_code:200",
+            "ratelimit:cost:user:user_cost_sustained:posthog_code:200:period:0",
+            "ratelimit:cost:user:user_cost_burst:posthog_code:300:tm2",
+            "ratelimit:cost:user:user_cost_sustained:posthog_code:300:tm2:period:1",
+        ]
+        for k in keys:
+            await redis.set(k, "10.0")
+
+        deleted = await reset_usage(redis, dry_run=False)
+
+        assert deleted == len(keys)
+        for k in keys:
+            assert await redis.get(k) is None
+
+    async def test_dry_run_counts_without_deleting(self, redis: fakeredis.FakeRedis) -> None:
+        await redis.set("ratelimit:cost:user:user_cost_burst:posthog_code:100", "1.0")
+        await redis.set("ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0", "1.0")
+
+        deleted = await reset_usage(redis, dry_run=True)
+
+        assert deleted == 2
+        assert await redis.get("ratelimit:cost:user:user_cost_burst:posthog_code:100") is not None
+        assert await redis.get("ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0") is not None
+
+    async def test_returns_zero_when_no_keys(self, redis: fakeredis.FakeRedis) -> None:
+        assert await reset_usage(redis, dry_run=False) == 0
+
+    async def test_leaves_unrelated_keys_untouched(self, redis: fakeredis.FakeRedis) -> None:
+        # Other products, plan cache, and unrelated rate-limit scopes must survive.
+        survivors = [
+            "ratelimit:cost:user:user_cost_burst:other_product:100",
+            "ratelimit:cost:user:user_cost_sustained:other_product:100:period:0",
+            "plan:posthog_code:100",
+            "ratelimit:burst:user:100",
+            "some:other:key",
+        ]
+        for k in survivors:
+            await redis.set(k, "x")
+        await redis.set("ratelimit:cost:user:user_cost_burst:posthog_code:100", "1.0")
+
+        deleted = await reset_usage(redis, dry_run=False)
+
+        assert deleted == 1
+        for k in survivors:
+            assert await redis.get(k) is not None


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

sometimes we want to reset all posthog code users' usage limits

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds reset_posthog_code_usage management command to do so

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- unit tests
- ran against local stack

```
  docker compose -f /Users/adambowker/posthog/docker-compose.dev.yml exec -T redis7 redis-cli <<'EOF'
  SET ratelimit:cost:user:user_cost_burst:posthog_code:42 12.5
  SET ratelimit:cost:user:user_cost_sustained:posthog_code:42:period:0 12.5
  SET ratelimit:cost:user:user_cost_burst:posthog_code:99 7.0
  SET ratelimit:cost:user:user_cost_sustained:posthog_code:99:tm2:period:1 7.0
  SET ratelimit:cost:user:user_cost_burst:other_product:42 99.9
  KEYS ratelimit:cost:user:user_cost_*:*:*
  EOF
  
  LLM_GATEWAY_REDIS_URL=redis://localhost:6379 .venv/bin/reset-posthog-code-usage --dry-run
  
  LLM_GATEWAY_REDIS_URL=redis://localhost:6379 .venv/bin/reset-posthog-code-usage && \
  echo "--- remaining keys ---" && \
  docker compose -f /Users/adambowker/posthog/docker-compose.dev.yml exec -T redis7 \
    redis-cli KEYS 'ratelimit:cost:user:user_cost_*:*'
```

- will verify w/ dry run in prod

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->