### PR TITLE
chore(readme): add yolo marker at top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+yolo
+
 <p align="center">
   <img alt="posthoglogo" src="https://user-images.githubusercontent.com/65415371/205059737-c8a4f836-4889-4654-902e-f302b187b6a0.png">
 </p>


### PR DESCRIPTION
## Problem

Adds a `yolo` marker to the very top of the README per request.

## Changes

- Prepended `yolo` to `README.md` above the logo block.

## How did you test this code?

I'm an agent. No automated tests were run — the change is a single text addition to `README.md`.

## Publish to changelog?

do not publish to changelog

## Docs update

n/a

## 🤖 Agent context

- Tool used: PostHog Code (Claude Code agent).
- The user asked to add `yolo` to the README, then clarified placement should be "top". I added it as a single line above the existing centered logo block, preserving all other content unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*