### PR TITLE
fix(llma): drop math_property_type from assistant trends/stickiness nodes

### DIFF
--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -72,6 +72,7 @@ from ee.hogai.context.insight.format import (
     is_boxplot_query,
 )
 from ee.hogai.tool_errors import MaxToolRetryableError
+from ee.hogai.utils.helpers import assistant_query_to_dict
 from ee.hogai.utils.prompt import format_prompt_string
 from ee.hogai.utils.query import validate_assistant_query
 from ee.hogai.utils.types.base import AnyAssistantGeneratedQuery, AnyPydanticModelQuery
@@ -331,7 +332,7 @@ class AssistantQueryExecutor:
             parent_tag_kwargs = get_query_tags().model_dump(exclude_none=True)
             team = self._team
             user = self._user
-            query_dict = query.model_dump(mode="json")
+            query_dict = assistant_query_to_dict(query)
 
             def process_query_dict_with_tags() -> dict | BaseModel:
                 with tags_context(**parent_tag_kwargs):

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -223,9 +223,6 @@ class UpsertDashboardTool(MaxTool):
             else:
                 # State or Artifact source - need to create and save insight from artifact content
                 content = result.content
-                # Coerce query to the QuerySchema union. `assistant_query_to_dict` reattaches
-                # fields the assistant schema hides from the LLM (e.g. `math_property_type` on
-                # session-level trends math) so the runner sees them once persisted.
                 coerced_query = QuerySchemaRoot.model_validate(assistant_query_to_dict(content.query)).root
                 if isinstance(coerced_query, HogQLQuery):
                     converted = DataTableNode(source=coerced_query).model_dump(exclude_none=True)

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -29,6 +29,7 @@ from ee.hogai.tools.upsert_dashboard.prompts import (
     UPSERT_DASHBOARD_CONTEXT_PROMPT_TEMPLATE,
     UPSERT_DASHBOARD_TOOL_PROMPT,
 )
+from ee.hogai.utils.helpers import assistant_query_to_dict
 from ee.hogai.utils.prompt import format_prompt_string
 
 logger = structlog.get_logger(__name__)
@@ -222,8 +223,10 @@ class UpsertDashboardTool(MaxTool):
             else:
                 # State or Artifact source - need to create and save insight from artifact content
                 content = result.content
-                # Coerce query to the QuerySchema union
-                coerced_query = QuerySchemaRoot.model_validate(content.query.model_dump(mode="json")).root
+                # Coerce query to the QuerySchema union. `assistant_query_to_dict` reattaches
+                # fields the assistant schema hides from the LLM (e.g. `math_property_type` on
+                # session-level trends math) so the runner sees them once persisted.
+                coerced_query = QuerySchemaRoot.model_validate(assistant_query_to_dict(content.query)).root
                 if isinstance(coerced_query, HogQLQuery):
                     converted = DataTableNode(source=coerced_query).model_dump(exclude_none=True)
                 else:

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -384,13 +384,8 @@ def _fill_session_math_property_type(series: list[dict[str, Any]]) -> None:
     Mutates ``series`` in place.
     """
     for node in series:
-        if not isinstance(node, dict):
-            continue
         if node.get("kind") == "GroupNode":
             _fill_session_math_property_type(node.get("nodes") or [])
-            if node.get("math_property") in _SESSION_MATH_PROPERTIES:
-                node["math_property_type"] = "session_properties"
-            continue
         if node.get("math_property") in _SESSION_MATH_PROPERTIES:
             node["math_property_type"] = "session_properties"
 

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -15,6 +15,7 @@ from langchain_core.messages import (
     HumanMessage as LangchainHumanMessage,
     merge_message_runs,
 )
+from pydantic import BaseModel
 
 from posthog.schema import (
     AssistantFunnelsQuery,
@@ -38,6 +39,7 @@ from posthog.schema import (
 
 from posthog.event_usage import EventSource
 from posthog.hogql_queries.ai.team_taxonomy_query_runner import TeamTaxonomyQueryRunner
+from posthog.hogql_queries.insights.trends.aggregation_operations import ALLOWED_SESSION_MATH_PROPERTIES
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Team
 from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
@@ -359,22 +361,6 @@ def normalize_ai_message(message: AIMessage | AIMessageChunk) -> list[AssistantM
     return messages
 
 
-# Session math properties that require math_property_type="session_properties" for the runner to
-# perform session-level aggregation. Kept here (rather than imported from aggregation_operations) so
-# the assistant remains decoupled from runner internals. Must stay in sync with
-# posthog.hogql_queries.insights.trends.aggregation_operations.ALLOWED_SESSION_MATH_PROPERTIES.
-_SESSION_MATH_PROPERTIES = frozenset(
-    [
-        "$session_duration",
-        "$pageview_count",
-        "$screen_count",
-        "$autocapture_count",
-        "$num_uniq_urls",
-        "$is_bounce",
-    ]
-)
-
-
 def _fill_session_math_property_type(series: list[dict[str, Any]]) -> None:
     """
     Inject ``math_property_type="session_properties"`` into each series node whose ``math_property``
@@ -386,8 +372,23 @@ def _fill_session_math_property_type(series: list[dict[str, Any]]) -> None:
     for node in series:
         if node.get("kind") == "GroupNode":
             _fill_session_math_property_type(node.get("nodes") or [])
-        if node.get("math_property") in _SESSION_MATH_PROPERTIES:
+        if node.get("math_property") in ALLOWED_SESSION_MATH_PROPERTIES:
             node["math_property_type"] = "session_properties"
+
+
+def assistant_query_to_dict(
+    query: AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery | BaseModel,
+) -> dict[str, Any]:
+    """
+    Dump an assistant query to a JSON-compatible dict and reattach fields the assistant schema
+    hides from the LLM. Use this anywhere an assistant query is about to be passed to
+    ``process_query_dict`` / ``QuerySchemaRoot.model_validate`` — the assistant types omit
+    ``math_property_type`` for trends, but the runner still needs it set on session math.
+    """
+    dumped: dict[str, Any] = query.model_dump(mode="json")
+    if dumped.get("kind") == "TrendsQuery":
+        _fill_session_math_property_type(dumped.get("series") or [])
+    return dumped
 
 
 def cast_assistant_query(
@@ -397,9 +398,7 @@ def cast_assistant_query(
     Convert AssistantQuery types to regular Query types that the frontend expects.
     """
     if query.kind == "TrendsQuery":
-        dumped = query.model_dump()
-        _fill_session_math_property_type(dumped.get("series") or [])
-        return TrendsQuery(**dumped)
+        return TrendsQuery(**assistant_query_to_dict(query))
     elif query.kind == "FunnelsQuery":
         return FunnelsQuery(**query.model_dump())
     elif query.kind == "RetentionQuery":

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -15,7 +15,6 @@ from langchain_core.messages import (
     HumanMessage as LangchainHumanMessage,
     merge_message_runs,
 )
-from pydantic import BaseModel
 
 from posthog.schema import (
     AssistantFunnelsQuery,
@@ -46,6 +45,8 @@ from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
 
 from ee.hogai.utils.anthropic import SUPPORTED_ANTHROPIC_BLOCKS
 from ee.hogai.utils.types.base import (
+    AnyAssistantGeneratedQuery,
+    AnyPydanticModelQuery,
     ArtifactRefMessage,
     AssistantDispatcherEvent,
     AssistantMessageUnion,
@@ -376,9 +377,7 @@ def _fill_session_math_property_type(series: list[dict[str, Any]]) -> None:
             node["math_property_type"] = "session_properties"
 
 
-def assistant_query_to_dict(
-    query: AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery | BaseModel,
-) -> dict[str, Any]:
+def assistant_query_to_dict(query: AnyPydanticModelQuery | AnyAssistantGeneratedQuery) -> dict[str, Any]:
     """
     Dump an assistant query to a JSON-compatible dict and reattach fields the assistant schema
     hides from the LLM. Use this anywhere an assistant query is about to be passed to

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -359,6 +359,42 @@ def normalize_ai_message(message: AIMessage | AIMessageChunk) -> list[AssistantM
     return messages
 
 
+# Session math properties that require math_property_type="session_properties" for the runner to
+# perform session-level aggregation. Kept here (rather than imported from aggregation_operations) so
+# the assistant remains decoupled from runner internals. Must stay in sync with
+# posthog.hogql_queries.insights.trends.aggregation_operations.ALLOWED_SESSION_MATH_PROPERTIES.
+_SESSION_MATH_PROPERTIES = frozenset(
+    [
+        "$session_duration",
+        "$pageview_count",
+        "$screen_count",
+        "$autocapture_count",
+        "$num_uniq_urls",
+        "$is_bounce",
+    ]
+)
+
+
+def _fill_session_math_property_type(series: list[dict[str, Any]]) -> None:
+    """
+    Inject ``math_property_type="session_properties"`` into each series node whose ``math_property``
+    is a session-level property. ``AssistantTrendsEventsNode`` / ``AssistantTrendsActionsNode`` omit
+    this field from the LLM-facing schema so the model doesn't have to learn when to set it; the
+    runner still needs it to trigger session-level aggregation (see ``aggregating_on_session_property``).
+    Mutates ``series`` in place.
+    """
+    for node in series:
+        if not isinstance(node, dict):
+            continue
+        if node.get("kind") == "GroupNode":
+            _fill_session_math_property_type(node.get("nodes") or [])
+            if node.get("math_property") in _SESSION_MATH_PROPERTIES:
+                node["math_property_type"] = "session_properties"
+            continue
+        if node.get("math_property") in _SESSION_MATH_PROPERTIES:
+            node["math_property_type"] = "session_properties"
+
+
 def cast_assistant_query(
     query: AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery,
 ) -> TrendsQuery | FunnelsQuery | RetentionQuery | HogQLQuery:
@@ -366,7 +402,9 @@ def cast_assistant_query(
     Convert AssistantQuery types to regular Query types that the frontend expects.
     """
     if query.kind == "TrendsQuery":
-        return TrendsQuery(**query.model_dump())
+        dumped = query.model_dump()
+        _fill_session_math_property_type(dumped.get("series") or [])
+        return TrendsQuery(**dumped)
     elif query.kind == "FunnelsQuery":
         return FunnelsQuery(**query.model_dump())
     elif query.kind == "RetentionQuery":

--- a/ee/hogai/utils/test/test_assistant_helpers.py
+++ b/ee/hogai/utils/test/test_assistant_helpers.py
@@ -24,6 +24,7 @@ from posthog.schema import (
 )
 
 from ee.hogai.utils.helpers import (
+    assistant_query_to_dict,
     cast_assistant_query,
     convert_tool_messages_to_dict,
     find_start_message,
@@ -776,3 +777,62 @@ class TestCastAssistantQuery(unittest.TestCase):
         assert getattr(group, "math_property_type", None) == "session_properties"
         for inner in getattr(group, "nodes", []):
             assert getattr(inner, "math_property_type", None) == "session_properties"
+
+
+class TestAssistantQueryToDict(unittest.TestCase):
+    """
+    The runner reads `math_property_type` off the dict that crosses into `process_query_dict` /
+    `QuerySchemaRoot.model_validate`. Production callsites dump the assistant query directly with
+    `model_dump(mode="json")`, so the auto-fill MUST happen at that boundary — not later in
+    `cast_assistant_query`, which is only used by the legacy query-coercion path.
+    """
+
+    def test_session_math_property_filled_in_dump(self) -> None:
+        query = AssistantTrendsQuery(
+            kind=NodeKind.TRENDS_QUERY,
+            series=[AssistantTrendsEventsNode(event="$pageview", math="avg", math_property="$is_bounce")],
+        )
+
+        dumped = assistant_query_to_dict(query)
+
+        assert dumped["series"][0]["math_property_type"] == "session_properties"
+
+    def test_event_property_left_untouched_in_dump(self) -> None:
+        query = AssistantTrendsQuery(
+            kind=NodeKind.TRENDS_QUERY,
+            series=[AssistantTrendsEventsNode(event="$pageview", math="avg", math_property="refreshAge")],
+        )
+
+        dumped = assistant_query_to_dict(query)
+
+        assert "math_property_type" not in dumped["series"][0]
+
+    def test_no_op_for_non_trends_query(self) -> None:
+        query = AssistantFunnelsQuery(
+            kind=NodeKind.FUNNELS_QUERY,
+            series=[AssistantFunnelsEventsNode(event="signed up"), AssistantFunnelsEventsNode(event="purchase")],
+        )
+
+        # Should not raise, and should not inject series-level fields.
+        dumped = assistant_query_to_dict(query)
+
+        assert dumped["kind"] == "FunnelsQuery"
+        assert all("math_property_type" not in node for node in dumped["series"])
+
+
+class TestSessionMathPropertiesAllowlist(unittest.TestCase):
+    """
+    `_fill_session_math_property_type` imports `ALLOWED_SESSION_MATH_PROPERTIES` from the trends
+    runner so we don't have two copies. This test pins that contract: if the runner allowlist is
+    renamed or removed, the assistant helper must move with it.
+    """
+
+    def test_runner_allowlist_is_imported(self) -> None:
+        from posthog.hogql_queries.insights.trends.aggregation_operations import (
+            ALLOWED_SESSION_MATH_PROPERTIES as runner_allowlist,
+        )
+
+        from ee.hogai.utils import helpers
+
+        # Same object identity — the helper imports the runner constant directly, no local copy.
+        assert helpers.ALLOWED_SESSION_MATH_PROPERTIES is runner_allowlist

--- a/ee/hogai/utils/test/test_assistant_helpers.py
+++ b/ee/hogai/utils/test/test_assistant_helpers.py
@@ -780,13 +780,6 @@ class TestCastAssistantQuery(unittest.TestCase):
 
 
 class TestAssistantQueryToDict(unittest.TestCase):
-    """
-    The runner reads `math_property_type` off the dict that crosses into `process_query_dict` /
-    `QuerySchemaRoot.model_validate`. Production callsites dump the assistant query directly with
-    `model_dump(mode="json")`, so the auto-fill MUST happen at that boundary — not later in
-    `cast_assistant_query`, which is only used by the legacy query-coercion path.
-    """
-
     def test_session_math_property_filled_in_dump(self) -> None:
         query = AssistantTrendsQuery(
             kind=NodeKind.TRENDS_QUERY,
@@ -813,7 +806,6 @@ class TestAssistantQueryToDict(unittest.TestCase):
             series=[AssistantFunnelsEventsNode(event="signed up"), AssistantFunnelsEventsNode(event="purchase")],
         )
 
-        # Should not raise, and should not inject series-level fields.
         dumped = assistant_query_to_dict(query)
 
         assert dumped["kind"] == "FunnelsQuery"
@@ -821,12 +813,6 @@ class TestAssistantQueryToDict(unittest.TestCase):
 
 
 class TestSessionMathPropertiesAllowlist(unittest.TestCase):
-    """
-    `_fill_session_math_property_type` imports `ALLOWED_SESSION_MATH_PROPERTIES` from the trends
-    runner so we don't have two copies. This test pins that contract: if the runner allowlist is
-    renamed or removed, the assistant helper must move with it.
-    """
-
     def test_runner_allowlist_is_imported(self) -> None:
         from posthog.hogql_queries.insights.trends.aggregation_operations import (
             ALLOWED_SESSION_MATH_PROPERTIES as runner_allowlist,
@@ -834,5 +820,4 @@ class TestSessionMathPropertiesAllowlist(unittest.TestCase):
 
         from ee.hogai.utils import helpers
 
-        # Same object identity — the helper imports the runner constant directly, no local copy.
         assert helpers.ALLOWED_SESSION_MATH_PROPERTIES is runner_allowlist

--- a/ee/hogai/utils/test/test_assistant_helpers.py
+++ b/ee/hogai/utils/test/test_assistant_helpers.py
@@ -13,6 +13,9 @@ from posthog.schema import (
     AssistantFunnelsQuery,
     AssistantMessage,
     AssistantToolCallMessage,
+    AssistantTrendsActionsNode,
+    AssistantTrendsEventsNode,
+    AssistantTrendsGroupNode,
     AssistantTrendsQuery,
     HumanMessage,
     NodeKind,
@@ -700,3 +703,76 @@ class TestCastAssistantQuery(unittest.TestCase):
         self.assertFalse(bool(getattr(result.series[0], "optionalInFunnel", False)))
         self.assertTrue(bool(getattr(result.series[1], "optionalInFunnel", False)))
         self.assertFalse(bool(getattr(result.series[2], "optionalInFunnel", False)))
+
+    @parameterized.expand(
+        [
+            ("$session_duration",),
+            ("$is_bounce",),
+            ("$pageview_count",),
+            ("$screen_count",),
+            ("$autocapture_count",),
+            ("$num_uniq_urls",),
+        ]
+    )
+    def test_session_math_property_type_is_filled_for_events_node(self, math_property: str) -> None:
+        query = AssistantTrendsQuery(
+            kind=NodeKind.TRENDS_QUERY,
+            series=[
+                AssistantTrendsEventsNode(event="$pageview", math="avg", math_property=math_property),
+            ],
+        )
+
+        result = cast_assistant_query(query)
+
+        assert result.kind == "TrendsQuery"
+        assert getattr(result.series[0], "math_property_type", None) == "session_properties"
+
+    def test_session_math_property_type_is_filled_for_actions_node(self) -> None:
+        query = AssistantTrendsQuery(
+            kind=NodeKind.TRENDS_QUERY,
+            series=[
+                AssistantTrendsActionsNode(id=1, name="signed up", math="avg", math_property="$session_duration"),
+            ],
+        )
+
+        result = cast_assistant_query(query)
+
+        assert result.kind == "TrendsQuery"
+        assert getattr(result.series[0], "math_property_type", None) == "session_properties"
+
+    def test_session_math_property_type_left_untouched_for_event_property(self) -> None:
+        query = AssistantTrendsQuery(
+            kind=NodeKind.TRENDS_QUERY,
+            series=[
+                AssistantTrendsEventsNode(event="$pageview", math="avg", math_property="refreshAge"),
+            ],
+        )
+
+        result = cast_assistant_query(query)
+
+        assert result.kind == "TrendsQuery"
+        assert getattr(result.series[0], "math_property_type", None) is None
+
+    def test_session_math_property_type_filled_inside_group_node(self) -> None:
+        query = AssistantTrendsQuery(
+            kind=NodeKind.TRENDS_QUERY,
+            series=[
+                AssistantTrendsGroupNode(
+                    operator="OR",
+                    math="avg",
+                    math_property="$is_bounce",
+                    nodes=[
+                        AssistantTrendsEventsNode(event="$pageview", math="avg", math_property="$is_bounce"),
+                        AssistantTrendsEventsNode(event="$pageleave", math="avg", math_property="$is_bounce"),
+                    ],
+                ),
+            ],
+        )
+
+        result = cast_assistant_query(query)
+
+        assert result.kind == "TrendsQuery"
+        group = result.series[0]
+        assert getattr(group, "math_property_type", None) == "session_properties"
+        for inner in getattr(group, "nodes", []):
+            assert getattr(inner, "math_property_type", None) == "session_properties"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3299,9 +3299,6 @@
                 "math_property": {
                     "type": "string"
                 },
-                "math_property_type": {
-                    "type": "string"
-                },
                 "name": {
                     "description": "Action name from the plan.",
                     "type": "string"
@@ -3351,9 +3348,6 @@
                     "type": "number"
                 },
                 "math_property": {
-                    "type": "string"
-                },
-                "math_property_type": {
                     "type": "string"
                 },
                 "name": {
@@ -3740,9 +3734,6 @@
                 "math_property": {
                     "type": "string"
                 },
-                "math_property_type": {
-                    "type": "string"
-                },
                 "name": {
                     "description": "Action name from the plan.",
                     "type": "string"
@@ -3924,9 +3915,6 @@
                 "math_property": {
                     "type": "string"
                 },
-                "math_property_type": {
-                    "type": "string"
-                },
                 "name": {
                     "type": "string"
                 },
@@ -4066,9 +4054,6 @@
                     "type": "number"
                 },
                 "math_property": {
-                    "type": "string"
-                },
-                "math_property_type": {
                     "type": "string"
                 },
                 "name": {

--- a/frontend/src/queries/schema/schema-assistant-queries.ts
+++ b/frontend/src/queries/schema/schema-assistant-queries.ts
@@ -316,6 +316,7 @@ export interface AssistantTrendsEventsNode extends Omit<
     | 'fixedProperties'
     | 'properties'
     | 'math_hogql'
+    | 'math_property_type'
     | 'limit'
     | 'groupBy'
     | 'orderBy'
@@ -346,6 +347,7 @@ export interface AssistantTrendsActionsNode extends Omit<
     | 'fixedProperties'
     | 'properties'
     | 'math_hogql'
+    | 'math_property_type'
     | 'limit'
     | 'groupBy'
     | 'orderBy'
@@ -395,7 +397,6 @@ export interface AssistantTrendsGroupNode {
     /** Math aggregation for the combined series. The engine reads aggregation from here, not from inner nodes. */
     math?: AssistantTrendsEventsNode['math']
     math_property?: AssistantTrendsEventsNode['math_property']
-    math_property_type?: AssistantTrendsEventsNode['math_property_type']
     math_multiplier?: AssistantTrendsEventsNode['math_multiplier']
     math_group_type_index?: AssistantTrendsEventsNode['math_group_type_index']
     /** Custom HogQL aggregation. When set, `math` must be `hogql`. */
@@ -910,15 +911,7 @@ export type AssistantStickinessDisplayType =
  */
 export interface AssistantStickinessEventsNode extends Pick<
     EventsNode,
-    | 'kind'
-    | 'event'
-    | 'name'
-    | 'custom_name'
-    | 'math'
-    | 'math_multiplier'
-    | 'math_property'
-    | 'math_property_type'
-    | 'math_group_type_index'
+    'kind' | 'event' | 'name' | 'custom_name' | 'math' | 'math_multiplier' | 'math_property' | 'math_group_type_index'
 > {
     properties?: AssistantPropertyFilter[]
 
@@ -942,14 +935,7 @@ export interface AssistantStickinessEventsNode extends Pick<
  */
 export interface AssistantStickinessActionsNode extends Pick<
     ActionsNode,
-    | 'kind'
-    | 'id'
-    | 'custom_name'
-    | 'math'
-    | 'math_multiplier'
-    | 'math_property'
-    | 'math_property_type'
-    | 'math_group_type_index'
+    'kind' | 'id' | 'custom_name' | 'math' | 'math_multiplier' | 'math_property' | 'math_group_type_index'
 > {
     properties?: AssistantPropertyFilter[]
     /**

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -10223,7 +10223,6 @@ class AssistantStickinessActionsNode(BaseModel):
     )
     math_multiplier: float | None = None
     math_property: str | None = None
-    math_property_type: str | None = None
     name: str = Field(..., description="Action name from the plan.")
     properties: (
         list[
@@ -10284,7 +10283,6 @@ class AssistantStickinessEventsNode(BaseModel):
     )
     math_multiplier: float | None = None
     math_property: str | None = None
-    math_property_type: str | None = None
     name: str | None = None
     properties: (
         list[
@@ -10453,7 +10451,6 @@ class AssistantTrendsActionsNode(BaseModel):
     )
     math_multiplier: float | None = None
     math_property: str | None = None
-    math_property_type: str | None = None
     name: str = Field(..., description="Action name from the plan.")
     optionalInFunnel: bool | None = None
     properties: (
@@ -10516,7 +10513,6 @@ class AssistantTrendsEventsNode(BaseModel):
     )
     math_multiplier: float | None = None
     math_property: str | None = None
-    math_property_type: str | None = None
     name: str | None = None
     optionalInFunnel: bool | None = None
     properties: (
@@ -10574,7 +10570,6 @@ class AssistantTrendsGroupNode(BaseModel):
     )
     math_multiplier: float | None = None
     math_property: str | None = None
-    math_property_type: str | None = None
     name: str | None = Field(default=None, description="Display name for the combined series.")
     nodes: list[AssistantTrendsEventsNode | AssistantTrendsActionsNode] = Field(
         ...,

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -405,7 +405,6 @@ const AssistantTrendsEventsNode = z.object({
         .optional(),
     math_multiplier: z.coerce.number().optional(),
     math_property: z.string().optional(),
-    math_property_type: z.string().optional(),
     name: z.string().optional(),
     optionalInFunnel: z.coerce.boolean().optional(),
     properties: z.array(AssistantPropertyFilter).optional(),
@@ -426,7 +425,6 @@ const AssistantTrendsActionsNode = z.object({
         .optional(),
     math_multiplier: z.coerce.number().optional(),
     math_property: z.string().optional(),
-    math_property_type: z.string().optional(),
     name: z.string().describe('Action name from the plan.'),
     optionalInFunnel: z.coerce.boolean().optional(),
     properties: z.array(AssistantPropertyFilter).optional(),
@@ -443,7 +441,6 @@ const AssistantTrendsGroupNode = z.object({
     math_hogql: z.string().describe('Custom HogQL aggregation. When set, `math` must be `hogql`.').optional(),
     math_multiplier: z.coerce.number().optional(),
     math_property: z.string().optional(),
-    math_property_type: z.string().optional(),
     name: z.string().describe('Display name for the combined series.').optional(),
     nodes: z
         .array(z.union([AssistantTrendsEventsNode, AssistantTrendsActionsNode]))
@@ -881,7 +878,6 @@ const AssistantStickinessEventsNode = z.object({
         .optional(),
     math_multiplier: z.coerce.number().optional(),
     math_property: z.string().optional(),
-    math_property_type: z.string().optional(),
     name: z.string().optional(),
     properties: z.array(AssistantPropertyFilter).optional(),
 })
@@ -900,7 +896,6 @@ const AssistantStickinessActionsNode = z.object({
         .optional(),
     math_multiplier: z.coerce.number().optional(),
     math_property: z.string().optional(),
-    math_property_type: z.string().optional(),
     name: z.string().describe('Action name from the plan.'),
     properties: z.array(AssistantPropertyFilter).optional(),
 })

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/query-stickiness.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/query-stickiness.json
@@ -695,9 +695,6 @@
                             "math_property": {
                                 "type": "string"
                             },
-                            "math_property_type": {
-                                "type": "string"
-                            },
                             "name": {
                                 "type": "string"
                             },
@@ -1325,9 +1322,6 @@
                                 "type": "number"
                             },
                             "math_property": {
-                                "type": "string"
-                            },
-                            "math_property_type": {
                                 "type": "string"
                             },
                             "name": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/query-trends-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/query-trends-actors.json
@@ -838,9 +838,6 @@
                                     "math_property": {
                                         "type": "string"
                                     },
-                                    "math_property_type": {
-                                        "type": "string"
-                                    },
                                     "name": {
                                         "type": "string"
                                     },
@@ -1511,9 +1508,6 @@
                                     "math_property": {
                                         "type": "string"
                                     },
-                                    "math_property_type": {
-                                        "type": "string"
-                                    },
                                     "name": {
                                         "description": "Action name from the plan.",
                                         "type": "string"
@@ -2182,9 +2176,6 @@
                                     "math_property": {
                                         "type": "string"
                                     },
-                                    "math_property_type": {
-                                        "type": "string"
-                                    },
                                     "name": {
                                         "description": "Display name for the combined series.",
                                         "type": "string"
@@ -2323,9 +2314,6 @@
                                                             "type": "number"
                                                         },
                                                         "math_property": {
-                                                            "type": "string"
-                                                        },
-                                                        "math_property_type": {
                                                             "type": "string"
                                                         },
                                                         "name": {
@@ -3095,9 +3083,6 @@
                                                             "type": "number"
                                                         },
                                                         "math_property": {
-                                                            "type": "string"
-                                                        },
-                                                        "math_property_type": {
                                                             "type": "string"
                                                         },
                                                         "name": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/query-trends.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v2/query-trends.json
@@ -768,9 +768,6 @@
                             "math_property": {
                                 "type": "string"
                             },
-                            "math_property_type": {
-                                "type": "string"
-                            },
                             "name": {
                                 "type": "string"
                             },
@@ -1407,9 +1404,6 @@
                             "math_property": {
                                 "type": "string"
                             },
-                            "math_property_type": {
-                                "type": "string"
-                            },
                             "name": {
                                 "description": "Action name from the plan.",
                                 "type": "string"
@@ -2044,9 +2038,6 @@
                             "math_property": {
                                 "type": "string"
                             },
-                            "math_property_type": {
-                                "type": "string"
-                            },
                             "name": {
                                 "description": "Display name for the combined series.",
                                 "type": "string"
@@ -2185,9 +2176,6 @@
                                                     "type": "number"
                                                 },
                                                 "math_property": {
-                                                    "type": "string"
-                                                },
-                                                "math_property_type": {
                                                     "type": "string"
                                                 },
                                                 "name": {
@@ -2932,9 +2920,6 @@
                                                     "type": "number"
                                                 },
                                                 "math_property": {
-                                                    "type": "string"
-                                                },
-                                                "math_property_type": {
                                                     "type": "string"
                                                 },
                                                 "name": {


### PR DESCRIPTION
## Problem

Production monitoring of `posthog_ai` LLM generations flagged the
`trends_generator` emitting `"math_property_type":"session_properties"`
inside `$ai_generation` outputs. The field is undocumented in the
trends/schema-generator prompts, has no enum constraint on the assistant
schema, and is essentially mechanical: it must be `"session_properties"`
whenever `math_property` is a session-level property like `$is_bounce` or
`$session_duration`, otherwise it should be omitted. The model was inferring
it from the bare JSON schema, sometimes redundantly for `$session_duration`
(where the runner's backwards-compat path makes it unnecessary).

## Changes

- Drop `math_property_type` from the assistant-facing schema by adding it to
  the `Omit` / removing it from the `Pick` for `AssistantTrendsEventsNode`,
  `AssistantTrendsActionsNode`, `AssistantTrendsGroupNode`,
  `AssistantStickinessEventsNode`, and `AssistantStickinessActionsNode` in
  `frontend/src/queries/schema/schema-assistant-queries.ts`.
- Regenerate `frontend/src/queries/schema.json` and `posthog/schema.py`.
- Inside `cast_assistant_query` (`ee/hogai/utils/helpers.py`), auto-populate
  `math_property_type="session_properties"` on series whose `math_property`
  is in the session math allowlist (matching
  `ALLOWED_SESSION_MATH_PROPERTIES` in
  `posthog/hogql_queries/insights/trends/aggregation_operations.py`). Walks
  into `AssistantTrendsGroupNode` to handle inner events/actions too.
- The runner still receives the field it needs to trigger session-level
  aggregation via `aggregating_on_session_property`; the LLM just no longer
  has to reason about it.

## How did you test this code?

I'm an agent. I added unit tests in
`ee/hogai/utils/test/test_assistant_helpers.py::TestCastAssistantQuery`:

- Parameterized over the full `ALLOWED_SESSION_MATH_PROPERTIES` set
  (`$session_duration`, `$is_bounce`, `$pageview_count`, `$screen_count`,
  `$autocapture_count`, `$num_uniq_urls`) for `AssistantTrendsEventsNode`,
  asserting the cast result carries `math_property_type="session_properties"`.
- A case for `AssistantTrendsActionsNode` with `$session_duration`.
- A negative case asserting non-session `math_property` (e.g. `refreshAge`)
  leaves `math_property_type` unset.
- A `AssistantTrendsGroupNode` case asserting both the group and its inner
  nodes get the field populated.

I could not run the Django test suite locally (no flox/uv venv in this
environment); CI will exercise the suite on the PR. I did smoke-test the
recursive fill logic in isolation.

## Publish to changelog?

no

## Docs update

No docs needed — the schema change is internal to the AI agent's tool
schema; the user-facing trends query schema is unchanged.

## 🤖 Agent context

Tool used: PostHog Code (Claude).

Investigation steps:
- Located the trends generator (`ee/hogai/chat_agent/trends/nodes.py`,
  `prompts.py`, `toolkit.py`) and the shared schema-generator
  (`ee/hogai/chat_agent/schema_generator/nodes.py`,
  `prompts.py`). Confirmed neither prompt mentions
  `math_property_type` or session-level math anywhere — the model was
  inferring usage purely from the JSON schema fed via
  `with_structured_output`.
- Confirmed via `posthog/hogql_queries/insights/trends/aggregation_operations.py`
  that the valid `math_property_type` values are `"session_properties"`,
  `"data_warehouse_person_properties"`, and `"person_properties"`, and that
  only the session case is reachable from the assistant (no data warehouse or
  person-property math via the assistant schema today).
- Considered alternatives that were rejected:
  - **Prompt-only fix**: telling the LLM "don't emit `math_property_type` for
    `$session_duration`" would still leave the field in the schema and the
    LLM would still emit it for `$is_bounce` (the runner requires it), so
    occurrences wouldn't drop to zero.
  - **Constrain `math_property_type` to a `Literal`**: cleaner schema but the
    field would still appear in LLM output, defeating the monitoring rule.
  - **Strip the field post-hoc**: doesn't change what the LLM emits, so the
    monitor would still fire.
- Chosen approach: remove the field from the assistant schema (so the LLM has
  no place to put it) and inject it server-side based on `math_property` in
  `cast_assistant_query`. This keeps the runner contract intact while
  eliminating the LLM-side emission.

Did not regenerate `services/mcp/src/tools/generated/query-wrappers.ts`
because it requires `hogli build:openapi-schema` (drf-spectacular introspection
of the live Django app), which isn't reachable in this environment. CI's
regenerate gates should refresh it on the PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*