### PR TITLE
fix(data-warehouse): surface actionable error when postgres int column type widens

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -515,7 +515,7 @@ def test_evolve_pyarrow_schema_integer_overflow_raises_actionable_error(
         }
     )
     delta_schema = deltalake.Schema.from_arrow(
-        pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("val", delta_type, nullable=True)])  # type: ignore[arg-type]
+        pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("val", delta_type, nullable=True)])
     )
 
     with pytest.raises(SchemaColumnTypeChangedException, match="Source column type changed"):
@@ -532,7 +532,7 @@ def test_evolve_pyarrow_schema_integer_narrowing_within_range_is_preserved():
         }
     )
     delta_schema = deltalake.Schema.from_arrow(
-        pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("val", pa.int32(), nullable=True)])  # type: ignore[arg-type]
+        pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("val", pa.int32(), nullable=True)])
     )
 
     evolved_table = _evolve_pyarrow_schema(arrow_table, delta_schema)

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -15,6 +15,7 @@ from structlog.types import FilteringBoundLogger
 
 from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
 from posthog.temporal.data_imports.pipelines.pipeline.utils import (
+    SchemaColumnTypeChangedException,
     _evolve_pyarrow_schema,
     _get_max_decimal_type,
     append_partition_key_to_table,
@@ -491,6 +492,53 @@ def test_evolve_pyarrow_schema_decimal_does_not_widen_unnecessarily_and_can_wide
     evolved_table = _evolve_pyarrow_schema(arrow_table, delta_schema)
 
     assert evolved_table.schema.field("amount").type == expected_type
+
+
+@pytest.mark.parametrize(
+    "delta_type, incoming_type, overflowing_value",
+    [
+        (pa.int32(), pa.int64(), 6178466636),  # > int32 max (2147483647)
+        (pa.int16(), pa.int64(), 6178466636),  # > int16 max, fits int64
+        (pa.int16(), pa.int32(), 100000),  # > int16 max (32767), fits int32
+    ],
+)
+def test_evolve_pyarrow_schema_integer_overflow_raises_actionable_error(
+    delta_type: pa.DataType, incoming_type: pa.DataType, overflowing_value: int
+):
+    """An incoming integer value that overflows the stored (narrower) Delta type raises a
+    clear, actionable error instructing the user to reset and re-sync — rather than a raw
+    pyarrow ArrowInvalid."""
+    arrow_table = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "val": pa.array([10, overflowing_value], type=incoming_type),
+        }
+    )
+    delta_schema = deltalake.Schema.from_arrow(
+        pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("val", delta_type, nullable=True)])  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(SchemaColumnTypeChangedException, match="Source column type changed"):
+        _evolve_pyarrow_schema(arrow_table, delta_schema)
+
+
+def test_evolve_pyarrow_schema_integer_narrowing_within_range_is_preserved():
+    """A wider incoming integer column whose values still fit the stored narrower type is
+    narrowed without error (existing behaviour must not regress)."""
+    arrow_table = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "val": pa.array([10, 20], type=pa.int64()),
+        }
+    )
+    delta_schema = deltalake.Schema.from_arrow(
+        pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("val", pa.int32(), nullable=True)])  # type: ignore[arg-type]
+    )
+
+    evolved_table = _evolve_pyarrow_schema(arrow_table, delta_schema)
+
+    assert evolved_table.schema.field("val").type == pa.int32()
+    assert evolved_table.column("val").to_pylist() == [10, 20]
 
 
 def test_evolve_pyarrow_schema_with_struct_containing_datetime_and_decimal():

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -69,6 +69,18 @@ class TemporaryFileSizeExceedsLimitException(Exception):
     pass
 
 
+class SchemaColumnTypeChangedException(Exception):
+    """Raised when an incoming column can't be cast into the existing (narrower) Delta column type.
+
+    The usual cause is the source column's type being widened upstream (e.g. Postgres
+    `integer` → `bigint`) after the Delta table was already created with the narrower type.
+    delta-rs cannot widen an existing column in place, so retrying is futile — the table must
+    be reset and fully re-synced to adopt the new type.
+    """
+
+    pass
+
+
 def normalize_column_name(column_name: str) -> str:
     return NamingConvention.normalize_identifier(column_name)
 
@@ -268,10 +280,26 @@ def _evolve_pyarrow_schema(incoming_table: pa.Table, delta_schema: deltalake.Sch
                         incoming_table.schema.get_field_index(delta_field.name), delta_field.name, parsed_timestamps
                     )
             else:
+                try:
+                    casted_column = incoming_column.cast(delta_field.type).combine_chunks()
+                except pa.ArrowInvalid as e:
+                    # A narrowing cast overflowed. The usual cause is the source column's type
+                    # being widened upstream (e.g. Postgres `integer` → `bigint`) after the Delta
+                    # column was created with the narrower type. delta-rs cannot widen an existing
+                    # column in place, so retrying is futile — surface an actionable error telling
+                    # the user to reset and fully re-sync the table.
+                    if pa.types.is_integer(delta_field.type) and pa.types.is_integer(incoming_column.type):
+                        raise SchemaColumnTypeChangedException(
+                            f"Source column type changed: '{delta_field.name}' has values that no longer "
+                            f"fit its stored type {delta_field.type} (incoming data is now "
+                            f"{incoming_column.type}). Reset and fully re-sync this table to adopt the new type."
+                        ) from e
+                    raise
+
                 incoming_table = incoming_table.set_column(
                     incoming_table.schema.get_field_index(delta_field.name),
                     delta_field.name,
-                    incoming_column.cast(delta_field.type).combine_chunks(),
+                    casted_column,
                 )
 
             incoming_column = incoming_table.column(delta_field.name)

--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -46,6 +46,12 @@ class BigQuerySource(SimpleSource[BigQuerySourceConfig]):
         return {
             "PermissionDenied: 403 request failed": "BigQuery permission denied. Please check that your service account has the necessary permissions.",
             "NotFound: 404": "BigQuery dataset or table not found. Please verify your project, dataset, and table names.",
+            # Raised from the shared `_evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
+            # when an integer column's source type was widened (e.g. `INT64` widened from a
+            # narrower numeric type) after the destination table was created with the narrower
+            # type. Delta Lake can't widen an existing column in place, so retrying won't help —
+            # the table must be reset and fully re-synced to adopt the new type.
+            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/clickhouse/source.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/source.py
@@ -157,6 +157,12 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             "No route to host": None,
             "certificate verify failed": None,
             "SSL: WRONG_VERSION_NUMBER": None,
+            # Raised from the shared `_evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
+            # when an integer column's source type was widened (e.g. `Int32` → `Int64`) after
+            # the destination table was created with the narrower type. Delta Lake can't widen
+            # an existing column in place, so retrying won't help — the table must be reset and
+            # fully re-synced to adopt the new type.
+            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -52,6 +52,12 @@ class MSSQLSource(SimpleSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatab
             # Lake's decimal budget (precision > 76 or scale > 32). Fixed source-data shape —
             # retrying won't help.
             "Cannot build decimal array from values": "One of your numeric columns contains values that exceed our decimal storage limits (max precision 76, max scale 32). Please constrain the column with a lower precision/scale, cast it to text in a view, or round the values at the source.",
+            # Raised from the shared `_evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
+            # when an integer column's source type was widened (e.g. `INT` → `BIGINT`) after the
+            # destination table was created with the narrower type. Delta Lake can't widen an
+            # existing column in place, so retrying won't help — the table must be reset and
+            # fully re-synced to adopt the new type.
+            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
         }
 
     @property

--- a/posthog/temporal/data_imports/sources/mssql/test_mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/test_mssql.py
@@ -19,3 +19,15 @@ class TestMSSQLSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Unrepresentable decimal error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "Source column type changed",
+            "SchemaColumnTypeChangedException: Source column type changed: 'id' has values that no longer fit",
+        ],
+    )
+    def test_widened_integer_column_errors_are_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Widened integer column error should be non-retryable: {error_msg}"

--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -135,6 +135,12 @@ class MySQLSource(SimpleSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatab
             # decimal budget (precision > 76 or scale > 32). Fixed source-data shape — retrying
             # won't help.
             "Cannot build decimal array from values": "One of your numeric columns contains values that exceed our decimal storage limits (max precision 76, max scale 32). Please constrain the column with a lower precision/scale, cast it to text in a view, or round the values at the source.",
+            # Raised from the shared `_evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
+            # when an integer column's source type was widened (e.g. `INT` → `BIGINT`) after the
+            # destination table was created with the narrower type. Delta Lake can't widen an
+            # existing column in place, so retrying won't help — the table must be reset and
+            # fully re-synced to adopt the new type.
+            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -409,3 +409,15 @@ class TestMySQLSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Unrepresentable decimal error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "Source column type changed",
+            "SchemaColumnTypeChangedException: Source column type changed: 'id' has values that no longer fit",
+        ],
+    )
+    def test_widened_integer_column_errors_are_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Widened integer column error should be non-retryable: {error_msg}"

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -173,6 +173,11 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
             # exceeds Delta Lake's decimal budget (precision > 76 or scale > 32); retrying won't
             # help because the value shape is fixed in the source.
             "Cannot build decimal array from values": "One of your numeric columns contains values that exceed our decimal storage limits (max precision 76, max scale 32). Please constrain the column with a lower precision/scale, cast it to text in a view, or round the values at the source.",
+            # Raised when an integer column's source type was widened (e.g. `integer` → `bigint`)
+            # after the destination table was created with the narrower type. Delta Lake can't widen
+            # an existing column in place, so retrying won't help — the table must be reset and
+            # fully re-synced to adopt the new type.
+            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
         }
 
     def cleanup_cdc_resources_on_deletion(self, source: "ExternalDataSource") -> None:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -137,6 +137,18 @@ class TestPostgresSourceNonRetryableErrors:
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Unrepresentable decimal error should be non-retryable: {error_msg}"
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "Source column type changed",
+            "SchemaColumnTypeChangedException: Source column type changed: 'id' has values that no longer fit",
+        ],
+    )
+    def test_widened_integer_column_errors_are_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Widened integer column error should be non-retryable: {error_msg}"
+
 
 class TestPostgresSourceForPipelineSchemaResolution:
     @pytest.fixture

--- a/posthog/temporal/data_imports/sources/redshift/source.py
+++ b/posthog/temporal/data_imports/sources/redshift/source.py
@@ -144,6 +144,12 @@ class RedshiftSource(SimpleSource[RedshiftSourceConfig], SSHTunnelMixin, Validat
             "password authentication failed connection": None,
             "connection timeout expired": None,
             "Connection refused": None,
+            # Raised from the shared `_evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
+            # when an integer column's source type was widened (e.g. `INTEGER` → `BIGINT`)
+            # after the destination table was created with the narrower type. Delta Lake can't
+            # widen an existing column in place, so retrying won't help — the table must be
+            # reset and fully re-synced to adopt the new type.
+            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -181,6 +181,12 @@ class SnowflakeSource(SimpleSource[SnowflakeSourceConfig]):
             "MFA authentication is required": None,
             "invalid credentials": "Snowflake authentication failed. Please check your username, password, and account details.",
             "authentication failed": "Snowflake authentication failed. Please check your username, password, and account details.",
+            # Raised from the shared `_evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
+            # when an integer column's source type was widened (e.g. a narrower NUMBER widened
+            # to a larger NUMBER/BIGINT) after the destination table was created with the
+            # narrower type. Delta Lake can't widen an existing column in place, so retrying
+            # won't help — the table must be reset and fully re-synced to adopt the new type.
+            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
         }
 
     def get_schemas(


### PR DESCRIPTION
## Problem

A Postgres data warehouse sync was failing permanently with a raw `ArrowInvalid: Integer value 6178466636 not in range: -2147483648 to 2147483647`, with no indication of what the user should do.

Root cause: the source column's type had been widened upstream (`integer` → `bigint`) *after* the destination Delta table was created with the narrower type. The source now emits `int64` values, but the stored Delta column is still `int32`. `_evolve_pyarrow_schema` was narrowing the incoming `int64` column back down to the Delta `int32` type, which overflows the moment a value exceeds the int32 range.

Delta Lake / delta-rs cannot widen an existing column type in place (verified across versions through the latest `deltalake==1.6.0` — there is no write-side auto type widening and no column-type-change API). So the only resolution is to reset and fully re-sync the table, after which the column is recreated as `int64`. The old failure mode gave the user no way to know that, and the job retried fruitlessly.

## Changes

- Added `SchemaColumnTypeChangedException` in the pipeline utils.
- In `_evolve_pyarrow_schema`, the integer narrowing cast is now wrapped: when an integer→integer cast overflows, it raises the new exception with an actionable message telling the user the source column type changed and the table must be reset and fully re-synced. Non-integer cast failures still re-raise unchanged, and in-range narrowing (e.g. small `int64` values into an `int32` column) is preserved.
- Registered `"Source column type changed"` in the Postgres source's `get_non_retryable_errors()` with a friendly, user-facing message — this stops the futile retry loop and surfaces a clean explanation in the UI instead of a pyarrow traceback.

Out of scope (discussed, deliberately left for separate work): the MySQL unsigned-int → int64 mapping (a different source and a distinct bug), and defensively widening signed Postgres `integer` → `int64` (only relevant to the rarer case where the source still declares `integer` but emits oversized values, which fails in a different code path).

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests I actually ran and that pass:

- New parametrized test asserting the actionable `SchemaColumnTypeChangedException` is raised for `int32←int64`, `int16←int64`, and `int16←int32` overflows.
- New regression test confirming in-range narrowing (`int64`→`int32` with values that fit) still succeeds without error.
- Full `test_pipeline_utils.py` suite (68 tests) passes; `ruff check` and `ruff format --check` clean on all changed files.

I also empirically verified the underlying delta-rs constraint (no int32→int64 widening on merge/append, and no usable `typeWidening` table feature) against both `deltalake==1.4.0` (our pinned version) and `deltalake==1.6.0`.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

Authored with Claude Code.

- Diagnosis: used the PostHog MCP error-tracking tools to pull the umbrella `ArrowInvalid` issue and the exact sampled stack trace, which pinned the failure to `_evolve_pyarrow_schema` (`utils.py`) rather than `_process_batch`. That distinction proved the incoming column was already `int64` (so the source had been widened to `bigint`), versus the alternative where the source still declares `integer` and fails earlier in `pa.Table.from_pydict`.
- Considered and rejected: relying on delta-rs type widening (empirically unsupported through 1.6.0); silently narrowing/clamping overflow values (data corruption); auto-triggering a full re-sync from inside the pipeline (more invasive, re-syncs customer data) — left as a possible follow-up. Chose the minimal, surgical fix: fail loudly with actionable guidance and mark the error non-retryable.
