### PR TITLE
fix(ProjectNotice): Fix Banner overlap + Refactor settings sidebar sizing

### DIFF
--- a/frontend/src/scenes/settings/Settings.scss
+++ b/frontend/src/scenes/settings/Settings.scss
@@ -1,13 +1,7 @@
 .Settings {
     display: flex;
-    gap: 2rem;
     align-items: flex-start;
     margin-top: 0;
-
-    &--compact {
-        flex-direction: column;
-        gap: 0;
-    }
 
     .LemonModal & {
         margin-top: 0;

--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -11,7 +11,6 @@ import { LemonButton, LemonDivider, Link } from '@posthog/lemon-ui'
 import { NotFound } from 'lib/components/NotFound'
 import { SupportedPlatforms } from 'lib/components/SupportedPlatforms/SupportedPlatforms'
 import { TimeSensitiveAuthenticationArea } from 'lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication'
-import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { IconLink } from 'lib/lemon-ui/icons'
 import { LinkPrimitive } from 'lib/lemon-ui/Link'
 import {
@@ -34,7 +33,6 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from 'lib/ui/quill'
-import { inStorybookTestRunner } from 'lib/utils'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { urls } from 'scenes/urls'
 
@@ -67,7 +65,6 @@ export function Settings({
     const {
         selectedSectionId,
         selectedLevel,
-        selectedSettingId,
         selectedSetting,
         settings,
         isCompactNavigationOpen,
@@ -90,22 +87,19 @@ export function Settings({
         navigateToSetting,
     } = useActions(settingsLogic(props))
 
-    const { ref, size } = useResizeBreakpoints(
-        {
-            0: 'small',
-            700: 'medium',
-        },
-        {
-            initialSize: 'medium',
-        }
-    )
-
-    const isCompact = !inStorybookTestRunner() && size === 'small'
-
     // The full settings scene fills the scene area, so its nav can be viewport-fixed.
     // Embeds (replay settings, error tracking config, side panel, modal) place the nav
     // in normal flow instead, so it sits beside the content rather than overlapping.
     const isFullScene = props.logicKey === 'settingsScene'
+
+    const responsive = {
+        compactHide: isFullScene ? 'md:hidden w-full' : '@min-[768px]/settings:hidden',
+        desktopShow: isFullScene ? 'hidden md:flex' : 'hidden @min-[768px]/settings:flex',
+        rootLayout: isFullScene
+            ? 'flex-col gap-0 md:flex-row md:gap-8'
+            : 'flex-col gap-0 @min-[768px]/settings:flex-row @min-[768px]/settings:gap-8',
+        contentPl: isFullScene && !hideSections ? 'md:pl-[calc(var(--settings-nav-width)+2rem)]' : undefined,
+    }
 
     const settingsInSidebar = props.sectionId && !!selectedSetting
 
@@ -116,18 +110,17 @@ export function Settings({
 
     // Track the visual viewport so the mobile drawer shrinks above the on-screen
     // keyboard (`dvh` units don't account for the keyboard) — keeps the list scrollable.
-    // Only needed in compact mode, where the Drawer is used.
     const [visualViewportHeight, setVisualViewportHeight] = React.useState<number | null>(null)
     React.useEffect(() => {
         const vv = window.visualViewport
-        if (!isCompact || !vv) {
+        if (!vv) {
             return
         }
         const update = (): void => setVisualViewportHeight(vv.height)
         update()
         vv.addEventListener('resize', update)
         return () => vv.removeEventListener('resize', update)
-    }, [isCompact])
+    }, [])
 
     // Scroll the active item into view in the nav, on load and whenever the selected
     // section changes. Delayed so any auto-expanded collapsible has finished animating.
@@ -156,7 +149,6 @@ export function Settings({
               key: s.id,
               content: (
                   <OptionButton
-                      active={selectedSettingId === s.id}
                       handleLocally={handleLocally}
                       onClick={() => selectSetting(s.id)}
                       data-attr={`settings-menu-item-${s.id}`}
@@ -320,59 +312,56 @@ export function Settings({
     )
 
     return (
-        <div className={clsx('Settings flex items-start', isCompact && 'Settings--compact')} ref={ref}>
-            {hideSections ? null : isCompact ? (
+        <div className={clsx('Settings @container/settings flex items-start', responsive.rootLayout)}>
+            {hideSections ? null : (
                 <>
-                    <Button variant="outline" left className="w-full" onClick={() => openCompactNavigation()}>
-                        <IconList className="stroke-2 size-4 mr-1" />{' '}
-                        <span className="flex-1 truncate text-left font-semibold text-base">Settings menu</span>
-                    </Button>
-                    <Drawer
-                        swipeDirection="left"
-                        open={isCompactNavigationOpen}
-                        onOpenChange={(open) => (open ? openCompactNavigation() : closeCompactNavigation())}
+                    <div className={responsive.compactHide}>
+                        <Button variant="outline" left className="w-full" onClick={() => openCompactNavigation()}>
+                            <IconList className="stroke-2 size-4 mr-1" />{' '}
+                            <span className="flex-1 truncate text-left font-semibold text-base">Settings menu</span>
+                        </Button>
+                        <Drawer
+                            swipeDirection="left"
+                            open={isCompactNavigationOpen}
+                            onOpenChange={(open) => (open ? openCompactNavigation() : closeCompactNavigation())}
+                        >
+                            <DrawerContent data-quill>
+                                <DrawerTitle className="sr-only">Settings navigation</DrawerTitle>
+                                {/* Pin the height to the visual viewport (minus the drawer's 1rem
+                                    padding) so the search stays put, the list scrolls within, and
+                                    the panel shrinks above the on-screen keyboard. */}
+                                <div
+                                    className="flex flex-col min-h-0"
+                                    style={{
+                                        height:
+                                            visualViewportHeight != null
+                                                ? `${visualViewportHeight - 16}px`
+                                                : 'calc(100dvh - 1rem)',
+                                    }}
+                                >
+                                    {navContent}
+                                </div>
+                            </DrawerContent>
+                        </Drawer>
+                        <LemonDivider />
+                    </div>
+                    <div
+                        data-quill
+                        className={clsx(
+                            'border rounded w-[var(--settings-nav-width)] flex flex-col',
+                            responsive.desktopShow,
+                            isFullScene
+                                ? 'fixed top-[calc(var(--scene-layout-header-height)+var(--scene-padding))] bottom-[var(--scene-padding)]'
+                                : 'sticky top-[var(--scene-layout-header-height)] self-start max-h-[calc(100dvh-var(--scene-layout-header-height)-var(--scene-padding))]'
+                        )}
                     >
-                        <DrawerContent data-quill>
-                            <DrawerTitle className="sr-only">Settings navigation</DrawerTitle>
-                            {/* Pin the height to the visual viewport (minus the drawer's 1rem
-                                padding) so the search stays put, the list scrolls within, and
-                                the panel shrinks above the on-screen keyboard. */}
-                            <div
-                                className="flex flex-col min-h-0"
-                                style={{
-                                    height:
-                                        visualViewportHeight != null
-                                            ? `${visualViewportHeight - 16}px`
-                                            : 'calc(100dvh - 1rem)',
-                                }}
-                            >
-                                {navContent}
-                            </div>
-                        </DrawerContent>
-                    </Drawer>
-                    <LemonDivider />
+                        {navContent}
+                    </div>
                 </>
-            ) : (
-                <div
-                    data-quill
-                    className={clsx(
-                        'border rounded w-[var(--settings-nav-width)] flex flex-col',
-                        isFullScene
-                            ? 'fixed top-[calc(var(--scene-layout-header-height)+var(--scene-padding))] bottom-[var(--scene-padding)]'
-                            : 'sticky top-[var(--scene-layout-header-height)] self-start max-h-[calc(100dvh-var(--scene-layout-header-height)-var(--scene-padding))]'
-                    )}
-                >
-                    {navContent}
-                </div>
             )}
 
             <AuthenticationAreaComponent>
-                <div
-                    className={clsx(
-                        'flex-1 w-full min-w-0 space-y-2 self-start pb-32',
-                        isFullScene && !hideSections && !isCompact && 'pl-[calc(var(--settings-nav-width)+2rem)]'
-                    )}
-                >
+                <div className={clsx('flex-1 w-full min-w-0 space-y-2 self-start pb-32', responsive.contentPl)}>
                     {headerSlot}
                     <SettingsRenderer {...props} handleLocally={handleLocally} />
                 </div>


### PR DESCRIPTION
## Problem

Settings used `useResizeBreakpoints` (ResizeObserver) to switch between a mobile drawer and a desktop sidebar. That hook is deprecated because it can flap in visual regression snapshots, and the full settings scene breakpoint did not match how `Navigation` already offsets the ProjectNotice (`md:` at 768px).

Embeds (replay settings, error tracking configuration, logs, etc.) still need layout based on the available width inside a panel, not only the viewport.

Closes #59203

## Changes

- Remove `useResizeBreakpoints`, `ref`, `isCompact`, and the `inStorybookTestRunner` desktop override from [`Settings.tsx`](frontend/src/scenes/settings/Settings.tsx).
- **Full scene** (`logicKey === 'settingsScene'`): viewport `md:` (768px) for drawer vs fixed sidebar, content `md:pl-[…]`, aligned with [`Navigation.tsx`](frontend/src/layout/navigation-3000/Navigation.tsx).
- **Embeds**: `@container/settings` + `@min-[768px]/settings:` so narrow panels stay compact when the window is wide.
- Mount compact and desktop nav in parallel; toggle visibility with CSS (no ResizeObserver).
- Drop `Settings--compact` from [`Settings.scss`](frontend/src/scenes/settings/Settings.scss); layout gap/direction live on the root via Tailwind.
- Keep `visualViewport` listener for drawer height above the mobile keyboard.

**Intentional behavior change:** on the full settings scene, viewport ≥768px always shows the sidebar, even if `#main-content` is narrow (e.g. side panel open). That matches Navigation’s `md:` ProjectNotice offset. Embeds still use container width.

## How did you test this code?

Manually verified on `/settings` and embed paths below. Screenshots at the 767px / 768px breakpoint.

| Scenario | 767px | 768px |
| --- | --- | --- |
| Full settings — nav layout (drawer vs sidebar)|<img width="1512" height="982" alt="Screenshot 2026-05-21 at 13 51 03" src="https://github.com/user-attachments/assets/d97aa17a-a467-438a-a6fe-37873960be62" />|<img width="1512" height="982" alt="Screenshot 2026-05-21 at 13 53 48" src="https://github.com/user-attachments/assets/784559bb-65ff-4a27-a5ed-52daeb54f7a4" />|
| Full settings — content aligns with ProjectNotice |<img width="1512" height="982" alt="Screenshot 2026-05-21 at 13 50 49" src="https://github.com/user-attachments/assets/f4d654d9-a492-403a-af27-c459c08ec351" />|<img width="1512" height="982" alt="Screenshot 2026-05-21 at 13 50 39" src="https://github.com/user-attachments/assets/a0735c3b-d96a-4616-a23a-9fe19e46a2fe" />|
| Mobile drawer + keyboard (list scrollable) |<img width="1512" height="982" alt="Screenshot 2026-05-21 at 13 55 58" src="https://github.com/user-attachments/assets/775c9b9f-ffd8-41e4-91cc-e309c39771f7" />| n/a |
| Wide viewport + side panel (full scene uses sidebar) | n/a |<img width="1512" height="982" alt="Screenshot 2026-05-21 at 13 54 48" src="https://github.com/user-attachments/assets/3723d050-ced3-416c-8338-124db361500e" />|
| Embed in narrow column (e.g. error tracking Configuration) |<img width="1512" height="982" alt="Screenshot 2026-05-21 at 13 57 18" src="https://github.com/user-attachments/assets/d487acaa-7def-4ced-bf6f-cdd9eafbc528" />|<img width="1512" height="982" alt="Screenshot 2026-05-21 at 13 57 15" src="https://github.com/user-attachments/assets/8b667e7e-a67b-46b3-ac82-827a73cd14b5" />|

**Automated:** `pnpm --filter=@posthog/frontend format` on changed files.

**Also checked:** open/close “Settings menu” drawer; Storybook settings stories at default layout.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

Co-authored with Cursor (Auto). Replaced deprecated `useResizeBreakpoints` per hook guidance and Navigation alignment; hybrid viewport `md:` for `settingsScene` plus `@container/settings` for embeds. Human author ran manual testing and attached screenshots above.