### PR TITLE
feat(insights): promote builder-bug clickhouse errors to query_build_bug category

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -24,6 +24,33 @@ class QueryErrorCategory(StrEnum):
     USER_ERROR = "user_error"
     ERROR = "error"
     QUERY_PERFORMANCE_ERROR = "query_performance_error"
+    QUERY_BUILD_BUG = "query_build_bug"
+
+
+# ClickHouse codes that, when raised by a query containing no user-authored HogQL,
+# indicate the platform built bad SQL — not a user input problem. Drawn from the
+# Metabase triage card (dashboard 207, card 2074). When this set fires with
+# has_user_authored_hogql=False the category is promoted to QUERY_BUILD_BUG so
+# observability can alert on builder regressions separately from user-error noise.
+QUERY_BUILD_BUG_CODES: frozenset[int] = frozenset(
+    {
+        6,  # CANNOT_PARSE_TEXT
+        36,  # BAD_ARGUMENTS
+        42,  # NUMBER_OF_ARGUMENTS_DOESNT_MATCH
+        43,  # ILLEGAL_TYPE_OF_ARGUMENT
+        46,  # UNKNOWN_FUNCTION
+        47,  # UNKNOWN_IDENTIFIER
+        53,  # TYPE_MISMATCH
+        60,  # UNKNOWN_TABLE
+        72,  # CANNOT_PARSE_NUMBER
+        184,  # ILLEGAL_AGGREGATION
+        215,  # NOT_AN_AGGREGATE
+        376,  # CANNOT_PARSE_UUID
+        386,  # NO_COMMON_TYPE
+        427,  # CANNOT_COMPILE_REGEXP
+        467,  # CANNOT_PARSE_BOOL
+    }
+)
 
 
 class InternalCHQueryError(ServerException):
@@ -162,9 +189,17 @@ def look_up_clickhouse_error_code_meta(error: ServerException) -> ErrorCodeMeta:
     return CLICKHOUSE_ERROR_CODE_LOOKUP[code]
 
 
-def classify_query_error(e: Exception) -> QueryErrorCategory:
-    """Classify a query execution exception into a high-level category for observability."""
+def classify_query_error(e: Exception, *, has_user_authored_hogql: bool | None = None) -> QueryErrorCategory:
+    """Classify a query execution exception into a high-level category for observability.
+
+    When `has_user_authored_hogql` is explicitly False and the exception is a ClickHouse
+    server error in `QUERY_BUILD_BUG_CODES`, the category is promoted to QUERY_BUILD_BUG —
+    the platform built bad SQL from purely structured input. Callers without that
+    context (e.g. the logs alert classifier) leave it None and get today's behavior.
+    """
     if isinstance(e, ServerException):
+        if has_user_authored_hogql is False and getattr(e, "code", None) in QUERY_BUILD_BUG_CODES:
+            return QueryErrorCategory.QUERY_BUILD_BUG
         return look_up_clickhouse_error_code_meta(e).get_category()
 
     if isinstance(e, (ClickHouseAtCapacity, ConcurrencyLimitExceeded)):

--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -27,11 +27,7 @@ class QueryErrorCategory(StrEnum):
     QUERY_BUILD_BUG = "query_build_bug"
 
 
-# ClickHouse codes that, when raised by a query containing no user-authored HogQL,
-# indicate the platform built bad SQL — not a user input problem. Drawn from the
-# Metabase triage card (dashboard 207, card 2074). When this set fires with
-# has_user_authored_hogql=False the category is promoted to QUERY_BUILD_BUG so
-# observability can alert on builder regressions separately from user-error noise.
+# ClickHouse codes that imply the platform built bad SQL when no user HogQL is involved.
 QUERY_BUILD_BUG_CODES: frozenset[int] = frozenset(
     {
         6,  # CANNOT_PARSE_TEXT
@@ -192,13 +188,12 @@ def look_up_clickhouse_error_code_meta(error: ServerException) -> ErrorCodeMeta:
 def classify_query_error(e: Exception, *, has_user_authored_hogql: bool | None = None) -> QueryErrorCategory:
     """Classify a query execution exception into a high-level category for observability.
 
-    When `has_user_authored_hogql` is explicitly False and the exception is a ClickHouse
-    server error in `QUERY_BUILD_BUG_CODES`, the category is promoted to QUERY_BUILD_BUG —
-    the platform built bad SQL from purely structured input. Callers without that
-    context (e.g. the logs alert classifier) leave it None and get today's behavior.
+    Pass `has_user_authored_hogql=False` to promote builder-bug ClickHouse codes
+    (`QUERY_BUILD_BUG_CODES`) to `QUERY_BUILD_BUG`. Default `None` preserves today's
+    behavior.
     """
     if isinstance(e, ServerException):
-        if has_user_authored_hogql is False and getattr(e, "code", None) in QUERY_BUILD_BUG_CODES:
+        if has_user_authored_hogql is False and e.code in QUERY_BUILD_BUG_CODES:
             return QueryErrorCategory.QUERY_BUILD_BUG
         return look_up_clickhouse_error_code_meta(e).get_category()
 

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1605,7 +1605,8 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             self.modifiers.useMaterializedViews = True
 
         query_type = getattr(self.query, "kind", "Other")
-        has_user_authored_hogql = str(query_uses_user_authored_hogql(self.query)).lower()
+        has_user_authored_hogql = query_uses_user_authored_hogql(self.query)
+        has_user_authored_hogql_label = str(has_user_authored_hogql).lower()
         survey_query_metric_labels = get_survey_query_metric_labels(self.query)
         query_start = perf_counter()
         try:
@@ -1614,23 +1615,24 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 query_type=query_type,
                 category="success",
                 error_type="none",
-                has_user_authored_hogql=has_user_authored_hogql,
+                has_user_authored_hogql=has_user_authored_hogql_label,
             ).inc()
             if survey_query_metric_labels:
                 SURVEY_QUERY_EXECUTION_TOTAL.labels(
                     **survey_query_metric_labels, category="success", error_type="none"
                 ).inc()
         except Exception as e:
+            category = classify_query_error(e, has_user_authored_hogql=has_user_authored_hogql)
             QUERY_EXECUTION_TOTAL.labels(
                 query_type=query_type,
-                category=classify_query_error(e),
+                category=category,
                 error_type=clickhouse_error_type(e),
-                has_user_authored_hogql=has_user_authored_hogql,
+                has_user_authored_hogql=has_user_authored_hogql_label,
             ).inc()
             if survey_query_metric_labels:
                 SURVEY_QUERY_EXECUTION_TOTAL.labels(
                     **survey_query_metric_labels,
-                    category=classify_query_error(e),
+                    category=category,
                     error_type=clickhouse_error_type(e),
                 ).inc()
             raise

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -149,11 +149,11 @@ SURVEY_QUERY_EXECUTION_DURATION = Histogram(
 _GROUP_AGGREGATION_RE = re.compile(r"^\$group_\d+$")
 
 
-def query_uses_user_authored_hogql(query: Any) -> bool:
+def query_uses_user_authored_hogql(query: Any) -> bool | None:
     """Whether the query contains a user-authored HogQL expression — a HogQL property
-    filter, breakdown, funnel aggregation, or series math. A failure on a query built
-    purely from structured input (no user HogQL) is almost always a query-builder bug,
-    so this label lets observability separate those from user-written-HogQL failures."""
+    filter, breakdown, funnel aggregation, or series math. Returns None if the walk
+    fails so callers can distinguish "unknown" from a confident False (the
+    QUERY_BUILD_BUG promotion in classify_query_error only fires on explicit False)."""
 
     def _walk(obj: Any) -> bool:
         if isinstance(obj, dict):
@@ -178,10 +178,8 @@ def query_uses_user_authored_hogql(query: Any) -> bool:
     try:
         return _walk(query.model_dump())
     except Exception:
-        # query is always a pydantic BaseModel here, so model_dump() should not
-        # raise — log rather than silently mislabel a real bug in _walk as false.
         logger.warning("query_uses_user_authored_hogql failed", exc_info=True)
-        return False
+        return None
 
 
 EXTENDED_CACHE_AGE = timedelta(days=1)
@@ -1606,7 +1604,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
         query_type = getattr(self.query, "kind", "Other")
         has_user_authored_hogql = query_uses_user_authored_hogql(self.query)
-        has_user_authored_hogql_label = str(has_user_authored_hogql).lower()
+        has_user_authored_hogql_label = (
+            "unknown" if has_user_authored_hogql is None else str(has_user_authored_hogql).lower()
+        )
         survey_query_metric_labels = get_survey_query_metric_labels(self.query)
         query_start = perf_counter()
         try:
@@ -1623,17 +1623,18 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 ).inc()
         except Exception as e:
             category = classify_query_error(e, has_user_authored_hogql=has_user_authored_hogql)
+            error_type = clickhouse_error_type(e)
             QUERY_EXECUTION_TOTAL.labels(
                 query_type=query_type,
                 category=category,
-                error_type=clickhouse_error_type(e),
+                error_type=error_type,
                 has_user_authored_hogql=has_user_authored_hogql_label,
             ).inc()
             if survey_query_metric_labels:
                 SURVEY_QUERY_EXECUTION_TOTAL.labels(
                     **survey_query_metric_labels,
                     category=category,
-                    error_type=clickhouse_error_type(e),
+                    error_type=error_type,
                 ).inc()
             raise
         finally:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -121,7 +121,7 @@ logger = structlog.get_logger(__name__)
 QUERY_EXECUTION_TOTAL = Counter(
     "posthog_query_execution_total",
     "Query executions by category",
-    labelnames=["query_type", "category", "error_type"],
+    labelnames=["query_type", "category", "error_type", "has_user_authored_hogql"],
 )
 
 QUERY_EXECUTION_DURATION = Histogram(
@@ -143,6 +143,34 @@ SURVEY_QUERY_EXECUTION_DURATION = Histogram(
     labelnames=["query_type", "query_name"],
     buckets=[0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 7.5, 10.0, 15.0, 20.0, 30.0, 60.0, 120.0],
 )
+
+
+def query_uses_user_authored_hogql(query: Any) -> bool:
+    """Whether the query contains a user-authored HogQL expression — a HogQL property
+    filter, breakdown, funnel aggregation, or series math. A failure on a query built
+    purely from structured input (no user HogQL) is almost always a query-builder bug,
+    so this label lets observability separate those from user-written-HogQL failures."""
+
+    def _walk(obj: Any) -> bool:
+        if isinstance(obj, dict):
+            if obj.get("type") == "hogql" or obj.get("kind") == "HogQLQuery":
+                return True
+            if obj.get("breakdown_type") == "hogql":
+                return True
+            if obj.get("math") == "hogql" or obj.get("math_hogql"):
+                return True
+            if obj.get("funnelAggregateByHogQL") not in (None, "", "person_id"):
+                return True
+            return any(_walk(value) for value in obj.values())
+        if isinstance(obj, list):
+            return any(_walk(item) for item in obj)
+        return False
+
+    try:
+        return _walk(query.model_dump())
+    except Exception:
+        return False
+
 
 EXTENDED_CACHE_AGE = timedelta(days=1)
 
@@ -1565,11 +1593,17 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             self.modifiers.useMaterializedViews = True
 
         query_type = getattr(self.query, "kind", "Other")
+        has_user_authored_hogql = str(query_uses_user_authored_hogql(self.query)).lower()
         survey_query_metric_labels = get_survey_query_metric_labels(self.query)
         query_start = perf_counter()
         try:
             query_result, query_duration_ms = self._call_with_rate_limits(dashboard_id=dashboard_id)
-            QUERY_EXECUTION_TOTAL.labels(query_type=query_type, category="success", error_type="none").inc()
+            QUERY_EXECUTION_TOTAL.labels(
+                query_type=query_type,
+                category="success",
+                error_type="none",
+                has_user_authored_hogql=has_user_authored_hogql,
+            ).inc()
             if survey_query_metric_labels:
                 SURVEY_QUERY_EXECUTION_TOTAL.labels(
                     **survey_query_metric_labels, category="success", error_type="none"
@@ -1579,6 +1613,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 query_type=query_type,
                 category=classify_query_error(e),
                 error_type=clickhouse_error_type(e),
+                has_user_authored_hogql=has_user_authored_hogql,
             ).inc()
             if survey_query_metric_labels:
                 SURVEY_QUERY_EXECUTION_TOTAL.labels(

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
@@ -145,6 +146,9 @@ SURVEY_QUERY_EXECUTION_DURATION = Histogram(
 )
 
 
+_GROUP_AGGREGATION_RE = re.compile(r"^\$group_\d+$")
+
+
 def query_uses_user_authored_hogql(query: Any) -> bool:
     """Whether the query contains a user-authored HogQL expression — a HogQL property
     filter, breakdown, funnel aggregation, or series math. A failure on a query built
@@ -157,9 +161,14 @@ def query_uses_user_authored_hogql(query: Any) -> bool:
                 return True
             if obj.get("breakdown_type") == "hogql":
                 return True
-            if obj.get("math") == "hogql" or obj.get("math_hogql"):
+            # math_hogql is only meaningful alongside math == "hogql"; checking
+            # it standalone would false-positive on stale data where math changed.
+            if obj.get("math") == "hogql":
                 return True
-            if obj.get("funnelAggregateByHogQL") not in (None, "", "person_id"):
+            # funnelAggregateByHogQL holds a user-authored HogQL expression, except
+            # for the structured "person_id" / "$group_N" values picked from a dropdown.
+            funnel_agg = obj.get("funnelAggregateByHogQL")
+            if funnel_agg and funnel_agg != "person_id" and not _GROUP_AGGREGATION_RE.match(funnel_agg):
                 return True
             return any(_walk(value) for value in obj.values())
         if isinstance(obj, list):
@@ -169,6 +178,9 @@ def query_uses_user_authored_hogql(query: Any) -> bool:
     try:
         return _walk(query.model_dump())
     except Exception:
+        # query is always a pydantic BaseModel here, so model_dump() should not
+        # raise — log rather than silently mislabel a real bug in _walk as false.
+        logger.warning("query_uses_user_authored_hogql failed", exc_info=True)
         return False
 
 

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -568,6 +568,38 @@ class TestQueryRunner(BaseTest):
         assert completed_kwargs["properties"].outcome == expected_outcome
         assert completed_kwargs["extra_properties"]["error_category"] == expected_error_category
 
+    def test_query_execution_metric_promotes_query_build_bug_category(self):
+        from clickhouse_driver.errors import ServerException
+
+        from posthog.hogql_queries.query_runner import QUERY_EXECUTION_TOTAL
+
+        TestQueryRunner = self.setup_test_query_runner_class()
+
+        def calculate_raises(self):
+            raise ServerException("DB::Exception: synthetic UNKNOWN_IDENTIFIER", code=47)
+
+        TestQueryRunner.calculate = calculate_raises
+        runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
+
+        before = QUERY_EXECUTION_TOTAL.labels(
+            query_type="TestQuery",
+            category="query_build_bug",
+            error_type="CHQueryErrorUnknownIdentifier",
+            has_user_authored_hogql="false",
+        )._value.get()
+
+        with pytest.raises(ServerException):
+            runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+
+        after = QUERY_EXECUTION_TOTAL.labels(
+            query_type="TestQuery",
+            category="query_build_bug",
+            error_type="CHQueryErrorUnknownIdentifier",
+            has_user_authored_hogql="false",
+        )._value.get()
+
+        assert after - before == 1
+
     def test_query_execution_metrics_not_recorded_on_cache_hit(self):
         from posthog.hogql_queries.query_runner import QUERY_EXECUTION_DURATION, QUERY_EXECUTION_TOTAL
 

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from django.core.cache import cache
 
+from clickhouse_driver.errors import ServerException
 from parameterized import parameterized
 from pydantic import BaseModel
 from rest_framework.exceptions import ValidationError
@@ -46,6 +47,7 @@ from posthog.hogql.constants import LimitContext
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.hogql_queries.query_runner import (
+    QUERY_EXECUTION_TOTAL,
     ExecutionMode,
     QueryRunner,
     get_query_runner,
@@ -569,10 +571,6 @@ class TestQueryRunner(BaseTest):
         assert completed_kwargs["extra_properties"]["error_category"] == expected_error_category
 
     def test_query_execution_metric_promotes_query_build_bug_category(self):
-        from clickhouse_driver.errors import ServerException
-
-        from posthog.hogql_queries.query_runner import QUERY_EXECUTION_TOTAL
-
         TestQueryRunner = self.setup_test_query_runner_class()
 
         def calculate_raises(self):
@@ -581,23 +579,18 @@ class TestQueryRunner(BaseTest):
         TestQueryRunner.calculate = calculate_raises
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
 
-        before = QUERY_EXECUTION_TOTAL.labels(
-            query_type="TestQuery",
-            category="query_build_bug",
-            error_type="CHQueryErrorUnknownIdentifier",
-            has_user_authored_hogql="false",
-        )._value.get()
+        labels = {
+            "query_type": "TestQuery",
+            "category": "query_build_bug",
+            "error_type": "CHQueryErrorUnknownIdentifier",
+            "has_user_authored_hogql": "false",
+        }
+        before = QUERY_EXECUTION_TOTAL.labels(**labels)._value.get()
 
         with pytest.raises(ServerException):
             runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
 
-        after = QUERY_EXECUTION_TOTAL.labels(
-            query_type="TestQuery",
-            category="query_build_bug",
-            error_type="CHQueryErrorUnknownIdentifier",
-            has_user_authored_hogql="false",
-        )._value.get()
-
+        after = QUERY_EXECUTION_TOTAL.labels(**labels)._value.get()
         assert after - before == 1
 
     def test_query_execution_metrics_not_recorded_on_cache_hit(self):

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -15,11 +15,15 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
     BounceRatePageViewMode,
+    BreakdownFilter,
     CacheMissResponse,
     CurrencyCode,
     DataTableNode,
     DataVisualizationNode,
     EventsNode,
+    FunnelsFilter,
+    FunnelsQuery,
+    HogQLPropertyFilter,
     HogQLQuery,
     HogQLQueryModifiers,
     InCohortVia,
@@ -45,6 +49,7 @@ from posthog.hogql_queries.query_runner import (
     ExecutionMode,
     QueryRunner,
     get_query_runner,
+    query_uses_user_authored_hogql,
     shared_insights_execution_mode,
 )
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -501,10 +506,10 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
 
         before_success = QUERY_EXECUTION_TOTAL.labels(
-            query_type="TestQuery", category="success", error_type="none"
+            query_type="TestQuery", category="success", error_type="none", has_user_authored_hogql="false"
         )._value.get()
         before_failure = QUERY_EXECUTION_TOTAL.labels(
-            query_type="TestQuery", category="error", error_type="ValueError"
+            query_type="TestQuery", category="error", error_type="ValueError", has_user_authored_hogql="false"
         )._value.get()
         before_duration_sum = QUERY_EXECUTION_DURATION.labels(query_type="TestQuery")._sum.get()
 
@@ -515,12 +520,16 @@ class TestQueryRunner(BaseTest):
             runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
 
         assert (
-            QUERY_EXECUTION_TOTAL.labels(query_type="TestQuery", category="success", error_type="none")._value.get()
+            QUERY_EXECUTION_TOTAL.labels(
+                query_type="TestQuery", category="success", error_type="none", has_user_authored_hogql="false"
+            )._value.get()
             - before_success
             == success_delta
         )
         assert (
-            QUERY_EXECUTION_TOTAL.labels(query_type="TestQuery", category="error", error_type="ValueError")._value.get()
+            QUERY_EXECUTION_TOTAL.labels(
+                query_type="TestQuery", category="error", error_type="ValueError", has_user_authored_hogql="false"
+            )._value.get()
             - before_failure
             == failure_delta
         )
@@ -569,10 +578,10 @@ class TestQueryRunner(BaseTest):
             runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
 
         before_success = QUERY_EXECUTION_TOTAL.labels(
-            query_type="TestQuery", category="success", error_type="none"
+            query_type="TestQuery", category="success", error_type="none", has_user_authored_hogql="false"
         )._value.get()
         before_failure = QUERY_EXECUTION_TOTAL.labels(
-            query_type="TestQuery", category="error", error_type="ValueError"
+            query_type="TestQuery", category="error", error_type="ValueError", has_user_authored_hogql="false"
         )._value.get()
         before_duration_sum = QUERY_EXECUTION_DURATION.labels(query_type="TestQuery")._sum.get()
 
@@ -581,11 +590,15 @@ class TestQueryRunner(BaseTest):
             runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
 
         assert (
-            QUERY_EXECUTION_TOTAL.labels(query_type="TestQuery", category="success", error_type="none")._value.get()
+            QUERY_EXECUTION_TOTAL.labels(
+                query_type="TestQuery", category="success", error_type="none", has_user_authored_hogql="false"
+            )._value.get()
             == before_success
         )
         assert (
-            QUERY_EXECUTION_TOTAL.labels(query_type="TestQuery", category="error", error_type="ValueError")._value.get()
+            QUERY_EXECUTION_TOTAL.labels(
+                query_type="TestQuery", category="error", error_type="ValueError", has_user_authored_hogql="false"
+            )._value.get()
             == before_failure
         )
         assert QUERY_EXECUTION_DURATION.labels(query_type="TestQuery")._sum.get() == before_duration_sum
@@ -1138,3 +1151,37 @@ class TestSharedInsightsExecutionMode(BaseTest):
         last_refresh = None if last_refresh_offset is None else datetime.now(UTC) - last_refresh_offset
         result = shared_insights_execution_mode(execution_mode, last_refresh=last_refresh)
         self.assertEqual(result, expected_mode)
+
+
+class TestQueryUsesUserAuthoredHogQL(BaseTest):
+    @parameterized.expand(
+        [
+            ("plain_trends", TrendsQuery(series=[EventsNode(event="$pageview")]), False),
+            (
+                "hogql_property_filter",
+                TrendsQuery(
+                    series=[EventsNode(event="$pageview", properties=[HogQLPropertyFilter(type="hogql", key="1 = 1")])]
+                ),
+                True,
+            ),
+            (
+                "hogql_breakdown",
+                TrendsQuery(
+                    series=[EventsNode(event="$pageview")],
+                    breakdownFilter=BreakdownFilter(breakdown_type="hogql", breakdown="properties.x"),
+                ),
+                True,
+            ),
+            ("hogql_query", HogQLQuery(query="select 1"), True),
+            (
+                "funnel_hogql_aggregation",
+                FunnelsQuery(
+                    series=[EventsNode(event="a"), EventsNode(event="b")],
+                    funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="properties.x"),
+                ),
+                True,
+            ),
+        ]
+    )
+    def test_detects_user_authored_hogql(self, _name: str, query: Any, expected: bool) -> None:
+        assert query_uses_user_authored_hogql(query) is expected

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -1174,12 +1174,33 @@ class TestQueryUsesUserAuthoredHogQL(BaseTest):
             ),
             ("hogql_query", HogQLQuery(query="select 1"), True),
             (
+                "hogql_series_math",
+                TrendsQuery(series=[EventsNode(event="$pageview", math="hogql", math_hogql="properties.revenue")]),
+                True,
+            ),
+            (
                 "funnel_hogql_aggregation",
                 FunnelsQuery(
                     series=[EventsNode(event="a"), EventsNode(event="b")],
                     funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="properties.x"),
                 ),
                 True,
+            ),
+            (
+                "funnel_group_aggregation_is_structured",
+                FunnelsQuery(
+                    series=[EventsNode(event="a"), EventsNode(event="b")],
+                    funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="$group_0"),
+                ),
+                False,
+            ),
+            (
+                "funnel_person_id_aggregation_is_structured",
+                FunnelsQuery(
+                    series=[EventsNode(event="a"), EventsNode(event="b")],
+                    funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="person_id"),
+                ),
+                False,
             ),
         ]
     )

--- a/posthog/test/test_errors.py
+++ b/posthog/test/test_errors.py
@@ -1,0 +1,47 @@
+import pytest
+
+from clickhouse_driver.errors import ServerException
+from parameterized import parameterized
+
+from posthog.errors import QUERY_BUILD_BUG_CODES, QueryErrorCategory, classify_query_error
+
+
+def _server_exception(code: int) -> ServerException:
+    return ServerException("DB::Exception: synthetic", code=code)
+
+
+class TestClassifyQueryError:
+    @parameterized.expand([(code,) for code in sorted(QUERY_BUILD_BUG_CODES)])
+    def test_build_bug_code_promoted_when_no_user_hogql(self, code: int) -> None:
+        category = classify_query_error(_server_exception(code), has_user_authored_hogql=False)
+        assert category == QueryErrorCategory.QUERY_BUILD_BUG
+
+    @parameterized.expand([(code,) for code in sorted(QUERY_BUILD_BUG_CODES)])
+    def test_build_bug_code_not_promoted_when_user_hogql(self, code: int) -> None:
+        category = classify_query_error(_server_exception(code), has_user_authored_hogql=True)
+        assert category != QueryErrorCategory.QUERY_BUILD_BUG
+
+    @parameterized.expand([(code,) for code in sorted(QUERY_BUILD_BUG_CODES)])
+    def test_build_bug_code_not_promoted_when_context_missing(self, code: int) -> None:
+        category = classify_query_error(_server_exception(code))
+        assert category != QueryErrorCategory.QUERY_BUILD_BUG
+
+    @parameterized.expand(
+        [
+            (159, QueryErrorCategory.QUERY_PERFORMANCE_ERROR),
+            (241, QueryErrorCategory.QUERY_PERFORMANCE_ERROR),
+            (202, QueryErrorCategory.RATE_LIMITED),
+            (394, QueryErrorCategory.CANCELLED),
+        ]
+    )
+    def test_non_build_bug_codes_unchanged_with_has_user_authored_hogql_false(
+        self, code: int, expected: QueryErrorCategory
+    ) -> None:
+        assert classify_query_error(_server_exception(code), has_user_authored_hogql=False) == expected
+
+    def test_non_server_exception_unaffected(self) -> None:
+        assert classify_query_error(ValueError("boom"), has_user_authored_hogql=False) == QueryErrorCategory.ERROR
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/posthog/test/test_errors.py
+++ b/posthog/test/test_errors.py
@@ -1,5 +1,3 @@
-import pytest
-
 from clickhouse_driver.errors import ServerException
 from parameterized import parameterized
 
@@ -28,10 +26,11 @@ class TestClassifyQueryError:
 
     @parameterized.expand(
         [
-            (159, QueryErrorCategory.QUERY_PERFORMANCE_ERROR),
-            (241, QueryErrorCategory.QUERY_PERFORMANCE_ERROR),
-            (202, QueryErrorCategory.RATE_LIMITED),
-            (394, QueryErrorCategory.CANCELLED),
+            (62, QueryErrorCategory.USER_ERROR),  # SYNTAX_ERROR — USER_ERROR not in build-bug set, must stay USER_ERROR
+            (159, QueryErrorCategory.QUERY_PERFORMANCE_ERROR),  # TIMEOUT_EXCEEDED
+            (241, QueryErrorCategory.QUERY_PERFORMANCE_ERROR),  # MEMORY_LIMIT_EXCEEDED
+            (202, QueryErrorCategory.RATE_LIMITED),  # TOO_MANY_SIMULTANEOUS_QUERIES
+            (394, QueryErrorCategory.CANCELLED),  # QUERY_WAS_CANCELLED
         ]
     )
     def test_non_build_bug_codes_unchanged_with_has_user_authored_hogql_false(
@@ -41,7 +40,3 @@ class TestClassifyQueryError:
 
     def test_non_server_exception_unaffected(self) -> None:
         assert classify_query_error(ValueError("boom"), has_user_authored_hogql=False) == QueryErrorCategory.ERROR
-
-
-if __name__ == "__main__":
-    pytest.main([__file__])


### PR DESCRIPTION
## Problem

`posthog_query_execution_total{category="user_error"}` lumps together two very different failure modes: (a) the user wrote bad input (a bad regex, a HogQL property filter that doesn't type-check), and (b) the platform's query builder generated invalid SQL from purely structured input. Existing alert rules fire on `category="error"` (the residual bucket), so case (b) is silent — the recent retention incident (every team on the new analyzer hitting code 47 UNKNOWN_IDENTIFIER) didn't page anyone. The [Metabase triage dashboard](https://metabase.prod-us.posthog.dev/dashboard/207) already separates these via a curated list of 15 ClickHouse codes; this PR lifts that taxonomy into the Prometheus metric so alerts can target builder bugs directly.

## Changes

- New `QueryErrorCategory.QUERY_BUILD_BUG` and `QUERY_BUILD_BUG_CODES` frozenset in `posthog/errors.py` (15 codes: 6, 36, 42, 43, 46, 47, 53, 60, 72, 184, 215, 376, 386, 427, 467).
- `classify_query_error(e, *, has_user_authored_hogql=None)` — promotes a `ServerException` to `QUERY_BUILD_BUG` only when the caller explicitly passes `False` and the code is in the set. Default `None` keeps every existing caller (logs alert classifier, SLO path) on today's behavior.
- `_execute_and_cache_blocking` in `query_runner.py` passes `has_user_authored_hogql` into `classify_query_error` so the new category surfaces on the `posthog_query_execution_total` counter. SLO emission is untouched.
- Parameterized classifier tests in `posthog/test/test_errors.py`; one new emission test in `test_query_runner.py`.

## How did you test this code?

I'm an agent. Automated tests run locally:
- New `posthog/test/test_errors.py` — 51 cases covering promotion, non-promotion when `has_user_authored_hogql` is True or omitted, and that non-build-bug codes keep their existing category.
- `test_query_runner.py::TestQueryRunner` — 11 metric/SLO tests pass (including a new one asserting `category=query_build_bug` increments for `ServerException(code=47)` on a structured query).

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Stacks on #58715 (which adds the `has_user_authored_hogql` Prometheus label and the `query_uses_user_authored_hogql` helper this PR reuses).

Considered options for tagging:
- A: leave categories alone and key the alert on `category="user_error" AND has_user_authored_hogql="false"` — what charts#11095 does today. Rejected as the next step but acceptable as-is — keeps `user_error` a mixed bag for everyone reading Prometheus.
- B (this PR): promote to a first-class `query_build_bug` category. Aligns Prometheus with the Metabase taxonomy and makes alerts/dashboards target the builder-bug bucket without a label join.
- C: derive `query_build_bug` via a recording rule. Two ways to express the same thing — rejected.

Initially also wired the new category into `_classify_error_for_slo` (treating it as SLO FAILURE since it's a platform bug). Reverted — the SLO emission belongs to a different team and shifting their burn rate isn't this PR's call. SLO behavior is unchanged; only the Prometheus counter sees the new label.

Excluded 499 (S3_ERROR) and 754 (UDF_EXECUTION_FAILED) from the build-bug set even though they appear in the Metabase card — they're infra/runtime issues rather than SQL-build issues.

Follow-up not in this PR: simplify [charts#11095](https://github.com/PostHog/charts/pull/11095) to fire on `category="query_build_bug"` directly after this ships.

Agent-authored; requires human review.