### PR TITLE
ci(security): pin semgrep image to 1.163.0

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout
@@ -60,7 +60,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout
@@ -84,7 +84,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout
@@ -110,7 +110,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout
@@ -133,7 +133,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout
@@ -157,7 +157,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout
@@ -200,7 +200,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout
@@ -234,7 +234,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout


### PR DESCRIPTION
## Problem

`.github/workflows/ci-security.yaml` uses unpinned `semgrep/semgrep` (resolves to `:latest` → 1.162.0). Every semgrep-* job in this workflow can hang silently and get timeout-killed; over ~849 jobs in the last 32h: semgrep-python 15.7%, semgrep-js 3.5%, semgrep-devex 1.2%. Symptom is identical across jobs — `running N rules from M configs` then no output until the runner kills the step at `timeout-minutes`.

## Changes

- Pin all 8 `image:` refs to `semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03`.
- Stops `:latest` from floating; moves off the version that's hanging today.

## How did you test this code?

Agent-authored. Ran the exact failing `semgrep-devex` CI command (`semgrep --config .semgrep/devex-rules/ --severity=ERROR --error --metrics=off --verbose bin/ common/ ee/ frontend/ posthog/ products/`) locally against the pinned image — completed cleanly, 0 findings on 3 targets. Did not retry CI. No manual testing in CI itself.

## Publish to changelog?

no

## Docs update

no docs update needed

## 🤖 Agent context

Claude Code (claude-opus-4-7). Investigation showed semgrep-devex on PR #57494 wasn't PR-caused — same hang pattern hits many unrelated PRs. 1.163.0 is the newest published version (`:latest` still points to 1.162.0). Not a known fix — the 1.163.0 changelog mentions parallel rule validation at scan startup, which is exactly where the hang occurs, but Semgrep doesn't call out a hang fix. Worst case: nothing changes and we now control upgrades. If hang rate doesn't drop after ~24h on master, next step is vendoring the registry rulepacks (`p/python`, `p/owasp-top-ten`, ...) to remove startup network calls.