### PR TITLE
fix(admin): repair GroupTypeMapping admin for cross-DB routing

### DIFF
--- a/posthog/admin/admins/group_type_mapping_admin.py
+++ b/posthog/admin/admins/group_type_mapping_admin.py
@@ -14,6 +14,7 @@ class GroupTypeMappingAdmin(admin.ModelAdmin):
         "name_singular",
         "name_plural",
         "team_link",
+        "created_at",
     )
     search_fields = ("group_type", "name_singular", "name_plural")
     fields = (

--- a/posthog/admin/admins/group_type_mapping_admin.py
+++ b/posthog/admin/admins/group_type_mapping_admin.py
@@ -1,3 +1,5 @@
+import threading
+
 from django.contrib import admin
 from django.urls import NoReverseMatch, reverse
 from django.utils.html import format_html
@@ -36,6 +38,10 @@ class GroupTypeMappingAdmin(admin.ModelAdmin):
         "detail_dashboard_link",
     )
 
+    # ModelAdmin is a per-site singleton; under threaded WSGI we can't stash request-scoped
+    # state on `self` without one thread's cache leaking into another's row rendering.
+    _request_local = threading.local()
+
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
         if obj.project_id:
@@ -47,7 +53,7 @@ class GroupTypeMappingAdmin(admin.ModelAdmin):
         # live in the main DB, so Django can't JOIN across them. Prefetch the Team rows
         # for the current page from the main DB to avoid N+1 in team_link's list-view use.
         team_ids = list(qs.values_list("team_id", flat=True).distinct()[:1000])
-        self._team_cache = Team.objects.in_bulk(team_ids) if team_ids else {}
+        self._request_local.team_cache = Team.objects.in_bulk(team_ids) if team_ids else {}
         return qs
 
     @admin.display(description="Team")
@@ -55,7 +61,7 @@ class GroupTypeMappingAdmin(admin.ModelAdmin):
         team_id = group_type_mapping.team_id
         if not team_id:
             return "-"
-        team = getattr(self, "_team_cache", {}).get(team_id)
+        team = getattr(self._request_local, "team_cache", {}).get(team_id)
         if team is None:
             team = Team.objects.filter(pk=team_id).only("id", "name").first()
         if team is None:

--- a/posthog/admin/admins/group_type_mapping_admin.py
+++ b/posthog/admin/admins/group_type_mapping_admin.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.utils.html import format_html
 
-from posthog.models.group_type_mapping import GroupTypeMapping
+from posthog.models import Project, Team
+from posthog.models.group_type_mapping import GroupTypeMapping, invalidate_group_types_cache
 
 
 @admin.register(GroupTypeMapping)
@@ -14,14 +15,77 @@ class GroupTypeMappingAdmin(admin.ModelAdmin):
         "name_plural",
         "team_link",
     )
-    list_select_related = ("team", "team__organization")
-    search_fields = ("name_singular", "team__name", "team__organization__name")
-    readonly_fields = ("team", "project", "group_type", "group_type_index", "detail_dashboard")
+    search_fields = ("group_type", "name_singular", "name_plural")
+    fields = (
+        "team_link",
+        "project_link",
+        "group_type",
+        "group_type_index",
+        "name_singular",
+        "name_plural",
+        "default_columns",
+        "detail_dashboard_link",
+        "created_at",
+    )
+    readonly_fields = (
+        "team_link",
+        "project_link",
+        "group_type",
+        "group_type_index",
+        "detail_dashboard_link",
+    )
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if obj.project_id:
+            invalidate_group_types_cache(obj.project_id)
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        # `posthog_grouptypemapping` lives in the persons DB while Team/Project/Dashboard
+        # live in the main DB, so Django can't JOIN across them. Prefetch the Team rows
+        # for the current page from the main DB to avoid N+1 in team_link's list-view use.
+        team_ids = list(qs.values_list("team_id", flat=True).distinct()[:1000])
+        self._team_cache = Team.objects.in_bulk(team_ids) if team_ids else {}
+        return qs
 
     @admin.display(description="Team")
-    def team_link(self, group_type_mapping: GroupTypeMapping):
+    def team_link(self, group_type_mapping: GroupTypeMapping) -> str:
+        team_id = group_type_mapping.team_id
+        if not team_id:
+            return "-"
+        team = getattr(self, "_team_cache", {}).get(team_id)
+        if team is None:
+            team = Team.objects.filter(pk=team_id).only("id", "name").first()
+        if team is None:
+            return f"Team {team_id} (not found)"
         return format_html(
             '<a href="{}">{}</a>',
-            reverse("admin:posthog_team_change", args=[group_type_mapping.team.pk]),
-            group_type_mapping.team.name,
+            reverse("admin:posthog_team_change", args=[team.pk]),
+            team.name,
         )
+
+    @admin.display(description="Project")
+    def project_link(self, group_type_mapping: GroupTypeMapping) -> str:
+        project_id = group_type_mapping.project_id
+        if not project_id:
+            return "-"
+        project = Project.objects.filter(pk=project_id).only("id", "name").first()
+        if project is None:
+            return f"Project {project_id} (not found)"
+        return format_html(
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_project_change", args=[project.pk]),
+            project.name,
+        )
+
+    @admin.display(description="Detail dashboard")
+    def detail_dashboard_link(self, group_type_mapping: GroupTypeMapping) -> str:
+        dashboard_id = group_type_mapping.detail_dashboard_id
+        if not dashboard_id:
+            return "-"
+        try:
+            url = reverse("admin:dashboards_dashboard_change", args=[dashboard_id])
+        except NoReverseMatch:
+            return f"Dashboard {dashboard_id}"
+        return format_html('<a href="{}">Dashboard {}</a>', url, dashboard_id)


### PR DESCRIPTION
## Problem

`/admin/posthog/grouptypemapping/` throws `ProgrammingError: relation "posthog_team" does not exist` on both the list view and the change view, so support cannot inspect or edit group type mappings. The model was routed to the persons DB in #37130 (2025-08-25) but the admin still emits cross-database JOINs against `posthog_team`, `posthog_project`, and `dashboards_dashboard`, which Postgres rejects because those tables don't exist in the persons DB.

Context on how I came accross this:

This blocks back-dating `GroupTypeMapping.created_at` from the admin – needed to surface historically migrated events whose `timestamp` predates the wall-clock moment the mapping was lazily created during ingestion (`_setup_group_key_fields` in `posthog/hogql/database/database.py` silences `$group_N` for any event with `timestamp < mapping.created_at`).

Out of scope: the production `PostgresTable` routing in HogQL also doesn't know about the persons DB, so `system.group_type_mappings` and `system.groups` queries currently fail with `PostgreSQL table … does not exist` in production. Will look into a fix for this seperately.

## Changes

- Drop `list_select_related = ("team", "team__organization")` – the source of the JOIN on every list view render.
- Restrict `search_fields` to columns on `GroupTypeMapping` itself (`group_type`, `name_singular`, `name_plural`). Searching by `team__name` would also JOIN cross-DB.
- Replace the FK readonly fields (`team`, `project`, `detail_dashboard`) with explicit display methods. The previous setup hit the FK descriptor's connection inheritance: a `GroupTypeMapping` fetched from the persons DB carries `_state.db = 'persons_db_writer'`, and `obj.team` lazy-loads on that same connection, where `posthog_team` is absent. The new methods call `Team.objects.filter(...)` / `Project.objects.filter(...)` directly so the persons-DB router maps them back to the default DB.
- Prefetch Team rows in `get_queryset` so `team_link` doesn't N+1 across a paginated list.
- Expose `created_at` as an editable field (it was hidden before) – this is the field whose value gates the rewrite.
- Wire `invalidate_group_types_cache(project_id)` into `save_model` so the project-level cache for `get_group_types_for_project` flushes immediately on save; otherwise the HogQL rewrite keeps using the stale `created_at` for up to 5 minutes.

## How did you test this code?

- list view at `/admin/posthog/grouptypemapping/` loads without `ProgrammingError`
- change view at `/admin/posthog/grouptypemapping/<id>/change/` renders with team / project / dashboard shown as links and `created_at` shown as an editable date/time field

<img width="1335" height="735" alt="image" src="https://github.com/user-attachments/assets/a4f9c36b-0c35-4b9e-8ec0-5b277eb48581" />

<img width="1334" height="851" alt="image" src="https://github.com/user-attachments/assets/39e5cc93-6b8e-4db8-b52a-58bd86332dfd" />


No unit tests added – this is admin-only configuration with no business logic that's reasonable to test in isolation. The lint and format checks pass (`ruff check` / `ruff format --check`).

## Publish to changelog?

no

## Docs update

no.

## 🤖 Agent context

Authored with Claude Code. Started from a user question about why events with `$group_0` set weren't appearing under group analytics for a customer doing a Mixpanel-to-PostHog historical migration. Traced the failure to `_setup_group_key_fields` at `posthog/hogql/database/database.py:1520`, which rewrites the `events.$group_0` field to `if(event.timestamp < GroupTypeMapping.created_at, '', $group_0)`. Because the Node.js ingest path (`postgres-group-repository.ts:333`) writes `created_at = new Date()` (wall-clock) when lazily creating a mapping, every backfilled event ends up on the wrong side of that comparison.

Trying to back-date `created_at` from the admin surfaced this second, separate bug. The fix touches only the admin – it does not reconsider the rewrite itself or the ingestion-time `created_at` assignment (both candidates for follow-up).

Approach decisions: first attempt removed only `list_select_related`; the change view then failed independently on the FK readonly lazy-load. Settled on explicit display methods rather than overriding `change_view` because the explicit-query approach is local, easy to reason about, and keeps Django admin's standard form rendering intact.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
