### PR TITLE
fix(node): commit offsets for in-flight batches before partition revoke

### DIFF
--- a/nodejs/src/kafka/consumer/consumer-v2.test.ts
+++ b/nodejs/src/kafka/consumer/consumer-v2.test.ts
@@ -278,7 +278,7 @@ describe('KafkaConsumerV2', () => {
         expect(mockRdKafka.incrementalUnassign).toHaveBeenCalledWith([{ topic: 'test-topic', partition: 0 }])
     })
 
-    it('H2 regression: stale tasks across generations skip storeOffsets and never trigger unassign', async () => {
+    it('H2 regression: tasks completing within drain store offsets; reassign does not trigger stale stores', async () => {
         ;(consumer as any).maxBackgroundTasks = 5
         const eachBatch = jest.fn(() => Promise.resolve({}))
         await startConsuming(eachBatch)
@@ -295,9 +295,10 @@ describe('KafkaConsumerV2', () => {
         slow.resolve()
         await delay(20)
         expect(mockRdKafka.incrementalUnassign).toHaveBeenCalledTimes(1)
-        // The slow task crossed the rebalance generation — its storeOffsets MUST have been
-        // skipped (generation-tag mechanism). Validates the H2 protection directly.
-        expect(mockRdKafka.offsetsStore).not.toHaveBeenCalled()
+        // The slow task completed WITHIN drain — its storeOffsets ran before the post-drain
+        // generation bump, so librdkafka has the offset to commit as part of incrementalUnassign.
+        // This is the duplicate-reduction guarantee for the clean-drain case.
+        expect(mockRdKafka.offsetsStore).toHaveBeenCalledWith([{ topic: 'test-topic', partition: 0, offset: 2 }])
 
         // Snapshot offsetsStore + unassign call counts before the reassign so we can assert
         // nothing further happens once we re-acquire the partition.
@@ -318,16 +319,12 @@ describe('KafkaConsumerV2', () => {
 
     it('H3 regression: out-of-order task completion — drain awaits ALL settled before unassign', async () => {
         // The v1 H3 race was: drain awaited t.promise (raw), so the late task's storeOffsets
-        // could fire AFTER incrementalUnassign. v2 fixes this two ways:
-        //   (a) drain awaits the post-storeOffsets `settled` chain, not the raw task; and
-        //   (b) the generation tag in trackTask makes any storeOffsets call during DRAINING
-        //       a no-op (see the "Generation tag" test).
-        //
-        // (b) means we can't meaningfully assert offsetsStore-vs-unassign ordering during a
-        // REVOKE — storeOffsets simply never runs in that path. So this test verifies the
-        // (a) property directly: with two tasks resolving out of order, drainAll awaits both
-        // settled callbacks before incrementalUnassign fires. If drain awaited only `raw`,
-        // it could fire before the second task settled.
+        // could fire AFTER incrementalUnassign. v2 fixes this by awaiting the post-storeOffsets
+        // `settled` chain (not the raw task) and by only bumping `generation` AFTER drain — so
+        // tasks finishing within drain store their offsets cleanly, and only post-drain
+        // laggards (drain-timeout case) are fenced. This test verifies the ordering property:
+        // with two tasks resolving out of order, drainAll awaits both settled callbacks before
+        // incrementalUnassign fires.
         ;(consumer as any).maxBackgroundTasks = 5
         const eachBatch = jest.fn(() => Promise.resolve({}))
         await startConsuming(eachBatch)

--- a/nodejs/src/kafka/consumer/consumer-v2.ts
+++ b/nodejs/src/kafka/consumer/consumer-v2.ts
@@ -69,9 +69,11 @@ type TaskEntry = {
 
 /**
  * Single-coroutine Kafka consumer. The loop is the only mutator; the rebalance callback
- * just enqueues events. On REVOKE the loop synchronously drains in-flight settle promises
- * (post-storeOffsets, not raw user tasks), bumps `generation` so any laggard task skips
- * its now-invalid storeOffsets, then calls incrementalUnassign.
+ * just enqueues events. On REVOKE the loop drains in-flight settle promises (post-
+ * storeOffsets, not raw user tasks) — tasks that finish within drain still store their
+ * offsets, which librdkafka commits on incrementalUnassign. Only after drain returns do
+ * we bump `generation` so any laggard task (drain timeout case) skips its now-invalid
+ * storeOffsets, then call incrementalUnassign.
  */
 export class KafkaConsumerV2 {
     private rdKafkaConsumer: RdKafkaConsumer
@@ -412,13 +414,18 @@ export class KafkaConsumerV2 {
         }
 
         if (event.type === 'REVOKE') {
-            this.generation++
             logger.info('🔁', 'kafka_consumer_v2_revoke_starting', {
                 inFlight: this.inFlight.length,
                 generation: this.generation,
                 partitions: event.partitions.map((p) => `${p.topic}/${p.partition}`),
             })
+            // Drain BEFORE bumping generation. Tasks that finish within drain see the
+            // current generation, store their offsets, and librdkafka commits them as part
+            // of incrementalUnassign. Bumping after drain still fences any laggard task
+            // that crosses the drain timeout (Node is single-threaded, so the bump + unassign
+            // below run synchronously — no late storeOffsets can sneak in).
             await this.drainAll('revoke')
+            this.generation++
 
             try {
                 if (this.rdKafkaConsumer.rebalanceProtocol() === 'COOPERATIVE') {


### PR DESCRIPTION
## Problem

`KafkaConsumerV2`'s REVOKE handler bumps the rebalance generation *before* draining in-flight tasks. The drain awaits each in-flight `settled` promise, but the gen check inside each task's body now sees a bumped generation and skips its `storeOffsets` call — even though the partition is still ours (we haven't called `incrementalUnassign` yet).

The net effect: every cleanly-draining revoke leaves the in-flight batch's offsets uncommitted. When the partition reassigns, the new owner replays those messages, producing a duplicate spike during rolling deploys.


## Changes

Swap the order in `handleRebalanceEvent` for the REVOKE branch so the generation bump happens *after* `drainAll('revoke')` returns:

- Tasks that finish within drain see the current generation, store offsets normally, and librdkafka commits them as part of `incrementalUnassign` (standard `enable.auto.commit=true` behavior, same path v1 has relied on in production).
- Tasks that miss the drain window (drain timeout) still see the bumped generation and skip — Node's single-threaded execution guarantees the `bump → unassign` block runs atomically, so no late `storeOffsets` can sneak in for a now-unassigned partition.
- H2 test assertion flipped: the bridging task now stores its offset (the previous "must not be called" assertion encoded the implementation, not the safety property — the real invariant is "don't store for partitions you no longer own," which is preserved by the synchronous bump+unassign block).
- H3 test comment rewritten to reflect that `storeOffsets` does run for in-drain tasks.
- All other regression tests (H1, REVOKE drain, Drain timeout, Generation tag, etc.) pass unchanged.

## How did you test this code?

I'm an agent — I have not run the test suite end-to-end myself in CI. Locally José ran `hogli test nodejs/src/kafka/consumer/consumer-v2.test.ts` after fixing an unrelated `tsconfig.test.json` issue. The behavioral analysis covers the H1/H2/H3 regression scenarios plus drain timeout, multi-revoke, disconnect-during-drain, and predecessorSettled-chain edge cases. CI will run the full v2 suite including the integration tests.

## Publish to changelog?

no

## 🤖 Agent context

