### PR TITLE
chore(insights): colour code breakdown values automatically and naively

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardBreakdownColors.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardBreakdownColors.test.ts
@@ -1,0 +1,58 @@
+import { dataColorVars } from 'lib/colors'
+
+import { autoAssignBreakdownColors, BreakdownValueAndType } from './dashboardBreakdownColors'
+
+describe('autoAssignBreakdownColors', () => {
+    const valuesFromNames = (names: string[]): BreakdownValueAndType[] =>
+        names.map((breakdownValue) => ({ breakdownValue, breakdownType: 'event' }))
+
+    it('is deterministic for the same input', () => {
+        const values = valuesFromNames(['Alibaba', 'Google', 'Amazon', 'Meta'])
+        const first = autoAssignBreakdownColors(values)
+        const second = autoAssignBreakdownColors(values)
+        expect(first).toEqual(second)
+    })
+
+    it('produces no collisions when value count <= palette size', () => {
+        const names = Array.from({ length: dataColorVars.length }, (_, i) => `value-${i}`)
+        const out = autoAssignBreakdownColors(valuesFromNames(names))
+        const tokens = out.map((c) => c.colorToken)
+        expect(new Set(tokens).size).toBe(tokens.length)
+        expect(tokens).toHaveLength(dataColorVars.length)
+    })
+
+    it('does not shift existing assignments when a lexically-later value is appended', () => {
+        // extractBreakdownValues feeds us deterministically-sorted input,
+        // so appending a value that sorts AFTER all existing ones must not
+        // change colors for the existing values.
+        const initial = valuesFromNames(['Alibaba', 'Amazon', 'Google', 'Meta'])
+        const extended = [...initial, { breakdownValue: 'Stripe', breakdownType: 'event' as const }]
+
+        const initialOut = autoAssignBreakdownColors(initial)
+        const extendedOut = autoAssignBreakdownColors(extended)
+
+        for (let i = 0; i < initial.length; i++) {
+            expect(extendedOut[i].breakdownValue).toBe(initialOut[i].breakdownValue)
+            expect(extendedOut[i].colorToken).toBe(initialOut[i].colorToken)
+        }
+    })
+
+    it('skips null/undefined breakdown values', () => {
+        const values: BreakdownValueAndType[] = [
+            { breakdownValue: 'Alibaba', breakdownType: 'event' },
+            { breakdownValue: null as any, breakdownType: 'event' },
+            { breakdownValue: 'Google', breakdownType: 'event' },
+        ]
+        const out = autoAssignBreakdownColors(values)
+        expect(out).toHaveLength(2)
+        expect(out.map((c) => c.breakdownValue)).toEqual(['Alibaba', 'Google'])
+    })
+
+    it('still assigns all values when count exceeds palette size (allows reuse)', () => {
+        const names = Array.from({ length: dataColorVars.length + 5 }, (_, i) => `value-${i}`)
+        const out = autoAssignBreakdownColors(valuesFromNames(names))
+        expect(out).toHaveLength(dataColorVars.length + 5)
+        // every assignment is a valid preset
+        out.forEach((c) => expect(c.colorToken).toMatch(/^preset-\d+$/))
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboardBreakdownColors.ts
+++ b/frontend/src/scenes/dashboard/dashboardBreakdownColors.ts
@@ -1,0 +1,131 @@
+import { DataColorToken, dataColorVars } from 'lib/colors'
+import { getFunnelDatasetKey, getTrendDatasetKey, sortCohorts } from 'scenes/insights/utils'
+
+import { isFunnelsQuery, isInsightVizNode, isTrendsQuery } from '~/queries/utils'
+import { CohortType, DashboardTile, FunnelVizType, QueryBasedInsightModel } from '~/types'
+
+import { BreakdownColorConfig } from './DashboardInsightColorsModal'
+
+export type BreakdownValueAndType = Omit<BreakdownColorConfig, 'colorToken'>
+
+export function extractBreakdownValues(
+    insightTiles: DashboardTile<QueryBasedInsightModel>[] | null,
+    cohorts: CohortType[] | null
+): BreakdownValueAndType[] {
+    if (insightTiles == null) {
+        return []
+    }
+
+    return insightTiles
+        .flatMap((tile) => {
+            if (isInsightVizNode(tile.insight?.query)) {
+                const querySource = tile.insight?.query.source
+                if (
+                    isFunnelsQuery(querySource) &&
+                    (querySource.funnelsFilter?.funnelVizType === undefined ||
+                        querySource.funnelsFilter?.funnelVizType === FunnelVizType.Steps)
+                ) {
+                    const breakdownType = querySource.breakdownFilter?.breakdown_type || 'event'
+                    const breakdownValues: BreakdownValueAndType[] = [
+                        {
+                            breakdownValue: 'Baseline',
+                            breakdownType,
+                        },
+                    ]
+                    tile.insight?.result?.forEach((result: any) => {
+                        const key = getFunnelDatasetKey(result)
+                        const keyParts = JSON.parse(key)
+                        const breakdownValue = keyParts['breakdown_value']
+                        breakdownValues.push({
+                            breakdownValue: Array.isArray(breakdownValue) ? breakdownValue.join('::') : breakdownValue,
+                            breakdownType,
+                        })
+                    })
+                    return breakdownValues
+                } else if (isTrendsQuery(querySource)) {
+                    const breakdownType = querySource.breakdownFilter?.breakdown_type || 'event'
+                    return tile.insight?.result?.map((result: any) => {
+                        const key = getTrendDatasetKey(result)
+                        const keyParts = JSON.parse(key)
+                        const breakdownValue = keyParts['breakdown_value']
+                        return {
+                            breakdownValue: Array.isArray(breakdownValue) ? breakdownValue.join('::') : breakdownValue,
+                            breakdownType,
+                        }
+                    })
+                }
+                return []
+            }
+            return []
+        })
+        .filter((value) => value != null)
+        .reduce<BreakdownValueAndType[]>((acc, curr) => {
+            if (!acc.some((x) => x.breakdownValue === curr.breakdownValue && x.breakdownType === curr.breakdownType)) {
+                acc.push(curr)
+            }
+            return acc
+        }, [])
+        .sort((a, b) => {
+            if (a.breakdownType === 'cohort' && b.breakdownType === 'cohort') {
+                return sortCohorts(a.breakdownValue, b.breakdownValue, cohorts)
+            }
+
+            // put cohorts at the end
+            if (a.breakdownType === 'cohort' || b.breakdownType === 'cohort') {
+                return a.breakdownType === 'cohort' ? 1 : -1
+            }
+
+            return String(a.breakdownValue).localeCompare(String(b.breakdownValue))
+        })
+}
+
+/**
+ * FNV-1a 32-bit hash. Deterministic, good distribution for short strings.
+ * Used to pick a stable palette slot for a breakdown value so the same value
+ * gets the same color across charts on a dashboard.
+ */
+function fnv1aHash(input: string): number {
+    let hash = 0x811c9dc5
+    for (let i = 0; i < input.length; i++) {
+        hash ^= input.charCodeAt(i)
+        hash = Math.imul(hash, 0x01000193)
+    }
+    return hash >>> 0
+}
+
+/**
+ * Assign palette slots to breakdown values via hash with collision-avoidance.
+ *
+ * - Hash maps each value to a preferred palette slot.
+ * - On collision, walks forward to the next free slot (modular).
+ * - When the palette is exhausted, allows re-use (still deterministic in input order).
+ *
+ * Inputs are expected to be deterministically sorted (extractBreakdownValues already is)
+ * so assignments don't shift when new values are appended lexically-later.
+ */
+export function autoAssignBreakdownColors(
+    values: BreakdownValueAndType[],
+    paletteSize: number = dataColorVars.length
+): BreakdownColorConfig[] {
+    const used = new Set<number>()
+    const out: BreakdownColorConfig[] = []
+
+    for (const v of values) {
+        if (v.breakdownValue == null) {
+            continue
+        }
+        const key = String(v.breakdownValue)
+        const preferred = fnv1aHash(key) % paletteSize
+        let slot = preferred
+        for (let probe = 0; probe < paletteSize && used.has(slot); probe++) {
+            slot = (slot + 1) % paletteSize
+        }
+        used.add(slot)
+        out.push({
+            breakdownValue: v.breakdownValue,
+            breakdownType: v.breakdownType,
+            colorToken: `preset-${slot + 1}` as DataColorToken,
+        })
+    }
+    return out
+}

--- a/frontend/src/scenes/dashboard/dashboardInsightColorsModalLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardInsightColorsModalLogic.ts
@@ -1,87 +1,15 @@
 import { actions, connect, kea, path, reducers, selectors } from 'kea'
 
-import { getFunnelDatasetKey, getTrendDatasetKey, sortCohorts } from 'scenes/insights/utils'
-
 import { cohortsModel } from '~/models/cohortsModel'
-import { isFunnelsQuery, isInsightVizNode, isTrendsQuery } from '~/queries/utils'
-import { CohortType, DashboardTile, FunnelVizType, QueryBasedInsightModel } from '~/types'
+import { DashboardTile, QueryBasedInsightModel } from '~/types'
 
-import { BreakdownColorConfig } from './DashboardInsightColorsModal'
+import { BreakdownValueAndType, extractBreakdownValues } from './dashboardBreakdownColors'
 import type { dashboardInsightColorsModalLogicType } from './dashboardInsightColorsModalLogicType'
 import { dashboardLogic } from './dashboardLogic'
 
-export type BreakdownValueAndType = Omit<BreakdownColorConfig, 'colorToken'>
-
-export function extractBreakdownValues(
-    insightTiles: DashboardTile<QueryBasedInsightModel>[] | null,
-    cohorts: CohortType[] | null
-): BreakdownValueAndType[] {
-    if (insightTiles == null) {
-        return []
-    }
-
-    return insightTiles
-        .flatMap((tile) => {
-            if (isInsightVizNode(tile.insight?.query)) {
-                const querySource = tile.insight?.query.source
-                if (
-                    isFunnelsQuery(querySource) &&
-                    (querySource.funnelsFilter?.funnelVizType === undefined ||
-                        querySource.funnelsFilter?.funnelVizType === FunnelVizType.Steps)
-                ) {
-                    const breakdownType = querySource.breakdownFilter?.breakdown_type || 'event'
-                    const breakdownValues: BreakdownValueAndType[] = [
-                        {
-                            breakdownValue: 'Baseline',
-                            breakdownType,
-                        },
-                    ]
-                    tile.insight?.result?.forEach((result: any) => {
-                        const key = getFunnelDatasetKey(result)
-                        const keyParts = JSON.parse(key)
-                        const breakdownValue = keyParts['breakdown_value']
-                        breakdownValues.push({
-                            breakdownValue: Array.isArray(breakdownValue) ? breakdownValue.join('::') : breakdownValue,
-                            breakdownType,
-                        })
-                    })
-                    return breakdownValues
-                } else if (isTrendsQuery(querySource)) {
-                    const breakdownType = querySource.breakdownFilter?.breakdown_type || 'event'
-                    return tile.insight?.result?.map((result: any) => {
-                        const key = getTrendDatasetKey(result)
-                        const keyParts = JSON.parse(key)
-                        const breakdownValue = keyParts['breakdown_value']
-                        return {
-                            breakdownValue: Array.isArray(breakdownValue) ? breakdownValue.join('::') : breakdownValue,
-                            breakdownType,
-                        }
-                    })
-                }
-                return []
-            }
-            return []
-        })
-        .filter((value) => value != null)
-        .reduce<BreakdownValueAndType[]>((acc, curr) => {
-            if (!acc.some((x) => x.breakdownValue === curr.breakdownValue && x.breakdownType === curr.breakdownType)) {
-                acc.push(curr)
-            }
-            return acc
-        }, [])
-        .sort((a, b) => {
-            if (a.breakdownType === 'cohort' && b.breakdownType === 'cohort') {
-                return sortCohorts(a.breakdownValue, b.breakdownValue, cohorts)
-            }
-
-            // put cohorts at the end
-            if (a.breakdownType === 'cohort' || b.breakdownType === 'cohort') {
-                return a.breakdownType === 'cohort' ? 1 : -1
-            }
-
-            return String(a.breakdownValue).localeCompare(String(b.breakdownValue))
-        })
-}
+// Re-export for back-compat with existing imports/tests.
+export { extractBreakdownValues }
+export type { BreakdownValueAndType }
 
 export const dashboardInsightColorsModalLogic = kea<dashboardInsightColorsModalLogicType>([
     path(['scenes', 'dashboard', 'dashboardInsightColorsModalLogic']),

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -82,6 +82,7 @@ import {
 import { getResponseBytes, sortDayJsDates } from '../insights/utils'
 import { filterVariablesReferencedInQuery } from '../insights/utils/queryUtils'
 import { teamLogic } from '../teamLogic'
+import { autoAssignBreakdownColors, extractBreakdownValues } from './dashboardBreakdownColors'
 import { AUTO_REFRESH_INITIAL_INTERVAL_SECONDS } from './dashboardConstants'
 import { BreakdownColorConfig } from './DashboardInsightColorsModal'
 import type { dashboardLogicType } from './dashboardLogicType'
@@ -1408,6 +1409,23 @@ export const dashboardLogic = kea<dashboardLogicType>([
             (tiles) => tiles.filter((t) => !!t.insight).filter((i) => !i.insight?.deleted),
         ],
         textTiles: [(s) => [s.tiles], (tiles) => tiles.filter((t) => !!t.text)],
+        autoBreakdownColors: [
+            (s) => [s.insightTiles, s.featureFlags],
+            (insightTiles, featureFlags): BreakdownColorConfig[] => {
+                if (!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_DASHBOARD_COLORS]) {
+                    return []
+                }
+                return autoAssignBreakdownColors(extractBreakdownValues(insightTiles, null))
+            },
+        ],
+        effectiveBreakdownColors: [
+            (s) => [s.temporaryBreakdownColors, s.autoBreakdownColors],
+            (temporaryBreakdownColors, autoBreakdownColors): BreakdownColorConfig[] => {
+                // User-explicit (and persisted dashboard.breakdown_colors) wins over auto.
+                // Both consumers (trendsDataLogic/funnelDataLogic) use Array.find — first match wins.
+                return [...temporaryBreakdownColors, ...autoBreakdownColors]
+            },
+        ],
         itemsLoading: [
             (s) => [
                 s.dashboardLoading,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -42,6 +42,7 @@ import { userLogic } from 'scenes/userLogic'
 
 import { isSharedView } from '~/exporter/exporterViewLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
+import { cohortsModel } from '~/models/cohortsModel'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { variableDataLogic } from '~/queries/nodes/DataVisualization/Components/Variables/variableDataLogic'
@@ -174,6 +175,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             ['getTheme'],
             dashboardQuickFiltersLogic,
             ['quickFilterPropertyFiltersById'],
+            cohortsModel,
+            ['allCohorts'],
         ],
         logic: [dashboardsModel, insightsModel, eventUsageLogic],
     })),
@@ -1410,12 +1413,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
         ],
         textTiles: [(s) => [s.tiles], (tiles) => tiles.filter((t) => !!t.text)],
         autoBreakdownColors: [
-            (s) => [s.insightTiles, s.featureFlags],
-            (insightTiles, featureFlags): BreakdownColorConfig[] => {
+            (s) => [s.insightTiles, s.allCohorts, s.featureFlags],
+            (insightTiles, allCohorts, featureFlags): BreakdownColorConfig[] => {
                 if (!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_DASHBOARD_COLORS]) {
                     return []
                 }
-                return autoAssignBreakdownColors(extractBreakdownValues(insightTiles, null))
+                return autoAssignBreakdownColors(extractBreakdownValues(insightTiles, allCohorts?.results ?? null))
             },
         ],
         effectiveBreakdownColors: [

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -650,9 +650,9 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                     let breakdownValue = JSON.parse(key)['breakdown_value']
                     breakdownValue = Array.isArray(breakdownValue) ? breakdownValue.join('::') : breakdownValue
 
-                    // dashboard color overrides
+                    // dashboard color overrides (user-explicit, then auto-assigned)
                     const logic = dashboardLogic.findMounted({ id: props.dashboardId })
-                    const dashboardBreakdownColors = logic?.values.temporaryBreakdownColors
+                    const dashboardBreakdownColors = logic?.values.effectiveBreakdownColors
                     const colorOverride = dashboardBreakdownColors?.find(
                         (config) =>
                             config.breakdownValue === breakdownValue &&

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -433,9 +433,9 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
                     let breakdownValue = JSON.parse(key)['breakdown_value']
                     breakdownValue = Array.isArray(breakdownValue) ? breakdownValue.join('::') : breakdownValue
 
-                    // dashboard color overrides
+                    // dashboard color overrides (user-explicit, then auto-assigned)
                     const logic = dashboardLogic.findMounted({ id: props.dashboardId })
-                    const dashboardBreakdownColors = logic?.values.temporaryBreakdownColors
+                    const dashboardBreakdownColors = logic?.values.effectiveBreakdownColors
                     const colorOverride = dashboardBreakdownColors?.find(
                         (config) =>
                             config.breakdownValue === breakdownValue &&


### PR DESCRIPTION
## Problem

On a dashboard, the same breakdown value (e.g. `Google`) gets a different color on every tile. Today the only fix is to set each color by hand in the override modal.

## Changes

Assign a deterministic palette slot per breakdown value, so the same value gets the same color across every chart on the dashboard. User-set overrides still win.

Riding the existing `dashboard-colors` feature flag so this lights up alongside the manual override UI.

## How did you test this code?

I'm an agent. Added unit tests for `autoAssignBreakdownColors` covering determinism, palette exhaustion, append-stability, and null skipping. No manual UI testing.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Self-review caught one bug — `null` was being passed for cohorts to `extractBreakdownValues`, causing cohort sort divergence between the auto path and the override modal. Fixed in a follow-up commit by wiring `cohortsModel.allCohorts` through `dashboardLogic`.
