### PR TITLE
chore(llm-gateway): add signals user cost limits

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -51,6 +51,12 @@ DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
         sustained_limit_usd=1000.0,
         sustained_window_seconds=2592000,
     ),
+    "signals": UserCostLimit(
+        burst_limit_usd=500.0,
+        burst_window_seconds=604800,
+        sustained_limit_usd=1000.0,
+        sustained_window_seconds=2592000,
+    ),
 }
 
 FREE_PLAN_COST_LIMIT = UserCostLimit(


### PR DESCRIPTION
## Problem

We recently split signals/report-generation traffic out of the larger `ai_product = signals` cost-tracking bucket, but the `signals` product in the LLM gateway has no explicit entry in `DEFAULT_USER_COST_LIMITS`. It falls back to the global default (\$100 USD per 24h burst), which is too low for report-generation runs and risks hitting the per-user burst limit before a single report finishes.

## Changes

Add an explicit `UserCostLimit` for the `signals` product in `services/llm-gateway/src/llm_gateway/config.py`:

- burst limit: **\$500 USD / 7 days**
- sustained limit: **\$1000 USD / 30 days**

(Mirrors the cadence we use for `background_agents`.)

No product-wide (`product_cost_limits`) entry is added — the existing fallback (\$1000/24h) is still applied via `ProductCostThrottle._get_limit_and_window`.

## How did you test this code?

I'm an agent. I ran `ruff check` and `ruff format --check` on the changed file. I did not run the gateway test suite (requires Redis).

## Publish to changelog?

no

## Docs update

n/a — internal config only.

## 🤖 Agent context

Authored by PostHog Code on behalf of Josh Snyder. Origin: a Slack thread asking how to track signals LLM cost now that session-summary spend was pulled out of `ai_product = signals`. We confirmed that `signals` exists as a product in the gateway (`services/llm-gateway/src/llm_gateway/products/config.py`) and is OAuth-gated to the PostHog Code apps, but had no user cost limit override, so it was inheriting the conservative \$100/24h default. This PR aligns it with the cadence we use for the other internal-task product (`background_agents`).

Paired with [posthog/code#TBD](https://github.com/PostHog/code) which routes internal `signal_report` tasks to the `signals` gateway product.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*