### PR TITLE
chore(readme): add yolo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
   </a>
 </p>
 
+> yolo
+
 ## PostHog is an all-in-one, open source platform for building successful products
 
 [PostHog](https://posthog.com/) provides every tool you need to build a successful product including:


### PR DESCRIPTION
## Problem

Minor README tweak requested.

## Changes

Adds a short `yolo` blockquote to the top of `README.md`.

## How did you test this code?

I'm an agent. No automated tests were run — this is a documentation-only change to a markdown blockquote.

## Publish to changelog?

no

## Docs update

n/a — README-only change.

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- Decision: added the line as a blockquote (`> yolo`) directly above the main heading so it doesn't disrupt the existing heading structure or table-of-contents anchors.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*