### PR TITLE
fix(experiments): Send exposure event from prompt experiment snippets

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
+++ b/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
@@ -282,8 +282,9 @@ flag_key = "${flagKey}"
 
 # 1. Evaluate the flag and pull the variant payload — each variant carries its own
 #    {"prompt_name", "prompt_version"} payload set when the experiment was created.
-flags = posthog.evaluate_flags(distinct_id, flag_keys=[flag_key])
-payload = flags.get_flag_payload(flag_key)
+#    send_feature_flag_events=True emits the $feature_flag_called exposure event the
+#    experiment metric joins against — without it the results page stays blank.
+payload = posthog.get_feature_flag_payload(flag_key, distinct_id, send_feature_flag_events=True)
 if not payload:
     raise RuntimeError(f"No payload set for flag {flag_key}; was this experiment created via /create_from_prompt/?")
 if isinstance(payload, str):
@@ -332,8 +333,10 @@ const flagKey = '${flagKey}'
 
 // 1. Evaluate the flag and read the variant payload — each variant carries its own
 //    { prompt_name, prompt_version } payload set when the experiment was created.
-const flags = await posthog.evaluateFlags({ distinctId, flagKeys: [flagKey] })
-let payload = flags.getFlagPayload(flagKey)
+//    getFeatureFlagResult emits the $feature_flag_called exposure event the experiment
+//    metric joins against — without it the results page stays blank.
+const result = await posthog.getFeatureFlagResult(flagKey, distinctId)
+let payload = result?.payload
 if (!payload) {
     throw new Error(\`No payload set for flag \${flagKey}; was this experiment created via /create_from_prompt/?\`)
 }
@@ -388,9 +391,14 @@ What to do
 3. Find where the project makes LLM calls (route handler, service module, agent loop,
    background job — match the existing structure). For each LLM call, before invoking
    the model:
-   a) Evaluate the feature flag "${flagKey}" for the current user.
-   b) Read the variant's payload via the flag-payload API. Parse JSON if it returns a
-      string. Extract prompt_name and prompt_version.
+   a) Evaluate the feature flag "${flagKey}" for the current user, and make sure the
+      evaluation call also emits the $feature_flag_called exposure event (e.g. via
+      posthog.get_feature_flag_payload(..., send_feature_flag_events=True) in Python or
+      posthog.getFeatureFlagResult(...) in Node — without this event the experiment
+      metric has nothing to join the $ai_generation events against and the results
+      page stays blank).
+   b) Read the variant's payload from the evaluation result. Parse JSON if it returns
+      a string. Extract prompt_name and prompt_version.
    c) Use PostHog's prompt management API to fetch the prompt by name + version, then
       compile it. Pass the compiled prompt as the system message.
    d) Wrap the LLM client with PostHog's AI tracing wrapper (e.g. @posthog/ai for


### PR DESCRIPTION
## Problem

The Python and JS snippets shown after creating a prompt experiment don't send the `$feature_flag_called` event. Without it, the experiments won't work.

## Changes

Use feature-flag APIs that send the exposure event:
- Python: `get_feature_flag_payload(..., send_feature_flag_events=True)`
- JS: `getFeatureFlagResult(...)` (posthog-node's `getFeatureFlagPayload` hardcodes the exposure off)
- Agent prompt: one-line note about the exposure event

## How did you test this code?

Ran the Python snippet locally. 20 `$ai_generation` events paired with 20 `$feature_flag_called` events. Cost and Latency metrics populate per variant. JS not validated yet.

## 🤖 Agent context

Co-authored with Claude Code under @jurajmajerik's direction. Chose the deprecated one-liner over an explicit `posthog.capture('$feature_flag_called', ...)` to keep the snippet small. Both SDKs warn the chosen APIs are deprecated — replacing them is a follow-up.