### PR TITLE
feat(hogql): generalize presorted-fetch optimization to all queries

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -20963,6 +20963,10 @@
                 "optimizeJoinedFilters": {
                     "type": "boolean"
                 },
+                "optimizePresortedFetch": {
+                    "description": "Resolve narrow row identifiers before fetching wide columns for ORDER BY ... LIMIT queries *",
+                    "type": "boolean"
+                },
                 "optimizeProjections": {
                     "type": "boolean"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -448,6 +448,8 @@ export interface HogQLQueryModifiers {
     usePreaggregatedTableTransforms?: boolean
     usePreaggregatedIntermediateResults?: boolean
     optimizeProjections?: boolean
+    /** Resolve narrow row identifiers before fetching wide columns for ORDER BY ... LIMIT queries **/
+    optimizePresortedFetch?: boolean
     /** If these are provided, the query will fail if these skip indexes are not used */
     forceClickhouseDataSkippingIndexes?: string[]
     inlineCohortCalculation?: 'off' | 'auto' | 'always'

--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -71,6 +71,9 @@ def create_default_modifiers_for_team(
     if modifiers.optimizeProjections is None:
         modifiers.optimizeProjections = True
 
+    if modifiers.optimizePresortedFetch is None:
+        modifiers.optimizePresortedFetch = True
+
     set_default_modifier_values(modifiers, team)
 
     return modifiers

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -48,6 +48,7 @@ from posthog.hogql.resolver import Resolver
 from posthog.hogql.resolver_utils import extract_base_table_types, extract_select_queries
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql.transforms.preaggregated_table_transformation import do_preaggregated_table_transforms
+from posthog.hogql.transforms.presorted_fetch import do_presorted_fetch_transform
 from posthog.hogql.variables import replace_variables
 from posthog.hogql.visitor import clone_expr
 
@@ -363,6 +364,13 @@ class HogQLQueryExecutor:
 
                 transformer = DailyUniquePersonsPageviewsTransformer(self.hogql_context)
                 transformed_node = transformer.visit(self.select_query)
+                if isinstance(transformed_node, ast.SelectQuery) or isinstance(transformed_node, ast.SelectSetQuery):
+                    self.select_query = transformed_node
+
+        if self.query_modifiers.optimizePresortedFetch:
+            with self.timings.measure("presorted_fetch_transform"):
+                assert self.hogql_context is not None
+                transformed_node = do_presorted_fetch_transform(self.select_query, self.hogql_context)
                 if isinstance(transformed_node, ast.SelectQuery) or isinstance(transformed_node, ast.SelectSetQuery):
                     self.select_query = transformed_node
 

--- a/posthog/hogql/transforms/presorted_fetch.py
+++ b/posthog/hogql/transforms/presorted_fetch.py
@@ -1,0 +1,223 @@
+"""AST-to-AST transform: resolve narrow row identifiers first, then fetch wide columns.
+
+For an ``ORDER BY ... LIMIT n`` query that selects a wide column — the raw ``properties``
+or ``elements_chain`` blob, or ``*`` — reading that blob for every candidate row before
+sorting dominates the query cost. This transform rewrites::
+
+    SELECT uuid, properties FROM events WHERE ... ORDER BY timestamp LIMIT 100
+
+into::
+
+    SELECT uuid, properties FROM events
+    WHERE uuid IN (SELECT uuid FROM events WHERE ... ORDER BY timestamp LIMIT 100) AND ...
+    ORDER BY timestamp LIMIT 100
+
+so the sort runs over the narrow identifier only and the wide blob is read for the matched
+rows alone. This generalizes the optimization that previously lived inside
+``EventsQueryRunner`` so that raw ``HogQLQuery`` (and any other events query) benefits too.
+
+The transform runs on the *unresolved* AST (before ``resolve_types``), like
+``do_preaggregated_table_transforms``, because ``resolve_types`` is not re-entrant — it
+raises if it revisits a node that already has a type. The single downstream resolution pass
+types the rewritten tree naturally.
+
+Exports:
+* do_presorted_fetch_transform
+"""
+
+from dataclasses import dataclass
+from typing import TypeVar, cast
+
+from posthog.hogql import ast
+from posthog.hogql.base import AST
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.models import Table
+from posthog.hogql.database.schema.events import EventsTable
+from posthog.hogql.property import has_aggregation
+from posthog.hogql.visitor import CloningVisitor, TraversingVisitor, clone_expr
+
+_T_AST = TypeVar("_T_AST", bound=AST)
+
+# A query whose LIMIT exceeds this is left alone: the IN-set would be large and the outer
+# re-scan needed to apply it stops paying for itself. Mirrors ClickHouse's own
+# lazy-materialization row cap.
+PRESORTED_MAX_LIMIT = 10000
+
+
+@dataclass(frozen=True)
+class _PresortedTable:
+    # The identifier MUST be unique per row, or the IN-subquery rewrite is incorrect.
+    identifier: str
+    wide_columns: frozenset[str]
+
+
+# Tables eligible for the rewrite, matched by their resolved Table subclass. Add new tables
+# here once their unique identifier and wide columns are known.
+_PRESORTED_TABLES: dict[type[Table], _PresortedTable] = {
+    EventsTable: _PresortedTable(identifier="uuid", wide_columns=frozenset({"properties", "elements_chain"})),
+}
+
+
+class _WideFieldFinder(TraversingVisitor):
+    """Detects references to a table's raw wide columns (and ``*``) within an expression.
+
+    A *raw* reference reads the whole blob (``properties``, ``elements_chain`` or
+    ``table.properties``); a value extraction (``properties.$foo``) does not count, since it
+    can be sorted/selected cheaply. Subqueries are not descended into — a wide read nested in
+    a subquery is that subquery's own concern.
+    """
+
+    def __init__(self, table_names: frozenset[str], wide_columns: frozenset[str]) -> None:
+        super().__init__()
+        self._table_names = table_names
+        self._wide_columns = wide_columns
+        self.found_wide: bool = False
+        self.found_star: bool = False
+
+    def visit_select_query(self, node: ast.SelectQuery) -> None:
+        return
+
+    def visit_select_set_query(self, node: ast.SelectSetQuery) -> None:
+        return
+
+    def visit_field(self, node: ast.Field) -> None:
+        chain = [str(c) for c in node.chain]
+        if self._is_raw_wide(chain):
+            self.found_wide = True
+        elif self._is_star(chain):
+            self.found_star = True
+
+    def _is_raw_wide(self, chain: list[str]) -> bool:
+        if len(chain) == 1:
+            return chain[0] in self._wide_columns
+        if len(chain) == 2:
+            return chain[1] in self._wide_columns and chain[0] in self._table_names
+        return False
+
+    def _is_star(self, chain: list[str]) -> bool:
+        if chain == ["*"]:
+            return True
+        return len(chain) == 2 and chain[1] == "*" and chain[0] in self._table_names
+
+
+class _PresortedFetchTransformer(CloningVisitor):
+    def __init__(self, context: HogQLContext) -> None:
+        super().__init__()
+        self._context = context
+        # CTE names visible at the current point in the tree. A CTE named like a registered
+        # table shadows the real table, so we must not rewrite a FROM that resolves to it.
+        self._cte_names_in_scope: set[str] = set()
+
+    def visit_select_query(self, node: ast.SelectQuery) -> ast.SelectQuery:
+        added = {name for name in (node.ctes or {}) if name not in self._cte_names_in_scope}
+        self._cte_names_in_scope |= added
+        try:
+            cloned = cast(ast.SelectQuery, super().visit_select_query(node))
+            config = self._eligible(cloned)
+            if config is not None:
+                return self._rewrite(cloned, config)
+            return cloned
+        finally:
+            self._cte_names_in_scope -= added
+
+    def _eligible(self, node: ast.SelectQuery) -> _PresortedTable | None:
+        select_from = node.select_from
+        if select_from is None or select_from.next_join is not None:
+            return None
+        if not isinstance(select_from.table, ast.Field):
+            return None
+        if node.distinct or node.group_by or node.having or node.qualify:
+            return None
+        if node.array_join_list or node.array_join_op or node.window_exprs or node.prewhere:
+            return None
+        if node.limit_by is not None or node.limit_with_ties or node.limit_percent:
+            return None
+        if not node.order_by:
+            return None
+
+        limit = node.limit
+        if not isinstance(limit, ast.Constant) or not isinstance(limit.value, int):
+            return None
+        if limit.value <= 0 or limit.value > PRESORTED_MAX_LIMIT:
+            return None
+
+        table_chain = [str(c) for c in select_from.table.chain]
+        if len(table_chain) == 1 and table_chain[0] in self._cte_names_in_scope:
+            return None
+
+        if self._context.database is None:
+            return None
+        try:
+            resolved = self._context.database.get_table(table_chain)
+        except Exception:
+            return None
+        config = next((c for table_cls, c in _PRESORTED_TABLES.items() if isinstance(resolved, table_cls)), None)
+        if config is None:
+            return None
+
+        if any(has_aggregation(expr) for expr in node.select):
+            return None
+
+        table_names = frozenset({table_chain[-1]} | ({select_from.alias} if select_from.alias else set()))
+
+        # Sorting by the raw blob would force the inner (narrow) query to read it anyway,
+        # defeating the optimization.
+        for order_expr in node.order_by:
+            finder = _WideFieldFinder(table_names, config.wide_columns)
+            finder.visit(order_expr.expr)
+            if finder.found_wide:
+                return None
+
+        # No benefit unless a wide blob is actually selected.
+        if not self._select_reads_wide(node, table_names, config.wide_columns):
+            return None
+
+        return config
+
+    @staticmethod
+    def _select_reads_wide(node: ast.SelectQuery, table_names: frozenset[str], wide_columns: frozenset[str]) -> bool:
+        for select_expr in node.select:
+            finder = _WideFieldFinder(table_names, wide_columns)
+            finder.visit(select_expr)
+            if finder.found_wide or finder.found_star:
+                return True
+        return False
+
+    def _rewrite(self, node: ast.SelectQuery, config: _PresortedTable) -> ast.SelectQuery:
+        identifier = config.identifier
+        limit_value = cast(int, cast(ast.Constant, node.limit).value)
+        offset_value = (
+            cast(int, node.offset.value)
+            if isinstance(node.offset, ast.Constant) and isinstance(node.offset.value, int)
+            else 0
+        )
+
+        # Reuse the outer FROM (table + alias, guaranteed join-free) so the cloned WHERE and
+        # ORDER BY — which may reference the table alias — still resolve inside the subquery.
+        inner = ast.SelectQuery(
+            select=[ast.Field(chain=[identifier])],
+            select_from=clone_expr(node.select_from, clear_types=True),
+            where=clone_expr(node.where, clear_types=True) if node.where is not None else None,
+            order_by=[clone_expr(order_expr, clear_types=True) for order_expr in (node.order_by or [])],
+            limit=ast.Constant(value=limit_value + offset_value),
+        )
+        prefilter = ast.CompareOperation(
+            op=ast.CompareOperationOp.In,
+            left=ast.Field(chain=[identifier]),
+            right=inner,
+        )
+        node.where = ast.And(exprs=[prefilter, node.where]) if node.where is not None else prefilter
+        return node
+
+
+def do_presorted_fetch_transform(node: _T_AST, context: HogQLContext) -> _T_AST:
+    """Rewrite eligible ``ORDER BY ... LIMIT`` queries to sort by a narrow identifier first.
+
+    Returns the original node unchanged when nothing is eligible. Must run before
+    ``resolve_types``.
+    """
+    if not isinstance(node, ast.SelectQuery | ast.SelectSetQuery):
+        return node
+    if context.database is None:
+        return node
+    return cast(_T_AST, _PresortedFetchTransformer(context).visit(node))

--- a/posthog/hogql/transforms/test/test_presorted_fetch.py
+++ b/posthog/hogql/transforms/test/test_presorted_fetch.py
@@ -1,0 +1,110 @@
+import re
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
+
+from parameterized import parameterized
+
+from posthog.schema import HogQLQueryModifiers
+
+from posthog.hogql.query import HogQLQueryExecutor, execute_hogql_query
+
+
+class TestPresortedFetch(ClickhouseTestMixin, APIBaseTest):
+    def _ch_sql(self, query: str, optimize: bool = True) -> str:
+        modifiers = HogQLQueryModifiers(optimizePresortedFetch=optimize)
+        sql, _ = HogQLQueryExecutor(
+            query=query, team=self.team, modifiers=modifiers, pretty=False
+        ).generate_clickhouse_sql()
+        return sql
+
+    def _assert_rewritten(self, sql: str) -> None:
+        # An identifier-only subquery selecting `<table>.uuid AS uuid` is the rewrite's fingerprint.
+        # The table prefix is the alias when the outer query aliases events.
+        assert re.search(r"\(SELECT \w+\.uuid AS uuid", sql), sql
+        assert sql.count("FROM events") >= 2, sql
+
+    def _assert_not_rewritten(self, sql: str) -> None:
+        assert re.search(r"\(SELECT \w+\.uuid AS uuid", sql) is None, sql
+
+    def test_rewrites_select_properties_order_by_timestamp(self):
+        sql = self._ch_sql("SELECT uuid, properties FROM events ORDER BY timestamp DESC LIMIT 100")
+        self._assert_rewritten(sql)
+        assert "LIMIT 100" in sql
+
+    def test_rewrites_select_star(self):
+        self._assert_rewritten(self._ch_sql("SELECT * FROM events ORDER BY timestamp LIMIT 50"))
+
+    def test_rewrites_select_elements_chain(self):
+        self._assert_rewritten(self._ch_sql("SELECT elements_chain FROM events ORDER BY timestamp LIMIT 10"))
+
+    def test_rewrites_with_aliased_table(self):
+        self._assert_rewritten(self._ch_sql("SELECT e.properties FROM events AS e ORDER BY e.timestamp LIMIT 10"))
+
+    def test_rewrites_property_extraction_in_order_by(self):
+        # Sorting by an extracted value (not the raw blob) is allowed.
+        self._assert_rewritten(self._ch_sql("SELECT properties FROM events ORDER BY properties.$browser DESC LIMIT 10"))
+
+    def test_inner_limit_includes_offset(self):
+        sql = self._ch_sql("SELECT uuid, properties FROM events ORDER BY timestamp LIMIT 10 OFFSET 5")
+        self._assert_rewritten(sql)
+        # Inner must fetch limit + offset rows; outer keeps limit/offset.
+        assert "LIMIT 15" in sql
+        assert "OFFSET 5" in sql
+
+    @parameterized.expand(
+        [
+            ("no_wide_column", "SELECT uuid, timestamp, event FROM events ORDER BY timestamp LIMIT 100"),
+            ("no_order_by", "SELECT uuid, properties FROM events LIMIT 100"),
+            ("aggregation", "SELECT count(), properties FROM events GROUP BY properties ORDER BY count() LIMIT 100"),
+            ("distinct", "SELECT DISTINCT properties FROM events ORDER BY properties LIMIT 100"),
+            ("raw_properties_in_order_by", "SELECT properties FROM events ORDER BY properties LIMIT 100"),
+            ("elements_chain_in_order_by", "SELECT properties FROM events ORDER BY elements_chain LIMIT 100"),
+            ("limit_above_cap", "SELECT uuid, properties FROM events ORDER BY timestamp LIMIT 10001"),
+        ]
+    )
+    def test_not_rewritten(self, _name: str, query: str):
+        self._assert_not_rewritten(self._ch_sql(query))
+
+    def test_disabled_by_modifier(self):
+        self._assert_not_rewritten(
+            self._ch_sql("SELECT uuid, properties FROM events ORDER BY timestamp DESC LIMIT 100", optimize=False)
+        )
+
+    def test_cte_named_events_not_rewritten(self):
+        # `events` here is a CTE, not the real table, so the rewrite must not fire.
+        sql = self._ch_sql(
+            "WITH events AS (SELECT 1 AS uuid, 2 AS properties) "
+            "SELECT uuid, properties FROM events ORDER BY uuid LIMIT 10"
+        )
+        self._assert_not_rewritten(sql)
+
+    def _make_events(self, count: int) -> None:
+        for i in range(count):
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                distinct_id=f"d{i}",
+                timestamp=f"2024-01-01 00:00:{i:02d}",
+                properties={"idx": i},
+            )
+        flush_persons_and_events()
+
+    def _results(self, query: str, optimize: bool) -> list:
+        response = execute_hogql_query(
+            query, self.team, modifiers=HogQLQueryModifiers(optimizePresortedFetch=optimize), pretty=False
+        )
+        return response.results or []
+
+    def test_parity_results_identical(self):
+        self._make_events(10)
+        query = "SELECT uuid, properties.idx FROM events ORDER BY timestamp DESC LIMIT 4"
+        assert self._results(query, optimize=True) == self._results(query, optimize=False)
+
+    def test_parity_with_offset(self):
+        self._make_events(10)
+        query = "SELECT properties.idx FROM events ORDER BY timestamp ASC LIMIT 3 OFFSET 4"
+        on = self._results(query, optimize=True)
+        off = self._results(query, optimize=False)
+        assert on == off
+        # Confirms the offset is applied once (not doubled): rows 4-6 of the ascending order.
+        assert [int(row[0]) for row in on] == [4, 5, 6]

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -12,7 +12,7 @@ from posthog.schema import CachedEventsQueryResponse, DashboardFilter, EventsQue
 
 from posthog.hogql import ast
 from posthog.hogql.ast import Alias
-from posthog.hogql.parser import parse_expr, parse_order_expr, parse_select
+from posthog.hogql.parser import parse_expr, parse_order_expr
 from posthog.hogql.property import (
     action_to_expr,
     has_aggregation,
@@ -48,9 +48,6 @@ SELECT_STAR_FROM_EVENTS_FIELDS = [
     "created_at",
     "person_mode",
 ]
-
-# Wide columns that defeat presorted optimization
-WIDE_COLUMNS = {"elements_chain", "properties"}
 
 
 class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
@@ -107,28 +104,6 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
         return select_input, [
             map_virtual_properties(parse_expr(column, timings=self.timings)) for column in select_input
         ]
-
-    def _can_use_presorted_optimization(self, order_by: list[ast.OrderExpr] | None) -> bool:
-        """
-        Check if ORDER BY can use presorted optimization.
-
-        We can optimize any ORDER BY that doesn't need wide columns directly.
-        - properties.$foo is fine (we extract just that value)
-        - elements_chain or raw properties blob is not fine
-        """
-        if not order_by:
-            return False
-
-        for order_expr in order_by:
-            if isinstance(order_expr.expr, ast.Field) and order_expr.expr.chain:
-                first = order_expr.expr.chain[0]
-                if first in WIDE_COLUMNS:
-                    # properties.$foo is fine - we extract just that property
-                    if first == "properties" and len(order_expr.expr.chain) >= 2:
-                        continue
-                    return False
-
-        return True
 
     def apply_pagination_cursor(self, cursor: str) -> None:
         # NB: This uses the last row's timestamp as the cursor, so events sharing
@@ -393,26 +368,9 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
                     order_by=order_by,
                 )
 
-                # Presorted optimization: sort narrow data (uuid) first, then fetch wide data for matched rows.
-                # Avoids sorting giant rows with properties and elements_chain cols - instead sorts uuids.
-                if self._can_use_presorted_optimization(order_by) and not has_any_aggregation:
-                    logger.info(
-                        "events_query_runner_presorted_optimization",
-                        team_id=self.team.pk,
-                    )
-                    inner_query = parse_select("SELECT uuid FROM events")
-                    assert isinstance(inner_query, ast.SelectQuery)
-                    inner_query.where = where
-                    inner_query.order_by = order_by
-                    inner_query.limit = ast.Constant(value=self.paginator.limit + self.paginator.offset + 1)
-
-                    prefilter_sorted = parse_expr("uuid in ({inner_query})", {"inner_query": inner_query})
-
-                    if where is not None:
-                        stmt.where = ast.And(exprs=[prefilter_sorted, where])
-                    else:
-                        stmt.where = prefilter_sorted
-
+                # The presorted optimization (sort by narrow uuid, then fetch wide columns for the
+                # matched rows) now lives in the general do_presorted_fetch_transform pass, applied
+                # to every HogQL query during printing.
                 return stmt
 
     def _calculate(self) -> EventsQueryResponse:

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7299,6 +7299,10 @@ class HogQLQueryModifiers(BaseModel):
     materializationMode: MaterializationMode | None = None
     materializedColumnsOptimizationMode: MaterializedColumnsOptimizationMode | None = None
     optimizeJoinedFilters: bool | None = None
+    optimizePresortedFetch: bool | None = Field(
+        default=None,
+        description=("Resolve narrow row identifiers before fetching wide columns for ORDER BY ... LIMIT queries *"),
+    )
     optimizeProjections: bool | None = None
     personsArgMaxVersion: PersonsArgMaxVersion | None = None
     personsJoinMode: PersonsJoinMode | None = None

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -414,6 +414,8 @@ export interface HogQLQueryModifiersApi {
     materializationMode?: MaterializationModeApi | null
     materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationModeApi | null
     optimizeJoinedFilters?: boolean | null
+    /** Resolve narrow row identifiers before fetching wide columns for ORDER BY ... LIMIT queries * */
+    optimizePresortedFetch?: boolean | null
     optimizeProjections?: boolean | null
     personsArgMaxVersion?: PersonsArgMaxVersionApi | null
     personsJoinMode?: PersonsJoinModeApi | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1524,6 +1524,8 @@ export namespace Schemas {
       materializationMode?: MaterializationMode | null;
       materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationMode | null;
       optimizeJoinedFilters?: boolean | null;
+      /** Resolve narrow row identifiers before fetching wide columns for ORDER BY ... LIMIT queries * */
+      optimizePresortedFetch?: boolean | null;
       optimizeProjections?: boolean | null;
       personsArgMaxVersion?: PersonsArgMaxVersion | null;
       personsJoinMode?: PersonsJoinMode | null;


### PR DESCRIPTION
## Problem

HogQL queries that select a wide column — the raw `properties` or `elements_chain` blob, or `*` — and sort with `ORDER BY ... LIMIT n` read that wide blob for **every** candidate row before sorting, then throw away all but `n` rows. For an events query the blob read dominates the cost.

`EventsQueryRunner` already worked around this (resolve the matching rows by `uuid` first, then fetch the wide columns for only those rows), but the workaround lived inside that one runner — so raw `HogQLQuery` and other events queries got no benefit. ClickHouse's own lazy materialization does not engage on the Distributed `events` table, so HogQL has to perform the rewrite itself.

## Changes

- **New transform** `do_presorted_fetch_transform` (`posthog/hogql/transforms/presorted_fetch.py`). It rewrites an eligible

  ```sql
  SELECT uuid, properties FROM events WHERE ... ORDER BY timestamp LIMIT 100
  ```

  into

  ```sql
  SELECT uuid, properties FROM events
  WHERE uuid IN (SELECT uuid FROM events WHERE ... ORDER BY timestamp LIMIT 100) AND ...
  ORDER BY timestamp LIMIT 100
  ```

  so the sort runs over the narrow `uuid` and the wide blob is read only for the matched rows.
- **Wired into** `HogQLQueryExecutor._apply_optimizers`, alongside the preaggregated-table transform, gated on a new `optimizePresortedFetch` modifier (default on; acts as a kill switch).
- **Eligibility** is conservative: a constant `LIMIT` within a cap (`PRESORTED_MAX_LIMIT`), no aggregation / join / `GROUP BY` / `DISTINCT`, a raw wide column actually selected, and no raw wide column in `ORDER BY` (sorting by an extracted value like `properties.$foo` is still fine). A CTE that shadows the table name (`WITH events AS (...)`) is left alone, and the table is resolved via `database.get_table()` so only the real events table matches.
- **Removed** the now-duplicate copy from `EventsQueryRunner` (`WIDE_COLUMNS`, `_can_use_presorted_optimization`, and the inline rewrite). The general pass covers it.
- Added the `optimizePresortedFetch` modifier to the query schema and regenerated the TypeScript/Python types.

A notable implementation decision: the transform runs on the **unresolved** AST. The resolver is not re-entrant (it raises if it revisits an already-typed node), so rewriting after type resolution and re-resolving would crash — running before resolution lets the single downstream pass type the rewritten tree, matching the existing preaggregated-table transform.

### Scope and performance characteristics

- **What it targets:** a *raw* wide blob actually selected — `SELECT *`, `SELECT properties`, `SELECT elements_chain` (and those columns nested in expressions/tuples). `SELECT *` is covered because it expands to include the raw `properties`/`elements_chain` columns.
- **What it deliberately skips:** property *extractions* (`properties.$foo`). When backed by a materialized column an extraction is already narrow, so wrapping it in an `IN`-subquery would add a scan for no benefit. Since materialization is resolved later in the pipeline, the transform stays conservative and only fires on the raw blob, which is never materialized.
- **Why regressions are unlikely where it does fire:** ClickHouse's lazy materialization does not engage on the Distributed `events` table, so a naive raw-blob `ORDER BY … LIMIT` reads the blob for *every* candidate row — exactly what the rewrite removes. The only added cost is a second pass over the narrow identifier; a net slow-down requires a candidate set so small that this narrow re-scan outweighs the (then tiny) blob bytes saved, where the absolute cost is negligible. A `LIMIT` cap bounds the `IN`-set size, and `GROUP BY` / aggregation / joins / `DISTINCT` are excluded.

## How did you test this code?

I'm an agent (Claude Code); below are the automated checks I actually ran.

- **New `test_presorted_fetch.py` (17 tests):** generated-SQL shape assertions (positive), parameterized negatives (no wide column, no `ORDER BY`, aggregation, `DISTINCT`, raw wide column in `ORDER BY`, limit over the cap), the CTE-shadow guard, the modifier kill switch, and **two execution-parity tests** that assert identical results with the modifier on vs off, including offset pagination.
- **`test_events_query_runner.py` (31 tests):** all behavior assertions pass after the dedup, confirming query results are unchanged by moving the optimization.
- **`test_query.py` (74 tests):** broad pass, no transform-induced resolution errors.
- **Production validation:** ran the original vs rewritten shape of a representative high-cardinality `SELECT uuid, properties FROM events ... ORDER BY timestamp LIMIT n` against production (ClickHouse, US). The rewrite returned **identical rows** while reducing bytes read by roughly **two orders of magnitude** and cutting latency several-fold — the wide blob is read only for the matched rows. This also confirms the `uuid IN (subquery)` rewrite is correct on the Distributed `events` table. The benefit narrows (but stays large) as the time window widens, because the outer `uuid IN` re-scans the window over the narrow column.

`.ambr` snapshots are intentionally left for CI to regenerate.

## Publish to changelog?

no

## Docs update

No user-facing docs changes; add `skip-inkeep-docs` if the bot triggers.

## 🤖 Agent context

Authored by an agent (Claude Code, Opus). Requires human review — not self-approved.

Decisions worth surfacing for review:

- **Where to run the pass.** The initial plan placed it after `resolve_types` and re-ran resolution. Rejected: the resolver raises on already-typed nodes. Chosen: run on the unresolved AST in `_apply_optimizers`, the same place and style as `do_preaggregated_table_transforms`.
- **What counts as "wide".** Eligibility deliberately triggers only on **raw** blob reads (`properties` / `elements_chain` / `*`), not extractions like `properties.$foo`. A raw blob is always expensive to read, so the rewrite reliably pays off; an extraction may be backed by a materialized column (already cheap), where the extra `uuid IN` re-scan could be a net loss.
- **Safety guards** added beyond the original EventsQueryRunner logic: CTE-shadowing check, `database.get_table()`-based table identification, and a `LIMIT` cap to avoid huge `IN` sets.
- **Known limitation / out of scope:** for unbounded time ranges the outer `uuid IN` re-scan stays large, so the win is smaller there than for time-bounded queries; a follow-up time-bounding step would compose with this. Joins and non-events tables are also out of scope for now (the table registry is extensible).
