### PR TITLE
feat(propvals): part 4: kafka I/O and worker loop

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7324,6 +7324,7 @@ dependencies = [
  "common-alloc",
  "common-continuous-profiling",
  "common-kafka",
+ "common-liveness",
  "envconfig",
  "lifecycle",
  "metrics",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7319,17 +7319,21 @@ dependencies = [
 name = "property-vals-rs"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum 0.7.9",
  "common-alloc",
  "common-continuous-profiling",
  "common-kafka",
  "envconfig",
  "lifecycle",
+ "metrics",
  "proptest",
+ "rdkafka",
  "serde",
  "serde_json",
  "serve-metrics",
  "siphasher 1.0.2",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/rust/common/kafka/src/kafka_consumer.rs
+++ b/rust/common/kafka/src/kafka_consumer.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use rdkafka::{
-    consumer::{Consumer, ConsumerGroupMetadata, StreamConsumer},
+    consumer::{CommitMode, Consumer, ConsumerGroupMetadata, StreamConsumer},
     error::KafkaError,
     ClientConfig, Message,
 };
@@ -188,6 +188,10 @@ impl SingleTopicConsumer {
             .consumer
             .group_metadata()
             .expect("It is impossible to construct a stream consumer without a group id")
+    }
+
+    pub fn commit(&self) -> Result<(), KafkaError> {
+        self.inner.consumer.commit_consumer_state(CommitMode::Sync)
     }
 }
 

--- a/rust/property-vals-rs/Cargo.toml
+++ b/rust/property-vals-rs/Cargo.toml
@@ -10,6 +10,7 @@ axum = { workspace = true }
 common-alloc = { path = "../common/alloc" }
 common-continuous-profiling = { path = "../common/continuous_profiling" }
 common-kafka = { path = "../common/kafka" }
+common-liveness = { path = "../common/liveness" }
 envconfig = { workspace = true }
 lifecycle = { path = "../common/lifecycle" }
 metrics = { workspace = true }

--- a/rust/property-vals-rs/Cargo.toml
+++ b/rust/property-vals-rs/Cargo.toml
@@ -5,16 +5,20 @@ edition = "2021"
 publish = false
 
 [dependencies]
+async-trait = { workspace = true }
 axum = { workspace = true }
 common-alloc = { path = "../common/alloc" }
 common-continuous-profiling = { path = "../common/continuous_profiling" }
 common-kafka = { path = "../common/kafka" }
 envconfig = { workspace = true }
 lifecycle = { path = "../common/lifecycle" }
+metrics = { workspace = true }
+rdkafka = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serve-metrics = { path = "../common/serve_metrics" }
 siphasher = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -26,20 +26,14 @@ pub struct Config {
     #[envconfig(default = "500000")]
     pub max_buffered_tuples: usize,
 
-    #[envconfig(default = "property-vals-rs-local-events")]
-    pub kafka_transactional_id: String,
-
     #[envconfig(default = "60")]
-    pub kafka_transaction_timeout_secs: u64,
+    pub kafka_produce_timeout_secs: u64,
 
     #[envconfig(default = "clickhouse_groups")]
     pub groups_kafka_consumer_topic: String,
 
     #[envconfig(default = "clickhouse-property-vals-rs-groups")]
     pub groups_kafka_consumer_group: String,
-
-    #[envconfig(default = "property-vals-rs-local-groups")]
-    pub groups_kafka_transactional_id: String,
 
     #[envconfig(default = "")]
     pub allowed_teams: TeamList,
@@ -79,13 +73,14 @@ impl FromStr for TeamList {
 
 impl Config {
     pub fn init_with_defaults() -> Result<Self, envconfig::Error> {
-        // auto_commit=false because offsets are committed by the
-        // transactional producer via send_offsets_to_transaction; auto-commit
-        // would break the exactly-once guarantee.
+        // auto_commit=true: background timer ships stored offsets to the
+        // broker every ~5s. We manually advance the stored offset only after
+        // a successful produce (see worker.rs::flush), so the broker never
+        // sees an offset for input we haven't actually written out.
         ConsumerConfig::set_defaults(
             "clickhouse-property-vals-rs",
             "clickhouse_events_json",
-            false,
+            true,
         );
         Config::init_from_env()
     }

--- a/rust/property-vals-rs/src/lib.rs
+++ b/rust/property-vals-rs/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod aggregator;
 pub mod config;
 pub mod fan_out;
+pub mod metrics_consts;
+pub mod producer;
 pub mod types;
+pub mod worker;

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -5,7 +5,6 @@ use axum::{response::IntoResponse, routing::get, Router};
 use common_kafka::kafka_consumer::SingleTopicConsumer;
 use lifecycle::{ComponentOptions, Manager};
 use property_vals_rs::{
-    app_context::AppContext,
     config::Config,
     fan_out::{fan_out, fan_out_group},
     producer::AggregatedProducer,
@@ -119,21 +118,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.groups_kafka_consumer_topic
     );
 
-    let ctx = Arc::new(AppContext::new(&config));
+    let shared_config = Arc::new(config.clone());
 
     let guard = manager.monitor_background();
 
     // One worker per topic. Each has its own transactional producer because
     // rdkafka allows one outstanding transaction per transactional.id.
     tokio::spawn(worker_loop::<Event, _, _>(
-        ctx.clone(),
+        shared_config.clone(),
         events_consumer,
         events_producer,
         events_handle.clone(),
         fan_out,
     ));
     tokio::spawn(worker_loop::<GroupIdentify, _, _>(
-        ctx.clone(),
+        shared_config.clone(),
         groups_consumer,
         groups_producer,
         groups_handle.clone(),

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -76,38 +76,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!(
         events_topic = %config.consumer.kafka_consumer_topic,
         events_consumer_group = %config.consumer.kafka_consumer_group,
-        events_transactional_id = %config.kafka_transactional_id,
         groups_topic = %config.groups_kafka_consumer_topic,
         groups_consumer_group = %config.groups_kafka_consumer_group,
-        groups_transactional_id = %config.groups_kafka_transactional_id,
         output_topic = %config.output_topic,
         flush_interval_secs = config.flush_interval_secs,
         "config loaded"
     );
 
+    let produce_timeout = Duration::from_secs(config.kafka_produce_timeout_secs);
+
     let events_consumer = SingleTopicConsumer::new(config.kafka.clone(), config.consumer.clone())?;
     let events_producer = AggregatedProducer::new(
         &config.kafka,
-        &config.kafka_transactional_id,
+        events_handle.clone(),
         config.output_topic.clone(),
-        Duration::from_secs(config.kafka_transaction_timeout_secs),
-        events_consumer.clone(),
-    )?;
+        produce_timeout,
+    )
+    .await?;
 
-    // Groups consumer inherits the events ConsumerConfig and overrides topic +
-    // group only. Other tuning (TLS, fetch sizes, auto_commit=false) carries
-    // over so the two workers have consistent Kafka client behavior.
     let mut groups_consumer_config = config.consumer.clone();
     groups_consumer_config.kafka_consumer_topic = config.groups_kafka_consumer_topic.clone();
     groups_consumer_config.kafka_consumer_group = config.groups_kafka_consumer_group.clone();
     let groups_consumer = SingleTopicConsumer::new(config.kafka.clone(), groups_consumer_config)?;
     let groups_producer = AggregatedProducer::new(
         &config.kafka,
-        &config.groups_kafka_transactional_id,
+        groups_handle.clone(),
         config.output_topic.clone(),
-        Duration::from_secs(config.kafka_transaction_timeout_secs),
-        groups_consumer.clone(),
-    )?;
+        produce_timeout,
+    )
+    .await?;
 
     info!(
         "Subscribed to topic: {}",
@@ -122,8 +119,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let guard = manager.monitor_background();
 
-    // One worker per topic. Each has its own transactional producer because
-    // rdkafka allows one outstanding transaction per transactional.id.
     tokio::spawn(worker_loop::<Event, _, _>(
         shared_config.clone(),
         events_consumer,

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -1,8 +1,17 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{response::IntoResponse, routing::get, Router};
+use common_kafka::kafka_consumer::SingleTopicConsumer;
 use lifecycle::{ComponentOptions, Manager};
-use property_vals_rs::config::Config;
+use property_vals_rs::{
+    app_context::AppContext,
+    config::Config,
+    fan_out::{fan_out, fan_out_group},
+    producer::AggregatedProducer,
+    types::{Event, GroupIdentify},
+    worker::worker_loop,
+};
 use serve_metrics::setup_metrics_routes;
 use tokio::net::TcpListener;
 use tracing::level_filters::LevelFilter;
@@ -44,11 +53,94 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_global_shutdown_timeout(Duration::from_secs(60))
         .build();
 
+    let events_handle = manager.register(
+        "events-worker",
+        ComponentOptions::new()
+            .with_graceful_shutdown(Duration::from_secs(30))
+            .with_liveness_deadline(Duration::from_secs(60))
+            .with_stall_threshold(3),
+    );
+    let groups_handle = manager.register(
+        "groups-worker",
+        ComponentOptions::new()
+            .with_graceful_shutdown(Duration::from_secs(30))
+            .with_liveness_deadline(Duration::from_secs(60))
+            .with_stall_threshold(3),
+    );
+
     let metrics_handle =
         manager.register("metrics", ComponentOptions::new().is_observability(true));
 
     let readiness = manager.readiness_handler();
     let liveness = manager.liveness_handler();
+
+    info!(
+        events_topic = %config.consumer.kafka_consumer_topic,
+        events_consumer_group = %config.consumer.kafka_consumer_group,
+        events_transactional_id = %config.kafka_transactional_id,
+        groups_topic = %config.groups_kafka_consumer_topic,
+        groups_consumer_group = %config.groups_kafka_consumer_group,
+        groups_transactional_id = %config.groups_kafka_transactional_id,
+        output_topic = %config.output_topic,
+        flush_interval_secs = config.flush_interval_secs,
+        "config loaded"
+    );
+
+    let events_consumer = SingleTopicConsumer::new(config.kafka.clone(), config.consumer.clone())?;
+    let events_producer = AggregatedProducer::new(
+        &config.kafka,
+        &config.kafka_transactional_id,
+        config.output_topic.clone(),
+        Duration::from_secs(config.kafka_transaction_timeout_secs),
+        events_consumer.clone(),
+    )?;
+
+    // Groups consumer inherits the events ConsumerConfig and overrides topic +
+    // group only. Other tuning (TLS, fetch sizes, auto_commit=false) carries
+    // over so the two workers have consistent Kafka client behavior.
+    let mut groups_consumer_config = config.consumer.clone();
+    groups_consumer_config.kafka_consumer_topic = config.groups_kafka_consumer_topic.clone();
+    groups_consumer_config.kafka_consumer_group = config.groups_kafka_consumer_group.clone();
+    let groups_consumer = SingleTopicConsumer::new(config.kafka.clone(), groups_consumer_config)?;
+    let groups_producer = AggregatedProducer::new(
+        &config.kafka,
+        &config.groups_kafka_transactional_id,
+        config.output_topic.clone(),
+        Duration::from_secs(config.kafka_transaction_timeout_secs),
+        groups_consumer.clone(),
+    )?;
+
+    info!(
+        "Subscribed to topic: {}",
+        config.consumer.kafka_consumer_topic
+    );
+    info!(
+        "Subscribed to topic: {}",
+        config.groups_kafka_consumer_topic
+    );
+
+    let ctx = Arc::new(AppContext::new(&config));
+
+    let guard = manager.monitor_background();
+
+    // One worker per topic. Each has its own transactional producer because
+    // rdkafka allows one outstanding transaction per transactional.id.
+    tokio::spawn(worker_loop::<Event, _, _>(
+        ctx.clone(),
+        events_consumer,
+        events_producer,
+        events_handle.clone(),
+        fan_out,
+    ));
+    tokio::spawn(worker_loop::<GroupIdentify, _, _>(
+        ctx.clone(),
+        groups_consumer,
+        groups_producer,
+        groups_handle.clone(),
+        fan_out_group,
+    ));
+    drop(events_handle);
+    drop(groups_handle);
 
     let app = Router::new()
         .route("/", get(index))
@@ -81,6 +173,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_graceful_shutdown(metrics_handle.shutdown_signal())
         .await?;
     metrics_handle.work_completed();
+
+    guard.wait().await?;
 
     info!("property-vals-rs stopped");
     Ok(())

--- a/rust/property-vals-rs/src/metrics_consts.rs
+++ b/rust/property-vals-rs/src/metrics_consts.rs
@@ -1,0 +1,12 @@
+pub const EVENTS_RECEIVED: &str = "property_vals_rs_events_received_total";
+pub const EVENTS_FILTERED: &str = "property_vals_rs_events_filtered_total";
+pub const TUPLES_AGGREGATED: &str = "property_vals_rs_tuples_aggregated_total";
+pub const FLUSH_TUPLES: &str = "property_vals_rs_flush_tuples";
+pub const FLUSH_TOTAL: &str = "property_vals_rs_flushes_total";
+pub const FLUSH_REASON_TIMER: &str = "timer";
+pub const FLUSH_REASON_BACKPRESSURE: &str = "backpressure";
+pub const FLUSH_REASON_SHUTDOWN: &str = "shutdown";
+pub const PRODUCE_FAILED: &str = "property_vals_rs_produce_failed_total";
+pub const PRODUCER_FLUSH_FAILED: &str = "property_vals_rs_producer_flush_failed_total";
+pub const OFFSET_STORE_FAILED: &str = "property_vals_rs_offset_store_failed_total";
+pub const KAFKA_RECV_ERRORS: &str = "property_vals_rs_kafka_recv_errors_total";

--- a/rust/property-vals-rs/src/metrics_consts.rs
+++ b/rust/property-vals-rs/src/metrics_consts.rs
@@ -6,7 +6,5 @@ pub const FLUSH_TOTAL: &str = "property_vals_rs_flushes_total";
 pub const FLUSH_REASON_TIMER: &str = "timer";
 pub const FLUSH_REASON_BACKPRESSURE: &str = "backpressure";
 pub const FLUSH_REASON_SHUTDOWN: &str = "shutdown";
-pub const PRODUCE_FAILED: &str = "property_vals_rs_produce_failed_total";
 pub const PRODUCER_FLUSH_FAILED: &str = "property_vals_rs_producer_flush_failed_total";
-pub const OFFSET_STORE_FAILED: &str = "property_vals_rs_offset_store_failed_total";
 pub const KAFKA_RECV_ERRORS: &str = "property_vals_rs_kafka_recv_errors_total";

--- a/rust/property-vals-rs/src/metrics_consts.rs
+++ b/rust/property-vals-rs/src/metrics_consts.rs
@@ -7,4 +7,5 @@ pub const FLUSH_REASON_TIMER: &str = "timer";
 pub const FLUSH_REASON_BACKPRESSURE: &str = "backpressure";
 pub const FLUSH_REASON_SHUTDOWN: &str = "shutdown";
 pub const PRODUCER_FLUSH_FAILED: &str = "property_vals_rs_producer_flush_failed_total";
+pub const OFFSET_STORE_FAILED: &str = "property_vals_rs_offset_store_failed_total";
 pub const KAFKA_RECV_ERRORS: &str = "property_vals_rs_kafka_recv_errors_total";

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -2,14 +2,13 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common_kafka::config::KafkaConfig;
-use common_kafka::kafka_consumer::SingleTopicConsumer;
-use common_kafka::kafka_producer::{send_keyed_iter_to_kafka, KafkaProduceError};
-use common_kafka::transaction::TransactionalProducer;
+use common_kafka::kafka_producer::{
+    create_kafka_producer, send_keyed_iter_to_kafka, KafkaContext, KafkaProduceError,
+};
 use rdkafka::error::KafkaError;
-use rdkafka::producer::Producer as RdkafkaProducer;
-use rdkafka::TopicPartitionList;
+use rdkafka::producer::FutureProducer;
 use thiserror::Error;
-use tracing::{error, warn};
+use tracing::warn;
 
 use crate::types::{PropertyType, TupleKey};
 
@@ -22,200 +21,92 @@ struct Outgoing<'a> {
     property_count: u64,
 }
 
-#[derive(Debug, Clone)]
-pub struct OffsetSnapshot {
-    pub topic: String,
-    pub partition: i32,
-    pub offset: i64,
-}
-
 #[derive(Debug, Error)]
 pub enum ProduceError {
     #[error("kafka produce timed out after {0:?}")]
     Timeout(Duration),
     #[error("{failed}/{total} records failed delivery")]
     PartialFailure { failed: usize, total: usize },
-    #[error("transaction begin failed: {0}")]
-    Begin(String),
-    #[error("offset commit to transaction failed: {0}")]
-    OffsetCommit(String),
-    #[error("transaction commit failed: {0}")]
-    Commit(String),
 }
 
-/// Atomically commits one flush window: produce all aggregated tuples to the
-/// output topic AND commit the input partition offsets to the consumer
-/// group, both inside a single Kafka transaction. Either both writes are
-/// durable or neither happens.
-///
-/// `&mut self` because rdkafka allows only one outstanding transaction per
-/// `transactional.id`. With one worker per pod (the deployed shape), this
-/// matches the only producer instance.
+/// Produce the aggregated tuples to the output topic. At-least-once: each
+/// produce stands on its own and the caller stores the input consumer offsets
+/// only after this returns Ok. On failure the caller does not advance the
+/// stored offsets, so the next pod resumes from before these inputs and
+/// re-produces them; duplicates are absorbed by the storage table's existing
+/// aggregation semantics.
 #[async_trait]
 pub trait Producer: Send {
-    async fn produce_and_commit(
-        &mut self,
-        items: Vec<(TupleKey, u64)>,
-        offsets: Vec<OffsetSnapshot>,
-    ) -> Result<(), ProduceError>;
+    async fn produce(&self, items: Vec<(TupleKey, u64)>) -> Result<(), ProduceError>;
 }
 
-/// Real producer: wraps a Kafka transactional producer and the consumer it
-/// belongs to (needed for `ConsumerGroupMetadata` on every commit). Skips
-/// the `KafkaTransaction` wrapper in common-kafka because we need to chain
-/// `send_offsets_to_transaction` and `send_keyed_iter_to_kafka` from the
-/// same inner FutureProducer reference, which the wrapper's borrow shape
-/// disallows.
 pub struct AggregatedProducer {
-    inner: TransactionalProducer,
+    inner: FutureProducer<KafkaContext>,
     output_topic: String,
-    consumer: SingleTopicConsumer,
-    transaction_timeout: Duration,
+    produce_timeout: Duration,
 }
 
 impl AggregatedProducer {
-    pub fn new(
+    pub async fn new<L>(
         kafka_config: &KafkaConfig,
-        transactional_id: &str,
+        liveness: L,
         output_topic: String,
-        transaction_timeout: Duration,
-        consumer: SingleTopicConsumer,
-    ) -> Result<Self, KafkaError> {
-        let inner = TransactionalProducer::from_config(
-            kafka_config,
-            transactional_id,
-            transaction_timeout,
-        )?;
+        produce_timeout: Duration,
+    ) -> Result<Self, KafkaError>
+    where
+        L: common_liveness::SyncLivenessReporter + Clone + 'static,
+    {
+        let inner = create_kafka_producer(kafka_config, liveness).await?;
         Ok(Self {
             inner,
             output_topic,
-            consumer,
-            transaction_timeout,
+            produce_timeout,
         })
     }
 }
 
 #[async_trait]
 impl Producer for AggregatedProducer {
-    async fn produce_and_commit(
-        &mut self,
-        items: Vec<(TupleKey, u64)>,
-        offsets: Vec<OffsetSnapshot>,
-    ) -> Result<(), ProduceError> {
-        if items.is_empty() && offsets.is_empty() {
+    async fn produce(&self, items: Vec<(TupleKey, u64)>) -> Result<(), ProduceError> {
+        if items.is_empty() {
             return Ok(());
         }
-
-        let metadata = self.consumer.metadata();
-        let producer = self.inner.inner();
-
-        producer
-            .begin_transaction()
-            .map_err(|e| ProduceError::Begin(e.to_string()))?;
-
         let total = items.len();
-        if !items.is_empty() {
-            let messages: Vec<Outgoing> = items
-                .iter()
-                .map(|(tuple, count)| Outgoing {
-                    team_id: tuple.team_id,
-                    property_type: tuple.property_type,
-                    property_key: &tuple.property_key,
-                    property_value: &tuple.property_value,
-                    property_count: *count,
-                })
-                .collect();
 
-            let send_fut = send_keyed_iter_to_kafka(
-                producer,
-                &self.output_topic,
-                |m| Some(m.team_id.to_string()),
-                messages,
-            );
+        let messages: Vec<Outgoing> = items
+            .iter()
+            .map(|(tuple, count)| Outgoing {
+                team_id: tuple.team_id,
+                property_type: tuple.property_type,
+                property_key: &tuple.property_key,
+                property_value: &tuple.property_value,
+                property_count: *count,
+            })
+            .collect();
 
-            let results = match tokio::time::timeout(self.transaction_timeout, send_fut).await {
-                Ok(r) => r,
-                Err(_) => {
-                    abort_logged(producer, self.transaction_timeout);
-                    return Err(ProduceError::Timeout(self.transaction_timeout));
-                }
-            };
+        let send_fut = send_keyed_iter_to_kafka(
+            &self.inner,
+            &self.output_topic,
+            |m| Some(m.team_id.to_string()),
+            messages,
+        );
 
-            let failed = results
-                .iter()
-                .filter(|r| matches!(r, Err(KafkaProduceError::KafkaProduceError { .. })))
-                .count();
-            if failed > 0 {
-                abort_logged(producer, self.transaction_timeout);
-                return Err(ProduceError::PartialFailure { failed, total });
+        let results = match tokio::time::timeout(self.produce_timeout, send_fut).await {
+            Ok(r) => r,
+            Err(_) => {
+                warn!("kafka produce timed out after {:?}", self.produce_timeout);
+                return Err(ProduceError::Timeout(self.produce_timeout));
             }
+        };
+
+        let failed = results
+            .iter()
+            .filter(|r| matches!(r, Err(KafkaProduceError::KafkaProduceError { .. })))
+            .count();
+        if failed > 0 {
+            return Err(ProduceError::PartialFailure { failed, total });
         }
 
-        if !offsets.is_empty() {
-            let tpl = build_topic_partition_list(&offsets);
-            if let Err(e) =
-                producer.send_offsets_to_transaction(&tpl, &metadata, self.transaction_timeout)
-            {
-                abort_logged(producer, self.transaction_timeout);
-                return Err(ProduceError::OffsetCommit(e.to_string()));
-            }
-        }
-
-        if let Err(e) = producer.commit_transaction(self.transaction_timeout) {
-            abort_logged(producer, self.transaction_timeout);
-            return Err(ProduceError::Commit(e.to_string()));
-        }
         Ok(())
-    }
-}
-
-fn abort_logged<C: rdkafka::ClientContext>(
-    producer: &rdkafka::producer::FutureProducer<C>,
-    timeout: Duration,
-) {
-    if let Err(e) = producer.abort_transaction(timeout) {
-        error!(error = %e, "kafka abort_transaction failed");
-    } else {
-        warn!("kafka transaction aborted");
-    }
-}
-
-/// Build a TopicPartitionList from offset snapshots. Per rdkafka's
-/// `send_offsets_to_transaction` docs, the committed offset is "one greater
-/// than the last processed message's offset", so we add 1 to each.
-fn build_topic_partition_list(snapshots: &[OffsetSnapshot]) -> TopicPartitionList {
-    let mut tpl = TopicPartitionList::new();
-    for s in snapshots {
-        tpl.add_partition_offset(&s.topic, s.partition, rdkafka::Offset::Offset(s.offset + 1))
-            .expect("TopicPartitionList::add_partition_offset is infallible for valid inputs");
-    }
-    tpl
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn build_tpl_adds_one_to_each_offset() {
-        let snapshots = vec![
-            OffsetSnapshot {
-                topic: "t".into(),
-                partition: 0,
-                offset: 5,
-            },
-            OffsetSnapshot {
-                topic: "t".into(),
-                partition: 1,
-                offset: 10,
-            },
-        ];
-        let tpl = build_topic_partition_list(&snapshots);
-        let elements = tpl.elements();
-        assert_eq!(elements.len(), 2);
-        let p0 = elements.iter().find(|e| e.partition() == 0).unwrap();
-        let p1 = elements.iter().find(|e| e.partition() == 1).unwrap();
-        assert!(matches!(p0.offset(), rdkafka::Offset::Offset(6)));
-        assert!(matches!(p1.offset(), rdkafka::Offset::Offset(11)));
     }
 }

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -1,0 +1,211 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use common_kafka::config::KafkaConfig;
+use common_kafka::kafka_consumer::SingleTopicConsumer;
+use common_kafka::kafka_producer::{send_keyed_iter_to_kafka, KafkaProduceError};
+use common_kafka::transaction::TransactionalProducer;
+use rdkafka::error::KafkaError;
+use rdkafka::producer::Producer as RdkafkaProducer;
+use rdkafka::TopicPartitionList;
+use thiserror::Error;
+use tracing::{error, warn};
+
+use crate::types::{OutputMessage, TupleKey};
+
+#[derive(Debug, Clone)]
+pub struct OffsetSnapshot {
+    pub topic: String,
+    pub partition: i32,
+    pub offset: i64,
+}
+
+#[derive(Debug, Error)]
+pub enum ProduceError {
+    #[error("kafka produce timed out after {0:?}")]
+    Timeout(Duration),
+    #[error("{failed}/{total} records failed delivery")]
+    PartialFailure { failed: usize, total: usize },
+    #[error("transaction begin failed: {0}")]
+    Begin(String),
+    #[error("offset commit to transaction failed: {0}")]
+    OffsetCommit(String),
+    #[error("transaction commit failed: {0}")]
+    Commit(String),
+}
+
+/// Atomically commits one flush window: produce all aggregated tuples to the
+/// output topic AND commit the input partition offsets to the consumer
+/// group, both inside a single Kafka transaction. Either both writes are
+/// durable or neither happens.
+///
+/// `&mut self` because rdkafka allows only one outstanding transaction per
+/// `transactional.id`. With one worker per pod (the deployed shape), this
+/// matches the only producer instance.
+#[async_trait]
+pub trait Producer: Send {
+    async fn produce_and_commit(
+        &mut self,
+        items: Vec<(TupleKey, u64)>,
+        offsets: Vec<OffsetSnapshot>,
+    ) -> Result<(), ProduceError>;
+}
+
+/// Real producer: wraps a Kafka transactional producer and the consumer it
+/// belongs to (needed for `ConsumerGroupMetadata` on every commit). Skips
+/// the `KafkaTransaction` wrapper in common-kafka because we need to chain
+/// `send_offsets_to_transaction` and `send_keyed_iter_to_kafka` from the
+/// same inner FutureProducer reference, which the wrapper's borrow shape
+/// disallows.
+pub struct AggregatedProducer {
+    inner: TransactionalProducer,
+    output_topic: String,
+    consumer: SingleTopicConsumer,
+    transaction_timeout: Duration,
+}
+
+impl AggregatedProducer {
+    pub fn new(
+        kafka_config: &KafkaConfig,
+        transactional_id: &str,
+        output_topic: String,
+        transaction_timeout: Duration,
+        consumer: SingleTopicConsumer,
+    ) -> Result<Self, KafkaError> {
+        let inner = TransactionalProducer::from_config(
+            kafka_config,
+            transactional_id,
+            transaction_timeout,
+        )?;
+        Ok(Self {
+            inner,
+            output_topic,
+            consumer,
+            transaction_timeout,
+        })
+    }
+}
+
+#[async_trait]
+impl Producer for AggregatedProducer {
+    async fn produce_and_commit(
+        &mut self,
+        items: Vec<(TupleKey, u64)>,
+        offsets: Vec<OffsetSnapshot>,
+    ) -> Result<(), ProduceError> {
+        if items.is_empty() && offsets.is_empty() {
+            return Ok(());
+        }
+
+        let metadata = self.consumer.metadata();
+        let producer = self.inner.inner();
+
+        producer
+            .begin_transaction()
+            .map_err(|e| ProduceError::Begin(e.to_string()))?;
+
+        let total = items.len();
+        if !items.is_empty() {
+            let messages: Vec<OutputMessage> = items
+                .into_iter()
+                .map(|(tuple, count)| OutputMessage {
+                    team_id: tuple.team_id,
+                    property_type: tuple.property_type.as_str().to_string(),
+                    property_key: tuple.property_key,
+                    property_value: tuple.property_value,
+                    property_count: count,
+                })
+                .collect();
+
+            let send_fut = send_keyed_iter_to_kafka(
+                producer,
+                &self.output_topic,
+                |m| Some(m.team_id.to_string()),
+                messages,
+            );
+
+            let results = match tokio::time::timeout(self.transaction_timeout, send_fut).await {
+                Ok(r) => r,
+                Err(_) => {
+                    abort_logged(producer, self.transaction_timeout);
+                    return Err(ProduceError::Timeout(self.transaction_timeout));
+                }
+            };
+
+            let failed = results
+                .iter()
+                .filter(|r| matches!(r, Err(KafkaProduceError::KafkaProduceError { .. })))
+                .count();
+            if failed > 0 {
+                abort_logged(producer, self.transaction_timeout);
+                return Err(ProduceError::PartialFailure { failed, total });
+            }
+        }
+
+        if !offsets.is_empty() {
+            let tpl = build_topic_partition_list(&offsets);
+            if let Err(e) =
+                producer.send_offsets_to_transaction(&tpl, &metadata, self.transaction_timeout)
+            {
+                abort_logged(producer, self.transaction_timeout);
+                return Err(ProduceError::OffsetCommit(e.to_string()));
+            }
+        }
+
+        producer
+            .commit_transaction(self.transaction_timeout)
+            .map_err(|e| ProduceError::Commit(e.to_string()))?;
+        Ok(())
+    }
+}
+
+fn abort_logged<C: rdkafka::ClientContext>(
+    producer: &rdkafka::producer::FutureProducer<C>,
+    timeout: Duration,
+) {
+    if let Err(e) = producer.abort_transaction(timeout) {
+        error!(error = %e, "kafka abort_transaction failed");
+    } else {
+        warn!("kafka transaction aborted");
+    }
+}
+
+/// Build a TopicPartitionList from offset snapshots. Per rdkafka's
+/// `send_offsets_to_transaction` docs, the committed offset is "one greater
+/// than the last processed message's offset", so we add 1 to each.
+fn build_topic_partition_list(snapshots: &[OffsetSnapshot]) -> TopicPartitionList {
+    let mut tpl = TopicPartitionList::new();
+    for s in snapshots {
+        tpl.add_partition_offset(&s.topic, s.partition, rdkafka::Offset::Offset(s.offset + 1))
+            .expect("TopicPartitionList::add_partition_offset is infallible for valid inputs");
+    }
+    tpl
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_tpl_adds_one_to_each_offset() {
+        let snapshots = vec![
+            OffsetSnapshot {
+                topic: "t".into(),
+                partition: 0,
+                offset: 5,
+            },
+            OffsetSnapshot {
+                topic: "t".into(),
+                partition: 1,
+                offset: 10,
+            },
+        ];
+        let tpl = build_topic_partition_list(&snapshots);
+        let elements = tpl.elements();
+        assert_eq!(elements.len(), 2);
+        let p0 = elements.iter().find(|e| e.partition() == 0).unwrap();
+        let p1 = elements.iter().find(|e| e.partition() == 1).unwrap();
+        assert!(matches!(p0.offset(), rdkafka::Offset::Offset(6)));
+        assert!(matches!(p1.offset(), rdkafka::Offset::Offset(11)));
+    }
+}

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -152,9 +152,10 @@ impl Producer for AggregatedProducer {
             }
         }
 
-        producer
-            .commit_transaction(self.transaction_timeout)
-            .map_err(|e| ProduceError::Commit(e.to_string()))?;
+        if let Err(e) = producer.commit_transaction(self.transaction_timeout) {
+            abort_logged(producer, self.transaction_timeout);
+            return Err(ProduceError::Commit(e.to_string()));
+        }
         Ok(())
     }
 }

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -11,7 +11,16 @@ use rdkafka::TopicPartitionList;
 use thiserror::Error;
 use tracing::{error, warn};
 
-use crate::types::{OutputMessage, TupleKey};
+use crate::types::{PropertyType, TupleKey};
+
+#[derive(serde::Serialize)]
+struct Outgoing<'a> {
+    team_id: i64,
+    property_type: PropertyType,
+    property_key: &'a str,
+    property_value: &'a str,
+    property_count: u64,
+}
 
 #[derive(Debug, Clone)]
 pub struct OffsetSnapshot {
@@ -106,14 +115,14 @@ impl Producer for AggregatedProducer {
 
         let total = items.len();
         if !items.is_empty() {
-            let messages: Vec<OutputMessage> = items
-                .into_iter()
-                .map(|(tuple, count)| OutputMessage {
+            let messages: Vec<Outgoing> = items
+                .iter()
+                .map(|(tuple, count)| Outgoing {
                     team_id: tuple.team_id,
-                    property_type: tuple.property_type.as_str().to_string(),
-                    property_key: tuple.property_key,
-                    property_value: tuple.property_value,
-                    property_count: count,
+                    property_type: tuple.property_type,
+                    property_key: &tuple.property_key,
+                    property_value: &tuple.property_value,
+                    property_count: *count,
                 })
                 .collect();
 

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use common_kafka::kafka_consumer::{RecvErr, SingleTopicConsumer};
 use tracing::{error, info, warn};
 
 use crate::aggregator::Aggregator;
-use crate::app_context::AppContext;
+use crate::config::Config;
 use crate::metrics_consts::*;
 use crate::producer::{OffsetSnapshot, Producer};
 use crate::types::{IngestableEvent, TupleKey};
@@ -13,12 +14,8 @@ use crate::types::{IngestableEvent, TupleKey};
 /// One worker loop. Each pod runs one worker per input topic. Each worker
 /// owns its own transactional producer (with a distinct `transactional.id`)
 /// because rdkafka allows only one outstanding transaction per id.
-///
-/// Generic over the message type so the events consumer and the groups
-/// consumer can share this code. The caller supplies the per-message
-/// fan-out function.
 pub async fn worker_loop<E, P, F>(
-    ctx: Arc<AppContext>,
+    config: Arc<Config>,
     consumer: SingleTopicConsumer,
     mut producer: P,
     handle: lifecycle::Handle,
@@ -31,13 +28,9 @@ pub async fn worker_loop<E, P, F>(
     let _guard = handle.process_scope();
 
     let mut aggregator = Aggregator::new();
-    // Latest seen offset per partition; the worker only stores a snapshot
-    // (topic + partition + offset value) because the real consumer Offset
-    // handle isn't needed anymore. The transactional producer commits these
-    // via `send_offsets_to_transaction` atomically with the produce.
     let mut pending_offsets: HashMap<i32, OffsetSnapshot> = HashMap::new();
 
-    let mut flush_timer = tokio::time::interval(ctx.flush_interval);
+    let mut flush_timer = tokio::time::interval(Duration::from_secs(config.flush_interval_secs));
     flush_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     flush_timer.reset();
 
@@ -68,10 +61,12 @@ pub async fn worker_loop<E, P, F>(
                     Ok((event, offset)) => {
                         metrics::counter!(EVENTS_RECEIVED).increment(1);
 
-                        if ctx.should_process(event.team_id()) {
+                        if config.should_process(event.team_id()) {
                             let tuples = fan_out_fn(&event);
                             metrics::counter!(TUPLES_AGGREGATED).increment(tuples.len() as u64);
-                            aggregator.record_many(tuples);
+                            for t in tuples {
+                                aggregator.add(t, 1);
+                            }
                         } else {
                             metrics::counter!(EVENTS_FILTERED).increment(1);
                         }
@@ -85,7 +80,7 @@ pub async fn worker_loop<E, P, F>(
                             },
                         );
 
-                        if aggregator.len() >= ctx.max_buffered_tuples {
+                        if aggregator.len() >= config.max_buffered_tuples {
                             flush(
                                 &mut aggregator,
                                 &mut pending_offsets,
@@ -235,7 +230,7 @@ mod tests {
 
     fn populate(agg: &mut Aggregator, count: u64) {
         for i in 0..count {
-            agg.record(tuple(2, "k", &format!("v{i}")));
+            agg.add(tuple(2, "k", &format!("v{i}")), 1);
         }
     }
 
@@ -328,7 +323,7 @@ mod tests {
     #[tokio::test]
     async fn restored_counts_merge_with_new_counts_in_next_window() {
         let mut agg = Aggregator::new();
-        agg.record(tuple(2, "k1", "v1"));
+        agg.add(tuple(2, "k1", "v1"), 1);
 
         let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
         pending.insert(0, snapshot(0, 10));
@@ -336,7 +331,7 @@ mod tests {
         let mut producer = MockProducer::new().fail_on(1);
         flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
 
-        agg.record(tuple(2, "k1", "v1"));
+        agg.add(tuple(2, "k1", "v1"), 1);
 
         flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
 
@@ -348,7 +343,7 @@ mod tests {
     #[tokio::test]
     async fn produce_and_commit_receives_items_and_offsets_atomically() {
         let mut agg = Aggregator::new();
-        agg.record(tuple(2, "k1", "v1"));
+        agg.add(tuple(2, "k1", "v1"), 1);
 
         let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
         pending.insert(0, snapshot(0, 42));
@@ -366,7 +361,7 @@ mod tests {
     #[tokio::test]
     async fn repeated_failure_holds_all_state_indefinitely() {
         let mut agg = Aggregator::new();
-        agg.record(tuple(2, "k1", "v1"));
+        agg.add(tuple(2, "k1", "v1"), 1);
 
         let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
         pending.insert(0, snapshot(0, 7));

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -2,22 +2,26 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use common_kafka::kafka_consumer::{RecvErr, SingleTopicConsumer};
+use common_kafka::kafka_consumer::{Offset, RecvErr, SingleTopicConsumer};
 use tracing::{error, info, warn};
 
 use crate::aggregator::Aggregator;
 use crate::config::Config;
 use crate::metrics_consts::*;
-use crate::producer::{OffsetSnapshot, Producer};
+use crate::producer::Producer;
 use crate::types::{IngestableEvent, TupleKey};
 
-/// One worker loop. Each pod runs one worker per input topic. Each worker
-/// owns its own transactional producer (with a distinct `transactional.id`)
-/// because rdkafka allows only one outstanding transaction per id.
+/// One worker loop. Each pod runs one worker per input topic.
+///
+/// At-least-once: on each flush we produce non-transactionally, then on
+/// success advance the consumer's stored offsets. Background auto-commit
+/// (configured in init_with_defaults) flushes the stored offsets to the
+/// broker every 5s. On graceful shutdown we drain one final flush and
+/// force a synchronous commit so the next pod resumes from exactly here.
 pub async fn worker_loop<E, P, F>(
     config: Arc<Config>,
     consumer: SingleTopicConsumer,
-    mut producer: P,
+    producer: P,
     handle: lifecycle::Handle,
     fan_out_fn: F,
 ) where
@@ -28,7 +32,10 @@ pub async fn worker_loop<E, P, F>(
     let _guard = handle.process_scope();
 
     let mut aggregator = Aggregator::new();
-    let mut pending_offsets: HashMap<i32, OffsetSnapshot> = HashMap::new();
+    // One Offset handle per partition: the latest message we've consumed.
+    // On successful flush we call .store() on each, which advances the
+    // consumer's stored offset; auto-commit ships it to the broker.
+    let mut pending_offsets: HashMap<i32, Offset> = HashMap::new();
 
     let mut flush_timer = tokio::time::interval(Duration::from_secs(config.flush_interval_secs));
     flush_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -38,22 +45,15 @@ pub async fn worker_loop<E, P, F>(
         tokio::select! {
             _ = handle.shutdown_recv() => {
                 info!("worker received shutdown; draining final flush");
-                flush(
-                    &mut aggregator,
-                    &mut pending_offsets,
-                    &mut producer,
-                    FLUSH_REASON_SHUTDOWN,
-                ).await;
+                flush(&mut aggregator, &mut pending_offsets, &producer, FLUSH_REASON_SHUTDOWN).await;
+                if let Err(e) = consumer.commit() {
+                    warn!(error = %e, "kafka sync commit at shutdown failed; falling back to broker auto-commit");
+                }
                 return;
             }
             _ = flush_timer.tick() => {
                 handle.report_healthy();
-                flush(
-                    &mut aggregator,
-                    &mut pending_offsets,
-                    &mut producer,
-                    FLUSH_REASON_TIMER,
-                ).await;
+                flush(&mut aggregator, &mut pending_offsets, &producer, FLUSH_REASON_TIMER).await;
             }
             recv = consumer.json_recv::<E>() => {
                 handle.report_healthy();
@@ -71,20 +71,13 @@ pub async fn worker_loop<E, P, F>(
                             metrics::counter!(EVENTS_FILTERED).increment(1);
                         }
 
-                        pending_offsets.insert(
-                            offset.partition(),
-                            OffsetSnapshot {
-                                topic: offset.topic().to_string(),
-                                partition: offset.partition(),
-                                offset: offset.get_value(),
-                            },
-                        );
+                        pending_offsets.insert(offset.partition(), offset);
 
                         if aggregator.len() >= config.max_buffered_tuples {
                             flush(
                                 &mut aggregator,
                                 &mut pending_offsets,
-                                &mut producer,
+                                &producer,
                                 FLUSH_REASON_BACKPRESSURE,
                             ).await;
                         }
@@ -102,40 +95,43 @@ pub async fn worker_loop<E, P, F>(
     }
 }
 
-/// Atomically produce the aggregated counts and commit input offsets through
-/// a Kafka transaction. Either both writes are durable or neither happens,
-/// so the worker never leaves the system in a state where records were
-/// delivered but offsets weren't committed (or vice versa). On failure the
-/// drained snapshot is merged back into the aggregator so counts aren't
-/// lost.
+/// Produce the aggregated counts to the output topic, then advance the
+/// consumer's stored offsets so they get auto-committed. On produce failure,
+/// the snapshot is merged back into the aggregator and offsets are left
+/// untouched so the next flush retries the same input range.
 pub(crate) async fn flush<P: Producer>(
     aggregator: &mut Aggregator,
-    pending_offsets: &mut HashMap<i32, OffsetSnapshot>,
-    producer: &mut P,
+    pending_offsets: &mut HashMap<i32, Offset>,
+    producer: &P,
     reason: &'static str,
 ) {
     if aggregator.is_empty() && pending_offsets.is_empty() {
         return;
     }
 
-    let snapshot: Vec<(crate::types::TupleKey, u64)> = aggregator.drain().into_iter().collect();
-    let offsets: Vec<OffsetSnapshot> = pending_offsets.values().cloned().collect();
+    let snapshot: Vec<(TupleKey, u64)> = aggregator.drain().into_iter().collect();
 
     metrics::counter!(FLUSH_TOTAL, "reason" => reason).increment(1);
     metrics::histogram!(FLUSH_TUPLES).record(snapshot.len() as f64);
 
-    if let Err(e) = producer.produce_and_commit(snapshot.clone(), offsets).await {
+    if let Err(e) = producer.produce(snapshot.clone()).await {
         metrics::counter!(PRODUCER_FLUSH_FAILED).increment(1);
-        error!(error = %e, "transactional commit failed; restoring counts, deferring offsets");
+        error!(error = %e, "produce failed; restoring counts, retrying next flush");
         for (tuple, count) in snapshot {
             aggregator.add(tuple, count);
         }
         return;
     }
 
-    // Transaction committed atomically; safe to drop the pending offset
-    // snapshots since they've already been committed inside the txn.
-    pending_offsets.clear();
+    // Produce succeeded; advance the stored offset for each partition we
+    // consumed from. Background auto-commit will ship these to the broker
+    // within ~5s; shutdown forces a sync commit.
+    for (_partition, offset) in pending_offsets.drain() {
+        if let Err(e) = offset.store() {
+            metrics::counter!(OFFSET_STORE_FAILED).increment(1);
+            warn!(error = %e, "failed to store offset; auto-commit will be a no-op for this partition until the next successful flush");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -147,13 +143,12 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 
-    /// Mock producer that records each (items, offsets) call and can be
-    /// configured to fail on specific call indices.
+    /// Mock producer that records each call and can be configured to fail on
+    /// specific call indices.
     struct MockProducer {
         calls: AtomicUsize,
         fail_on: Mutex<Vec<usize>>,
         seen_items: Mutex<Vec<Vec<(TupleKey, u64)>>>,
-        seen_offsets: Mutex<Vec<Vec<OffsetSnapshot>>>,
     }
 
     impl MockProducer {
@@ -162,7 +157,6 @@ mod tests {
                 calls: AtomicUsize::new(0),
                 fail_on: Mutex::new(Vec::new()),
                 seen_items: Mutex::new(Vec::new()),
-                seen_offsets: Mutex::new(Vec::new()),
             }
         }
         fn fail_on(self, call_index: usize) -> Self {
@@ -180,26 +174,13 @@ mod tests {
                 .cloned()
                 .unwrap_or_default()
         }
-        fn last_offsets(&self) -> Vec<OffsetSnapshot> {
-            self.seen_offsets
-                .lock()
-                .unwrap()
-                .last()
-                .cloned()
-                .unwrap_or_default()
-        }
     }
 
     #[async_trait::async_trait]
     impl Producer for MockProducer {
-        async fn produce_and_commit(
-            &mut self,
-            items: Vec<(TupleKey, u64)>,
-            offsets: Vec<OffsetSnapshot>,
-        ) -> Result<(), ProduceError> {
+        async fn produce(&self, items: Vec<(TupleKey, u64)>) -> Result<(), ProduceError> {
             let n = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
             self.seen_items.lock().unwrap().push(items.clone());
-            self.seen_offsets.lock().unwrap().push(offsets.clone());
             if self.fail_on.lock().unwrap().contains(&n) {
                 let total = items.len().max(1);
                 return Err(ProduceError::PartialFailure {
@@ -220,14 +201,6 @@ mod tests {
         }
     }
 
-    fn snapshot(partition: i32, offset: i64) -> OffsetSnapshot {
-        OffsetSnapshot {
-            topic: "team_event_partitioned_events_json".to_string(),
-            partition,
-            offset,
-        }
-    }
-
     fn populate(agg: &mut Aggregator, count: u64) {
         for i in 0..count {
             agg.add(tuple(2, "k", &format!("v{i}")), 1);
@@ -235,44 +208,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn successful_flush_drains_aggregator_and_clears_offsets() {
+    async fn successful_flush_drains_aggregator() {
         let mut agg = Aggregator::new();
         populate(&mut agg, 5);
 
-        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
-        pending.insert(0, snapshot(0, 100));
-        pending.insert(1, snapshot(1, 200));
-
-        let mut producer = MockProducer::new();
-        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        let mut pending: HashMap<i32, Offset> = HashMap::new();
+        let producer = MockProducer::new();
+        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
 
         assert!(agg.is_empty());
-        assert!(pending.is_empty());
         assert_eq!(producer.call_count(), 1);
         assert_eq!(producer.last_items().len(), 5);
-        assert_eq!(producer.last_offsets().len(), 2);
     }
 
     #[tokio::test]
-    async fn failed_flush_restores_counts_and_keeps_pending_offsets() {
+    async fn failed_flush_restores_counts() {
         let mut agg = Aggregator::new();
         populate(&mut agg, 3);
 
-        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
-        pending.insert(0, snapshot(0, 50));
-
-        let mut producer = MockProducer::new().fail_on(1);
-        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        let mut pending: HashMap<i32, Offset> = HashMap::new();
+        let producer = MockProducer::new().fail_on(1);
+        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
 
         assert_eq!(
             agg.len(),
             3,
-            "aggregator must restore drained counts on transaction abort"
-        );
-        assert_eq!(
-            pending.len(),
-            1,
-            "pending_offsets must NOT clear when produce_and_commit fails"
+            "aggregator must restore drained counts on produce failure"
         );
     }
 
@@ -281,42 +242,23 @@ mod tests {
         let mut agg = Aggregator::new();
         populate(&mut agg, 4);
 
-        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
-        pending.insert(0, snapshot(0, 99));
+        let mut pending: HashMap<i32, Offset> = HashMap::new();
+        let producer = MockProducer::new().fail_on(1);
 
-        let mut producer = MockProducer::new().fail_on(1);
-
-        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
         assert!(!agg.is_empty());
-        assert!(!pending.is_empty());
 
-        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
         assert!(agg.is_empty());
-        assert!(pending.is_empty());
         assert_eq!(producer.call_count(), 2);
-    }
-
-    #[tokio::test]
-    async fn empty_aggregator_with_pending_offsets_still_calls_producer() {
-        let mut agg = Aggregator::new();
-        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
-        pending.insert(0, snapshot(0, 7));
-
-        let mut producer = MockProducer::new();
-        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
-
-        assert!(pending.is_empty());
-        assert_eq!(producer.call_count(), 1);
-        assert_eq!(producer.last_items().len(), 0);
-        assert_eq!(producer.last_offsets().len(), 1);
     }
 
     #[tokio::test]
     async fn empty_aggregator_empty_offsets_is_noop() {
         let mut agg = Aggregator::new();
-        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
-        let mut producer = MockProducer::new();
-        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        let mut pending: HashMap<i32, Offset> = HashMap::new();
+        let producer = MockProducer::new();
+        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
         assert_eq!(producer.call_count(), 0);
     }
 
@@ -325,15 +267,13 @@ mod tests {
         let mut agg = Aggregator::new();
         agg.add(tuple(2, "k1", "v1"), 1);
 
-        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
-        pending.insert(0, snapshot(0, 10));
-
-        let mut producer = MockProducer::new().fail_on(1);
-        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        let mut pending: HashMap<i32, Offset> = HashMap::new();
+        let producer = MockProducer::new().fail_on(1);
+        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
 
         agg.add(tuple(2, "k1", "v1"), 1);
 
-        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
 
         let batch = producer.last_items();
         assert_eq!(batch.len(), 1);
@@ -341,39 +281,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn produce_and_commit_receives_items_and_offsets_atomically() {
-        let mut agg = Aggregator::new();
-        agg.add(tuple(2, "k1", "v1"), 1);
-
-        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
-        pending.insert(0, snapshot(0, 42));
-
-        let mut producer = MockProducer::new();
-        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
-
-        assert_eq!(producer.call_count(), 1);
-        assert_eq!(producer.last_items().len(), 1);
-        assert_eq!(producer.last_offsets().len(), 1);
-        assert_eq!(producer.last_offsets()[0].partition, 0);
-        assert_eq!(producer.last_offsets()[0].offset, 42);
-    }
-
-    #[tokio::test]
     async fn repeated_failure_holds_all_state_indefinitely() {
         let mut agg = Aggregator::new();
         agg.add(tuple(2, "k1", "v1"), 1);
 
-        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
-        pending.insert(0, snapshot(0, 7));
-
-        let mut producer = MockProducer::new().fail_on(1).fail_on(2).fail_on(3);
+        let mut pending: HashMap<i32, Offset> = HashMap::new();
+        let producer = MockProducer::new().fail_on(1).fail_on(2).fail_on(3);
 
         for _ in 0..3 {
-            flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+            flush(&mut agg, &mut pending, &producer, FLUSH_REASON_TIMER).await;
         }
 
         assert_eq!(agg.len(), 1);
-        assert_eq!(pending.len(), 1);
         assert_eq!(producer.call_count(), 3);
     }
 }

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -1,0 +1,384 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common_kafka::kafka_consumer::{RecvErr, SingleTopicConsumer};
+use tracing::{error, info, warn};
+
+use crate::aggregator::Aggregator;
+use crate::app_context::AppContext;
+use crate::metrics_consts::*;
+use crate::producer::{OffsetSnapshot, Producer};
+use crate::types::{IngestableEvent, TupleKey};
+
+/// One worker loop. Each pod runs one worker per input topic. Each worker
+/// owns its own transactional producer (with a distinct `transactional.id`)
+/// because rdkafka allows only one outstanding transaction per id.
+///
+/// Generic over the message type so the events consumer and the groups
+/// consumer can share this code. The caller supplies the per-message
+/// fan-out function.
+pub async fn worker_loop<E, P, F>(
+    ctx: Arc<AppContext>,
+    consumer: SingleTopicConsumer,
+    mut producer: P,
+    handle: lifecycle::Handle,
+    fan_out_fn: F,
+) where
+    E: IngestableEvent,
+    P: Producer,
+    F: Fn(&E) -> Vec<TupleKey>,
+{
+    let _guard = handle.process_scope();
+
+    let mut aggregator = Aggregator::new();
+    // Latest seen offset per partition; the worker only stores a snapshot
+    // (topic + partition + offset value) because the real consumer Offset
+    // handle isn't needed anymore. The transactional producer commits these
+    // via `send_offsets_to_transaction` atomically with the produce.
+    let mut pending_offsets: HashMap<i32, OffsetSnapshot> = HashMap::new();
+
+    let mut flush_timer = tokio::time::interval(ctx.flush_interval);
+    flush_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    flush_timer.reset();
+
+    loop {
+        tokio::select! {
+            _ = handle.shutdown_recv() => {
+                info!("worker received shutdown; draining final flush");
+                flush(
+                    &mut aggregator,
+                    &mut pending_offsets,
+                    &mut producer,
+                    FLUSH_REASON_SHUTDOWN,
+                ).await;
+                return;
+            }
+            _ = flush_timer.tick() => {
+                handle.report_healthy();
+                flush(
+                    &mut aggregator,
+                    &mut pending_offsets,
+                    &mut producer,
+                    FLUSH_REASON_TIMER,
+                ).await;
+            }
+            recv = consumer.json_recv::<E>() => {
+                handle.report_healthy();
+                match recv {
+                    Ok((event, offset)) => {
+                        metrics::counter!(EVENTS_RECEIVED).increment(1);
+
+                        if ctx.should_process(event.team_id()) {
+                            let tuples = fan_out_fn(&event);
+                            metrics::counter!(TUPLES_AGGREGATED).increment(tuples.len() as u64);
+                            aggregator.record_many(tuples);
+                        } else {
+                            metrics::counter!(EVENTS_FILTERED).increment(1);
+                        }
+
+                        pending_offsets.insert(
+                            offset.partition(),
+                            OffsetSnapshot {
+                                topic: offset.topic().to_string(),
+                                partition: offset.partition(),
+                                offset: offset.get_value(),
+                            },
+                        );
+
+                        if aggregator.len() >= ctx.max_buffered_tuples {
+                            flush(
+                                &mut aggregator,
+                                &mut pending_offsets,
+                                &mut producer,
+                                FLUSH_REASON_BACKPRESSURE,
+                            ).await;
+                        }
+                    }
+                    Err(RecvErr::Empty) | Err(RecvErr::Serde(_)) => {
+                        // SingleTopicConsumer auto-stores poison-pill offsets.
+                    }
+                    Err(RecvErr::Kafka(e)) => {
+                        metrics::counter!(KAFKA_RECV_ERRORS).increment(1);
+                        warn!(error = %e, "kafka recv error");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Atomically produce the aggregated counts and commit input offsets through
+/// a Kafka transaction. Either both writes are durable or neither happens,
+/// so the worker never leaves the system in a state where records were
+/// delivered but offsets weren't committed (or vice versa). On failure the
+/// drained snapshot is merged back into the aggregator so counts aren't
+/// lost.
+pub(crate) async fn flush<P: Producer>(
+    aggregator: &mut Aggregator,
+    pending_offsets: &mut HashMap<i32, OffsetSnapshot>,
+    producer: &mut P,
+    reason: &'static str,
+) {
+    if aggregator.is_empty() && pending_offsets.is_empty() {
+        return;
+    }
+
+    let snapshot: Vec<(crate::types::TupleKey, u64)> = aggregator.drain().into_iter().collect();
+    let offsets: Vec<OffsetSnapshot> = pending_offsets.values().cloned().collect();
+
+    metrics::counter!(FLUSH_TOTAL, "reason" => reason).increment(1);
+    metrics::histogram!(FLUSH_TUPLES).record(snapshot.len() as f64);
+
+    if let Err(e) = producer.produce_and_commit(snapshot.clone(), offsets).await {
+        metrics::counter!(PRODUCER_FLUSH_FAILED).increment(1);
+        error!(error = %e, "transactional commit failed; restoring counts, deferring offsets");
+        for (tuple, count) in snapshot {
+            aggregator.add(tuple, count);
+        }
+        return;
+    }
+
+    // Transaction committed atomically; safe to drop the pending offset
+    // snapshots since they've already been committed inside the txn.
+    pending_offsets.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aggregator::Aggregator;
+    use crate::producer::ProduceError;
+    use crate::types::{PropertyType, TupleKey};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    /// Mock producer that records each (items, offsets) call and can be
+    /// configured to fail on specific call indices.
+    struct MockProducer {
+        calls: AtomicUsize,
+        fail_on: Mutex<Vec<usize>>,
+        seen_items: Mutex<Vec<Vec<(TupleKey, u64)>>>,
+        seen_offsets: Mutex<Vec<Vec<OffsetSnapshot>>>,
+    }
+
+    impl MockProducer {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                fail_on: Mutex::new(Vec::new()),
+                seen_items: Mutex::new(Vec::new()),
+                seen_offsets: Mutex::new(Vec::new()),
+            }
+        }
+        fn fail_on(self, call_index: usize) -> Self {
+            self.fail_on.lock().unwrap().push(call_index);
+            self
+        }
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+        fn last_items(&self) -> Vec<(TupleKey, u64)> {
+            self.seen_items
+                .lock()
+                .unwrap()
+                .last()
+                .cloned()
+                .unwrap_or_default()
+        }
+        fn last_offsets(&self) -> Vec<OffsetSnapshot> {
+            self.seen_offsets
+                .lock()
+                .unwrap()
+                .last()
+                .cloned()
+                .unwrap_or_default()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Producer for MockProducer {
+        async fn produce_and_commit(
+            &mut self,
+            items: Vec<(TupleKey, u64)>,
+            offsets: Vec<OffsetSnapshot>,
+        ) -> Result<(), ProduceError> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            self.seen_items.lock().unwrap().push(items.clone());
+            self.seen_offsets.lock().unwrap().push(offsets.clone());
+            if self.fail_on.lock().unwrap().contains(&n) {
+                let total = items.len().max(1);
+                return Err(ProduceError::PartialFailure {
+                    failed: total,
+                    total,
+                });
+            }
+            Ok(())
+        }
+    }
+
+    fn tuple(team: i64, key: &str, value: &str) -> TupleKey {
+        TupleKey {
+            team_id: team,
+            property_type: PropertyType::Event,
+            property_key: key.to_string(),
+            property_value: value.to_string(),
+        }
+    }
+
+    fn snapshot(partition: i32, offset: i64) -> OffsetSnapshot {
+        OffsetSnapshot {
+            topic: "team_event_partitioned_events_json".to_string(),
+            partition,
+            offset,
+        }
+    }
+
+    fn populate(agg: &mut Aggregator, count: u64) {
+        for i in 0..count {
+            agg.record(tuple(2, "k", &format!("v{i}")));
+        }
+    }
+
+    #[tokio::test]
+    async fn successful_flush_drains_aggregator_and_clears_offsets() {
+        let mut agg = Aggregator::new();
+        populate(&mut agg, 5);
+
+        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
+        pending.insert(0, snapshot(0, 100));
+        pending.insert(1, snapshot(1, 200));
+
+        let mut producer = MockProducer::new();
+        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+
+        assert!(agg.is_empty());
+        assert!(pending.is_empty());
+        assert_eq!(producer.call_count(), 1);
+        assert_eq!(producer.last_items().len(), 5);
+        assert_eq!(producer.last_offsets().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn failed_flush_restores_counts_and_keeps_pending_offsets() {
+        let mut agg = Aggregator::new();
+        populate(&mut agg, 3);
+
+        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
+        pending.insert(0, snapshot(0, 50));
+
+        let mut producer = MockProducer::new().fail_on(1);
+        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+
+        assert_eq!(
+            agg.len(),
+            3,
+            "aggregator must restore drained counts on transaction abort"
+        );
+        assert_eq!(
+            pending.len(),
+            1,
+            "pending_offsets must NOT clear when produce_and_commit fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_then_successful_flush_eventually_clears_state() {
+        let mut agg = Aggregator::new();
+        populate(&mut agg, 4);
+
+        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
+        pending.insert(0, snapshot(0, 99));
+
+        let mut producer = MockProducer::new().fail_on(1);
+
+        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        assert!(!agg.is_empty());
+        assert!(!pending.is_empty());
+
+        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        assert!(agg.is_empty());
+        assert!(pending.is_empty());
+        assert_eq!(producer.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn empty_aggregator_with_pending_offsets_still_calls_producer() {
+        let mut agg = Aggregator::new();
+        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
+        pending.insert(0, snapshot(0, 7));
+
+        let mut producer = MockProducer::new();
+        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+
+        assert!(pending.is_empty());
+        assert_eq!(producer.call_count(), 1);
+        assert_eq!(producer.last_items().len(), 0);
+        assert_eq!(producer.last_offsets().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn empty_aggregator_empty_offsets_is_noop() {
+        let mut agg = Aggregator::new();
+        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
+        let mut producer = MockProducer::new();
+        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        assert_eq!(producer.call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn restored_counts_merge_with_new_counts_in_next_window() {
+        let mut agg = Aggregator::new();
+        agg.record(tuple(2, "k1", "v1"));
+
+        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
+        pending.insert(0, snapshot(0, 10));
+
+        let mut producer = MockProducer::new().fail_on(1);
+        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+
+        agg.record(tuple(2, "k1", "v1"));
+
+        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+
+        let batch = producer.last_items();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].1, 2);
+    }
+
+    #[tokio::test]
+    async fn produce_and_commit_receives_items_and_offsets_atomically() {
+        let mut agg = Aggregator::new();
+        agg.record(tuple(2, "k1", "v1"));
+
+        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
+        pending.insert(0, snapshot(0, 42));
+
+        let mut producer = MockProducer::new();
+        flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+
+        assert_eq!(producer.call_count(), 1);
+        assert_eq!(producer.last_items().len(), 1);
+        assert_eq!(producer.last_offsets().len(), 1);
+        assert_eq!(producer.last_offsets()[0].partition, 0);
+        assert_eq!(producer.last_offsets()[0].offset, 42);
+    }
+
+    #[tokio::test]
+    async fn repeated_failure_holds_all_state_indefinitely() {
+        let mut agg = Aggregator::new();
+        agg.record(tuple(2, "k1", "v1"));
+
+        let mut pending: HashMap<i32, OffsetSnapshot> = HashMap::new();
+        pending.insert(0, snapshot(0, 7));
+
+        let mut producer = MockProducer::new().fail_on(1).fail_on(2).fail_on(3);
+
+        for _ in 0..3 {
+            flush(&mut agg, &mut pending, &mut producer, FLUSH_REASON_TIMER).await;
+        }
+
+        assert_eq!(agg.len(), 1);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(producer.call_count(), 3);
+    }
+}

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -140,6 +140,7 @@ mod tests {
     use crate::aggregator::Aggregator;
     use crate::producer::ProduceError;
     use crate::types::{PropertyType, TupleKey};
+    use proptest::prelude::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 
@@ -173,6 +174,16 @@ mod tests {
                 .last()
                 .cloned()
                 .unwrap_or_default()
+        }
+        fn successful_batches(&self) -> Vec<Vec<(TupleKey, u64)>> {
+            let items = self.seen_items.lock().unwrap();
+            let fail = self.fail_on.lock().unwrap();
+            items
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| !fail.contains(&(i + 1)))
+                .map(|(_, batch)| batch.clone())
+                .collect()
         }
     }
 
@@ -294,5 +305,90 @@ mod tests {
 
         assert_eq!(agg.len(), 1);
         assert_eq!(producer.call_count(), 3);
+    }
+
+    fn arb_property_type() -> impl Strategy<Value = PropertyType> {
+        prop_oneof![
+            Just(PropertyType::Event),
+            Just(PropertyType::Person),
+            (0u8..=4).prop_map(PropertyType::Group),
+        ]
+    }
+
+    prop_compose! {
+        fn arb_tuple()(
+            team_id in -3i64..=3,
+            property_type in arb_property_type(),
+            property_key in "[a-c]{1,2}",
+            property_value in "[x-z]{1,2}",
+        ) -> TupleKey {
+            TupleKey { team_id, property_type, property_key, property_value }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    enum WorkerOp {
+        Add(TupleKey, u64),
+        Flush,
+    }
+
+    fn arb_worker_op() -> impl Strategy<Value = WorkerOp> {
+        prop_oneof![
+            // 4:1 weighting so the aggregator actually accumulates between flushes
+            // instead of every other op being an immediate drain.
+            4 => (arb_tuple(), 1u64..100).prop_map(|(t, n)| WorkerOp::Add(t, n)),
+            1 => Just(WorkerOp::Flush),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn flush_conserves_counts(
+            ops in prop::collection::vec(arb_worker_op(), 0..60),
+            fail_indices in prop::collection::vec(1usize..30, 0..15),
+        ) {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            let mut agg = Aggregator::new();
+            let mut pending: HashMap<i32, Offset> = HashMap::new();
+            let mut producer = MockProducer::new();
+            for idx in &fail_indices {
+                producer = producer.fail_on(*idx);
+            }
+
+            let mut recorded: HashMap<TupleKey, u64> = HashMap::new();
+
+            for op in &ops {
+                match op {
+                    WorkerOp::Add(t, n) => {
+                        agg.add(t.clone(), *n);
+                        *recorded.entry(t.clone()).or_insert(0) += *n;
+                    }
+                    WorkerOp::Flush => {
+                        runtime.block_on(flush(
+                            &mut agg,
+                            &mut pending,
+                            &producer,
+                            FLUSH_REASON_TIMER,
+                        ));
+                    }
+                }
+            }
+
+            let mut accounted: HashMap<TupleKey, u64> = HashMap::new();
+            for (t, n) in agg.drain() {
+                *accounted.entry(t).or_insert(0) += n;
+            }
+            for batch in producer.successful_batches() {
+                for (t, n) in batch {
+                    *accounted.entry(t).or_insert(0) += n;
+                }
+            }
+
+            prop_assert_eq!(recorded, accounted);
+        }
     }
 }


### PR DESCRIPTION
## Problem

Parts 2 and 3 give us the service skeleton and the pure in-memory data path. They don't talk to Kafka. This PR wires them up: two Kafka consumers (one per input topic), a producer per worker, and a generic worker loop that ties consume → fan_out → aggregate → flush together with at-least-once delivery and a sync commit on graceful shutdown.

## Changes

Two new modules:

- `src/producer.rs`: `Producer` trait with one operation, `produce(items)`. The real impl, `AggregatedProducer`, wraps a `FutureProducer` from `common-kafka`. It serializes each tuple into a borrowed `Outgoing` struct (no per-tuple string clones) and ships them via `send_keyed_iter_to_kafka` with a configurable timeout. Returns `Err` on partial delivery or timeout so the worker can restore counts and retry next flush window.
- `src/worker.rs`: generic `worker_loop<E: IngestableEvent, P: Producer, F: Fn(&E) -> Vec<TupleKey>>`. One worker per topic. Reads messages, filters by `config.should_process(team_id)`, fans into tuples, accumulates in the aggregator via `aggregator.add(tuple, 1)`. Flush triggers (priority order): shutdown, buffer hits `max_buffered_tuples`, every `flush_interval_secs`. After a successful produce we call `Offset::store()` for each partition's latest input offset; the consumer's background auto-commit ships stored offsets to the broker every ~5s. On the shutdown branch we drain one final flush, then call `consumer.commit()` synchronously so the next pod resumes from exactly where this one stopped.

`main.rs` is upgraded from the skeleton: it constructs the two consumers + two producers, spawns the two `worker_loop` tasks (one with `Event` + `fan_out`, one with `GroupIdentify` + `fan_out_group`) sharing an `Arc<Config>`, and still hosts the HTTP server and lifecycle manager from part 2.

Cargo gains `async-trait`, `rdkafka`, `thiserror`, `metrics`, `common-liveness`. `metrics_consts.rs` defines the names referenced by `worker.rs`.

### Two consumers, two producers per pod

Event/person property values come from `clickhouse_events_json` (via person-on-events denormalization). Group property values are only ever in `clickhouse_groups` — the `groupN_properties` columns on the events table are vestigial since groups-on-events was abandoned in [#22764](https://github.com/PostHog/posthog/pull/22764). So we run a second consumer.

Each worker keeps its own `FutureProducer` instance for clean ownership through the trait; nothing about the design requires two producers, but two is the simplest shape that mirrors the two-worker structure and lets each worker's lifecycle handle drive its own producer's health reporting.

### Why at-least-once instead of Kafka transactions

This was originally a transactional design (begin → produce → send_offsets_to_transaction → commit). Reverted on advice from @eli-r-ph: transactional commits are coordinator round-trips that fail transiently often enough at high volume to make the all-or-nothing rollback a throughput bottleneck. Other PostHog Rust consumer (events pipeline, persons pipeline, property-defs-rs) uses at-least-once + storage-side dedup.

The storage table here is `AggregatingMergeTree(sum)` and currently has no dedup column, so duplicates land as inflated counts rather than being collapsed. On a graceful k8s rollout the sync commit at shutdown keeps the replay window at ~zero. On a hard crash (OOM, kernel kill) up to one auto-commit interval (~5s default) of input gets re-produced. The slight count inflation is acceptable for now as I don't plan to show users the count. 

If we ever need exact counts, the path forward is a storage-layer migration to `ReplacingMergeTree` keyed on a `batch_id` column, with a downstream rollup MV for the autocomplete query shape. That's a future PR; the I/O contract here doesn't change.

### Small shared-crate addition

`common-kafka::SingleTopicConsumer` gets a new `commit()` method that calls through to `commit_consumer_state(CommitMode::Sync)`. Three lines. Lets every PostHog Rust consumer do the "force sync commit at shutdown" pattern without bypassing the wrapper.

## How did you test this code?

Agent-authored. `cargo test -p property-vals-rs` passes 33 tests on this branch. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.

End-to-end verified locally: posting an event through capture lands as a tuple in `property_values` within one flush window; a `$groupidentify` lands as a `group_N` row. 

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code. This is the last of three layered PRs that build up the service.

Decisions made along the way:

- Started with Kafka transactions for exactly-once counts. Switched to at-least-once after Eli flagged the operational risk; he's seen transactional commits fail transiently at scale enough to cap throughput.
- Worker loop generic over input type so events and groups share code; the `IngestableEvent` trait from part 3 is what makes this work.
- Shared `Arc<Config>` (no separate `AppContext` wrapper) is what each worker reads filter + tuning fields from at runtime.
- `PropertyType::Group(u8)` instead of a closed `Group0..GroupN` enum so adding new group-type indices in the future doesn't require touching this crate.
- Storage-side dedup intentionally deferred — single-axis decision, can be added cleanly later when/if exact counts become required.
