### PR TITLE
chore(dashboards): remove customer dashboard template authoring flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -259,7 +259,6 @@ export const FEATURE_FLAGS = {
     CUSTOMER_ANALYTICS: 'customer-analytics-roadmap', // owner: @arthurdedeus #team-customer-analytics
     CUSTOMER_ANALYTICS_CSP: 'customer-analytics-csp', // owner: @arthurdedeus #team-customer-analytics, gates the Customer analytics > Accounts settings tab (account_group_type_index dropdown)
     CUSTOMER_ANALYTICS_JOURNEYS: 'customer-analytics-journeys', // owner: @arthurdedeus #team-customer-analytics
-    CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING: 'customer-dashboard-template-authoring', // owner: @mattp #team-analytics-platform org-scoped; project templates for non-staff
     CUSTOMER_PROFILE_CONFIG_BUTTON: 'customer-profile-config-button', // owner: @arthurdedeus #team-customer-analytics
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
     DASHBOARD_LAYOUT_DISCARD_PROMPT: 'dashboard-layout-discard-prompt', // owner: @cory.s #team-analytics-platform

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1540,18 +1540,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     : false
             },
         ],
-        /** Save-as-project-template from dashboard scene: editor on dashboard, payload has tiles; customers also need authoring flag. Staff use the same modal, with an optional JSON editor entry inside. */
+        /** Save-as-project-template from dashboard scene: editor on dashboard and payload has tiles. Staff use the same modal, with an optional JSON editor entry inside. */
         canSaveProjectDashboardTemplate: [
-            (s) => [userLogic.selectors.user, s.featureFlags, s.canEditDashboard, s.asDashboardTemplate],
-            (user, featureFlags, canEditDashboard, asDashboardTemplate): boolean => {
-                if (!canEditDashboard || !(asDashboardTemplate?.tiles?.length ?? 0)) {
-                    return false
-                }
-                if (user?.is_staff) {
-                    return true
-                }
-                return !!featureFlags[FEATURE_FLAGS.CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING]
-            },
+            (s) => [s.canEditDashboard, s.asDashboardTemplate],
+            (canEditDashboard, asDashboardTemplate): boolean =>
+                canEditDashboard && !!(asDashboardTemplate?.tiles?.length ?? 0),
         ],
         canRestrictDashboard: [
             // Sync conditions with backend can_user_restrict

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateModal.stories.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateModal.stories.tsx
@@ -3,8 +3,6 @@ import { MOCK_DEFAULT_USER, MOCK_TEAM_ID } from 'lib/api.mock'
 import { Meta, StoryObj, type Decorator } from '@storybook/react'
 import { useEffect } from 'react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DashboardTemplateEditor } from 'scenes/dashboard/DashboardTemplateEditor'
 import { dashboardTemplateEditorLogic } from 'scenes/dashboard/dashboardTemplateEditorLogic'
 import { urls } from 'scenes/urls'
@@ -125,10 +123,6 @@ function DashboardTemplateModalStory({
     variant: ModalStoryVariant
 }): JSX.Element {
     useEffect(() => {
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING], {
-            [FEATURE_FLAGS.CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING]: viewerMode === 'nonStaff',
-        })
         userLogic.mount()
         userLogic.actions.loadUser()
         dashboardTemplateModalLogic.mount()
@@ -164,10 +158,6 @@ export const Edit: ModalStory = {
 
 function DashboardTemplateEditorStory({ viewerMode }: { viewerMode: ViewerMode }): JSX.Element {
     useEffect(() => {
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING], {
-            [FEATURE_FLAGS.CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING]: viewerMode === 'nonStaff',
-        })
         userLogic.mount()
         userLogic.actions.loadUser()
         dashboardTemplateEditorLogic.mount()

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.stories.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.stories.tsx
@@ -11,8 +11,6 @@ import {
 import { Meta, StoryObj, type Decorator } from '@storybook/react'
 import { useEffect } from 'react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DashboardTemplateEditor } from 'scenes/dashboard/DashboardTemplateEditor'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -262,10 +260,6 @@ function DashboardTemplatesTableStory({
     organization?: OrganizationType
 }): JSX.Element {
     useEffect(() => {
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING], {
-            [FEATURE_FLAGS.CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING]: perspective === 'nonstaff',
-        })
         userLogic.mount()
         // `userLogic` afterMount fires `loadUser()` while Kea resets MSW; that fetch often wins before this story's
         // `worker.use` override is registered, leaving `is_staff: true`. Hydrate explicitly so viewer mode matches UI.

--- a/products/dashboards/backend/api/dashboard_templates.py
+++ b/products/dashboards/backend/api/dashboard_templates.py
@@ -12,7 +12,6 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 
 import structlog
-import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import request, response, serializers, status, viewsets
@@ -28,7 +27,6 @@ from posthog.event_usage import report_user_action
 from posthog.helpers.full_text_search import build_rank
 from posthog.models.team.team import Team
 from posthog.models.user import User
-from posthog.permissions import get_organization_from_view
 from posthog.rbac.user_access_control import UserAccessControl
 from posthog.user_permissions import UserPermissions
 from posthog.utils import str_to_bool
@@ -36,9 +34,6 @@ from posthog.utils import str_to_bool
 from products.dashboards.backend.models.dashboard_templates import DashboardTemplate
 
 logger = structlog.get_logger(__name__)
-
-# Keep in sync with frontend `FEATURE_FLAGS.CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING`
-CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING_FLAG = "customer-dashboard-template-authoring"
 
 # arbitary limit, just to prevent abuse
 MAX_DASHBOARD_TEMPLATES_PER_ORGANIZATION = 100
@@ -81,30 +76,13 @@ def _dashboard_template_list_order_by(ordering: str | None) -> list[Any]:
 class CustomerDashboardTemplateWritePermission(BasePermission):
     """
     Staff: any unsafe method (delegates object rules to has_object_permission).
-    Non-staff: org-level authoring feature flag (see CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING_FLAG).
-    Project RBAC for this resource is enforced separately by AccessControlPermission (editor on `dashboard_template`).
+    Non-staff: team-scoped templates only (see has_object_permission); global / feature-flag rows forbidden.
+    Project RBAC is enforced separately by AccessControlPermission (editor on `dashboard_template`).
     """
 
     message = "You don't have edit permissions for this dashboard template."
 
     def has_permission(self, request: Request, view) -> bool:
-        if request.method in SAFE_METHODS:
-            return True
-        user = request.user
-        if getattr(user, "is_staff", False):
-            return True
-        organization = get_organization_from_view(view)
-        org_id = str(organization.id)
-        user_orm = cast(User, user)
-        distinct_id = user_orm.distinct_id or str(user_orm.uuid)
-        if not posthoganalytics.feature_enabled(
-            CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING_FLAG,
-            distinct_id,
-            groups={"organization": org_id},
-            group_properties={"organization": {"id": org_id}},
-            only_evaluate_locally=False,
-        ):
-            return False
         return True
 
     def has_object_permission(self, request: Request, view, obj: Any) -> bool:

--- a/products/dashboards/backend/api/test/test_dashboard_templates.py
+++ b/products/dashboards/backend/api/test/test_dashboard_templates.py
@@ -395,14 +395,10 @@ class TestDashboardTemplates(APIBaseTest):
         self.user.is_staff = False
         self.user.save()
 
-        with patch(
-            "products.dashboards.backend.api.dashboard_templates.posthoganalytics.feature_enabled",
-            return_value=True,
-        ):
-            update_response = self.client.patch(
-                f"/api/projects/{self.team.pk}/dashboard_templates/{response.json()['id']}",
-                {"scope": "global"},
-            )
+        update_response = self.client.patch(
+            f"/api/projects/{self.team.pk}/dashboard_templates/{response.json()['id']}",
+            {"scope": "global"},
+        )
         assert update_response.status_code == status.HTTP_400_BAD_REQUEST, update_response
 
     def test_non_staff_cannot_edit_dashboard_template(self) -> None:
@@ -452,7 +448,7 @@ class TestDashboardTemplates(APIBaseTest):
             variable_template,
         )
 
-    def test_non_staff_user_cannot_create_dashboard(self) -> None:
+    def test_non_staff_can_create_team_scoped_dashboard_template(self) -> None:
         n0 = DashboardTemplate.objects.count()
         self.user.is_staff = False
         self.user.save()
@@ -461,9 +457,10 @@ class TestDashboardTemplates(APIBaseTest):
             f"/api/projects/{self.team.pk}/dashboard_templates",
             variable_template,
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN, response
+        assert response.status_code == status.HTTP_201_CREATED, response
+        assert response.json()["scope"] == "team"
 
-        assert DashboardTemplate.objects.count() == n0
+        assert DashboardTemplate.objects.count() == n0 + 1
 
     def test_get_dashboard_template_by_id(self) -> None:
         n0 = DashboardTemplate.objects.count()
@@ -535,7 +532,7 @@ class TestDashboardTemplates(APIBaseTest):
         assert list_response.status_code == status.HTTP_200_OK
         assert get_template_from_response(list_response, template_id) is not None
 
-    def test_non_staff_user_cannot_delete_dashboard_template_by_id(self) -> None:
+    def test_non_staff_can_delete_own_team_dashboard_template(self) -> None:
         n0 = DashboardTemplate.objects.count()
         response = self.client.post(
             f"/api/projects/{self.team.pk}/dashboard_templates",
@@ -543,20 +540,35 @@ class TestDashboardTemplates(APIBaseTest):
         )
         assert response.status_code == status.HTTP_201_CREATED, response
         assert DashboardTemplate.objects.count() == n0 + 1
+        template_id = response.json()["id"]
 
         self.user.is_staff = False
         self.user.save()
 
         patch_response = self.client.patch(
-            f"/api/projects/{self.team.pk}/dashboard_templates/{response.json()['id']}",
+            f"/api/projects/{self.team.pk}/dashboard_templates/{template_id}",
             {"deleted": True},
         )
-        assert patch_response.status_code == status.HTTP_403_FORBIDDEN, patch_response
+        assert patch_response.status_code == status.HTTP_200_OK, patch_response
 
         get_response = self.client.get(f"/api/projects/{self.team.pk}/dashboard_templates")
         assert get_response.status_code == status.HTTP_200_OK, get_response
 
+        assert get_template_from_response(get_response, template_id) is None
         assert len(get_response.json()["results"]) == _listable_dashboard_template_db_count(self.team.pk)
+
+    def test_non_staff_cannot_delete_global_dashboard_template(self) -> None:
+        global_tpl = DashboardTemplate.objects.filter(scope=DashboardTemplate.Scope.GLOBAL).first()
+        assert global_tpl is not None
+
+        self.user.is_staff = False
+        self.user.save()
+
+        patch_response = self.client.patch(
+            f"/api/projects/{self.team.pk}/dashboard_templates/{global_tpl.id}",
+            {"deleted": True},
+        )
+        assert patch_response.status_code == status.HTTP_403_FORBIDDEN, patch_response
 
     def test_update_dashboard_template_by_id(self) -> None:
         n0 = DashboardTemplate.objects.count()

--- a/products/dashboards/backend/api/test/test_dashboard_templates.py
+++ b/products/dashboards/backend/api/test/test_dashboard_templates.py
@@ -1,5 +1,4 @@
 import uuid
-from contextlib import contextmanager
 from datetime import UTC, datetime
 from typing import Any, Optional
 
@@ -932,17 +931,8 @@ class TestDashboardTemplates(APIBaseTest):
         assert id not in [r["id"] for r in another_attempted_escape_response.json()["results"]]
 
 
-@contextmanager
-def _customer_dashboard_template_authoring_flag_on():
-    with patch(
-        "products.dashboards.backend.api.dashboard_templates.posthoganalytics.feature_enabled",
-        return_value=True,
-    ):
-        yield
-
-
 class TestCustomerDashboardTemplateAuthoring(APIBaseTest):
-    """Phase 1 customer authoring: org flag + editor on `dashboard_template` (not flag alone)."""
+    """Customer authoring: editor on `dashboard_template` (RBAC), team-scoped templates only for non-staff."""
 
     def setUp(self):
         super().setUp()
@@ -966,35 +956,27 @@ class TestCustomerDashboardTemplateAuthoring(APIBaseTest):
             access_level="viewer",
         )
 
-    def test_non_staff_flag_off_unsafe_forbidden(self) -> None:
+    def test_non_staff_viewer_forbidden(self) -> None:
+        self._grant_template_viewer()
         response = self.client.post(f"/api/projects/{self.team.pk}/dashboard_templates", variable_template)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_non_staff_flag_on_viewer_forbidden(self) -> None:
-        self._grant_template_viewer()
-        with _customer_dashboard_template_authoring_flag_on():
-            response = self.client.post(f"/api/projects/{self.team.pk}/dashboard_templates", variable_template)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    def test_non_staff_flag_on_editor_post_patch_delete_team_template(self) -> None:
-        with _customer_dashboard_template_authoring_flag_on():
-            create = self.client.post(f"/api/projects/{self.team.pk}/dashboard_templates", variable_template)
+    def test_non_staff_editor_post_patch_delete_team_template(self) -> None:
+        create = self.client.post(f"/api/projects/{self.team.pk}/dashboard_templates", variable_template)
         assert create.status_code == status.HTTP_201_CREATED, create
         tid = create.json()["id"]
 
-        with _customer_dashboard_template_authoring_flag_on():
-            patch_resp = self.client.patch(
-                f"/api/projects/{self.team.pk}/dashboard_templates/{tid}",
-                {"template_name": "Renamed", "tags": ["a"]},
-            )
+        patch_resp = self.client.patch(
+            f"/api/projects/{self.team.pk}/dashboard_templates/{tid}",
+            {"template_name": "Renamed", "tags": ["a"]},
+        )
         assert patch_resp.status_code == status.HTTP_200_OK, patch_resp
         assert patch_resp.json()["template_name"] == "Renamed"
 
-        with _customer_dashboard_template_authoring_flag_on():
-            del_resp = self.client.patch(
-                f"/api/projects/{self.team.pk}/dashboard_templates/{tid}",
-                {"deleted": True},
-            )
+        del_resp = self.client.patch(
+            f"/api/projects/{self.team.pk}/dashboard_templates/{tid}",
+            {"deleted": True},
+        )
         assert del_resp.status_code == status.HTTP_200_OK, del_resp
 
     def test_non_staff_patch_with_tiles_returns_400(self) -> None:
@@ -1005,11 +987,10 @@ class TestCustomerDashboardTemplateAuthoring(APIBaseTest):
         self.user.is_staff = False
         self.user.save()
 
-        with _customer_dashboard_template_authoring_flag_on():
-            bad = self.client.patch(
-                f"/api/projects/{self.team.pk}/dashboard_templates/{tid}",
-                {"template_name": "x", "tiles": variable_template["tiles"]},
-            )
+        bad = self.client.patch(
+            f"/api/projects/{self.team.pk}/dashboard_templates/{tid}",
+            {"template_name": "x", "tiles": variable_template["tiles"]},
+        )
         assert bad.status_code == status.HTTP_400_BAD_REQUEST
         assert bad.json().get("attr") == "tiles"
 
@@ -1021,8 +1002,7 @@ class TestCustomerDashboardTemplateAuthoring(APIBaseTest):
     )
     def test_non_staff_post_staff_only_fields_400(self, field: str, value: Any) -> None:
         body = {**variable_template, field: value}
-        with _customer_dashboard_template_authoring_flag_on():
-            response = self.client.post(f"/api/projects/{self.team.pk}/dashboard_templates", body)
+        response = self.client.post(f"/api/projects/{self.team.pk}/dashboard_templates", body)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json().get("attr") == field
 
@@ -1041,15 +1021,14 @@ class TestCustomerDashboardTemplateAuthoring(APIBaseTest):
             tags=[],
         )
 
-        with _customer_dashboard_template_authoring_flag_on():
-            r1 = self.client.patch(
-                f"/api/projects/{self.team.pk}/dashboard_templates/{global_tpl.id}",
-                {"template_name": "nope"},
-            )
-            r2 = self.client.patch(
-                f"/api/projects/{self.team.pk}/dashboard_templates/{ff_tpl.id}",
-                {"template_name": "nope"},
-            )
+        r1 = self.client.patch(
+            f"/api/projects/{self.team.pk}/dashboard_templates/{global_tpl.id}",
+            {"template_name": "nope"},
+        )
+        r2 = self.client.patch(
+            f"/api/projects/{self.team.pk}/dashboard_templates/{ff_tpl.id}",
+            {"template_name": "nope"},
+        )
         assert r1.status_code == status.HTTP_403_FORBIDDEN
         assert r2.status_code == status.HTTP_403_FORBIDDEN
 
@@ -1067,14 +1046,13 @@ class TestCustomerDashboardTemplateAuthoring(APIBaseTest):
             tags=[],
         )
 
-        with _customer_dashboard_template_authoring_flag_on():
-            response = self.client.patch(
-                f"/api/projects/{self.team.pk}/dashboard_templates/{other_tpl.id}",
-                {"template_name": "hax"},
-            )
+        response = self.client.patch(
+            f"/api/projects/{self.team.pk}/dashboard_templates/{other_tpl.id}",
+            {"template_name": "hax"},
+        )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_staff_unsafe_succeeds_when_flag_off(self) -> None:
+    def test_staff_can_create_global_featured_template(self) -> None:
         self.user.is_staff = True
         self.user.save()
         response = self.client.post(
@@ -1330,7 +1308,7 @@ class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
     def _copy_url(self, team_pk: int) -> str:
         return f"/api/projects/{team_pk}/dashboard_templates/copy_between_projects/"
 
-    def test_non_staff_copy_requires_authoring_flag_and_editor_on_target(self) -> None:
+    def test_non_staff_copy_requires_editor_on_target(self) -> None:
         AccessControl.objects.create(
             team=self.team,
             resource="dashboard_template",
@@ -1347,16 +1325,14 @@ class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
             role=None,
             access_level="editor",
         )
-        with _customer_dashboard_template_authoring_flag_on():
-            src = self.client.post(
-                f"/api/projects/{self.team.pk}/dashboard_templates",
-                {**variable_template, "template_name": "Customer inter-project", "scope": "team"},
-            )
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Customer inter-project", "scope": "team"},
+        )
         assert src.status_code == status.HTTP_201_CREATED, src.content
         src_id = src.json()["id"]
 
-        with _customer_dashboard_template_authoring_flag_on():
-            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
         assert resp.status_code == status.HTTP_201_CREATED, resp.content
         assert resp.json()["team_id"] == self.team_b.pk
 
@@ -1383,45 +1359,14 @@ class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
         ).first()
         assert global_tpl is not None
 
-        with _customer_dashboard_template_authoring_flag_on():
-            resp = self.client.post(
-                self._copy_url(self.team_b.pk), {"source_template_id": str(global_tpl.id)}, format="json"
-            )
+        resp = self.client.post(
+            self._copy_url(self.team_b.pk), {"source_template_id": str(global_tpl.id)}, format="json"
+        )
         assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.content
         data = resp.json()
         assert data["type"] == "validation_error"
         assert data["attr"] == "source_template_id"
         assert data["detail"] == "Only project-scoped templates can be copied to another project."
-
-    def test_non_staff_copy_forbidden_without_authoring_flag(self) -> None:
-        AccessControl.objects.create(
-            team=self.team,
-            resource="dashboard_template",
-            resource_id=None,
-            organization_member=self.organization_membership,
-            role=None,
-            access_level="editor",
-        )
-        AccessControl.objects.create(
-            team=self.team_b,
-            resource="dashboard_template",
-            resource_id=None,
-            organization_member=self.organization_membership,
-            role=None,
-            access_level="editor",
-        )
-        self.user.is_staff = True
-        self.user.save()
-        src = self.client.post(
-            f"/api/projects/{self.team.pk}/dashboard_templates",
-            {**variable_template, "template_name": "No flag copy", "scope": "team"},
-        )
-        src_id = src.json()["id"]
-        self.user.is_staff = False
-        self.user.save()
-
-        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
 
     def test_non_staff_copy_403_when_only_viewer_on_target(self) -> None:
         # `dashboard_template` inherits access from `dashboard`, so ACs must target the parent resource
@@ -1441,15 +1386,13 @@ class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
             role=None,
             access_level="viewer",
         )
-        with _customer_dashboard_template_authoring_flag_on():
-            src = self.client.post(
-                f"/api/projects/{self.team.pk}/dashboard_templates",
-                {**variable_template, "template_name": "Viewer on target", "scope": "team"},
-            )
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Viewer on target", "scope": "team"},
+        )
         src_id = src.json()["id"]
 
-        with _customer_dashboard_template_authoring_flag_on():
-            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
         assert resp.status_code == status.HTTP_403_FORBIDDEN
 
     def test_non_staff_copy_404_when_no_dashboard_template_access_on_source_project(self) -> None:
@@ -1481,6 +1424,5 @@ class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
             role=None,
             access_level="editor",
         )
-        with _customer_dashboard_template_authoring_flag_on():
-            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": str(tpl.id)}, format="json")
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": str(tpl.id)}, format="json")
         assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/products/error_tracking/frontend/generated/api.zod.ts
+++ b/products/error_tracking/frontend/generated/api.zod.ts
@@ -134,13 +134,33 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
         .describe('Optional human-readable description of what this grouping rule is for.'),
 })
 
-export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod
-    .record(zod.string(), zod.unknown())
-    .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
+export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
+    filters: zod
+        .union([
+            zod
+                .record(zod.string(), zod.unknown())
+                .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters.'
+        ),
+})
 
-export const ErrorTrackingGroupingRulesPartialUpdateBody = /* @__PURE__ */ zod
-    .record(zod.string(), zod.unknown())
-    .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
+export const ErrorTrackingGroupingRulesPartialUpdateBody = /* @__PURE__ */ zod.object({
+    filters: zod
+        .union([
+            zod
+                .record(zod.string(), zod.unknown())
+                .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters.'
+        ),
+})
 
 export const errorTrackingGroupingRulesReorderPartialUpdateBodyOrderKeyMin = -2147483648
 export const errorTrackingGroupingRulesReorderPartialUpdateBodyOrderKeyMax = 2147483647


### PR DESCRIPTION
Feature is fully rolled out; non-staff authoring is always on with existing RBAC and object-scope checks.

<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
