### PR TITLE
perf(insights): bound the earliest-event timestamp probe

### DIFF
--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_external_clicks_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_external_clicks_table.ambr
@@ -2,15 +2,64 @@
 # name: TestExternalClicksTableQueryRunner.test_all_time
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestExternalClicksTableQueryRunner.test_all_time.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_all_time.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-09-21 09:09:17'
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_all_time.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2021-01-21 09:09:17'
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_all_time.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-21 09:09:17'
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_all_time.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2025-01-21 09:09:17'
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_all_time.6
   '''
   SELECT url AS `context.columns.url`,
          tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))), uniqIf(filtered_person_id, 0)) AS `context.columns.visitors`,

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_overview.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_overview.ambr
@@ -2,15 +2,64 @@
 # name: TestWebOverviewQueryRunner.test_all_time
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebOverviewQueryRunner.test_all_time.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebOverviewQueryRunner.test_all_time.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebOverviewQueryRunner.test_all_time.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebOverviewQueryRunner.test_all_time.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebOverviewQueryRunner.test_all_time.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebOverviewQueryRunner.test_all_time.6
   '''
   SELECT uniq(session_person_id) AS unique_users,
          NULL AS previous_unique_users,

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -2,15 +2,64 @@
 # name: TestWebStatsTableQueryRunner.test_all_time
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_all_time.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_all_time.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_all_time.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_all_time.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_all_time.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_all_time.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -151,15 +200,64 @@
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.6
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -227,115 +325,6 @@
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
         WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
-  WHERE isNotNull(counts.breakdown_value)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.2
-  '''
-  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
-         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
-         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
-         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT breakdown_value AS breakdown_value,
-            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
-            uniqIf(filtered_person_id, 0) AS previous_visitors,
-            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
-            sumIf(filtered_pageview_count, 0) AS previous_views
-     FROM
-       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-               count() AS filtered_pageview_count,
-               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.person_id,
-                  events.properties,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-        LEFT JOIN
-          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS counts
-  LEFT JOIN
-    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
-                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
-            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
-                            0) AS previous_avg_time_on_page
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.properties,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
-  LEFT JOIN
-    (SELECT breakdown_value AS breakdown_value,
-            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
-            avgIf(is_bounce, 0) AS previous_bounce_rate
-     FROM
-       (SELECT events__session.`$entry_pathname` AS breakdown_value,
-               any(events__session.`$is_bounce`) AS is_bounce,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-        LEFT JOIN
-          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
@@ -359,15 +348,64 @@
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.6
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -424,96 +462,6 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
-        LEFT JOIN
-          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
-  WHERE isNotNull(counts.breakdown_value)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.2
-  '''
-  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
-         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
-         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
-         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT breakdown_value AS breakdown_value,
-            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
-            uniqIf(filtered_person_id, 0) AS previous_visitors,
-            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
-            sumIf(filtered_pageview_count, 0) AS previous_views
-     FROM
-       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-               count() AS filtered_pageview_count,
-               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.person_id,
-                  events.properties,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-        LEFT JOIN
-          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS counts
-  LEFT JOIN
-    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
-                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
-            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
-                            0) AS previous_avg_time_on_page
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.properties,
-               events.timestamp
         FROM events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
@@ -548,15 +496,64 @@
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.6
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -644,227 +641,67 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.2
-  '''
-  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
-         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
-         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
-         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT breakdown_value AS breakdown_value,
-            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
-            uniqIf(filtered_person_id, 0) AS previous_visitors,
-            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
-            sumIf(filtered_pageview_count, 0) AS previous_views
-     FROM
-       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-               count() AS filtered_pageview_count,
-               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.person_id,
-                  events.properties,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-        LEFT JOIN
-          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS counts
-  LEFT JOIN
-    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
-                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
-            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
-                            0) AS previous_avg_time_on_page
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.properties,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
-  LEFT JOIN
-    (SELECT breakdown_value AS breakdown_value,
-            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
-            avgIf(is_bounce, 0) AS previous_bounce_rate
-     FROM
-       (SELECT events__session.`$entry_pathname` AS breakdown_value,
-               any(events__session.`$is_bounce`) AS is_bounce,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-        LEFT JOIN
-          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
-  WHERE isNotNull(counts.breakdown_value)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate.1
   '''
-  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
-         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
-         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT breakdown_value AS breakdown_value,
-            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
-            uniqIf(filtered_person_id, 0) AS previous_visitors,
-            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
-            sumIf(filtered_pageview_count, 0) AS previous_views
-     FROM
-       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-               count() AS filtered_pageview_count,
-               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
-        LEFT JOIN
-          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS counts
-  LEFT JOIN
-    (SELECT breakdown_value AS breakdown_value,
-            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
-            avgIf(is_bounce, 0) AS previous_bounce_rate
-     FROM
-       (SELECT events__session.`$entry_pathname` AS breakdown_value,
-               any(events__session.`$is_bounce`) AS is_bounce,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
-        LEFT JOIN
-          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
-  WHERE isNotNull(counts.breakdown_value)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate.2
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2019-09-29 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user
+# name: TestWebStatsTableQueryRunner.test_bounce_rate.3
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2022-05-29 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.1
+# name: TestWebStatsTableQueryRunner.test_bounce_rate.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate.6
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -942,7 +779,67 @@
                     use_hive_partitioning=0
   '''
 # ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-02-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.6
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -961,15 +858,7 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.person_id,
-                  events.properties,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        FROM events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -984,7 +873,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -997,13 +886,7 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        FROM events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -1013,7 +896,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
@@ -1037,94 +920,65 @@
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_path_cleaning
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_path_cleaning.1
   '''
-  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
-         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
-         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT breakdown_value AS breakdown_value,
-            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
-            uniqIf(filtered_person_id, 0) AS previous_visitors,
-            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
-            sumIf(filtered_pageview_count, 0) AS previous_views
-     FROM
-       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-               count() AS filtered_pageview_count,
-               replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
-        LEFT JOIN
-          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS counts
-  LEFT JOIN
-    (SELECT breakdown_value AS breakdown_value,
-            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
-            avgIf(is_bounce, 0) AS previous_bounce_rate
-     FROM
-       (SELECT replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(events__session.`$entry_pathname`, '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
-               any(events__session.`$is_bounce`) AS is_bounce,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
-        LEFT JOIN
-          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
-  WHERE isNotNull(counts.breakdown_value)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_path_cleaning.2
   '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_path_cleaning.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_path_cleaning.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_path_cleaning.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_path_cleaning.6
+  '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
          tuple(counts.views, counts.previous_views) AS `context.columns.views`,
@@ -1142,15 +996,7 @@
                replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.person_id,
-                  events.properties,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        FROM events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -1165,7 +1011,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -1178,13 +1024,7 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        FROM events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -1194,7 +1034,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
@@ -1218,15 +1058,64 @@
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_with_multiple_pathname_filters
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_with_multiple_pathname_filters.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_multiple_pathname_filters.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_multiple_pathname_filters.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_multiple_pathname_filters.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_multiple_pathname_filters.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_multiple_pathname_filters.6
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -1307,15 +1196,64 @@
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_with_property
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_with_property.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_property.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_property.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_property.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_property.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_property.6
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -1457,15 +1395,74 @@
 # name: TestWebStatsTableQueryRunner.test_cohort_test_filters.1
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_cohort_test_filters.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_cohort_test_filters.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_cohort_test_filters.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_cohort_test_filters.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_cohort_test_filters.6
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_cohort_test_filters.7
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_cohort_test_filters.8
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2018,15 +2015,64 @@
 # name: TestWebStatsTableQueryRunner.test_entry_bounce_rate
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_entry_bounce_rate.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2078,77 +2124,67 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate.2
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         tuple(avg(is_bounce), NULL) AS `context.columns.bounce_rate`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events__session.`$entry_pathname` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-     LEFT JOIN
-       (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_one_user
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_one_user.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_one_user.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_one_user.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_one_user.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_one_user.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_one_user.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2203,15 +2239,64 @@
 # name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_path_cleaning
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_path_cleaning.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_path_cleaning.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_path_cleaning.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_path_cleaning.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_path_cleaning.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_path_cleaning.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2266,15 +2351,64 @@
 # name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_with_property
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_with_property.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_with_property.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_with_property.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_with_property.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_with_property.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_with_property.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2389,15 +2523,64 @@
 # name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_0_Page
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_0_Page.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_0_Page.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_0_Page.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_0_Page.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_0_Page.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_0_Page.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2450,15 +2633,64 @@
 # name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_1_InitialPage
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_1_InitialPage.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_1_InitialPage.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_1_InitialPage.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_1_InitialPage.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_1_InitialPage.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_1_InitialPage.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2513,15 +2745,64 @@
 # name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_2_ExitPage
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_2_ExitPage.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_2_ExitPage.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_2_ExitPage.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_2_ExitPage.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_2_ExitPage.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_concatenates_host_and_path_2_ExitPage.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2576,15 +2857,64 @@
 # name: TestWebStatsTableQueryRunner.test_include_host_exit_page_breakdown_counts_correctly
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_include_host_exit_page_breakdown_counts_correctly.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_exit_page_breakdown_counts_correctly.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_exit_page_breakdown_counts_correctly.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_exit_page_breakdown_counts_correctly.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_exit_page_breakdown_counts_correctly.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_exit_page_breakdown_counts_correctly.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2639,15 +2969,64 @@
 # name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_0_Page
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_0_Page.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_0_Page.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_0_Page.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_0_Page.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_0_Page.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_0_Page.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2656,7 +3035,7 @@
   FROM
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
             count() AS filtered_pageview_count,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            nullIf(concat(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '')), '')), '') AS breakdown_value,
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
@@ -2700,15 +3079,64 @@
 # name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_1_InitialPage
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_1_InitialPage.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_1_InitialPage.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_1_InitialPage.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_1_InitialPage.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_1_InitialPage.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_1_InitialPage.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2762,15 +3190,64 @@
 # name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_2_ExitPage
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_2_ExitPage.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_2_ExitPage.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_2_ExitPage.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_2_ExitPage.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_2_ExitPage.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_false_returns_path_only_2_ExitPage.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2824,15 +3301,64 @@
 # name: TestWebStatsTableQueryRunner.test_include_host_initial_page_breakdown_with_bounce_rate
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_include_host_initial_page_breakdown_with_bounce_rate.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_initial_page_breakdown_with_bounce_rate.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_initial_page_breakdown_with_bounce_rate.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_initial_page_breakdown_with_bounce_rate.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_initial_page_breakdown_with_bounce_rate.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_initial_page_breakdown_with_bounce_rate.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -2888,76 +3414,54 @@
 # name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.1
   '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            nullIf(concat(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '')), '')), '') AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.2
-  '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-04-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.3
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.10
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.11
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.12
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.13
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3005,6 +3509,126 @@
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.6
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  HAVING isNotNull(`context.columns.breakdown_value`)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.7
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-02-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.8
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_include_host_page_breakdown_groups_same_paths_on_different_hosts_separately.9
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_increase_in_users
@@ -3110,15 +3734,74 @@
 # name: TestWebStatsTableQueryRunner.test_is_not_set_filter
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_is_not_set_filter.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_is_not_set_filter.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_is_not_set_filter.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_is_not_set_filter.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_is_not_set_filter.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_is_not_set_filter.6
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_is_not_set_filter.7
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3171,15 +3854,74 @@
 # name: TestWebStatsTableQueryRunner.test_language_filter
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_language_filter.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_language_filter.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_language_filter.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_language_filter.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_language_filter.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_language_filter.6
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_language_filter.7
   '''
   SELECT arrayElement(splitByChar('-', assumeNotNull(breakdown_value), 2), 1) AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3243,76 +3985,54 @@
 # name: TestWebStatsTableQueryRunner.test_limit
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_limit.1
   '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 2
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_limit.2
-  '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-04-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_limit.3
+# name: TestWebStatsTableQueryRunner.test_limit.10
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.11
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.12
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.13
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3362,7 +4082,47 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_no_crash_when_no_data
+# name: TestWebStatsTableQueryRunner.test_limit.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3382,7 +4142,7 @@
                min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
                raw_sessions.session_id_v7 AS session_id_v7
         FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-08 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
         GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
      LEFT OUTER JOIN
        (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
@@ -3391,7 +4151,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-08 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
@@ -3399,7 +4159,7 @@
   ORDER BY `context.columns.visitors` DESC,
            `context.columns.views` DESC,
            `context.columns.breakdown_value` ASC
-  LIMIT 101
+  LIMIT 2
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
@@ -3412,18 +4172,37 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_no_session_id
+# name: TestWebStatsTableQueryRunner.test_limit.7
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_no_session_id.1
+# name: TestWebStatsTableQueryRunner.test_limit.8
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.9
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_crash_when_no_data
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3444,7 +4223,7 @@
                min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
                raw_sessions.session_id_v7 AS session_id_v7
         FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-07-31 23:59:59', 'UTC')), toIntervalDay(3))))
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-08 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
         GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
      LEFT OUTER JOIN
        (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
@@ -3453,7 +4232,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-31 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-08 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
@@ -3474,18 +4253,77 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_no_session_id.2
+# name: TestWebStatsTableQueryRunner.test_no_session_id
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_no_session_id.3
+# name: TestWebStatsTableQueryRunner.test_no_session_id.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.10
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.11
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.12
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.13
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.14
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.15
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3536,18 +4374,87 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_no_session_id.4
+# name: TestWebStatsTableQueryRunner.test_no_session_id.16
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_no_session_id.5
+# name: TestWebStatsTableQueryRunner.test_no_session_id.17
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.18
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.19
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.20
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.21
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.22
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.23
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3597,18 +4504,187 @@
                     use_hive_partitioning=0
   '''
 # ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.6
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.7
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-07-31 23:59:59', 'UTC')), toIntervalDay(3))))
+        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-31 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  HAVING isNotNull(`context.columns.breakdown_value`)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.8
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-02-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.9
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
 # name: TestWebStatsTableQueryRunner.test_null_in_utm_tags
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_null_in_utm_tags.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_in_utm_tags.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_in_utm_tags.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_in_utm_tags.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_in_utm_tags.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_in_utm_tags.6
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_in_utm_tags.7
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3661,15 +4737,64 @@
 # name: TestWebStatsTableQueryRunner.test_null_prev_pageview_duration_excluded_from_p90
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_null_prev_pageview_duration_excluded_from_p90.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_prev_pageview_duration_excluded_from_p90.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_prev_pageview_duration_excluded_from_p90.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_prev_pageview_duration_excluded_from_p90.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_prev_pageview_duration_excluded_from_p90.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_prev_pageview_duration_excluded_from_p90.6
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -3760,15 +4885,64 @@
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_filters
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_filters.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3821,15 +4995,64 @@
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_applied_in_order
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_applied_in_order.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_applied_in_order.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_applied_in_order.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_applied_in_order.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_applied_in_order.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_applied_in_order.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3882,15 +5105,64 @@
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleanable_path_property
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleanable_path_property.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleanable_path_property.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleanable_path_property.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleanable_path_property.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleanable_path_property.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleanable_path_property.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -3944,77 +5216,54 @@
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.1
   '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c') AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), ifNull(equals(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c'), replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll('/cleaned/:id', '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c')), isNull(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c'))
-                                                                                                                                                                                                                                                                                                                                                                        and isNull(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll('/cleaned/:id', '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c')))))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.2
-  '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-04-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.3
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.10
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.11
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.12
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.13
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -4065,18 +5314,188 @@
                     use_hive_partitioning=0
   '''
 # ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.6
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), ifNull(equals(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c'), replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll('/cleaned/:id', '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c')), isNull(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c'))
+                                                                                                                                                                                                                                                                                                                                                                        and isNull(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll('/cleaned/:id', '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c')))))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  HAVING isNotNull(`context.columns.breakdown_value`)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.7
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-02-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.8
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_cleaned_path_property.9
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_multiple_capture_groups
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_multiple_capture_groups.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_multiple_capture_groups.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_multiple_capture_groups.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_multiple_capture_groups.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_multiple_capture_groups.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_filters_with_multiple_capture_groups.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -4129,15 +5548,64 @@
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_with_order_field_and_baseline_urls
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_path_cleaning_with_order_field_and_baseline_urls.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_with_order_field_and_baseline_urls.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_with_order_field_and_baseline_urls.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_with_order_field_and_baseline_urls.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_with_order_field_and_baseline_urls.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_with_order_field_and_baseline_urls.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -4190,76 +5658,74 @@
 # name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.1
   '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events__session.`$entry_utm_source` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
-     LEFT JOIN
-       (SELECT nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
-               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-07-31 23:59:59', 'UTC')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-31 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.2
-  '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-04-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.3
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.10
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.11
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.12
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.13
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.14
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.15
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -4309,18 +5775,87 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.4
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.16
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.5
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.17
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.18
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.19
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.20
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.21
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.22
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.23
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -4398,18 +5933,286 @@
                     use_hive_partitioning=0
   '''
 # ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.6
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.7
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_utm_source` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-07-31 23:59:59', 'UTC')), toIntervalDay(3))))
+        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-31 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.8
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-02-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.9
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
 # name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.10
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.11
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.12
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.13
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         `context.columns.bounce_rate`.1 AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.bounce_rate` DESC,
+           `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.6
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -4488,94 +6291,34 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.2
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.7
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.3
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.8
   '''
-  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
-         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
-         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
-         `context.columns.bounce_rate`.1 AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT breakdown_value AS breakdown_value,
-            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
-            uniqIf(filtered_person_id, 0) AS previous_visitors,
-            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
-            sumIf(filtered_pageview_count, 0) AS previous_views
-     FROM
-       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-               count() AS filtered_pageview_count,
-               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
-        LEFT JOIN
-          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS counts
-  LEFT JOIN
-    (SELECT breakdown_value AS breakdown_value,
-            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
-            avgIf(is_bounce, 0) AS previous_bounce_rate
-     FROM
-       (SELECT events__session.`$entry_pathname` AS breakdown_value,
-               any(events__session.`$is_bounce`) AS is_bounce,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
-        LEFT JOIN
-          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
-  WHERE isNotNull(counts.breakdown_value)
-  ORDER BY `context.columns.bounce_rate` DESC,
-           `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_bounce_rate.9
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_sorting_by_conversion_rate
@@ -4815,76 +6558,54 @@
 # name: TestWebStatsTableQueryRunner.test_sorting_by_views
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_sorting_by_views.1
   '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.views`.1, sum(`context.columns.views`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-01 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  HAVING isNotNull(`context.columns.breakdown_value`)
-  ORDER BY `context.columns.views` ASC,
-           `context.columns.visitors` ASC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_sorting_by_views.2
-  '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-04-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_sorting_by_views.3
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.10
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.11
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.12
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.13
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -4934,23 +6655,52 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.2
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2019-09-29 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.1
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.6
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
          tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+         divide(`context.columns.views`.1, sum(`context.columns.views`.1) OVER ()) AS `context.columns.ui_fill_fraction`
   FROM
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
             count() AS filtered_pageview_count,
@@ -4979,8 +6729,8 @@
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
   HAVING isNotNull(`context.columns.breakdown_value`)
-  ORDER BY `context.columns.visitors` ASC,
-           `context.columns.views` ASC,
+  ORDER BY `context.columns.views` ASC,
+           `context.columns.visitors` ASC,
            `context.columns.breakdown_value` ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -4995,18 +6745,87 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.2
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.7
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.3
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.8
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_views.9
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-02-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.10
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.11
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.12
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.13
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -5056,18 +6875,197 @@
                     use_hive_partitioning=0
   '''
 # ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.6
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-01 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  HAVING isNotNull(`context.columns.breakdown_value`)
+  ORDER BY `context.columns.visitors` ASC,
+           `context.columns.views` ASC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.7
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-02-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.8
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_sorting_by_visitors.9
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
 # name: TestWebStatsTableQueryRunner.test_source_medium_campaign
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_source_medium_campaign.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_source_medium_campaign.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_source_medium_campaign.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_source_medium_campaign.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_source_medium_campaign.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_source_medium_campaign.6
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_source_medium_campaign.7
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -5124,15 +7122,64 @@
 # name: TestWebStatsTableQueryRunner.test_time_on_page_caps_at_24_hours
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_time_on_page_caps_at_24_hours.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_time_on_page_caps_at_24_hours.2
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_time_on_page_caps_at_24_hours.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_time_on_page_caps_at_24_hours.4
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_time_on_page_caps_at_24_hours.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_time_on_page_caps_at_24_hours.6
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -5273,15 +7320,74 @@
 # name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2015-02-01 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.1
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.10
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.11
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.12
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.13
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.14
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.15
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -5329,20 +7435,89 @@
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.16
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-02-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.17
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.18
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2019-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.19
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.2
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2019-09-29 00:00:00'
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.3
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.20
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2023-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.21
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.22
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.23
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -5390,20 +7565,49 @@
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.3
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2022-05-29 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.4
   '''
   
-  SELECT timestamp
-  from events
+  SELECT min(timestamp)
+  FROM events
   WHERE team_id = 99999
     AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+    AND timestamp < '2023-09-29 00:00:00'
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.5
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-05-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.6
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2024-09-29 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.7
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,
          tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
@@ -5451,5 +7655,25 @@
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.8
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-02-01 00:00:00'
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.9
+  '''
+  
+  SELECT min(timestamp)
+  FROM events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+    AND timestamp < '2015-04-01 00:00:00'
   '''
 # ---

--- a/posthog/queries/test/test_util.py
+++ b/posthog/queries/test/test_util.py
@@ -1,6 +1,21 @@
-from django.test import TestCase
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
-from posthog.queries.util import correct_result_for_sampling
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event
+
+from django.test import TestCase
+from django.utils import timezone
+
+from parameterized import parameterized
+
+from posthog.models.event import DEFAULT_EARLIEST_TIME_DELTA
+from posthog.queries.util import (
+    EARLIEST_TIMESTAMP_DATETIME,
+    _earliest_timestamp_upper_bounds,
+    correct_result_for_sampling,
+    get_earliest_timestamp,
+)
 
 
 class TestQueriesUtil(TestCase):
@@ -22,3 +37,76 @@ class TestQueriesUtil(TestCase):
 
         res = correct_result_for_sampling(1, 0.01, "sum")
         self.assertEqual(res, 100)
+
+
+class TestEarliestTimestampUpperBounds(TestCase):
+    @parameterized.expand(
+        [
+            ("recent_now", datetime(2024, 6, 15, tzinfo=ZoneInfo("UTC"))),
+            ("now_just_above_floor", datetime(2015, 6, 1, tzinfo=ZoneInfo("UTC"))),
+            ("now_at_floor", EARLIEST_TIMESTAMP_DATETIME),
+        ]
+    )
+    def test_bounds_are_strictly_ascending_and_above_floor(self, _name, now):
+        bounds = _earliest_timestamp_upper_bounds(now)
+
+        self.assertTrue(all(EARLIEST_TIMESTAMP_DATETIME < bound for bound in bounds))
+        self.assertEqual(bounds, sorted(bounds))
+        self.assertEqual(len(bounds), len(set(bounds)), "bounds must be de-duplicated")
+
+    def test_last_bound_covers_now(self):
+        now = datetime(2024, 6, 15, 10, 30, tzinfo=ZoneInfo("UTC"))
+        bounds = _earliest_timestamp_upper_bounds(now)
+
+        self.assertGreater(bounds[-1], now)
+
+    def test_includes_narrow_windows_at_the_floor(self):
+        now = datetime(2024, 6, 15, tzinfo=ZoneInfo("UTC"))
+        bounds = _earliest_timestamp_upper_bounds(now)
+
+        # The two short windows just above the floor catch corrupt/legacy events clustered there.
+        self.assertIn(EARLIEST_TIMESTAMP_DATETIME.replace(month=2), bounds)
+        self.assertIn(EARLIEST_TIMESTAMP_DATETIME.replace(month=4), bounds)
+
+
+class TestGetEarliestTimestamp(ClickhouseTestMixin, APIBaseTest):
+    def _earliest(self) -> datetime:
+        # use_cache=False so each scenario hits ClickHouse rather than the 2s memo
+        return get_earliest_timestamp(self.team.pk, use_cache=False)
+
+    @freeze_time("2024-06-15T12:00:00Z")
+    def test_returns_earliest_event_timestamp(self):
+        _create_event(team=self.team, event="$pageview", distinct_id="u1", timestamp="2023-03-04T09:10:11Z")
+        _create_event(team=self.team, event="$pageview", distinct_id="u1", timestamp="2024-01-01T00:00:00Z")
+
+        self.assertEqual(self._earliest(), datetime(2023, 3, 4, 9, 10, 11, tzinfo=ZoneInfo("UTC")))
+
+    @freeze_time("2024-06-15T12:00:00Z")
+    def test_returns_earliest_when_data_clustered_at_floor(self):
+        # Corrupt/legacy events that land right at the epoch floor are the common heavy case.
+        _create_event(team=self.team, event="$pageview", distinct_id="u1", timestamp="2015-01-01T00:01:04Z")
+        _create_event(team=self.team, event="$pageview", distinct_id="u1", timestamp="2024-05-01T00:00:00Z")
+
+        self.assertEqual(self._earliest(), datetime(2015, 1, 1, 0, 1, 4, tzinfo=ZoneInfo("UTC")))
+
+    @freeze_time("2024-06-15T12:00:00Z")
+    def test_returns_earliest_when_data_only_recent(self):
+        # Teams whose first event is recent must still resolve to the exact earliest event.
+        _create_event(team=self.team, event="$pageview", distinct_id="u1", timestamp="2024-05-20T08:00:00Z")
+        _create_event(team=self.team, event="$pageview", distinct_id="u1", timestamp="2024-06-01T08:00:00Z")
+
+        self.assertEqual(self._earliest(), datetime(2024, 5, 20, 8, 0, 0, tzinfo=ZoneInfo("UTC")))
+
+    @freeze_time("2024-06-15T12:00:00Z")
+    def test_ignores_events_before_the_floor(self):
+        # Pre-2015 timestamps (e.g. epoch-zero corruption) are excluded, matching the floor filter.
+        _create_event(team=self.team, event="$pageview", distinct_id="u1", timestamp="1970-01-01T00:00:00Z")
+        _create_event(team=self.team, event="$pageview", distinct_id="u1", timestamp="2020-07-08T09:10:11Z")
+
+        self.assertEqual(self._earliest(), datetime(2020, 7, 8, 9, 10, 11, tzinfo=ZoneInfo("UTC")))
+
+    @freeze_time("2024-06-15T12:00:00Z")
+    def test_returns_default_fallback_when_no_events(self):
+        earliest = self._earliest()
+
+        self.assertEqual(earliest, timezone.now() - DEFAULT_EARLIEST_TIME_DELTA)

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -6,6 +6,7 @@ from zoneinfo import ZoneInfo
 
 from django.utils import timezone
 
+from dateutil.relativedelta import relativedelta
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import PersonsOnEventsMode
@@ -55,8 +56,20 @@ def alias_poe_mode_for_legacy(persons_on_events_mode: PersonsOnEventsMode | None
 
 EARLIEST_TIMESTAMP = "2015-01-01"
 
-GET_EARLIEST_TIMESTAMP_SQL = """
-SELECT timestamp from events WHERE team_id = %(team_id)s AND timestamp > %(earliest_timestamp)s order by timestamp limit 1
+# Lower bound below which timestamps are treated as corrupt/invalid and ignored.
+EARLIEST_TIMESTAMP_DATETIME = datetime(2015, 1, 1, tzinfo=UTC)
+
+# Probe for the earliest event of a team with a *bounded* `min(timestamp)` rather than an
+# open-ended `ORDER BY timestamp LIMIT 1`. The events table sort key is
+# `(team_id, toDate(timestamp), ...)` and it carries a minmax skip index on `timestamp`, so a
+# query constrained to a narrow `[lower, upper)` window only reads the granules inside that window.
+# An unbounded `ORDER BY timestamp LIMIT 1` cannot short-circuit on a Distributed ReplacingMergeTree
+# and ends up scanning the whole team, so we instead walk an exponentially widening window from the
+# floor and stop at the first window that contains data — `min` over `[floor, upper)` is exactly the
+# global earliest once that window is non-empty.
+GET_EARLIEST_TIMESTAMP_BOUNDED_SQL = """
+SELECT min(timestamp) FROM events
+WHERE team_id = %(team_id)s AND timestamp > %(earliest_timestamp)s AND timestamp < %(upper_bound)s
 """
 
 TIME_IN_SECONDS: dict[str, Any] = {
@@ -93,19 +106,58 @@ def format_ch_timestamp(timestamp: datetime, convert_to_timezone: Optional[str] 
     return timestamp.strftime("%Y-%m-%d %H:%M:%S")
 
 
+def _earliest_timestamp_upper_bounds(now: datetime) -> list[datetime]:
+    """Ascending upper bounds for the widening-window earliest-event probe.
+
+    Each bound is a literal (constant-folded) datetime so ClickHouse can prune partitions and
+    skip-index granules — only the granules inside `[floor, upper)` get read. We want the windows
+    to be narrow wherever a team's first event is likely to fall:
+
+    - Two short windows just above the floor catch the very common case of legacy/corrupt events
+      clustered at the epoch floor, resolving those teams in a single cheap probe.
+    - Windows at `now - 2**k` months give progressively finer resolution toward the present, where
+      most teams' genuine first event lands. This keeps the first non-empty window tight even for
+      teams whose data only starts recently.
+
+    The final bound is strictly after `now`, so the last probe always covers every event a team
+    could have (and an empty result there means the team has no events).
+    """
+    final_bound = now + relativedelta(days=1)
+    candidates: set[datetime] = {
+        EARLIEST_TIMESTAMP_DATETIME + relativedelta(months=1),
+        EARLIEST_TIMESTAMP_DATETIME + relativedelta(months=3),
+        final_bound,
+    }
+    months = 1
+    while now - relativedelta(months=months) > EARLIEST_TIMESTAMP_DATETIME:
+        candidates.add(now - relativedelta(months=months))
+        months *= 2
+    return sorted(bound for bound in candidates if EARLIEST_TIMESTAMP_DATETIME < bound <= final_bound)
+
+
 @cache_for(timedelta(seconds=2))
 def get_earliest_timestamp(team_id: int) -> datetime:
-    results = insight_sync_execute(
-        GET_EARLIEST_TIMESTAMP_SQL,
-        {"team_id": team_id, "earliest_timestamp": EARLIEST_TIMESTAMP},
-        query_type="get_earliest_timestamp",
-        team_id=team_id,
-    )
+    for upper_bound in _earliest_timestamp_upper_bounds(timezone.now()):
+        results = insight_sync_execute(
+            GET_EARLIEST_TIMESTAMP_BOUNDED_SQL,
+            {
+                "team_id": team_id,
+                "earliest_timestamp": EARLIEST_TIMESTAMP,
+                "upper_bound": upper_bound.strftime("%Y-%m-%d %H:%M:%S"),
+            },
+            query_type="get_earliest_timestamp",
+            team_id=team_id,
+        )
+        # `min` over an empty window returns the DateTime epoch (1970), which is below the floor.
+        # Any genuine result is strictly after the floor, so the first such value is the earliest event.
+        if (
+            results
+            and results[0][0] is not None
+            and convert_to_datetime_aware(results[0][0]) > EARLIEST_TIMESTAMP_DATETIME
+        ):
+            return results[0][0]
 
-    if len(results) > 0:
-        return results[0][0]
-    else:
-        return timezone.now() - DEFAULT_EARLIEST_TIME_DELTA
+    return timezone.now() - DEFAULT_EARLIEST_TIME_DELTA
 
 
 def get_start_of_interval_sql(


### PR DESCRIPTION
## Problem

The "all time" date-range default for insights resolves a team's earliest event
through `get_earliest_timestamp`, which ran an open-ended
`SELECT timestamp FROM events WHERE team_id = X AND timestamp > '2015-01-01' ORDER BY timestamp LIMIT 1`.

The `events` table sort key is `(team_id, toDate(timestamp), ...)` — day-bucketed,
not raw `timestamp` — and the table is a Distributed `ReplacingMergeTree`. As a
result this query cannot short-circuit on the primary index: to return one row it
reads the whole team's `timestamp` column across every granule. For high-volume
teams this reads an enormous amount of data to produce a single value, and the
slow tail reaches into the tens of seconds.

## Changes

Replace the open-ended `ORDER BY ... LIMIT 1` with a widening-window
`min(timestamp)` probe:

- Probe a small ascending set of **literal** `[floor, upper)` windows.
- Two narrow windows just above the 2015 floor catch the common case of
  legacy/corrupt events clustered at the epoch floor (resolves those teams in a
  single cheap probe).
- `now - 2**k` month windows give progressively finer resolution toward the
  present, where a team's genuine first event usually lands — keeping the first
  non-empty window tight even for teams whose data only starts recently.
- Return the first non-empty window's `min`. Since nothing below the floor counts,
  that minimum is exactly the global earliest event.

Because each upper bound is a constant, ClickHouse prunes partitions and the
existing `timestamp` minmax skip index prunes granules, so each probe only reads
the data inside its window rather than the entire team.

The returned value is **behaviour-identical** to the old query, including the
zero-events case (still falls back to `now - DEFAULT_EARLIEST_TIME_DELTA`) and the
exclusion of pre-floor (e.g. epoch-zero) corrupt timestamps.

## How did you test this code?

I'm an agent (Claude Code). Automated tests I actually ran (`hogli test`, all
passing):

- `posthog/queries/test/test_util.py` — new coverage for `get_earliest_timestamp`
  (earliest event returned, data-at-floor case, recent-only data, pre-floor
  timestamps ignored, empty-team fallback) and the bound-schedule helper.
- `posthog/models/filters/test/test_stickiness_filter.py`,
  `posthog/hogql_queries/utils/test/test_query_date_range.py`,
  `posthog/queries/funnels/test/test_funnel_trends.py`, and the legacy
  `test_all_time_timerange` trends test — consumers of the helper, all green.

Correctness and cost were also validated by replaying both the old and new query
shapes against production `system.query_log` for several representative teams with
differently-distributed data: the new probe returns the identical timestamp in
every case (and `None`/fallback for an empty team), while reading roughly one to
five orders of magnitude fewer bytes depending on the team's data distribution.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (agent), invoked by the repo owner; requires human review
before merge.

Approach and decisions:

- **Located the source**: this is the legacy raw-SQL path in
  `posthog/queries/util.py`. The HogQL path (`hogql_queries/utils/timestamp_utils.py`)
  prints a different statement and is cached for 24h; production query_log confirmed
  the costly shape comes exclusively from the legacy helper. No `DESC`/latest-event
  variant of this raw shape exists, so the change is scoped to the earliest-event probe.
- **Why the original is slow**: confirmed via `EXPLAIN` that the sort-key prefix is
  `toDate(timestamp)` and the table is a Distributed `ReplacingMergeTree`, so
  `ORDER BY timestamp LIMIT 1` cannot read-in-order to completion and scans the team.
- **Candidates measured and rejected**: plain `min(timestamp)` and
  `optimize_aggregation_in_order` (same full scan); `ORDER BY toDate(timestamp) LIMIT 1`
  (correct, ~1 order of magnitude, but still heavy due to part fragmentation across the
  distributed merge); a `count()`-based binary search (each probe spans `[floor, mid)`,
  so it scans ~everything). The winning observation: a **bounded** `min` over a window
  that does not extend into a team's dense recent data is pruned to near-nothing by the
  partition key + timestamp minmax skip index. Empty windows are cheap (the skip index
  prunes them), and `min` over an empty window returns the epoch sentinel, which the
  loop treats as "keep searching".
- **Schedule choice**: a single fixed bound is fragile (a recent-data team's window can
  still cover all its data). Pure doubling from the floor leaves a coarse gap near the
  present; a date-relative `now - 2**k` schedule (plus two floor windows) keeps the hit
  window tight for both old/corrupt and recent-data teams and is robust as time passes.
- **Tradeoff**: the helper now issues up to a handful of sequential ClickHouse queries
  (typically 1–6, bounded ~11) instead of one. Each is cheap, the result is memoised,
  and this bounds the previous multi-second/tens-of-seconds tail. Net latency improves
  on the slow tail; the formerly-fast recent-team path may add a few sub-second probes.

Tool: Claude Code. Production query analysis was run read-only against `system.query_log`
via the internal Metabase API; no schema or migration changes are involved.
