### PR TITLE
feat(error-tracking): add per-issue rate limit

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -31,6 +31,8 @@ API_QUERIES_PER_TEAM={"1": 100}
 INTERNAL_REQUEST_TOKEN=dev-internal-token
 # Node.js ingestion consumer reaches Cymbal (Rust) on the host via lvh.me (cross-platform)
 ERROR_TRACKING_CYMBAL_BASE_URL=http://lvh.me:3302
+ERROR_TRACKING_RATE_LIMITER_ENABLED=true
+ERROR_TRACKING_RATE_LIMITER_REPORTING_MODE=false
 # Duckgres host port
 DUCKGRES_PORT=15432
 

--- a/nodejs/src/common/redis/redis-token-bucket-v4.lua.ts
+++ b/nodejs/src/common/redis/redis-token-bucket-v4.lua.ts
@@ -1,0 +1,89 @@
+import { Redis } from 'ioredis'
+
+// V4 single-key token-bucket script.
+//
+// Same fast path as V3 (HMGET + multi-field HSET + conditional EXPIRE),
+// but restores the V2 denial-path fix that V3 dropped: on denial we still
+// return tokensAfter = -1 (caller-side `tokens <= 0` contract is unchanged)
+// but persist the un-deducted balance so partial refills accumulate across
+// calls. Without this, sub-2 fractional fillRates wedge at -1 forever under
+// sustained 1 req/s traffic (e.g. per-issue limits like 100 per 15 min).
+//
+// Public output (tokensBefore, tokensAfter) is identical to V3. Only the
+// stored `pool` field differs on denied calls.
+const LUA_TOKEN_BUCKET_V4 = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local cost = tonumber(ARGV[2])
+local poolMax = tonumber(ARGV[3])
+local fillRate = tonumber(ARGV[4])
+local expiry = tonumber(ARGV[5])
+
+local existing = redis.call('hmget', key, 'ts', 'pool')
+local rawBefore = existing[1]
+local rawPool = existing[2]
+
+local tokensBefore
+local before
+if rawBefore == false then
+  before = false
+  tokensBefore = poolMax
+else
+  before = tonumber(rawBefore)
+  local timeDiffSeconds = now - before
+  if timeDiffSeconds < 0 then
+    timeDiffSeconds = 0
+  end
+  local currentTokens
+  if rawPool == false then
+    currentTokens = poolMax
+  else
+    currentTokens = tonumber(rawPool)
+  end
+  -- tokensBefore is the uncapped accrued credit. A catch-up call after a long
+  -- silent period can therefore spend more than poolMax in one go. The cap is
+  -- applied below on tokensAfter so the *stored* pool can never exceed poolMax.
+  tokensBefore = currentTokens + (timeDiffSeconds * fillRate)
+end
+
+-- On denial we still return tokensAfter = -1 (preserves the caller-side
+-- tokensAfter <= 0 contract) but persist the un-deducted balance so partial
+-- refills accumulate across calls. Matches the V2 fix; V3 dropped this and
+-- wedges at -1 forever under sustained sub-2 fractional fillRate traffic.
+local tokensAfter
+local poolToStore
+if tokensBefore - cost >= 0 then
+  tokensAfter = math.min(tokensBefore - cost, poolMax)
+  poolToStore = tokensAfter
+else
+  tokensAfter = -1
+  poolToStore = math.min(tokensBefore, poolMax)
+end
+
+-- Don't regress ts when now < before; otherwise advance to now.
+local tsToWrite
+if before ~= false and now < before then
+  tsToWrite = before
+else
+  tsToWrite = now
+end
+
+redis.call('hset', key, 'ts', tsToWrite, 'pool', poolToStore)
+
+-- Set TTL ceiling at (expiry * 2) on creation, then refresh when remaining
+-- TTL drops below expiry/2. PTTL returns -1 (no TTL) and -2 (missing key)
+-- which are both < any positive threshold, so the refresh fires defensively
+-- if the TTL is ever lost.
+if before == false or redis.call('pttl', key) < (expiry * 500) then
+  redis.call('expire', key, expiry * 2)
+end
+
+return {tokensBefore, tokensAfter}
+`
+
+export const defineLuaTokenBucketV4 = (client: Redis) => {
+    client.defineCommand('checkRateLimitV4', {
+        numberOfKeys: 1,
+        lua: LUA_TOKEN_BUCKET_V4,
+    })
+}

--- a/nodejs/src/common/redis/redis-v2.ts
+++ b/nodejs/src/common/redis/redis-v2.ts
@@ -7,16 +7,18 @@ import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
 import { defineLuaTokenBucketV2 } from './redis-token-bucket-v2.lua'
 import { defineLuaTokenBucketV3 } from './redis-token-bucket-v3.lua'
+import { defineLuaTokenBucketV4 } from './redis-token-bucket-v4.lua'
 
-type WithCheckRateLimit<TV2, TV3> = {
+type WithCheckRateLimit<TV2, TV3, TV4> = {
     checkRateLimitV2: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => TV2
     checkRateLimitV3: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => TV3
+    checkRateLimitV4: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => TV4
 }
 
-export type RedisClientPipeline = Pipeline & WithCheckRateLimit<[number, number], [number, number]>
+export type RedisClientPipeline = Pipeline & WithCheckRateLimit<[number, number], [number, number], [number, number]>
 
 export type RedisClient = Omit<Redis, 'pipeline'> &
-    WithCheckRateLimit<Promise<[number, number]>, Promise<[number, number]>> & {
+    WithCheckRateLimit<Promise<[number, number]>, Promise<[number, number]>, Promise<[number, number]>> & {
         pipeline: () => RedisClientPipeline
     }
 
@@ -42,6 +44,7 @@ export const createRedisV2PoolFromConfig = (config: RedisPoolConfig): RedisV2 =>
 
                 defineLuaTokenBucketV2(client)
                 defineLuaTokenBucketV3(client)
+                defineLuaTokenBucketV4(client)
 
                 return client as RedisClient
             },

--- a/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
@@ -80,9 +80,11 @@ describe('KeyedRateLimiterService', () => {
             let res = await limiter.rateLimitMany([{ id: 'team-1', cost: 99 }])
             expect(res[0][1]).toEqual({ tokensBefore: 100, tokens: 1, isRateLimited: false })
 
+            // Last token is spent — the request is served and bucket lands at 0.
             res = await limiter.rateLimitMany([{ id: 'team-1', cost: 1 }])
-            expect(res[0][1]).toEqual({ tokensBefore: 1, tokens: 0, isRateLimited: true })
+            expect(res[0][1]).toEqual({ tokensBefore: 1, tokens: 0, isRateLimited: false })
 
+            // Now the bucket is empty — next call is denied.
             res = await limiter.rateLimitMany([{ id: 'team-1', cost: 20 }])
             expect(res[0][1].isRateLimited).toBe(true)
         })
@@ -218,7 +220,7 @@ describe('KeyedRateLimiterService', () => {
 
             // After call 3 (cost=2) is denied with pool=1, the V2 wedge fix means the
             // bucket retains its 1 token — leftover budget isn't discarded on denial. So
-            // call 4 (cost=1) can spend it and lands at tokens=0.
+            // call 4 (cost=1) can spend it and lands at tokens=0 (served).
             const res = await limiter.rateLimitMany([
                 { id: 'team-1', cost: 90 },
                 { id: 'team-1', cost: 9 },
@@ -230,7 +232,7 @@ describe('KeyedRateLimiterService', () => {
                 ['team-1', { tokensBefore: 100, tokens: 10, isRateLimited: false }],
                 ['team-1', { tokensBefore: 10, tokens: 1, isRateLimited: false }],
                 ['team-1', { tokensBefore: 1, tokens: -1, isRateLimited: true }],
-                ['team-1', { tokensBefore: 1, tokens: 0, isRateLimited: true }],
+                ['team-1', { tokensBefore: 1, tokens: 0, isRateLimited: false }],
             ])
         })
 
@@ -296,10 +298,9 @@ describe('KeyedRateLimiterService', () => {
         })
 
         it('allows the first N inputs of an over-budget batch and denies the rest', async () => {
-            // The user case: 10 cost-1 requests against a bucket of 4. Per the
-            // V2/V3 contract, `isRateLimited = tokens <= 0`, so the 4th request
-            // (which brings tokens to exactly 0) is flagged as rate-limited
-            // even though its cost was paid. The remaining 6 hit tokens=-1.
+            // 10 cost-1 requests against a bucket of 4. The 4th request spends
+            // the last token (bucket lands at 0) and is still served; the
+            // remaining 6 fail to deduct and come back as tokens=-1.
             const limiter = buildLimiter('grouped-fanout', { bucketSize: 4, refillRate: 0 })
             await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
 
@@ -311,7 +312,7 @@ describe('KeyedRateLimiterService', () => {
                 false,
                 false,
                 false,
-                true, // tokens=0 — boundary, flagged as rate-limited
+                false, // tokens=0 — last token spent, request served
                 true,
                 true,
                 true,
@@ -347,10 +348,11 @@ describe('KeyedRateLimiterService', () => {
             await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
 
             // Two ids interleaved with 3 cost-1 requests each. Each id's budget
-            // of 2 fits its 1st request cleanly (tokens=1), depletes on the 2nd
-            // (tokens=0 → rate-limited boundary), and denies the 3rd (tokens=-1).
-            // If the budgets were shared, t2's first call would already be
-            // rate-limited because t1 would have drained the shared bucket.
+            // of 2 fits its 1st request cleanly (tokens=1), spends the last
+            // token on the 2nd (tokens=0 — still served), and denies the 3rd
+            // (tokens=-1, bucket empty). If the budgets were shared, t2's first
+            // call would already be rate-limited because t1 would have drained
+            // the shared bucket.
             const res = await limiter.rateLimitGrouped([
                 { id: 'team-1', cost: 1 },
                 { id: 'team-2', cost: 1 },
@@ -361,7 +363,7 @@ describe('KeyedRateLimiterService', () => {
             ])
 
             expect(res.map(([, r]) => r.tokens)).toEqual([1, 1, 0, 0, -1, -1])
-            expect(res.map(([, r]) => r.isRateLimited)).toEqual([false, false, true, true, true, true])
+            expect(res.map(([, r]) => r.isRateLimited)).toEqual([false, false, false, false, true, true])
         })
 
         it('issues exactly one Redis dispatch per unique id (call-count win)', async () => {
@@ -495,6 +497,38 @@ describe('KeyedRateLimiterService', () => {
             const stored = await readBucket(key)
             expect(stored.ts).toBe(String(Math.round(now / 1000)))
             expect(stored.pool).toBe('95')
+        })
+
+        // Regression for the V3-era wedge bug. V3 stored pool=-1 on denial,
+        // throwing away any accrued refill credit and wedging the bucket at -1
+        // forever under sustained sub-2 fractional fillRate traffic. V4 (the
+        // default for `rateLimitGrouped`) persists the un-deducted balance on
+        // denial so refill credit accumulates across calls — the bucket
+        // recovers as soon as the running budget catches up to the cost.
+        it('recovers from overdraft under sustained sub-2 fillRate', async () => {
+            const limiter = buildLimiter('grouped-sustained-recovery', { bucketSize: 10, refillRate: 1.5 })
+            await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
+
+            // Drain into denial: 100 cost-1 calls against a 10-token bucket, same now.
+            let lastDuringDrain = 0
+            for (let i = 0; i < 100; i++) {
+                const res = await limiter.rateLimitGrouped([{ id: 'team-1', cost: 1 }])
+                lastDuringDrain = res[0][1].tokens
+            }
+            expect(lastDuringDrain).toBe(-1)
+
+            // 1 req/s with refillRate=1.5 → first tick has 1.5 tokens, enough to serve.
+            let firstRecoveryIndex = -1
+            for (let i = 0; i < 10; i++) {
+                advanceTime(1000)
+                const res = await limiter.rateLimitGrouped([{ id: 'team-1', cost: 1 }])
+                if (!res[0][1].isRateLimited) {
+                    firstRecoveryIndex = i
+                    break
+                }
+            }
+            expect(firstRecoveryIndex).toBeGreaterThanOrEqual(0)
+            expect(firstRecoveryIndex).toBeLessThan(5)
         })
     })
 })

--- a/nodejs/src/common/services/keyed-rate-limiter.service.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.ts
@@ -119,7 +119,10 @@ export class KeyedRateLimiterService {
             const [tokenRes] = getRedisPipelineResults(res, index, 1)
             const tokensBefore = Number(tokenRes[1]?.[0] ?? bucketSizes[index])
             const tokensAfter = Number(tokenRes[1]?.[1] ?? bucketSizes[index])
-            const isRateLimited = tokensAfter <= 0
+            // Lua returns -1 when the cost couldn't be served. tokensAfter=0
+            // means the deduction succeeded and emptied the bucket — that's a
+            // served request, not a denied one.
+            const isRateLimited = tokensAfter < 0
             if (isRateLimited) {
                 limited++
             } else {
@@ -173,7 +176,7 @@ export class KeyedRateLimiterService {
             { name: `keyed-rate-limiter-grouped:${this.config.name}`, failOpen: true },
             (pipeline) => {
                 items.forEach((req) => {
-                    pipeline.checkRateLimitV3(...this.rateLimitArgs(req))
+                    pipeline.checkRateLimitV4(...this.rateLimitArgs(req))
                 })
             }
         )
@@ -210,15 +213,14 @@ export class KeyedRateLimiterService {
         const out: [string, KeyedRateLimit][] = requests.map((req) => {
             const tokensBefore = budgetById.get(req.id) ?? 0
             if (tokensBefore >= req.cost) {
+                // Deduction succeeded — request is served. Landing at exactly 0
+                // means we just spent the last token; the bucket is empty but
+                // this request still got through. Only the *next* call (which
+                // will see budget=0 < cost) is denied.
                 const next = tokensBefore - req.cost
                 budgetById.set(req.id, next)
-                const isRateLimited = next <= 0
-                if (isRateLimited) {
-                    limited++
-                } else {
-                    allowed++
-                }
-                return [req.id, { tokensBefore, tokens: next, isRateLimited }]
+                allowed++
+                return [req.id, { tokensBefore, tokens: next, isRateLimited: false }]
             }
             limited++
             return [req.id, { tokensBefore, tokens: -1, isRateLimited: true }]

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -493,7 +493,7 @@ describe('ErrorTrackingConsumer', () => {
             jest.spyOn(Date, 'now').mockReturnValue(Date.now() + seconds * 1000)
         }
 
-        it('per-team limit lets early batches through and rate-limits once the budget is exhausted', async () => {
+        it('per-team limit lets early batches through and partially passes through once the budget is exhausted', async () => {
             await upsertSettings({ projectRateLimit: 15 })
             await enableRateLimiter()
 
@@ -508,17 +508,18 @@ describe('ErrorTrackingConsumer', () => {
                     ])
                 )
 
-            // tokens 15 → 11
+            // tokens 15 → 11 (4 allowed)
             await sendBatch()
-            // tokens 11 → 7
+            // tokens 11 → 7 (4 allowed)
             await sendBatch()
-            // tokens 7 → 3
+            // tokens 7 → 3 (4 allowed)
             await sendBatch()
-            // cost 4 > tokens 3 → batch dropped
+            // budget 3, cost 4 → partial pass-through: 3 allowed (the 3rd spends the
+            // last token, bucket lands at 0 but the request is served), 1 dropped.
             await sendBatch()
             await drainProduces()
 
-            expect(producedCount()).toBe(12)
+            expect(producedCount()).toBe(15)
         })
 
         it('per-issue limit applies independently to each stack signature', async () => {
@@ -533,16 +534,18 @@ describe('ErrorTrackingConsumer', () => {
             await send('A')
             // 2 → 1
             await send('A')
-            // 1 → 0 → rate-limited
+            // 1 → 0 — last token spent, request served
+            await send('A')
+            // bucket empty — next A is dropped
             await send('A')
 
-            expect(producedCount()).toBe(3)
+            expect(producedCount()).toBe(4)
 
             // issue B has its own fresh bucket: 4 → 3
             await send('B')
             await drainProduces()
 
-            expect(producedCount()).toBe(4) // 3 from A + 1 from B
+            expect(producedCount()).toBe(5) // 4 from A + 1 from B
         })
 
         it('signature groups by stack and ignores message interpolation', async () => {
@@ -558,20 +561,21 @@ describe('ErrorTrackingConsumer', () => {
             await send('foo')
             // 2 → 1
             await send('foo')
-            // 1 → 0 → rate-limited
+            // 1 → 0 — last token spent, request served
             await send('foo')
 
             // bar has its own bucket: 4 → 3
             await send('bar')
 
-            expect(producedCount()).toBe(4)
+            expect(producedCount()).toBe(5)
 
             // foo with different `value` → same key as foo's burst (value is
-            // dropped from the hash when a stack exists) → still rate-limited.
+            // dropped from the hash when a stack exists) → bucket already empty,
+            // request denied.
             await send('foo', 'different')
             await drainProduces()
 
-            expect(producedCount()).toBe(4)
+            expect(producedCount()).toBe(5)
         })
 
         it('refills tokens over time once the bucket window has elapsed', async () => {
@@ -586,10 +590,10 @@ describe('ErrorTrackingConsumer', () => {
             await send('foo')
             // 2 → 1
             await send('foo')
-            // 1 → 0 → rate-limited
+            // 1 → 0 — last token spent, request served
             await send('foo')
             await drainProduces()
-            expect(producedCount()).toBe(3)
+            expect(producedCount()).toBe(4)
 
             // Advance one full bucket window (60 min); refillRate = 4 / 3600s → bucket back to full.
             advanceTime(60 * 60)
@@ -597,7 +601,7 @@ describe('ErrorTrackingConsumer', () => {
             // tokens 4 → 3
             await send('foo')
             await drainProduces()
-            expect(producedCount()).toBe(4)
+            expect(producedCount()).toBe(5)
         })
     })
 })

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -430,24 +430,22 @@ describe('ErrorTrackingConsumer', () => {
     })
 
     describe('rate limiting', () => {
-        const upsertSettings = async (
-            projectValue: number | null,
-            projectMinutes: number | null,
-            perIssueValue: number | null,
-            perIssueMinutes: number | null
-        ): Promise<void> => {
+        const upsertSettings = async (args: {
+            projectRateLimit?: number | null
+            perIssueRateLimit?: number | null
+        }): Promise<void> => {
             await hub.postgres.query(
                 PostgresUse.COMMON_WRITE,
                 `INSERT INTO posthog_errortrackingsettings
                     (team_id, project_rate_limit_value, project_rate_limit_bucket_size_minutes,
                      per_issue_rate_limit_value, per_issue_rate_limit_bucket_size_minutes)
-                 VALUES ($1, $2, $3, $4, $5)
+                 VALUES ($1, $2, 60, $3, 60)
                  ON CONFLICT (team_id) DO UPDATE SET
                     project_rate_limit_value = EXCLUDED.project_rate_limit_value,
                     project_rate_limit_bucket_size_minutes = EXCLUDED.project_rate_limit_bucket_size_minutes,
                     per_issue_rate_limit_value = EXCLUDED.per_issue_rate_limit_value,
                     per_issue_rate_limit_bucket_size_minutes = EXCLUDED.per_issue_rate_limit_bucket_size_minutes`,
-                [team.id, projectValue, projectMinutes, perIssueValue, perIssueMinutes],
+                [team.id, args.projectRateLimit ?? null, args.perIssueRateLimit ?? null],
                 'test-upsert-error-tracking-settings'
             )
         }
@@ -491,51 +489,105 @@ describe('ErrorTrackingConsumer', () => {
             await consumer['promiseScheduler'].waitForAll()
         }
 
-        // The limiter sums cost per key within a batch and `isRateLimited` is
-        // `tokensAfter <= 0`, so bucketSize=1 trips on the first request. Use 2+.
-        const BUDGET = 2
+        const producedCount = (): number =>
+            mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test').length
 
-        it('per-team limit drops the whole batch when team budget is exceeded', async () => {
-            await upsertSettings(BUDGET, 60, null, null)
+        it('per-team limit lets early batches through and rate-limits once the budget is exhausted', async () => {
+            await upsertSettings({ projectRateLimit: 15 })
             await enableRateLimiter()
 
-            const events = [1, 2, 3, 4, 5].map((i) =>
-                eventWithStack({ distinctId: `u-${i}`, type: 'TypeError', value: `v-${i}`, fn: `fn${i}` })
-            )
-            await consumer.handleKafkaBatch(createKafkaMessages(events))
+            // Bucket starts at 15. Each batch sums to cost=4, so tokens walk
+            // 15→11→7→3 (3 batches accepted), then batch 4's cost=4 vs tokens=3
+            // trips the limit and the whole batch drops.
+            const sendBatch = async (label: string): Promise<void> => {
+                const events = [1, 2, 3, 4].map((i) =>
+                    eventWithStack({
+                        distinctId: `${label}-${i}`,
+                        type: 'TypeError',
+                        value: `${label}-${i}`,
+                        fn: `${label}-${i}`,
+                    })
+                )
+                await consumer.handleKafkaBatch(createKafkaMessages(events))
+            }
+
+            for (const label of ['a', 'b', 'c', 'd']) {
+                await sendBatch(label)
+            }
             await drainProduces()
 
-            const produced = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
-            expect(produced).toHaveLength(0)
+            expect(producedCount()).toBe(12)
         })
 
-        it('per-issue limit drops the batch when same-stack repeats exceed the budget', async () => {
-            await upsertSettings(null, null, BUDGET, 60)
+        it('per-issue limit applies independently to each stack signature', async () => {
+            await upsertSettings({ perIssueRateLimit: 4 })
             await enableRateLimiter()
 
-            // Same frames, varying `value` — proves the signature ignores message interpolation.
-            const events = [1, 2, 3, 4, 5].map((i) =>
-                eventWithStack({ distinctId: `u-${i}`, type: 'TypeError', value: `dynamic-${i}`, fn: 'sharedFn' })
-            )
-            await consumer.handleKafkaBatch(createKafkaMessages(events))
-            await drainProduces()
+            // Each batch carries the same three issues (alpha/beta/gamma). Each
+            // issue's bucket walks 4→3→2→1→0 — batches 1-3 pass for all three
+            // issues, batch 4 rate-limits all three.
+            const batchAcrossIssues = (variant: number): Message[] =>
+                createKafkaMessages(
+                    ['alpha', 'beta', 'gamma'].map((iss) =>
+                        eventWithStack({
+                            distinctId: `${iss}-${variant}`,
+                            type: 'TypeError',
+                            value: `v-${variant}`,
+                            fn: iss,
+                        })
+                    )
+                )
 
-            const produced = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
-            expect(produced).toHaveLength(0)
+            for (const variant of [1, 2, 3, 4]) {
+                await consumer.handleKafkaBatch(batchAcrossIssues(variant))
+            }
+            await drainProduces()
+            expect(producedCount()).toBe(9)
+
+            // A previously-unseen issue has its own untouched bucket and passes.
+            await consumer.handleKafkaBatch(
+                createKafkaMessages([
+                    eventWithStack({ distinctId: 'delta-1', type: 'TypeError', value: 'v', fn: 'delta' }),
+                ])
+            )
+            await drainProduces()
+            expect(producedCount()).toBe(10)
         })
 
-        it('per-issue limit does not throttle events with distinct stack signatures', async () => {
-            await upsertSettings(null, null, BUDGET, 60)
+        it('signature groups by stack and ignores message interpolation', async () => {
+            await upsertSettings({ perIssueRateLimit: 4 })
             await enableRateLimiter()
 
-            const events = [1, 2, 3, 4, 5].map((i) =>
-                eventWithStack({ distinctId: `u-${i}`, type: 'TypeError', value: 'v', fn: `fn${i}` })
-            )
-            await consumer.handleKafkaBatch(createKafkaMessages(events))
+            // Phase 1: same exception 4 times → bucket exhausts on the 4th. Three pass.
+            for (let i = 0; i < 4; i++) {
+                await consumer.handleKafkaBatch(
+                    createKafkaMessages([
+                        eventWithStack({ distinctId: `same-${i}`, type: 'TypeError', value: 'msg', fn: 'foo' }),
+                    ])
+                )
+            }
             await drainProduces()
+            expect(producedCount()).toBe(3)
 
-            const produced = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
-            expect(produced).toHaveLength(5)
+            // Phase 2: different stack → fresh bucket → passes.
+            await consumer.handleKafkaBatch(
+                createKafkaMessages([
+                    eventWithStack({ distinctId: 'new-stack', type: 'TypeError', value: 'msg', fn: 'bar' }),
+                ])
+            )
+            await drainProduces()
+            expect(producedCount()).toBe(4)
+
+            // Phase 3: revert to the original stack, only `value` differs. The
+            // signature drops `value` when a stack exists, so this hits the
+            // exhausted bucket from phase 1 and gets rate-limited.
+            await consumer.handleKafkaBatch(
+                createKafkaMessages([
+                    eventWithStack({ distinctId: 'new-value', type: 'TypeError', value: 'msg-2', fn: 'foo' }),
+                ])
+            )
+            await drainProduces()
+            expect(producedCount()).toBe(4)
         })
     })
 })

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -487,6 +487,12 @@ describe('ErrorTrackingConsumer', () => {
         const producedCount = (): number =>
             mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test').length
 
+        // The Lua script reads time via `Date.now()`. `beforeEach` mocks it to a
+        // fixed value; bumping the same spy advances "now" so the bucket refills.
+        const advanceTime = (seconds: number): void => {
+            jest.spyOn(Date, 'now').mockReturnValue(Date.now() + seconds * 1000)
+        }
+
         it('per-team limit lets early batches through and rate-limits once the budget is exhausted', async () => {
             await upsertSettings({ projectRateLimit: 15 })
             await enableRateLimiter()
@@ -565,6 +571,32 @@ describe('ErrorTrackingConsumer', () => {
             await send('foo', 'different')
             await drainProduces()
 
+            expect(producedCount()).toBe(4)
+        })
+
+        it('refills tokens over time once the bucket window has elapsed', async () => {
+            await upsertSettings({ perIssueRateLimit: 4 })
+            await enableRateLimiter()
+
+            const send = (fn: string) => consumer.handleKafkaBatch(createKafkaMessages([exceptionEvent(fn)]))
+
+            // tokens 4 → 3
+            await send('foo')
+            // 3 → 2
+            await send('foo')
+            // 2 → 1
+            await send('foo')
+            // 1 → 0 → rate-limited
+            await send('foo')
+            await drainProduces()
+            expect(producedCount()).toBe(3)
+
+            // Advance one full bucket window (60 min); refillRate = 4 / 3600s → bucket back to full.
+            advanceTime(60 * 60)
+
+            // tokens 4 → 3
+            await send('foo')
+            await drainProduces()
             expect(producedCount()).toBe(4)
         })
     })

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -466,17 +466,14 @@ describe('ErrorTrackingConsumer', () => {
             })
         }
 
-        const eventWithStack = (overrides: { distinctId: string; type: string; value: string; fn: string }) =>
+        const exceptionEvent = (fn: string, value: string = 'msg'): PipelineEvent =>
             createEvent({
-                distinct_id: overrides.distinctId,
                 properties: {
                     $exception_list: [
                         {
-                            type: overrides.type,
-                            value: overrides.value,
-                            stacktrace: {
-                                frames: [{ function: overrides.fn, filename: `${overrides.fn}.js`, lineno: 1 }],
-                            },
+                            type: 'TypeError',
+                            value,
+                            stacktrace: { frames: [{ function: fn, filename: `${fn}.js`, lineno: 1 }] },
                             mechanism: { type: 'generic', handled: true },
                         },
                     ],
@@ -485,9 +482,7 @@ describe('ErrorTrackingConsumer', () => {
 
         // The pipeline produces via `.handleSideEffects(_, { await: false })`,
         // so the mock observer only reflects emits once the scheduler drains.
-        const drainProduces = async (): Promise<void> => {
-            await consumer['promiseScheduler'].waitForAll()
-        }
+        const drainProduces = () => consumer['promiseScheduler'].waitForAll()
 
         const producedCount = (): number =>
             mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test').length
@@ -496,24 +491,25 @@ describe('ErrorTrackingConsumer', () => {
             await upsertSettings({ projectRateLimit: 15 })
             await enableRateLimiter()
 
-            // Bucket starts at 15. Each batch sums to cost=4, so tokens walk
-            // 15→11→7→3 (3 batches accepted), then batch 4's cost=4 vs tokens=3
-            // trips the limit and the whole batch drops.
-            const sendBatch = async (label: string): Promise<void> => {
-                const events = [1, 2, 3, 4].map((i) =>
-                    eventWithStack({
-                        distinctId: `${label}-${i}`,
-                        type: 'TypeError',
-                        value: `${label}-${i}`,
-                        fn: `${label}-${i}`,
-                    })
+            // Each batch carries 4 events all sharing the team-global key → cost=4.
+            const sendBatch = () =>
+                consumer.handleKafkaBatch(
+                    createKafkaMessages([
+                        exceptionEvent('a'),
+                        exceptionEvent('b'),
+                        exceptionEvent('c'),
+                        exceptionEvent('d'),
+                    ])
                 )
-                await consumer.handleKafkaBatch(createKafkaMessages(events))
-            }
 
-            for (const label of ['a', 'b', 'c', 'd']) {
-                await sendBatch(label)
-            }
+            // tokens 15 → 11
+            await sendBatch()
+            // tokens 11 → 7
+            await sendBatch()
+            // tokens 7 → 3
+            await sendBatch()
+            // cost 4 > tokens 3 → batch dropped
+            await sendBatch()
             await drainProduces()
 
             expect(producedCount()).toBe(12)
@@ -523,70 +519,50 @@ describe('ErrorTrackingConsumer', () => {
             await upsertSettings({ perIssueRateLimit: 4 })
             await enableRateLimiter()
 
-            // Each batch carries the same three issues (alpha/beta/gamma). Each
-            // issue's bucket walks 4→3→2→1→0 — batches 1-3 pass for all three
-            // issues, batch 4 rate-limits all three.
-            const batchAcrossIssues = (variant: number): Message[] =>
-                createKafkaMessages(
-                    ['alpha', 'beta', 'gamma'].map((iss) =>
-                        eventWithStack({
-                            distinctId: `${iss}-${variant}`,
-                            type: 'TypeError',
-                            value: `v-${variant}`,
-                            fn: iss,
-                        })
-                    )
-                )
+            const send = (fn: string) => consumer.handleKafkaBatch(createKafkaMessages([exceptionEvent(fn)]))
 
-            for (const variant of [1, 2, 3, 4]) {
-                await consumer.handleKafkaBatch(batchAcrossIssues(variant))
-            }
-            await drainProduces()
-            expect(producedCount()).toBe(9)
+            // issue A: tokens 4 → 3
+            await send('A')
+            // 3 → 2
+            await send('A')
+            // 2 → 1
+            await send('A')
+            // 1 → 0 → rate-limited
+            await send('A')
 
-            // A previously-unseen issue has its own untouched bucket and passes.
-            await consumer.handleKafkaBatch(
-                createKafkaMessages([
-                    eventWithStack({ distinctId: 'delta-1', type: 'TypeError', value: 'v', fn: 'delta' }),
-                ])
-            )
+            expect(producedCount()).toBe(3)
+
+            // issue B has its own fresh bucket: 4 → 3
+            await send('B')
             await drainProduces()
-            expect(producedCount()).toBe(10)
+
+            expect(producedCount()).toBe(4) // 3 from A + 1 from B
         })
 
         it('signature groups by stack and ignores message interpolation', async () => {
             await upsertSettings({ perIssueRateLimit: 4 })
             await enableRateLimiter()
 
-            // Phase 1: same exception 4 times → bucket exhausts on the 4th. Three pass.
-            for (let i = 0; i < 4; i++) {
-                await consumer.handleKafkaBatch(
-                    createKafkaMessages([
-                        eventWithStack({ distinctId: `same-${i}`, type: 'TypeError', value: 'msg', fn: 'foo' }),
-                    ])
-                )
-            }
-            await drainProduces()
-            expect(producedCount()).toBe(3)
+            const send = (fn: string, value: string = 'msg') =>
+                consumer.handleKafkaBatch(createKafkaMessages([exceptionEvent(fn, value)]))
 
-            // Phase 2: different stack → fresh bucket → passes.
-            await consumer.handleKafkaBatch(
-                createKafkaMessages([
-                    eventWithStack({ distinctId: 'new-stack', type: 'TypeError', value: 'msg', fn: 'bar' }),
-                ])
-            )
-            await drainProduces()
-            expect(producedCount()).toBe(4)
+            // foo: tokens 4 → 3
+            await send('foo')
+            // 3 → 2
+            await send('foo')
+            // 2 → 1
+            await send('foo')
+            // 1 → 0 → rate-limited
+            await send('foo')
 
-            // Phase 3: revert to the original stack, only `value` differs. The
-            // signature drops `value` when a stack exists, so this hits the
-            // exhausted bucket from phase 1 and gets rate-limited.
-            await consumer.handleKafkaBatch(
-                createKafkaMessages([
-                    eventWithStack({ distinctId: 'new-value', type: 'TypeError', value: 'msg-2', fn: 'foo' }),
-                ])
-            )
+            // bar has its own bucket: 4 → 3
+            await send('bar')
+
+            // foo with different `value` → same key as foo's burst (value is
+            // dropped from the hash when a stack exists) → still rate-limited.
+            await send('foo', 'different')
             await drainProduces()
+
             expect(producedCount()).toBe(4)
         })
     })

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -558,6 +558,8 @@ describe('ErrorTrackingConsumer', () => {
             // bar has its own bucket: 4 → 3
             await send('bar')
 
+            expect(producedCount()).toBe(4)
+
             // foo with different `value` → same key as foo's burst (value is
             // dropped from the hash when a stack exists) → still rate-limited.
             await send('foo', 'different')

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -7,6 +7,7 @@ import { KafkaConsumer } from '~/kafka/consumer/consumer-v1'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { Hub, PipelineEvent, Team } from '~/types'
 import { closeHub, createHub } from '~/utils/db/hub'
+import { PostgresUse } from '~/utils/db/postgres'
 import { ErrorTrackingSettingsManager } from '~/utils/error-tracking-settings-manager'
 import { parseJSON } from '~/utils/json-parse'
 import { UUIDT } from '~/utils/utils'
@@ -425,6 +426,116 @@ describe('ErrorTrackingConsumer', () => {
                 mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
             expect(producedMessages).toHaveLength(1)
             expect(producedMessages[0].value.person_mode).toBe('full')
+        })
+    })
+
+    describe('rate limiting', () => {
+        const upsertSettings = async (
+            projectValue: number | null,
+            projectMinutes: number | null,
+            perIssueValue: number | null,
+            perIssueMinutes: number | null
+        ): Promise<void> => {
+            await hub.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `INSERT INTO posthog_errortrackingsettings
+                    (team_id, project_rate_limit_value, project_rate_limit_bucket_size_minutes,
+                     per_issue_rate_limit_value, per_issue_rate_limit_bucket_size_minutes)
+                 VALUES ($1, $2, $3, $4, $5)
+                 ON CONFLICT (team_id) DO UPDATE SET
+                    project_rate_limit_value = EXCLUDED.project_rate_limit_value,
+                    project_rate_limit_bucket_size_minutes = EXCLUDED.project_rate_limit_bucket_size_minutes,
+                    per_issue_rate_limit_value = EXCLUDED.per_issue_rate_limit_value,
+                    per_issue_rate_limit_bucket_size_minutes = EXCLUDED.per_issue_rate_limit_bucket_size_minutes`,
+                [team.id, projectValue, projectMinutes, perIssueValue, perIssueMinutes],
+                'test-upsert-error-tracking-settings'
+            )
+        }
+
+        const enableRateLimiter = async (): Promise<void> => {
+            await consumer.stop()
+            hub.ERROR_TRACKING_RATE_LIMITER_ENABLED = true
+            hub.ERROR_TRACKING_RATE_LIMITER_REPORTING_MODE = false
+            consumer = await createConsumer(hub)
+
+            await consumer['rateLimiterRedis']!.useClient({ name: 'test-flush' }, async (client) => {
+                const keys = await client.keys(
+                    `@posthog-test/error-tracking-rate-limiter/tokens/${team.id}:exceptions:*`
+                )
+                if (keys.length > 0) {
+                    await client.del(...keys)
+                }
+            })
+        }
+
+        const eventWithStack = (overrides: { distinctId: string; type: string; value: string; fn: string }) =>
+            createEvent({
+                distinct_id: overrides.distinctId,
+                properties: {
+                    $exception_list: [
+                        {
+                            type: overrides.type,
+                            value: overrides.value,
+                            stacktrace: {
+                                frames: [{ function: overrides.fn, filename: `${overrides.fn}.js`, lineno: 1 }],
+                            },
+                            mechanism: { type: 'generic', handled: true },
+                        },
+                    ],
+                },
+            })
+
+        // The pipeline produces via `.handleSideEffects(_, { await: false })`,
+        // so the mock observer only reflects emits once the scheduler drains.
+        const drainProduces = async (): Promise<void> => {
+            await consumer['promiseScheduler'].waitForAll()
+        }
+
+        // The limiter sums cost per key within a batch and `isRateLimited` is
+        // `tokensAfter <= 0`, so bucketSize=1 trips on the first request. Use 2+.
+        const BUDGET = 2
+
+        it('per-team limit drops the whole batch when team budget is exceeded', async () => {
+            await upsertSettings(BUDGET, 60, null, null)
+            await enableRateLimiter()
+
+            const events = [1, 2, 3, 4, 5].map((i) =>
+                eventWithStack({ distinctId: `u-${i}`, type: 'TypeError', value: `v-${i}`, fn: `fn${i}` })
+            )
+            await consumer.handleKafkaBatch(createKafkaMessages(events))
+            await drainProduces()
+
+            const produced = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
+            expect(produced).toHaveLength(0)
+        })
+
+        it('per-issue limit drops the batch when same-stack repeats exceed the budget', async () => {
+            await upsertSettings(null, null, BUDGET, 60)
+            await enableRateLimiter()
+
+            // Same frames, varying `value` — proves the signature ignores message interpolation.
+            const events = [1, 2, 3, 4, 5].map((i) =>
+                eventWithStack({ distinctId: `u-${i}`, type: 'TypeError', value: `dynamic-${i}`, fn: 'sharedFn' })
+            )
+            await consumer.handleKafkaBatch(createKafkaMessages(events))
+            await drainProduces()
+
+            const produced = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
+            expect(produced).toHaveLength(0)
+        })
+
+        it('per-issue limit does not throttle events with distinct stack signatures', async () => {
+            await upsertSettings(null, null, BUDGET, 60)
+            await enableRateLimiter()
+
+            const events = [1, 2, 3, 4, 5].map((i) =>
+                eventWithStack({ distinctId: `u-${i}`, type: 'TypeError', value: 'v', fn: `fn${i}` })
+            )
+            await consumer.handleKafkaBatch(createKafkaMessages(events))
+            await drainProduces()
+
+            const produced = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
+            expect(produced).toHaveLength(5)
         })
     })
 })

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { Pool as GenericPool } from 'generic-pool'
 import { Redis } from 'ioredis'
 import { Message } from 'node-rdkafka'
@@ -113,6 +114,27 @@ const latestOffsetTimestampGauge = new Gauge({
     labelNames: ['topic', 'partition', 'groupId'],
     aggregator: 'max',
 })
+
+// Stable-within-release grouping key. Drops `value` when a stack is available
+// (mirrors cymbal/src/types/mod.rs:218) so dynamic message interpolation
+// doesn't fragment. Across releases the hash drifts; the bucket's TTL absorbs it.
+function preCymbalGroupKey(event: PluginEvent): string | null {
+    const exc = event.properties?.$exception_list?.[0]
+    if (!exc) {
+        return null
+    }
+
+    const frames = exc.stacktrace?.frames
+    const payload = frames?.length ? JSON.stringify(frames) : (exc.value ?? '')
+    if (!payload) {
+        return null
+    }
+
+    return createHash('sha1')
+        .update(`${exc.type ?? ''}|${payload}`)
+        .digest('hex')
+        .slice(0, 16)
+}
 
 export class ErrorTrackingConsumer {
     protected name = 'error-tracking-consumer'
@@ -314,27 +336,31 @@ export class ErrorTrackingConsumer {
                     }
                 },
             },
-            // TODO: Per-exception-hash limit using a coarse pre-Cymbal fingerprint
-            // (Cymbal's proper fingerprint is post-symbolication, so we accept a
-            // weaker-but-cheaper bucket here). Wiring would look like:
-            // {
-            //     rateLimiter: this.rateLimiter,
-            //     appMetricsAggregator: this.rateLimiterAppMetricsAggregator,
-            //     appSource: 'exceptions',
-            //     getKey: (input) => {
-            //         const first = input.event.properties?.$exception_list?.[0]
-            //         if (!first?.type && !first?.value) return null
-            //         const hash = createHash('sha1')
-            //             .update(`${first?.type ?? ''}|${first?.value ?? ''}`)
-            //             .digest('hex')
-            //             .slice(0, 16)
-            //         return `${input.team.id}:exceptions:hash:${hash}`
-            //     },
-            //     getTeamId: (input) => input.team.id,
-            //     reportingMode: this.config.rateLimiterReportingMode,
-            //     dropReason: 'rate_limited:per_hash',
-            //     // getBucketConfig: ... (see TODO above)
-            // },
+            // Per-stack cap: independent opt-in from the team-global limit.
+            {
+                rateLimiter: this.rateLimiter,
+                appMetricsAggregator: this.rateLimiterAppMetricsAggregator,
+                appSource: 'exceptions',
+                getKey: (input) => {
+                    if (input.errorTrackingSettings?.perIssueRateLimitValue == null) {
+                        return null
+                    }
+                    const sig = preCymbalGroupKey(input.event)
+                    return sig ? `${input.team.id}:exceptions:stack:${sig}` : null
+                },
+                getTeamId: (input) => input.team.id,
+                reportingMode: this.config.rateLimiterReportingMode,
+                dropReason: 'rate_limited:per_stack',
+                getBucketConfig: (input) => {
+                    const settings = input.errorTrackingSettings!
+                    const value = settings.perIssueRateLimitValue!
+                    const minutes = settings.perIssueRateLimitBucketSizeMinutes ?? 60
+                    return {
+                        bucketSize: value,
+                        refillRate: value / (minutes * 60),
+                    }
+                },
+            },
         ]
 
         return specs

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto'
 import { Pool as GenericPool } from 'generic-pool'
 import { Redis } from 'ioredis'
 import { Message } from 'node-rdkafka'
@@ -36,6 +35,7 @@ import {
     runErrorTrackingPipeline,
 } from './error-tracking-pipeline'
 import { KeyedRateLimiterStepOptions } from './keyed-rate-limiter-step'
+import { preCymbalGroupKey } from './pre-cymbal-group-key'
 
 /**
  * Configuration values for ErrorTrackingConsumer.
@@ -114,27 +114,6 @@ const latestOffsetTimestampGauge = new Gauge({
     labelNames: ['topic', 'partition', 'groupId'],
     aggregator: 'max',
 })
-
-// Stable-within-release grouping key. Drops `value` when a stack is available
-// (mirrors cymbal/src/types/mod.rs:218) so dynamic message interpolation
-// doesn't fragment. Across releases the hash drifts; the bucket's TTL absorbs it.
-function preCymbalGroupKey(event: PluginEvent): string | null {
-    const exc = event.properties?.$exception_list?.[0]
-    if (!exc) {
-        return null
-    }
-
-    const frames = exc.stacktrace?.frames
-    const payload = frames?.length ? JSON.stringify(frames) : (exc.value ?? '')
-    if (!payload) {
-        return null
-    }
-
-    return createHash('sha1')
-        .update(`${exc.type ?? ''}|${payload}`)
-        .digest('hex')
-        .slice(0, 16)
-}
 
 export class ErrorTrackingConsumer {
     protected name = 'error-tracking-consumer'

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -309,10 +309,18 @@ export class ErrorTrackingConsumer {
                     const settings = input.errorTrackingSettings!
                     const value = settings.projectRateLimitValue!
                     const minutes = settings.projectRateLimitBucketSizeMinutes ?? 60
-                    return {
+                    const config = {
                         bucketSize: value,
                         refillRate: value / (minutes * 60),
                     }
+
+                    console.log('[ET-RL] project bucket config', {
+                        teamId: input.team.id,
+                        value,
+                        minutes,
+                        ...config,
+                    })
+                    return config
                 },
             },
             // Per-stack cap: independent opt-in from the team-global limit.
@@ -334,10 +342,18 @@ export class ErrorTrackingConsumer {
                     const settings = input.errorTrackingSettings!
                     const value = settings.perIssueRateLimitValue!
                     const minutes = settings.perIssueRateLimitBucketSizeMinutes ?? 60
-                    return {
+                    const config = {
                         bucketSize: value,
                         refillRate: value / (minutes * 60),
                     }
+
+                    console.log('[ET-RL] per-issue bucket config', {
+                        teamId: input.team.id,
+                        value,
+                        minutes,
+                        ...config,
+                    })
+                    return config
                 },
             },
         ]

--- a/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.test.ts
@@ -16,7 +16,7 @@ const mkLimiter = (decisions: Record<string, boolean>): KeyedRateLimiterService 
             return Promise.resolve(
                 requests.map(({ id }): [string, KeyedRateLimit] => [
                     id,
-                    { tokensBefore: 100, tokens: decisions[id] ? 0 : 99, isRateLimited: !!decisions[id] },
+                    { tokensBefore: 100, tokens: decisions[id] ? -1 : 99, isRateLimited: !!decisions[id] },
                 ])
             )
         }),
@@ -106,7 +106,7 @@ describe('createKeyedRateLimiterStep', () => {
         expect(limiter.rateLimitGrouped).not.toHaveBeenCalled()
     })
 
-    it('aggregates cost per unique key in a single Redis call', async () => {
+    it('forwards one request per input so the limiter can perform partial fan-out', async () => {
         const limiter = mkLimiter({})
         const step = createKeyedRateLimiterStep<Input>(baseOpts({ rateLimiter: limiter }))
 
@@ -118,8 +118,47 @@ describe('createKeyedRateLimiterStep', () => {
 
         expect(limiter.rateLimitGrouped).toHaveBeenCalledTimes(1)
         const calledWith = (limiter.rateLimitGrouped as jest.Mock).mock.calls[0][0] as KeyedRateLimitRequest[]
-        const byId = Object.fromEntries(calledWith.map((req) => [req.id, req.cost]))
-        expect(byId).toEqual({ k1: 7, k2: 5 })
+        expect(calledWith.map((req) => ({ id: req.id, cost: req.cost }))).toEqual([
+            { id: 'k1', cost: 3 },
+            { id: 'k1', cost: 4 },
+            { id: 'k2', cost: 5 },
+        ])
+    })
+
+    it('performs partial pass-through within a rate-limited key group', async () => {
+        // Mock a budget of 2 for key 'k' — first 2 inputs allowed, rest denied.
+        const limiter = {
+            rateLimitGrouped: jest.fn((requests: KeyedRateLimitRequest[]) => {
+                let budget = 2
+                return Promise.resolve(
+                    requests.map(({ id, cost }): [string, KeyedRateLimit] => {
+                        if (id !== 'k') {
+                            return [id, { tokensBefore: 100, tokens: 99, isRateLimited: false }]
+                        }
+                        if (budget >= cost) {
+                            budget -= cost
+                            return [id, { tokensBefore: 2, tokens: budget, isRateLimited: false }]
+                        }
+                        return [id, { tokensBefore: budget, tokens: -1, isRateLimited: true }]
+                    })
+                )
+            }),
+        } as unknown as KeyedRateLimiterService
+
+        const step = createKeyedRateLimiterStep<Input>(baseOpts({ rateLimiter: limiter, reportingMode: false }))
+
+        const results = await step([
+            { teamId: 1, key: 'k' },
+            { teamId: 1, key: 'k' },
+            { teamId: 1, key: 'k' },
+            { teamId: 1, key: 'k' },
+        ])
+
+        // First 2 inputs spend the budget (1 and 0 remaining); last 2 hit empty bucket.
+        expect(isOkResult(results[0])).toBe(true)
+        expect(isOkResult(results[1])).toBe(true)
+        expect(isDropResult(results[2])).toBe(true)
+        expect(isDropResult(results[3])).toBe(true)
     })
 
     it('forwards per-input bucket config overrides to the limiter (snapshotted from first input per key)', async () => {
@@ -134,15 +173,20 @@ describe('createKeyedRateLimiterStep', () => {
 
         await step([
             { teamId: 1, key: 'k1', bucketOverride: 5 },
-            { teamId: 1, key: 'k1', bucketOverride: 999 }, // ignored — first wins
+            { teamId: 1, key: 'k1', bucketOverride: 999 }, // ignored — first per key wins
             { teamId: 2, key: 'k2' }, // no override
         ])
 
         const requests = (limiter.rateLimitGrouped as jest.Mock).mock.calls[0][0] as KeyedRateLimitRequest[]
-        const byId = Object.fromEntries(requests.map((req) => [req.id, req]))
-        expect(byId.k1).toMatchObject({ id: 'k1', bucketSize: 5, refillRate: 1 })
-        expect(byId.k2.bucketSize).toBeUndefined()
-        expect(byId.k2.refillRate).toBeUndefined()
+        expect(requests).toHaveLength(3)
+        // first input per key carries the bucket config; later inputs forward without it.
+        expect(requests[0]).toMatchObject({ id: 'k1', bucketSize: 5, refillRate: 1 })
+        expect(requests[1].id).toBe('k1')
+        expect(requests[1].bucketSize).toBeUndefined()
+        expect(requests[1].refillRate).toBeUndefined()
+        expect(requests[2].id).toBe('k2')
+        expect(requests[2].bucketSize).toBeUndefined()
+        expect(requests[2].refillRate).toBeUndefined()
     })
 
     it('emits one app_metrics2 row per (team, key, outcome) with summed counts', async () => {

--- a/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.ts
+++ b/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.ts
@@ -4,7 +4,7 @@ import { AppMetricsAggregator } from '~/common/services/app-metrics-aggregator'
 import { KeyedRateLimitRequest, KeyedRateLimiterService } from '~/common/services/keyed-rate-limiter.service'
 
 import { BatchProcessingStep } from '../pipelines/base-batch-pipeline'
-import { drop, ok } from '../pipelines/results'
+import { drop, isDropResult, ok } from '../pipelines/results'
 
 const outcomeCounter = new Counter({
     name: 'keyed_rate_limiter_outcomes_total',
@@ -49,10 +49,16 @@ export interface KeyedRateLimiterStepOptions<T> {
  * - rateLimiter undefined → no-op, all `ok()`.
  * - getKey returns null  → that input bypasses rate limiting (still `ok()`).
  * - reportingMode true   → decisions tracked but never enforced.
- * - reportingMode false  → inputs in rate-limited groups become `drop(dropReason)`.
+ * - reportingMode false  → inputs whose per-input decision is `rate_limited`
+ *   become `drop(dropReason)`. Within a key group, as many inputs as the
+ *   available tokens permit are allowed; the rest are dropped (partial
+ *   pass-through, not all-or-nothing).
  *
- * Cost is summed per unique key within a batch so we make one Redis call per key
- * regardless of how many inputs share it.
+ * Internally we forward one request per input; `rateLimitGrouped` coalesces by
+ * id (one Redis call per unique key) and fans out per-input decisions
+ * client-side from each key's pre-deduction budget. Bucket config (if provided)
+ * is snapshotted from the first input per key — all inputs in a key group are
+ * expected to agree (e.g. team-keyed limits all share a team).
  */
 export function createKeyedRateLimiterStep<T>(opts: KeyedRateLimiterStepOptions<T>): BatchProcessingStep<T, T> {
     const costFn = opts.getCost ?? (() => 1)
@@ -61,40 +67,68 @@ export function createKeyedRateLimiterStep<T>(opts: KeyedRateLimiterStepOptions<
 
     return async function keyedRateLimiterStep(inputs) {
         if (!opts.rateLimiter || inputs.length === 0) {
+            console.log('[ET-RL] step entry: no-op', {
+                appSource: opts.appSource,
+                hasRateLimiter: !!opts.rateLimiter,
+                inputCount: inputs.length,
+            })
             return inputs.map((input) => ok(input))
         }
 
-        // Per-input key (null means "skip this input"). Cost summed per unique key
-        // so we issue exactly one Redis call per key — same pattern as logs-rate-limiter.
-        // Bucket config (if provided) snapshots the first input per key — all inputs in
-        // a key group are expected to agree (e.g. team-keyed limits all share a team).
+        console.log('[ET-RL] step entry', {
+            appSource: opts.appSource,
+            inputCount: inputs.length,
+            reportingMode: opts.reportingMode,
+        })
+
         const keyForInput: (string | null)[] = new Array(inputs.length)
-        const requestByKey = new Map<string, KeyedRateLimitRequest>()
+        const requestIndexForInput: (number | null)[] = new Array(inputs.length)
+        const requests: KeyedRateLimitRequest[] = []
+        const seenKey = new Set<string>()
 
         for (let i = 0; i < inputs.length; i++) {
             const key = opts.getKey(inputs[i])
             keyForInput[i] = key
             if (key === null) {
+                requestIndexForInput[i] = null
                 continue
             }
-            const inputCost = costFn(inputs[i])
-            const existing = requestByKey.get(key)
-            if (existing) {
-                existing.cost += inputCost
-            } else {
-                const overrides = opts.getBucketConfig?.(inputs[i]) ?? {}
-                requestByKey.set(key, { id: key, cost: inputCost, ...overrides })
-            }
+            const isFirstForKey = !seenKey.has(key)
+            seenKey.add(key)
+            const overrides = isFirstForKey ? (opts.getBucketConfig?.(inputs[i]) ?? {}) : {}
+            requests.push({ id: key, cost: costFn(inputs[i]), ...overrides })
+            requestIndexForInput[i] = requests.length - 1
         }
 
-        const limitedKeys = new Set<string>()
-        if (requestByKey.size > 0) {
-            const rateLimitResults = await opts.rateLimiter.rateLimitGrouped(Array.from(requestByKey.values()))
-            for (const [key, result] of rateLimitResults) {
-                if (result.isRateLimited) {
-                    limitedKeys.add(key)
-                }
-            }
+        console.log('[ET-RL] requests built', {
+            appSource: opts.appSource,
+            requestCount: requests.length,
+            skippedNullKey: inputs.length - requests.length,
+            uniqueKeys: seenKey.size,
+            requests: requests.map((r) => ({
+                id: r.id,
+                cost: r.cost,
+                bucketSize: r.bucketSize,
+                refillRate: r.refillRate,
+                ttlSeconds: r.ttlSeconds,
+            })),
+        })
+
+        let limitedByRequestIndex: boolean[] = []
+        if (requests.length > 0) {
+            const rateLimitResults = await opts.rateLimiter.rateLimitGrouped(requests)
+            limitedByRequestIndex = rateLimitResults.map(([, result]) => result.isRateLimited)
+
+            console.log('[ET-RL] rate-limit results', {
+                appSource: opts.appSource,
+                results: rateLimitResults.map(([id, result], idx) => ({
+                    idx,
+                    id,
+                    tokensBefore: result.tokensBefore,
+                    tokens: result.tokens,
+                    isRateLimited: result.isRateLimited,
+                })),
+            })
         }
 
         // Aggregate outcomes per (team, key, outcome) so we emit one app_metrics2
@@ -105,10 +139,11 @@ export function createKeyedRateLimiterStep<T>(opts: KeyedRateLimiterStepOptions<
         >()
         for (let i = 0; i < inputs.length; i++) {
             const key = keyForInput[i]
-            if (key === null) {
+            const requestIndex = requestIndexForInput[i]
+            if (key === null || requestIndex === null) {
                 continue
             }
-            const outcome: RateLimitOutcome = limitedKeys.has(key) ? 'rate_limited' : 'allowed'
+            const outcome: RateLimitOutcome = limitedByRequestIndex[requestIndex] ? 'rate_limited' : 'allowed'
             outcomeCounter.inc({ app_source: opts.appSource, outcome, reporting_mode: reportingModeLabel })
 
             if (opts.appMetricsAggregator) {
@@ -136,12 +171,25 @@ export function createKeyedRateLimiterStep<T>(opts: KeyedRateLimiterStepOptions<
             }
         }
 
-        return inputs.map((input, i) => {
-            const key = keyForInput[i]
-            if (key === null || !limitedKeys.has(key) || opts.reportingMode) {
+        const finalResults = inputs.map((input, i) => {
+            const requestIndex = requestIndexForInput[i]
+            if (requestIndex === null || !limitedByRequestIndex[requestIndex] || opts.reportingMode) {
                 return ok(input)
             }
             return drop<T>(dropReason)
         })
+
+        const droppedCount = finalResults.filter(isDropResult).length
+        const allowedCount = finalResults.length - droppedCount
+
+        console.log('[ET-RL] step exit', {
+            appSource: opts.appSource,
+            reportingMode: opts.reportingMode,
+            allowed: allowedCount,
+            dropped: droppedCount,
+            dropReason,
+        })
+
+        return finalResults
     }
 }

--- a/nodejs/src/ingestion/error-tracking/load-error-tracking-settings-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/load-error-tracking-settings-step.test.ts
@@ -1,14 +1,11 @@
-import { ErrorTrackingSettingsManager } from '~/utils/error-tracking-settings-manager'
+import { ErrorTrackingSettings, ErrorTrackingSettingsManager } from '~/utils/error-tracking-settings-manager'
 
 import { isOkResult } from '../pipelines/results'
 import { createLoadErrorTrackingSettingsStep } from './load-error-tracking-settings-step'
 
 describe('createLoadErrorTrackingSettingsStep', () => {
     const buildManager = (
-        settingsByTeam: Record<
-            string,
-            { projectRateLimitValue: number | null; projectRateLimitBucketSizeMinutes: number | null } | null
-        >
+        settingsByTeam: Record<string, ErrorTrackingSettings | null>
     ): jest.Mocked<Pick<ErrorTrackingSettingsManager, 'getSettings'>> => ({
         getSettings: jest.fn((teamId: number) => Promise.resolve(settingsByTeam[String(teamId)] ?? null)),
     })
@@ -27,7 +24,12 @@ describe('createLoadErrorTrackingSettingsStep', () => {
 
     it('attaches the loaded settings', async () => {
         const manager = buildManager({
-            '1': { projectRateLimitValue: 100, projectRateLimitBucketSizeMinutes: 5 },
+            '1': {
+                projectRateLimitValue: 100,
+                projectRateLimitBucketSizeMinutes: 5,
+                perIssueRateLimitValue: null,
+                perIssueRateLimitBucketSizeMinutes: null,
+            },
         })
         const step = createLoadErrorTrackingSettingsStep(manager as unknown as ErrorTrackingSettingsManager)
 
@@ -38,6 +40,8 @@ describe('createLoadErrorTrackingSettingsStep', () => {
             expect(result.value.errorTrackingSettings).toEqual({
                 projectRateLimitValue: 100,
                 projectRateLimitBucketSizeMinutes: 5,
+                perIssueRateLimitValue: null,
+                perIssueRateLimitBucketSizeMinutes: null,
             })
         }
     })

--- a/nodejs/src/ingestion/error-tracking/load-error-tracking-settings-step.ts
+++ b/nodejs/src/ingestion/error-tracking/load-error-tracking-settings-step.ts
@@ -16,6 +16,12 @@ export function createLoadErrorTrackingSettingsStep<T extends LoadErrorTrackingS
 ): ProcessingStep<T, WithErrorTrackingSettings<T>> {
     return async function loadErrorTrackingSettingsStep(input) {
         const errorTrackingSettings = manager ? await manager.getSettings(input.team.id) : null
+
+        console.log('[ET-RL] settings loaded', {
+            teamId: input.team.id,
+            hasManager: !!manager,
+            settings: errorTrackingSettings,
+        })
         return ok({ ...input, errorTrackingSettings })
     }
 }

--- a/nodejs/src/ingestion/error-tracking/pre-cymbal-group-key.test.ts
+++ b/nodejs/src/ingestion/error-tracking/pre-cymbal-group-key.test.ts
@@ -1,0 +1,122 @@
+import { createTestPluginEvent } from '~/tests/helpers/plugin-event'
+
+import { preCymbalGroupKey } from './pre-cymbal-group-key'
+
+const exceptionEvent = (exception: Record<string, unknown>) =>
+    createTestPluginEvent({ properties: { $exception_list: [exception] } })
+
+describe('preCymbalGroupKey', () => {
+    it('returns null when $exception_list is missing', () => {
+        expect(preCymbalGroupKey(createTestPluginEvent())).toBeNull()
+    })
+
+    it('returns null when there is no message and no frames', () => {
+        expect(preCymbalGroupKey(exceptionEvent({ type: 'Error' }))).toBeNull()
+    })
+
+    it('returns a 16-char hex digest', () => {
+        const key = preCymbalGroupKey(exceptionEvent({ type: 'Error', value: 'boom' }))
+        expect(key).toMatch(/^[0-9a-f]{16}$/)
+    })
+
+    describe('message-only exceptions', () => {
+        it('groups by type and value', () => {
+            const a = preCymbalGroupKey(exceptionEvent({ type: 'TypeError', value: 'same' }))
+            const b = preCymbalGroupKey(exceptionEvent({ type: 'TypeError', value: 'same' }))
+            const c = preCymbalGroupKey(exceptionEvent({ type: 'TypeError', value: 'other' }))
+
+            expect(a).toBe(b)
+            expect(a).not.toBe(c)
+        })
+    })
+
+    describe('stack exceptions', () => {
+        const stackEvent = (fn: string, value: string = 'msg') =>
+            exceptionEvent({
+                type: 'TypeError',
+                value,
+                stacktrace: {
+                    frames: [{ function: fn, filename: `${fn}.js`, lineno: 1 }],
+                },
+            })
+
+        it('groups by stack and ignores message when frames exist', () => {
+            const a = preCymbalGroupKey(stackEvent('foo'))
+            const b = preCymbalGroupKey(stackEvent('foo', 'different'))
+
+            expect(a).toBe(b)
+        })
+
+        it('separates different stacks', () => {
+            expect(preCymbalGroupKey(stackEvent('foo'))).not.toBe(preCymbalGroupKey(stackEvent('bar')))
+        })
+
+        it('does not conflate adjacent empty fields across frame boundaries', () => {
+            const split = preCymbalGroupKey(
+                exceptionEvent({
+                    type: 'Error',
+                    stacktrace: {
+                        frames: [
+                            { function: 'a', filename: 'bc' },
+                            { function: '', filename: '' },
+                        ],
+                    },
+                })
+            )
+            const merged = preCymbalGroupKey(
+                exceptionEvent({
+                    type: 'Error',
+                    stacktrace: {
+                        frames: [{ function: 'a', filename: 'bc' }],
+                    },
+                })
+            )
+
+            expect(split).not.toBe(merged)
+        })
+
+        it('uses abs_path, line, and column aliases', () => {
+            const withAliases = preCymbalGroupKey(
+                exceptionEvent({
+                    type: 'Error',
+                    stacktrace: {
+                        frames: [{ function: 'fn', abs_path: '/app/x.js', line: 10, column: 2 }],
+                    },
+                })
+            )
+            const withCanonical = preCymbalGroupKey(
+                exceptionEvent({
+                    type: 'Error',
+                    stacktrace: {
+                        frames: [{ function: 'fn', filename: '/app/x.js', lineno: 10, colno: 2 }],
+                    },
+                })
+            )
+
+            expect(withAliases).toBe(withCanonical)
+        })
+
+        it('ignores extra frame properties', () => {
+            const minimal = preCymbalGroupKey(stackEvent('fn'))
+            const verbose = preCymbalGroupKey(
+                exceptionEvent({
+                    type: 'TypeError',
+                    value: 'msg',
+                    stacktrace: {
+                        frames: [
+                            {
+                                function: 'fn',
+                                filename: 'fn.js',
+                                lineno: 1,
+                                context_line: 'const x = 1',
+                                vars: { x: 1 },
+                            },
+                        ],
+                    },
+                })
+            )
+
+            expect(minimal).toBe(verbose)
+        })
+    })
+})

--- a/nodejs/src/ingestion/error-tracking/pre-cymbal-group-key.ts
+++ b/nodejs/src/ingestion/error-tracking/pre-cymbal-group-key.ts
@@ -1,0 +1,46 @@
+import { createHash } from 'crypto'
+
+import { PluginEvent } from '~/plugin-scaffold'
+
+const PRE_CYMBAL_FRAME_FIELD_SEP = '\0'
+const PRE_CYMBAL_FRAME_SEP = '\x1e'
+
+function updatePreCymbalFrameHash(hash: ReturnType<typeof createHash>, frame: Record<string, unknown>): void {
+    hash.update(String(frame.function ?? ''))
+    hash.update(PRE_CYMBAL_FRAME_FIELD_SEP)
+    hash.update(String(frame.filename ?? frame.abs_path ?? ''))
+    hash.update(PRE_CYMBAL_FRAME_FIELD_SEP)
+    hash.update(String(frame.lineno ?? frame.line ?? ''))
+    hash.update(PRE_CYMBAL_FRAME_FIELD_SEP)
+    hash.update(String(frame.colno ?? frame.column ?? ''))
+    hash.update(PRE_CYMBAL_FRAME_FIELD_SEP)
+}
+
+/** Pre-Cymbal stack signature for per-issue rate limit buckets. */
+export function preCymbalGroupKey(event: PluginEvent): string | null {
+    const exc = event.properties?.$exception_list?.[0]
+    if (!exc) {
+        return null
+    }
+
+    const frames = exc.stacktrace?.frames
+    if (!frames?.length) {
+        const value = exc.value ?? ''
+        if (!value) {
+            return null
+        }
+        return createHash('sha1')
+            .update(`${exc.type ?? ''}|${value}`)
+            .digest('hex')
+            .slice(0, 16)
+    }
+
+    const hash = createHash('sha1')
+    hash.update(String(exc.type ?? ''))
+    hash.update('|')
+    for (const frame of frames) {
+        updatePreCymbalFrameHash(hash, frame as Record<string, unknown>)
+        hash.update(PRE_CYMBAL_FRAME_SEP)
+    }
+    return hash.digest('hex').slice(0, 16)
+}

--- a/nodejs/src/utils/error-tracking-settings-manager.test.ts
+++ b/nodejs/src/utils/error-tracking-settings-manager.test.ts
@@ -63,6 +63,8 @@ describe('ErrorTrackingSettingsManager', () => {
         expect(result).toEqual({
             projectRateLimitValue: 100,
             projectRateLimitBucketSizeMinutes: 5,
+            perIssueRateLimitValue: null,
+            perIssueRateLimitBucketSizeMinutes: null,
         })
     })
 
@@ -73,6 +75,8 @@ describe('ErrorTrackingSettingsManager', () => {
         expect(result).toEqual({
             projectRateLimitValue: null,
             projectRateLimitBucketSizeMinutes: null,
+            perIssueRateLimitValue: null,
+            perIssueRateLimitBucketSizeMinutes: null,
         })
     })
 

--- a/nodejs/src/utils/error-tracking-settings-manager.ts
+++ b/nodejs/src/utils/error-tracking-settings-manager.ts
@@ -4,12 +4,16 @@ import { LazyLoader } from './lazy-loader'
 export interface ErrorTrackingSettings {
     projectRateLimitValue: number | null
     projectRateLimitBucketSizeMinutes: number | null
+    perIssueRateLimitValue: number | null
+    perIssueRateLimitBucketSizeMinutes: number | null
 }
 
 interface RawSettingsRow {
     team_id: number
     project_rate_limit_value: number | null
     project_rate_limit_bucket_size_minutes: number | null
+    per_issue_rate_limit_value: number | null
+    per_issue_rate_limit_bucket_size_minutes: number | null
 }
 
 export class ErrorTrackingSettingsManager {
@@ -47,7 +51,9 @@ export class ErrorTrackingSettingsManager {
             `SELECT
                 team_id,
                 project_rate_limit_value,
-                project_rate_limit_bucket_size_minutes
+                project_rate_limit_bucket_size_minutes,
+                per_issue_rate_limit_value,
+                per_issue_rate_limit_bucket_size_minutes
             FROM posthog_errortrackingsettings
             WHERE team_id = ANY($1)`,
             [numericTeamIds],
@@ -58,6 +64,8 @@ export class ErrorTrackingSettingsManager {
             result[String(row.team_id)] = {
                 projectRateLimitValue: row.project_rate_limit_value,
                 projectRateLimitBucketSizeMinutes: row.project_rate_limit_bucket_size_minutes,
+                perIssueRateLimitValue: row.per_issue_rate_limit_value,
+                perIssueRateLimitBucketSizeMinutes: row.per_issue_rate_limit_bucket_size_minutes,
             }
         }
 


### PR DESCRIPTION
## Problem

- added missing implementation for the issue-based rate limiting
- changed rate limiter strategy from all-or-nothing to a partial pass through so if we have 100 tokens and we are trying to ingest 200 exceptions, we will ingest 100 of them instead of dropping the entire batch.

## Changes

We don't really know at this point (during ingestion) how exceptions will be grouped into issues so we compute a hash like that:
- we have frames -> type + frames
- we dont have frames -> type + message

We then rate limit based on this hash. This is not ideal obviously but it's the best we can do pre-cymbal

## How did you test this code?

- added some unit tests,
- added some e2e tests,
- actually ran all of this locally and confirmed that this works

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7).

Design choices worth flagging for review:

- **Pre-Cymbal, not post-Cymbal.** We considered keying on \`\$exception_issue_id\` post-Cymbal (perfectly accurate, matches the UI's grouping), but pre-Cymbal saves the symbolication round-trip on dropped events and keeps the existing limiter wiring untouched. The trade-off is grouping accuracy degrades for minified bundles where mangled names + content hashes shift across deploys — accepted because the bucket TTL ages keys out and the burst-cap behavior is what we want anyway.
- **Hash both frames and \`type\`.** \`type\` alone is too coarse (\`TypeError\` would collapse everything); \`type + value\` was the original sketch but \`value\` is the cardinality bomb (interpolated user IDs, URLs, timestamps would explode keys). Hashing the raw frames sidesteps both issues, and matches Cymbal's own \"drop value when a stack exists\" rule.
- **No across-deploy normalization.** Earlier iterations did basename stripping, content-hash regex, mangled-name detection, etc. The short TTL makes within-release stability sufficient — two events in the same release produce byte-identical frames, so the dumb \`JSON.stringify\` is enough.
- The keyed limiter's batch semantics are all-or-nothing per key (\`cost\` sums per key, bucket rejected when \`tokensAfter <= 0\`). Tests assert that behavior directly rather than asserting partial pass-through.