### PR TITLE
fix(surveys): tailor resume UX for hosted surveys

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -25,7 +25,12 @@ import { SurveyNotificationModal } from 'scenes/surveys/components/SurveyNotific
 import { SurveyNotifications } from 'scenes/surveys/components/SurveyNotifications'
 import { SurveyNotificationsCallout } from 'scenes/surveys/components/SurveyNotificationsCallout'
 import { DuplicateToProjectModal } from 'scenes/surveys/DuplicateToProjectModal'
-import { canDeleteSurvey, openArchiveSurveyDialog, openDeleteSurveyDialog } from 'scenes/surveys/surveyDialogs'
+import {
+    canDeleteSurvey,
+    openArchiveSurveyDialog,
+    openDeleteSurveyDialog,
+    openResumeSurveyDialog,
+} from 'scenes/surveys/surveyDialogs'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 import { SurveyNoResponsesBanner } from 'scenes/surveys/SurveyNoResponsesBanner'
 import { SurveyOverview } from 'scenes/surveys/SurveyOverview'
@@ -228,28 +233,7 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
                                         <LemonButton
                                             type="secondary"
                                             size="small"
-                                            onClick={() => {
-                                                LemonDialog.open({
-                                                    title: 'Resume this survey?',
-                                                    content: (
-                                                        <div className="text-sm text-secondary">
-                                                            Once resumed, the survey will be visible to your users
-                                                            again.
-                                                        </div>
-                                                    ),
-                                                    primaryButton: {
-                                                        children: 'Resume',
-                                                        type: 'primary',
-                                                        onClick: () => resumeSurvey(),
-                                                        size: 'small',
-                                                    },
-                                                    secondaryButton: {
-                                                        children: 'Cancel',
-                                                        type: 'tertiary',
-                                                        size: 'small',
-                                                    },
-                                                })
-                                            }}
+                                            onClick={() => openResumeSurveyDialog(survey, () => resumeSurvey())}
                                         >
                                             Resume
                                         </LemonButton>

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -26,7 +26,12 @@ import { SurveyNotifications } from 'scenes/surveys/components/SurveyNotificatio
 import { SurveyNotificationsCallout } from 'scenes/surveys/components/SurveyNotificationsCallout'
 import { DuplicateToProjectModal } from 'scenes/surveys/DuplicateToProjectModal'
 import { useSurveyResponseColumns } from 'scenes/surveys/hooks/useSurveyResponseColumns'
-import { canDeleteSurvey, openArchiveSurveyDialog, openDeleteSurveyDialog } from 'scenes/surveys/surveyDialogs'
+import {
+    canDeleteSurvey,
+    openArchiveSurveyDialog,
+    openDeleteSurveyDialog,
+    openResumeSurveyDialog,
+} from 'scenes/surveys/surveyDialogs'
 import { SurveyHeadline } from 'scenes/surveys/SurveyHeadline'
 import { SurveyTab, surveyLogic } from 'scenes/surveys/surveyLogic'
 import { SurveyNoResponsesBanner } from 'scenes/surveys/SurveyNoResponsesBanner'
@@ -516,27 +521,7 @@ function SurveyStatusAction(): JSX.Element | null {
                 <LemonButton
                     type="secondary"
                     size="small"
-                    onClick={() => {
-                        LemonDialog.open({
-                            title: 'Resume this survey?',
-                            content: (
-                                <div className="text-sm text-secondary">
-                                    Once resumed, the survey will be visible to your users again.
-                                </div>
-                            ),
-                            primaryButton: {
-                                children: 'Resume',
-                                type: 'primary',
-                                onClick: () => resumeSurvey(),
-                                size: 'small',
-                            },
-                            secondaryButton: {
-                                children: 'Cancel',
-                                type: 'tertiary',
-                                size: 'small',
-                            },
-                        })
-                    }}
+                    onClick={() => openResumeSurveyDialog(survey, () => resumeSurvey())}
                 >
                     Resume
                 </LemonButton>

--- a/frontend/src/scenes/surveys/components/SurveysTable.tsx
+++ b/frontend/src/scenes/surveys/components/SurveysTable.tsx
@@ -20,7 +20,12 @@ import { SurveysEmptyState } from 'scenes/surveys/components/empty-state/Surveys
 import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings'
 import { SurveyStatusTag } from 'scenes/surveys/components/SurveyStatusTag'
 import { SURVEY_TYPE_LABEL_MAP, SurveyQuestionLabel } from 'scenes/surveys/constants'
-import { canDeleteSurvey, openArchiveSurveyDialog, openDeleteSurveyDialog } from 'scenes/surveys/surveyDialogs'
+import {
+    canDeleteSurvey,
+    openArchiveSurveyDialog,
+    openDeleteSurveyDialog,
+    openResumeSurveyDialog,
+} from 'scenes/surveys/surveyDialogs'
 import { SurveysTabs, surveysLogic } from 'scenes/surveys/surveysLogic'
 import { getSurveyWarnings } from 'scenes/surveys/surveyVersionRequirements'
 import { isSurveyRunning } from 'scenes/surveys/utils'
@@ -348,37 +353,15 @@ export function SurveysTable(): JSX.Element {
                                                 >
                                                     <LemonButton
                                                         fullWidth
-                                                        onClick={() => {
-                                                            LemonDialog.open({
-                                                                title: 'Resume this survey?',
-                                                                content: (
-                                                                    <div className="text-sm text-secondary">
-                                                                        Once resumed, the survey will be visible to your
-                                                                        users again.
-                                                                    </div>
-                                                                ),
-                                                                primaryButton: {
-                                                                    children: 'Resume',
-                                                                    type: 'primary',
-                                                                    onClick: () => {
-                                                                        updateSurvey({
-                                                                            id: survey.id,
-                                                                            updatePayload: {
-                                                                                end_date: null,
-                                                                            },
-                                                                            intentContext:
-                                                                                ProductIntentContext.SURVEY_RESUMED,
-                                                                        })
-                                                                    },
-                                                                    size: 'small',
-                                                                },
-                                                                secondaryButton: {
-                                                                    children: 'Cancel',
-                                                                    type: 'tertiary',
-                                                                    size: 'small',
-                                                                },
-                                                            })
-                                                        }}
+                                                        onClick={() =>
+                                                            openResumeSurveyDialog(survey, () =>
+                                                                updateSurvey({
+                                                                    id: survey.id,
+                                                                    updatePayload: { end_date: null },
+                                                                    intentContext: ProductIntentContext.SURVEY_RESUMED,
+                                                                })
+                                                            )
+                                                        }
                                                     >
                                                         Resume survey
                                                     </LemonButton>

--- a/frontend/src/scenes/surveys/surveyDialogs.tsx
+++ b/frontend/src/scenes/surveys/surveyDialogs.tsx
@@ -1,7 +1,11 @@
 import { LemonDialog } from '@posthog/lemon-ui'
 
-import { Survey } from '~/types'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
+import { Survey, SurveyType } from '~/types'
+
+import { HostedSurveyRespondentHint } from './components/HostedSurveyRespondentHint'
+import { getSurveyUrl } from './CopySurveyLink'
 import { isSurveyRunning } from './utils'
 
 export function openDeleteSurveyDialog(survey: Pick<Survey, 'start_date'>, onConfirm: () => void): void {
@@ -59,6 +63,41 @@ export function openArchiveSurveyDialog(survey: Pick<Survey, 'start_date' | 'end
             children: isRunning ? 'Stop and archive' : 'Archive',
             type: 'primary',
             onClick: onConfirm,
+            size: 'small',
+        },
+        secondaryButton: {
+            children: 'Cancel',
+            type: 'tertiary',
+            size: 'small',
+        },
+    })
+}
+
+export function openResumeSurveyDialog(survey: Pick<Survey, 'id' | 'type'>, onConfirm: () => void): void {
+    const isHostedSurvey = survey.type === SurveyType.ExternalSurvey
+
+    LemonDialog.open({
+        title: 'Resume this survey?',
+        content: isHostedSurvey ? (
+            <div className="flex flex-col gap-3 text-sm">
+                <p className="text-secondary m-0">
+                    Once resumed, anyone with the link can answer the survey again. We'll copy the link to your
+                    clipboard so you can share it right away.
+                </p>
+                <HostedSurveyRespondentHint />
+            </div>
+        ) : (
+            <div className="text-sm text-secondary">Once resumed, the survey will be visible to your users again.</div>
+        ),
+        primaryButton: {
+            children: isHostedSurvey ? 'Resume and copy link' : 'Resume',
+            type: 'primary',
+            onClick: () => {
+                if (isHostedSurvey) {
+                    void copyToClipboard(getSurveyUrl(survey.id), 'survey link')
+                }
+                onConfirm()
+            },
             size: 'small',
         },
         secondaryButton: {


### PR DESCRIPTION
## Problem

The previous PR ([#59312](https://github.com/PostHog/posthog/pull/59312)) tailored the **launch** confirmation for hosted surveys — explained what happens on launch, listed useful URL parameters, and copied the share link to the clipboard. The **resume** flow (stopped/paused → active again) still showed the generic in-app dialog:

> Once resumed, the survey will be visible to your users again.

That's misleading for hosted surveys, which never auto-show to anyone — they're only reachable via their shareable link. Same three places (`SurveyView`, `SurveyViewRedesign`, `SurveysTable` row menu) had the dialog copy-pasted verbatim.

## Changes

- Added `openResumeSurveyDialog(survey, onConfirm)` to `scenes/surveys/surveyDialogs.tsx`, alongside the existing `openArchiveSurveyDialog` / `openDeleteSurveyDialog`. Matches their `(survey, onConfirm)` signature for consistency.
- For hosted surveys, the dialog:
  - Tells the user "anyone with the link can answer the survey again" and that the link will be copied
  - Shows the same `HostedSurveyRespondentHint` cheatsheet of URL parameters (`distinct_id`, `q{N}`, custom `key=value`) we already use at launch
  - Renames the primary button to **Resume and copy link** and runs `copyToClipboard(getSurveyUrl(survey.id), 'survey link')` before invoking the resume action
- In-app (non-hosted) surveys keep the existing copy and "Resume" button label — no behavior change for that path.
- All three call sites collapsed from ~30 lines of inline `LemonDialog.open` to a single helper call.

## How did you test this code?

I'm an agent — I did not run the full test suite or perform manual QA. I ran:

- `pnpm exec oxlint` on the four modified files — 0 warnings, 0 errors.
- `pnpm exec oxfmt` on the four modified files — applied.

Reviewer should manually verify:
- Hosted survey, paused/stopped → click Resume on the detail page, redesigned detail page, **and** the surveys list row menu → confirm dialog shows the new copy + URL hints, primary button reads "Resume and copy link", clicking it copies the link to clipboard and resumes.
- In-app (popover) survey, paused/stopped → click Resume on each surface → dialog is unchanged (no URL hints, button still says "Resume").

## Publish to changelog?

do not publish to changelog

## Docs update

No docs change — same hint that's already documented in PR #59312.

## 🤖 Agent context

Follow-up to [#59312](https://github.com/PostHog/posthog/pull/59312). After that PR shipped, the user pointed out that the resume flow had the same problem — a hosted-survey owner re-launching gets the same misleading "visible to your users again" message and doesn't get the link handed back to them.

Chose to put the helper in the existing `surveyDialogs.tsx` (which already exports `openArchiveSurveyDialog` and `openDeleteSurveyDialog`) rather than a new file — matches the established pattern and keeps the dialog primitives co-located.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*