### PR TITLE
feat(insights): add reset button for invalid dwh settings

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 
+import { LemonButton } from '@posthog/lemon-ui'
+
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { InsightLegend } from 'lib/components/InsightLegend/InsightLegend'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -148,9 +150,10 @@ export function InsightVizDisplay({
         series,
         insightData,
         validationError,
+        validationErrorCode,
         theme,
     } = useValues(insightVizDataLogic(insightProps))
-    const { loadData } = useActions(insightVizDataLogic(insightProps))
+    const { loadData, updateQuerySource } = useActions(insightVizDataLogic(insightProps))
     const { exportContext, queryId } = useValues(insightDataLogic(insightProps))
     const { funnelsFilter, hasFunnelResults, isFunnelWithEnoughSteps, isFunnelWithIncompleteDataWarehouseStep } =
         useValues(funnelDataLogic(insightProps))
@@ -190,13 +193,35 @@ export function InsightVizDisplay({
         }
 
         if (validationError) {
+            const isUnsupportedDataWarehouseSettings =
+                validationErrorCode === 'data_warehouse_series_unsupported_settings'
+            const resetCta = isUnsupportedDataWarehouseSettings ? (
+                <LemonButton
+                    type="primary"
+                    loading={insightDataLoading}
+                    onClick={() =>
+                        updateQuerySource({
+                            filterTestAccounts: false,
+                            properties: undefined,
+                            samplingFactor: undefined,
+                        })
+                    }
+                >
+                    Reset unsupported settings
+                </LemonButton>
+            ) : undefined
             return (
                 <InsightValidationError
                     query={query}
                     detail={validationError}
-                    onRetry={() => {
-                        loadData(query && shouldQueryBeAsync(query) ? 'force_async' : 'force_blocking')
-                    }}
+                    onRetry={
+                        resetCta
+                            ? undefined
+                            : () => {
+                                  loadData(query && shouldQueryBeAsync(query) ? 'force_async' : 'force_blocking')
+                              }
+                    }
+                    cta={resetCta}
                 />
             )
         }

--- a/frontend/src/queries/nodes/InsightViz/utils.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.ts
@@ -194,6 +194,16 @@ export const extractValidationError = (error: Error | Record<string, any> | null
     return null
 }
 
+export const extractValidationErrorCode = (error: Error | Record<string, any> | null | undefined): string | null => {
+    if (error instanceof ApiError || (error && typeof error === 'object' && 'status' in error)) {
+        if (error?.status === 400 || error?.status === 512) {
+            return error.code ?? error.data?.code ?? null
+        }
+    }
+
+    return null
+}
+
 export const isTimeoutError = (error: Error | Record<string, any> | null | undefined): boolean => {
     if (error instanceof ApiError || (error && typeof error === 'object' && 'status' in error)) {
         return error?.status === 512

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -490,10 +490,12 @@ export function InsightValidationError({
     detail,
     query,
     onRetry,
+    cta,
 }: {
     detail: string
     query?: Record<string, any> | null
     onRetry?: () => void
+    cta?: JSX.Element
 }): JSX.Element {
     return (
         <div
@@ -516,7 +518,7 @@ export function InsightValidationError({
 
             <p className="text-sm text-muted max-w-120 mb-2">{detail}</p>
 
-            {onRetry ? <RetryButton onRetry={onRetry} query={query} /> : <QueryDebuggerButton query={query} />}
+            {cta ?? (onRetry ? <RetryButton onRetry={onRetry} query={query} /> : <QueryDebuggerButton query={query} />)}
 
             {detail.includes('Exclusion') && (
                 <div className="mt-4">

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -24,7 +24,12 @@ import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/fil
 import { BASE_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
 
 import { actionsModel } from '~/models/actionsModel'
-import { extractValidationError, getAllEventNames, queryFromKind } from '~/queries/nodes/InsightViz/utils'
+import {
+    extractValidationError,
+    extractValidationErrorCode,
+    getAllEventNames,
+    queryFromKind,
+} from '~/queries/nodes/InsightViz/utils'
 import {
     AnyDataWarehouseNode,
     AnyEntityNode,
@@ -496,6 +501,10 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         validationError: [
             (s) => [s.insightDataError],
             (insightDataError): string | null => extractValidationError(insightDataError),
+        ],
+        validationErrorCode: [
+            (s) => [s.insightDataError],
+            (insightDataError): string | null => extractValidationErrorCode(insightDataError),
         ],
 
         timezone: [(s) => [s.insightData], (insightData) => insightData?.timezone || 'UTC'],


### PR DESCRIPTION
## Problem

We have a validation error for invalid settings with a Data Warehouse series. However, it's not really clear to the user what they should do next. 

## Changes

This PR adds a CTA to reset the invalid settings. 

## How did you test this code?

Tried locally. 