### PR TITLE
fix(notebooks): auto-reconnect collab SSE and show warning

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4741,13 +4741,14 @@ const api = {
                 onMessage,
                 onError,
                 onOpen,
+                onClose,
                 signal,
                 lastEventId,
             }: {
                 onMessage: (data: EventSourceMessage) => void
                 onError: (error: any) => void
-                /** Fires on initial open and every time fetch-event-source successfully reconnects internally. */
                 onOpen?: () => void
+                onClose?: () => void
                 signal?: AbortSignal
                 /** Stream id of the last received event; sent as `Last-Event-ID` so the
                  *  server resumes from there instead of restarting at the stream tip. */
@@ -4760,6 +4761,7 @@ const api = {
                 onMessage,
                 onError,
                 onOpen,
+                onClose,
                 signal,
                 headers: lastEventId ? { 'Last-Event-ID': lastEventId } : undefined,
             })
@@ -6763,6 +6765,7 @@ const api = {
             onMessage,
             onError,
             onOpen,
+            onClose,
             headers,
             signal,
         }:
@@ -6775,6 +6778,9 @@ const api = {
                   /** Fires every time the underlying fetch returns a healthy response — i.e.
                    *  on initial open *and* on each successful internal reconnect by fetch-event-source. */
                   onOpen?: () => void
+                  /** Fires when the server cleanly closes the response body (not on errors,
+                   *  not on abort). Use this to react to server-initiated stream rotation. */
+                  onClose?: () => void
                   headers?: Record<string, string>
                   signal?: AbortSignal
               }
@@ -6785,6 +6791,7 @@ const api = {
                   onMessage: (data: EventSourceMessage) => void
                   onError: (error: any) => void
                   onOpen?: () => void
+                  onClose?: () => void
                   headers?: Record<string, string>
                   signal?: AbortSignal
               }
@@ -6855,6 +6862,7 @@ const api = {
             },
             onmessage: onMessage,
             onerror: onError,
+            onclose: onClose,
             // By default fetch-event-source stops connection when document is no longer focused, but that is not how
             // EventSource works normally, hence reverting (https://github.com/Azure/fetch-event-source/issues/36)
             openWhenHidden: true,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4740,15 +4740,29 @@ const api = {
             {
                 onMessage,
                 onError,
+                onOpen,
                 signal,
+                lastEventId,
             }: {
                 onMessage: (data: EventSourceMessage) => void
                 onError: (error: any) => void
+                /** Fires on initial open and every time fetch-event-source successfully reconnects internally. */
+                onOpen?: () => void
                 signal?: AbortSignal
+                /** Stream id of the last received event; sent as `Last-Event-ID` so the
+                 *  server resumes from there instead of restarting at the stream tip. */
+                lastEventId?: string
             }
         ): Promise<void> {
             const url = new ApiRequest().notebook(notebookId).withAction('collab/stream').assembleFullUrl(true)
-            await api.stream(url, { method: 'GET', onMessage, onError, signal })
+            await api.stream(url, {
+                method: 'GET',
+                onMessage,
+                onError,
+                onOpen,
+                signal,
+                headers: lastEventId ? { 'Last-Event-ID': lastEventId } : undefined,
+            })
         },
     },
 
@@ -6748,6 +6762,7 @@ const api = {
             data,
             onMessage,
             onError,
+            onOpen,
             headers,
             signal,
         }:
@@ -6757,6 +6772,9 @@ const api = {
                   data?: never
                   onMessage: (data: EventSourceMessage) => void
                   onError: (error: any) => void
+                  /** Fires every time the underlying fetch returns a healthy response — i.e.
+                   *  on initial open *and* on each successful internal reconnect by fetch-event-source. */
+                  onOpen?: () => void
                   headers?: Record<string, string>
                   signal?: AbortSignal
               }
@@ -6766,6 +6784,7 @@ const api = {
                   data: any
                   onMessage: (data: EventSourceMessage) => void
                   onError: (error: any) => void
+                  onOpen?: () => void
                   headers?: Record<string, string>
                   signal?: AbortSignal
               }
@@ -6824,11 +6843,14 @@ const api = {
                         )
                     )
                     abortController.abort()
-                } else if (isLivestreamUrl) {
-                    posthog.capture('livestream_sse_opened', {
-                        url,
-                        status: response.status,
-                    })
+                } else {
+                    onOpen?.()
+                    if (isLivestreamUrl) {
+                        posthog.capture('livestream_sse_opened', {
+                            url,
+                            status: response.status,
+                        })
+                    }
                 }
             },
             onmessage: onMessage,

--- a/frontend/src/scenes/notebooks/Notebook/NotebookMeta.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookMeta.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useCallback, useEffect, useState } from 'react'
 
-import { IconBook, IconTerminal } from '@posthog/icons'
+import { IconBook, IconTerminal, IconWarning } from '@posthog/icons'
 import { LemonButton, LemonButtonProps, LemonTag } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -12,6 +12,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 
 import { NotebookSyncStatus } from '../types'
+import { notebookCollabLogic } from './notebookCollabLogic'
 import { NotebookLogicProps, notebookLogic } from './notebookLogic'
 import { notebookSettingsLogic } from './notebookSettingsLogic'
 
@@ -86,6 +87,30 @@ export const NotebookSyncInfo = (props: NotebookLogicProps): JSX.Element | null 
             <LemonTag className="uppercase select-none">{content.content}</LemonTag>
         </Tooltip>
     ) : null
+}
+
+/**
+ * Surfaces when the collab SSE is currently disconnected, so the user knows live updates
+ * are paused. Stays hidden while the stream await is in flight — green check would just
+ * be noise for the steady-state case.
+ */
+export const NotebookCollabStatus = (props: NotebookLogicProps): JSX.Element | null => {
+    const { collabEnabled } = useValues(notebookLogic(props))
+    const { streamConnected, streamError } = useValues(notebookCollabLogic({ shortId: props.shortId }))
+
+    if (!collabEnabled || streamConnected) {
+        return null
+    }
+
+    const tooltip = streamError
+        ? `Live updates paused — reconnecting. Last error: ${streamError}`
+        : 'Live updates paused — reconnecting…'
+
+    return (
+        <Tooltip title={tooltip} placement="left">
+            <LemonButton size="small" icon={<IconWarning className="text-warning" />} type="tertiary" />
+        </Tooltip>
+    )
 }
 
 interface NotebookExpandButtonProps extends Pick<LemonButtonProps, 'size' | 'type'> {

--- a/frontend/src/scenes/notebooks/Notebook/NotebookMeta.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookMeta.tsx
@@ -102,9 +102,7 @@ export const NotebookCollabStatus = (props: NotebookLogicProps): JSX.Element | n
         return null
     }
 
-    const tooltip = streamError
-        ? `Live updates paused — reconnecting. Last error: ${streamError}`
-        : 'Live updates paused — reconnecting…'
+    const tooltip = streamError ? `Live updates paused. Last error: ${streamError}` : 'Live updates paused.'
 
     return (
         <Tooltip title={tooltip} placement="left">

--- a/frontend/src/scenes/notebooks/Notebook/NotebookMeta.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookMeta.tsx
@@ -90,15 +90,15 @@ export const NotebookSyncInfo = (props: NotebookLogicProps): JSX.Element | null 
 }
 
 /**
- * Surfaces when the collab SSE is currently disconnected, so the user knows live updates
- * are paused. Stays hidden while the stream await is in flight — green check would just
- * be noise for the steady-state case.
+ * Surfaces when the collab SSE is disconnected *and* no reconnect attempt is in flight,
+ * so the user only sees the warning when something is actually wrong — not during the
+ * initial connect or the brief gap on a normal reconnect.
  */
 export const NotebookCollabStatus = (props: NotebookLogicProps): JSX.Element | null => {
     const { collabEnabled } = useValues(notebookLogic(props))
-    const { streamConnected, streamError } = useValues(notebookCollabLogic({ shortId: props.shortId }))
+    const { streamConnected, isConnecting, streamError } = useValues(notebookCollabLogic({ shortId: props.shortId }))
 
-    if (!collabEnabled || streamConnected) {
+    if (!collabEnabled || streamConnected || isConnecting) {
         return null
     }
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -119,6 +119,7 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
             {
                 connectStream: () => true,
                 streamOpened: () => false,
+                streamClosed: () => false,
                 disconnectStream: () => false,
             },
         ],
@@ -279,7 +280,6 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                 }
                 actions.streamClosed(e instanceof Error ? e.message : String(e))
                 posthog.captureException(e as Error, { action: 'notebook collab stream open' })
-                actions.connectStream()
             }
         },
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -2,6 +2,8 @@ import { EventSourceMessage } from '@microsoft/fetch-event-source'
 import { getVersion, receiveTransaction } from '@tiptap/pm/collab'
 import { Step } from '@tiptap/pm/transform'
 import { actions, beforeUnmount, kea, key, listeners, path, props, reducers } from 'kea'
+
+const RECONNECT_DELAY_MS = 1000
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
@@ -92,6 +94,8 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
         rebaseFailed: (params: { localContent: JSONContent; localText: string }) => params,
         connectStream: true,
         disconnectStream: true,
+        streamOpened: true,
+        streamClosed: (error: string | null = null) => ({ error }),
     }),
 
     reducers({
@@ -104,6 +108,24 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
         ],
         // Stable per-logic clientID; shared with the PM collab plugin for self-event filtering.
         clientID: [uuid() as string, {}],
+        // Optimistic: true while the SSE await is in flight. Flips false on close/error so
+        // the UI can show a "live updates paused" indicator during the brief reconnect gap.
+        streamConnected: [
+            false,
+            {
+                streamOpened: () => true,
+                streamClosed: () => false,
+                disconnectStream: () => false,
+            },
+        ],
+        streamError: [
+            null as string | null,
+            {
+                streamOpened: () => null,
+                streamClosed: (_, { error }) => error,
+                disconnectStream: () => null,
+            },
+        ],
     }),
 
     listeners(({ actions, values, props, cache }) => ({
@@ -159,6 +181,7 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
 
         connectStream: async () => {
             cache.abortController?.abort()
+            cache.disposables.dispose('reconnectTimer')
             const controller = new AbortController()
             cache.abortController = controller
 
@@ -168,6 +191,7 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                 }
                 // SSE id is the Redis stream id `N-0` and N is the prosemirror version.
                 // We use it for both reconnection (Last-Event-ID) and idempotency.
+                cache.lastEventId = msg.id
                 const version = parseInt(msg.id.split('-', 1)[0], 10)
                 if (!Number.isFinite(version)) {
                     return
@@ -209,29 +233,65 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                 if (controller.signal.aborted) {
                     return
                 }
-                posthog.captureException(error instanceof Error ? error : new Error(String(error)), {
+                const message = error instanceof Error ? error.message : String(error)
+                actions.streamClosed(message)
+                posthog.captureException(error instanceof Error ? error : new Error(message), {
                     action: 'notebook collab stream',
                 })
             }
 
-            // fetchEventSource handles reconnection via Last-Event-ID; this awaits for the connection's lifetime.
+            // The await runs for the connection's lifetime. fetch-event-source retries
+            // internal errors on its own, but resolves silently when the server closes the
+            // body cleanly — which the backend does every STREAM_LIFETIME_SECONDS (5 min)
+            // by design. We have to schedule the reconnect ourselves, passing the last
+            // seen event id so the resumed stream picks up where this one left off.
+            // onOpen fires on every successful fetch — including fetch-event-source's
+            // internal retries — so the UI flips back to "live" once we're reconnected.
+            const onOpen = (): void => {
+                if (controller.signal.aborted) {
+                    return
+                }
+                actions.streamOpened()
+            }
             try {
                 await api.notebooks.collabStream(props.shortId, {
                     onMessage,
                     onError,
+                    onOpen,
                     signal: controller.signal,
+                    lastEventId: cache.lastEventId,
                 })
             } catch (e) {
                 if (controller.signal.aborted) {
                     return
                 }
+                actions.streamClosed(e instanceof Error ? e.message : String(e))
                 posthog.captureException(e as Error, { action: 'notebook collab stream open' })
             }
+
+            if (controller.signal.aborted) {
+                return
+            }
+
+            actions.streamClosed()
+
+            // pauseOnPageHidden: false so a server-side lifetime cap that hits while the tab
+            // is backgrounded still triggers a reconnect — the underlying SSE uses
+            // openWhenHidden: true and is expected to stay live regardless of visibility.
+            cache.disposables.add(
+                () => {
+                    const id = window.setTimeout(() => actions.connectStream(), RECONNECT_DELAY_MS)
+                    return () => window.clearTimeout(id)
+                },
+                'reconnectTimer',
+                { pauseOnPageHidden: false }
+            )
         },
 
         disconnectStream: () => {
             cache.abortController?.abort()
             cache.abortController = null
+            cache.disposables.dispose('reconnectTimer')
         },
     })),
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -286,6 +286,7 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
         disconnectStream: () => {
             cache.abortController?.abort()
             cache.abortController = null
+            cache.lastEventId = undefined
         },
     })),
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -2,8 +2,6 @@ import { EventSourceMessage } from '@microsoft/fetch-event-source'
 import { getVersion, receiveTransaction } from '@tiptap/pm/collab'
 import { Step } from '@tiptap/pm/transform'
 import { actions, beforeUnmount, kea, key, listeners, path, props, reducers } from 'kea'
-
-const RECONNECT_DELAY_MS = 1000
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
@@ -108,13 +106,19 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
         ],
         // Stable per-logic clientID; shared with the PM collab plugin for self-event filtering.
         clientID: [uuid() as string, {}],
-        // Optimistic: true while the SSE await is in flight. Flips false on close/error so
-        // the UI can show a "live updates paused" indicator during the brief reconnect gap.
         streamConnected: [
             false,
             {
                 streamOpened: () => true,
                 streamClosed: () => false,
+                disconnectStream: () => false,
+            },
+        ],
+        isConnecting: [
+            false,
+            {
+                connectStream: () => true,
+                streamOpened: () => false,
                 disconnectStream: () => false,
             },
         ],
@@ -181,7 +185,6 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
 
         connectStream: async () => {
             cache.abortController?.abort()
-            cache.disposables.dispose('reconnectTimer')
             const controller = new AbortController()
             cache.abortController = controller
 
@@ -240,24 +243,33 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                 })
             }
 
-            // The await runs for the connection's lifetime. fetch-event-source retries
-            // internal errors on its own, but resolves silently when the server closes the
-            // body cleanly — which the backend does every STREAM_LIFETIME_SECONDS (5 min)
-            // by design. We have to schedule the reconnect ourselves, passing the last
-            // seen event id so the resumed stream picks up where this one left off.
-            // onOpen fires on every successful fetch — including fetch-event-source's
-            // internal retries — so the UI flips back to "live" once we're reconnected.
+            // onOpen fires on every successful fetch — including fetch-event-source's own
+            // internal retries — so the UI flips back to "live" the moment a connection
+            // opens, whether it's the initial one or a recovery after a transient error.
             const onOpen = (): void => {
                 if (controller.signal.aborted) {
                     return
                 }
                 actions.streamOpened()
             }
+
+            // onClose fires when the server cleanly ends the body — the backend does this
+            // every STREAM_LIFETIME_SECONDS (5 min) by design. Errors and abort don't trigger
+            // this hook, so it cleanly isolates the "rotation" case from the failure case.
+            const onClose = (): void => {
+                if (controller.signal.aborted) {
+                    return
+                }
+                actions.streamClosed()
+                actions.connectStream()
+            }
+
             try {
                 await api.notebooks.collabStream(props.shortId, {
                     onMessage,
                     onError,
                     onOpen,
+                    onClose,
                     signal: controller.signal,
                     lastEventId: cache.lastEventId,
                 })
@@ -267,31 +279,13 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                 }
                 actions.streamClosed(e instanceof Error ? e.message : String(e))
                 posthog.captureException(e as Error, { action: 'notebook collab stream open' })
+                actions.connectStream()
             }
-
-            if (controller.signal.aborted) {
-                return
-            }
-
-            actions.streamClosed()
-
-            // pauseOnPageHidden: false so a server-side lifetime cap that hits while the tab
-            // is backgrounded still triggers a reconnect — the underlying SSE uses
-            // openWhenHidden: true and is expected to stay live regardless of visibility.
-            cache.disposables.add(
-                () => {
-                    const id = window.setTimeout(() => actions.connectStream(), RECONNECT_DELAY_MS)
-                    return () => window.clearTimeout(id)
-                },
-                'reconnectTimer',
-                { pauseOnPageHidden: false }
-            )
         },
 
         disconnectStream: () => {
             cache.abortController?.abort()
             cache.abortController = null
-            cache.disposables.dispose('reconnectTimer')
         },
     })),
 

--- a/frontend/src/scenes/notebooks/NotebookPanel/NotebookPanel.tsx
+++ b/frontend/src/scenes/notebooks/NotebookPanel/NotebookPanel.tsx
@@ -16,7 +16,7 @@ import { SidePanelContentContainer } from '~/layout/navigation-3000/sidepanel/Si
 import { Notebook } from '../Notebook/Notebook'
 import { NotebookListMini } from '../Notebook/NotebookListMini'
 import { notebookLogic } from '../Notebook/notebookLogic'
-import { NotebookExpandButton, NotebookSyncInfo } from '../Notebook/NotebookMeta'
+import { NotebookCollabStatus, NotebookExpandButton, NotebookSyncInfo } from '../Notebook/NotebookMeta'
 import { NotebookMenu } from '../NotebookMenu'
 import { NotebookTarget } from '../types'
 import { NotebookPanelDropzone } from './NotebookPanelDropzone'
@@ -49,7 +49,12 @@ export function NotebookPanel(): JSX.Element | null {
                                     buttonProps={{ className: 'max-w-[120px]', truncate: true }}
                                 />
 
-                                {selectedNotebook && <NotebookSyncInfo shortId={selectedNotebook} />}
+                                {selectedNotebook && (
+                                    <>
+                                        <NotebookCollabStatus shortId={selectedNotebook} />
+                                        <NotebookSyncInfo shortId={selectedNotebook} />
+                                    </>
+                                )}
                             </div>
 
                             <div className="flex-1" />

--- a/frontend/src/scenes/notebooks/NotebookScene.tsx
+++ b/frontend/src/scenes/notebooks/NotebookScene.tsx
@@ -18,6 +18,7 @@ import { Notebook } from './Notebook/Notebook'
 import { NotebookLoadingState } from './Notebook/NotebookLoadingState'
 import { notebookLogic } from './Notebook/notebookLogic'
 import {
+    NotebookCollabStatus,
     NotebookExpandButton,
     NotebookKernelInfoButton,
     NotebookSyncInfo,
@@ -124,6 +125,7 @@ export function NotebookScene(): JSX.Element {
                 </div>
 
                 <div className="flex gap-2 items-center">
+                    <NotebookCollabStatus shortId={notebookId} />
                     <NotebookSyncInfo shortId={notebookId} />
 
                     <NotebookMenu shortId={notebookId} />


### PR DESCRIPTION
## Problem

The notebook collab SSE has a server-side lifetime cap (similar to livestream service) — the backend closes the connection every 5 minutes (`STREAM_LIFETIME_SECONDS`) by design, so workers can be cleanly rotated. 
But the client doesn't reconnect after that close: `fetch-event-source` only auto-retries on errors, so users silently lose live updates from collaborators after 5 minutes. There is also no UI warning that the stream is down.

## Changes

<img width="589" height="132" alt="Screenshot 2026-05-21 at 21 45 39" src="https://github.com/user-attachments/assets/17bfca26-6713-48d9-b1fb-4578a9667239" />

- **Detect server rotation explicitly** via `fetch-event-source`'s `onclose` hook (wired through `api.stream` → `api.notebooks.collabStream`). On clean close we dispatch `streamClosed()` + `connectStream()` immediately, passing the cached `Last-Event-ID` so the resumed stream picks up where it left off without replaying or missing steps. The errors path is unchanged — `fetch-event-source` already retries those internally.
- **`onOpen` callback** also wired through, firing on initial open and every internal reconnect, so the UI flips back to "live" as soon as a connection opens.
- **`NotebookCollabStatus` indicator** — small warning icon (with tooltip) that surfaces *only* when we've genuinely given up. Suppressed during the initial connect and the brief gap between rotations so it never flashes.
- **`streamConnected` / `isConnecting` / `streamError` reducers** added to `notebookCollabLogic` for the UI to key off.

## How did you test this code?

Through chrome-devtools-mcp:

1. Opened the notebook and confirmed the initial `GET /collab/stream` request opened and emitted `: keepalive` comments.
2. Waited ~5 minutes without touching the tab. At exactly 5m1s the stream rotated automatically — a second `GET /collab/stream` request fired on its own with no user interaction.
3. Opened the same notebook in a second tab and typed edits there. The first tab's stream started receiving `event: step` payloads with monotonic Redis stream ids (`id: 921-0`, `922-0`, …) — confirming `cache.lastEventId` is now populated for future rotations.
4. Verified no notebook collab errors in the browser console and no warning icon in the UI during normal operation.