### PR TITLE
fix(replay): keep inactive periods in mp4 recording exports

### DIFF
--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -159,6 +159,7 @@ export const exportsLogic = kea<exportsLogicType>([
                     height: options?.height || 600,
                     filename: options?.filename || `replay-${sessionRecordingId}${timestamp ? `-t${timestamp}` : ''}`,
                     duration: duration,
+                    skip_inactivity: false,
                 },
             }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5231,6 +5231,7 @@ export interface ReplayExportContext {
     filename?: string
     duration?: number
     mode?: SessionRecordingPlayerMode
+    skip_inactivity?: boolean
 }
 
 export interface HeatmapExportContext {


### PR DESCRIPTION
## Problem

The session replay MP4 export renders the recording through the recording-rasterizer, which fast-forwards through inactive segments by default. A user exporting a session as MP4 expects the full session in real time — the in-player "skip inactivity" toggle is a viewing preference, not an export contract.

## Changes

Frontend `startReplayExport` now sets `skip_inactivity: false` in the `export_context`. The backend and rasterizer already honor this flag; we just weren't sending it. The AI summary pipeline builds its own `ExportedAsset` in Python and isn't affected.

## How did you test this code?

Agent-authored. Ran TypeScript check and oxlint/oxfmt on the changed files — no manual export verification.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code. Considered flipping the backend default but rejected it because the AI summary pipeline shares the same codepath and wants the skipping behavior.
