### PR TITLE
feat(cymbal): add symbol cache warming

### DIFF
--- a/rust/common/symbol_data/src/lib.rs
+++ b/rust/common/symbol_data/src/lib.rs
@@ -9,8 +9,10 @@ pub use error::Error as SymbolDataError;
 // The core data type
 pub use symbol_data::read_as as read_symbol_data;
 pub use symbol_data::read_as_with_byte_count as read_symbol_data_with_byte_count;
+pub use symbol_data::sniff_data_type;
 pub use symbol_data::write as write_symbol_data;
 pub use symbol_data::write_uncompressed as write_symbol_data_uncompressed;
+pub use symbol_data::SymbolDataType;
 
 // Javascript
 pub use data_types::sourcemap::SourceAndMap;

--- a/rust/common/symbol_data/src/symbol_data.rs
+++ b/rust/common/symbol_data/src/symbol_data.rs
@@ -14,6 +14,31 @@ pub enum SymbolDataType {
     AppleDsym = 5,
 }
 
+impl TryFrom<u32> for SymbolDataType {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            2 => Ok(SymbolDataType::SourceAndMap),
+            3 => Ok(SymbolDataType::HermesMap),
+            4 => Ok(SymbolDataType::ProguardMapping),
+            5 => Ok(SymbolDataType::AppleDsym),
+            other => Err(Error::InvalidDataType(other, "any".to_string())),
+        }
+    }
+}
+
+/// Reads the type discriminator from a `posthog_symbol_data` byte slice without
+/// performing decompression or deserialization. The type field sits at the same
+/// offset in both v1 and v2 formats, after the magic bytes and version.
+pub fn sniff_data_type(data: &[u8]) -> Result<SymbolDataType, Error> {
+    let type_offset = MAGIC.len() + 4;
+    assert_at_least_as_long_as(type_offset + 4, data.len())?;
+    assert_has_magic(data)?;
+    let raw = u32::from_le_bytes(data[type_offset..type_offset + 4].try_into().unwrap());
+    SymbolDataType::try_from(raw)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Compression {

--- a/rust/common/symbol_data/tests/test.rs
+++ b/rust/common/symbol_data/tests/test.rs
@@ -1,6 +1,6 @@
 use posthog_symbol_data::{
     read_symbol_data, sniff_data_type, write_symbol_data, write_symbol_data_uncompressed,
-    HermesMap, ProguardMapping, SourceAndMap, SymbolDataType,
+    AppleDsym, HermesMap, ProguardMapping, SourceAndMap, SymbolDataType,
 };
 
 const MAGIC_LEN: usize = b"posthog_error_tracking".len();
@@ -108,19 +108,39 @@ fn test_v2_compressed_large_payload() {
 
 #[test]
 fn test_sniff_data_type() {
-    let sourcemap = write_symbol_data(SourceAndMap {
-        minified_source: "minified_source".to_string(),
-        sourcemap: "sourcemap".to_string(),
-    })
-    .unwrap();
-    let hermes = write_symbol_data(HermesMap {
-        sourcemap: "hermes map data".to_string(),
-    })
-    .unwrap();
+    let cases = [
+        (
+            SymbolDataType::SourceAndMap,
+            write_symbol_data(SourceAndMap {
+                minified_source: "minified_source".to_string(),
+                sourcemap: "sourcemap".to_string(),
+            })
+            .unwrap(),
+        ),
+        (
+            SymbolDataType::HermesMap,
+            write_symbol_data(HermesMap {
+                sourcemap: "hermes map data".to_string(),
+            })
+            .unwrap(),
+        ),
+        (
+            SymbolDataType::ProguardMapping,
+            write_symbol_data(ProguardMapping {
+                content: "proguard mapping data".to_string(),
+            })
+            .unwrap(),
+        ),
+        (
+            SymbolDataType::AppleDsym,
+            write_symbol_data(AppleDsym {
+                data: b"dsym data".to_vec(),
+            })
+            .unwrap(),
+        ),
+    ];
 
-    assert_eq!(
-        sniff_data_type(&sourcemap).unwrap(),
-        SymbolDataType::SourceAndMap
-    );
-    assert_eq!(sniff_data_type(&hermes).unwrap(), SymbolDataType::HermesMap);
+    for (expected_type, data) in cases {
+        assert_eq!(sniff_data_type(&data).unwrap(), expected_type);
+    }
 }

--- a/rust/common/symbol_data/tests/test.rs
+++ b/rust/common/symbol_data/tests/test.rs
@@ -1,6 +1,6 @@
 use posthog_symbol_data::{
-    read_symbol_data, write_symbol_data, write_symbol_data_uncompressed, HermesMap,
-    ProguardMapping, SourceAndMap,
+    read_symbol_data, sniff_data_type, write_symbol_data, write_symbol_data_uncompressed,
+    HermesMap, ProguardMapping, SourceAndMap, SymbolDataType,
 };
 
 const MAGIC_LEN: usize = b"posthog_error_tracking".len();
@@ -104,4 +104,23 @@ fn test_v2_compressed_large_payload() {
 
     let output = read_symbol_data::<SourceAndMap>(&bytes).unwrap();
     assert_eq!(input, output);
+}
+
+#[test]
+fn test_sniff_data_type() {
+    let sourcemap = write_symbol_data(SourceAndMap {
+        minified_source: "minified_source".to_string(),
+        sourcemap: "sourcemap".to_string(),
+    })
+    .unwrap();
+    let hermes = write_symbol_data(HermesMap {
+        sourcemap: "hermes map data".to_string(),
+    })
+    .unwrap();
+
+    assert_eq!(
+        sniff_data_type(&sourcemap).unwrap(),
+        SymbolDataType::SourceAndMap
+    );
+    assert_eq!(sniff_data_type(&hermes).unwrap(), SymbolDataType::HermesMap);
 }

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -4,7 +4,10 @@ use health::HealthRegistry;
 use moka::future::{Cache, CacheBuilder};
 use rdkafka::producer::FutureProducer;
 use sqlx::{postgres::PgPoolOptions, PgPool};
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{atomic::AtomicBool, Arc},
+    time::Duration,
+};
 use tokio::sync::{Mutex, Semaphore};
 use tracing::info;
 use uuid::Uuid;
@@ -50,6 +53,9 @@ pub struct AppContext {
     // itself, so suppression / reopen always see current PG state (see `IssueLinker`).
     // moka caches are cheap to clone (internally Arc'd).
     pub issue_cache: Cache<(TeamId, String), Uuid>,
+    pub ss_cache: Arc<Mutex<SymbolSetCache>>,
+    pub s3_client: Arc<dyn BlobClient>,
+    pub cache_warmed: Arc<AtomicBool>,
 }
 
 impl AppContext {
@@ -210,6 +216,8 @@ impl AppContext {
             .time_to_live(Duration::from_secs(config.issue_cache_ttl_seconds))
             .build();
 
+        let cache_warmed = Arc::new(AtomicBool::new(!config.cache_warming_enabled));
+
         Ok(Self {
             health_registry,
             immediate_producer,
@@ -224,6 +232,9 @@ impl AppContext {
             signal_client,
             symbol_resolver,
             issue_cache,
+            ss_cache,
+            s3_client,
+            cache_warmed,
         })
     }
 }

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -178,6 +178,22 @@ pub struct Config {
 
     #[envconfig(default = "")]
     pub internal_api_secret: String,
+
+    // Cache warming pre-populates the symbol set cache from recently used DB records on startup.
+    #[envconfig(default = "true")]
+    pub cache_warming_enabled: bool,
+
+    #[envconfig(default = "1")]
+    pub cache_warming_lookback_hours: u64,
+
+    #[envconfig(default = "10000")]
+    pub cache_warming_max_entries: usize,
+
+    #[envconfig(default = "32")]
+    pub cache_warming_concurrency: usize,
+
+    #[envconfig(default = "180")]
+    pub cache_warming_timeout_seconds: u64,
 }
 
 impl Config {

--- a/rust/cymbal/src/main.rs
+++ b/rust/cymbal/src/main.rs
@@ -1,6 +1,9 @@
-use std::sync::Arc;
+use std::sync::{atomic::Ordering, Arc};
 
-use cymbal::{app_context::AppContext, config::Config, server::start_server};
+use cymbal::{
+    app_context::AppContext, config::Config, server::start_server,
+    symbol_store::warming::warm_cache,
+};
 use tracing::level_filters::LevelFilter;
 use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
@@ -55,5 +58,27 @@ async fn main() {
 
     let context = Arc::new(AppContext::from_config(&config).await.unwrap());
 
-    start_server(config.clone(), context.clone()).await;
+    // Start the HTTP server before warming so liveness probes keep passing.
+    // Readiness stays closed until warming finishes or fails.
+    let server_handle = tokio::spawn(start_server(config.clone(), context.clone()));
+
+    if config.cache_warming_enabled {
+        info!("Starting cache warming");
+        if let Err(error) = warm_cache(
+            &context.posthog_pool,
+            &context.s3_client,
+            &config.object_storage_bucket,
+            &context.ss_cache,
+            &config,
+        )
+        .await
+        {
+            error!(%error, "Cache warming failed, proceeding with cold cache");
+        }
+    }
+
+    context.cache_warmed.store(true, Ordering::Relaxed);
+    info!("Pod is ready to serve traffic");
+
+    server_handle.await.unwrap();
 }

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -126,3 +126,9 @@ pub const FINGERPRINT_GENERATOR_OPERATOR: &str = "cymbal_exception_fingerprint_g
 pub const RULE_SUPPRESSED_EVENTS: &str = "cymbal_rule_suppressed_events";
 pub const SUPPRESSION_RULES_TRIED: &str = "cymbal_suppression_rules_tried";
 pub const SUPPRESSION_RULES_DISABLED: &str = "cymbal_suppression_rules_disabled";
+
+// Cache warming metrics
+pub const CACHE_WARMING_DURATION: &str = "cymbal_cache_warming_duration";
+pub const CACHE_WARMING_ENTRIES_LOADED: &str = "cymbal_cache_warming_entries_loaded";
+pub const CACHE_WARMING_ENTRIES_FAILED: &str = "cymbal_cache_warming_entries_failed";
+pub const CACHE_WARMING_BYTES_LOADED: &str = "cymbal_cache_warming_bytes_loaded";

--- a/rust/cymbal/src/router/mod.rs
+++ b/rust/cymbal/src/router/mod.rs
@@ -8,6 +8,7 @@ pub use event::*;
 use health::HealthStatus;
 use reqwest::StatusCode;
 use std::future::ready;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::app_context::AppContext;
@@ -20,6 +21,14 @@ async fn liveness(State(ctx): State<Arc<AppContext>>) -> HealthStatus {
     ready(ctx.health_registry.get_status()).await
 }
 
+async fn readiness(State(ctx): State<Arc<AppContext>>) -> impl IntoResponse {
+    if ctx.cache_warmed.load(Ordering::Relaxed) {
+        (StatusCode::OK, "ready")
+    } else {
+        (StatusCode::SERVICE_UNAVAILABLE, "warming cache")
+    }
+}
+
 async fn not_found() -> impl IntoResponse {
     (StatusCode::NOT_FOUND, "Not Found")
 }
@@ -28,7 +37,7 @@ pub fn get_router(context: Arc<AppContext>) -> Router {
     Router::new()
         .route("/", get(index))
         .route("/process", post(process_events))
-        .route("/_readiness", get(index))
+        .route("/_readiness", get(readiness))
         .route("/_liveness", get(liveness))
         .fallback(not_found)
         .with_state(context.clone())

--- a/rust/cymbal/src/symbol_store/caching.rs
+++ b/rust/cymbal/src/symbol_store/caching.rs
@@ -93,19 +93,26 @@ impl SymbolSetCache {
         }
     }
 
+    pub fn held_bytes(&self) -> usize {
+        self.held_bytes
+    }
+
     pub fn insert<T>(&mut self, key: String, value: Arc<T>, bytes: usize)
     where
         T: Any + Send + Sync,
     {
-        self.held_bytes += bytes;
-        self.cached.insert(
+        if let Some(previous) = self.cached.insert(
             key,
             CachedSymbolSet {
                 data: value,
                 bytes,
                 last_used: Instant::now(),
             },
-        );
+        ) {
+            self.held_bytes = self.held_bytes.saturating_sub(previous.bytes);
+        }
+
+        self.held_bytes += bytes;
 
         self.evict();
     }
@@ -167,5 +174,30 @@ pub trait Countable {
 impl Countable for Vec<u8> {
     fn byte_count(&self) -> usize {
         self.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::SymbolSetCache;
+
+    #[test]
+    fn replacing_existing_key_keeps_byte_accounting_accurate() {
+        let mut cache = SymbolSetCache::new(usize::MAX);
+
+        cache.insert("key".to_string(), Arc::new(vec![1_u8, 2, 3]), 3);
+        assert_eq!(cache.held_bytes, 3);
+        assert_eq!(cache.cached.len(), 1);
+
+        cache.insert("key".to_string(), Arc::new(vec![1_u8, 2, 3, 4, 5]), 5);
+
+        assert_eq!(cache.held_bytes, 5);
+        assert_eq!(cache.cached.len(), 1);
+        assert_eq!(
+            *cache.get::<Vec<u8>>("key").unwrap(),
+            vec![1_u8, 2, 3, 4, 5]
+        );
     }
 }

--- a/rust/cymbal/src/symbol_store/mod.rs
+++ b/rust/cymbal/src/symbol_store/mod.rs
@@ -25,6 +25,7 @@ pub mod hermesmap;
 pub mod proguard;
 pub mod saving;
 pub mod sourcemap;
+pub mod warming;
 
 mod s3;
 pub use s3::BlobClient;

--- a/rust/cymbal/src/symbol_store/s3.rs
+++ b/rust/cymbal/src/symbol_store/s3.rs
@@ -14,6 +14,7 @@ use crate::{
 #[async_trait]
 pub trait BlobClient: Send + Sync {
     async fn get(&self, bucket: &str, key: &str) -> Result<Option<Bytes>, UnhandledError>;
+    async fn get_size(&self, bucket: &str, key: &str) -> Result<Option<usize>, UnhandledError>;
     async fn put(&self, bucket: &str, key: &str, data: Bytes) -> Result<(), UnhandledError>;
     async fn ping_bucket(&self, bucket: &str) -> Result<(), UnhandledError>;
 }
@@ -60,6 +61,28 @@ impl BlobClient for S3Impl {
                 // If we simply failed to talk to s3, return an error
                 start.label("outcome", "failure").fin();
                 error!("Failed to fetch object {} from S3: {:?}", key, err);
+                Err(S3Error::from(err).into())
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    async fn get_size(&self, bucket: &str, key: &str) -> Result<Option<usize>, UnhandledError> {
+        let res = self
+            .inner
+            .head_object()
+            .bucket(bucket)
+            .key(key)
+            .send()
+            .await;
+
+        match res {
+            Ok(res) => Ok(res
+                .content_length()
+                .and_then(|len| usize::try_from(len).ok())),
+            Err(SdkError::ServiceError(err)) if err.err().is_not_found() => Ok(None),
+            Err(err) => {
+                error!("Failed to fetch object metadata {} from S3: {:?}", key, err);
                 Err(S3Error::from(err).into())
             }
         }

--- a/rust/cymbal/src/symbol_store/warming.rs
+++ b/rust/cymbal/src/symbol_store/warming.rs
@@ -36,6 +36,52 @@ struct WarmingParsers {
     apple: AppleProvider,
 }
 
+#[derive(Debug)]
+struct WarmingBudget {
+    max_bytes: usize,
+    loaded_bytes: usize,
+    reserved_bytes: usize,
+}
+
+impl WarmingBudget {
+    fn new(max_bytes: usize, loaded_bytes: usize) -> Self {
+        Self {
+            max_bytes,
+            loaded_bytes,
+            reserved_bytes: 0,
+        }
+    }
+
+    fn remaining_bytes(&self) -> usize {
+        self.max_bytes
+            .saturating_sub(self.loaded_bytes)
+            .saturating_sub(self.reserved_bytes)
+    }
+
+    fn reserve(&mut self, bytes: usize) -> bool {
+        if bytes > self.remaining_bytes() {
+            return false;
+        }
+
+        self.reserved_bytes += bytes;
+        true
+    }
+
+    fn release(&mut self, bytes: usize) {
+        self.reserved_bytes = self.reserved_bytes.saturating_sub(bytes);
+    }
+
+    fn commit(&mut self, reserved_bytes: usize, loaded_bytes: usize) -> bool {
+        self.release(reserved_bytes);
+        if loaded_bytes > self.remaining_bytes() {
+            return false;
+        }
+
+        self.loaded_bytes += loaded_bytes;
+        true
+    }
+}
+
 /// Pre-populates the symbol set cache from DB + S3 on startup.
 ///
 /// We warm recently used symbol sets across all teams. Each pod warms the same global top-N set:
@@ -59,6 +105,11 @@ pub async fn warm_cache(
         return Ok(());
     }
 
+    let initial_loaded_bytes = ss_cache.lock().await.held_bytes();
+    let budget = Arc::new(Mutex::new(WarmingBudget::new(
+        byte_budget,
+        initial_loaded_bytes,
+    )));
     let semaphore = Arc::new(Semaphore::new(config.cache_warming_concurrency.max(1)));
     let parsers = Arc::new(WarmingParsers {
         sourcemap: SourcemapProvider::new(config),
@@ -76,21 +127,15 @@ pub async fn warm_cache(
         let bucket = bucket.to_string();
         let ss_cache = ss_cache.clone();
         let parsers = parsers.clone();
+        let budget = budget.clone();
 
         let handle = tokio::spawn(async move {
             let _permit = semaphore
                 .acquire_owned()
                 .await
                 .expect("warming semaphore open");
-            let result = warm_single_entry(
-                &s3_client,
-                &bucket,
-                &ss_cache,
-                &parsers,
-                &record,
-                byte_budget,
-            )
-            .await;
+            let result =
+                warm_single_entry(&s3_client, &bucket, &ss_cache, &parsers, &record, &budget).await;
             (record.set_ref, result)
         });
         abort_handles.push(handle.abort_handle());
@@ -194,71 +239,126 @@ async fn warm_single_entry(
     cache: &Arc<Mutex<SymbolSetCache>>,
     parsers: &WarmingParsers,
     record: &SymbolSetRecord,
-    byte_budget: usize,
+    budget: &Arc<Mutex<WarmingBudget>>,
 ) -> Result<Option<usize>, UnhandledError> {
-    if cache.lock().await.held_bytes() >= byte_budget {
-        return Ok(None);
-    }
-
     let storage_ptr = record
         .storage_ptr
         .as_ref()
         .ok_or_else(|| UnhandledError::Other("missing storage_ptr".to_string()))?;
 
-    let data = s3_client
-        .get(bucket, storage_ptr)
+    if budget.lock().await.remaining_bytes() == 0 {
+        return Ok(None);
+    }
+
+    let object_size = s3_client
+        .get_size(bucket, storage_ptr)
         .await?
         .ok_or_else(|| UnhandledError::Other("S3 object not found".to_string()))?;
 
-    let data_type = sniff_data_type(&data).map_err(|error| {
-        UnhandledError::Other(format!("failed to sniff symbol data type: {error}"))
-    })?;
+    if !budget.lock().await.reserve(object_size) {
+        return Ok(None);
+    }
+
+    let data = match s3_client.get(bucket, storage_ptr).await? {
+        Some(data) => data,
+        None => {
+            budget.lock().await.release(object_size);
+            return Err(UnhandledError::Other("S3 object not found".to_string()));
+        }
+    };
+
+    let data_type = match sniff_data_type(&data) {
+        Ok(data_type) => data_type,
+        Err(error) => {
+            budget.lock().await.release(object_size);
+            return Err(UnhandledError::Other(format!(
+                "failed to sniff symbol data type: {error}"
+            )));
+        }
+    };
     let cache_key = format!("{}:{}", record.team_id, record.set_ref);
 
     match data_type {
         SymbolDataType::SourceAndMap => {
-            let parsed = parsers.sourcemap.parse(data).await.map_err(|error| {
-                UnhandledError::Other(format!("sourcemap parse failed: {error}"))
-            })?;
-            insert_warmed_entry::<OwnedSourceMapCache>(cache, cache_key, parsed, byte_budget).await
+            let parsed = match parsers.sourcemap.parse(data).await {
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    budget.lock().await.release(object_size);
+                    return Err(UnhandledError::Other(format!(
+                        "sourcemap parse failed: {error}"
+                    )));
+                }
+            };
+            insert_warmed_entry::<OwnedSourceMapCache>(
+                cache,
+                budget,
+                object_size,
+                cache_key,
+                parsed,
+            )
+            .await
         }
         SymbolDataType::HermesMap => {
-            let parsed = parsers.hermes.parse(data).await.map_err(|error| {
-                UnhandledError::Other(format!("hermes map parse failed: {error}"))
-            })?;
-            insert_warmed_entry::<ParsedHermesMap>(cache, cache_key, parsed, byte_budget).await
+            let parsed = match parsers.hermes.parse(data).await {
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    budget.lock().await.release(object_size);
+                    return Err(UnhandledError::Other(format!(
+                        "hermes map parse failed: {error}"
+                    )));
+                }
+            };
+            insert_warmed_entry::<ParsedHermesMap>(cache, budget, object_size, cache_key, parsed)
+                .await
         }
         SymbolDataType::ProguardMapping => {
-            let parsed = parsers.proguard.parse(data).await.map_err(|error| {
-                UnhandledError::Other(format!("proguard mapping parse failed: {error}"))
-            })?;
-            insert_warmed_entry::<FetchedMapping>(cache, cache_key, parsed, byte_budget).await
+            let parsed = match parsers.proguard.parse(data).await {
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    budget.lock().await.release(object_size);
+                    return Err(UnhandledError::Other(format!(
+                        "proguard mapping parse failed: {error}"
+                    )));
+                }
+            };
+            insert_warmed_entry::<FetchedMapping>(cache, budget, object_size, cache_key, parsed)
+                .await
         }
         SymbolDataType::AppleDsym => {
-            let parsed = parsers.apple.parse(data).await.map_err(|error| {
-                UnhandledError::Other(format!("apple symbols parse failed: {error}"))
-            })?;
-            insert_warmed_entry::<ParsedAppleSymbols>(cache, cache_key, parsed, byte_budget).await
+            let parsed = match parsers.apple.parse(data).await {
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    budget.lock().await.release(object_size);
+                    return Err(UnhandledError::Other(format!(
+                        "apple symbols parse failed: {error}"
+                    )));
+                }
+            };
+            insert_warmed_entry::<ParsedAppleSymbols>(cache, budget, object_size, cache_key, parsed)
+                .await
         }
     }
 }
 
 async fn insert_warmed_entry<T>(
     cache: &Arc<Mutex<SymbolSetCache>>,
+    budget: &Arc<Mutex<WarmingBudget>>,
+    reserved_bytes: usize,
     cache_key: String,
     parsed: T,
-    byte_budget: usize,
 ) -> Result<Option<usize>, UnhandledError>
 where
     T: Countable + Send + Sync + 'static,
 {
     let bytes = parsed.byte_count();
-    let mut cache_guard = cache.lock().await;
-    if cache_guard.held_bytes() >= byte_budget {
+    if !budget.lock().await.commit(reserved_bytes, bytes) {
         return Ok(None);
     }
 
-    cache_guard.insert::<T>(cache_key, Arc::new(parsed), bytes);
+    cache
+        .lock()
+        .await
+        .insert::<T>(cache_key, Arc::new(parsed), bytes);
     Ok(Some(bytes))
 }
 
@@ -318,10 +418,32 @@ mod tests {
         let s3_client: Arc<dyn BlobClient> = Arc::new(MockS3Client::new());
         let record = make_record("test-key");
 
-        let result = warm_single_entry(&s3_client, "bucket", &cache, &parsers, &record, 100).await;
+        let budget = Arc::new(Mutex::new(WarmingBudget::new(100, 500)));
+
+        let result =
+            warm_single_entry(&s3_client, "bucket", &cache, &parsers, &record, &budget).await;
 
         assert!(result.unwrap().is_none());
         assert_eq!(cache.lock().await.held_bytes(), 500);
+    }
+
+    #[tokio::test]
+    async fn skips_entry_when_object_size_exceeds_remaining_budget() {
+        let parsers = make_parsers();
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(1000)));
+
+        let mut s3_client = MockS3Client::new();
+        s3_client.expect_get_size().returning(|_, _| Ok(Some(500)));
+
+        let s3_client: Arc<dyn BlobClient> = Arc::new(s3_client);
+        let record = make_record("test-key");
+        let budget = Arc::new(Mutex::new(WarmingBudget::new(100, 0)));
+
+        let result =
+            warm_single_entry(&s3_client, "bucket", &cache, &parsers, &record, &budget).await;
+
+        assert!(result.unwrap().is_none());
+        assert_eq!(cache.lock().await.held_bytes(), 0);
     }
 
     #[tokio::test]
@@ -330,16 +452,21 @@ mod tests {
         let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
 
         let data = test_symbol_data();
+        let data_size = data.len();
         let mut s3_client = MockS3Client::new();
+        s3_client
+            .expect_get_size()
+            .returning(move |_, _| Ok(Some(data_size)));
         s3_client
             .expect_get()
             .returning(move |_, _| Ok(Some(data.clone())));
 
         let s3_client: Arc<dyn BlobClient> = Arc::new(s3_client);
         let record = make_record("test-key");
+        let budget = Arc::new(Mutex::new(WarmingBudget::new(100_000_000, 0)));
 
         let result =
-            warm_single_entry(&s3_client, "bucket", &cache, &parsers, &record, 100_000_000).await;
+            warm_single_entry(&s3_client, "bucket", &cache, &parsers, &record, &budget).await;
 
         let bytes = result.unwrap().unwrap();
         assert!(bytes > 0);

--- a/rust/cymbal/src/symbol_store/warming.rs
+++ b/rust/cymbal/src/symbol_store/warming.rs
@@ -1,0 +1,345 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use futures::stream::{FuturesUnordered, StreamExt};
+use posthog_symbol_data::{sniff_data_type, SymbolDataType};
+use sqlx::PgPool;
+use tokio::sync::{Mutex, Semaphore};
+use tokio::time::Duration;
+use tracing::{info, warn};
+
+use crate::{
+    config::Config,
+    error::UnhandledError,
+    metric_consts::{
+        CACHE_WARMING_BYTES_LOADED, CACHE_WARMING_DURATION, CACHE_WARMING_ENTRIES_FAILED,
+        CACHE_WARMING_ENTRIES_LOADED,
+    },
+    symbol_store::{
+        apple::{AppleProvider, ParsedAppleSymbols},
+        caching::{Countable, SymbolSetCache},
+        hermesmap::{HermesMapProvider, ParsedHermesMap},
+        proguard::{FetchedMapping, ProguardProvider},
+        saving::SymbolSetRecord,
+        sourcemap::{OwnedSourceMapCache, SourcemapProvider},
+        BlobClient, Parser,
+    },
+};
+
+// Leave headroom in the shared cache for traffic that arrives right after the pod is ready.
+const WARMING_FILL_FRACTION: f64 = 0.85;
+
+struct WarmingParsers {
+    sourcemap: SourcemapProvider,
+    hermes: HermesMapProvider,
+    proguard: ProguardProvider,
+    apple: AppleProvider,
+}
+
+/// Pre-populates the symbol set cache from DB + S3 on startup.
+///
+/// We warm recently used symbol sets across all teams. Each pod warms the same global top-N set:
+/// this is intentionally simple until Cymbal has stable sharding/routing assignments.
+pub async fn warm_cache(
+    pool: &PgPool,
+    s3_client: &Arc<dyn BlobClient>,
+    bucket: &str,
+    ss_cache: &Arc<Mutex<SymbolSetCache>>,
+    config: &Config,
+) -> Result<(), UnhandledError> {
+    let start = Instant::now();
+    let byte_budget = (config.symbol_store_cache_max_bytes as f64 * WARMING_FILL_FRACTION) as usize;
+
+    let records = load_warming_candidates(pool, config).await?;
+    let total = records.len();
+    info!(total, byte_budget, "Fetched cache warming candidates");
+
+    if total == 0 {
+        metrics::histogram!(CACHE_WARMING_DURATION).record(start.elapsed().as_secs_f64());
+        return Ok(());
+    }
+
+    let semaphore = Arc::new(Semaphore::new(config.cache_warming_concurrency.max(1)));
+    let parsers = Arc::new(WarmingParsers {
+        sourcemap: SourcemapProvider::new(config),
+        hermes: HermesMapProvider {},
+        proguard: ProguardProvider {},
+        apple: AppleProvider {},
+    });
+
+    let mut abort_handles = Vec::with_capacity(total);
+    let mut tasks = FuturesUnordered::new();
+
+    for record in records {
+        let semaphore = semaphore.clone();
+        let s3_client = s3_client.clone();
+        let bucket = bucket.to_string();
+        let ss_cache = ss_cache.clone();
+        let parsers = parsers.clone();
+
+        let handle = tokio::spawn(async move {
+            let _permit = semaphore
+                .acquire_owned()
+                .await
+                .expect("warming semaphore open");
+            let result = warm_single_entry(
+                &s3_client,
+                &bucket,
+                &ss_cache,
+                &parsers,
+                &record,
+                byte_budget,
+            )
+            .await;
+            (record.set_ref, result)
+        });
+        abort_handles.push(handle.abort_handle());
+        tasks.push(handle);
+    }
+
+    let mut loaded = 0_u64;
+    let mut failed = 0_u64;
+    let mut skipped = 0_u64;
+    let mut bytes_loaded = 0_u64;
+    let mut timed_out = false;
+    let timeout = tokio::time::sleep(Duration::from_secs(config.cache_warming_timeout_seconds));
+    tokio::pin!(timeout);
+
+    loop {
+        tokio::select! {
+            maybe_result = tasks.next() => {
+                match maybe_result {
+                    Some(Ok((_, Ok(Some(bytes))))) => {
+                        loaded += 1;
+                        bytes_loaded += bytes as u64;
+                    }
+                    Some(Ok((_, Ok(None)))) => {
+                        skipped += 1;
+                    }
+                    Some(Ok((set_ref, Err(error)))) => {
+                        warn!(%set_ref, %error, "Failed to warm symbol set");
+                        failed += 1;
+                    }
+                    Some(Err(error)) => {
+                        warn!(%error, "Cache warming task failed");
+                        failed += 1;
+                    }
+                    None => break,
+                }
+            }
+            _ = &mut timeout => {
+                timed_out = true;
+                break;
+            }
+        }
+    }
+
+    if timed_out {
+        let aborted = tasks.len() as u64;
+        for abort_handle in abort_handles {
+            abort_handle.abort();
+        }
+        warn!(
+            timeout_seconds = config.cache_warming_timeout_seconds,
+            loaded, failed, skipped, aborted, "Cache warming timed out, aborting remaining tasks"
+        );
+    }
+
+    let elapsed = start.elapsed();
+    info!(
+        loaded,
+        failed,
+        skipped,
+        total,
+        bytes_loaded,
+        byte_budget,
+        elapsed_ms = elapsed.as_millis() as u64,
+        "Cache warming complete"
+    );
+
+    metrics::counter!(CACHE_WARMING_ENTRIES_LOADED).increment(loaded);
+    metrics::counter!(CACHE_WARMING_ENTRIES_FAILED).increment(failed);
+    metrics::counter!(CACHE_WARMING_BYTES_LOADED).increment(bytes_loaded);
+    metrics::histogram!(CACHE_WARMING_DURATION).record(elapsed.as_secs_f64());
+
+    Ok(())
+}
+
+async fn load_warming_candidates(
+    pool: &PgPool,
+    config: &Config,
+) -> Result<Vec<SymbolSetRecord>, UnhandledError> {
+    let records = sqlx::query_as::<_, SymbolSetRecord>(
+        r#"
+        SELECT id, team_id, ref AS set_ref, storage_ptr, failure_reason, created_at, content_hash, last_used
+        FROM posthog_errortrackingsymbolset
+        WHERE content_hash IS NOT NULL
+          AND storage_ptr IS NOT NULL
+          AND last_used > NOW() - make_interval(hours => $1::integer)
+        ORDER BY last_used DESC
+        LIMIT $2
+        "#,
+    )
+    .bind(config.cache_warming_lookback_hours as i32)
+    .bind(config.cache_warming_max_entries as i64)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(records)
+}
+
+async fn warm_single_entry(
+    s3_client: &Arc<dyn BlobClient>,
+    bucket: &str,
+    cache: &Arc<Mutex<SymbolSetCache>>,
+    parsers: &WarmingParsers,
+    record: &SymbolSetRecord,
+    byte_budget: usize,
+) -> Result<Option<usize>, UnhandledError> {
+    if cache.lock().await.held_bytes() >= byte_budget {
+        return Ok(None);
+    }
+
+    let storage_ptr = record
+        .storage_ptr
+        .as_ref()
+        .ok_or_else(|| UnhandledError::Other("missing storage_ptr".to_string()))?;
+
+    let data = s3_client
+        .get(bucket, storage_ptr)
+        .await?
+        .ok_or_else(|| UnhandledError::Other("S3 object not found".to_string()))?;
+
+    let data_type = sniff_data_type(&data).map_err(|error| {
+        UnhandledError::Other(format!("failed to sniff symbol data type: {error}"))
+    })?;
+    let cache_key = format!("{}:{}", record.team_id, record.set_ref);
+
+    match data_type {
+        SymbolDataType::SourceAndMap => {
+            let parsed = parsers.sourcemap.parse(data).await.map_err(|error| {
+                UnhandledError::Other(format!("sourcemap parse failed: {error}"))
+            })?;
+            insert_warmed_entry::<OwnedSourceMapCache>(cache, cache_key, parsed).await
+        }
+        SymbolDataType::HermesMap => {
+            let parsed = parsers.hermes.parse(data).await.map_err(|error| {
+                UnhandledError::Other(format!("hermes map parse failed: {error}"))
+            })?;
+            insert_warmed_entry::<ParsedHermesMap>(cache, cache_key, parsed).await
+        }
+        SymbolDataType::ProguardMapping => {
+            let parsed = parsers.proguard.parse(data).await.map_err(|error| {
+                UnhandledError::Other(format!("proguard mapping parse failed: {error}"))
+            })?;
+            insert_warmed_entry::<FetchedMapping>(cache, cache_key, parsed).await
+        }
+        SymbolDataType::AppleDsym => {
+            let parsed = parsers.apple.parse(data).await.map_err(|error| {
+                UnhandledError::Other(format!("apple symbols parse failed: {error}"))
+            })?;
+            insert_warmed_entry::<ParsedAppleSymbols>(cache, cache_key, parsed).await
+        }
+    }
+}
+
+async fn insert_warmed_entry<T>(
+    cache: &Arc<Mutex<SymbolSetCache>>,
+    cache_key: String,
+    parsed: T,
+) -> Result<Option<usize>, UnhandledError>
+where
+    T: Countable + Send + Sync + 'static,
+{
+    let bytes = parsed.byte_count();
+    cache
+        .lock()
+        .await
+        .insert::<T>(cache_key, Arc::new(parsed), bytes);
+    Ok(Some(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use posthog_symbol_data::write_symbol_data;
+    use uuid::Uuid;
+
+    use crate::symbol_store::MockS3Client;
+
+    const MINIFIED: &[u8] = include_bytes!("../../tests/static/chunk-PGUQKT6S.js");
+    const MAP: &[u8] = include_bytes!("../../tests/static/chunk-PGUQKT6S.js.map");
+
+    fn test_symbol_data() -> bytes::Bytes {
+        write_symbol_data(posthog_symbol_data::SourceAndMap {
+            minified_source: String::from_utf8(MINIFIED.to_vec()).unwrap(),
+            sourcemap: String::from_utf8(MAP.to_vec()).unwrap(),
+        })
+        .unwrap()
+        .into()
+    }
+
+    fn make_record(key: &str) -> SymbolSetRecord {
+        SymbolSetRecord {
+            id: Uuid::now_v7(),
+            team_id: 1,
+            set_ref: format!("http://example.com/{key}"),
+            storage_ptr: Some(key.to_string()),
+            failure_reason: None,
+            created_at: Utc::now(),
+            content_hash: Some("abc123".to_string()),
+            last_used: Some(Utc::now()),
+        }
+    }
+
+    fn make_parsers() -> WarmingParsers {
+        let config = Config::init_with_defaults().unwrap();
+        WarmingParsers {
+            sourcemap: SourcemapProvider::new(&config),
+            hermes: HermesMapProvider {},
+            proguard: ProguardProvider {},
+            apple: AppleProvider {},
+        }
+    }
+
+    #[tokio::test]
+    async fn skips_entry_when_over_byte_budget() {
+        let parsers = make_parsers();
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(1000)));
+        cache
+            .lock()
+            .await
+            .insert("prefill".to_string(), Arc::new(vec![0_u8; 500]), 500);
+
+        let s3_client: Arc<dyn BlobClient> = Arc::new(MockS3Client::new());
+        let record = make_record("test-key");
+
+        let result = warm_single_entry(&s3_client, "bucket", &cache, &parsers, &record, 100).await;
+
+        assert!(result.unwrap().is_none());
+        assert_eq!(cache.lock().await.held_bytes(), 500);
+    }
+
+    #[tokio::test]
+    async fn loads_entry_when_under_byte_budget() {
+        let parsers = make_parsers();
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
+
+        let data = test_symbol_data();
+        let mut s3_client = MockS3Client::new();
+        s3_client
+            .expect_get()
+            .returning(move |_, _| Ok(Some(data.clone())));
+
+        let s3_client: Arc<dyn BlobClient> = Arc::new(s3_client);
+        let record = make_record("test-key");
+
+        let result =
+            warm_single_entry(&s3_client, "bucket", &cache, &parsers, &record, 100_000_000).await;
+
+        let bytes = result.unwrap().unwrap();
+        assert!(bytes > 0);
+        assert_eq!(cache.lock().await.held_bytes(), bytes);
+    }
+}

--- a/rust/cymbal/src/symbol_store/warming.rs
+++ b/rust/cymbal/src/symbol_store/warming.rs
@@ -175,12 +175,12 @@ async fn load_warming_candidates(
         FROM posthog_errortrackingsymbolset
         WHERE content_hash IS NOT NULL
           AND storage_ptr IS NOT NULL
-          AND last_used > NOW() - make_interval(hours => $1::integer)
+          AND last_used > NOW() - ($1::double precision * INTERVAL '1 hour')
         ORDER BY last_used DESC
         LIMIT $2
         "#,
     )
-    .bind(config.cache_warming_lookback_hours as i32)
+    .bind(config.cache_warming_lookback_hours as f64)
     .bind(config.cache_warming_max_entries as i64)
     .fetch_all(pool)
     .await?;
@@ -220,25 +220,25 @@ async fn warm_single_entry(
             let parsed = parsers.sourcemap.parse(data).await.map_err(|error| {
                 UnhandledError::Other(format!("sourcemap parse failed: {error}"))
             })?;
-            insert_warmed_entry::<OwnedSourceMapCache>(cache, cache_key, parsed).await
+            insert_warmed_entry::<OwnedSourceMapCache>(cache, cache_key, parsed, byte_budget).await
         }
         SymbolDataType::HermesMap => {
             let parsed = parsers.hermes.parse(data).await.map_err(|error| {
                 UnhandledError::Other(format!("hermes map parse failed: {error}"))
             })?;
-            insert_warmed_entry::<ParsedHermesMap>(cache, cache_key, parsed).await
+            insert_warmed_entry::<ParsedHermesMap>(cache, cache_key, parsed, byte_budget).await
         }
         SymbolDataType::ProguardMapping => {
             let parsed = parsers.proguard.parse(data).await.map_err(|error| {
                 UnhandledError::Other(format!("proguard mapping parse failed: {error}"))
             })?;
-            insert_warmed_entry::<FetchedMapping>(cache, cache_key, parsed).await
+            insert_warmed_entry::<FetchedMapping>(cache, cache_key, parsed, byte_budget).await
         }
         SymbolDataType::AppleDsym => {
             let parsed = parsers.apple.parse(data).await.map_err(|error| {
                 UnhandledError::Other(format!("apple symbols parse failed: {error}"))
             })?;
-            insert_warmed_entry::<ParsedAppleSymbols>(cache, cache_key, parsed).await
+            insert_warmed_entry::<ParsedAppleSymbols>(cache, cache_key, parsed, byte_budget).await
         }
     }
 }
@@ -247,15 +247,18 @@ async fn insert_warmed_entry<T>(
     cache: &Arc<Mutex<SymbolSetCache>>,
     cache_key: String,
     parsed: T,
+    byte_budget: usize,
 ) -> Result<Option<usize>, UnhandledError>
 where
     T: Countable + Send + Sync + 'static,
 {
     let bytes = parsed.byte_count();
-    cache
-        .lock()
-        .await
-        .insert::<T>(cache_key, Arc::new(parsed), bytes);
+    let mut cache_guard = cache.lock().await;
+    if cache_guard.held_bytes() >= byte_budget {
+        return Ok(None);
+    }
+
+    cache_guard.insert::<T>(cache_key, Arc::new(parsed), bytes);
     Ok(Some(bytes))
 }
 

--- a/rust/cymbal/src/test_utils.rs
+++ b/rust/cymbal/src/test_utils.rs
@@ -19,6 +19,7 @@ mock! {
     #[async_trait]
     impl BlobClient for S3Client {
         async fn get(&self, bucket: &str, key: &str) -> Result<Option<Bytes>, UnhandledError>;
+        async fn get_size(&self, bucket: &str, key: &str) -> Result<Option<usize>, UnhandledError>;
         async fn put(&self, bucket: &str, key: &str, data: Bytes) -> Result<(), UnhandledError>;
         async fn ping_bucket(&self, bucket: &str) -> Result<(), UnhandledError>;
     }

--- a/rust/cymbal/tests/readiness.rs
+++ b/rust/cymbal/tests/readiness.rs
@@ -1,0 +1,98 @@
+use std::sync::{atomic::Ordering, Arc};
+
+use axum::{body::Body, http::Request};
+use common_redis::MockRedisClient;
+use cymbal::{app_context::AppContext, config::Config, router::get_router};
+use reqwest::StatusCode;
+use sqlx::PgPool;
+use tower::ServiceExt;
+
+use crate::utils::MockS3Client;
+
+mod utils;
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn readiness_returns_503_before_warming_and_200_after(db: PgPool) {
+    let mut config = Config::init_with_defaults().unwrap();
+    config.cache_warming_enabled = true;
+    config.object_storage_bucket = "test-bucket".to_string();
+
+    let mut s3_client = MockS3Client::default();
+    s3_client.expect_ping_bucket().returning(|_| Ok(()));
+
+    let issue_buckets_redis_client = Arc::new(MockRedisClient::new());
+
+    let ctx = Arc::new(
+        AppContext::new(
+            &config,
+            Arc::new(s3_client),
+            db.clone(),
+            issue_buckets_redis_client,
+        )
+        .await
+        .unwrap(),
+    );
+
+    let router = get_router(ctx.clone());
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/_readiness")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    ctx.cache_warmed.store(true, Ordering::Relaxed);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/_readiness")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn readiness_returns_200_immediately_when_warming_disabled(db: PgPool) {
+    let mut config = Config::init_with_defaults().unwrap();
+    config.cache_warming_enabled = false;
+    config.object_storage_bucket = "test-bucket".to_string();
+
+    let mut s3_client = MockS3Client::default();
+    s3_client.expect_ping_bucket().returning(|_| Ok(()));
+
+    let issue_buckets_redis_client = Arc::new(MockRedisClient::new());
+
+    let ctx = Arc::new(
+        AppContext::new(
+            &config,
+            Arc::new(s3_client),
+            db.clone(),
+            issue_buckets_redis_client,
+        )
+        .await
+        .unwrap(),
+    );
+
+    let router = get_router(ctx);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/_readiness")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/rust/cymbal/tests/utils.rs
+++ b/rust/cymbal/tests/utils.rs
@@ -23,6 +23,7 @@ mock! {
     #[async_trait]
     impl BlobClient for S3Client {
         async fn get(&self, bucket: &str, key: &str) -> Result<Option<Bytes>, UnhandledError>;
+        async fn get_size(&self, bucket: &str, key: &str) -> Result<Option<usize>, UnhandledError>;
         async fn put(&self, bucket: &str, key: &str, data: Bytes) -> Result<(), UnhandledError>;
         async fn ping_bucket(&self, bucket: &str) -> Result<(), UnhandledError>;
     }


### PR DESCRIPTION
## Problem

Cymbal loses its in-memory symbol cache on restart, which makes freshly restarted pods pay the cost of database lookups, S3 downloads, and symbol parsing for hot symbol sets.

## Changes

- Add a Cymbal startup cache warming step for recently used symbol sets.
- Query Postgres for recent saved symbol set records, download their stored bytes from object storage, parse by symbol-data type, and insert parsed results into the shared symbol cache.
- Gate readiness until warming finishes or fails, while still starting the HTTP server immediately so liveness remains available.
- Add cache warming configuration and metrics.
- Add symbol-data type sniffing so warming can choose the parser without full deserialization.
- Fix symbol cache byte accounting when replacing an existing cache entry.

## How did you test this code?

Agent-authored. Ran:

- `cd rust && cargo fmt --package posthog-symbol-data --package cymbal`
- `cd rust && cargo test -p cymbal symbol_store::warming::tests --lib`
- `cd rust && cargo test -p cymbal symbol_store::caching::tests::replacing_existing_key_keeps_byte_accounting_accurate --lib`
- `cd rust && cargo test -p posthog-symbol-data`
- `cd rust && cargo test -p cymbal --no-run`
- `git diff --check`

Also attempted `cd rust && cargo test -p cymbal --test readiness`, but the local SQLx test database setup timed out with `PoolTimedOut` before running the tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 Agent context

This PR was authored by an AI coding agent using pi. The implementation follows the prior Cymbal cache-warming PR shape: warm recently used symbol sets from saved Postgres records and object storage, keep liveness open while readiness is blocked, and stop warming under a timeout/byte budget. The warming path uses direct parser dispatch based on a lightweight symbol-data type sniff rather than running the full provider stack, because saved records already point at object storage.