### PR TITLE
 fix(devex): guard celery and persons migrate on Postgres tables

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -43,9 +43,6 @@ procs:
         # no capability: always_required via intent-map.yaml
 
     celery-worker:
-        # Django imports query posthog_instancesetting at startup; guard
-        # against racing migrate-postgres on a fresh DB (see migrate-clickhouse
-        # below for the same pattern).
         shell: 'bin/wait-for-docker && bin/wait-for-postgres-tables posthog_instancesetting && ./bin/start-celery worker'
         capability: celery_workers
         ready_pattern: 'celery@'
@@ -463,9 +460,6 @@ procs:
             tech: Migrations
 
     migrate-persons-db:
-        # apply_persons_migrations is a Django management command, so it
-        # queries posthog_instancesetting at import time -- same race as
-        # migrate-clickhouse on a fresh DB.
         shell: 'bin/wait-for-docker && bin/wait-for-postgres-tables posthog_instancesetting && bin/migrate --scope=persons'
         ready_pattern: 'All migrations completed successfully'
         groups:

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -43,7 +43,10 @@ procs:
         # no capability: always_required via intent-map.yaml
 
     celery-worker:
-        shell: 'bin/wait-for-docker && ./bin/start-celery worker'
+        # Django imports query posthog_instancesetting at startup; guard
+        # against racing migrate-postgres on a fresh DB (see migrate-clickhouse
+        # below for the same pattern).
+        shell: 'bin/wait-for-docker && bin/wait-for-postgres-tables posthog_instancesetting && ./bin/start-celery worker'
         capability: celery_workers
         ready_pattern: 'celery@'
         groups:
@@ -51,7 +54,7 @@ procs:
             tech: Python
 
     celery-beat:
-        shell: 'bin/wait-for-docker && ./bin/start-celery beat'
+        shell: 'bin/wait-for-docker && bin/wait-for-postgres-tables posthog_instancesetting && ./bin/start-celery beat'
         capability: celery_scheduler
         ready_pattern: 'celery beat'
         groups:
@@ -460,7 +463,10 @@ procs:
             tech: Migrations
 
     migrate-persons-db:
-        shell: 'bin/wait-for-docker && bin/migrate --scope=persons'
+        # apply_persons_migrations is a Django management command, so it
+        # queries posthog_instancesetting at import time -- same race as
+        # migrate-clickhouse on a fresh DB.
+        shell: 'bin/wait-for-docker && bin/wait-for-postgres-tables posthog_instancesetting && bin/migrate --scope=persons'
         ready_pattern: 'All migrations completed successfully'
         groups:
             layer: Infrastructure


### PR DESCRIPTION
## Problem

`bin/mprocs.yaml` cold-boot race: `celery-worker`, `celery-beat`, and `migrate-persons-db` import Django at startup, which queries `posthog_instancesetting` before `migrate-postgres` has created it. On a fresh `hogli up -d` they crash and rely on phrocs auto-restart. Same race PR #58686 fixed for `migrate-clickhouse`.

## Changes

Prefix the three shells with `bin/wait-for-postgres-tables posthog_instancesetting && …`, reusing the existing guard script. No new code.

Kafka-topic guards for `nodejs`/`ingestion`/`capture` deferred to a follow-up (needs a new probe script + per-unit topic mapping).

## How did you test this code?

Agent-authored. No manual repro this session. Edit is a literal copy of the `migrate-clickhouse` guard prefix from #58686, applied to three sibling shells. Reviewer check: `docker compose down -v && hogli up -d`, confirm the three units no longer crash on first boot.

## Publish to changelog?

no

## Docs update

No docs change.

## 🤖 Agent context

- Claude Code, `/wt` worktree flow; edits to `bin/mprocs.yaml` only.
- Chose `posthog_instancesetting` for all three — same Django-import-time sentinel `migrate-clickhouse` already waits on.
- Did not touch `.posthog/.generated/mprocs.yaml` (derived).
- Reviewer (`/code-review` xhigh) flagged two more unguarded Django-touching units worth a follow-up: `temporal-worker` and `webhook-s3-sink` (both call `python manage.py …` after `bin/wait-for-docker`). Left out to keep this PR scoped.
- Also flagged: with 4 call sites of the same prefix, a `bin/wait-for-django-ready` wrapper would earn its keep — deferred.