### PR TITLE
feat(logs): add severity_level, trace_id, span_id top-level filters

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -267,12 +267,20 @@ export function OperatorValueSelect({
         }
 
         // Restrict trace_id, span_id, kind, and status_code to only equals/not equals
-        if (['trace_id', 'span_id', 'kind', 'status_code'].includes(propertyKey) && type === PropertyFilterType.Span) {
+        if (
+            propertyKey &&
+            ['trace_id', 'span_id', 'kind', 'status_code'].includes(propertyKey) &&
+            type === PropertyFilterType.Span
+        ) {
             operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
         }
 
         // Restrict log trace_id, span_id and severity_level to only equals/not equals
-        if (['trace_id', 'span_id', 'severity_level'].includes(propertyKey) && type === PropertyFilterType.Log) {
+        if (
+            propertyKey &&
+            ['trace_id', 'span_id', 'severity_level'].includes(propertyKey) &&
+            type === PropertyFilterType.Log
+        ) {
             operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
         }
 

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -52,8 +52,7 @@ const STATUS_CODE_OPTIONS: { key: number; label: string }[] = [
 ]
 
 // OTel severity level (https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber).
-// Ordered low → high so range operators (>, <) yield expected semantics; the backend maps to
-// severity_number for ordered comparisons.
+// Ordered low → high for display; only equals / not-equals operators are supported.
 const SEVERITY_LEVEL_OPTIONS: { key: string; label: string }[] = [
     { key: 'trace', label: 'trace' },
     { key: 'debug', label: 'debug' },

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -52,7 +52,6 @@ const STATUS_CODE_OPTIONS: { key: number; label: string }[] = [
 ]
 
 // OTel severity level (https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber).
-// Ordered low → high for display; only equals / not-equals operators are supported.
 const SEVERITY_LEVEL_OPTIONS: { key: string; label: string }[] = [
     { key: 'trace', label: 'trace' },
     { key: 'debug', label: 'debug' },
@@ -267,18 +266,13 @@ export function OperatorValueSelect({
             )
         }
 
-        // Restrict trace_id and span_id to only equals/not equals
-        if ((propertyKey === 'trace_id' || propertyKey === 'span_id') && type === PropertyFilterType.Span) {
+        // Restrict trace_id, span_id, kind, and status_code to only equals/not equals
+        if (['trace_id', 'span_id', 'kind', 'status_code'].includes(propertyKey) && type === PropertyFilterType.Span) {
             operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
         }
 
-        // Restrict log trace_id and span_id to only equals/not equals
-        if ((propertyKey === 'trace_id' || propertyKey === 'span_id') && type === PropertyFilterType.Log) {
-            operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
-        }
-
-        // Restrict log severity_level to equality only
-        if (propertyKey === 'severity_level' && type === PropertyFilterType.Log) {
+        // Restrict log trace_id, span_id and severity_level to only equals/not equals
+        if (['trace_id', 'span_id', 'severity_level'].includes(propertyKey) && type === PropertyFilterType.Log) {
             operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
         }
 
@@ -308,11 +302,6 @@ export function OperatorValueSelect({
                     PropertyOperator.NotRegex,
                 ].includes(op)
             )
-        }
-
-        // Restrict span kind and status_code (fixed int enums) to equality operators
-        if ((propertyKey === 'kind' || propertyKey === 'status_code') && type === PropertyFilterType.Span) {
-            operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
         }
 
         setOperators(operators)

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -51,6 +51,18 @@ const STATUS_CODE_OPTIONS: { key: number; label: string }[] = [
     { key: 2, label: 'Error' },
 ]
 
+// OTel severity level (https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber).
+// Ordered low → high so range operators (>, <) yield expected semantics; the backend maps to
+// severity_number for ordered comparisons.
+const SEVERITY_LEVEL_OPTIONS: { key: string; label: string }[] = [
+    { key: 'trace', label: 'trace' },
+    { key: 'debug', label: 'debug' },
+    { key: 'info', label: 'info' },
+    { key: 'warn', label: 'warn' },
+    { key: 'error', label: 'error' },
+    { key: 'fatal', label: 'fatal' },
+]
+
 function SpanEnumValueSelect({
     options,
     value,
@@ -58,7 +70,7 @@ function SpanEnumValueSelect({
     isMultiSelect,
     size,
 }: {
-    options: { key: number; label: string }[]
+    options: { key: string | number; label: string }[]
     value?: PropertyFilterValue
     onChange: (value: PropertyFilterValue) => void
     isMultiSelect: boolean
@@ -261,6 +273,16 @@ export function OperatorValueSelect({
             operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
         }
 
+        // Restrict log trace_id and span_id to only equals/not equals
+        if ((propertyKey === 'trace_id' || propertyKey === 'span_id') && type === PropertyFilterType.Log) {
+            operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
+        }
+
+        // Restrict log severity_level to equality only
+        if (propertyKey === 'severity_level' && type === PropertyFilterType.Log) {
+            operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
+        }
+
         // Restrict duration to equals, not equals, and numeric comparisons
         if (propertyKey === 'duration' && type === PropertyFilterType.Span) {
             operators = operators.filter((op) =>
@@ -362,10 +384,17 @@ export function OperatorValueSelect({
                     className="shrink grow-[1000] min-w-[10rem] overflow-hidden"
                     data-attr="taxonomic-value-select"
                 >
-                    {type === PropertyFilterType.Span && (propertyKey === 'kind' || propertyKey === 'status_code') ? (
+                    {(type === PropertyFilterType.Span && (propertyKey === 'kind' || propertyKey === 'status_code')) ||
+                    (type === PropertyFilterType.Log && propertyKey === 'severity_level') ? (
                         editable ? (
                             <SpanEnumValueSelect
-                                options={propertyKey === 'kind' ? SPAN_KIND_OPTIONS : STATUS_CODE_OPTIONS}
+                                options={
+                                    propertyKey === 'kind'
+                                        ? SPAN_KIND_OPTIONS
+                                        : propertyKey === 'status_code'
+                                          ? STATUS_CODE_OPTIONS
+                                          : SEVERITY_LEVEL_OPTIONS
+                                }
                                 value={value}
                                 isMultiSelect={
                                     forceSingleSelect

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -914,7 +914,12 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         name: 'Logs',
                         searchPlaceholder: 'logs',
                         type: TaxonomicFilterGroupType.Logs,
-                        options: [{ key: 'message', name: 'Message', propertyFilterType: 'log' }],
+                        options: [
+                            { key: 'message', name: 'message', propertyFilterType: 'log' },
+                            { key: 'severity_level', name: 'severity_level', propertyFilterType: 'log' },
+                            { key: 'trace_id', name: 'trace_id', propertyFilterType: 'log' },
+                            { key: 'span_id', name: 'span_id', propertyFilterType: 'log' },
+                        ],
                         localItemsSearch: (items: any[], q: string): any[] => {
                             if (!q) {
                                 return items

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -489,7 +489,12 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
             name: 'Logs',
             searchPlaceholder: 'logs',
             type: TaxonomicFilterGroupType.Logs,
-            options: [{ key: 'message', name: 'Message', propertyFilterType: 'log' }],
+            options: [
+                { key: 'message', name: 'message', propertyFilterType: 'log' },
+                { key: 'severity_level', name: 'severity_level', propertyFilterType: 'log' },
+                { key: 'trace_id', name: 'trace_id', propertyFilterType: 'log' },
+                { key: 'span_id', name: 'span_id', propertyFilterType: 'log' },
+            ],
             localItemsSearch: (items: any[], q: string): any[] => {
                 if (!q) {
                     return items

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -31,6 +31,49 @@ if TYPE_CHECKING:
     from posthog.models import Team, User
 
 
+def _trace_id_normalise_to_base64(value: str) -> str:
+    """Accept either hex or base64 encoded trace_id/span_id values.
+
+    The `trace_id` and `span_id` columns store base64-encoded bytes. Hex input (32-char for
+    trace_id, 16-char for span_id) is the form users normally see in trace UIs, so we accept
+    it and convert. Values that aren't valid hex are passed through as-is (assumed base64).
+    """
+    try:
+        int(value, 16)
+        return base64.b64encode(bytes.fromhex(value)).decode()
+    except ValueError:
+        return value
+
+
+def _normalise_trace_id_filter(log_filter: LogPropertyFilter) -> None:
+    """In-place: normalize trace_id/span_id filter values to base64 to match column storage."""
+    if isinstance(log_filter.value, list):
+        log_filter.value = [_trace_id_normalise_to_base64(str(v)) for v in log_filter.value]
+    elif log_filter.value is not None:
+        log_filter.value = _trace_id_normalise_to_base64(str(log_filter.value))
+
+
+def _severity_level_to_expr(log_filter: LogPropertyFilter) -> ast.Expr:
+    """Translate a `severity_level` log property filter to a HogQL expression on `severity_text`.
+
+    Only equality operators (Exact/IsNot) are exposed in the UI.
+    """
+    values: list[str]
+    if isinstance(log_filter.value, list):
+        values = [str(v) for v in log_filter.value]
+    elif log_filter.value is None:
+        values = []
+    else:
+        values = [str(log_filter.value)]
+
+    op = ast.CompareOperationOp.NotIn if log_filter.operator == PropertyOperator.IS_NOT else ast.CompareOperationOp.In
+    return ast.CompareOperation(
+        op=op,
+        left=ast.Field(chain=["severity_text"]),
+        right=ast.Tuple(exprs=[ast.Constant(value=v) for v in values]),
+    )
+
+
 def _generate_resource_attribute_filters(
     resource_attribute_filters, *, existing_filters, query_date_range, team, is_negative_filter
 ):
@@ -246,6 +289,12 @@ class LogsFilterBuilder:
 
             if self.log_filters:
                 for log_filter in self.log_filters:
+                    if log_filter.key == "severity_level":
+                        exprs.append(_severity_level_to_expr(log_filter))
+                        continue
+                    if log_filter.key in ("trace_id", "span_id"):
+                        log_filter = log_filter.copy(deep=True)
+                        _normalise_trace_id_filter(log_filter)
                     if log_filter.key == "message":
                         exprs.append(get_lowercase_index_hint(log_filter, team=self.team))
                     exprs.append(property_to_expr(log_filter, team=self.team))


### PR DESCRIPTION
## Problem

The logs filter search only exposed `message` as a top-level attribute. Users had to know which log attributes/resource_attributes a row had to filter by trace correlation IDs or severity — even though `trace_id`, `span_id`, and `severity_text` are real columns on the logs table. Traces already exposes the equivalent fields in its Spans group, so this brings logs to parity.

## Changes

- **Taxonomic group**: added `severity_level`, `trace_id`, `span_id` next to `message` in the Logs group (mirrors the Spans group). Edited in both `buildTaxonomicGroups.tsx` and the legacy duplicate in `taxonomicFilterLogic.tsx`.
- **Operator restriction**: all three new fields are restricted to equals / not-equals in `OperatorValueSelect.tsx`, matching how the Spans group restricts `trace_id` / `span_id` / `kind`.
- **severity_level autocomplete**: reuses the existing `SpanEnumValueSelect` component with the six OTel severity strings (`trace`, `debug`, `info`, `warn`, `error`, `fatal`). Generalized the component's `options.key` to `string | number` so it can also serve string-keyed enums.
- **trace_id / span_id hex-or-base64**: the ClickHouse columns store base64-encoded bytes, but users typically copy the hex form from trace URLs. Added a small normalizer in `logs_query_runner.py` that detects hex input and converts to base64 before the filter hits `property_to_expr` — same pattern as `_normalise_to_base64` in `products/tracing/backend/logic.py`.
- **severity_level translation**: filters with `key == "severity_level"` are intercepted in the filter loop and compiled directly to `severity_text IN/NOT IN (...)`, since `severity_level` is a UI label, not a real column.

## How did you test this code?

I'm an agent (PostHog Code). I ran the backend filter tests:

```
hogli test products/logs/backend/test/test_logs_query_runner.py -k "filter"
# 19 passed, 15 deselected
```

The user manually verified the UI in a running dev stack — the severity_level dropdown, the operator restrictions on trace_id/span_id, and the hex-paste flow all worked end-to-end. No new automated tests added for the normalization helpers; worth adding follow-ups if reviewers want them.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7).

Decisions along the way:
- First pass added a `severity_text` key with display name `severity_level`; renamed to `severity_level` end-to-end after the user clarified they wanted that to be the public field name, with the backend translating to `severity_text`.
- Briefly implemented range operators on `severity_level` by mapping severity strings to their OTel `severity_number` anchors (1/5/9/13/17/21) so `severity > info` returned warn/error/fatal. Reviewed with the user and reverted — equality-only is simpler and consistent with how `trace_id`/`span_id` are constrained.
- Considered importing the trace normalizer from `products/tracing/backend/logic.py` but kept a local copy to avoid coupling the two products across the product boundary.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*