### PR TITLE
fix(ci): serialise concurrent playwright browser cache access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -314,7 +314,7 @@ ENV PATH=/python-runtime/bin:$PATH \
 # Use cache mount for browser binaries to avoid re-downloading on every build
 USER root
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN --mount=type=cache,id=playwright-browsers,target=/tmp/playwright-cache \
+RUN --mount=type=cache,id=playwright-browsers,target=/tmp/playwright-cache,sharing=locked \
     PLAYWRIGHT_BROWSERS_PATH=/tmp/playwright-cache \
     /python-runtime/bin/python -m playwright install --with-deps chromium && \
     mkdir -p /ms-playwright && \


### PR DESCRIPTION
## Problem

The Depot image builds occasionally fail at the Playwright Chromium install step with a `__dirlock` lock-acquisition error (example: https://depot.dev/orgs/ntsdt08fpt/projects/x19jffd9zf/builds/rr7rlb74qw/logs). The `playwright-browsers` BuildKit cache mount uses the default `sharing=shared` mode, which lets multiple concurrent builders read and write the same cache directory at once. Playwright's installer takes an exclusive `__dirlock` file inside that directory, so when two builds race for it one of them fails outright.

## Changes

Add `sharing=locked` to the `playwright-browsers` cache mount in `Dockerfile`. With `locked`, BuildKit serialises any concurrent `RUN` steps that mount this specific cache id, so only one builder is inside the Playwright install at a time. Other cache mounts (pnpm, pip, etc.) are unaffected because they use different ids.

The cache mount only exists during the build step itself — nothing about the resulting image, runtime container, or registry state changes. Worst case is that two simultaneous builds serialise on this one `RUN` instead of racing; in practice warm-cache hits are fast and overlapping cold installs were the failure mode we want to avoid.

## How did you test this code?

I'm an agent. I did not run a Depot build locally. The change is a single Dockerfile flag with no test surface; verification will come from CI image builds no longer failing on `__dirlock`.

## Publish to changelog?

no

## 🤖 Agent context

Authored with PostHog Code (Claude). Paul flagged a recurring Depot build failure on the Playwright install step and proposed `sharing=locked` as the fix. I confirmed the diagnosis from the BuildKit cache-mount semantics: default `shared` mode permits concurrent access to the same cache, which is exactly what collides with Playwright's `__dirlock`. `sharing=private` was considered but rejected — it would give each concurrent build a fresh copy of the cache and defeat the purpose of caching browsers across builds. `locked` keeps the cache shared across sequential builds while preventing concurrent writers from racing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*