### PR TITLE
feat(slack-app): warn when no personal GitHub at PR-open time

### DIFF
--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -231,6 +231,38 @@ class TestSlackIntegration:
         assert not channel["is_private"]
         assert not channel["is_private_without_access"]
 
+    def test_granted_scopes_parses_comma_separated_string(self):
+        self.integration.config["scope"] = "chat:write,users:read,users:read.email"
+        slack = SlackIntegration(self.integration)
+        assert slack.granted_scopes() == frozenset({"chat:write", "users:read", "users:read.email"})
+
+    def test_granted_scopes_tolerates_whitespace_and_empty_entries(self):
+        self.integration.config["scope"] = " chat:write , ,users:read"
+        slack = SlackIntegration(self.integration)
+        assert slack.granted_scopes() == frozenset({"chat:write", "users:read"})
+
+    def test_granted_scopes_returns_empty_when_field_missing(self):
+        self.integration.config.pop("scope", None)
+        slack = SlackIntegration(self.integration)
+        assert slack.granted_scopes() == frozenset()
+
+    def test_granted_scopes_returns_empty_when_field_is_empty_string(self):
+        self.integration.config["scope"] = ""
+        slack = SlackIntegration(self.integration)
+        assert slack.granted_scopes() == frozenset()
+
+    def test_missing_scopes_returns_difference(self):
+        self.integration.config["scope"] = "chat:write,users:read"
+        slack = SlackIntegration(self.integration)
+        required = {"chat:write", "users:read", "users:read.email", "reactions:write"}
+        assert slack.missing_scopes(required) == frozenset({"users:read.email", "reactions:write"})
+
+    def test_missing_scopes_returns_empty_when_all_granted(self):
+        required = {"chat:write", "users:read"}
+        self.integration.config["scope"] = "chat:write,users:read,extra:scope"
+        slack = SlackIntegration(self.integration)
+        assert slack.missing_scopes(required) == frozenset()
+
 
 class TestEmailIntegration:
     @pytest.fixture(autouse=True)

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -4,6 +4,7 @@ import time
 import base64
 import socket
 import hashlib
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NoReturn, Optional
@@ -1144,6 +1145,14 @@ class SlackIntegration:
 
     def async_client(self, session: Optional["aiohttp.ClientSession"] = None) -> AsyncWebClient:
         return AsyncWebClient(self.integration.sensitive_config["access_token"], session=session)
+
+    def granted_scopes(self) -> frozenset[str]:
+        """OAuth scopes Slack granted this install, stored on Integration.config["scope"]."""
+        raw = self.integration.config.get("scope") or ""
+        return frozenset(scope.strip() for scope in raw.split(",") if scope.strip())
+
+    def missing_scopes(self, required: Iterable[str]) -> frozenset[str]:
+        return frozenset(required) - self.granted_scopes()
 
     def list_channels(self, should_include_private_channels: bool, authed_user: str) -> list[dict]:
         # NOTE: Annoyingly the Slack API has no search so we have to load all channels...

--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -11,6 +11,7 @@ from posthog.temporal.ai.posthog_code_slack_interactivity import (
 )
 from posthog.temporal.ai.posthog_code_slack_mention import (
     PostHogCodeSlackMentionWorkflow,
+    block_posthog_code_task_if_no_personal_github_activity,
     classify_posthog_code_task_needs_repo_activity,
     collect_posthog_code_thread_messages_activity,
     create_posthog_code_routing_rule_activity,
@@ -73,6 +74,7 @@ AI_ACTIVITIES = [
     classify_posthog_code_task_needs_repo_activity,
     post_posthog_code_no_repos_activity,
     post_posthog_code_repo_picker_activity,
+    block_posthog_code_task_if_no_personal_github_activity,
     create_posthog_code_task_for_repo_activity,
     forward_posthog_code_followup_activity,
     post_posthog_code_picker_timeout_activity,

--- a/posthog/temporal/ai/posthog_code_slack_interactivity.py
+++ b/posthog/temporal/ai/posthog_code_slack_interactivity.py
@@ -10,6 +10,7 @@ from temporalio.common import RetryPolicy
 from posthog.temporal.common.base import PostHogWorkflow
 
 POSTHOG_CODE_SLACK_INTERACTIVITY_TIMEOUT_SECONDS = 5 * 60
+SLACK_INTEGRATION_KIND = "slack"
 logger = structlog.get_logger(__name__)
 
 
@@ -96,7 +97,7 @@ def process_posthog_code_task_termination_payload(payload: dict[str, Any]) -> No
 
     try:
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
     except Integration.DoesNotExist:
         logger.warning("posthog_code_terminate_integration_not_found", integration_id=integration_id)

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -231,6 +231,9 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                     )
                     return
 
+                if self._selected_repo and await _gate_on_personal_github(inputs, channel, thread_ts, user_id):
+                    return
+
                 await _execute_posthog_code_activity(
                     create_posthog_code_task_for_repo_activity,
                     inputs,
@@ -246,6 +249,9 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
 
             repository = decision.repository
             if not repository:
+                return
+
+            if await _gate_on_personal_github(inputs, channel, thread_ts, user_id):
                 return
 
             await _execute_posthog_code_activity(
@@ -283,6 +289,30 @@ async def _execute_posthog_code_activity(activity_fn: Any, *args: Any) -> Any:
         args=args,
         start_to_close_timeout=timedelta(seconds=POSTHOG_CODE_SLACK_MENTION_TIMEOUT_SECONDS),
         retry_policy=RetryPolicy(maximum_attempts=3),
+    )
+
+
+async def _gate_on_personal_github(
+    inputs: "PostHogCodeSlackMentionWorkflowInputs",
+    channel: str,
+    thread_ts: str,
+    user_id: int,
+) -> bool:
+    """Return True when the workflow must abort because the mentioner has no personal GitHub.
+
+    Gated by `workflow.patched` so in-flight workflows started before this code was
+    deployed don't introduce a new activity command on replay and trip nondeterminism.
+    Pre-patch workflows skip the gate entirely and behave as before; post-patch
+    workflows always evaluate it.
+    """
+    if not workflow.patched("posthog-code-block-no-personal-github-2026-05"):
+        return False
+    return await _execute_posthog_code_activity(
+        block_posthog_code_task_if_no_personal_github_activity,
+        inputs,
+        channel,
+        thread_ts,
+        user_id,
     )
 
 
@@ -701,6 +731,80 @@ def post_posthog_code_repo_picker_activity(
         workflow_id=workflow_id,
         allow_no_repo=allow_no_repo,
     )
+
+
+@activity.defn
+def block_posthog_code_task_if_no_personal_github_activity(
+    inputs: PostHogCodeSlackMentionWorkflowInputs,
+    channel: str,
+    thread_ts: str,
+    user_id: int,
+) -> bool:
+    """Gate a repo-bound coding-agent task on the mentioner having a personal GitHub.
+
+    Returns True (and posts an in-thread Slack message with a "Connect GitHub" button)
+    when the user has no `UserIntegration` of kind=github; the caller must then skip
+    `create_posthog_code_task_for_repo_activity`. Returns False to let the task proceed.
+
+    The team-level GitHub App can still author commits, but PRs would land under the
+    PostHog app identity instead of the user's. Rather than degrading silently, hold
+    the task and surface the one-click path to the personal integration setup.
+    """
+    from django.conf import settings
+
+    import structlog
+
+    from posthog.models.integration import Integration, SlackIntegration
+    from posthog.models.user_integration import UserIntegration
+
+    log = structlog.get_logger(__name__)
+
+    has_personal_github = UserIntegration.objects.filter(
+        user_id=user_id,
+        kind=UserIntegration.IntegrationKind.GITHUB,
+    ).exists()
+    if has_personal_github:
+        return False
+
+    integration = Integration.objects.select_related("team", "team__organization").get(
+        id=inputs.integration_id,
+        kind=SLACK_INTEGRATION_KIND,
+        integration_id=inputs.slack_team_id,
+    )
+    slack = SlackIntegration(integration)
+
+    settings_url = f"{settings.SITE_URL}/project/{integration.team_id}/settings/user-personal-integrations"
+    text = (
+        "I can't start this task yet — you haven't connected your personal GitHub. "
+        "Connect it so I can open the pull request as you, then mention me again."
+    )
+    slack.client.chat_postMessage(
+        channel=channel,
+        thread_ts=thread_ts,
+        text=text,
+        blocks=[
+            {"type": "section", "text": {"type": "mrkdwn", "text": text}},
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Connect GitHub", "emoji": True},
+                        "url": settings_url,
+                        "style": "primary",
+                    }
+                ],
+            },
+        ],
+    )
+    log.info(
+        "posthog_code_task_blocked_no_personal_github",
+        user_id=user_id,
+        team_id=integration.team_id,
+        channel=channel,
+        thread_ts=thread_ts,
+    )
+    return True
 
 
 @activity.defn

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -24,6 +24,7 @@ def _safe_react(client: Any, channel: str, timestamp: str, name: str) -> None:
 POSTHOG_CODE_SLACK_MENTION_TIMEOUT_SECONDS = 10 * 60
 _RESUME_ERROR_MSG = "Sorry, I ran into an internal error restarting the agent. Please try again in a minute."
 POSTHOG_CODE_SLACK_PICKER_TIMEOUT_MINUTES = 15
+SLACK_INTEGRATION_KIND = "slack"
 POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE = (
     "Please select the repository for this task. "
     "Or click *No repo needed* to continue without one. "
@@ -298,7 +299,7 @@ def resolve_posthog_code_slack_user_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -324,7 +325,7 @@ def handle_posthog_code_rules_command_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -590,7 +591,7 @@ def collect_posthog_code_thread_messages_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -613,7 +614,7 @@ def select_posthog_code_repository_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     all_repos = _get_full_repo_names(integration)
@@ -651,7 +652,7 @@ def post_posthog_code_no_repos_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -682,7 +683,7 @@ def post_posthog_code_repo_picker_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -726,7 +727,7 @@ def create_posthog_code_task_for_repo_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -852,7 +853,7 @@ def create_posthog_code_routing_rule_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -932,7 +933,7 @@ def forward_posthog_code_followup_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1375,7 +1376,7 @@ def post_posthog_code_picker_timeout_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)
@@ -1405,7 +1406,7 @@ def post_posthog_code_internal_error_activity(
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
-        kind="slack-posthog-code",
+        kind=SLACK_INTEGRATION_KIND,
         integration_id=inputs.slack_team_id,
     )
     slack = SlackIntegration(integration)

--- a/posthog/temporal/tests/ai/test_block_missing_user_github.py
+++ b/posthog/temporal/tests/ai/test_block_missing_user_github.py
@@ -1,0 +1,108 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+from posthog.models.user import User
+from posthog.models.user_integration import UserIntegration
+from posthog.temporal.ai.posthog_code_slack_mention import (
+    PostHogCodeSlackMentionWorkflowInputs,
+    block_posthog_code_task_if_no_personal_github_activity,
+)
+
+
+def _make_inputs(integration_id: int, slack_team_id: str = "T_SLACK") -> PostHogCodeSlackMentionWorkflowInputs:
+    return PostHogCodeSlackMentionWorkflowInputs(
+        event={"channel": "C123", "ts": "1234.5678", "user": "U_ALICE", "text": "<@BOT> do something"},
+        integration_id=integration_id,
+        slack_team_id=slack_team_id,
+    )
+
+
+class TestBlockPostHogCodeTaskIfNoPersonalGitHub(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="TestOrg")
+        self.team = Team.objects.create(organization=self.org, name="TestTeam")
+        self.user = User.objects.create(email="alice@test.com")
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
+
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_returns_true_and_posts_block_when_user_has_no_personal_github(self, mock_slack_cls):
+        mock_slack = MagicMock()
+        mock_slack_cls.return_value = mock_slack
+
+        blocked = block_posthog_code_task_if_no_personal_github_activity(
+            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+        )
+
+        assert blocked is True
+        mock_slack.client.chat_postMessage.assert_called_once()
+        kwargs = mock_slack.client.chat_postMessage.call_args.kwargs
+        assert kwargs["channel"] == "C123"
+        assert kwargs["thread_ts"] == "1234.5678"
+        assert "haven't connected" in kwargs["text"]
+
+        action_block = next(b for b in kwargs["blocks"] if b.get("type") == "actions")
+        button = action_block["elements"][0]
+        assert button["text"]["text"] == "Connect GitHub"
+        assert button["url"].endswith(f"/project/{self.team.id}/settings/user-personal-integrations")
+
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_returns_false_and_posts_nothing_when_user_has_personal_github(self, mock_slack_cls):
+        UserIntegration.objects.create(
+            user=self.user,
+            kind="github",
+            integration_id="gh-1",
+            config={},
+            sensitive_config={"access_token": "tok"},
+        )
+        mock_slack = MagicMock()
+        mock_slack_cls.return_value = mock_slack
+
+        blocked = block_posthog_code_task_if_no_personal_github_activity(
+            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+        )
+
+        assert blocked is False
+        mock_slack.client.chat_postMessage.assert_not_called()
+
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_only_github_kind_counts_as_personal_integration(self, mock_slack_cls):
+        UserIntegration.objects.create(
+            user=self.user,
+            kind="other-service",
+            integration_id="x",
+            config={},
+            sensitive_config={},
+        )
+        mock_slack = MagicMock()
+        mock_slack_cls.return_value = mock_slack
+
+        blocked = block_posthog_code_task_if_no_personal_github_activity(
+            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+        )
+
+        assert blocked is True
+        mock_slack.client.chat_postMessage.assert_called_once()
+
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_another_users_github_integration_does_not_count(self, mock_slack_cls):
+        other_user = User.objects.create(email="bob@test.com")
+        UserIntegration.objects.create(
+            user=other_user,
+            kind="github",
+            integration_id="gh-2",
+            config={},
+            sensitive_config={"access_token": "tok"},
+        )
+        mock_slack = MagicMock()
+        mock_slack_cls.return_value = mock_slack
+
+        blocked = block_posthog_code_task_if_no_personal_github_activity(
+            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
+        )
+
+        assert blocked is True
+        mock_slack.client.chat_postMessage.assert_called_once()

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -62,6 +62,7 @@ class TestAITemporalModuleIntegrity:
             "classify_posthog_code_task_needs_repo_activity",
             "post_posthog_code_no_repos_activity",
             "post_posthog_code_repo_picker_activity",
+            "block_posthog_code_task_if_no_personal_github_activity",
             "create_posthog_code_task_for_repo_activity",
             "forward_posthog_code_followup_activity",
             "post_posthog_code_picker_timeout_activity",

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1238,12 +1238,12 @@ def posthog_code_event_handler(request: HttpRequest) -> HttpResponse:
         slack_config = SlackIntegration.slack_config()
         validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
-        logger.warning("posthog_code_event_invalid_request", error=str(e))
+        logger.warning("slack_event_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
 
     retry_num = request.headers.get("X-Slack-Retry-Num")
     if retry_num:
-        logger.info("posthog_code_event_retry", retry_num=retry_num)
+        logger.info("slack_event_retry", retry_num=retry_num)
         return HttpResponse(status=200)
 
     try:
@@ -1628,7 +1628,7 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
         slack_config = SlackIntegration.slack_config()
         validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
-        logger.warning("posthog_code_interactivity_invalid_request", error=str(e))
+        logger.warning("slack_interactivity_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
 
     try:

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -48,6 +48,7 @@ logger = structlog.get_logger(__name__)
 
 HANDLED_EVENT_TYPES = ["app_mention", "link_shared"]
 
+SLACK_INTEGRATION_KIND = "slack"
 POSTHOG_CODE_SLACK_AVAILABILITY_FLAG = "posthog-code-slack-availability"
 
 ROUTE_HANDLED_LOCALLY = "handled_locally"
@@ -776,7 +777,7 @@ def _replace_repo_picker_message_with_selection(
     try:
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
         slack = SlackIntegration(integration)
         text = f"Repository selected: `{selected_repo}`"
@@ -810,7 +811,7 @@ def _replace_repo_picker_message_with_no_repo(
     try:
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
         slack = SlackIntegration(integration)
         text = "Continuing without a repository."
@@ -1143,28 +1144,19 @@ def route_posthog_code_event_to_relevant_region(
     slack_team_id: str,
     event_id: str | None = None,
 ) -> str:
-    # One webhook endpoint serves both the notifications integration (kind="slack") and the
-    # coding-agent integration (kind="slack-posthog-code"). What counts as a "local match" has
-    # to depend on event type: app_mention needs the coding-agent integration specifically,
-    # while link_shared (unfurl) works with either kind. Without this, a region that has only a
-    # notifications install for a workspace would silently swallow mentions instead of
-    # proxying to the region that holds the coding-agent install.
-    integrations = list(
+    # The webhook serves the regular slack integration; app_mention activation is gated
+    # by the posthog-code-slack-availability feature flag rather than a separate kind.
+    local_match = (
         Integration.objects.filter(
-            kind__in=["slack", "slack-posthog-code"],
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         )
         .select_related("team", "team__organization", "created_by")
         .order_by("id")
+        .first()
     )
-    coding_agent_integration = next((i for i in integrations if i.kind == "slack-posthog-code"), None)
-    any_integration = integrations[0] if integrations else None
 
     event_type = event.get("type")
-    if event_type == "app_mention":
-        local_match = coding_agent_integration
-    else:
-        local_match = any_integration
 
     if local_match and not (settings.DEBUG and request.get_host() == SLACK_PRIMARY_REGION_DOMAIN):
         if event_type == "app_mention":
@@ -1380,7 +1372,7 @@ def _handle_repo_picker_options(payload: dict) -> JsonResponse:
         team_id = payload.get("team", {}).get("id")
         if team_id:
             fallback_integration = (
-                Integration.objects.filter(kind="slack-posthog-code", integration_id=team_id).order_by("id").first()
+                Integration.objects.filter(kind=SLACK_INTEGRATION_KIND, integration_id=team_id).order_by("id").first()
             )
             if fallback_integration:
                 hinted_integration_id = fallback_integration.id
@@ -1415,7 +1407,7 @@ def _handle_repo_picker_options(payload: dict) -> JsonResponse:
             raise Integration.DoesNotExist
         # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
         integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+            id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
     except Integration.DoesNotExist:
         logger.info("posthog_code_repo_picker_options_no_integration", context_token=context_token)
@@ -1494,7 +1486,7 @@ def _handle_repo_picker_submit(payload: dict) -> HttpResponse:
         try:
             # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
             integration = Integration.objects.get(
-                id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+                id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
             )
             SlackIntegration(integration).client.chat_postMessage(
                 channel=channel,
@@ -1666,19 +1658,19 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
     if slack_team_id and ctx_integration_id:
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=ctx_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind="slack-posthog-code",
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
     elif slack_team_id and hinted_integration_id and hinted_user_id and requesting_user == hinted_user_id:
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=hinted_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind="slack-posthog-code",
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
     elif slack_team_id and terminate_integration_id and (not terminate_user_id or requesting_user == terminate_user_id):
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
             id=terminate_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
-            kind="slack-posthog-code",
+            kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
 

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1162,7 +1162,7 @@ def route_posthog_code_event_to_relevant_region(
         if event_type == "app_mention":
             if not _posthog_code_enabled_for_integration(local_match):
                 logger.info(
-                    "posthog_code_event_flag_off",
+                    "slack_app_mention_flag_disabled",
                     slack_team_id=slack_team_id,
                     organization_id=str(local_match.team.organization_id),
                 )
@@ -1194,7 +1194,7 @@ def route_posthog_code_event_to_relevant_region(
         success = proxy_slack_event_to_secondary_region(request)
         return ROUTE_PROXIED if success else ROUTE_PROXY_FAILED
     else:
-        logger.warning("posthog_code_no_integration_found", slack_team_id=slack_team_id)
+        logger.warning("slack_app_integration_not_found", slack_team_id=slack_team_id)
         return ROUTE_NO_INTEGRATION
 
 
@@ -1235,8 +1235,8 @@ def posthog_code_event_handler(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=405)
 
     try:
-        posthog_code_config = SlackIntegration.posthog_code_slack_config()
-        validate_slack_request(request, posthog_code_config["SLACK_POSTHOG_CODE_SIGNING_SECRET"])
+        slack_config = SlackIntegration.slack_config()
+        validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
         logger.warning("posthog_code_event_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
@@ -1625,8 +1625,8 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=405)
 
     try:
-        posthog_code_config = SlackIntegration.posthog_code_slack_config()
-        validate_slack_request(request, posthog_code_config["SLACK_POSTHOG_CODE_SIGNING_SECRET"])
+        slack_config = SlackIntegration.slack_config()
+        validate_slack_request(request, slack_config["SLACK_APP_SIGNING_SECRET"])
     except SlackIntegrationError as e:
         logger.warning("posthog_code_interactivity_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -51,6 +51,21 @@ HANDLED_EVENT_TYPES = ["app_mention", "link_shared"]
 SLACK_INTEGRATION_KIND = "slack"
 POSTHOG_CODE_SLACK_AVAILABILITY_FLAG = "posthog-code-slack-availability"
 
+# Scopes the coding-agent flow exercises end-to-end. Slack stores the granted scope set
+# per install, so tenants who connected the Slack integration before the full scope set
+# was requested in prod (2026-05-04, #57177) must reconnect before mentions can work.
+POSTHOG_CODE_REQUIRED_SLACK_SCOPES: frozenset[str] = frozenset(
+    {
+        "app_mentions:read",
+        "users:read",
+        "users:read.email",
+        "chat:write",
+        "channels:history",
+        "groups:history",
+        "reactions:write",
+    }
+)
+
 ROUTE_HANDLED_LOCALLY = "handled_locally"
 ROUTE_PROXIED = "proxied"
 ROUTE_PROXY_FAILED = "proxy_failed"
@@ -1138,6 +1153,41 @@ def _posthog_code_enabled_for_integration(integration: Integration) -> bool:
         return False
 
 
+def _notify_missing_slack_scopes(
+    slack: SlackIntegration,
+    event: dict,
+    missing: frozenset[str],
+) -> None:
+    """Tell the user the install is missing scopes and how to fix it.
+
+    `chat:write` has been part of the base Slack scope set since the integration existed,
+    so the feedback post itself is safe to attempt even when other scopes are absent.
+    """
+    channel = event.get("channel", "")
+    thread_ts = event.get("thread_ts") or event.get("ts", "")
+    slack_user_id = event.get("user", "")
+    integration = slack.integration
+
+    logger.warning(
+        "posthog_code_slack_missing_scopes",
+        integration_id=integration.id,
+        team_id=integration.team_id,
+        missing=sorted(missing),
+    )
+
+    if not channel or not thread_ts or not slack_user_id:
+        return
+
+    settings_url = f"{settings.SITE_URL}/settings/project-integrations"
+    text = (
+        ":warning: PostHog can't reply because the Slack integration is missing required "
+        f"permissions: `{', '.join(sorted(missing))}`.\n"
+        f"A project admin needs to reconnect Slack from project settings: {settings_url}"
+    )
+
+    _post_slack_user_feedback(slack, channel, slack_user_id, thread_ts, text, prefer_thread_message=True)
+
+
 def route_posthog_code_event_to_relevant_region(
     request: HttpRequest,
     event: dict,
@@ -1166,6 +1216,11 @@ def route_posthog_code_event_to_relevant_region(
                     slack_team_id=slack_team_id,
                     organization_id=str(local_match.team.organization_id),
                 )
+                return ROUTE_HANDLED_LOCALLY
+            slack = SlackIntegration(local_match)
+            missing_scopes = slack.missing_scopes(POSTHOG_CODE_REQUIRED_SLACK_SCOPES)
+            if missing_scopes:
+                _notify_missing_slack_scopes(slack, event, missing_scopes)
                 return ROUTE_HANDLED_LOCALLY
             if _resolve_pending_repo_picker_from_followup(event, local_match):
                 return ROUTE_HANDLED_LOCALLY

--- a/products/slack_app/backend/tests/test_collect_thread_messages.py
+++ b/products/slack_app/backend/tests/test_collect_thread_messages.py
@@ -169,7 +169,7 @@ class TestCollectThreadMessages:
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
         self.integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -40,9 +40,7 @@ class TestSlackThreadTaskMapping(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         self.task = self.Task.objects.create(
             team=self.team,
             title="Test task",
@@ -138,9 +136,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com", distinct_id="user-1")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     @patch("posthog.models.integration.SlackIntegration")
@@ -295,9 +291,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         self.task = self.Task.objects.create(
             team=self.team,
             title="Test task",

--- a/products/slack_app/backend/tests/test_guess_repository.py
+++ b/products/slack_app/backend/tests/test_guess_repository.py
@@ -40,7 +40,7 @@ class TestGetFullRepoNames:
 
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )
@@ -163,7 +163,7 @@ class TestGetFullRepoNamesCache:
         self.team = Team.objects.create(organization=self.organization, name="Cache Team")
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_CACHE",
             sensitive_config={"access_token": "xoxb-cache"},
         )
@@ -206,7 +206,7 @@ class TestGetFullRepoNamesCache:
         team_b = Team.objects.create(organization=org_b, name="Other Team")
         slack_b = Integration.objects.create(
             team=team_b,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_OTHER",
             sensitive_config={"access_token": "xoxb-other"},
         )
@@ -323,7 +323,7 @@ class TestPostRepoPickerPrewarm:
         self.team = Team.objects.create(organization=self.organization, name="Prewarm Team")
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T_PREWARM",
             sensitive_config={"access_token": "xoxb-prewarm"},
         )
@@ -390,7 +390,7 @@ class TestSelectRepository:
 
         self.slack_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )
@@ -748,7 +748,7 @@ class TestHandleRulesCommandActivity:
 
         self.integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -34,22 +34,22 @@ class TestPostHogCodeEventHandler(TestCase):
             **extra_headers,
         )
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_url_verification(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         response = self._post_event({"type": "url_verification", "challenge": "test-challenge-123"})
         assert response.status_code == 200
         assert response.json() == {"challenge": "test-challenge-123"}
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_invalid_signature(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": "different-secret"}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": "different-secret"}
         response = self._post_event({"type": "url_verification", "challenge": "test"})
         assert response.status_code == 403
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_retry_returns_200(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         body = json.dumps({"type": "event_callback", "event": {"type": "app_mention"}}).encode()
         signature, ts = sign_slack_request(body, self.signing_secret)
         response = self.client.post(
@@ -73,7 +73,7 @@ class TestPostHogCodeEventHandler(TestCase):
         ]
     )
     @patch("products.slack_app.backend.api.route_posthog_code_event_to_relevant_region")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_event_callback_dispatch(
         self,
         _name,
@@ -84,7 +84,7 @@ class TestPostHogCodeEventHandler(TestCase):
         mock_config,
         mock_route,
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_route.return_value = route_result
         payload = {
             "type": "event_callback",
@@ -237,21 +237,6 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
                 assert pending_picker is None
         else:
             assert pending_picker is None
-
-    @patch("products.slack_app.backend.api._posthog_code_enabled_for_integration", return_value=False)
-    @patch("products.slack_app.backend.api.asyncio.run")
-    @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
-    def test_local_match_flag_off_skips_workflow(self, mock_sync_connect, mock_asyncio_run, _mock_flag):
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
-
-        from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
-
-        result = route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
-
-        assert result == ROUTE_HANDLED_LOCALLY
-        mock_sync_connect.assert_not_called()
-        mock_asyncio_run.assert_not_called()
 
     @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
     @override_settings(DEBUG=False)

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -101,6 +101,8 @@ class TestPostHogCodeEventHandler(TestCase):
 
 class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     def setUp(self):
+        from products.slack_app.backend.api import POSTHOG_CODE_REQUIRED_SLACK_SCOPES
+
         cache.clear()
         self.factory = RequestFactory()
         self.organization = Organization.objects.create(name="Test Org")
@@ -109,6 +111,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
             team=self.team,
             kind="slack",
             integration_id="T12345",
+            config={"scope": ",".join(sorted(POSTHOG_CODE_REQUIRED_SLACK_SCOPES))},
             sensitive_config={"access_token": "xoxb-posthog-code-test"},
         )
         self.event = {"type": "app_mention", "channel": "C001", "user": "U123", "ts": "1234.5678"}
@@ -179,6 +182,10 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     ):
         request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
         mock_get_repos.return_value = repo_list
+        # The route runs _missing_posthog_code_slack_scopes against a real SlackIntegration
+        # before the picker / workflow path. Since SlackIntegration is mocked wholesale here,
+        # explicitly say no scopes are missing so the gate passes through.
+        mock_slack_cls.return_value.missing_scopes.return_value = frozenset()
 
         from products.slack_app.backend.api import (
             ROUTE_HANDLED_LOCALLY,
@@ -295,3 +302,76 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         mock_sync_connect.assert_not_called()
         mock_asyncio_run.assert_not_called()
         mock_proxy.assert_not_called()
+
+    @parameterized.expand(
+        [
+            # Pre-2026-05-04 prod installs only granted the 4 base scopes.
+            ("four_base_scopes", "channels:read,groups:read,chat:write,chat:write.customize", False),
+            # Fail-closed when the scope field is absent entirely.
+            ("no_scope_field", None, False),
+            # Follow-up mentions in an existing thread must also be gated.
+            ("followup_with_partial_scopes", "channels:read,chat:write", True),
+        ]
+    )
+    @patch("products.slack_app.backend.api._post_slack_user_feedback")
+    @patch("products.slack_app.backend.api._posthog_code_enabled_for_integration", return_value=True)
+    @patch("products.slack_app.backend.api.asyncio.run")
+    @patch("products.slack_app.backend.api.sync_connect")
+    @override_settings(DEBUG=False)
+    def test_app_mention_with_missing_scopes_posts_reauth_and_skips_workflow(
+        self,
+        _name,
+        scope_value: str | None,
+        seed_pending_picker: bool,
+        mock_sync_connect,
+        mock_asyncio_run,
+        _mock_flag,
+        mock_post_feedback,
+    ):
+        if scope_value is None:
+            self.posthog_code_integration.config = {}
+        else:
+            self.posthog_code_integration.config["scope"] = scope_value
+        self.posthog_code_integration.save(update_fields=["config"])
+
+        from products.slack_app.backend.api import (
+            ROUTE_HANDLED_LOCALLY,
+            _set_pending_repo_picker,
+            route_posthog_code_event_to_relevant_region,
+        )
+
+        if seed_pending_picker:
+            _set_pending_repo_picker(
+                integration_id=self.posthog_code_integration.id,
+                channel="C001",
+                thread_ts="1234.5678",
+                slack_user_id="U123",
+                workflow_id="posthog-code-mention-T12345:pending",
+                context_token="ctx-1",
+                message_ts="1234.7777",
+            )
+
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
+        event = {
+            "type": "app_mention",
+            "channel": "C001",
+            "user": "U123",
+            "ts": "1234.5678",
+            "thread_ts": "1234.5678",
+        }
+
+        result = route_posthog_code_event_to_relevant_region(request, event, "T12345")
+
+        assert result == ROUTE_HANDLED_LOCALLY
+        mock_sync_connect.assert_not_called()
+        mock_sync_connect.return_value.get_workflow_handle.assert_not_called()
+        mock_asyncio_run.assert_not_called()
+        mock_post_feedback.assert_called_once()
+
+        feedback_text = mock_post_feedback.call_args.args[4]
+        assert "missing" in feedback_text.lower() and "reconnect" in feedback_text.lower()
+        # The message enumerates scopes that are actually missing (e.g. app_mentions:read is
+        # never in a pre-2026-05-04 install). Scopes the install already has must not appear.
+        assert "app_mentions:read" in feedback_text
+        if scope_value and "chat:write.customize" in scope_value:
+            assert "chat:write.customize" not in feedback_text

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -107,7 +107,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
         self.posthog_code_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-posthog-code-test"},
         )
@@ -267,83 +267,6 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         mock_unfurl.assert_called_once()
         passed_integration = mock_unfurl.call_args[0][1]
         assert passed_integration.id == self.posthog_code_integration.id
-
-    @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
-    @override_settings(DEBUG=False)
-    def test_link_shared_works_with_only_notifications_integration(self, mock_unfurl):
-        # Delete the coding-agent integration and create a notifications-only integration for same workspace
-        self.posthog_code_integration.delete()
-        Integration.objects.create(
-            team=self.team,
-            kind="slack",
-            integration_id="T12345",
-            sensitive_config={"access_token": "xoxb-notifications"},
-        )
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
-        link_shared_event = {"type": "link_shared", "channel": "C001", "links": []}
-
-        from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
-
-        result = route_posthog_code_event_to_relevant_region(request, link_shared_event, "T12345")
-
-        assert result == ROUTE_HANDLED_LOCALLY
-        mock_unfurl.assert_called_once()
-        # Don't assert on which integration row was passed: "first row by id" picking is a known
-        # limitation for multi-team workspaces and shouldn't be baked into the test contract.
-        passed_integration = mock_unfurl.call_args[0][1]
-        assert passed_integration.integration_id == "T12345"
-
-    @patch("products.slack_app.backend.api.asyncio.run")
-    @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.proxy_slack_event_to_secondary_region")
-    @patch("products.slack_app.backend.api.SLACK_PRIMARY_REGION_DOMAIN", "eu.posthog.com")
-    @override_settings(DEBUG=False)
-    def test_app_mention_in_primary_with_only_notifications_proxies_to_secondary(
-        self, mock_proxy, mock_sync_connect, mock_asyncio_run
-    ):
-        # Regression test: the coding-agent install may live in the other region. A notifications-only
-        # row in the primary region must NOT short-circuit the proxy path for app_mention.
-        self.posthog_code_integration.delete()
-        Integration.objects.create(
-            team=self.team,
-            kind="slack",
-            integration_id="T12345",
-            sensitive_config={"access_token": "xoxb-notifications"},
-        )
-        mock_proxy.return_value = True
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
-
-        from products.slack_app.backend.api import ROUTE_PROXIED, route_posthog_code_event_to_relevant_region
-
-        result = route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
-
-        assert result == ROUTE_PROXIED
-        mock_proxy.assert_called_once_with(request)
-        mock_sync_connect.assert_not_called()
-        mock_asyncio_run.assert_not_called()
-
-    @patch("products.slack_app.backend.api.asyncio.run")
-    @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
-    def test_app_mention_in_secondary_with_only_notifications_noop(self, mock_sync_connect, mock_asyncio_run):
-        # In the secondary region with only a notifications install, app_mention should
-        # report no_integration (no coding-agent install anywhere reachable from here).
-        self.posthog_code_integration.delete()
-        Integration.objects.create(
-            team=self.team,
-            kind="slack",
-            integration_id="T12345",
-            sensitive_config={"access_token": "xoxb-notifications"},
-        )
-        request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
-
-        from products.slack_app.backend.api import ROUTE_NO_INTEGRATION, route_posthog_code_event_to_relevant_region
-
-        result = route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
-
-        assert result == ROUTE_NO_INTEGRATION
-        mock_sync_connect.assert_not_called()
-        mock_asyncio_run.assert_not_called()
 
     @patch("products.slack_app.backend.api.proxy_slack_event_to_secondary_region")
     @patch("products.slack_app.backend.api.SLACK_PRIMARY_REGION_DOMAIN", "eu.posthog.com")

--- a/products/slack_app/backend/tests/test_posthog_code_interactivity.py
+++ b/products/slack_app/backend/tests/test_posthog_code_interactivity.py
@@ -60,7 +60,7 @@ class TestRepoPickerOptions(TestCase):
         OrganizationMembership.objects.create(user=self.user, organization=self.organization)
         self.posthog_code_integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-posthog-code-test"},
         )

--- a/products/slack_app/backend/tests/test_posthog_code_interactivity.py
+++ b/products/slack_app/backend/tests/test_posthog_code_interactivity.py
@@ -41,9 +41,9 @@ class TestPostHogCodeInteractivityHandler(TestCase):
         response = self.client.get("/slack/interactivity-callback/")
         assert response.status_code == 405
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_invalid_signature_returns_403(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": "different-secret"}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": "different-secret"}
         response = self._post_interactivity({"type": "block_suggestion"})
         assert response.status_code == 403
 
@@ -96,9 +96,9 @@ class TestRepoPickerOptions(TestCase):
         )
 
     @patch("products.slack_app.backend.api._get_full_repo_names")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_returns_filtered_repos(self, mock_config, mock_get_repos):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_get_repos.return_value = ["posthog/posthog", "posthog/posthog-js", "posthog/hogvm"]
 
         payload = {
@@ -115,9 +115,9 @@ class TestRepoPickerOptions(TestCase):
         assert options[0]["value"] == "posthog/posthog-js"
 
     @patch("products.slack_app.backend.api._get_full_repo_names")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_empty_query_returns_all(self, mock_config, mock_get_repos):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_get_repos.return_value = ["posthog/posthog", "posthog/posthog-js"]
 
         payload = {
@@ -131,9 +131,9 @@ class TestRepoPickerOptions(TestCase):
         assert response.status_code == 200
         assert len(response.json()["options"]) == 2
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_wrong_user_returns_empty(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
 
         payload = {
             "type": "block_suggestion",
@@ -146,9 +146,9 @@ class TestRepoPickerOptions(TestCase):
         assert response.status_code == 200
         assert response.json()["options"] == []
 
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_options_expired_token_returns_empty(self, mock_config):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         cache.delete(f"posthog_code_repo_picker_ctx:{self.context_token}")
 
         payload = {
@@ -165,11 +165,11 @@ class TestRepoPickerOptions(TestCase):
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_submit_signals_temporal_workflow(
         self, mock_config, mock_sync_connect, mock_asyncio_run, mock_webclient_class
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_webclient_class.return_value = MagicMock()
         self.context_payload["workflow_id"] = "posthog-code-mention-T12345:C001:1234.5678"
         cache.set(f"posthog_code_repo_picker_ctx:{self.context_token}", self.context_payload, timeout=900)
@@ -199,11 +199,11 @@ class TestRepoPickerOptions(TestCase):
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_no_repo_button_signals_temporal_workflow(
         self, mock_config, mock_sync_connect, mock_asyncio_run, mock_webclient_class
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_webclient_class.return_value = MagicMock()
         self.context_payload["workflow_id"] = "posthog-code-mention-T12345:C001:1234.5678"
         cache.set(f"posthog_code_repo_picker_ctx:{self.context_token}", self.context_payload, timeout=900)
@@ -233,9 +233,9 @@ class TestRepoPickerOptions(TestCase):
         assert "without a repository" in update_call["text"].lower()
 
     @patch("posthog.models.integration.WebClient")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_submit_without_workflow_id_posts_expired(self, mock_config, mock_webclient_class):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client
         self.context_payload.pop("workflow_id", None)
@@ -263,7 +263,7 @@ class TestRepoPickerOptions(TestCase):
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_submit_signal_failure_posts_expired(
         self,
         mock_config,
@@ -271,7 +271,7 @@ class TestRepoPickerOptions(TestCase):
         mock_asyncio_run,
         mock_webclient_class,
     ):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client
         self.context_payload["workflow_id"] = "posthog-code-mention-T12345:C001:1234.5678"
@@ -300,9 +300,9 @@ class TestRepoPickerOptions(TestCase):
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_terminate_action_starts_temporal_workflow(self, mock_config, mock_sync_connect, mock_asyncio_run):
-        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
 
         payload = {
             "type": "block_actions",

--- a/products/slack_app/backend/tests/test_resolve_slack_user.py
+++ b/products/slack_app/backend/tests/test_resolve_slack_user.py
@@ -23,7 +23,7 @@ class TestResolveSlackUser:
 
         self.integration = Integration.objects.create(
             team=self.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T12345",
             sensitive_config={"access_token": "xoxb-test"},
         )

--- a/products/slack_app/backend/tests/test_terminate.py
+++ b/products/slack_app/backend/tests/test_terminate.py
@@ -27,9 +27,7 @@ class TestProcessPostHogCodeTaskTermination(TestCase):
         self.org = Organization.objects.create(name="TestOrg")
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.user = User.objects.create(email="alice@test.com")
-        self.integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         self.task = self.Task.objects.create(
             team=self.team,
             title="Test task",

--- a/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
@@ -47,7 +47,7 @@ class TestForwardPendingUserMessage(TestCase):
         )
         cls.slack_integration = Integration.objects.create(
             team=cls.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T123",
             config={},
         )

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -50,7 +50,7 @@ class TestRelaySlackMessage(TestCase):
         )
         cls.integration = Integration.objects.create(
             team=cls.team,
-            kind="slack-posthog-code",
+            kind="slack",
             integration_id="T123",
             config={},
         )

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3004,9 +3004,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
         SlackThreadTaskMapping.objects.create(
             team=self.team,
@@ -3055,9 +3053,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
         SlackThreadTaskMapping.objects.create(
             team=self.team,
@@ -3185,9 +3181,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
         mock_execute_relay.return_value = "relay-1"
 
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         SlackThreadTaskMapping.objects.create(
             team=self.team,
             integration=integration,
@@ -3269,9 +3263,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
 
-        integration = Integration.objects.create(
-            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
-        )
+        integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
         SlackThreadTaskMapping.objects.create(
             team=self.team,
             integration=integration,


### PR DESCRIPTION
## Problem

When the Slack coding-agent opens a PR, attribution falls back to the PostHog app if the mentioning PostHog user has no personal `UserIntegration(kind="github")` connected — silently, with no signal to the user. They only notice once they spot a bot-authored PR.

A mention-time check is too early: a user can start a no-repo "analytics" task and then steer the agent toward cloning a repo and opening a PR, in which case a mention-time gate never fires.

Stacks on #59416.

## Changes

- Add `_post_user_github_warning_if_missing` inside `post_slack_update` (`products/tasks/backend/temporal/process_task/activities/post_slack_update.py`).
- Call it from both PR-opened code paths (sandbox-cleaned and regular), right after the PR-opened thread message and before `_mark_pr_opened_notified`. The existing one-shot `_is_pr_opened_notified` guard makes the warning fire **exactly once per PR**, regardless of how many times `post_slack_update` is invoked.
- Uses `SlackThreadHandler.post_thread_message` to share the thread context already loaded for the PR-opened message — no new Slack client wiring.

## How did you test this code?

- Locally end-to-end: opened a PR via the coding agent on a user without a personal GitHub `UserIntegration` and confirmed the warning posts in-thread right after the PR-opened message; confirmed silence when the user already has a personal GH connected; confirmed the warning only posts once even when `post_slack_update` is invoked multiple times for the same PR.
- `pytest products/tasks/backend/temporal/process_task/tests/test_post_slack_update.py products/tasks/backend/tests/test_api.py::TestTaskRunAPI -k 'set_output or pr_url'` — 8 tests pass (5 new + 3 existing set-output coverage).
- `ruff check` + `ruff format --check` clean.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7).