### PR TITLE
fix(frontend): break import cycle in lib/api.ts via type-only import

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -244,7 +244,7 @@ import type {
 } from 'products/workflows/frontend/Workflows/hogflows/types'
 
 import { AgentMode } from '../queries/schema'
-import { MaxUIContext } from '../scenes/max/maxTypes'
+import type { MaxUIContext } from '../scenes/max/maxTypes'
 import { AlertSimulationResult, AlertType, AlertTypeWrite } from './components/Alerts/types'
 import {
     ErrorTrackingFingerprint,


### PR DESCRIPTION
## Problem

`oxlint`'s `import/no-cycle` rule flags a dependency cycle starting at `frontend/src/lib/api.ts:247` whenever the file is touched, blocking lint-staged. The cycle predates this change — the surfaced path is:

```
lib/api.ts -> scenes/max/maxTypes -> revenue_analytics/revenueAnalyticsLogic -> queries/schema-guards -> queries/schema/schema-general -> TaxonomicFilter/types -> entityFilterLogic -> PropertyFilters/utils -> taxonomy/helpers -> surveys/surveyQuestionLabelsLogic -> lib/api
```

The edge from `lib/api.ts` into `maxTypes` was a value import even though `MaxUIContext` is only ever used in type position inside `api.ts`.

## Changes

Convert the import to `import type` so it gets erased at compile time and `import/no-cycle` skips that edge. Other suppressions for this same cycle already exist in `maxTypes.ts` and `revenueAnalyticsLogic.ts`; this change removes the need for a new suppression at the `api.ts` entry point.

## How did you test this code?

I'm an agent. I ran:

- `pnpm exec oxlint frontend/src/lib/api.ts` — before: 1 cycle error, after: 0 errors.
- `pnpm exec oxlint frontend/src/lib/api.ts frontend/src/scenes/max/maxTypes.ts products/revenue_analytics/frontend/revenueAnalyticsLogic.ts` — 0 errors across all three files in the cycle.

No manual UI testing — this is a type-only import change with no runtime behaviour difference.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code. Reproduced the cycle via `oxlint`, then chose `import type` over an `eslint-disable-next-line` suppression because the import is genuinely type-only and the existing suppressions on the other side of the cycle already document the runtime edge. No other call sites of `MaxUIContext` in `api.ts` needed changes (lines 6386 and 6431 are both type annotations).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
