### PR TITLE
feat(slack-app): use slack integration kind for coding-agent mentions

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_interactivity.py
+++ b/posthog/temporal/ai/posthog_code_slack_interactivity.py
@@ -10,6 +10,7 @@ from temporalio.common import RetryPolicy
 from posthog.temporal.common.base import PostHogWorkflow
 
 POSTHOG_CODE_SLACK_INTERACTIVITY_TIMEOUT_SECONDS = 5 * 60
+SLACK_INTEGRATION_KIND = "slack"
 logger = structlog.get_logger(__name__)
 
 
@@ -96,7 +97,7 @@ def process_posthog_code_task_termination_payload(payload: dict[str, Any]) -> No
 
     try:
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
     except Integration.DoesNotExist:
         logger.warning("posthog_code_terminate_integration_not_found", integration_id=integration_id)

--- a/posthog/temporal/ai/posthog_code_slack_interactivity.py
+++ b/posthog/temporal/ai/posthog_code_slack_interactivity.py
@@ -10,7 +10,6 @@ from temporalio.common import RetryPolicy
 from posthog.temporal.common.base import PostHogWorkflow
 
 POSTHOG_CODE_SLACK_INTERACTIVITY_TIMEOUT_SECONDS = 5 * 60
-SLACK_INTEGRATION_KIND = "slack"
 logger = structlog.get_logger(__name__)
 
 
@@ -96,9 +95,7 @@ def process_posthog_code_task_termination_payload(payload: dict[str, Any]) -> No
         return
 
     try:
-        integration = Integration.objects.get(
-            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
-        )
+        integration = Integration.objects.get(id=integration_id, kind="slack", integration_id=slack_team_id)
     except Integration.DoesNotExist:
         logger.warning("posthog_code_terminate_integration_not_found", integration_id=integration_id)
         return

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -24,6 +24,7 @@ def _safe_react(client: Any, channel: str, timestamp: str, name: str) -> None:
 POSTHOG_CODE_SLACK_MENTION_TIMEOUT_SECONDS = 10 * 60
 _RESUME_ERROR_MSG = "Sorry, I ran into an internal error restarting the agent. Please try again in a minute."
 POSTHOG_CODE_SLACK_PICKER_TIMEOUT_MINUTES = 15
+SLACK_INTEGRATION_KIND = "slack"
 POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE = (
     "Please select the repository for this task. "
     "Or click *No repo needed* to continue without one. "
@@ -360,7 +361,7 @@ def resolve_posthog_code_slack_user_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -386,7 +387,7 @@ def handle_posthog_code_rules_command_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -652,7 +653,7 @@ def collect_posthog_code_thread_messages_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -675,7 +676,7 @@ def select_posthog_code_repository_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     all_repos = _get_full_repo_names(integration)
@@ -713,7 +714,7 @@ def post_posthog_code_no_repos_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -744,7 +745,7 @@ def post_posthog_code_repo_picker_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -788,7 +789,7 @@ def create_posthog_code_task_for_repo_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -914,7 +915,7 @@ def create_posthog_code_routing_rule_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -994,7 +995,7 @@ def forward_posthog_code_followup_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1437,7 +1438,7 @@ def post_posthog_code_picker_timeout_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1467,7 +1468,7 @@ def post_posthog_code_internal_error_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -24,7 +24,6 @@ def _safe_react(client: Any, channel: str, timestamp: str, name: str) -> None:
 POSTHOG_CODE_SLACK_MENTION_TIMEOUT_SECONDS = 10 * 60
 _RESUME_ERROR_MSG = "Sorry, I ran into an internal error restarting the agent. Please try again in a minute."
 POSTHOG_CODE_SLACK_PICKER_TIMEOUT_MINUTES = 15
-SLACK_INTEGRATION_KIND = "slack"
 POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE = (
     "Please select the repository for this task. "
     "Or click *No repo needed* to continue without one. "
@@ -361,7 +360,7 @@ def resolve_posthog_code_slack_user_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -387,7 +386,7 @@ def handle_posthog_code_rules_command_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -653,7 +652,7 @@ def collect_posthog_code_thread_messages_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -676,7 +675,7 @@ def select_posthog_code_repository_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     all_repos = _get_full_repo_names(integration)
@@ -714,7 +713,7 @@ def post_posthog_code_no_repos_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -745,7 +744,7 @@ def post_posthog_code_repo_picker_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -789,7 +788,7 @@ def create_posthog_code_task_for_repo_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -915,7 +914,7 @@ def create_posthog_code_routing_rule_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -995,7 +994,7 @@ def forward_posthog_code_followup_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1438,7 +1437,7 @@ def post_posthog_code_picker_timeout_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1468,7 +1467,7 @@ def post_posthog_code_internal_error_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind=SLACK_INTEGRATION_KIND,
+        kind="slack",
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1244,12 +1244,12 @@ def posthog_code_event_handler(request: HttpRequest) -> HttpResponse:
         slack_config = SlackIntegration.slack_config()
         validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
-        logger.warning("posthog_code_event_invalid_request", error=str(e))
+        logger.warning("slack_event_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
 
     retry_num = request.headers.get("X-Slack-Retry-Num")
     if retry_num:
-        logger.info("posthog_code_event_retry", retry_num=retry_num)
+        logger.info("slack_event_retry", retry_num=retry_num)
         return HttpResponse(status=200)
 
     try:
@@ -1634,7 +1634,7 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
         slack_config = SlackIntegration.slack_config()
         validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
-        logger.warning("posthog_code_interactivity_invalid_request", error=str(e))
+        logger.warning("slack_interactivity_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
 
     try:

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -48,7 +48,6 @@ logger = structlog.get_logger(__name__)
 
 HANDLED_EVENT_TYPES = ["app_mention", "link_shared"]
 
-SLACK_INTEGRATION_KIND = "slack"
 POSTHOG_CODE_SLACK_AVAILABILITY_FLAG = "posthog-code-slack-availability"
 
 ROUTE_HANDLED_LOCALLY = "handled_locally"
@@ -782,9 +781,7 @@ def _replace_repo_picker_message_with_selection(
 ) -> None:
     try:
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
-        integration = Integration.objects.get(
-            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
-        )
+        integration = Integration.objects.get(id=integration_id, kind="slack", integration_id=slack_team_id)
         slack = SlackIntegration(integration)
         text = f"Repository selected: `{selected_repo}`"
         slack.client.chat_update(
@@ -816,9 +813,7 @@ def _replace_repo_picker_message_with_no_repo(
 ) -> None:
     try:
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
-        integration = Integration.objects.get(
-            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
-        )
+        integration = Integration.objects.get(id=integration_id, kind="slack", integration_id=slack_team_id)
         slack = SlackIntegration(integration)
         text = "Continuing without a repository."
         slack.client.chat_update(
@@ -1154,7 +1149,7 @@ def route_posthog_code_event_to_relevant_region(
     # by the posthog-code-slack-availability feature flag rather than a separate kind.
     local_match = (
         Integration.objects.filter(
-            kind=SLACK_INTEGRATION_KIND,
+            kind="slack",
             integration_id=slack_team_id,
         )
         .select_related("team", "team__organization", "created_by")
@@ -1378,7 +1373,7 @@ def _handle_repo_picker_options(payload: dict) -> JsonResponse:
         team_id = payload.get("team", {}).get("id")
         if team_id:
             fallback_integration = (
-                Integration.objects.filter(kind=SLACK_INTEGRATION_KIND, integration_id=team_id).order_by("id").first()
+                Integration.objects.filter(kind="slack", integration_id=team_id).order_by("id").first()
             )
             if fallback_integration:
                 hinted_integration_id = fallback_integration.id
@@ -1412,9 +1407,7 @@ def _handle_repo_picker_options(payload: dict) -> JsonResponse:
         if not integration_id:
             raise Integration.DoesNotExist
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
-        integration = Integration.objects.get(
-            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
-        )
+        integration = Integration.objects.get(id=integration_id, kind="slack", integration_id=slack_team_id)
     except Integration.DoesNotExist:
         logger.info("posthog_code_repo_picker_options_no_integration", context_token=context_token)
         return JsonResponse({"options": []})
@@ -1491,9 +1484,7 @@ def _handle_repo_picker_submit(payload: dict) -> HttpResponse:
 
         try:
             # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
-            integration = Integration.objects.get(
-                id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
-            )
+            integration = Integration.objects.get(id=integration_id, kind="slack", integration_id=slack_team_id)
             SlackIntegration(integration).client.chat_postMessage(
                 channel=channel,
                 thread_ts=thread_ts,
@@ -1664,19 +1655,19 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
     if slack_team_id and ctx_integration_id:
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=ctx_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind=SLACK_INTEGRATION_KIND,
+            kind="slack",
             integration_id=slack_team_id,
         ).exists()
     elif slack_team_id and hinted_integration_id and hinted_user_id and requesting_user == hinted_user_id:
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=hinted_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind=SLACK_INTEGRATION_KIND,
+            kind="slack",
             integration_id=slack_team_id,
         ).exists()
     elif slack_team_id and terminate_integration_id and (not terminate_user_id or requesting_user == terminate_user_id):
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=terminate_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind=SLACK_INTEGRATION_KIND,
+            kind="slack",
             integration_id=slack_team_id,
         ).exists()
 

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -48,6 +48,7 @@ logger = structlog.get_logger(__name__)
 
 HANDLED_EVENT_TYPES = ["app_mention", "link_shared"]
 
+SLACK_INTEGRATION_KIND = "slack"
 POSTHOG_CODE_SLACK_AVAILABILITY_FLAG = "posthog-code-slack-availability"
 
 ROUTE_HANDLED_LOCALLY = "handled_locally"
@@ -782,7 +783,7 @@ def _replace_repo_picker_message_with_selection(
     try:
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
         slack = SlackIntegration(integration)
         text = f"Repository selected: `{selected_repo}`"
@@ -816,7 +817,7 @@ def _replace_repo_picker_message_with_no_repo(
     try:
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
         slack = SlackIntegration(integration)
         text = "Continuing without a repository."
@@ -1149,28 +1150,19 @@ def route_posthog_code_event_to_relevant_region(
     slack_team_id: str,
     event_id: str | None = None,
 ) -> str:
-    # One webhook endpoint serves both the notifications integration (kind="slack") and the
-    # coding-agent integration (kind="slack-posthog-code"). What counts as a "local match" has
-    # to depend on event type: app_mention needs the coding-agent integration specifically,
-    # while link_shared (unfurl) works with either kind. Without this, a region that has only a
-    # notifications install for a workspace would silently swallow mentions instead of
-    # proxying to the region that holds the coding-agent install.
-    integrations = list(
+    # The webhook serves the regular slack integration; app_mention activation is gated
+    # by the posthog-code-slack-availability feature flag rather than a separate kind.
+    local_match = (
         Integration.objects.filter(
-            kind__in=["slack", "slack-posthog-code"],
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         )
         .select_related("team", "team__organization", "created_by")
         .order_by("id")
+        .first()
     )
-    coding_agent_integration = next((i for i in integrations if i.kind == "slack-posthog-code"), None)
-    any_integration = integrations[0] if integrations else None
 
     event_type = event.get("type")
-    if event_type == "app_mention":
-        local_match = coding_agent_integration
-    else:
-        local_match = any_integration
 
     if local_match and not (settings.DEBUG and request.get_host() == SLACK_PRIMARY_REGION_DOMAIN):
         if event_type == "app_mention":
@@ -1386,7 +1378,7 @@ def _handle_repo_picker_options(payload: dict) -> JsonResponse:
         team_id = payload.get("team", {}).get("id")
         if team_id:
             fallback_integration = (
-                Integration.objects.filter(kind="slack-posthog-code", integration_id=team_id).order_by("id").first()
+                Integration.objects.filter(kind=SLACK_INTEGRATION_KIND, integration_id=team_id).order_by("id").first()
             )
             if fallback_integration:
                 hinted_integration_id = fallback_integration.id
@@ -1421,7 +1413,7 @@ def _handle_repo_picker_options(payload: dict) -> JsonResponse:
             raise Integration.DoesNotExist
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
     except Integration.DoesNotExist:
         logger.info("posthog_code_repo_picker_options_no_integration", context_token=context_token)
@@ -1500,7 +1492,7 @@ def _handle_repo_picker_submit(payload: dict) -> HttpResponse:
         try:
             # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
             integration = Integration.objects.get(
-                id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+                id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
             )
             SlackIntegration(integration).client.chat_postMessage(
                 channel=channel,
@@ -1672,19 +1664,19 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
     if slack_team_id and ctx_integration_id:
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=ctx_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind="slack-posthog-code",
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
     elif slack_team_id and hinted_integration_id and hinted_user_id and requesting_user == hinted_user_id:
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=hinted_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind="slack-posthog-code",
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
     elif slack_team_id and terminate_integration_id and (not terminate_user_id or requesting_user == terminate_user_id):
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=terminate_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind="slack-posthog-code",
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
 

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1168,7 +1168,7 @@ def route_posthog_code_event_to_relevant_region(
         if event_type == "app_mention":
             if not _posthog_code_enabled_for_integration(local_match):
                 logger.info(
-                    "posthog_code_event_flag_off",
+                    "slack_app_mention_flag_disabled",
                     slack_team_id=slack_team_id,
                     organization_id=str(local_match.team.organization_id),
                 )
@@ -1200,7 +1200,7 @@ def route_posthog_code_event_to_relevant_region(
         success = proxy_slack_event_to_secondary_region(request)
         return ROUTE_PROXIED if success else ROUTE_PROXY_FAILED
     else:
-        logger.warning("posthog_code_no_integration_found", slack_team_id=slack_team_id)
+        logger.warning("slack_app_integration_not_found", slack_team_id=slack_team_id)
         return ROUTE_NO_INTEGRATION
 
 
@@ -1241,8 +1241,8 @@ def posthog_code_event_handler(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=405)
 
     try:
-        posthog_code_config = SlackIntegration.posthog_code_slack_config()
-        validate_slack_request(request, posthog_code_config["SLACK_POSTHOG_CODE_SIGNING_SECRET"])
+        slack_config = SlackIntegration.slack_config()
+        validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
         logger.warning("posthog_code_event_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
@@ -1631,8 +1631,8 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=405)
 
     try:
-        posthog_code_config = SlackIntegration.posthog_code_slack_config()
-        validate_slack_request(request, posthog_code_config["SLACK_POSTHOG_CODE_SIGNING_SECRET"])
+        slack_config = SlackIntegration.slack_config()
+        validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
         logger.warning("posthog_code_interactivity_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)

--- a/products/slack_app/backend/tests/test_collect_thread_messages.py
+++ b/products/slack_app/backend/tests/test_collect_thread_messages.py
@@ -169,7 +169,7 @@ class TestCollectThreadMessages:
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
         self.integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -40,9 +40,7 @@ class TestSlackThreadTaskMapping(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         self.task = self.Task.objects.create(
             team=self.team,
             title="Test task",
@@ -138,9 +136,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com", distinct_id="user-1")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     @patch("posthog.models.integration.SlackIntegration")
@@ -409,9 +405,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         self.task = self.Task.objects.create(
             team=self.team,
             title="Test task",

--- a/products/slack_app/backend/tests/test_guess_repository.py
+++ b/products/slack_app/backend/tests/test_guess_repository.py
@@ -40,7 +40,7 @@ class TestGetFullRepoNames:
 
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )
@@ -163,7 +163,7 @@ class TestGetFullRepoNamesCache:
         self.team = Team.objects.create(organization=self.organization, name="Cache Team")
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_CACHE",
             sensitive_config={"access_token": "xoxb-cache"},
         )
@@ -206,7 +206,7 @@ class TestGetFullRepoNamesCache:
         team_b = Team.objects.create(organization=org_b, name="Other Team")
         slack_b = Integration.objects.create(
             team=team_b,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_OTHER",
             sensitive_config={"access_token": "xoxb-other"},
         )
@@ -323,7 +323,7 @@ class TestPostRepoPickerPrewarm:
         self.team = Team.objects.create(organization=self.organization, name="Prewarm Team")
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_PREWARM",
             sensitive_config={"access_token": "xoxb-prewarm"},
         )
@@ -390,7 +390,7 @@ class TestSelectRepository:
 
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )
@@ -748,7 +748,7 @@ class TestHandleRulesCommandActivity:
 
         self.integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -34,22 +34,22 @@ class TestPostHogCodeEventHandler(TestCase):
             **extra_headers,
         )
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_url_verification(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         response = self._post_event({"type": "url_verification", "challenge": "test-challenge-123"})
         assert response.status_code == 200
         assert response.json() == {"challenge": "test-challenge-123"}
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_invalid_signature(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": "different-secret"}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": "different-secret"}
         response = self._post_event({"type": "url_verification", "challenge": "test"})
         assert response.status_code == 403
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_retry_returns_200(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         body = json.dumps({"type": "event_callback", "event": {"type": "app_mention"}}).encode()
         signature, ts = sign_slack_request(body, self.signing_secret)
         response = self.client.post(
@@ -73,7 +73,7 @@ class TestPostHogCodeEventHandler(TestCase):
         ]
     )
     @patch("products.slack_app.backend.api.route_posthog_code_event_to_relevant_region")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_event_callback_dispatch(
         self,
         _name,
@@ -84,7 +84,7 @@ class TestPostHogCodeEventHandler(TestCase):
         mock_config,
         mock_route,
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_route.return_value = route_result
         payload = {
             "type": "event_callback",
@@ -237,21 +237,6 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
                 assert pending_picker is None
         else:
             assert pending_picker is None
-
-    @patch("products.slack_app.backend.api._posthog_code_enabled_for_integration", return_value=False)
-    @patch("products.slack_app.backend.api.asyncio.run")
-    @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
-    def test_local_match_flag_off_skips_workflow(self, mock_sync_connect, mock_asyncio_run, _mock_flag):
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
-
-        from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
-
-        result = route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
-
-        assert result == ROUTE_HANDLED_LOCALLY
-        mock_sync_connect.assert_not_called()
-        mock_asyncio_run.assert_not_called()
 
     @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
     @override_settings(DEBUG=False)

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -107,7 +107,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
         self.posthog_code_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-posthog-code-test"},
         )
@@ -267,83 +267,6 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         mock_unfurl.assert_called_once()
         passed_integration = mock_unfurl.call_args[0][1]
         assert passed_integration.id == self.posthog_code_integration.id
-
-    @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
-    @override_settings(DEBUG=False)
-    def test_link_shared_works_with_only_notifications_integration(self, mock_unfurl):
-        # Delete the coding-agent integration and create a notifications-only integration for same workspace
-        self.posthog_code_integration.delete()
-        Integration.objects.create(
-            team=self.team,
-            kind="slack",
-            integration_id="T12345",
-            sensitive_config={"access_token": "xoxb-notifications"},
-        )
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
-        link_shared_event = {"type": "link_shared", "channel": "C001", "links": []}
-
-        from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
-
-        result = route_posthog_code_event_to_relevant_region(request, link_shared_event, "T12345")
-
-        assert result == ROUTE_HANDLED_LOCALLY
-        mock_unfurl.assert_called_once()
-        # Don't assert on which integration row was passed: "first row by id" picking is a known
-        # limitation for multi-team workspaces and shouldn't be baked into the test contract.
-        passed_integration = mock_unfurl.call_args[0][1]
-        assert passed_integration.integration_id == "T12345"
-
-    @patch("products.slack_app.backend.api.asyncio.run")
-    @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.proxy_slack_event_to_secondary_region")
-    @patch("products.slack_app.backend.api.SLACK_PRIMARY_REGION_DOMAIN", "eu.posthog.com")
-    @override_settings(DEBUG=False)
-    def test_app_mention_in_primary_with_only_notifications_proxies_to_secondary(
-        self, mock_proxy, mock_sync_connect, mock_asyncio_run
-    ):
-        # Regression test: the coding-agent install may live in the other region. A notifications-only
-        # row in the primary region must NOT short-circuit the proxy path for app_mention.
-        self.posthog_code_integration.delete()
-        Integration.objects.create(
-            team=self.team,
-            kind="slack",
-            integration_id="T12345",
-            sensitive_config={"access_token": "xoxb-notifications"},
-        )
-        mock_proxy.return_value = True
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
-
-        from products.slack_app.backend.api import ROUTE_PROXIED, route_posthog_code_event_to_relevant_region
-
-        result = route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
-
-        assert result == ROUTE_PROXIED
-        mock_proxy.assert_called_once_with(request)
-        mock_sync_connect.assert_not_called()
-        mock_asyncio_run.assert_not_called()
-
-    @patch("products.slack_app.backend.api.asyncio.run")
-    @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
-    def test_app_mention_in_secondary_with_only_notifications_noop(self, mock_sync_connect, mock_asyncio_run):
-        # In the secondary region with only a notifications install, app_mention should
-        # report no_integration (no coding-agent install anywhere reachable from here).
-        self.posthog_code_integration.delete()
-        Integration.objects.create(
-            team=self.team,
-            kind="slack",
-            integration_id="T12345",
-            sensitive_config={"access_token": "xoxb-notifications"},
-        )
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
-
-        from products.slack_app.backend.api import ROUTE_NO_INTEGRATION, route_posthog_code_event_to_relevant_region
-
-        result = route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
-
-        assert result == ROUTE_NO_INTEGRATION
-        mock_sync_connect.assert_not_called()
-        mock_asyncio_run.assert_not_called()
 
     @patch("products.slack_app.backend.api.proxy_slack_event_to_secondary_region")
     @patch("products.slack_app.backend.api.SLACK_PRIMARY_REGION_DOMAIN", "eu.posthog.com")

--- a/products/slack_app/backend/tests/test_posthog_code_interactivity.py
+++ b/products/slack_app/backend/tests/test_posthog_code_interactivity.py
@@ -60,7 +60,7 @@ class TestRepoPickerOptions(TestCase):
         OrganizationMembership.objects.create(user=self.user, organization=self.organization)
         self.posthog_code_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-posthog-code-test"},
         )

--- a/products/slack_app/backend/tests/test_posthog_code_interactivity.py
+++ b/products/slack_app/backend/tests/test_posthog_code_interactivity.py
@@ -41,9 +41,9 @@ class TestPostHogCodeInteractivityHandler(TestCase):
         response = self.client.get("/slack/interactivity-callback/")
         assert response.status_code == 405
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_invalid_signature_returns_403(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": "different-secret"}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": "different-secret"}
         response = self._post_interactivity({"type": "block_suggestion"})
         assert response.status_code == 403
 
@@ -96,9 +96,9 @@ class TestRepoPickerOptions(TestCase):
         )
 
     @patch("products.slack_app.backend.api._get_full_repo_names")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_returns_filtered_repos(self, mock_config, mock_get_repos):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_get_repos.return_value = ["posthog/posthog", "posthog/posthog-js", "posthog/hogvm"]
 
         payload = {
@@ -115,9 +115,9 @@ class TestRepoPickerOptions(TestCase):
         assert options[0]["value"] == "posthog/posthog-js"
 
     @patch("products.slack_app.backend.api._get_full_repo_names")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_empty_query_returns_all(self, mock_config, mock_get_repos):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_get_repos.return_value = ["posthog/posthog", "posthog/posthog-js"]
 
         payload = {
@@ -131,9 +131,9 @@ class TestRepoPickerOptions(TestCase):
         assert response.status_code == 200
         assert len(response.json()["options"]) == 2
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_wrong_user_returns_empty(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
 
         payload = {
             "type": "block_suggestion",
@@ -146,9 +146,9 @@ class TestRepoPickerOptions(TestCase):
         assert response.status_code == 200
         assert response.json()["options"] == []
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_expired_token_returns_empty(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         cache.delete(f"posthog_code_repo_picker_ctx:{self.context_token}")
 
         payload = {
@@ -165,11 +165,11 @@ class TestRepoPickerOptions(TestCase):
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_submit_signals_temporal_workflow(
         self, mock_config, mock_sync_connect, mock_asyncio_run, mock_webclient_class
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_webclient_class.return_value = MagicMock()
         self.context_payload["workflow_id"] = "posthog-code-mention-T12345:C001:1234.5678"
         cache.set(f"posthog_code_repo_picker_ctx:{self.context_token}", self.context_payload, timeout=900)
@@ -199,11 +199,11 @@ class TestRepoPickerOptions(TestCase):
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_no_repo_button_signals_temporal_workflow(
         self, mock_config, mock_sync_connect, mock_asyncio_run, mock_webclient_class
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_webclient_class.return_value = MagicMock()
         self.context_payload["workflow_id"] = "posthog-code-mention-T12345:C001:1234.5678"
         cache.set(f"posthog_code_repo_picker_ctx:{self.context_token}", self.context_payload, timeout=900)
@@ -233,9 +233,9 @@ class TestRepoPickerOptions(TestCase):
         assert "without a repository" in update_call["text"].lower()
 
     @patch("posthog.models.integration.WebClient")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_submit_without_workflow_id_posts_expired(self, mock_config, mock_webclient_class):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client
         self.context_payload.pop("workflow_id", None)
@@ -263,7 +263,7 @@ class TestRepoPickerOptions(TestCase):
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_submit_signal_failure_posts_expired(
         self,
         mock_config,
@@ -271,7 +271,7 @@ class TestRepoPickerOptions(TestCase):
         mock_asyncio_run,
         mock_webclient_class,
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client
         self.context_payload["workflow_id"] = "posthog-code-mention-T12345:C001:1234.5678"
@@ -300,9 +300,9 @@ class TestRepoPickerOptions(TestCase):
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_terminate_action_starts_temporal_workflow(self, mock_config, mock_sync_connect, mock_asyncio_run):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
 
         payload = {
             "type": "block_actions",

--- a/products/slack_app/backend/tests/test_resolve_slack_user.py
+++ b/products/slack_app/backend/tests/test_resolve_slack_user.py
@@ -23,7 +23,7 @@ class TestResolveSlackUser:
 
         self.integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )

--- a/products/slack_app/backend/tests/test_terminate.py
+++ b/products/slack_app/backend/tests/test_terminate.py
@@ -27,9 +27,7 @@ class TestProcessPostHogCodeTaskTermination(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         self.task = self.Task.objects.create(
             team=self.team,
             title="Test task",

--- a/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
@@ -47,7 +47,7 @@ class TestForwardPendingUserMessage(TestCase):
         )
         cls.slack_integration = Integration.objects.create(
             team=cls.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T123",
             config={},
         )

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -50,7 +50,7 @@ class TestRelaySlackMessage(TestCase):
         )
         cls.integration = Integration.objects.create(
             team=cls.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T123",
             config={},
         )

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3113,9 +3113,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
         SlackThreadTaskMapping.objects.create(
             team=self.team,
@@ -3164,9 +3162,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
         SlackThreadTaskMapping.objects.create(
             team=self.team,
@@ -3294,9 +3290,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
         mock_execute_relay.return_value = "relay-1"
 
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         SlackThreadTaskMapping.objects.create(
             team=self.team,
             integration=integration,
@@ -3378,9 +3372,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
 
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         SlackThreadTaskMapping.objects.create(
             team=self.team,
             integration=integration,

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2878,7 +2878,7 @@
     },
     "llma-personal-spend": {
         "description": "Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days (default 30, max 90). Returns a summary plus breakdowns by product, tool, model, and top traces. Pass `product` (e.g. `posthog_code`, `background_agents`) to scope the tool / model / trace breakdowns to a single product; `by_product` always returns the cross-product view. Pass `refresh=true` to bypass the 5-minute cache.",
-        "category": "LLM analytics",
+        "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get my LLM spend analysis",
         "title": "Get my LLM spend analysis",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -3191,7 +3191,7 @@
     },
     "llma-personal-spend": {
         "description": "Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days (default 30, max 90). Returns a summary plus breakdowns by product, tool, model, and top traces. Pass `product` (e.g. `posthog_code`, `background_agents`) to scope the tool / model / trace breakdowns to a single product; `by_product` always returns the cross-product view. Pass `refresh=true` to bypass the 5-minute cache.",
-        "category": "LLM analytics",
+        "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get my LLM spend analysis",
         "title": "Get my LLM spend analysis",


### PR DESCRIPTION
## Problem

The PostHog Code coding-agent Slack mention flow ran against its own dedicated Slack app (`Integration.kind="slack-posthog-code"`), separate from the regular notifications Slack app (`kind="slack"`). That meant orgs had to install two PostHog Slack apps to use `@PostHog` mentions, even though the notifications Slack app already requests every OAuth scope the coding agent needs.

This PR retires that split — the coding agent now uses the regular `kind="slack"` integration, and the `posthog-code-slack-availability` feature flag is the only gate for who can use it.

## Changes

- **Integration lookup** (`products/slack_app/backend/api.py`, `posthog/temporal/ai/posthog_code_slack_*.py`): all `kind="slack-posthog-code"` lookups now use `kind="slack"`. Extracted `SLACK_INTEGRATION_KIND` module constant.
- **Webhook validation**: `/slack/event-callback` and `/slack/interactivity-callback` now validate with `SLACK_APP_SIGNING_SECRET` (notifications app) instead of `SLACK_POSTHOG_CODE_SIGNING_SECRET`. The notifications Slack app's Event Subscriptions + Interactivity URLs already point here, so traffic from it starts passing validation immediately.
- **Routing**: simplified `route_posthog_code_event_to_relevant_region` — single `kind="slack"` lookup, no more dual-kind dispatch.
- **Log keys**: renamed misleading `posthog_code_*` keys around the webhook/routing layer to `slack_*` where they're no longer coding-agent specific (e.g. signature failures, slack-integration-not-found).
- **Tests**: updated fixtures to `kind="slack"`, updated webhook signing-secret mocks to `slack_config()` / `SLACK_APP_SIGNING_SECRET`, removed obsolete dual-kind routing tests.

## How did you test this code?

- Tested end-to-end locally: `@PostHog <task>` in Slack against a `kind="slack"` integration starts the Temporal mention workflow and creates a task.
- `hogli test products/slack_app/backend/tests/` — 212/212 pass
- `ruff check` clean on edited files

### Risks to watch

-. Orgs with **only** the posthog-code Slack app installed (no `kind="slack"` row) lose the mention flow. DB audit recommended before this rolls out broadly.
    - checked, just internal orgs 381971 and 2
-. `kind="slack"` rows authorized before `ba8b5b5` (2026-05-04) may not have the required scopes — `app_mentions:read`, `channels:history`, `reactions:write`, `users:read.email`, etc. Detect via `config->>'scope'` and prompt reauth.
    - will be follow up PR to let't them know they need to reauth

## Publish to changelog?

no

## Docs update

No user-facing docs change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*