### PR TITLE
feat(data-warehouse): warn when querying stale or failed warehouse syncs

### DIFF
--- a/ee/hogai/context/insight/format/__init__.py
+++ b/ee/hogai/context/insight/format/__init__.py
@@ -59,8 +59,11 @@ def get_boxplot_results(response: dict[str, Any]) -> list[Any]:
 
 
 def format_warehouse_sync_warnings(response: dict[str, Any]) -> str:
-    """Render data warehouse sync warnings as a leading block for LLM-facing output."""
-    warnings = response.get("warnings")
+    """Render data warehouse sync warnings as a leading block for LLM-facing output.
+
+    Returns empty string when the response has no warnings.
+    """
+    warnings = response.get("warnings") or []
     if not warnings:
         return ""
     lines = ["[Data warehouse sync warnings — results may not reflect current source data]"]
@@ -93,8 +96,6 @@ def format_query_results_for_llm(
     if isinstance(query, InsightVizNode | DataVisualizationNode | DataTableNode):
         query = query.source
 
-    warning_prefix = format_warehouse_sync_warnings(response)
-
     formatted: str | None = None
     if isinstance(query, AssistantTrendsQuery | TrendsQuery):
         if is_boxplot_query(query):
@@ -124,6 +125,7 @@ def format_query_results_for_llm(
 
     if formatted is None:
         return None
+    warning_prefix = format_warehouse_sync_warnings(response)
     return warning_prefix + formatted if warning_prefix else formatted
 
 

--- a/ee/hogai/context/insight/format/__init__.py
+++ b/ee/hogai/context/insight/format/__init__.py
@@ -58,6 +58,20 @@ def get_boxplot_results(response: dict[str, Any]) -> list[Any]:
     return results if results else response.get("boxplot_data", [])
 
 
+def format_warehouse_sync_warnings(response: dict[str, Any]) -> str:
+    """Render data warehouse sync warnings as a leading block for LLM-facing output."""
+    warnings = response.get("warnings")
+    if not warnings:
+        return ""
+    lines = ["[Data warehouse sync warnings — results may not reflect current source data]"]
+    for warning in warnings:
+        message = warning.get("message") if isinstance(warning, dict) else getattr(warning, "message", None)
+        if message:
+            lines.append(f"- {message}")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def format_query_results_for_llm(
     query: BaseModel,
     response: dict[str, Any],
@@ -79,32 +93,38 @@ def format_query_results_for_llm(
     if isinstance(query, InsightVizNode | DataVisualizationNode | DataTableNode):
         query = query.source
 
+    warning_prefix = format_warehouse_sync_warnings(response)
+
+    formatted: str | None = None
     if isinstance(query, AssistantTrendsQuery | TrendsQuery):
         if is_boxplot_query(query):
-            return BoxPlotResultsFormatter(get_boxplot_results(response)).format()
-        return TrendsResultsFormatter(query, response["results"]).format()
+            formatted = BoxPlotResultsFormatter(get_boxplot_results(response)).format()
+        else:
+            formatted = TrendsResultsFormatter(query, response["results"]).format()
     elif isinstance(query, AssistantFunnelsQuery | FunnelsQuery):
-        return FunnelResultsFormatter(query, response["results"], team, utc_now).format()
+        formatted = FunnelResultsFormatter(query, response["results"], team, utc_now).format()
     elif isinstance(query, AssistantLifecycleQuery | LifecycleQuery):
-        return LifecycleResultsFormatter(query, response["results"]).format()
+        formatted = LifecycleResultsFormatter(query, response["results"]).format()
     elif isinstance(query, AssistantPathsQuery | PathsQuery):
-        return PathsResultsFormatter(response["results"]).format()
+        formatted = PathsResultsFormatter(response["results"]).format()
     elif isinstance(query, AssistantStickinessQuery | StickinessQuery):
-        return StickinessResultsFormatter(query, response["results"]).format()
+        formatted = StickinessResultsFormatter(query, response["results"]).format()
     elif isinstance(query, AssistantRetentionQuery | RetentionQuery):
-        return RetentionResultsFormatter(query, response["results"]).format()
+        formatted = RetentionResultsFormatter(query, response["results"]).format()
     elif isinstance(query, AssistantHogQLQuery | HogQLQuery):
-        return SQLResultsFormatter(query, response["results"], response["columns"]).format()
+        formatted = SQLResultsFormatter(query, response["results"], response["columns"]).format()
     elif isinstance(query, RevenueAnalyticsGrossRevenueQuery):
-        return RevenueAnalyticsGrossRevenueResultsFormatter(query, response["results"]).format()
+        formatted = RevenueAnalyticsGrossRevenueResultsFormatter(query, response["results"]).format()
     elif isinstance(query, RevenueAnalyticsMetricsQuery):
-        return RevenueAnalyticsMetricsResultsFormatter(query, response["results"]).format()
+        formatted = RevenueAnalyticsMetricsResultsFormatter(query, response["results"]).format()
     elif isinstance(query, RevenueAnalyticsMRRQuery):
-        return RevenueAnalyticsMRRResultsFormatter(query, response["results"]).format()
+        formatted = RevenueAnalyticsMRRResultsFormatter(query, response["results"]).format()
     elif isinstance(query, RevenueAnalyticsTopCustomersQuery):
-        return RevenueAnalyticsTopCustomersResultsFormatter(query, response["results"]).format()
+        formatted = RevenueAnalyticsTopCustomersResultsFormatter(query, response["results"]).format()
 
-    return None
+    if formatted is None:
+        return None
+    return warning_prefix + formatted if warning_prefix else formatted
 
 
 __all__ = [
@@ -122,4 +142,5 @@ __all__ = [
     "RevenueAnalyticsTopCustomersResultsFormatter",
     "TRUNCATED_MARKER",
     "format_query_results_for_llm",
+    "format_warehouse_sync_warnings",
 ]

--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -68,6 +68,7 @@ from ee.hogai.context.insight.format import (
     SQLResultsFormatter,
     StickinessResultsFormatter,
     TrendsResultsFormatter,
+    format_warehouse_sync_warnings,
     get_boxplot_results,
     is_boxplot_query,
 )
@@ -540,6 +541,10 @@ class AssistantQueryExecutor:
                 logger.warning(
                     f"{TIMING_LOG_PREFIX} {formatter_name}.format() completed in {elapsed:.3f}s for {query_type}"
                 )
+
+            warning_prefix = format_warehouse_sync_warnings(response)
+            if warning_prefix:
+                result = warning_prefix + result
             return result
         except Exception:
             elapsed = time.time() - start_time

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -6498,6 +6498,13 @@
                     "description": "Types of returned columns",
                     "items": {},
                     "type": "array"
+                },
+                "warnings": {
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data.",
+                    "items": {
+                        "$ref": "#/definitions/DataWarehouseSyncWarning"
+                    },
+                    "type": "array"
                 }
             },
             "required": [
@@ -11835,6 +11842,13 @@
                                     "description": "Types of returned columns",
                                     "items": {},
                                     "type": "array"
+                                },
+                                "warnings": {
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data.",
+                                    "items": {
+                                        "$ref": "#/definitions/DataWarehouseSyncWarning"
+                                    },
+                                    "type": "array"
                                 }
                             },
                             "required": ["results"],
@@ -13478,6 +13492,33 @@
         "DataWarehouseSavedQueryOrigin": {
             "enum": ["data_warehouse", "endpoint", "managed_viewset"],
             "type": "string"
+        },
+        "DataWarehouseSyncWarning": {
+            "additionalProperties": false,
+            "properties": {
+                "message": {
+                    "description": "Human-readable warning shown to the user",
+                    "type": "string"
+                },
+                "schema_name": {
+                    "description": "Name of the ExternalDataSchema responsible for syncing the table",
+                    "type": "string"
+                },
+                "source_type": {
+                    "description": "Source type, e.g. \"Stripe\", \"Hubspot\"",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Sync status that triggered the warning, e.g. \"Failed\", \"Paused\", \"BillingLimitReached\"",
+                    "type": "string"
+                },
+                "table_name": {
+                    "description": "Name of the warehouse table the warning refers to",
+                    "type": "string"
+                }
+            },
+            "required": ["table_name", "schema_name", "source_type", "status", "message"],
+            "type": "object"
         },
         "DataWarehouseViewLink": {
             "additionalProperties": false,
@@ -21136,6 +21177,13 @@
                     "description": "Types of returned columns",
                     "items": {},
                     "type": "array"
+                },
+                "warnings": {
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data.",
+                    "items": {
+                        "$ref": "#/definitions/DataWarehouseSyncWarning"
+                    },
+                    "type": "array"
                 }
             },
             "required": ["results"],
@@ -28394,6 +28442,13 @@
                             "description": "Types of returned columns",
                             "items": {},
                             "type": "array"
+                        },
+                        "warnings": {
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data.",
+                            "items": {
+                                "$ref": "#/definitions/DataWarehouseSyncWarning"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": ["results"],
@@ -30186,6 +30241,13 @@
                         "types": {
                             "description": "Types of returned columns",
                             "items": {},
+                            "type": "array"
+                        },
+                        "warnings": {
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data.",
+                            "items": {
+                                "$ref": "#/definitions/DataWarehouseSyncWarning"
+                            },
                             "type": "array"
                         }
                     },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -468,6 +468,19 @@ export interface DataWarehouseEventsModifier {
     id_field: string
 }
 
+export interface DataWarehouseSyncWarning {
+    /** Name of the warehouse table the warning refers to */
+    table_name: string
+    /** Name of the ExternalDataSchema responsible for syncing the table */
+    schema_name: string
+    /** Source type, e.g. "Stripe", "Hubspot" */
+    source_type: string
+    /** Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached" */
+    status: string
+    /** Human-readable warning shown to the user */
+    message: string
+}
+
 export interface HogQLQueryResponse<T = any[]> extends AnalyticsQueryResponseBase {
     results: T
     /** Input query string */
@@ -482,6 +495,11 @@ export interface HogQLQueryResponse<T = any[]> extends AnalyticsQueryResponseBas
     explain?: string[]
     /** Query metadata output */
     metadata?: HogQLMetadataResponse
+    /**
+     * Warnings about data warehouse sources referenced by the query whose latest sync failed,
+     * is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data.
+     */
+    warnings?: DataWarehouseSyncWarning[]
     hasMore?: boolean
     limit?: integer
     offset?: integer

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -19,7 +19,7 @@ import {
     IconShare,
     IconScreen,
 } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonMenu, LemonModal, LemonTable, Tooltip } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonDivider, LemonMenu, LemonModal, LemonTable, Tooltip } from '@posthog/lemon-ui'
 
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { JSONViewer } from 'lib/components/JSONViewer'
@@ -946,6 +946,24 @@ function InternalDataTableVisualization(
     )
 }
 
+const SyncWarningsBanner = ({ warnings }: { warnings?: HogQLQueryResponse['warnings'] }): JSX.Element | null => {
+    if (!warnings || warnings.length === 0) {
+        return null
+    }
+    return (
+        <LemonBanner type="warning" className="m-2" data-attr="sql-editor-output-pane-sync-warnings">
+            <div className="font-semibold mb-1">
+                Some warehouse sources used by this query are out of date — results may not reflect current data
+            </div>
+            <ul className="list-disc pl-5 space-y-1">
+                {warnings.map((warning, index) => (
+                    <li key={`${warning.table_name}-${warning.schema_name}-${index}`}>{warning.message}</li>
+                ))}
+            </ul>
+        </LemonBanner>
+    )
+}
+
 const ErrorState = ({ responseError, sourceQuery, queryCancelled, response }: any): JSX.Element | null => {
     const error = queryCancelled
         ? 'The query was cancelled'
@@ -1055,7 +1073,8 @@ const Content = ({
         }
 
         return (
-            <div className="flex-1 absolute inset-0 hide-scrollbar border-t">
+            <div className="flex-1 absolute inset-0 hide-scrollbar border-t overflow-auto">
+                <SyncWarningsBanner warnings={response?.warnings} />
                 <InternalDataTableVisualization
                     uniqueKey={vizKey}
                     query={sourceQuery}
@@ -1110,6 +1129,7 @@ const Content = ({
     if (activeTab === OutputTab.Results) {
         return (
             <TabScroller data-attr="sql-editor-output-pane-results">
+                <SyncWarningsBanner warnings={response?.warnings} />
                 <DataGrid
                     className={clsx(isDarkModeOn ? 'rdg-dark h-full' : 'rdg-light h-full', 'ph-no-capture')}
                     columns={columns}

--- a/posthog/hogql/context.py
+++ b/posthog/hogql/context.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
-from posthog.schema import HogQLNotice, HogQLQueryModifiers
+from posthog.schema import DataWarehouseSyncWarning, HogQLNotice, HogQLQueryModifiers
 
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.timings import HogQLTimings
@@ -65,6 +65,10 @@ class HogQLContext:
     # Errors returned with the metadata query
     errors: list["HogQLNotice"] = field(default_factory=list)
 
+    # Data warehouse sync warnings collected while resolving warehouse tables referenced by the query.
+    # Keyed by (table_id, schema_name) to dedupe when a table is referenced multiple times.
+    data_warehouse_sync_warnings: dict[tuple[str, str], "DataWarehouseSyncWarning"] = field(default_factory=dict)
+
     # Timings in seconds for different parts of the HogQL query
     timings: HogQLTimings = field(default_factory=HogQLTimings)
     # Modifications requested by the HogQL client
@@ -123,6 +127,9 @@ class HogQLContext:
     ):
         if not any(n.start == start and n.end == end and n.message == message and n.fix == fix for n in self.errors):
             self.errors.append(HogQLNotice(start=start, end=end, message=message, fix=fix))
+
+    def add_data_warehouse_sync_warning(self, table_id: str, warning: "DataWarehouseSyncWarning") -> None:
+        self.data_warehouse_sync_warnings[(table_id, warning.schema_name)] = warning
 
     @cached_property
     def project_id(self) -> int:

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1,6 +1,7 @@
 import dataclasses
 from collections import defaultdict
 from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -1168,6 +1169,7 @@ class Database(BaseModel):
                             connection_id=cast(str, database._connection_id),
                         )
                     ]
+            sync_warnings_now = datetime.now(UTC)
             for table in tables:
                 if (
                     not database._is_direct_query()
@@ -1179,7 +1181,7 @@ class Database(BaseModel):
                 with timings.measure(f"table_{table.name}"):
                     s3_table = table.hogql_definition(modifiers)
 
-                    sync_warnings = get_warehouse_sync_warnings(table)
+                    sync_warnings = get_warehouse_sync_warnings(table, now=sync_warnings_now)
                     if sync_warnings:
                         database._data_warehouse_sync_warnings[str(table.id)] = sync_warnings
                     primary_table = s3_table
@@ -1681,7 +1683,9 @@ def _preload_active_external_data_schemas(warehouse_tables: Sequence[DataWarehou
         return
 
     schemas_by_table_id: dict[str, list[ExternalDataSchema]] = defaultdict(list)
-    for schema in ExternalDataSchema.objects.filter(NOT_DELETED_Q, table_id__in=table_ids):
+    # select_related("source"): warning rendering reads schema.source.source_type, so avoid a
+    # per-schema lazy fetch when any of these tables turns out to be unhealthy.
+    for schema in ExternalDataSchema.objects.filter(NOT_DELETED_Q, table_id__in=table_ids).select_related("source"):
         schemas_by_table_id[str(schema.table_id)].append(schema)
 
     for warehouse_table in warehouse_tables:

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -148,6 +148,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.team.team import WeekStartDay
 
+from products.data_warehouse.backend.sync_status import get_warehouse_sync_warnings
 from products.revenue_analytics.backend.views import RevenueAnalyticsBaseView
 from products.revenue_analytics.backend.views.orchestrator import build_all_revenue_analytics_views
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
@@ -156,6 +157,8 @@ from products.warehouse_sources.backend.models.external_data_source import Exter
 from products.warehouse_sources.backend.models.table import DataWarehouseTable, DataWarehouseTableColumns
 
 if TYPE_CHECKING:
+    from posthog.schema import DataWarehouseSyncWarning
+
     from posthog.models import Team, User
     from posthog.rbac.user_access_control import UserAccessControl
 
@@ -328,6 +331,9 @@ class Database(BaseModel):
     _connection_id: str | None = None
     _direct_connection_metadata: dict[str, Any] | None = None
     _direct_access_warehouse_table_names: set[str] = set()
+    # Warnings about data warehouse tables (failed/paused/billing-limited/stale syncs),
+    # keyed by HogQL DataWarehouseTable.table_id (str(Django table UUID)).
+    _data_warehouse_sync_warnings: dict[str, list["DataWarehouseSyncWarning"]] = {}
 
     _timezone: str | None
     _week_start_day: WeekStartDay | None
@@ -352,6 +358,7 @@ class Database(BaseModel):
         self._connection_id = None
         self._direct_connection_metadata = None
         self._direct_access_warehouse_table_names = set()
+        self._data_warehouse_sync_warnings = {}
         self._serialization_errors: dict[str, str] = {}  # table_key -> error_message
         self.user_access_control: Optional[UserAccessControl] = None
 
@@ -1171,6 +1178,10 @@ class Database(BaseModel):
 
                 with timings.measure(f"table_{table.name}"):
                     s3_table = table.hogql_definition(modifiers)
+
+                    sync_warnings = get_warehouse_sync_warnings(table)
+                    if sync_warnings:
+                        database._data_warehouse_sync_warnings[str(table.id)] = sync_warnings
                     primary_table = s3_table
 
                     # If the warehouse table has no _properties_ field, then set it as a virtual table

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -389,6 +389,11 @@ class HogQLQueryExecutor:
                 connection_id=self.connection_id,
             )
 
+        # Reset between executions: the resolver appends per query, and dataclasses.replace below
+        # shares this dict by reference. Without reset, callers reusing a HogQLContext across
+        # executors would see warnings from prior runs.
+        self.context.data_warehouse_sync_warnings.clear()
+
         self.hogql_context = dataclasses.replace(
             self.context,
             team_id=self.team.pk,

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -880,6 +880,7 @@ class HogQLQueryExecutor:
             elif self.clickhouse_sql is not None:
                 self._execute_clickhouse_query()
 
+        warnings = list(self.context.data_warehouse_sync_warnings.values()) if self.context else []
         return HogQLQueryResponse(
             query=self.query,
             hogql=self.hogql,
@@ -892,6 +893,7 @@ class HogQLQueryExecutor:
             modifiers=self.query_modifiers,
             explain=self.explain,
             metadata=self.metadata,
+            warnings=warnings or None,
             hasMore=self.has_more,
             limit=self.limit,
             offset=self.offset,

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -12,7 +12,10 @@ from posthog.hogql.constants import HogQLDialect
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import FunctionCallTable, LazyTable, SavedQuery, StringJSONDatabaseField
-from posthog.hogql.database.s3_table import S3Table
+from posthog.hogql.database.s3_table import (
+    DataWarehouseTable as HogQLDataWarehouseTable,
+    S3Table,
+)
 from posthog.hogql.database.schema.duckdb_table_functions import build_opaque_function_call_table
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.database.schema.persons import PersonsTable
@@ -1080,6 +1083,9 @@ class Resolver(CloningVisitor):
                 assert isinstance(database_table, ast.Table)
                 node_table_type = ast.TableType(table=database_table)
 
+            if isinstance(database_table, HogQLDataWarehouseTable) and database_table.table_id is not None:
+                self._emit_warehouse_sync_warnings(database_table.table_id)
+
             # Always add an alias for function call tables. This way `select table.* from table` is replaced with
             # `select table.* from something() as table`, and not with `select something().* from something()`.
             if node.column_aliases:
@@ -2056,6 +2062,15 @@ class Resolver(CloningVisitor):
             return isinstance(table.table, S3Table)
 
         return False
+
+    def _emit_warehouse_sync_warnings(self, table_id: str) -> None:
+        if self.database is None:
+            return
+        warnings = getattr(self.database, "_data_warehouse_sync_warnings", {}).get(table_id)
+        if not warnings:
+            return
+        for warning in warnings:
+            self.context.add_data_warehouse_sync_warning(table_id, warning)
 
     def _build_opaque_table_function(
         self, table_name_chain: list[str], node: ast.JoinExpr

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -1084,7 +1084,7 @@ class Resolver(CloningVisitor):
                 node_table_type = ast.TableType(table=database_table)
 
             if isinstance(database_table, HogQLDataWarehouseTable) and database_table.table_id is not None:
-                self._emit_warehouse_sync_warnings(database_table.table_id)
+                self._record_warehouse_sync_warnings(database_table.table_id)
 
             # Always add an alias for function call tables. This way `select table.* from table` is replaced with
             # `select table.* from something() as table`, and not with `select something().* from something()`.
@@ -2063,7 +2063,7 @@ class Resolver(CloningVisitor):
 
         return False
 
-    def _emit_warehouse_sync_warnings(self, table_id: str) -> None:
+    def _record_warehouse_sync_warnings(self, table_id: str) -> None:
         if self.database is None:
             return
         warnings = getattr(self.database, "_data_warehouse_sync_warnings", {}).get(table_id)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1350,6 +1350,23 @@ class DataWarehouseSavedQueryOrigin(StrEnum):
     MANAGED_VIEWSET = "managed_viewset"
 
 
+class DataWarehouseSyncWarning(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    message: str = Field(..., description="Human-readable warning shown to the user")
+    schema_name: str = Field(
+        ...,
+        description="Name of the ExternalDataSchema responsible for syncing the table",
+    )
+    source_type: str = Field(..., description='Source type, e.g. "Stripe", "Hubspot"')
+    status: str = Field(
+        ...,
+        description=('Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached"'),
+    )
+    table_name: str = Field(..., description="Name of the warehouse table the warning refers to")
+
+
 class DatabaseSchemaManagedViewTableKind(StrEnum):
     REVENUE_ANALYTICS_CHARGE = "revenue_analytics_charge"
     REVENUE_ANALYTICS_CUSTOMER = "revenue_analytics_customer"
@@ -15191,6 +15208,14 @@ class HogQLQueryResponse(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = Field(default=None, description="Types of returned columns")
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data."
+        ),
+    )
 
 
 class IQRDetectorConfig(BaseModel):
@@ -16056,6 +16081,14 @@ class QueryResponseAlternative8(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = Field(default=None, description="Types of returned columns")
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data."
+        ),
+    )
 
 
 class QueryResponseAlternative11(BaseModel):
@@ -16736,6 +16769,14 @@ class QueryResponseAlternative42(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = Field(default=None, description="Types of returned columns")
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data."
+        ),
+    )
 
 
 class QueryResponseAlternative43(BaseModel):
@@ -19271,6 +19312,14 @@ class CachedHogQLQueryResponse(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = Field(default=None, description="Types of returned columns")
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data."
+        ),
+    )
 
 
 class CachedInsightActorsQueryOptionsResponse(BaseModel):
@@ -19480,6 +19529,14 @@ class Response3(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = Field(default=None, description="Types of returned columns")
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data."
+        ),
+    )
 
 
 class Response21(BaseModel):

--- a/products/data_warehouse/backend/sync_status.py
+++ b/products/data_warehouse/backend/sync_status.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, cast
+
+from django.db.models import Q
+
+import humanize
 
 from posthog.schema import DataWarehouseSyncWarning
 
@@ -15,19 +19,25 @@ if TYPE_CHECKING:
 # (sync_frequency_interval * STALE_RUNNING_MULTIPLIER), we consider the data stale.
 STALE_RUNNING_MULTIPLIER = 2
 
+# Mirrors database._get_active_external_data_schemas / NOT_DELETED_Q. Kept local to avoid a
+# circular import between sync_status.py and posthog.hogql.database.database.
+_NOT_DELETED = Q(deleted=False) | Q(deleted__isnull=True)
 
-def _format_relative(now: datetime, then: datetime) -> str:
-    delta = now - then
-    if delta < timedelta(minutes=1):
-        return "less than a minute ago"
-    if delta < timedelta(hours=1):
-        minutes = int(delta.total_seconds() // 60)
-        return f"{minutes} minute{'s' if minutes != 1 else ''} ago"
-    if delta < timedelta(days=1):
-        hours = int(delta.total_seconds() // 3600)
-        return f"{hours} hour{'s' if hours != 1 else ''} ago"
-    days = delta.days
-    return f"{days} day{'s' if days != 1 else ''} ago"
+
+def _ensure_utc(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
+def _active_external_data_schemas(warehouse_table: DataWarehouseTable) -> list[ExternalDataSchema]:
+    preloaded = cast(
+        list[ExternalDataSchema] | None,
+        getattr(warehouse_table, "_active_external_data_schemas", None),
+    )
+    if preloaded is not None:
+        return preloaded
+    if warehouse_table.external_data_source_id is None:
+        return []
+    return list(ExternalDataSchema.objects.filter(_NOT_DELETED, table_id=warehouse_table.id))
 
 
 def _build_warning_for_schema(
@@ -39,47 +49,40 @@ def _build_warning_for_schema(
     status = schema.status
     source_type = schema.source.source_type if schema.source_id else "unknown"
 
-    def build(status_str: str, message: str) -> DataWarehouseSyncWarning:
+    def build(message: str) -> DataWarehouseSyncWarning:
         return DataWarehouseSyncWarning(
             table_name=table_name,
             schema_name=schema.name,
             source_type=source_type,
-            status=status_str,
+            status=status or ExternalDataSchema.Status.PAUSED,
             message=message,
         )
 
     if status == ExternalDataSchema.Status.FAILED:
         message = f"Last sync of `{table_name}` (from {source_type}) failed."
         if schema.last_synced_at:
-            message += f" Results reflect data from {_format_relative(now, _ensure_utc(schema.last_synced_at))}."
+            message += f" Results reflect data from {humanize.naturaltime(now - _ensure_utc(schema.last_synced_at))}."
         else:
             message += " No successful sync has completed yet — the table may be empty or incomplete."
         if schema.latest_error:
             message += f" Last error: {schema.latest_error}"
-        return build(str(status), message)
+        return build(message)
 
     if status == ExternalDataSchema.Status.BILLING_LIMIT_REACHED:
         return build(
-            str(status),
-            (
-                f"Sync of `{table_name}` (from {source_type}) is paused because the data warehouse "
-                "billing limit has been reached. Results may be out of date."
-            ),
+            f"Sync of `{table_name}` (from {source_type}) is paused because the data warehouse "
+            "billing limit has been reached. Results may be out of date."
         )
 
     if status == ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW:
         return build(
-            str(status),
-            (
-                f"Sync of `{table_name}` (from {source_type}) is paused because the configured "
-                "billing limit is too low. Results may be out of date."
-            ),
+            f"Sync of `{table_name}` (from {source_type}) is paused because the configured "
+            "billing limit is too low. Results may be out of date."
         )
 
     if status == ExternalDataSchema.Status.PAUSED or not schema.should_sync:
         return build(
-            str(status or ExternalDataSchema.Status.PAUSED),
-            (f"Sync of `{table_name}` (from {source_type}) is paused. Results reflect the last successful sync."),
+            f"Sync of `{table_name}` (from {source_type}) is paused. Results reflect the last successful sync."
         )
 
     if status == ExternalDataSchema.Status.RUNNING:
@@ -87,47 +90,34 @@ def _build_warning_for_schema(
         if interval is None or schema.last_synced_at is None:
             return None
         last_synced = _ensure_utc(schema.last_synced_at)
-        threshold = interval * STALE_RUNNING_MULTIPLIER
-        if (now - last_synced) <= threshold:
+        if (now - last_synced) <= interval * STALE_RUNNING_MULTIPLIER:
             return None
         return build(
-            str(status),
-            (
-                f"`{table_name}` (from {source_type}) last completed syncing "
-                f"{_format_relative(now, last_synced)}, more than twice its configured sync interval. "
-                "A new sync is in progress but results may be out of date."
-            ),
+            f"`{table_name}` (from {source_type}) last completed syncing "
+            f"{humanize.naturaltime(now - last_synced)}, more than twice its configured sync interval. "
+            "A new sync is in progress but results may be out of date."
         )
 
     return None
 
 
-def _ensure_utc(dt: datetime) -> datetime:
-    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
-
-
 def get_warehouse_sync_warnings(
     warehouse_table: DataWarehouseTable,
     *,
-    now: datetime | None = None,
+    now: datetime,
 ) -> list[DataWarehouseSyncWarning]:
     """Return sync warnings for a single data warehouse table.
 
     Uses the table's preloaded `_active_external_data_schemas` when available; falls back to a query.
-    Skips self-managed tables (no external data source).
+    Skips self-managed tables (no external data source). Caller must pass `now` so a single timestamp
+    is shared across all tables in a build.
     """
-    from posthog.hogql.database.database import _get_active_external_data_schemas
-
     if warehouse_table.external_data_source_id is None:
         return []
 
-    now = now or datetime.now(UTC)
-    schemas = _get_active_external_data_schemas(warehouse_table)
-
     warnings: list[DataWarehouseSyncWarning] = []
-    for schema in schemas:
+    for schema in _active_external_data_schemas(warehouse_table):
         warning = _build_warning_for_schema(table_name=warehouse_table.name, schema=schema, now=now)
         if warning is not None:
             warnings.append(warning)
-
     return warnings

--- a/products/data_warehouse/backend/sync_status.py
+++ b/products/data_warehouse/backend/sync_status.py
@@ -37,7 +37,8 @@ def _active_external_data_schemas(warehouse_table: DataWarehouseTable) -> list[E
         return preloaded
     if warehouse_table.external_data_source_id is None:
         return []
-    return list(ExternalDataSchema.objects.filter(_NOT_DELETED, table_id=warehouse_table.id))
+    # select_related("source"): _build_warning_for_schema reads schema.source.source_type.
+    return list(ExternalDataSchema.objects.filter(_NOT_DELETED, table_id=warehouse_table.id).select_related("source"))
 
 
 def _build_warning_for_schema(
@@ -46,46 +47,55 @@ def _build_warning_for_schema(
     schema: ExternalDataSchema,
     now: datetime,
 ) -> DataWarehouseSyncWarning | None:
-    status = schema.status
+    schema_status = schema.status
     source_type = schema.source.source_type if schema.source_id else "unknown"
 
-    def build(message: str) -> DataWarehouseSyncWarning:
+    def build(*, status: str, message: str) -> DataWarehouseSyncWarning:
         return DataWarehouseSyncWarning(
             table_name=table_name,
             schema_name=schema.name,
             source_type=source_type,
-            status=status or ExternalDataSchema.Status.PAUSED,
+            status=status,
             message=message,
         )
 
-    if status == ExternalDataSchema.Status.FAILED:
+    if schema_status == ExternalDataSchema.Status.FAILED:
         message = f"Last sync of `{table_name}` (from {source_type}) failed."
         if schema.last_synced_at:
             message += f" Results reflect data from {humanize.naturaltime(now - _ensure_utc(schema.last_synced_at))}."
         else:
             message += " No successful sync has completed yet — the table may be empty or incomplete."
-        if schema.latest_error:
-            message += f" Last error: {schema.latest_error}"
-        return build(message)
+        # Deliberately omit schema.latest_error: it holds raw exception text (DB hostnames,
+        # credentials, stack traces) and this message reaches LLM contexts via MCP/Max. The full
+        # error stays in the data warehouse source screen, which is access-scoped.
+        message += " Check the data warehouse source for details."
+        return build(status=ExternalDataSchema.Status.FAILED, message=message)
 
-    if status == ExternalDataSchema.Status.BILLING_LIMIT_REACHED:
+    if schema_status == ExternalDataSchema.Status.BILLING_LIMIT_REACHED:
         return build(
-            f"Sync of `{table_name}` (from {source_type}) is paused because the data warehouse "
-            "billing limit has been reached. Results may be out of date."
+            status=ExternalDataSchema.Status.BILLING_LIMIT_REACHED,
+            message=(
+                f"Sync of `{table_name}` (from {source_type}) is paused because the data warehouse "
+                "billing limit has been reached. Results may be out of date."
+            ),
         )
 
-    if status == ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW:
+    if schema_status == ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW:
         return build(
-            f"Sync of `{table_name}` (from {source_type}) is paused because the configured "
-            "billing limit is too low. Results may be out of date."
+            status=ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW,
+            message=(
+                f"Sync of `{table_name}` (from {source_type}) is paused because the configured "
+                "billing limit is too low. Results may be out of date."
+            ),
         )
 
-    if status == ExternalDataSchema.Status.PAUSED or not schema.should_sync:
+    if schema_status == ExternalDataSchema.Status.PAUSED or not schema.should_sync:
         return build(
-            f"Sync of `{table_name}` (from {source_type}) is paused. Results reflect the last successful sync."
+            status=ExternalDataSchema.Status.PAUSED,
+            message=f"Sync of `{table_name}` (from {source_type}) is paused. Results reflect the last successful sync.",
         )
 
-    if status == ExternalDataSchema.Status.RUNNING:
+    if schema_status == ExternalDataSchema.Status.RUNNING:
         interval = schema.sync_frequency_interval
         if interval is None or schema.last_synced_at is None:
             return None
@@ -93,9 +103,12 @@ def _build_warning_for_schema(
         if (now - last_synced) <= interval * STALE_RUNNING_MULTIPLIER:
             return None
         return build(
-            f"`{table_name}` (from {source_type}) last completed syncing "
-            f"{humanize.naturaltime(now - last_synced)}, more than twice its configured sync interval. "
-            "A new sync is in progress but results may be out of date."
+            status=ExternalDataSchema.Status.RUNNING,
+            message=(
+                f"`{table_name}` (from {source_type}) last completed syncing "
+                f"{humanize.naturaltime(now - last_synced)}, more than twice its configured sync interval. "
+                "A new sync is in progress but results may be out of date."
+            ),
         )
 
     return None

--- a/products/data_warehouse/backend/sync_status.py
+++ b/products/data_warehouse/backend/sync_status.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from posthog.schema import DataWarehouseSyncWarning
+
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+
+if TYPE_CHECKING:
+    from products.warehouse_sources.backend.models.table import DataWarehouseTable
+
+
+# When a schema is still in RUNNING state but its last successful sync is older than
+# (sync_frequency_interval * STALE_RUNNING_MULTIPLIER), we consider the data stale.
+STALE_RUNNING_MULTIPLIER = 2
+
+
+def _format_relative(now: datetime, then: datetime) -> str:
+    delta = now - then
+    if delta < timedelta(minutes=1):
+        return "less than a minute ago"
+    if delta < timedelta(hours=1):
+        minutes = int(delta.total_seconds() // 60)
+        return f"{minutes} minute{'s' if minutes != 1 else ''} ago"
+    if delta < timedelta(days=1):
+        hours = int(delta.total_seconds() // 3600)
+        return f"{hours} hour{'s' if hours != 1 else ''} ago"
+    days = delta.days
+    return f"{days} day{'s' if days != 1 else ''} ago"
+
+
+def _build_warning_for_schema(
+    *,
+    table_name: str,
+    schema: ExternalDataSchema,
+    now: datetime,
+) -> DataWarehouseSyncWarning | None:
+    status = schema.status
+    source_type = schema.source.source_type if schema.source_id else "unknown"
+
+    def build(status_str: str, message: str) -> DataWarehouseSyncWarning:
+        return DataWarehouseSyncWarning(
+            table_name=table_name,
+            schema_name=schema.name,
+            source_type=source_type,
+            status=status_str,
+            message=message,
+        )
+
+    if status == ExternalDataSchema.Status.FAILED:
+        message = f"Last sync of `{table_name}` (from {source_type}) failed."
+        if schema.last_synced_at:
+            message += f" Results reflect data from {_format_relative(now, _ensure_utc(schema.last_synced_at))}."
+        else:
+            message += " No successful sync has completed yet — the table may be empty or incomplete."
+        if schema.latest_error:
+            message += f" Last error: {schema.latest_error}"
+        return build(str(status), message)
+
+    if status == ExternalDataSchema.Status.BILLING_LIMIT_REACHED:
+        return build(
+            str(status),
+            (
+                f"Sync of `{table_name}` (from {source_type}) is paused because the data warehouse "
+                "billing limit has been reached. Results may be out of date."
+            ),
+        )
+
+    if status == ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW:
+        return build(
+            str(status),
+            (
+                f"Sync of `{table_name}` (from {source_type}) is paused because the configured "
+                "billing limit is too low. Results may be out of date."
+            ),
+        )
+
+    if status == ExternalDataSchema.Status.PAUSED or not schema.should_sync:
+        return build(
+            str(status or ExternalDataSchema.Status.PAUSED),
+            (f"Sync of `{table_name}` (from {source_type}) is paused. Results reflect the last successful sync."),
+        )
+
+    if status == ExternalDataSchema.Status.RUNNING:
+        interval = schema.sync_frequency_interval
+        if interval is None or schema.last_synced_at is None:
+            return None
+        last_synced = _ensure_utc(schema.last_synced_at)
+        threshold = interval * STALE_RUNNING_MULTIPLIER
+        if (now - last_synced) <= threshold:
+            return None
+        return build(
+            str(status),
+            (
+                f"`{table_name}` (from {source_type}) last completed syncing "
+                f"{_format_relative(now, last_synced)}, more than twice its configured sync interval. "
+                "A new sync is in progress but results may be out of date."
+            ),
+        )
+
+    return None
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
+def get_warehouse_sync_warnings(
+    warehouse_table: DataWarehouseTable,
+    *,
+    now: datetime | None = None,
+) -> list[DataWarehouseSyncWarning]:
+    """Return sync warnings for a single data warehouse table.
+
+    Uses the table's preloaded `_active_external_data_schemas` when available; falls back to a query.
+    Skips self-managed tables (no external data source).
+    """
+    from posthog.hogql.database.database import _get_active_external_data_schemas
+
+    if warehouse_table.external_data_source_id is None:
+        return []
+
+    now = now or datetime.now(UTC)
+    schemas = _get_active_external_data_schemas(warehouse_table)
+
+    warnings: list[DataWarehouseSyncWarning] = []
+    for schema in schemas:
+        warning = _build_warning_for_schema(table_name=warehouse_table.name, schema=schema, now=now)
+        if warning is not None:
+            warnings.append(warning)
+
+    return warnings

--- a/products/data_warehouse/backend/test/test_sync_status.py
+++ b/products/data_warehouse/backend/test/test_sync_status.py
@@ -106,15 +106,18 @@ class TestWarehouseSyncWarnings(BaseTest):
         assert warning.status == str(status)
         assert "stripe_charge" in warning.message
 
-    def test_failed_includes_latest_error(self) -> None:
+    def test_failed_does_not_leak_raw_error(self) -> None:
         self._make_schema(
             status=ExternalDataSchema.Status.FAILED,
             last_synced_at=self.now - timedelta(hours=2),
-            latest_error="API rate limit exceeded",
+            latest_error="connection to db-prod-1.internal:5432 failed: password authentication failed",
         )
         warnings = get_warehouse_sync_warnings(self.table, now=self.now)
         assert len(warnings) == 1
-        assert "API rate limit exceeded" in warnings[0].message
+        # Raw error text (hostnames, credentials) must not reach the warning message.
+        assert "db-prod-1.internal" not in warnings[0].message
+        assert "password" not in warnings[0].message
+        assert "data warehouse source" in warnings[0].message.lower()
 
     def test_warning_when_running_but_stale(self) -> None:
         self._make_schema(
@@ -154,6 +157,8 @@ class TestWarehouseSyncWarnings(BaseTest):
         warnings = get_warehouse_sync_warnings(self.table, now=self.now)
         assert len(warnings) == 1
         assert "paused" in warnings[0].message.lower()
+        # status must be consistent with the "paused" message, not the raw schema status (Completed).
+        assert warnings[0].status == ExternalDataSchema.Status.PAUSED
 
     def test_uses_preloaded_schemas_when_available(self) -> None:
         """If `_active_external_data_schemas` is set on the table, it's used directly without a DB query."""
@@ -172,4 +177,4 @@ class TestWarehouseSyncWarnings(BaseTest):
         warnings = get_warehouse_sync_warnings(self.table, now=self.now)
         assert len(warnings) == 1
         assert warnings[0].schema_name == "PreloadedSchema"
-        assert "preloaded error" in warnings[0].message
+        assert warnings[0].status == ExternalDataSchema.Status.FAILED

--- a/products/data_warehouse/backend/test/test_sync_status.py
+++ b/products/data_warehouse/backend/test/test_sync_status.py
@@ -1,0 +1,175 @@
+from datetime import UTC, datetime, timedelta
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock
+
+from parameterized import parameterized
+
+from products.data_warehouse.backend.sync_status import get_warehouse_sync_warnings
+from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.models.table import DataWarehouseTable
+
+
+class TestWarehouseSyncWarnings(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="source_id",
+            connection_id="connection_id",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type=ExternalDataSourceType.STRIPE,
+        )
+        self.credential = DataWarehouseCredential.objects.create(
+            team=self.team,
+            access_key="key",
+            access_secret="secret",
+        )
+        self.table = DataWarehouseTable.objects.create(
+            name="stripe_charge",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            external_data_source=self.source,
+            credential=self.credential,
+            url_pattern="http://host.docker.internal:19000/test/*.parquet",
+            columns={"id": "String"},
+        )
+        self.now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    def _make_schema(
+        self,
+        *,
+        status: str | None,
+        last_synced_at: datetime | None = None,
+        sync_frequency_interval: timedelta | None = timedelta(hours=6),
+        latest_error: str | None = None,
+        should_sync: bool = True,
+    ) -> ExternalDataSchema:
+        return ExternalDataSchema.objects.create(
+            name="Charge",
+            team=self.team,
+            source=self.source,
+            table=self.table,
+            status=status,
+            last_synced_at=last_synced_at,
+            sync_frequency_interval=sync_frequency_interval,
+            latest_error=latest_error,
+            should_sync=should_sync,
+        )
+
+    def test_no_warnings_for_self_managed_table(self) -> None:
+        self.table.external_data_source = None
+        self.table.save()
+        warnings = get_warehouse_sync_warnings(self.table, now=self.now)
+        assert warnings == []
+
+    def test_no_warnings_when_completed(self) -> None:
+        self._make_schema(
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=self.now - timedelta(hours=1),
+        )
+        warnings = get_warehouse_sync_warnings(self.table, now=self.now)
+        assert warnings == []
+
+    def test_no_warning_when_running_within_interval(self) -> None:
+        self._make_schema(
+            status=ExternalDataSchema.Status.RUNNING,
+            last_synced_at=self.now - timedelta(hours=6),
+            sync_frequency_interval=timedelta(hours=6),
+        )
+        warnings = get_warehouse_sync_warnings(self.table, now=self.now)
+        assert warnings == []
+
+    @parameterized.expand(
+        [
+            (ExternalDataSchema.Status.FAILED,),
+            (ExternalDataSchema.Status.BILLING_LIMIT_REACHED,),
+            (ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW,),
+            (ExternalDataSchema.Status.PAUSED,),
+        ]
+    )
+    def test_warning_for_problem_statuses(self, status: str) -> None:
+        self._make_schema(
+            status=status,
+            last_synced_at=self.now - timedelta(hours=2),
+            latest_error="boom" if status == ExternalDataSchema.Status.FAILED else None,
+        )
+        warnings = get_warehouse_sync_warnings(self.table, now=self.now)
+        assert len(warnings) == 1
+        warning = warnings[0]
+        assert warning.table_name == "stripe_charge"
+        assert warning.schema_name == "Charge"
+        assert warning.source_type == ExternalDataSourceType.STRIPE
+        assert warning.status == str(status)
+        assert "stripe_charge" in warning.message
+
+    def test_failed_includes_latest_error(self) -> None:
+        self._make_schema(
+            status=ExternalDataSchema.Status.FAILED,
+            last_synced_at=self.now - timedelta(hours=2),
+            latest_error="API rate limit exceeded",
+        )
+        warnings = get_warehouse_sync_warnings(self.table, now=self.now)
+        assert len(warnings) == 1
+        assert "API rate limit exceeded" in warnings[0].message
+
+    def test_warning_when_running_but_stale(self) -> None:
+        self._make_schema(
+            status=ExternalDataSchema.Status.RUNNING,
+            sync_frequency_interval=timedelta(hours=6),
+            last_synced_at=self.now - timedelta(hours=13),
+        )
+        warnings = get_warehouse_sync_warnings(self.table, now=self.now)
+        assert len(warnings) == 1
+        assert warnings[0].status == str(ExternalDataSchema.Status.RUNNING)
+        assert "more than twice" in warnings[0].message
+
+    def test_no_warning_when_running_at_exact_threshold(self) -> None:
+        self._make_schema(
+            status=ExternalDataSchema.Status.RUNNING,
+            sync_frequency_interval=timedelta(hours=6),
+            last_synced_at=self.now - timedelta(hours=12),
+        )
+        warnings = get_warehouse_sync_warnings(self.table, now=self.now)
+        assert warnings == []
+
+    def test_no_warning_when_running_without_interval(self) -> None:
+        self._make_schema(
+            status=ExternalDataSchema.Status.RUNNING,
+            sync_frequency_interval=None,
+            last_synced_at=self.now - timedelta(days=5),
+        )
+        warnings = get_warehouse_sync_warnings(self.table, now=self.now)
+        assert warnings == []
+
+    def test_should_not_sync_treated_as_paused(self) -> None:
+        self._make_schema(
+            status=ExternalDataSchema.Status.COMPLETED,
+            should_sync=False,
+            last_synced_at=self.now - timedelta(hours=1),
+        )
+        warnings = get_warehouse_sync_warnings(self.table, now=self.now)
+        assert len(warnings) == 1
+        assert "paused" in warnings[0].message.lower()
+
+    def test_uses_preloaded_schemas_when_available(self) -> None:
+        """If `_active_external_data_schemas` is set on the table, it's used directly without a DB query."""
+        fake_schema = MagicMock(spec=ExternalDataSchema)
+        fake_schema.name = "PreloadedSchema"
+        fake_schema.status = ExternalDataSchema.Status.FAILED
+        fake_schema.last_synced_at = self.now - timedelta(hours=3)
+        fake_schema.sync_frequency_interval = timedelta(hours=6)
+        fake_schema.latest_error = "preloaded error"
+        fake_schema.should_sync = True
+        fake_schema.source_id = self.source.id
+        fake_schema.source = self.source
+
+        self.table.__dict__["_active_external_data_schemas"] = [fake_schema]
+
+        warnings = get_warehouse_sync_warnings(self.table, now=self.now)
+        assert len(warnings) == 1
+        assert warnings[0].schema_name == "PreloadedSchema"
+        assert "preloaded error" in warnings[0].message

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -3031,6 +3031,19 @@ export interface HogQLMetadataResponseApi {
     warnings: HogQLNoticeApi[]
 }
 
+export interface DataWarehouseSyncWarningApi {
+    /** Human-readable warning shown to the user */
+    message: string
+    /** Name of the ExternalDataSchema responsible for syncing the table */
+    schema_name: string
+    /** Source type, e.g. "Stripe", "Hubspot" */
+    source_type: string
+    /** Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached" */
+    status: string
+    /** Name of the warehouse table the warning refers to */
+    table_name: string
+}
+
 export interface Response3Api {
     /** Executed ClickHouse query */
     clickhouse?: string | null
@@ -3060,6 +3073,8 @@ export interface Response3Api {
     timings?: QueryTimingApi[] | null
     /** Types of returned columns */
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface Response4Api {
@@ -4693,6 +4708,8 @@ export interface HogQLQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Types of returned columns */
     types?: unknown[] | null
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. */
+    warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
 export interface HogQLVariableApi {

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -81,7 +81,9 @@ export interface QueryEndpointResponse {
     results: unknown
     columns?: unknown
     formatted_results?: string
-    warnings?: DataWarehouseSyncWarning[]
+    // null (not just absent) when the query response carries no warnings — the backend
+    // serializes the field explicitly rather than omitting it.
+    warnings?: DataWarehouseSyncWarning[] | null
 }
 
 export interface ApiConfig {

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -69,6 +69,21 @@ export interface SearchResponse {
 
 export type Result<T, E = Error> = { success: true; data: T } | { success: false; error: E }
 
+export interface DataWarehouseSyncWarning {
+    table_name: string
+    schema_name: string
+    source_type: string
+    status: string
+    message: string
+}
+
+export interface QueryEndpointResponse {
+    results: unknown
+    columns?: unknown
+    formatted_results?: string
+    warnings?: DataWarehouseSyncWarning[]
+}
+
 export interface ApiConfig {
     apiToken: string
     baseUrl: string
@@ -982,38 +997,10 @@ export class ApiClient {
                 }
             },
 
-            query: async ({
-                query,
-            }: {
-                query: Record<string, any>
-            }): Promise<
-                Result<{
-                    results: unknown
-                    columns?: unknown
-                    formatted_results?: string
-                    warnings?: Array<{
-                        table_name: string
-                        schema_name: string
-                        source_type: string
-                        status: string
-                        message: string
-                    }>
-                }>
-            > => {
+            query: async ({ query }: { query: Record<string, any> }): Promise<Result<QueryEndpointResponse>> => {
                 const url = `${this.baseUrl}/api/environments/${projectId}/query/`
 
-                return this.fetchJson<{
-                    results: unknown
-                    columns?: unknown
-                    formatted_results?: string
-                    warnings?: Array<{
-                        table_name: string
-                        schema_name: string
-                        source_type: string
-                        status: string
-                        message: string
-                    }>
-                }>(url, {
+                return this.fetchJson<QueryEndpointResponse>(url, {
                     method: 'POST',
                     body: JSON.stringify({ query }),
                 })

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -986,10 +986,34 @@ export class ApiClient {
                 query,
             }: {
                 query: Record<string, any>
-            }): Promise<Result<{ results: unknown; columns?: unknown; formatted_results?: string }>> => {
+            }): Promise<
+                Result<{
+                    results: unknown
+                    columns?: unknown
+                    formatted_results?: string
+                    warnings?: Array<{
+                        table_name: string
+                        schema_name: string
+                        source_type: string
+                        status: string
+                        message: string
+                    }>
+                }>
+            > => {
                 const url = `${this.baseUrl}/api/environments/${projectId}/query/`
 
-                return this.fetchJson<{ results: unknown; columns?: unknown; formatted_results?: string }>(url, {
+                return this.fetchJson<{
+                    results: unknown
+                    columns?: unknown
+                    formatted_results?: string
+                    warnings?: Array<{
+                        table_name: string
+                        schema_name: string
+                        source_type: string
+                        status: string
+                        message: string
+                    }>
+                }>(url, {
                     method: 'POST',
                     body: JSON.stringify({ query }),
                 })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3556,6 +3556,19 @@ export namespace Schemas {
       warnings: HogQLNotice[];
     }
 
+    export interface DataWarehouseSyncWarning {
+      /** Human-readable warning shown to the user */
+      message: string;
+      /** Name of the ExternalDataSchema responsible for syncing the table */
+      schema_name: string;
+      /** Source type, e.g. "Stripe", "Hubspot" */
+      source_type: string;
+      /** Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached" */
+      status: string;
+      /** Name of the warehouse table the warning refers to */
+      table_name: string;
+    }
+
     export interface HogQLQueryResponse {
       /** Executed ClickHouse query */
       clickhouse?: string | null;
@@ -3585,6 +3598,8 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Types of returned columns */
       types?: unknown[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. */
+      warnings?: DataWarehouseSyncWarning[] | null;
     }
 
     export interface HogQLVariable {
@@ -9236,6 +9251,8 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Types of returned columns */
       types?: unknown[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. */
+      warnings?: DataWarehouseSyncWarning[] | null;
     }
 
     export interface Response4 {
@@ -33348,6 +33365,8 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Types of returned columns */
       types?: unknown[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. */
+      warnings?: DataWarehouseSyncWarning[] | null;
     }
 
     export interface QueryResponseAlternative9 {
@@ -33937,6 +33956,8 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Types of returned columns */
       types?: unknown[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. */
+      warnings?: DataWarehouseSyncWarning[] | null;
     }
 
     export interface QueryResponseAlternative43 {

--- a/services/mcp/src/tools/query/run.ts
+++ b/services/mcp/src/tools/query/run.ts
@@ -12,7 +12,15 @@ const schema = QueryRunInputSchema
 
 type Params = z.infer<typeof schema>
 
-type Result = WithPostHogUrl<{ query: unknown; results: unknown }>
+type DataWarehouseSyncWarning = {
+    table_name: string
+    schema_name: string
+    source_type: string
+    status: string
+    message: string
+}
+
+type Result = WithPostHogUrl<{ query: unknown; results: unknown; warnings?: DataWarehouseSyncWarning[] }>
 
 export const queryRunHandler: ToolBase<typeof schema, Result>['handler'] = async (context: Context, params: Params) => {
     const { query } = params
@@ -39,6 +47,8 @@ export const queryRunHandler: ToolBase<typeof schema, Result>['handler'] = async
     // TrendsQuery, FunnelsQuery, and PathsQuery return results directly as an array
     // HogQLQuery returns { results: [...], columns: [...] }
     // The UI app infers the visualization type from the data structure
+    const warnings = queryResult.data.warnings
+
     if (
         queryInfo.visualization === 'trends' ||
         queryInfo.visualization === 'funnel' ||
@@ -49,6 +59,7 @@ export const queryRunHandler: ToolBase<typeof schema, Result>['handler'] = async
             {
                 query: queryInfo.innerQuery || query,
                 results: queryResult.data.results,
+                ...(warnings && warnings.length > 0 ? { warnings } : {}),
             },
             path
         )
@@ -63,6 +74,7 @@ export const queryRunHandler: ToolBase<typeof schema, Result>['handler'] = async
                 columns: queryResult.data.columns || [],
                 results: queryResult.data.results || [],
             },
+            ...(warnings && warnings.length > 0 ? { warnings } : {}),
         },
         path
     )

--- a/services/mcp/src/tools/query/run.ts
+++ b/services/mcp/src/tools/query/run.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import type { DataWarehouseSyncWarning } from '@/api/client'
 import { withUiApp } from '@/resources/ui-apps'
 import { QueryRunInputSchema } from '@/schema/tool-inputs'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
@@ -11,14 +12,6 @@ import { extractHogQLMetadata, formatHogQLMetadataForAgent } from './hogql-error
 const schema = QueryRunInputSchema
 
 type Params = z.infer<typeof schema>
-
-type DataWarehouseSyncWarning = {
-    table_name: string
-    schema_name: string
-    source_type: string
-    status: string
-    message: string
-}
 
 type Result = WithPostHogUrl<{ query: unknown; results: unknown; warnings?: DataWarehouseSyncWarning[] }>
 
@@ -47,7 +40,7 @@ export const queryRunHandler: ToolBase<typeof schema, Result>['handler'] = async
     // TrendsQuery, FunnelsQuery, and PathsQuery return results directly as an array
     // HogQLQuery returns { results: [...], columns: [...] }
     // The UI app infers the visualization type from the data structure
-    const warnings = queryResult.data.warnings
+    const warningsField = queryResult.data.warnings?.length ? { warnings: queryResult.data.warnings } : {}
 
     if (
         queryInfo.visualization === 'trends' ||
@@ -59,7 +52,7 @@ export const queryRunHandler: ToolBase<typeof schema, Result>['handler'] = async
             {
                 query: queryInfo.innerQuery || query,
                 results: queryResult.data.results,
-                ...(warnings && warnings.length > 0 ? { warnings } : {}),
+                ...warningsField,
             },
             path
         )
@@ -74,7 +67,7 @@ export const queryRunHandler: ToolBase<typeof schema, Result>['handler'] = async
                 columns: queryResult.data.columns || [],
                 results: queryResult.data.results || [],
             },
-            ...(warnings && warnings.length > 0 ? { warnings } : {}),
+            ...warningsField,
         },
         path
     )


### PR DESCRIPTION
## Problem

When a HogQL query references a data warehouse table whose latest sync failed, hit a billing limit, was paused, or has fallen behind its schedule, the user silently gets stale (or empty) results with no indication. This is true across the SQL editor, MCP (`execute-sql` / `query-run`), and Max AI, so a stale Postgres or Stripe source can quietly skew any query that touches it.

## Changes

Detects unhealthy warehouse syncs during HogQL table resolution and surfaces a structured warning to every query consumer.

Tested with a Postgres DB I had lying around from a side project:

<img width="2396" height="770" alt="image" src="https://github.com/user-attachments/assets/2fb45aaa-9dc3-4c70-bb91-7e9cc9087884" />

<img width="2396" height="770" alt="image" src="https://github.com/user-attachments/assets/c5661a1f-ed66-4755-bd86-d076554271e7" />

<img width="2932" height="536" alt="image" src="https://github.com/user-attachments/assets/2bbd3662-8695-43df-9c12-caf84ea7c781" />


- **Helper** — `products/data_warehouse/backend/sync_status.py`:
  `get_warehouse_sync_warnings(table)` returns a `DataWarehouseSyncWarning` per schema attached to a warehouse table whose status is `FAILED`, `BILLING_LIMIT_REACHED`, `BILLING_LIMIT_TOO_LOW`, `PAUSED`/`should_sync=False`, or `RUNNING` with `last_synced_at` older than 2× `sync_frequency_interval`.
- **Schema** — added `DataWarehouseSyncWarning` and a top-level `warnings?: DataWarehouseSyncWarning[]` field on `HogQLQueryResponse` (and the cached variant). Regenerated `schema.json` / `schema.py` via `hogli build:schema`.
- **Backend** — `Database` precomputes warnings per warehouse table during table loading; the HogQL resolver emits them into the `HogQLContext` whenever it resolves a `DataWarehouseTable`. `HogQLQueryExecutor.execute()` attaches the collected warnings to the response.
- **Surfaces**:
  - SQL editor: yellow `LemonBanner` above the Results grid and the Visualization tab (`frontend/src/scenes/data-warehouse/editor/OutputPane.tsx`).
  - MCP `execute-sql` + Max AI: `format_warehouse_sync_warnings()` prepends a \`[Data warehouse sync warnings — …]\` block to LLM-facing output.
  - MCP `query-run`: forwards the structured `warnings` array through to the LLM (previously it only returned `results`/`columns`, throwing the field away).

## How did you test this code?

I'm an agent (Claude Code) — manual UI testing was done by the human author.

Automated:
- New parameterized backend tests covering all five trigger conditions plus the negative cases (self-managed table, completed, within interval, no interval, preloaded schemas): `products/data_warehouse/backend/test/test_sync_status.py`
  (13 tests, all passing locally).

Manual (by author):
- Toggled `ExternalDataSchema.status` via Django shell on a real warehouse table and confirmed the yellow banner appears in the SQL editor for each trigger status, plus the stale-running case (backdated `last_synced_at`).
- Confirmed MCP `execute-sql` formatter prepends the warning block.
- Found that the legacy MCP `query-run` tool was dropping the field — fixed by passing it through in `services/mcp/src/tools/query/run.ts`.

## Publish to changelog?

Yes

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) with the human author. Notable decisions:

- **Where to detect**: chose to compute warnings during \`Database\` warehouse table loading and surface them through the HogQL resolver, so every consumer (SQL editor / MCP / Max / direct API) gets them through one code path rather than duplicated checks at each call site.
- **Stale-running heuristic**: 2× the configured \`sync_frequency_interval\`. A fixed clock value was considered and rejected since intervals legitimately vary from 1 min to 30 days.
- **Schema field**: added a structured \`DataWarehouseSyncWarning\` type rather than reusing \`HogQLNotice\` — consumers (banner, LLM, MCP UI) benefit from having \`table_name\` / \`schema_name\` / \`status\` separately addressable.
- **Cache caveat**: warnings are populated on fresh compute and are part of the cached response schema, so they'll be served from cache on subsequent hits. Cache entries written before this change will load with \`warnings=None\` until invalidated — no migration done, this is the lowest-impact behavior.
- **\`query-run\` vs \`execute-sql\`**: discovered during dogfooding that the legacy \`query-run\` MCP tool stripped fields it didn't know about. Fixed in the same PR rather than declaring it out-of-scope, since it's part of the same user-visible behavior.