### PR TITLE
feat(propvals): part 3: add fan-out, aggregator, and tuple types

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7326,6 +7326,8 @@ dependencies = [
  "envconfig",
  "lifecycle",
  "proptest",
+ "serde",
+ "serde_json",
  "serve-metrics",
  "siphasher 1.0.2",
  "tokio",

--- a/rust/property-vals-rs/Cargo.toml
+++ b/rust/property-vals-rs/Cargo.toml
@@ -11,6 +11,8 @@ common-continuous-profiling = { path = "../common/continuous_profiling" }
 common-kafka = { path = "../common/kafka" }
 envconfig = { workspace = true }
 lifecycle = { path = "../common/lifecycle" }
+serde = { workspace = true }
+serde_json = { workspace = true }
 serve-metrics = { path = "../common/serve_metrics" }
 siphasher = { workspace = true }
 tokio = { workspace = true }

--- a/rust/property-vals-rs/src/aggregator.rs
+++ b/rust/property-vals-rs/src/aggregator.rs
@@ -2,9 +2,6 @@ use std::collections::HashMap;
 
 use crate::types::TupleKey;
 
-/// In-memory accumulator for one Kafka partition's worth of tuples. Inserts
-/// increment the per-tuple count; `drain` returns the accumulated map and
-/// clears state in one shot so the next flush window starts fresh.
 pub struct Aggregator {
     counts: HashMap<TupleKey, u64>,
 }
@@ -16,19 +13,6 @@ impl Aggregator {
         }
     }
 
-    pub fn record(&mut self, tuple: TupleKey) {
-        *self.counts.entry(tuple).or_insert(0) += 1;
-    }
-
-    pub fn record_many<I: IntoIterator<Item = TupleKey>>(&mut self, tuples: I) {
-        for t in tuples {
-            self.record(t);
-        }
-    }
-
-    /// Increment by an arbitrary count. Used by the flush-failure restore
-    /// path to merge a previously drained snapshot back into the live state
-    /// without re-counting one event at a time.
     pub fn add(&mut self, tuple: TupleKey, count: u64) {
         *self.counts.entry(tuple).or_insert(0) += count;
     }
@@ -41,7 +25,6 @@ impl Aggregator {
         self.counts.is_empty()
     }
 
-    /// Atomically take the accumulated state and reset for the next window.
     pub fn drain(&mut self) -> HashMap<TupleKey, u64> {
         std::mem::take(&mut self.counts)
     }
@@ -72,16 +55,10 @@ mod tests {
         prop_oneof![
             Just(PropertyType::Event),
             Just(PropertyType::Person),
-            Just(PropertyType::Group0),
-            Just(PropertyType::Group1),
-            Just(PropertyType::Group2),
-            Just(PropertyType::Group3),
-            Just(PropertyType::Group4),
+            (0u8..=10).prop_map(PropertyType::Group),
         ]
     }
 
-    // Small generator domain so duplicates are likely and the aggregator's
-    // dedup-and-sum behavior gets meaningful coverage.
     prop_compose! {
         fn arb_tuple()(
             team_id in -5i64..=5,
@@ -93,44 +70,17 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Clone)]
-    enum Op {
-        Record(TupleKey),
-        RecordMany(Vec<TupleKey>),
-        Add(TupleKey, u64),
-    }
-
-    fn arb_op() -> impl Strategy<Value = Op> {
-        prop_oneof![
-            arb_tuple().prop_map(Op::Record),
-            prop::collection::vec(arb_tuple(), 0..8).prop_map(Op::RecordMany),
-            (arb_tuple(), 1u64..1_000).prop_map(|(t, n)| Op::Add(t, n)),
-        ]
-    }
-
     proptest! {
         #[test]
-        fn drained_counts_equal_per_tuple_sum(ops in prop::collection::vec(arb_op(), 0..200)) {
+        fn drained_counts_equal_per_tuple_sum(
+            ops in prop::collection::vec((arb_tuple(), 1u64..1_000), 0..200),
+        ) {
             let mut agg = Aggregator::new();
             let mut expected: HashMap<TupleKey, u64> = HashMap::new();
 
-            for op in &ops {
-                match op {
-                    Op::Record(t) => {
-                        agg.record(t.clone());
-                        *expected.entry(t.clone()).or_insert(0) += 1;
-                    }
-                    Op::RecordMany(ts) => {
-                        agg.record_many(ts.clone());
-                        for t in ts {
-                            *expected.entry(t.clone()).or_insert(0) += 1;
-                        }
-                    }
-                    Op::Add(t, n) => {
-                        agg.add(t.clone(), *n);
-                        *expected.entry(t.clone()).or_insert(0) += *n;
-                    }
-                }
+            for (t, n) in &ops {
+                agg.add(t.clone(), *n);
+                *expected.entry(t.clone()).or_insert(0) += *n;
             }
 
             prop_assert_eq!(agg.drain(), expected);
@@ -140,7 +90,7 @@ mod tests {
     #[test]
     fn drain_clears_state() {
         let mut agg = Aggregator::new();
-        agg.record(tuple(2, "$browser", "Chrome"));
+        agg.add(tuple(2, "$browser", "Chrome"), 1);
 
         let first = agg.drain();
         assert_eq!(first.len(), 1);

--- a/rust/property-vals-rs/src/aggregator.rs
+++ b/rust/property-vals-rs/src/aggregator.rs
@@ -1,0 +1,152 @@
+use std::collections::HashMap;
+
+use crate::types::TupleKey;
+
+/// In-memory accumulator for one Kafka partition's worth of tuples. Inserts
+/// increment the per-tuple count; `drain` returns the accumulated map and
+/// clears state in one shot so the next flush window starts fresh.
+pub struct Aggregator {
+    counts: HashMap<TupleKey, u64>,
+}
+
+impl Aggregator {
+    pub fn new() -> Self {
+        Self {
+            counts: HashMap::new(),
+        }
+    }
+
+    pub fn record(&mut self, tuple: TupleKey) {
+        *self.counts.entry(tuple).or_insert(0) += 1;
+    }
+
+    pub fn record_many<I: IntoIterator<Item = TupleKey>>(&mut self, tuples: I) {
+        for t in tuples {
+            self.record(t);
+        }
+    }
+
+    /// Increment by an arbitrary count. Used by the flush-failure restore
+    /// path to merge a previously drained snapshot back into the live state
+    /// without re-counting one event at a time.
+    pub fn add(&mut self, tuple: TupleKey, count: u64) {
+        *self.counts.entry(tuple).or_insert(0) += count;
+    }
+
+    pub fn len(&self) -> usize {
+        self.counts.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.counts.is_empty()
+    }
+
+    /// Atomically take the accumulated state and reset for the next window.
+    pub fn drain(&mut self) -> HashMap<TupleKey, u64> {
+        std::mem::take(&mut self.counts)
+    }
+}
+
+impl Default for Aggregator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::PropertyType;
+    use proptest::prelude::*;
+
+    fn tuple(team: i64, key: &str, value: &str) -> TupleKey {
+        TupleKey {
+            team_id: team,
+            property_type: PropertyType::Event,
+            property_key: key.to_string(),
+            property_value: value.to_string(),
+        }
+    }
+
+    fn arb_property_type() -> impl Strategy<Value = PropertyType> {
+        prop_oneof![
+            Just(PropertyType::Event),
+            Just(PropertyType::Person),
+            Just(PropertyType::Group0),
+            Just(PropertyType::Group1),
+            Just(PropertyType::Group2),
+            Just(PropertyType::Group3),
+            Just(PropertyType::Group4),
+        ]
+    }
+
+    // Small generator domain so duplicates are likely and the aggregator's
+    // dedup-and-sum behavior gets meaningful coverage.
+    prop_compose! {
+        fn arb_tuple()(
+            team_id in -5i64..=5,
+            property_type in arb_property_type(),
+            property_key in "[a-c]{1,3}",
+            property_value in "[x-z]{1,3}",
+        ) -> TupleKey {
+            TupleKey { team_id, property_type, property_key, property_value }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    enum Op {
+        Record(TupleKey),
+        RecordMany(Vec<TupleKey>),
+        Add(TupleKey, u64),
+    }
+
+    fn arb_op() -> impl Strategy<Value = Op> {
+        prop_oneof![
+            arb_tuple().prop_map(Op::Record),
+            prop::collection::vec(arb_tuple(), 0..8).prop_map(Op::RecordMany),
+            (arb_tuple(), 1u64..1_000).prop_map(|(t, n)| Op::Add(t, n)),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn drained_counts_equal_per_tuple_sum(ops in prop::collection::vec(arb_op(), 0..200)) {
+            let mut agg = Aggregator::new();
+            let mut expected: HashMap<TupleKey, u64> = HashMap::new();
+
+            for op in &ops {
+                match op {
+                    Op::Record(t) => {
+                        agg.record(t.clone());
+                        *expected.entry(t.clone()).or_insert(0) += 1;
+                    }
+                    Op::RecordMany(ts) => {
+                        agg.record_many(ts.clone());
+                        for t in ts {
+                            *expected.entry(t.clone()).or_insert(0) += 1;
+                        }
+                    }
+                    Op::Add(t, n) => {
+                        agg.add(t.clone(), *n);
+                        *expected.entry(t.clone()).or_insert(0) += *n;
+                    }
+                }
+            }
+
+            prop_assert_eq!(agg.drain(), expected);
+        }
+    }
+
+    #[test]
+    fn drain_clears_state() {
+        let mut agg = Aggregator::new();
+        agg.record(tuple(2, "$browser", "Chrome"));
+
+        let first = agg.drain();
+        assert_eq!(first.len(), 1);
+        assert!(agg.is_empty());
+
+        let second = agg.drain();
+        assert!(second.is_empty());
+    }
+}

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -1,0 +1,318 @@
+use serde_json::Value;
+
+use crate::types::{Event, GroupIdentify, PropertyType, TupleKey};
+
+/// Length cap on `property_key` in Unicode codepoints. Matches Django
+/// `PropertyDefinition.name` max_length.
+pub const MAX_PROPERTY_KEY_LEN: usize = 400;
+
+/// Length cap on `property_value` in Unicode codepoints. Strictly less than
+/// this, 256 codepoints is dropped.
+pub const MAX_PROPERTY_VALUE_LEN: usize = 256;
+
+/// Fan one Event out to its constituent property-value tuples.
+///
+/// For each entry in `properties` / `person_properties`:
+///   - drop entries whose JSON value is `null`
+///   - coerce non-string values to their JSON string form (numbers, bools, etc.)
+///   - drop entries with empty `property_key` or `property_key` longer than 400 chars
+///   - drop entries with empty `property_value` or `property_value` 256+ chars
+///
+/// Group property values come from the `clickhouse_groups` topic via
+/// `fan_out_group`, not from this stream.
+pub fn fan_out(event: &Event) -> Vec<TupleKey> {
+    let mut out = Vec::new();
+
+    if let Some(raw) = &event.properties {
+        emit_from_blob(event.team_id, PropertyType::Event, raw, &mut out);
+    }
+    if let Some(raw) = &event.person_properties {
+        emit_from_blob(event.team_id, PropertyType::Person, raw, &mut out);
+    }
+
+    out
+}
+
+/// Fan one $groupidentify message out to its constituent (group_N, key, value)
+/// tuples. Same length caps and value coercion as the events fan-out so the
+/// produced tuples are guaranteed to match what the storage MV will accept.
+pub fn fan_out_group(event: &GroupIdentify) -> Vec<TupleKey> {
+    let mut out = Vec::new();
+    let property_type = match event.group_type_index {
+        0 => PropertyType::Group0,
+        1 => PropertyType::Group1,
+        2 => PropertyType::Group2,
+        3 => PropertyType::Group3,
+        4 => PropertyType::Group4,
+        _ => return out,
+    };
+    if let Some(raw) = &event.group_properties {
+        emit_from_blob(event.team_id, property_type, raw, &mut out);
+    }
+    out
+}
+
+fn emit_from_blob(team_id: i64, property_type: PropertyType, raw: &str, out: &mut Vec<TupleKey>) {
+    // Treat parse errors as an empty object (no emissions).
+    let parsed: Value = match serde_json::from_str(raw) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let obj = match parsed.as_object() {
+        Some(o) => o,
+        None => return,
+    };
+
+    for (key, value) in obj {
+        if value.is_null() {
+            continue;
+        }
+
+        let property_value = coerce_to_string(value);
+
+        if key.is_empty() || key.chars().count() > MAX_PROPERTY_KEY_LEN {
+            continue;
+        }
+        if property_value.is_empty() || property_value.chars().count() >= MAX_PROPERTY_VALUE_LEN {
+            continue;
+        }
+
+        out.push(TupleKey {
+            team_id,
+            property_type,
+            property_key: key.clone(),
+            property_value,
+        });
+    }
+}
+
+fn coerce_to_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Null => String::new(),
+        _ => v.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use serde_json::{Map, Value};
+
+    fn event(properties: &str) -> Event {
+        Event {
+            team_id: 2,
+            properties: Some(properties.to_string()),
+            person_properties: None,
+        }
+    }
+
+    fn group_identify(group_type_index: u8, properties: &str) -> GroupIdentify {
+        GroupIdentify {
+            team_id: 2,
+            group_type_index,
+            group_properties: Some(properties.to_string()),
+        }
+    }
+
+    // Generators span both sides of the codepoint caps so the length-cap
+    // invariants below get meaningful coverage. Multi-byte characters are
+    // included so codepoint vs byte-length confusion would also be caught.
+    fn arb_property_string() -> impl Strategy<Value = String> {
+        prop_oneof!["[a-zA-Z0-9_$ -]{0,450}", r#"[\x{3042}\x{1F600}]{0,500}"#,]
+    }
+
+    fn arb_value() -> impl Strategy<Value = Value> {
+        prop_oneof![
+            arb_property_string().prop_map(Value::String),
+            any::<bool>().prop_map(Value::Bool),
+            any::<i64>().prop_map(|n| Value::Number(n.into())),
+            Just(Value::Null),
+        ]
+    }
+
+    prop_compose! {
+        fn arb_blob()(
+            pairs in prop::collection::vec((arb_property_string(), arb_value()), 0..20),
+        ) -> String {
+            let map: Map<String, Value> = pairs.into_iter().collect();
+            serde_json::to_string(&map).unwrap()
+        }
+    }
+
+    prop_compose! {
+        fn arb_event()(
+            team_id: i64,
+            properties in prop::option::of(arb_blob()),
+            person_properties in prop::option::of(arb_blob()),
+        ) -> Event {
+            Event { team_id, properties, person_properties }
+        }
+    }
+
+    prop_compose! {
+        fn arb_group_identify()(
+            team_id: i64,
+            group_type_index in 0u8..=10,
+            group_properties in prop::option::of(arb_blob()),
+        ) -> GroupIdentify {
+            GroupIdentify { team_id, group_type_index, group_properties }
+        }
+    }
+
+    fn check_tuple_invariants(t: &TupleKey, expected_team: i64) {
+        assert_eq!(t.team_id, expected_team);
+        assert!(!t.property_key.is_empty());
+        assert!(!t.property_value.is_empty());
+        assert!(t.property_key.chars().count() <= MAX_PROPERTY_KEY_LEN);
+        assert!(t.property_value.chars().count() < MAX_PROPERTY_VALUE_LEN);
+    }
+
+    proptest! {
+        #[test]
+        fn fan_out_outputs_obey_caps_and_team(e in arb_event()) {
+            for t in fan_out(&e) {
+                check_tuple_invariants(&t, e.team_id);
+            }
+        }
+
+        #[test]
+        fn fan_out_group_outputs_obey_caps_and_team(g in arb_group_identify()) {
+            for t in fan_out_group(&g) {
+                check_tuple_invariants(&t, g.team_id);
+            }
+        }
+
+        #[test]
+        fn fan_out_is_pure(e in arb_event()) {
+            prop_assert_eq!(fan_out(&e), fan_out(&e));
+        }
+
+        #[test]
+        fn fan_out_group_is_pure(g in arb_group_identify()) {
+            prop_assert_eq!(fan_out_group(&g), fan_out_group(&g));
+        }
+
+        #[test]
+        fn fan_out_group_only_emits_matching_property_type(g in arb_group_identify()) {
+            let expected = match g.group_type_index {
+                0 => Some(PropertyType::Group0),
+                1 => Some(PropertyType::Group1),
+                2 => Some(PropertyType::Group2),
+                3 => Some(PropertyType::Group3),
+                4 => Some(PropertyType::Group4),
+                _ => None,
+            };
+            let tuples = fan_out_group(&g);
+            match expected {
+                Some(pt) => {
+                    for t in tuples {
+                        prop_assert_eq!(t.property_type, pt);
+                    }
+                }
+                None => prop_assert!(tuples.is_empty()),
+            }
+        }
+    }
+
+    #[test]
+    fn event_property_produces_event_type_tuple() {
+        let tuples = fan_out(&event(r#"{"$browser":"Chrome"}"#));
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(tuples[0].property_type, PropertyType::Event);
+        assert_eq!(tuples[0].property_key, "$browser");
+        assert_eq!(tuples[0].property_value, "Chrome");
+    }
+
+    #[test]
+    fn json_null_value_is_dropped() {
+        let tuples = fan_out(&event(r#"{"nullable_field":null}"#));
+        assert!(tuples.is_empty());
+    }
+
+    #[test]
+    fn empty_string_value_is_dropped() {
+        let tuples = fan_out(&event(r#"{"blank":""}"#));
+        assert!(tuples.is_empty());
+    }
+
+    #[test]
+    fn person_properties_emit_person_type() {
+        let ev = Event {
+            team_id: 2,
+            properties: None,
+            person_properties: Some(r#"{"email":"foo@bar.com"}"#.to_string()),
+        };
+        let tuples = fan_out(&ev);
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(tuples[0].property_type, PropertyType::Person);
+        assert_eq!(tuples[0].property_key, "email");
+        assert_eq!(tuples[0].property_value, "foo@bar.com");
+    }
+
+    #[test]
+    fn bool_value_coerces_to_string() {
+        let tuples = fan_out(&event(r#"{"a_bool":true}"#));
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(tuples[0].property_value, "true");
+    }
+
+    #[test]
+    fn number_value_coerces_to_string() {
+        let tuples = fan_out(&event(r#"{"a_number":42}"#));
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(tuples[0].property_value, "42");
+    }
+
+    #[test]
+    fn unparseable_blob_emits_nothing() {
+        let tuples = fan_out(&event(r#"not valid json"#));
+        assert!(tuples.is_empty());
+    }
+
+    #[test]
+    fn empty_object_emits_nothing() {
+        let tuples = fan_out(&event("{}"));
+        assert!(tuples.is_empty());
+    }
+
+    #[test]
+    fn group_identify_index_0_emits_group_0_type() {
+        let tuples = fan_out_group(&group_identify(0, r#"{"plan":"enterprise"}"#));
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(tuples[0].property_type, PropertyType::Group0);
+        assert_eq!(tuples[0].property_key, "plan");
+        assert_eq!(tuples[0].property_value, "enterprise");
+    }
+
+    #[test]
+    fn group_identify_index_4_emits_group_4_type() {
+        let tuples = fan_out_group(&group_identify(4, r#"{"region":"us-east"}"#));
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(tuples[0].property_type, PropertyType::Group4);
+    }
+
+    #[test]
+    fn group_identify_index_out_of_range_drops() {
+        let tuples = fan_out_group(&group_identify(5, r#"{"plan":"enterprise"}"#));
+        assert!(tuples.is_empty());
+    }
+
+    #[test]
+    fn group_identify_missing_properties_drops() {
+        let g = GroupIdentify {
+            team_id: 2,
+            group_type_index: 0,
+            group_properties: None,
+        };
+        assert!(fan_out_group(&g).is_empty());
+    }
+
+    #[test]
+    fn group_identify_unparseable_drops() {
+        let tuples = fan_out_group(&group_identify(0, "not valid json"));
+        assert!(tuples.is_empty());
+    }
+}

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -6,9 +6,9 @@ use crate::types::{Event, GroupIdentify, PropertyType, TupleKey};
 /// `PropertyDefinition.name` max_length.
 pub const MAX_PROPERTY_KEY_LEN: usize = 400;
 
-/// Length cap on `property_value` in Unicode codepoints. Strictly less than
-/// this, 256 codepoints is dropped.
-pub const MAX_PROPERTY_VALUE_LEN: usize = 256;
+/// Length cap on `property_value` in Unicode codepoints. Values longer
+/// than this are dropped. Matches the storage column width minus one.
+pub const MAX_PROPERTY_VALUE_LEN: usize = 255;
 
 /// Fan one Event out to its constituent property-value tuples.
 ///
@@ -74,7 +74,7 @@ fn emit_from_blob(team_id: i64, property_type: PropertyType, raw: &str, out: &mu
         if key.is_empty() || key.chars().count() > MAX_PROPERTY_KEY_LEN {
             continue;
         }
-        if property_value.is_empty() || property_value.chars().count() >= MAX_PROPERTY_VALUE_LEN {
+        if property_value.is_empty() || property_value.chars().count() > MAX_PROPERTY_VALUE_LEN {
             continue;
         }
 
@@ -90,7 +90,6 @@ fn emit_from_blob(team_id: i64, property_type: PropertyType, raw: &str, out: &mu
 fn coerce_to_string(v: &Value) -> String {
     match v {
         Value::String(s) => s.clone(),
-        Value::Null => String::new(),
         _ => v.to_string(),
     }
 }
@@ -167,7 +166,7 @@ mod tests {
         assert!(!t.property_key.is_empty());
         assert!(!t.property_value.is_empty());
         assert!(t.property_key.chars().count() <= MAX_PROPERTY_KEY_LEN);
-        assert!(t.property_value.chars().count() < MAX_PROPERTY_VALUE_LEN);
+        assert!(t.property_value.chars().count() <= MAX_PROPERTY_VALUE_LEN);
     }
 
     proptest! {

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -2,24 +2,9 @@ use serde_json::Value;
 
 use crate::types::{Event, GroupIdentify, PropertyType, TupleKey};
 
-/// Length cap on `property_key` in Unicode codepoints. Matches Django
-/// `PropertyDefinition.name` max_length.
 pub const MAX_PROPERTY_KEY_LEN: usize = 400;
-
-/// Length cap on `property_value` in Unicode codepoints. Values longer
-/// than this are dropped. Matches the storage column width minus one.
 pub const MAX_PROPERTY_VALUE_LEN: usize = 255;
 
-/// Fan one Event out to its constituent property-value tuples.
-///
-/// For each entry in `properties` / `person_properties`:
-///   - drop entries whose JSON value is `null`
-///   - coerce non-string values to their JSON string form (numbers, bools, etc.)
-///   - drop entries with empty `property_key` or `property_key` longer than 400 chars
-///   - drop entries with empty `property_value` or `property_value` 256+ chars
-///
-/// Group property values come from the `clickhouse_groups` topic via
-/// `fan_out_group`, not from this stream.
 pub fn fan_out(event: &Event) -> Vec<TupleKey> {
     let mut out = Vec::new();
 
@@ -33,27 +18,20 @@ pub fn fan_out(event: &Event) -> Vec<TupleKey> {
     out
 }
 
-/// Fan one $groupidentify message out to its constituent (group_N, key, value)
-/// tuples. Same length caps and value coercion as the events fan-out so the
-/// produced tuples are guaranteed to match what the storage MV will accept.
 pub fn fan_out_group(event: &GroupIdentify) -> Vec<TupleKey> {
     let mut out = Vec::new();
-    let property_type = match event.group_type_index {
-        0 => PropertyType::Group0,
-        1 => PropertyType::Group1,
-        2 => PropertyType::Group2,
-        3 => PropertyType::Group3,
-        4 => PropertyType::Group4,
-        _ => return out,
-    };
     if let Some(raw) = &event.group_properties {
-        emit_from_blob(event.team_id, property_type, raw, &mut out);
+        emit_from_blob(
+            event.team_id,
+            PropertyType::Group(event.group_type_index),
+            raw,
+            &mut out,
+        );
     }
     out
 }
 
 fn emit_from_blob(team_id: i64, property_type: PropertyType, raw: &str, out: &mut Vec<TupleKey>) {
-    // Treat parse errors as an empty object (no emissions).
     let parsed: Value = match serde_json::from_str(raw) {
         Ok(v) => v,
         Err(_) => return,
@@ -116,9 +94,6 @@ mod tests {
         }
     }
 
-    // Generators span both sides of the codepoint caps so the length-cap
-    // invariants below get meaningful coverage. Multi-byte characters are
-    // included so codepoint vs byte-length confusion would also be caught.
     fn arb_property_string() -> impl Strategy<Value = String> {
         prop_oneof!["[a-zA-Z0-9_$ -]{0,450}", r#"[\x{3042}\x{1F600}]{0,500}"#,]
     }
@@ -154,7 +129,7 @@ mod tests {
     prop_compose! {
         fn arb_group_identify()(
             team_id: i64,
-            group_type_index in 0u8..=10,
+            group_type_index: u8,
             group_properties in prop::option::of(arb_blob()),
         ) -> GroupIdentify {
             GroupIdentify { team_id, group_type_index, group_properties }
@@ -195,23 +170,9 @@ mod tests {
         }
 
         #[test]
-        fn fan_out_group_only_emits_matching_property_type(g in arb_group_identify()) {
-            let expected = match g.group_type_index {
-                0 => Some(PropertyType::Group0),
-                1 => Some(PropertyType::Group1),
-                2 => Some(PropertyType::Group2),
-                3 => Some(PropertyType::Group3),
-                4 => Some(PropertyType::Group4),
-                _ => None,
-            };
-            let tuples = fan_out_group(&g);
-            match expected {
-                Some(pt) => {
-                    for t in tuples {
-                        prop_assert_eq!(t.property_type, pt);
-                    }
-                }
-                None => prop_assert!(tuples.is_empty()),
+        fn fan_out_group_property_type_matches_index(g in arb_group_identify()) {
+            for t in fan_out_group(&g) {
+                prop_assert_eq!(t.property_type, PropertyType::Group(g.group_type_index));
             }
         }
     }
@@ -278,10 +239,10 @@ mod tests {
     }
 
     #[test]
-    fn group_identify_index_0_emits_group_0_type() {
+    fn group_identify_index_0_emits_group_type() {
         let tuples = fan_out_group(&group_identify(0, r#"{"plan":"enterprise"}"#));
         assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].property_type, PropertyType::Group0);
+        assert_eq!(tuples[0].property_type, PropertyType::Group(0));
         assert_eq!(tuples[0].property_key, "plan");
         assert_eq!(tuples[0].property_value, "enterprise");
     }
@@ -290,13 +251,14 @@ mod tests {
     fn group_identify_index_4_emits_group_4_type() {
         let tuples = fan_out_group(&group_identify(4, r#"{"region":"us-east"}"#));
         assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].property_type, PropertyType::Group4);
+        assert_eq!(tuples[0].property_type, PropertyType::Group(4));
     }
 
     #[test]
-    fn group_identify_index_out_of_range_drops() {
-        let tuples = fan_out_group(&group_identify(5, r#"{"plan":"enterprise"}"#));
-        assert!(tuples.is_empty());
+    fn group_identify_high_index_still_emits() {
+        let tuples = fan_out_group(&group_identify(7, r#"{"plan":"enterprise"}"#));
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(tuples[0].property_type, PropertyType::Group(7));
     }
 
     #[test]

--- a/rust/property-vals-rs/src/lib.rs
+++ b/rust/property-vals-rs/src/lib.rs
@@ -1,1 +1,4 @@
+pub mod aggregator;
 pub mod config;
+pub mod fan_out;
+pub mod types;

--- a/rust/property-vals-rs/src/types.rs
+++ b/rust/property-vals-rs/src/types.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+
+/// Abstracts the fields the worker needs from any consumed message. Lets
+/// `worker_loop` be generic over event-shaped inputs (`Event`) and group
+/// identify-shaped inputs (`GroupIdentify`) without duplicating the loop.
+pub trait IngestableEvent: serde::de::DeserializeOwned + Send + Sync + 'static {
+    fn team_id(&self) -> i64;
+}
+
+/// One event coming from the `team_event_partitioned_events_json` Kafka topic.
+/// The `*_properties` fields are JSON-encoded strings on the wire; we parse
+/// them lazily during fan-out.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Event {
+    pub team_id: i64,
+
+    #[serde(default)]
+    pub properties: Option<String>,
+    #[serde(default)]
+    pub person_properties: Option<String>,
+}
+
+impl IngestableEvent for Event {
+    fn team_id(&self) -> i64 {
+        self.team_id
+    }
+}
+
+/// One message coming from the `clickhouse_groups` Kafka topic, produced by
+/// the plugin server every time `$groupidentify` fires. Carries the entire
+/// group properties blob for one (team, type, key) combination.
+///
+/// Because group properties are never denormalized onto the events stream,
+/// this topic is the only source of group property values for autocomplete.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GroupIdentify {
+    pub team_id: i64,
+    pub group_type_index: u8,
+    #[serde(default)]
+    pub group_properties: Option<String>,
+}
+
+impl IngestableEvent for GroupIdentify {
+    fn team_id(&self) -> i64 {
+        self.team_id
+    }
+}
+
+/// The shape of one stored property-value tuple. Used both as the hashmap key
+/// for in-memory aggregation and (with a `property_count` added) as the
+/// outgoing Kafka payload.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct TupleKey {
+    pub team_id: i64,
+    pub property_type: PropertyType,
+    pub property_key: String,
+    pub property_value: String,
+}
+
+/// Property type that the storage table partitions on. The string forms map
+/// 1:1 to the values written into `posthog.property_values.property_type`.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub enum PropertyType {
+    Event,
+    Person,
+    Group0,
+    Group1,
+    Group2,
+    Group3,
+    Group4,
+}
+
+impl PropertyType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PropertyType::Event => "event",
+            PropertyType::Person => "person",
+            PropertyType::Group0 => "group_0",
+            PropertyType::Group1 => "group_1",
+            PropertyType::Group2 => "group_2",
+            PropertyType::Group3 => "group_3",
+            PropertyType::Group4 => "group_4",
+        }
+    }
+}
+
+/// One outgoing message produced to `clickhouse_property_values` per unique
+/// tuple per flush window. The CH Kafka engine table parses this as JSONEachRow.
+/// Owned so the producer helper can take it by value into rdkafka.
+#[derive(Debug, Clone, Serialize)]
+pub struct OutputMessage {
+    pub team_id: i64,
+    pub property_type: String,
+    pub property_key: String,
+    pub property_value: String,
+    pub property_count: u64,
+}

--- a/rust/property-vals-rs/src/types.rs
+++ b/rust/property-vals-rs/src/types.rs
@@ -1,16 +1,10 @@
-use serde::{Deserialize, Serialize};
+use serde::ser::{Serialize, Serializer};
 
-/// Abstracts the fields the worker needs from any consumed message. Lets
-/// `worker_loop` be generic over event-shaped inputs (`Event`) and group
-/// identify-shaped inputs (`GroupIdentify`) without duplicating the loop.
 pub trait IngestableEvent: serde::de::DeserializeOwned + Send + Sync + 'static {
     fn team_id(&self) -> i64;
 }
 
-/// One event coming from the `team_event_partitioned_events_json` Kafka topic.
-/// The `*_properties` fields are JSON-encoded strings on the wire; we parse
-/// them lazily during fan-out.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct Event {
     pub team_id: i64,
 
@@ -26,13 +20,7 @@ impl IngestableEvent for Event {
     }
 }
 
-/// One message coming from the `clickhouse_groups` Kafka topic, produced by
-/// the plugin server every time `$groupidentify` fires. Carries the entire
-/// group properties blob for one (team, type, key) combination.
-///
-/// Because group properties are never denormalized onto the events stream,
-/// this topic is the only source of group property values for autocomplete.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct GroupIdentify {
     pub team_id: i64,
     pub group_type_index: u8,
@@ -46,9 +34,6 @@ impl IngestableEvent for GroupIdentify {
     }
 }
 
-/// The shape of one stored property-value tuple. Used both as the hashmap key
-/// for in-memory aggregation and (with a `property_count` added) as the
-/// outgoing Kafka payload.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct TupleKey {
     pub team_id: i64,
@@ -57,41 +42,19 @@ pub struct TupleKey {
     pub property_value: String,
 }
 
-/// Property type that the storage table partitions on. The string forms map
-/// 1:1 to the values written into `posthog.property_values.property_type`.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum PropertyType {
     Event,
     Person,
-    Group0,
-    Group1,
-    Group2,
-    Group3,
-    Group4,
+    Group(u8),
 }
 
-impl PropertyType {
-    pub fn as_str(&self) -> &'static str {
+impl Serialize for PropertyType {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
-            PropertyType::Event => "event",
-            PropertyType::Person => "person",
-            PropertyType::Group0 => "group_0",
-            PropertyType::Group1 => "group_1",
-            PropertyType::Group2 => "group_2",
-            PropertyType::Group3 => "group_3",
-            PropertyType::Group4 => "group_4",
+            PropertyType::Event => serializer.serialize_str("event"),
+            PropertyType::Person => serializer.serialize_str("person"),
+            PropertyType::Group(n) => serializer.serialize_str(&format!("group_{n}")),
         }
     }
-}
-
-/// One outgoing message produced to `clickhouse_property_values` per unique
-/// tuple per flush window. The CH Kafka engine table parses this as JSONEachRow.
-/// Owned so the producer helper can take it by value into rdkafka.
-#[derive(Debug, Clone, Serialize)]
-pub struct OutputMessage {
-    pub team_id: i64,
-    pub property_type: String,
-    pub property_key: String,
-    pub property_value: String,
-    pub property_count: u64,
 }


### PR DESCRIPTION
## Problem

The skeleton from part 2 has no data path. This PR adds the pure in-memory transforms — no I/O, no Kafka — so they can be reviewed and tested in isolation before the worker loop wires them into Kafka in part 4.

## Changes

Three new modules:

- `src/types.rs`: `Event` (events topic input), `GroupIdentify` (groups topic input), `IngestableEvent` trait abstracting `team_id` access, `TupleKey` (the canonical `(team_id, property_type, property_key, property_value)` dedup key), and `PropertyType` enum (`Event` / `Person` / `Group(u8)`). `PropertyType` implements `Serialize` directly so it emits `"event"` / `"person"` / `"group_{n}"` on the wire; the producer in part 4 uses that without a separate "output message" type.
- `src/fan_out.rs`: `fan_out` turns an `Event` into a list of tuples (event properties and person properties); `fan_out_group` turns a `GroupIdentify` into a list of tuples (`Group(index)` carries the index straight through). Both share `emit_from_blob`, which parses the JSON property bag, drops nulls, coerces non-strings to JSON string form, applies the Unicode-codepoint-aware key (400) and value (255) length caps, and emits the surviving (key, value) pairs.
- `src/aggregator.rs`: `Aggregator` wraps a `HashMap<TupleKey, u64>` with one increment operation, `add(tuple, count)`. Callers pass `count = 1` for per-event increments; the flush-failure restore path passes the original count back. Plus `len` / `is_empty` / `drain`.

`lib.rs` exports them; nothing else changes. Cargo adds `serde` and `serde_json`.

## How did you test this code?

Agent-authored. `cargo test -p property-vals-rs` passes 27 tests on this branch. Mix of example tests and proptest invariants:

- `fan_out` / `fan_out_group`: outputs always respect the codepoint caps and carry the source `team_id`; pure (same input ⇒ same output); `fan_out_group` always emits `PropertyType::Group(g.group_type_index)`. Edge cases: null values dropped, empty strings dropped, multi-byte cap behavior, malformed JSON tolerated.
- `aggregator`: drained counts equal the per-tuple sum of all `add(tuple, n)` increments across arbitrary mixes; `drain` clears state.

`cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code. This is the middle of three layered PRs that together make up the property-vals-rs service. Part 2 is the skeleton; this part adds the pure data path; part 4 wires Kafka I/O around it.

`PropertyType::Group(u8)` was chosen over a closed `Group0..GroupN` enum so the service isn't pinned to a fixed group-type-index ceiling; the storage column is `LowCardinality(String)` and accepts any `group_{n}` value.
