### PR TITLE
feat(hogql): early-terminate events ORDER BY timestamp with LIMIT

### DIFF
--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -256,9 +256,10 @@
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key
   FROM events
   WHERE equals(events.team_id, 99999)
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
   LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=600,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -302,9 +303,10 @@
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key
   FROM events
   WHERE equals(events.team_id, 99999)
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
   LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -124,6 +124,10 @@ class HogQLQuerySettings(BaseModel):
     optimize_skip_unused_shards: Optional[bool] = None
     read_overflow_mode: Optional[str] = None
     max_bytes_to_read: Optional[int] = None
+    # Read-in-order's default read-ahead buffering over-reads under a LIMIT (it keeps reading
+    # granules past the point the LIMIT is satisfied) and inflates peak memory. Disabling it lets
+    # an ORDER-BY-sort-key-prefix + LIMIT query early-terminate. See timestamp_order_by.py.
+    read_in_order_use_buffering: Optional[bool] = None
 
 
 # Settings applied on top of all HogQL queries.

--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
@@ -2109,8 +2109,9 @@
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
   WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 1 SETTINGS readonly=2,
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+  LIMIT 1 SETTINGS read_in_order_use_buffering=0,
+                   readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
                    max_ast_elements=4000000,
@@ -2235,8 +2236,9 @@
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
   WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 1 SETTINGS readonly=2,
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+  LIMIT 1 SETTINGS read_in_order_use_buffering=0,
+                   readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
                    max_ast_elements=4000000,
@@ -2446,8 +2448,9 @@
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
   WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 1 SETTINGS readonly=2,
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+  LIMIT 1 SETTINGS read_in_order_use_buffering=0,
+                   readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
                    max_ast_elements=4000000,
@@ -2846,8 +2849,9 @@
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
   WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 1 SETTINGS readonly=2,
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+  LIMIT 1 SETTINGS read_in_order_use_buffering=0,
+                   readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
                    max_ast_elements=4000000,
@@ -3230,8 +3234,9 @@
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
   WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 1 SETTINGS readonly=2,
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+  LIMIT 1 SETTINGS read_in_order_use_buffering=0,
+                   readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
                    max_ast_elements=4000000,
@@ -3376,8 +3381,9 @@
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
   WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 1 SETTINGS readonly=2,
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+  LIMIT 1 SETTINGS read_in_order_use_buffering=0,
+                   readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
                    max_ast_elements=4000000,
@@ -3507,8 +3513,9 @@
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
   WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 1 SETTINGS readonly=2,
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+  LIMIT 1 SETTINGS read_in_order_use_buffering=0,
+                   readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
                    max_ast_elements=4000000,
@@ -3645,8 +3652,9 @@
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
   WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 1 SETTINGS readonly=2,
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+  LIMIT 1 SETTINGS read_in_order_use_buffering=0,
+                   readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
                    max_ast_elements=4000000,

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -19,6 +19,7 @@ from posthog.hogql.transforms.in_cohort import resolve_in_cohorts, resolve_in_co
 from posthog.hogql.transforms.lazy_tables import resolve_lazy_tables
 from posthog.hogql.transforms.projection_pushdown import pushdown_projections
 from posthog.hogql.transforms.property_types import PropertySwapper, build_property_swapper
+from posthog.hogql.transforms.timestamp_order_by import optimize_timestamp_order_by
 from posthog.hogql.visitor import clone_expr
 from posthog.hogql.workload import WorkloadCollector
 
@@ -155,6 +156,12 @@ def prepare_ast_for_printing(
                 context=context,
                 setTimeZones=context.modifiers.convertToProjectTimezone is not False,
             ).visit(node)
+
+        # Align leading `ORDER BY timestamp` with the events sort key so a LIMIT can read in
+        # primary-key order and early-terminate. Runs after swap_properties so the timestamp is
+        # already wrapped in toTimeZone (which this rewrite peels back off).
+        with context.timings.measure("optimize_timestamp_order_by"):
+            optimize_timestamp_order_by(node, context)
 
         # We support global query settings, and local subquery settings.
         # If the global query is a select query with settings, merge the two.

--- a/posthog/hogql/transforms/test/test_timestamp_order_by.py
+++ b/posthog/hogql/transforms/test/test_timestamp_order_by.py
@@ -1,0 +1,141 @@
+import re
+from datetime import datetime
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
+
+from parameterized import parameterized
+
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
+from posthog.hogql.query import execute_hogql_query
+
+
+def _normalize(sql: str) -> str:
+    # toTimeZone gets a parameterized timezone constant; collapse it for stable assertions.
+    return re.sub(r"%\(hogql_val_\d+\)s", "hogval", sql)
+
+
+class TestTimestampOrderByRewrite(ClickhouseTestMixin, BaseTest):
+    def _print(self, select: str, timezone: str = "UTC") -> str:
+        if self.team.timezone != timezone:
+            self.team.timezone = timezone
+            self.team.save()
+        context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
+        sql, _ = prepare_and_print_ast(parse_select(select), context, "clickhouse")
+        return _normalize(sql)
+
+    @parameterized.expand(["ASC", "DESC"])
+    def test_leading_timestamp_with_limit_is_rewritten(self, direction: str):
+        sql = self._print(f"SELECT uuid FROM events ORDER BY timestamp {direction} LIMIT 100")
+        assert f"ORDER BY toDate(events.timestamp) {direction}, events.timestamp {direction}" in sql
+        # The toDate argument must be the bare field — toDate(toTimeZone(...)) is the
+        # project-local date and would not match the UTC toDate(timestamp) sort key.
+        assert "toDate(toTimeZone(" not in sql
+        # The leading order term is no longer the (unprunable) toTimeZone form.
+        assert f"ORDER BY toTimeZone(events.timestamp, hogval) {direction}" not in sql
+        # Buffering off so the LIMIT early-terminates instead of over-reading.
+        assert "read_in_order_use_buffering=0" in sql
+
+    def test_rewrite_keeps_trailing_order_terms(self):
+        sql = self._print("SELECT uuid FROM events ORDER BY timestamp DESC, event ASC LIMIT 10")
+        assert "ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC, events.event ASC" in sql
+
+    def test_rewrite_applies_inside_subquery(self):
+        sql = self._print(
+            "SELECT e.uuid FROM (SELECT uuid, timestamp FROM events ORDER BY timestamp DESC LIMIT 100) AS e"
+        )
+        assert "ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC" in sql
+
+    def test_select_projection_keeps_project_timezone(self):
+        sql = self._print("SELECT timestamp FROM events ORDER BY timestamp DESC LIMIT 10", timezone="America/New_York")
+        # SELECT still converts the displayed value to the project timezone ...
+        assert "SELECT toTimeZone(events.timestamp, hogval)" in sql
+        # ... but ORDER BY leads with the bare, key-aligned toDate(timestamp).
+        assert "ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC" in sql
+
+    def test_rewrite_composes_with_where_range_pruning(self):
+        sql = self._print(
+            "SELECT distinct_id FROM events WHERE timestamp > '2024-02-11' ORDER BY timestamp ASC LIMIT 5",
+            timezone="US/Pacific",
+        )
+        # WHERE keeps the bare timestamp (so the partition/PK can prune the range) ...
+        assert "greater(events.timestamp" in sql
+        assert "greater(toTimeZone(events.timestamp" not in sql
+        # ... and ORDER BY leads with the key-aligned toDate(timestamp).
+        assert "ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC" in sql
+
+    def test_no_limit_not_rewritten(self):
+        sql = self._print("SELECT uuid FROM events ORDER BY timestamp DESC")
+        assert "toDate(events.timestamp)" not in sql
+        assert "ORDER BY toTimeZone(events.timestamp, hogval) DESC" in sql
+        # No rewrite means the buffering setting is not added either.
+        assert "read_in_order_use_buffering" not in sql
+
+    def test_group_by_not_rewritten(self):
+        sql = self._print("SELECT timestamp, count() FROM events GROUP BY timestamp ORDER BY timestamp DESC LIMIT 10")
+        assert "toDate(events.timestamp)" not in sql
+
+    def test_non_leading_timestamp_not_rewritten(self):
+        sql = self._print("SELECT uuid FROM events ORDER BY event ASC, timestamp DESC LIMIT 10")
+        assert "toDate(events.timestamp)" not in sql
+
+    def test_function_wrapped_timestamp_not_rewritten(self):
+        sql = self._print("SELECT uuid FROM events ORDER BY toStartOfHour(timestamp) DESC LIMIT 10")
+        assert "toDate(events.timestamp)" not in sql
+        assert "ORDER BY toStartOfHour(" in sql
+
+    def test_created_at_not_rewritten(self):
+        sql = self._print("SELECT uuid FROM events ORDER BY created_at DESC LIMIT 10")
+        assert "toDate(events.timestamp)" not in sql
+        assert "toDate(events.created_at)" not in sql
+
+    def test_subquery_alias_column_not_rewritten(self):
+        # Ordering by a subquery-projected column is not the events base-table timestamp,
+        # so the leading term must not be rewritten.
+        sql = self._print("SELECT t.ts FROM (SELECT timestamp AS ts FROM events) AS t ORDER BY ts DESC LIMIT 10")
+        assert "ORDER BY toDate(" not in sql
+
+
+class TestTimestampOrderByCorrectness(ClickhouseTestMixin, BaseTest):
+    # February 2024 keeps US/Pacific at a fixed UTC-8 (no DST transition), so the
+    # UTC-vs-local date split around midnight is unambiguous. Stored as UTC instants.
+    INSTANTS = [
+        ("u0", datetime(2024, 2, 10, 23, 0)),  # UTC 02-10, Pacific 02-10 15:00
+        ("u1", datetime(2024, 2, 11, 2, 0)),  # UTC 02-11, Pacific 02-10 18:00 (same Pacific day as u0)
+        ("u2", datetime(2024, 2, 11, 9, 0)),  # UTC 02-11, Pacific 02-11 01:00
+        ("u3", datetime(2024, 2, 12, 20, 0)),
+        ("u4", datetime(2024, 2, 12, 21, 30)),  # same UTC day as u3 (within-day tiebreaker)
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.team.timezone = "US/Pacific"
+        self.team.save()
+        for distinct_id, ts in self.INSTANTS:
+            _create_event(team=self.team, distinct_id=distinct_id, event="$pageview", timestamp=ts)
+        flush_persons_and_events()
+
+    def _order(self, direction: str, limit: int) -> tuple[list[str], str]:
+        response = execute_hogql_query(
+            f"SELECT distinct_id FROM events ORDER BY timestamp {direction} LIMIT {limit}", team=self.team
+        )
+        assert response.results is not None
+        # response.clickhouse is pretty-printed (newlines/indentation); collapse whitespace.
+        return [row[0] for row in response.results], re.sub(r"\s+", " ", response.clickhouse or "")
+
+    def test_ascending_matches_instant_order(self):
+        got, sql = self._order("ASC", 3)
+        assert "ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC" in sql
+        assert got == ["u0", "u1", "u2"]
+
+    def test_descending_matches_instant_order(self):
+        got, sql = self._order("DESC", 3)
+        assert "ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC" in sql
+        assert got == ["u4", "u3", "u2"]
+
+    def test_ascending_is_reverse_of_descending(self):
+        asc, _ = self._order("ASC", 5)
+        desc, _ = self._order("DESC", 5)
+        assert asc == list(reversed(desc))
+        assert asc == ["u0", "u1", "u2", "u3", "u4"]

--- a/posthog/hogql/transforms/timestamp_order_by.py
+++ b/posthog/hogql/transforms/timestamp_order_by.py
@@ -1,0 +1,152 @@
+"""Rewrite ``ORDER BY timestamp`` on the events table to lead with the sort-key prefix.
+
+The events table is sorted by
+``(team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))`` and
+partitioned by ``toYYYYMM(timestamp)``.
+
+HogQL emits ``ORDER BY toTimeZone(timestamp, <project_tz>)`` for timestamp ordering (see
+``PropertySwapper.visit_field``). That expression is not a prefix of the sort key — the key
+stores ``toDate(timestamp)`` at day granularity in UTC — so ClickHouse's
+``optimize_read_in_order`` cannot apply and a ``LIMIT`` cannot early-terminate: the engine
+reads every matching row and sorts it.
+
+Because every events query is printed with a ``team_id = X`` equality guard (see
+``team_id_guard_for_table``), the first sort-key column is always fixed. That makes
+``toDate(timestamp)`` the effective leading order, so we rewrite
+
+    ORDER BY toTimeZone(timestamp, tz) D   [LIMIT n]
+
+into
+
+    ORDER BY toDate(timestamp) D, timestamp D   [LIMIT n]
+
+``toTimeZone`` only changes display, not the underlying instant, and is order preserving;
+``toDate`` (UTC) is monotonic non-decreasing in the instant. Therefore, for any direction D::
+
+    ORDER BY toDate(timestamp) D, timestamp D
+        ≡ ORDER BY timestamp D
+        ≡ ORDER BY toTimeZone(timestamp, tz) D
+
+The leading ``toDate(timestamp)`` term now matches the sort-key prefix, so ClickHouse reads
+granules in primary-key order and a ``LIMIT`` can stop early instead of scanning the full
+range. The ``timestamp`` tiebreaker preserves exact within-day ordering. This is the ORDER BY
+analogue of the WHERE-clause rewrite in
+``PropertySwapper._move_timezone_from_field_to_constant``.
+
+The rewrite also sets ``read_in_order_use_buffering = 0`` on the query. ClickHouse's default
+read-ahead buffering for read-in-order keeps reading granules past the point a ``LIMIT`` is
+satisfied, so without disabling it the rewritten query over-reads by an order of magnitude and
+its peak memory balloons (read-in-order's merge buffer). Disabling buffering is what turns
+read-in-order into actual early termination — on a multi-billion-row team this took a
+``ORDER BY timestamp DESC LIMIT 100`` scan from ~1.5B rows / 46 GiB down to ~36M rows / 1 GiB
+at the same peak memory as the original.
+
+The rewrite runs after the property swapper (so the timestamp is already wrapped in
+``toTimeZone``) and is intentionally narrow — it only fires when:
+
+- the term resolves to the events table's ``timestamp`` column (not ``created_at``, not other
+  tables whose sort keys differ),
+- ``timestamp`` is the *leading* ORDER BY term (read-in-order only helps the first term),
+- there is a ``LIMIT`` (the payoff is early termination; without one the extra term is noise),
+- there is no ``GROUP BY`` (the target is the raw-event scan, not an aggregation), and
+- the term has no ``WITH FILL`` (gap filling has its own ordering semantics).
+
+Only the ORDER BY is touched; the SELECT projection keeps the project timezone, so displayed
+timestamp values are unchanged.
+"""
+
+from posthog.hogql import ast
+from posthog.hogql.constants import HogQLQuerySettings
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.models import DateTimeDatabaseField
+from posthog.hogql.database.schema.events import EventsTable
+from posthog.hogql.visitor import TraversingVisitor, clone_expr
+
+
+def optimize_timestamp_order_by(node: ast.Expr, context: HogQLContext) -> None:
+    """Mutate ``node`` in place, expanding qualifying events ``ORDER BY timestamp`` terms."""
+    TimestampOrderByRewriter(context).visit(node)
+
+
+def _unwrap_alias(expr: ast.Expr) -> ast.Expr:
+    while isinstance(expr, ast.Alias):
+        expr = expr.expr
+    return expr
+
+
+class TimestampOrderByRewriter(TraversingVisitor):
+    def __init__(self, context: HogQLContext) -> None:
+        super().__init__()
+        self.context = context
+
+    def visit_select_query(self, node: ast.SelectQuery) -> None:
+        # Recurse into subqueries, CTEs and joins first, then rewrite this query's ORDER BY.
+        super().visit_select_query(node)
+        self._rewrite_leading_timestamp_order(node)
+
+    def _rewrite_leading_timestamp_order(self, node: ast.SelectQuery) -> None:
+        # read-in-order only pays off when a LIMIT can early-terminate, and only on a raw
+        # event scan — aggregations don't read in primary-key order.
+        if not node.order_by or node.limit is None or node.group_by:
+            return
+
+        leading = node.order_by[0]
+        if leading.with_fill is not None:
+            return
+
+        bare_timestamp = self._events_timestamp_field(leading.expr)
+        if bare_timestamp is None:
+            return
+
+        # ORDER BY toDate(timestamp) D, timestamp D, <rest...> is order-equivalent to the
+        # original leading `timestamp D, <rest...>`, but the leading toDate(timestamp) now
+        # matches the events sort-key prefix (team_id is fixed by the printed team_id guard).
+        # Both inner fields must be the bare timestamp: toDate(toTimeZone(timestamp, tz)) is
+        # the project-local date and would NOT match the UTC toDate(timestamp) in the key.
+        node.order_by = [
+            ast.OrderExpr(expr=ast.Call(name="toDate", args=[clone_expr(bare_timestamp)]), order=leading.order),
+            ast.OrderExpr(expr=clone_expr(bare_timestamp), order=leading.order),
+            *node.order_by[1:],
+        ]
+
+        # Engaging read-in-order is only half the win: ClickHouse's default read-ahead buffering
+        # (read_in_order_use_buffering=1) keeps reading granules past the LIMIT, so the scan
+        # over-reads by an order of magnitude and peak memory balloons. Disabling it lets the
+        # LIMIT actually early-terminate. Preserve any explicit value the query already carries.
+        if node.settings is None:
+            node.settings = HogQLQuerySettings()
+        if node.settings.read_in_order_use_buffering is None:
+            node.settings.read_in_order_use_buffering = False
+
+    def _events_timestamp_field(self, expr: ast.Expr) -> ast.Field | None:
+        """Return the bare events ``timestamp`` Field if ``expr`` orders by it (bare, or
+        wrapped in a single ``toTimeZone``), otherwise None."""
+        inner = _unwrap_alias(expr)
+
+        # The property swapper wraps the bare timestamp field in toTimeZone(field, project_tz).
+        # Peel exactly one layer to recover the bare field whose toDate matches the sort key.
+        if isinstance(inner, ast.Call) and inner.name == "toTimeZone" and len(inner.args) >= 1:
+            inner = _unwrap_alias(inner.args[0])
+
+        if not isinstance(inner, ast.Field):
+            return None
+
+        field_type = inner.type
+        if isinstance(field_type, ast.FieldAliasType):
+            field_type = field_type.type
+        if not isinstance(field_type, ast.FieldType):
+            return None
+
+        database_field = field_type.resolve_database_field(self.context)
+        if not isinstance(database_field, DateTimeDatabaseField) or database_field.name != "timestamp":
+            return None
+
+        # Must be the events table specifically — its sort key leads with toDate(timestamp).
+        # Other tables with a "timestamp" column (sessions, warehouse, …) have different keys.
+        table_type = field_type.table_type
+        if not isinstance(table_type, ast.BaseTableType):
+            return None
+        if not isinstance(table_type.resolve_database_table(self.context), EventsTable):
+            return None
+
+        return inner

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_event_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_event_taxonomy_query_runner.ambr
@@ -9,8 +9,8 @@
     (SELECT JSONExtractKeysAndValues(events.properties, 'String') AS kv
      FROM events
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), equals(events.event, 'event1'))
-     ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
-     LIMIT 100) ARRAY
+     ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC
+     LIMIT 100 SETTINGS read_in_order_use_buffering=0) ARRAY
   JOIN (kv).1 AS key,
        (kv).2 AS value
   WHERE not(match(key, '(\\$set|\\$time|\\$set_once|\\$sent_at|distinct_id|\\$ip|\\$feature\\/|\\$feature_enrollment\\/|\\$feature_interaction\\/|\\$product_tour|__|survey_dismiss|survey_responded|phjs|partial_filter_chosen|changed_action|window-id|changed_event|partial_filter)'))
@@ -75,8 +75,8 @@
     (SELECT JSONExtractKeysAndValues(events.properties, 'String') AS kv
      FROM events
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), equals(events.event, '$pageview'))
-     ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
-     LIMIT 100) ARRAY
+     ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC
+     LIMIT 100 SETTINGS read_in_order_use_buffering=0) ARRAY
   JOIN (kv).1 AS key,
        (kv).2 AS value
   WHERE not(match(key, '(\\$set|\\$time|\\$set_once|\\$sent_at|distinct_id|\\$ip|\\$feature\\/|\\$feature_enrollment\\/|\\$feature_interaction\\/|\\$product_tour|__|survey_dismiss|survey_responded|phjs|partial_filter_chosen|changed_action|window-id|changed_event|partial_filter)'))

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends_data_warehouse_query.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends_data_warehouse_query.ambr
@@ -362,8 +362,9 @@
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
   WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 1 SETTINGS readonly=2,
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+  LIMIT 1 SETTINGS read_in_order_use_buffering=0,
+                   readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
                    max_ast_elements=4000000,
@@ -439,8 +440,9 @@
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
   WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 1 SETTINGS readonly=2,
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+  LIMIT 1 SETTINGS read_in_order_use_buffering=0,
+                   readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
                    max_ast_elements=4000000,

--- a/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
@@ -7,11 +7,12 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2020-01-12 23:59:59.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-12 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 101)), and(equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2020-01-12 23:59:59.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-12 00:00:00.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                 ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+                                                 LIMIT 101 SETTINGS read_in_order_use_buffering=0)), and(equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2020-01-12 23:59:59.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-12 00:00:00.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
   LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -218,11 +219,12 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                 ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+                                                 LIMIT 3 SETTINGS read_in_order_use_buffering=0)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
   LIMIT 3
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -243,11 +245,12 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                 ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+                                                 LIMIT 3 SETTINGS read_in_order_use_buffering=0)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
   LIMIT 3
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -268,11 +271,12 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                 ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+                                                 LIMIT 3 SETTINGS read_in_order_use_buffering=0)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
   LIMIT 3
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -443,11 +447,12 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
+                                                 ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC
+                                                 LIMIT 3 SETTINGS read_in_order_use_buffering=0)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC
   LIMIT 3
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -468,11 +473,12 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
+                                                 ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC
+                                                 LIMIT 3 SETTINGS read_in_order_use_buffering=0)), and(less(events.timestamp, toDateTime64('2020-01-11 12:00:04.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC
   LIMIT 3
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -493,11 +499,12 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
+                                                 ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC
+                                                 LIMIT 3 SETTINGS read_in_order_use_buffering=0)), and(less(events.timestamp, toDateTime64('2020-01-11 12:00:02.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC
   LIMIT 3
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -667,11 +674,12 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
-                                                 LIMIT 3)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') DESC
+                                                 ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC
+                                                 LIMIT 3 SETTINGS read_in_order_use_buffering=0)), and(less(events.timestamp, toDateTime64('2020-01-12 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC
   LIMIT 3
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -739,11 +747,12 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), notILike(toString(events.elements_chain), '%div%'), equals(events.event, '$autocapture'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-20 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 101)), and(notILike(toString(events.elements_chain), '%div%'), equals(events.event, '$autocapture'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-20 00:00:00.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                 ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+                                                 LIMIT 101 SETTINGS read_in_order_use_buffering=0)), and(notILike(toString(events.elements_chain), '%div%'), equals(events.event, '$autocapture'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-20 00:00:00.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
   LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -763,11 +772,12 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'some_prop'), ''), 'null'), '^"|"$', ''), 'a'), 0), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-                                                 LIMIT 101)), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'some_prop'), ''), 'null'), '^"|"$', ''), 'a'), 0), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+                                                 ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
+                                                 LIMIT 101 SETTINGS read_in_order_use_buffering=0)), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'some_prop'), ''), 'null'), '^"|"$', ''), 'a'), 0), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) ASC, events.timestamp ASC
   LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,
@@ -787,11 +797,13 @@
                                                 (SELECT events.uuid AS uuid
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
-                                                 ORDER BY toTimeZone(events.timestamp, 'UTC') DESC, events.event ASC
-                                                 LIMIT 101)), and(equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))))
-  ORDER BY toTimeZone(events.timestamp, 'UTC') DESC, events.event ASC
+                                                 ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC, events.event ASC
+                                                 LIMIT 101 SETTINGS read_in_order_use_buffering=0)), and(equals(events.event, '$pageview'), less(events.timestamp, toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(events.timestamp, toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC'))))
+  ORDER BY toDate(events.timestamp) DESC, events.timestamp DESC,
+                                          events.event ASC
   LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
+  OFFSET 0 SETTINGS read_in_order_use_buffering=0,
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     max_ast_elements=4000000,


### PR DESCRIPTION
## Problem

"Show me the latest/earliest events" is one of the most common things people do in PostHog — the events explorer, the activity/event lists on a person or session, "interesting events", etc. These compile to `... FROM events ORDER BY timestamp DESC|ASC LIMIT n`.

The `sharded_events` table is sorted by `(team_id, toDate(timestamp), event, …)`, but HogQL emits `ORDER BY toTimeZone(timestamp, <project_tz>)` for timezone support. `toTimeZone(timestamp)` is **not** a prefix of the sort key (the key stores `toDate(timestamp)` at day granularity, in UTC), so ClickHouse's `optimize_read_in_order` can't apply: the `LIMIT` can't early-terminate and the engine reads **every** matching row and sorts it.

In the last 24h on the production analytics cluster, ~118 queries/day across 14 teams matched this exact shape; **~51 of them took >5s** (p90 ≈ 18s, p99 ≈ 38s, max ≈ 105s), reading ~470 GiB/day. These are queries people actively wait on.

## Changes

A small HogQL transform (`posthog/hogql/transforms/timestamp_order_by.py`) that runs after the property swapper and rewrites a **leading** events timestamp order term:

```
ORDER BY toTimeZone(timestamp, tz) D   [LIMIT n]
        →  ORDER BY toDate(timestamp) D, timestamp D   [LIMIT n]
```

with **bare** inner fields (no `toTimeZone` inside `toDate`, so it matches the UTC `toDate(timestamp)` in the sort key). `toTimeZone` only changes display, not the underlying instant, and `toDate` is monotonic, so `ORDER BY toDate(t) D, t D ≡ ORDER BY t D` — the result rows and displayed timestamps are unchanged; only the read plan changes. This is the ORDER BY analogue of the existing WHERE-clause rewrite in `PropertySwapper._move_timezone_from_field_to_constant`.

It also sets `read_in_order_use_buffering = 0` on the rewritten query. This turned out to be essential: ClickHouse's default read-ahead buffering for read-in-order keeps reading granules past the point the `LIMIT` is satisfied, so without it the rewritten query both over-reads by ~17× **and** inflates peak memory ~30× (the merge buffer). Disabling buffering is what converts read-in-order into actual early termination.

The rewrite is intentionally narrow — it only fires for: the events table's `timestamp` column (not `created_at`, not other tables), as the **leading** ORDER BY term, with an explicit `LIMIT`, no `GROUP BY`, and no `WITH FILL`.

**Measured on the production analytics cluster** (read-only `system.query_log` analysis plus a handful of tagged benchmark queries), on a multi-billion-row team, `ORDER BY timestamp DESC LIMIT 100` selecting a narrow column over a 14-day window:

| | before (`toTimeZone`) | after (this PR) |
|---|---|---|
| rows read | 1.53 B | **36 M** |
| bytes read | 46.5 GiB | **1.06 GiB** |
| peak memory | 55 MiB | **53 MiB** |

i.e. ~43× fewer rows / ~44× less I/O at the same peak memory. Read-in-order engagement was confirmed both via `EXPLAIN` (`ReadType: InOrder`) and the execution algorithm in `query_log` (`ReadPoolInOrder / InReverseOrder`).

**Scope note for reviewers:** the win is largest for the narrow "resolve the ordered set" step (and for the events query runner's inner `uuid` subquery, which already exists). For queries that select wide columns (`properties`) directly, read-in-order still reads those columns across the over-read floor, so the column-read cost dominates — that's addressed by a separate "resolve then point-fetch" follow-up (under investigation in a sibling branch), which composes on top of this change. This PR is deliberately the focused, order-equivalent first step. No feature-flag/modifier gate was added (the rewrite is provably order-preserving and tightly shape-gated); a per-team modifier kill-switch would be a trivial follow-up if desired for rollout.

`.ambr` snapshots for affected suites (events query runner, etc.) are intentionally **not** included here — only the ORDER BY clause and a `SETTINGS read_in_order_use_buffering=0` change, regenerated by CI.

## How did you test this code?

I'm an agent; I did not do manual UI testing. Automated tests I actually ran (green locally against the dev ClickHouse/Postgres):

- New `posthog/hogql/transforms/test/test_timestamp_order_by.py` (15 tests): SQL-shape across every gate (fires / doesn't fire for no-LIMIT, GROUP BY, non-leading timestamp, `toStartOfHour`, `created_at`, non-events tables, subquery alias), assertion that the `toDate` argument is the bare field (never `toDate(toTimeZone(...))`), subquery recursion, WHERE-range-pruning composition, the `read_in_order_use_buffering=0` setting, and **execution parity**: events seeded across a UTC-midnight boundary in a US/Pacific project, asserting `ORDER BY timestamp ASC/DESC LIMIT k` matches the exact instant order.
- `posthog/hogql_queries/test/test_events_query_runner.py` cursor-pagination / ordering tests pass (results unchanged; only the SQL text + the new setting differ).
- `posthog/hogql/printer/test/test_printer.py` passes unchanged (confirms the print-time default `LIMIT 50000` correctly does **not** trigger the rewrite — only explicit AST limits do).
- Production validation via the internal `system.query_log` (read-only) plus a few tagged benchmark queries, numbers above.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) with tools: Read/Edit/Bash/Grep, the `query-clickhouse-via-metabase` skill (read-only `system.query_log` analysis + a few tagged benchmark queries on the production analytics cluster), and the test runner.

Key decisions:
- **Where to run it:** implemented as a dedicated transform run once after the property-swapper pass, rather than inside `PropertySwapper`, because the swapper runs multiple times (groups pass, main pass) and would double-apply; running after the swapper also lets it recognize/peel the already-applied `toTimeZone` wrap to recover the bare field.
- **Bare inner field:** the `toDate` argument must be the bare `timestamp` (not `toDate(toTimeZone(...))`, which is the project-local date and does not match the UTC `toDate(timestamp)` sort key). Tests assert this.
- **`read_in_order_use_buffering=0`:** discovered empirically. Without it the ORDER BY rewrite alone over-reads ~17× and uses ~30× more memory (a regression), so the setting is part of the change, not an afterthought. Added as a field on the hand-maintained `HogQLQuerySettings` (not the generated schema).
- **Rejected:** a feature-flag modifier gate (unnecessary for a provably order-equivalent, tightly shape-gated rewrite — though easy to add for rollout); expanding to print-time-default-`LIMIT 50000` queries (none exist in the target shape in practice).
- A sibling investigation (separate branch) is looking at the "resolve narrow then point-fetch wide columns" complement for wide-column selects, which composes on top of this.

Agent-authored; requires human review. Do not self-merge.
