### PR TITLE
chore(error-tracking): regen api.zod.ts for grouping rules update body

### DIFF
--- a/products/error_tracking/frontend/generated/api.zod.ts
+++ b/products/error_tracking/frontend/generated/api.zod.ts
@@ -134,13 +134,33 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
         .describe('Optional human-readable description of what this grouping rule is for.'),
 })
 
-export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod
-    .record(zod.string(), zod.unknown())
-    .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
+export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
+    filters: zod
+        .union([
+            zod
+                .record(zod.string(), zod.unknown())
+                .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters.'
+        ),
+})
 
-export const ErrorTrackingGroupingRulesPartialUpdateBody = /* @__PURE__ */ zod
-    .record(zod.string(), zod.unknown())
-    .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
+export const ErrorTrackingGroupingRulesPartialUpdateBody = /* @__PURE__ */ zod.object({
+    filters: zod
+        .union([
+            zod
+                .record(zod.string(), zod.unknown())
+                .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Property-group filters that define which exceptions should be grouped into the same issue. Omit to preserve the existing filters.'
+        ),
+})
 
 export const errorTrackingGroupingRulesReorderPartialUpdateBodyOrderKeyMin = -2147483648
 export const errorTrackingGroupingRulesReorderPartialUpdateBodyOrderKeyMax = 2147483647


### PR DESCRIPTION
## Problem

When PR #58179 (`feat(mcp): enable error-tracking-grouping-rules-update tool`) was merged, it regenerated the OpenAPI schema and most of the downstream type artifacts, but one file in `products/error_tracking/frontend/generated/` was left stale: `api.zod.ts`.

The committed file still carried the previous opaque body shapes for the grouping-rules update endpoints:

```ts
export const ErrorTrackingGroupingRulesUpdateBody = zod.record(zod.string(), zod.unknown())
export const ErrorTrackingGroupingRulesPartialUpdateBody = zod.record(zod.string(), zod.unknown())
```

These are the placeholder shapes Orval emits when the request body is unknown, but the actual update serializer is now `ErrorTrackingGroupingRuleUpdateRequestSerializer` with an optional `filters` field — so the Zod schema doesn't match what the API will validate.

## Changes

Re-runs `hogli build:openapi` against current master and commits the corrected Zod schemas, which now match the request serializer:

```ts
export const ErrorTrackingGroupingRulesUpdateBody = zod.object({
    filters: zod.union([zod.record(...), zod.null()]).optional().describe(...),
})
```

Only `products/error_tracking/frontend/generated/api.zod.ts` is touched — everything else was already up to date.

## How did you test this code?

I'm an agent. Verification:

- Ran `hogli build:openapi` against master at `44fff20a`; only `api.zod.ts` reported drift.
- Re-ran after the commit and `git status` is clean — the regeneration is idempotent.
- No production code changed; this is purely a refresh of one generated artifact.

## Publish to changelog?

no

## 🤖 Agent context

Agent-authored (PostHog Code / Claude). Detected during a separate task that exercised the `hogli build:openapi` pipeline end-to-end on top of master; this one file came back dirty. Confirmed it traces back to PR #58179 not committing the regenerated `api.zod.ts`.