### PR TITLE
fix(cli): handle git worktrees in git info detection

### DIFF
--- a/cli/src/utils/git.rs
+++ b/cli/src/utils/git.rs
@@ -109,9 +109,10 @@ fn find_git_dirs(dir: Option<PathBuf>) -> Option<GitDirs> {
     loop {
         let git_path = current_dir.join(".git");
         if git_path.is_dir() {
+            let git_dir = normalize_existing_path(git_path);
             return Some(GitDirs {
-                git_dir: git_path.clone(),
-                common_dir: git_path,
+                common_dir: git_dir.clone(),
+                git_dir,
                 worktree_dir: current_dir,
             });
         }
@@ -137,11 +138,13 @@ fn parse_git_dir_file(git_path: &Path) -> Option<PathBuf> {
     let git_dir = content.trim().strip_prefix("gitdir:")?.trim();
     let git_dir = PathBuf::from(git_dir);
 
-    if git_dir.is_absolute() {
-        Some(git_dir)
+    let git_dir = if git_dir.is_absolute() {
+        git_dir
     } else {
-        Some(git_path.parent()?.join(git_dir))
-    }
+        git_path.parent()?.join(git_dir)
+    };
+
+    Some(normalize_existing_path(git_dir))
 }
 
 fn get_common_dir(git_dir: &Path) -> PathBuf {
@@ -151,11 +154,17 @@ fn get_common_dir(git_dir: &Path) -> PathBuf {
     };
 
     let commondir = PathBuf::from(commondir.trim());
-    if commondir.is_absolute() {
+    let common_dir = if commondir.is_absolute() {
         commondir
     } else {
         git_dir.join(commondir)
-    }
+    };
+
+    normalize_existing_path(common_dir)
+}
+
+fn normalize_existing_path(path: PathBuf) -> PathBuf {
+    fs::canonicalize(&path).unwrap_or(path)
 }
 
 fn config_paths(git_dir: &Path, common_dir: &Path) -> Vec<PathBuf> {

--- a/cli/src/utils/git.rs
+++ b/cli/src/utils/git.rs
@@ -14,6 +14,12 @@ pub struct GitInfo {
     pub commit_id: String,
 }
 
+struct GitDirs {
+    git_dir: PathBuf,
+    common_dir: PathBuf,
+    worktree_dir: PathBuf,
+}
+
 pub fn get_git_info(dir: Option<PathBuf>) -> Result<Option<GitInfo>> {
     if let Some(info) = get_git_info_from_github() {
         return Ok(Some(info));
@@ -23,15 +29,21 @@ pub fn get_git_info(dir: Option<PathBuf>) -> Result<Option<GitInfo>> {
         return Ok(Some(info));
     }
 
-    let git_dir = match find_git_dir(dir) {
-        Some(dir) => dir,
+    let git_dirs = match find_git_dirs(dir) {
+        Some(dirs) => dirs,
         None => return Ok(None),
     };
 
-    let remote_url = get_remote_url(&git_dir);
-    let repo_name = get_repo_name(&git_dir);
-    let branch = get_branch_name(&git_dir).context("Failed to determine current branch")?;
-    let commit = get_commit_sha(&git_dir, &branch).context("Failed to determine commit sha")?;
+    let remote_url = get_remote_url_from_dirs(&git_dirs.git_dir, &git_dirs.common_dir);
+    let repo_name = get_repo_name_from_dirs(
+        &git_dirs.git_dir,
+        &git_dirs.common_dir,
+        Some(&git_dirs.worktree_dir),
+    );
+    let branch =
+        get_branch_name(&git_dirs.git_dir).context("Failed to determine current branch")?;
+    let commit = get_commit_sha(&git_dirs.git_dir, &git_dirs.common_dir, &branch)
+        .context("Failed to determine commit sha")?;
 
     Ok(Some(GitInfo {
         remote_url,
@@ -91,13 +103,27 @@ fn build_vercel_remote_url(repo_slug: &String) -> Option<String> {
     Some(format!("{base_url}/{owner}/{repo_slug}.git"))
 }
 
-fn find_git_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
+fn find_git_dirs(dir: Option<PathBuf>) -> Option<GitDirs> {
     let mut current_dir = dir.unwrap_or(std::env::current_dir().ok()?);
 
     loop {
-        let git_dir = current_dir.join(".git");
-        if git_dir.is_dir() {
-            return Some(git_dir);
+        let git_path = current_dir.join(".git");
+        if git_path.is_dir() {
+            return Some(GitDirs {
+                git_dir: git_path.clone(),
+                common_dir: git_path,
+                worktree_dir: current_dir,
+            });
+        }
+
+        if git_path.is_file() {
+            let git_dir = parse_git_dir_file(&git_path)?;
+            let common_dir = get_common_dir(&git_dir);
+            return Some(GitDirs {
+                git_dir,
+                common_dir,
+                worktree_dir: current_dir,
+            });
         }
 
         if !current_dir.pop() {
@@ -106,13 +132,56 @@ fn find_git_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
     }
 }
 
+fn parse_git_dir_file(git_path: &Path) -> Option<PathBuf> {
+    let content = fs::read_to_string(git_path).ok()?;
+    let git_dir = content.trim().strip_prefix("gitdir:")?.trim();
+    let git_dir = PathBuf::from(git_dir);
+
+    if git_dir.is_absolute() {
+        Some(git_dir)
+    } else {
+        Some(git_path.parent()?.join(git_dir))
+    }
+}
+
+fn get_common_dir(git_dir: &Path) -> PathBuf {
+    let commondir_path = git_dir.join("commondir");
+    let Ok(commondir) = fs::read_to_string(commondir_path) else {
+        return git_dir.to_path_buf();
+    };
+
+    let commondir = PathBuf::from(commondir.trim());
+    if commondir.is_absolute() {
+        commondir
+    } else {
+        git_dir.join(commondir)
+    }
+}
+
+fn config_paths(git_dir: &Path, common_dir: &Path) -> Vec<PathBuf> {
+    let mut paths = vec![git_dir.join("config"), git_dir.join("config.worktree")];
+
+    if common_dir != git_dir {
+        paths.push(common_dir.join("config"));
+    }
+
+    paths
+}
+
 pub fn get_remote_url(git_dir: &Path) -> Option<String> {
+    get_remote_url_from_dirs(git_dir, git_dir)
+}
+
+fn get_remote_url_from_dirs(git_dir: &Path, common_dir: &Path) -> Option<String> {
     // Try grab it from the git config
-    let config_path = git_dir.join("config");
-    if config_path.exists() {
+    for config_path in config_paths(git_dir, common_dir) {
+        if !config_path.exists() {
+            continue;
+        }
+
         let config_content = match fs::read_to_string(&config_path) {
             Ok(content) => content,
-            Err(_) => return None,
+            Err(_) => continue,
         };
 
         for line in config_content.lines() {
@@ -133,12 +202,23 @@ pub fn get_remote_url(git_dir: &Path) -> Option<String> {
 }
 
 pub fn get_repo_name(git_dir: &Path) -> Option<String> {
+    get_repo_name_from_dirs(git_dir, git_dir, git_dir.parent())
+}
+
+fn get_repo_name_from_dirs(
+    git_dir: &Path,
+    common_dir: &Path,
+    worktree_dir: Option<&Path>,
+) -> Option<String> {
     // Try grab it from the configured remote, otherwise just use the directory name
-    let config_path = git_dir.join("config");
-    if config_path.exists() {
+    for config_path in config_paths(git_dir, common_dir) {
+        if !config_path.exists() {
+            continue;
+        }
+
         let config_content = match fs::read_to_string(&config_path) {
             Ok(content) => content,
-            Err(_) => return None,
+            Err(_) => continue,
         };
 
         for line in config_content.lines() {
@@ -153,10 +233,8 @@ pub fn get_repo_name(git_dir: &Path) -> Option<String> {
         }
     }
 
-    if let Some(parent) = git_dir.parent() {
-        if let Some(name) = parent.file_name() {
-            return Some(name.to_string_lossy().to_string());
-        }
+    if let Some(name) = worktree_dir.and_then(|dir| dir.file_name()) {
+        return Some(name.to_string_lossy().to_string());
     }
 
     None
@@ -184,7 +262,7 @@ fn get_branch_name(git_dir: &Path) -> Result<String> {
     }
 }
 
-fn get_commit_sha(git_dir: &Path, branch: &str) -> Result<String> {
+fn get_commit_sha(git_dir: &Path, common_dir: &Path, branch: &str) -> Result<String> {
     if branch == "HEAD-detached" {
         // For detached HEAD, read directly from HEAD
         let head_path = git_dir.join("HEAD");
@@ -198,8 +276,11 @@ fn get_commit_sha(git_dir: &Path, branch: &str) -> Result<String> {
     }
 
     // Try to read the commit from the branch reference
-    let ref_path = git_dir.join("refs/heads").join(branch);
-    if ref_path.exists() {
+    for ref_path in branch_ref_paths(git_dir, common_dir, branch) {
+        if !ref_path.exists() {
+            continue;
+        }
+
         let mut commit_id = String::new();
         fs::File::open(&ref_path)
             .with_context(|| format!("Failed to open branch reference at {ref_path:?}"))?
@@ -209,7 +290,57 @@ fn get_commit_sha(git_dir: &Path, branch: &str) -> Result<String> {
         return Ok(commit_id.trim().to_string());
     }
 
+    if let Some(commit_id) = get_packed_ref(git_dir, common_dir, branch) {
+        return Ok(commit_id);
+    }
+
     anyhow::bail!("Could not determine commit ID")
+}
+
+fn branch_ref_paths(git_dir: &Path, common_dir: &Path, branch: &str) -> Vec<PathBuf> {
+    let mut paths = vec![git_dir.join("refs/heads").join(branch)];
+
+    if common_dir != git_dir {
+        paths.push(common_dir.join("refs/heads").join(branch));
+    }
+
+    paths
+}
+
+fn get_packed_ref(git_dir: &Path, common_dir: &Path, branch: &str) -> Option<String> {
+    let ref_name = format!("refs/heads/{branch}");
+    let mut paths = vec![git_dir.join("packed-refs")];
+
+    if common_dir != git_dir {
+        paths.push(common_dir.join("packed-refs"));
+    }
+
+    for path in paths {
+        let Ok(content) = fs::read_to_string(path) else {
+            continue;
+        };
+
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with('^') {
+                continue;
+            }
+
+            let mut parts = line.split_whitespace();
+            let Some(commit_id) = parts.next() else {
+                continue;
+            };
+            let Some(packed_ref) = parts.next() else {
+                continue;
+            };
+
+            if packed_ref == ref_name {
+                return Some(commit_id.to_string());
+            }
+        }
+    }
+
+    None
 }
 
 fn get_env_variable(name: &str) -> Option<String> {

--- a/cli/tests/git.rs
+++ b/cli/tests/git.rs
@@ -1,7 +1,16 @@
 use posthog_cli::utils::git::{get_git_info, get_remote_url, get_repo_name};
 use std::fs;
 use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard};
 use uuid::Uuid;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 fn make_git_dir_with_config(config_content: &str) -> PathBuf {
     let temp_root = std::env::temp_dir().join(format!("posthog_cli_git_test_{}", Uuid::now_v7()));
@@ -10,6 +19,26 @@ fn make_git_dir_with_config(config_content: &str) -> PathBuf {
     let config_path = git_dir.join("config");
     fs::write(&config_path, config_content).expect("failed to write config");
     git_dir
+}
+
+fn remove_env_vars(names: &[&str]) -> Vec<(String, Option<String>)> {
+    names
+        .iter()
+        .map(|name| {
+            let value = std::env::var(name).ok();
+            std::env::remove_var(name);
+            ((*name).to_string(), value)
+        })
+        .collect()
+}
+
+fn restore_env_vars(vars: Vec<(String, Option<String>)>) {
+    for (name, value) in vars {
+        match value {
+            Some(value) => std::env::set_var(name, value),
+            None => std::env::remove_var(name),
+        }
+    }
 }
 
 #[test]
@@ -85,7 +114,76 @@ fn test_get_repo_infos_ssh_without_dot_git() {
 }
 
 #[test]
+fn test_get_git_info_from_worktree_git_file() {
+    let _env_lock = lock_env();
+    let env = remove_env_vars(&[
+        "GITHUB_ACTIONS",
+        "GITHUB_SHA",
+        "GITHUB_REF_NAME",
+        "GITHUB_REPOSITORY",
+        "GITHUB_SERVER_URL",
+        "VERCEL",
+        "VERCEL_GIT_PROVIDER",
+        "VERCEL_GIT_REPO_OWNER",
+        "VERCEL_GIT_REPO_SLUG",
+        "VERCEL_GIT_COMMIT_REF",
+        "VERCEL_GIT_COMMIT_SHA",
+    ]);
+
+    let temp_root =
+        std::env::temp_dir().join(format!("posthog_cli_worktree_test_{}", Uuid::now_v7()));
+    let worktree_dir = temp_root.join("worktree");
+    let common_git_dir = temp_root.join("repo.git");
+    let worktree_git_dir = common_git_dir.join("worktrees/worktree");
+    let branch_ref = common_git_dir.join("refs/heads/feature/worktree");
+    let commit_id = "0123456789abcdef0123456789abcdef01234567";
+
+    fs::create_dir_all(&worktree_dir).expect("failed to create worktree directory");
+    fs::create_dir_all(&worktree_git_dir).expect("failed to create worktree git directory");
+    fs::create_dir_all(branch_ref.parent().unwrap()).expect("failed to create refs directory");
+    fs::write(
+        worktree_dir.join(".git"),
+        format!("gitdir: {}\n", worktree_git_dir.display()),
+    )
+    .expect("failed to write worktree .git file");
+    fs::write(worktree_git_dir.join("commondir"), "../..\n").expect("failed to write commondir");
+    fs::write(
+        worktree_git_dir.join("HEAD"),
+        "ref: refs/heads/feature/worktree\n",
+    )
+    .expect("failed to write HEAD");
+    fs::write(&branch_ref, format!("{commit_id}\n")).expect("failed to write branch ref");
+    fs::write(
+        common_git_dir.join("config"),
+        r#"
+[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = https://github.com/PostHog/posthog.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#,
+    )
+    .expect("failed to write config");
+
+    let info = get_git_info(Some(worktree_dir))
+        .expect("should not error")
+        .expect("should return info");
+
+    assert_eq!(info.branch, "feature/worktree");
+    assert_eq!(info.commit_id, commit_id);
+    assert_eq!(
+        info.remote_url.as_deref(),
+        Some("https://github.com/PostHog/posthog.git")
+    );
+    assert_eq!(info.repo_name.as_deref(), Some("posthog"));
+
+    let _ = fs::remove_dir_all(temp_root);
+    restore_env_vars(env);
+}
+
+#[test]
 fn test_get_git_info_from_vercel_env() {
+    let _env_lock = lock_env();
     std::env::set_var("VERCEL", "1");
     std::env::set_var("VERCEL_GIT_PROVIDER", "github");
     std::env::set_var("VERCEL_GIT_REPO_OWNER", "PostHog");
@@ -115,6 +213,7 @@ fn test_get_git_info_from_vercel_env() {
 
 #[test]
 fn test_get_git_info_from_github_env() {
+    let _env_lock = lock_env();
     std::env::set_var("GITHUB_ACTIONS", "true");
     std::env::set_var("GITHUB_SHA", "abc123def456");
     std::env::set_var("GITHUB_REF_NAME", "main");

--- a/cli/tests/git.rs
+++ b/cli/tests/git.rs
@@ -32,13 +32,83 @@ fn remove_env_vars(names: &[&str]) -> Vec<(String, Option<String>)> {
         .collect()
 }
 
-fn restore_env_vars(vars: Vec<(String, Option<String>)>) {
-    for (name, value) in vars {
-        match value {
-            Some(value) => std::env::set_var(name, value),
-            None => std::env::remove_var(name),
+struct EnvVarGuard(Vec<(String, Option<String>)>);
+
+impl EnvVarGuard {
+    fn clear(names: &[&str]) -> Self {
+        Self(remove_env_vars(names))
+    }
+
+    fn set(vars: &[(&str, &str)]) -> Self {
+        let saved = vars
+            .iter()
+            .map(|(name, value)| {
+                let previous = std::env::var(name).ok();
+                std::env::set_var(name, value);
+                ((*name).to_string(), previous)
+            })
+            .collect();
+
+        Self(saved)
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        for (name, value) in self.0.drain(..) {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
         }
     }
+}
+
+fn write_repo_config(git_dir: &std::path::Path) {
+    fs::write(
+        git_dir.join("config"),
+        r#"
+[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = https://github.com/PostHog/posthog.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#,
+    )
+    .expect("failed to write config");
+}
+
+fn write_head(git_dir: &std::path::Path, branch: &str) {
+    fs::write(git_dir.join("HEAD"), format!("ref: refs/heads/{branch}\n"))
+        .expect("failed to write HEAD");
+}
+
+fn write_loose_ref(git_dir: &std::path::Path, branch: &str, commit_id: &str) {
+    let branch_ref = git_dir.join("refs/heads").join(branch);
+    fs::create_dir_all(branch_ref.parent().unwrap()).expect("failed to create refs directory");
+    fs::write(branch_ref, format!("{commit_id}\n")).expect("failed to write branch ref");
+}
+
+fn write_packed_ref(git_dir: &std::path::Path, branch: &str, commit_id: &str) {
+    fs::write(
+        git_dir.join("packed-refs"),
+        format!("# pack-refs with: peeled fully-peeled sorted\n{commit_id} refs/heads/{branch}\n"),
+    )
+    .expect("failed to write packed-refs");
+}
+
+fn assert_posthog_git_info(worktree_dir: PathBuf, branch: &str, commit_id: &str) {
+    let info = get_git_info(Some(worktree_dir))
+        .expect("should not error")
+        .expect("should return info");
+
+    assert_eq!(info.branch, branch);
+    assert_eq!(info.commit_id, commit_id);
+    assert_eq!(
+        info.remote_url.as_deref(),
+        Some("https://github.com/PostHog/posthog.git")
+    );
+    assert_eq!(info.repo_name.as_deref(), Some("posthog"));
 }
 
 #[test]
@@ -114,9 +184,9 @@ fn test_get_repo_infos_ssh_without_dot_git() {
 }
 
 #[test]
-fn test_get_git_info_from_worktree_git_file() {
+fn test_get_git_info_from_regular_repo_packed_refs() {
     let _env_lock = lock_env();
-    let env = remove_env_vars(&[
+    let _env_guard = EnvVarGuard::clear(&[
         "GITHUB_ACTIONS",
         "GITHUB_SHA",
         "GITHUB_REF_NAME",
@@ -131,65 +201,121 @@ fn test_get_git_info_from_worktree_git_file() {
     ]);
 
     let temp_root =
-        std::env::temp_dir().join(format!("posthog_cli_worktree_test_{}", Uuid::now_v7()));
-    let worktree_dir = temp_root.join("worktree");
-    let common_git_dir = temp_root.join("repo.git");
-    let worktree_git_dir = common_git_dir.join("worktrees/worktree");
-    let branch_ref = common_git_dir.join("refs/heads/feature/worktree");
+        std::env::temp_dir().join(format!("posthog_cli_regular_repo_test_{}", Uuid::now_v7()));
+    let git_dir = temp_root.join(".git");
+    let branch = "feature/packed";
     let commit_id = "0123456789abcdef0123456789abcdef01234567";
 
-    fs::create_dir_all(&worktree_dir).expect("failed to create worktree directory");
-    fs::create_dir_all(&worktree_git_dir).expect("failed to create worktree git directory");
-    fs::create_dir_all(branch_ref.parent().unwrap()).expect("failed to create refs directory");
-    fs::write(
-        worktree_dir.join(".git"),
-        format!("gitdir: {}\n", worktree_git_dir.display()),
-    )
-    .expect("failed to write worktree .git file");
-    fs::write(worktree_git_dir.join("commondir"), "../..\n").expect("failed to write commondir");
-    fs::write(
-        worktree_git_dir.join("HEAD"),
-        "ref: refs/heads/feature/worktree\n",
-    )
-    .expect("failed to write HEAD");
-    fs::write(&branch_ref, format!("{commit_id}\n")).expect("failed to write branch ref");
-    fs::write(
-        common_git_dir.join("config"),
-        r#"
-[core]
-    repositoryformatversion = 0
-[remote "origin"]
-    url = https://github.com/PostHog/posthog.git
-    fetch = +refs/heads/*:refs/remotes/origin/*
-"#,
-    )
-    .expect("failed to write config");
+    fs::create_dir_all(&git_dir).expect("failed to create .git directory");
+    write_head(&git_dir, branch);
+    write_packed_ref(&git_dir, branch, commit_id);
+    write_repo_config(&git_dir);
 
-    let info = get_git_info(Some(worktree_dir))
-        .expect("should not error")
-        .expect("should return info");
-
-    assert_eq!(info.branch, "feature/worktree");
-    assert_eq!(info.commit_id, commit_id);
-    assert_eq!(
-        info.remote_url.as_deref(),
-        Some("https://github.com/PostHog/posthog.git")
-    );
-    assert_eq!(info.repo_name.as_deref(), Some("posthog"));
+    assert_posthog_git_info(temp_root.clone(), branch, commit_id);
 
     let _ = fs::remove_dir_all(temp_root);
-    restore_env_vars(env);
+}
+
+#[test]
+fn test_get_git_info_from_worktree_git_file_cases() {
+    let _env_lock = lock_env();
+    let _env_guard = EnvVarGuard::clear(&[
+        "GITHUB_ACTIONS",
+        "GITHUB_SHA",
+        "GITHUB_REF_NAME",
+        "GITHUB_REPOSITORY",
+        "GITHUB_SERVER_URL",
+        "VERCEL",
+        "VERCEL_GIT_PROVIDER",
+        "VERCEL_GIT_REPO_OWNER",
+        "VERCEL_GIT_REPO_SLUG",
+        "VERCEL_GIT_COMMIT_REF",
+        "VERCEL_GIT_COMMIT_SHA",
+    ]);
+
+    for (case_name, absolute_gitdir, commondir, use_packed_ref) in [
+        (
+            "relative loose ref in common dir",
+            false,
+            Some("../.."),
+            false,
+        ),
+        (
+            "absolute gitdir with packed ref in common dir",
+            true,
+            Some("../.."),
+            true,
+        ),
+        (
+            "no commondir uses worktree git dir packed ref",
+            true,
+            None,
+            true,
+        ),
+    ] {
+        let case_slug = case_name.replace(' ', "-");
+        let temp_root = std::env::temp_dir().join(format!(
+            "posthog_cli_worktree_test_{}_{}",
+            case_slug,
+            Uuid::now_v7()
+        ));
+        let worktree_dir = temp_root.join("worktree");
+        let common_git_dir = temp_root.join("repo.git");
+        let worktree_git_dir = common_git_dir.join("worktrees/worktree");
+        let git_dir = if commondir.is_some() {
+            worktree_git_dir.clone()
+        } else {
+            temp_root.join("single-worktree.git")
+        };
+        let branch = format!("feature/{case_slug}");
+        let commit_id = "0123456789abcdef0123456789abcdef01234567";
+
+        fs::create_dir_all(&worktree_dir).expect("failed to create worktree directory");
+        fs::create_dir_all(&git_dir).expect("failed to create worktree git directory");
+        fs::create_dir_all(&common_git_dir).expect("failed to create common git directory");
+
+        let gitdir = if absolute_gitdir {
+            git_dir.display().to_string()
+        } else {
+            "../repo.git/worktrees/worktree".to_string()
+        };
+        fs::write(worktree_dir.join(".git"), format!("gitdir: {gitdir}\n"))
+            .expect("failed to write worktree .git file");
+        if let Some(commondir) = commondir {
+            fs::write(git_dir.join("commondir"), format!("{commondir}\n"))
+                .expect("failed to write commondir");
+        }
+        write_head(&git_dir, &branch);
+
+        let ref_git_dir = if commondir.is_some() {
+            &common_git_dir
+        } else {
+            &git_dir
+        };
+        if use_packed_ref {
+            write_packed_ref(ref_git_dir, &branch, commit_id);
+        } else {
+            write_loose_ref(ref_git_dir, &branch, commit_id);
+        }
+        write_repo_config(ref_git_dir);
+
+        assert_posthog_git_info(worktree_dir, &branch, commit_id);
+
+        let _ = fs::remove_dir_all(temp_root);
+    }
 }
 
 #[test]
 fn test_get_git_info_from_vercel_env() {
     let _env_lock = lock_env();
-    std::env::set_var("VERCEL", "1");
-    std::env::set_var("VERCEL_GIT_PROVIDER", "github");
-    std::env::set_var("VERCEL_GIT_REPO_OWNER", "PostHog");
-    std::env::set_var("VERCEL_GIT_REPO_SLUG", "posthog");
-    std::env::set_var("VERCEL_GIT_COMMIT_REF", "main");
-    std::env::set_var("VERCEL_GIT_COMMIT_SHA", "abc123def456");
+    let _env_guard = EnvVarGuard::set(&[
+        ("VERCEL", "1"),
+        ("VERCEL_GIT_PROVIDER", "github"),
+        ("VERCEL_GIT_REPO_OWNER", "PostHog"),
+        ("VERCEL_GIT_REPO_SLUG", "posthog"),
+        ("VERCEL_GIT_COMMIT_REF", "main"),
+        ("VERCEL_GIT_COMMIT_SHA", "abc123def456"),
+    ]);
 
     let info = get_git_info(None)
         .expect("should not error")
@@ -202,23 +328,18 @@ fn test_get_git_info_from_vercel_env() {
         info.remote_url.as_deref(),
         Some("https://github.com/PostHog/posthog.git")
     );
-
-    std::env::remove_var("VERCEL");
-    std::env::remove_var("VERCEL_GIT_PROVIDER");
-    std::env::remove_var("VERCEL_GIT_REPO_OWNER");
-    std::env::remove_var("VERCEL_GIT_REPO_SLUG");
-    std::env::remove_var("VERCEL_GIT_COMMIT_REF");
-    std::env::remove_var("VERCEL_GIT_COMMIT_SHA");
 }
 
 #[test]
 fn test_get_git_info_from_github_env() {
     let _env_lock = lock_env();
-    std::env::set_var("GITHUB_ACTIONS", "true");
-    std::env::set_var("GITHUB_SHA", "abc123def456");
-    std::env::set_var("GITHUB_REF_NAME", "main");
-    std::env::set_var("GITHUB_REPOSITORY", "PostHog/posthog");
-    std::env::set_var("GITHUB_SERVER_URL", "https://github.com");
+    let _env_guard = EnvVarGuard::set(&[
+        ("GITHUB_ACTIONS", "true"),
+        ("GITHUB_SHA", "abc123def456"),
+        ("GITHUB_REF_NAME", "main"),
+        ("GITHUB_REPOSITORY", "PostHog/posthog"),
+        ("GITHUB_SERVER_URL", "https://github.com"),
+    ]);
 
     let info = get_git_info(None)
         .expect("should not error")
@@ -231,10 +352,4 @@ fn test_get_git_info_from_github_env() {
         info.remote_url.as_deref(),
         Some("https://github.com/PostHog/posthog.git")
     );
-
-    std::env::remove_var("GITHUB_ACTIONS");
-    std::env::remove_var("GITHUB_SHA");
-    std::env::remove_var("GITHUB_REF_NAME");
-    std::env::remove_var("GITHUB_REPOSITORY");
-    std::env::remove_var("GITHUB_SERVER_URL");
 }


### PR DESCRIPTION
## Problem

Closes #59107

The CLI git metadata helper only recognized `.git` as a directory. In a Git worktree, `.git` is a file that points at the worktree-specific git directory, so local metadata detection returned no Git info for commands run from a worktree.

## Changes

- Resolve `.git` files with `gitdir:` pointers in addition to normal `.git` directories.
- Use a worktree git directory's `commondir` for shared config and branch refs, while still reading worktree-specific config when present.
- Add coverage for a worktree layout where the branch ref and remote config live in the common git directory.

## How did you test this code?

I added `test_get_git_info_from_worktree_git_file` first. Before the implementation change it failed because `get_git_info(Some(worktree_dir))` returned `None` for a worktree-style `.git` file.

Then I verified the final patch with:

- `cargo test --test git`
- `cargo test`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

OpenAI GPT-5 assisted with drafting and checking this patch. I kept the implementation inside the existing standalone Git metadata reader instead of shelling out to `git`, so the CLI keeps working without adding a runtime dependency on a Git executable. The test models the worktree layout from the issue: `.git` is a file, `HEAD` lives in the worktree git directory, and the remote config plus branch ref live in the common git directory.
