### PR TITLE
fix(settings): align responsive breakpoint to 768px for consistency

### DIFF
--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -11,7 +11,6 @@ import { LemonButton, LemonDivider, Link } from '@posthog/lemon-ui'
 import { NotFound } from 'lib/components/NotFound'
 import { SupportedPlatforms } from 'lib/components/SupportedPlatforms/SupportedPlatforms'
 import { TimeSensitiveAuthenticationArea } from 'lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication'
-import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { IconLink } from 'lib/lemon-ui/icons'
 import { LinkPrimitive } from 'lib/lemon-ui/Link'
 import {
@@ -90,17 +89,22 @@ export function Settings({
         navigateToSetting,
     } = useActions(settingsLogic(props))
 
-    const { ref, size } = useResizeBreakpoints(
-        {
-            0: 'small',
-            768: 'medium',
-        },
-        {
-            initialSize: 'medium',
+    // Tailwind `md` breakpoint (768px). Matches `screens.md` in common/tailwind/tailwind.config.js.
+    const [isViewportCompact, setIsViewportCompact] = React.useState(() => {
+        if (typeof window === 'undefined') {
+            return false
         }
-    )
+        return window.matchMedia('(max-width: 767px)').matches
+    })
+    React.useEffect(() => {
+        const mql = window.matchMedia('(max-width: 767px)')
+        const update = (e: MediaQueryListEvent | MediaQueryList): void => setIsViewportCompact(e.matches)
+        update(mql)
+        mql.addEventListener('change', update)
+        return () => mql.removeEventListener('change', update)
+    }, [])
 
-    const isCompact = !inStorybookTestRunner() && size === 'small'
+    const isCompact = !inStorybookTestRunner() && isViewportCompact
 
     // The full settings scene fills the scene area, so its nav can be viewport-fixed.
     // Embeds (replay settings, error tracking config, side panel, modal) place the nav
@@ -320,7 +324,7 @@ export function Settings({
     )
 
     return (
-        <div className={clsx('Settings flex items-start', isCompact && 'Settings--compact')} ref={ref}>
+        <div className={clsx('Settings flex items-start', isCompact && 'Settings--compact')}>
             {hideSections ? null : isCompact ? (
                 <>
                     <Button variant="outline" left className="w-full" onClick={() => openCompactNavigation()}>

--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -93,7 +93,7 @@ export function Settings({
     const { ref, size } = useResizeBreakpoints(
         {
             0: 'small',
-            700: 'medium',
+            768: 'medium',
         },
         {
             initialSize: 'medium',


### PR DESCRIPTION
## Problem

The Settings nav switches between desktop sidebar and mobile drawer using `useResizeBreakpoints` on the `.Settings` div. Because the div is ~32px narrower than the viewport (scene + main padding), the 768px element-width threshold actually fires near a viewport width of ~800px. That doesn't match Tailwind's `md` breakpoint (768px), so the Settings nav swap was misaligned with everything else on the page that uses tailwind media queries.

## Changes

- Replace `useResizeBreakpoints({ 0:'small', 768:'medium' })` with a `window.matchMedia('(max-width: 767px)')` listener in `Settings.tsx`.
- Remove the `ref` plumbing on the root `.Settings` div — no longer needed.
- Behaviour: compact (drawer) below 768px viewport, sidebar at 768px and above. Matches `screens.md` in `common/tailwind/tailwind.config.js`.

## How did you test this code?

Agent-authored — no manual browser testing performed.

- Resizing devtools across the 768px threshold locally is **not** verified here; reviewers should sanity-check that the drawer/sidebar swap fires at exactly 768px viewport width and that the existing visual-viewport keyboard handling still kicks in on mobile.
- TypeScript check attempted via `pnpm --filter=@posthog/frontend typescript:check` but the local `tsc` process OOMed before completing — CI will run the real check.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code (Opus 4.7) at the user's direction.
- Tried first: keep the existing `useResizeBreakpoints` and just bump the threshold. Rejected after confirming the ~32px container/viewport gap means there is no element-width threshold that aligns exactly with Tailwind's `md` — the only honest fix is a viewport media query.
- No new shared hook was introduced; PostHog has no existing `useMediaQuery` and a single inline `matchMedia` listener is small enough not to need one.