### PR TITLE
chore(propvals): part 5: wire property-vals-rs into local hogli stack

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -287,6 +287,16 @@ procs:
             layer: Ingestion pipeline
             tech: Rust
 
+    property-vals-rs:
+        shell: |-
+            bin/wait-for-docker && \
+            bin/start-rust-service property-vals-rs
+        capability: property_values
+        ready_pattern: 'HTTP server starting'
+        groups:
+            layer: Ingestion pipeline
+            tech: Rust
+
     capture:
         shell: |-
             bin/wait-for-docker && \

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -292,7 +292,7 @@ procs:
             bin/wait-for-docker && \
             bin/start-rust-service property-vals-rs
         capability: property_values
-        ready_pattern: 'HTTP server starting'
+        ready_pattern: 'Subscribed to topic: *'
         groups:
             layer: Ingestion pipeline
             tech: Rust

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -38,6 +38,15 @@ case "$RS_SVC" in
     export DEBUG=1
     ;;
 
+  property-vals-rs)
+    export RUST_LOG=debug,rdkafka=warn
+    export RUST_BACKTRACE=1
+    export KAFKA_HOSTS="$DEFAULT_KAFKA"
+    export BIND_PORT=3303 # avoid local-dev clashes on 3302 (cymbal) and the property-defs-rs default
+    export KAFKA_CONSUMER_OFFSET_RESET=earliest
+    export DEBUG=1
+    ;;
+
   capture)
     SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -214,7 +214,7 @@ capabilities:
 intents:
     product_analytics:
         description: 'Core product analytics (insights, funnels, trends)'
-        capabilities: [event_ingestion, property_definitions, celery_workers, nodejs_cdp]
+        capabilities: [event_ingestion, property_definitions, property_values, celery_workers, nodejs_cdp]
 
     error_tracking:
         description: 'Track and analyze application errors'
@@ -224,6 +224,7 @@ intents:
                 error_symbolication,
                 embedding_service,
                 property_definitions,
+                property_values,
                 nodejs_cdp,
                 nodejs_error_tracking,
             ]
@@ -235,6 +236,7 @@ intents:
                 event_ingestion,
                 replay_storage,
                 property_definitions,
+                property_values,
                 celery_workers,
                 temporal_workflows,
                 nodejs_session_replay,
@@ -252,6 +254,7 @@ intents:
                 event_ingestion,
                 flag_evaluation,
                 property_definitions,
+                property_values,
                 celery_workers,
                 nodejs_feature_flags,
                 nodejs_cdp,
@@ -267,31 +270,56 @@ intents:
                 ai_capture,
                 llm_gateway,
                 property_definitions,
+                property_values,
                 temporal_workflows,
                 llm_analytics_sentiment,
             ]
 
     web_analytics:
         description: 'Web analytics, traffic analysis, and heatmaps'
-        capabilities: [event_ingestion, replay_storage, property_definitions, livestream]
+        capabilities: [event_ingestion, replay_storage, property_definitions, property_values, livestream]
 
     surveys:
         description: 'User surveys and feedback collection'
-        capabilities: [event_ingestion, property_definitions, celery_workers, celery_scheduler, nodejs_cdp]
+        capabilities:
+            [event_ingestion, property_definitions, property_values, celery_workers, celery_scheduler, nodejs_cdp]
 
     data_warehouse:
         description: 'Data warehouse queries and saved queries'
         capabilities:
-            [event_ingestion, property_definitions, celery_workers, temporal_workflows, warehouse_webhook_sink]
+            [
+                event_ingestion,
+                property_definitions,
+                property_values,
+                celery_workers,
+                temporal_workflows,
+                warehouse_webhook_sink,
+            ]
 
     cohorts:
         description: 'User cohort management'
-        capabilities: [event_ingestion, property_definitions, celery_workers, celery_scheduler, nodejs_realtime_cohorts]
+        capabilities:
+            [
+                event_ingestion,
+                property_definitions,
+                property_values,
+                celery_workers,
+                celery_scheduler,
+                nodejs_realtime_cohorts,
+            ]
 
     pipelines:
         description: 'Data pipeline transformations and destinations'
         capabilities:
-            [event_ingestion, property_definitions, celery_workers, temporal_workflows, nodejs_cdp_workflows, cyclotron]
+            [
+                event_ingestion,
+                property_definitions,
+                property_values,
+                celery_workers,
+                temporal_workflows,
+                nodejs_cdp_workflows,
+                cyclotron,
+            ]
 
     ai_features:
         description: 'AI features'
@@ -302,20 +330,30 @@ intents:
                 embedding_service,
                 opensearch_search,
                 property_definitions,
+                property_values,
                 temporal_workflows,
             ]
 
     logs:
         description: 'Log aggregation and viewing'
-        capabilities: [event_ingestion, property_definitions, logs_ingestion, nodejs_logs, nodejs_traces]
+        capabilities:
+            [event_ingestion, property_definitions, property_values, logs_ingestion, nodejs_logs, nodejs_traces]
 
     metrics:
         description: 'Metric ingestion and viewing'
-        capabilities: [event_ingestion, property_definitions, logs_ingestion, nodejs_metrics]
+        capabilities: [event_ingestion, property_definitions, property_values, logs_ingestion, nodejs_metrics]
 
     workflows:
         description: 'Workflow automation and orchestration'
-        capabilities: [event_ingestion, property_definitions, temporal_workflows, nodejs_cdp_workflows, cyclotron]
+        capabilities:
+            [
+                event_ingestion,
+                property_definitions,
+                property_values,
+                temporal_workflows,
+                nodejs_cdp_workflows,
+                cyclotron,
+            ]
 
     tracing:
         description: 'OpenTelemetry tracing with Jaeger UI'
@@ -339,11 +377,13 @@ intents:
 
     endpoints:
         description: 'Endpoints (the product)'
-        capabilities: [event_ingestion, property_definitions, celery_workers, temporal_workflows, duckgres]
+        capabilities:
+            [event_ingestion, property_definitions, property_values, celery_workers, temporal_workflows, duckgres]
 
     revenue_analytics:
         description: 'Mock Stripe API with seed billing data for revenue analytics testing'
-        capabilities: [event_ingestion, property_definitions, celery_workers, temporal_workflows, stripe_mock]
+        capabilities:
+            [event_ingestion, property_definitions, property_values, celery_workers, temporal_workflows, stripe_mock]
 
     dagster:
         description: 'Dagster for clickhouse maintenance, system workflows'

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -28,6 +28,11 @@ capabilities:
         requires: [event_ingestion]
         docker_profiles: []
 
+    property_values:
+        description: 'Aggregate distinct property values for autocomplete'
+        requires: [event_ingestion]
+        docker_profiles: []
+
     replay_storage:
         description: 'Session replay blob storage and capture'
         requires: [event_ingestion]


### PR DESCRIPTION
## Problem

property-vals-rs is not part of the local dev stack.

## Changes

Register the service the same way `property-defs-rs` is registered, in three places:

- `bin/start-rust-service` — adds a `property-vals-rs)` case so the launcher knows what env vars to export when the dev orchestrator asks it to run the service (Kafka host, log level, port 3303 to avoid the 3302 clash with cymbal, `KAFKA_CONSUMER_OFFSET_RESET=earliest`).
- `bin/mprocs.yaml` — adds the process entry that the dev orchestrator uses to actually launch it.
- `devenv/intent-map.yaml` — declares a new `property_values` capability and adds it to every intent that already pulls in `property_definitions`. Taxonomic keys (property-defs-rs) and values (property-vals-rs) both back autocomplete, so they should always run together.

The local ClickHouse side already works: `docker/clickhouse/config.d/default.xml` defines the `warpstream_ingestion` named collection pointing at `KAFKA_HOSTS`, so the kafka engine table from part 1 is functional locally.

## How did you test this code?

Ran `hogli start` against the local stack with this branch checked out, confirmed property-vals-rs starts and reaches the ready state. Posted an event through capture and confirmed it lands in `property_values` within one flush window; posted a `$groupidentify` and confirmed it lands as a `group_*` row.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code.

Considered: adding `property_values` only to a few intents to minimize blast radius. Rejected because every intent that includes `property_definitions` is a place where autocomplete is relevant; not pairing them creates partial state where property keys show but values don't. The right boundary is "wherever property_definitions runs, property_values runs too."
