### PR TITLE
fix(replay): make NEW badge legible in AI product context setting

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -1049,7 +1049,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 title: (
                     <>
                         AI product context
-                        <LemonTag type="success" className="ml-1 uppercase">
+                        <LemonTag type="highlight" size="small" className="ml-1">
                             New
                         </LemonTag>
                     </>


### PR DESCRIPTION
## Problem

The `NEW` badge next to **AI product context** in the session replay settings was illegible — it was rendered as small uppercase text in low-contrast success-green (`type=\"success\"`) on the settings page background.

## Changes

Switched the tag to `type=\"highlight\"` (accent color) and `size=\"small\"`, and dropped the `uppercase` class — matching how other \"New\" badges are rendered elsewhere in the app (e.g. `ProjectTree`, `FolderSelect`, `ItemSelectModal`, `ConfigurePinnedTabsModal`).

## How did you test this code?

I'm an agent. I did not run the dev server or visually verify the change in a browser. The change is a one-line styling tweak that aligns with the existing convention for \"New\" badges in the codebase; a reviewer should eyeball the badge on the session replay settings page before merging.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Authored with PostHog Code.
- Searched the codebase for the \"AI product context\" string to locate the badge in `frontend/src/scenes/settings/SettingsMap.tsx`.
- Reviewed `LemonTag.scss` to understand why `type=\"success\"` is hard to read (green-on-light, no background, tiny uppercase font) and surveyed other usages of `<LemonTag>New</LemonTag>` to find the prevailing convention — `type=\"highlight\"` with `size=\"small\"`.
- Did not run frontend lint, typecheck, or the dev server.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*