### PR TITLE
feat(slack-app): gate mention flow on granted Slack scopes

### DIFF
--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -232,6 +232,38 @@ class TestSlackIntegration:
         assert not channel["is_private"]
         assert not channel["is_private_without_access"]
 
+    def test_granted_scopes_parses_comma_separated_string(self):
+        self.integration.config["scope"] = "chat:write,users:read,users:read.email"
+        slack = SlackIntegration(self.integration)
+        assert slack.granted_scopes() == frozenset({"chat:write", "users:read", "users:read.email"})
+
+    def test_granted_scopes_tolerates_whitespace_and_empty_entries(self):
+        self.integration.config["scope"] = " chat:write , ,users:read"
+        slack = SlackIntegration(self.integration)
+        assert slack.granted_scopes() == frozenset({"chat:write", "users:read"})
+
+    def test_granted_scopes_returns_empty_when_field_missing(self):
+        self.integration.config.pop("scope", None)
+        slack = SlackIntegration(self.integration)
+        assert slack.granted_scopes() == frozenset()
+
+    def test_granted_scopes_returns_empty_when_field_is_empty_string(self):
+        self.integration.config["scope"] = ""
+        slack = SlackIntegration(self.integration)
+        assert slack.granted_scopes() == frozenset()
+
+    def test_missing_scopes_returns_difference(self):
+        self.integration.config["scope"] = "chat:write,users:read"
+        slack = SlackIntegration(self.integration)
+        required = {"chat:write", "users:read", "users:read.email", "reactions:write"}
+        assert slack.missing_scopes(required) == frozenset({"users:read.email", "reactions:write"})
+
+    def test_missing_scopes_returns_empty_when_all_granted(self):
+        required = {"chat:write", "users:read"}
+        self.integration.config["scope"] = "chat:write,users:read,extra:scope"
+        slack = SlackIntegration(self.integration)
+        assert slack.missing_scopes(required) == frozenset()
+
 
 class TestEmailIntegration:
     @pytest.fixture(autouse=True)

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -4,6 +4,7 @@ import time
 import base64
 import socket
 import hashlib
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NoReturn, Optional
@@ -1144,6 +1145,14 @@ class SlackIntegration:
 
     def async_client(self, session: Optional["aiohttp.ClientSession"] = None) -> AsyncWebClient:
         return AsyncWebClient(self.integration.sensitive_config["access_token"], session=session)
+
+    def granted_scopes(self) -> frozenset[str]:
+        """OAuth scopes Slack granted this install, stored on Integration.config["scope"]."""
+        raw = self.integration.config.get("scope") or ""
+        return frozenset(scope.strip() for scope in raw.split(",") if scope.strip())
+
+    def missing_scopes(self, required: Iterable[str]) -> frozenset[str]:
+        return frozenset(required) - self.granted_scopes()
 
     def list_channels(self, should_include_private_channels: bool, authed_user: str) -> list[dict]:
         # NOTE: Annoyingly the Slack API has no search so we have to load all channels...

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -51,6 +51,21 @@ HANDLED_EVENT_TYPES = ["app_mention", "link_shared"]
 
 POSTHOG_CODE_SLACK_AVAILABILITY_FLAG = "posthog-code-slack-availability"
 
+# Scopes the coding-agent flow exercises end-to-end. Slack stores the granted scope set
+# per install, so tenants who connected the Slack integration before the full scope set
+# was requested in prod (2026-05-04, #57177) must reconnect before mentions can work.
+POSTHOG_CODE_REQUIRED_SLACK_SCOPES: frozenset[str] = frozenset(
+    {
+        "app_mentions:read",
+        "users:read",
+        "users:read.email",
+        "chat:write",
+        "channels:history",
+        "groups:history",
+        "reactions:write",
+    }
+)
+
 ROUTE_HANDLED_LOCALLY = "handled_locally"
 ROUTE_PROXIED = "proxied"
 ROUTE_PROXY_FAILED = "proxy_failed"
@@ -1220,6 +1235,41 @@ def _posthog_code_enabled_for_integration(integration: Integration) -> bool:
         return False
 
 
+def _notify_missing_slack_scopes(
+    slack: SlackIntegration,
+    event: dict,
+    missing: frozenset[str],
+) -> None:
+    """Tell the user the install is missing scopes and how to fix it.
+
+    `chat:write` has been part of the base Slack scope set since the integration existed,
+    so the feedback post itself is safe to attempt even when other scopes are absent.
+    """
+    channel = event.get("channel", "")
+    thread_ts = event.get("thread_ts") or event.get("ts", "")
+    slack_user_id = event.get("user", "")
+    integration = slack.integration
+
+    logger.warning(
+        "posthog_code_slack_missing_scopes",
+        integration_id=integration.id,
+        team_id=integration.team_id,
+        missing=sorted(missing),
+    )
+
+    if not channel or not thread_ts or not slack_user_id:
+        return
+
+    settings_url = f"{settings.SITE_URL}/settings/project-integrations"
+    text = (
+        ":warning: PostHog can't reply because the Slack integration is missing required "
+        f"permissions: `{', '.join(sorted(missing))}`.\n"
+        f"A project admin needs to reconnect Slack from project settings: {settings_url}"
+    )
+
+    _post_slack_user_feedback(slack, channel, slack_user_id, thread_ts, text, prefer_thread_message=True)
+
+
 def route_posthog_code_event_to_relevant_region(
     request: HttpRequest,
     event: dict,
@@ -1257,6 +1307,11 @@ def route_posthog_code_event_to_relevant_region(
                     slack_team_id=slack_team_id,
                     organization_id=str(local_match.team.organization_id),
                 )
+                return ROUTE_HANDLED_LOCALLY
+            slack = SlackIntegration(local_match)
+            missing_scopes = slack.missing_scopes(POSTHOG_CODE_REQUIRED_SLACK_SCOPES)
+            if missing_scopes:
+                _notify_missing_slack_scopes(slack, event, missing_scopes)
                 return ROUTE_HANDLED_LOCALLY
             if _resolve_pending_repo_picker_from_followup(event, local_match):
                 return ROUTE_HANDLED_LOCALLY

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -101,6 +101,8 @@ class TestPostHogCodeEventHandler(TestCase):
 
 class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     def setUp(self):
+        from products.slack_app.backend.api import POSTHOG_CODE_REQUIRED_SLACK_SCOPES
+
         cache.clear()
         self.factory = RequestFactory()
         self.organization = Organization.objects.create(name="Test Org")
@@ -109,6 +111,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
             team=self.team,
             kind="slack-posthog-code",
             integration_id="T12345",
+            config={"scope": ",".join(sorted(POSTHOG_CODE_REQUIRED_SLACK_SCOPES))},
             sensitive_config={"access_token": "xoxb-posthog-code-test"},
         )
         self.event = {"type": "app_mention", "channel": "C001", "user": "U123", "ts": "1234.5678"}
@@ -179,6 +182,10 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     ):
         request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
         mock_get_repos.return_value = repo_list
+        # The route runs _missing_posthog_code_slack_scopes against a real SlackIntegration
+        # before the picker / workflow path. Since SlackIntegration is mocked wholesale here,
+        # explicitly say no scopes are missing so the gate passes through.
+        mock_slack_cls.return_value.missing_scopes.return_value = frozenset()
 
         from products.slack_app.backend.api import (
             ROUTE_HANDLED_LOCALLY,
@@ -387,3 +394,76 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         mock_sync_connect.assert_not_called()
         mock_asyncio_run.assert_not_called()
         mock_proxy.assert_not_called()
+
+    @parameterized.expand(
+        [
+            # Pre-2026-05-04 prod installs only granted the 4 base scopes.
+            ("four_base_scopes", "channels:read,groups:read,chat:write,chat:write.customize", False),
+            # Fail-closed when the scope field is absent entirely.
+            ("no_scope_field", None, False),
+            # Follow-up mentions in an existing thread must also be gated.
+            ("followup_with_partial_scopes", "channels:read,chat:write", True),
+        ]
+    )
+    @patch("products.slack_app.backend.api._post_slack_user_feedback")
+    @patch("products.slack_app.backend.api._posthog_code_enabled_for_integration", return_value=True)
+    @patch("products.slack_app.backend.api.asyncio.run")
+    @patch("products.slack_app.backend.api.sync_connect")
+    @override_settings(DEBUG=False)
+    def test_app_mention_with_missing_scopes_posts_reauth_and_skips_workflow(
+        self,
+        _name,
+        scope_value: str | None,
+        seed_pending_picker: bool,
+        mock_sync_connect,
+        mock_asyncio_run,
+        _mock_flag,
+        mock_post_feedback,
+    ):
+        if scope_value is None:
+            self.posthog_code_integration.config = {}
+        else:
+            self.posthog_code_integration.config["scope"] = scope_value
+        self.posthog_code_integration.save(update_fields=["config"])
+
+        from products.slack_app.backend.api import (
+            ROUTE_HANDLED_LOCALLY,
+            _set_pending_repo_picker,
+            route_posthog_code_event_to_relevant_region,
+        )
+
+        if seed_pending_picker:
+            _set_pending_repo_picker(
+                integration_id=self.posthog_code_integration.id,
+                channel="C001",
+                thread_ts="1234.5678",
+                slack_user_id="U123",
+                workflow_id="posthog-code-mention-T12345:pending",
+                context_token="ctx-1",
+                message_ts="1234.7777",
+            )
+
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
+        event = {
+            "type": "app_mention",
+            "channel": "C001",
+            "user": "U123",
+            "ts": "1234.5678",
+            "thread_ts": "1234.5678",
+        }
+
+        result = route_posthog_code_event_to_relevant_region(request, event, "T12345")
+
+        assert result == ROUTE_HANDLED_LOCALLY
+        mock_sync_connect.assert_not_called()
+        mock_sync_connect.return_value.get_workflow_handle.assert_not_called()
+        mock_asyncio_run.assert_not_called()
+        mock_post_feedback.assert_called_once()
+
+        feedback_text = mock_post_feedback.call_args.args[4]
+        assert "missing" in feedback_text.lower() and "reconnect" in feedback_text.lower()
+        # The message enumerates scopes that are actually missing (e.g. app_mentions:read is
+        # never in a pre-2026-05-04 install). Scopes the install already has must not appear.
+        assert "app_mentions:read" in feedback_text
+        if scope_value and "chat:write.customize" in scope_value:
+            assert "chat:write.customize" not in feedback_text


### PR DESCRIPTION
## Problem

The `slack` integration's OAuth flow only requested the full scope set in prod starting on 2026-05-04 (#57177). Tenants who connected Slack before that date are still on the old 4-scope grant (`channels:read, groups:read, chat:write, chat:write.customize`) and can't run the coding-agent flow — Slack persists granted scopes per install, so the in-app config change does not retroactively grant them.

Without a gate, mentioning the bot from those installs fails mid-flow with cryptic `missing_scope` errors on `users.info` / `conversations.replies` / `reactions.add`.

Stacks on #59354.

## Changes

- Add `SlackIntegration.granted_scopes()` / `missing_scopes(required)` reading from `Integration.config["scope"]`.
- Add `POSTHOG_CODE_REQUIRED_SLACK_SCOPES` listing the 7 scopes the mention + task flow exercises end-to-end (`app_mentions:read, users:read, users:read.email, chat:write, channels:history, groups:history, reactions:write`).
- In `route_posthog_code_event_to_relevant_region`, gate the `app_mention` branch on this set after the feature-flag check. Covers both fresh mentions and follow-up mentions on existing threads (single insertion point before `_resolve_pending_repo_picker_from_followup`). On miss, post a thread reply naming the missing scopes and pointing a project admin to project settings, skip workflow start.

## How did you test this code?

- Locally end-to-end: connected the Slack integration, manually downgraded `Integration.config["scope"]` to the 4 legacy scopes, mentioned the bot, confirmed the thread reply lists the missing scopes and no Temporal workflow starts. Restored the full scope set, mentioned again, confirmed the normal repo-picker / workflow path runs.
- `pytest products/slack_app/backend/tests/ posthog/api/test/test_integration.py::TestSlackIntegration` — 227 tests pass, including new ones for the gate and for the `granted_scopes` / `missing_scopes` helpers.
- `ruff check` + `ruff format --check` clean.

## Showcase

<img width="602" height="218" alt="Screenshot 2026-05-21 at 15 42 52" src="https://github.com/user-attachments/assets/9f58c167-9e91-4f51-8af8-be029aa7565b" />
<img width="607" height="363" alt="Screenshot 2026-05-21 at 15 42 37" src="https://github.com/user-attachments/assets/f10e5c73-4049-4bed-9716-c27f83f97875" />


## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7).