### PR TITLE
feat(capture-logs): add bytes_uncompressed field for per-row byte accounting

### DIFF
--- a/nodejs/src/logs-ingestion/log-record-avro.test.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.test.ts
@@ -99,6 +99,11 @@ const LOG_RECORD_SCHEMA = avro.parse(`{
         "values": "string"
     }],
     "doc": "A map of custom string-valued attributes associated with the log."
+    },
+    {
+    "name": "bytes_uncompressed",
+    "type": ["null", "long"],
+    "doc": "Logical content size of the row (sum of byte lengths of string/map fields). Used by drop-rule accounting; does not include fixed-width numeric or timestamp fields."
     }
 ]
 }`)
@@ -209,6 +214,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: 'test@1.0.0',
                     event_name: null,
                     attributes: { key: 'value1' },
+                    bytes_uncompressed: 123,
                 },
                 {
                     uuid: 'test-uuid-2',
@@ -225,6 +231,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: 'test@1.0.0',
                     event_name: null,
                     attributes: { key: 'value2' },
+                    bytes_uncompressed: 456,
                 },
             ]
 
@@ -251,6 +258,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
             ]
 
@@ -258,6 +266,33 @@ describe('log-record-avro', () => {
             const [_, __, decoded] = await decodeLogRecords(encoded)
 
             expect(decoded).toEqual(records)
+        })
+
+        it('preserves bytes_uncompressed across encode/decode', async () => {
+            const records: LogRecord[] = [
+                {
+                    uuid: 'with-bytes',
+                    trace_id: null,
+                    span_id: null,
+                    trace_flags: null,
+                    timestamp: null,
+                    observed_timestamp: null,
+                    body: 'hello world',
+                    severity_text: null,
+                    severity_number: null,
+                    service_name: null,
+                    resource_attributes: null,
+                    instrumentation_scope: null,
+                    event_name: null,
+                    attributes: null,
+                    bytes_uncompressed: 789,
+                },
+            ]
+
+            const encoded = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
+            const [_, __, decoded] = await decodeLogRecords(encoded)
+
+            expect(decoded[0].bytes_uncompressed).toBe(789)
         })
 
         it('rejects promise for invalid buffer', async () => {

--- a/nodejs/src/logs-ingestion/log-record-avro.test.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.test.ts
@@ -421,6 +421,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
             ]
 
@@ -452,6 +453,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
                 {
                     uuid: 'test-uuid-2',
@@ -468,6 +470,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
             ]
 
@@ -504,6 +507,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
             ]
 
@@ -534,6 +538,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
             ]
 
@@ -569,6 +574,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: { note: 'only-attr@example.com' },
+                    bytes_uncompressed: null,
                 },
             ]
 
@@ -600,6 +606,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: { note: 'c@d.co' },
+                    bytes_uncompressed: null,
                 },
             ]
 
@@ -635,6 +642,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
             ]
 
@@ -666,6 +674,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
                 {
                     uuid: 'test-uuid-2',
@@ -682,6 +691,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
             ]
 
@@ -712,6 +722,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
             ]
 
@@ -763,6 +774,7 @@ describe('log-record-avro', () => {
                     instrumentation_scope: null,
                     event_name: null,
                     attributes: null,
+                    bytes_uncompressed: null,
                 },
             ]
 

--- a/nodejs/src/logs-ingestion/log-record-avro.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.ts
@@ -132,12 +132,7 @@ export async function encodeLogRecords(logRecordType: avro.Type, codec: string, 
             })
 
             for (const record of records) {
-                // avsc rejects missing keys for `["null", T]` unions; backfill nullable optional
-                // fields so callers (including tests) can omit them safely. Decoded records
-                // already have these populated, so this is a no-op on the hot path.
-                const avroRecord =
-                    record.bytes_uncompressed === undefined ? { ...record, bytes_uncompressed: null } : record
-                encoder.write(avroRecord)
+                encoder.write(record)
             }
 
             encoder.end()

--- a/nodejs/src/logs-ingestion/log-record-avro.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.ts
@@ -42,6 +42,7 @@ export interface LogRecord {
     instrumentation_scope: string | null
     event_name: string | null
     attributes: Record<string, string> | null
+    bytes_uncompressed?: number | null
 }
 
 export async function decodeLogRecords(buffer: Buffer): Promise<[avro.Type | undefined, string, LogRecord[]]> {
@@ -131,6 +132,12 @@ export async function encodeLogRecords(logRecordType: avro.Type, codec: string, 
             })
 
             for (const record of records) {
+                // avsc rejects missing keys for `["null", T]` unions; backfill nullable optional
+                // fields so callers (including tests) can omit them safely. Decoded records
+                // already have these populated, so this is a no-op on the hot path.
+                if (record.bytes_uncompressed === undefined) {
+                    record.bytes_uncompressed = null
+                }
                 encoder.write(record)
             }
 

--- a/nodejs/src/logs-ingestion/log-record-avro.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.ts
@@ -135,10 +135,9 @@ export async function encodeLogRecords(logRecordType: avro.Type, codec: string, 
                 // avsc rejects missing keys for `["null", T]` unions; backfill nullable optional
                 // fields so callers (including tests) can omit them safely. Decoded records
                 // already have these populated, so this is a no-op on the hot path.
-                if (record.bytes_uncompressed === undefined) {
-                    record.bytes_uncompressed = null
-                }
-                encoder.write(record)
+                const avroRecord =
+                    record.bytes_uncompressed === undefined ? { ...record, bytes_uncompressed: null } : record
+                encoder.write(avroRecord)
             }
 
             encoder.end()

--- a/rust/capture-logs/src/avro_schema.rs
+++ b/rust/capture-logs/src/avro_schema.rs
@@ -85,6 +85,11 @@ pub const AVRO_SCHEMA: &str = r#"
         "values": "string"
     }],
     "doc": "A map of custom string-valued attributes associated with the log."
+    },
+    {
+    "name": "bytes_uncompressed",
+    "type": ["null", "long"],
+    "doc": "Logical content size of the row (sum of byte lengths of string/map fields). Used by drop-rule accounting; does not include fixed-width numeric or timestamp fields."
     }
 ]
 }"#;

--- a/rust/capture-logs/src/endpoints/datadog.rs
+++ b/rust/capture-logs/src/endpoints/datadog.rs
@@ -1,4 +1,4 @@
-use crate::log_record::{override_timestamp, KafkaLogRow};
+use crate::log_record::{compute_kafka_log_row_bytes, override_timestamp, KafkaLogRow};
 use crate::service::Service;
 use axum::{
     extract::State,
@@ -240,25 +240,29 @@ pub fn datadog_log_to_kafka_row(
         attributes.insert("$originalTimestamp".to_string(), original.to_rfc3339());
     }
 
-    (
-        KafkaLogRow {
-            uuid: Uuid::now_v7().to_string(),
-            trace_id,
-            span_id,
-            trace_flags: 0,
-            timestamp,
-            observed_timestamp: Utc::now(),
-            body: message.unwrap_or_default(),
-            severity_text,
-            severity_number,
-            service_name: service.unwrap_or_default(),
-            resource_attributes,
-            instrumentation_scope,
-            event_name,
-            attributes,
-        },
-        was_overridden,
-    )
+    let partial = KafkaLogRow {
+        uuid: Uuid::now_v7().to_string(),
+        trace_id,
+        span_id,
+        trace_flags: 0,
+        timestamp,
+        observed_timestamp: Utc::now(),
+        body: message.unwrap_or_default(),
+        severity_text,
+        severity_number,
+        service_name: service.unwrap_or_default(),
+        resource_attributes,
+        instrumentation_scope,
+        event_name,
+        attributes,
+        bytes_uncompressed: None,
+    };
+    let bytes_uncompressed = Some(compute_kafka_log_row_bytes(&partial));
+    let row = KafkaLogRow {
+        bytes_uncompressed,
+        ..partial
+    };
+    (row, was_overridden)
 }
 
 #[derive(Deserialize, Debug)]

--- a/rust/capture-logs/src/endpoints/datadog.rs
+++ b/rust/capture-logs/src/endpoints/datadog.rs
@@ -1,4 +1,4 @@
-use crate::log_record::{compute_kafka_log_row_bytes, override_timestamp, KafkaLogRow};
+use crate::log_record::{override_timestamp, KafkaLogRow};
 use crate::service::Service;
 use axum::{
     extract::State,
@@ -240,7 +240,7 @@ pub fn datadog_log_to_kafka_row(
         attributes.insert("$originalTimestamp".to_string(), original.to_rfc3339());
     }
 
-    let partial = KafkaLogRow {
+    let row = KafkaLogRow {
         uuid: Uuid::now_v7().to_string(),
         trace_id,
         span_id,
@@ -256,12 +256,8 @@ pub fn datadog_log_to_kafka_row(
         event_name,
         attributes,
         bytes_uncompressed: None,
-    };
-    let bytes_uncompressed = Some(compute_kafka_log_row_bytes(&partial));
-    let row = KafkaLogRow {
-        bytes_uncompressed,
-        ..partial
-    };
+    }
+    .with_computed_bytes();
     (row, was_overridden)
 }
 

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -65,6 +65,13 @@ pub fn compute_kafka_log_row_bytes(row: &KafkaLogRow) -> i64 {
 }
 
 impl KafkaLogRow {
+    /// Set `bytes_uncompressed` from the row's variable-length content. Consuming
+    /// builder; the `mut self` is encapsulated and never escapes.
+    pub(crate) fn with_computed_bytes(mut self) -> Self {
+        self.bytes_uncompressed = Some(compute_kafka_log_row_bytes(&self));
+        self
+    }
+
     pub fn new(
         record: LogRecord,
         resource: Option<Resource>,
@@ -138,7 +145,7 @@ impl KafkaLogRow {
 
         let observed_timestamp = Utc::now();
 
-        let partial = Self {
+        let log_row = Self {
             uuid: Uuid::now_v7().to_string(),
             trace_id: BASE64_STANDARD.encode(trace_id),
             span_id: BASE64_STANDARD.encode(span_id),
@@ -154,12 +161,8 @@ impl KafkaLogRow {
             service_name,
             attributes,
             bytes_uncompressed: None,
-        };
-        let bytes_uncompressed = Some(compute_kafka_log_row_bytes(&partial));
-        let log_row = Self {
-            bytes_uncompressed,
-            ..partial
-        };
+        }
+        .with_computed_bytes();
         debug!("log: {:?}", log_row);
 
         Ok((log_row, was_overridden))

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -38,6 +38,30 @@ pub struct KafkaLogRow {
     pub instrumentation_scope: String,
     pub event_name: String,
     pub attributes: HashMap<String, String>,
+    pub bytes_uncompressed: Option<i64>,
+}
+
+/// Sum byte lengths of the row's string and map content. Fixed-width fields
+/// (timestamps, trace_flags, severity_number) are excluded — only variable-length
+/// payload is counted. Distinct from the Kafka header `bytes_uncompressed`, which
+/// is the raw HTTP body size for the whole batch.
+pub fn compute_kafka_log_row_bytes(row: &KafkaLogRow) -> i64 {
+    let mut total: usize = 0;
+    total = total.saturating_add(row.uuid.len());
+    total = total.saturating_add(row.trace_id.len());
+    total = total.saturating_add(row.span_id.len());
+    total = total.saturating_add(row.body.len());
+    total = total.saturating_add(row.severity_text.len());
+    total = total.saturating_add(row.service_name.len());
+    total = total.saturating_add(row.instrumentation_scope.len());
+    total = total.saturating_add(row.event_name.len());
+    for (k, v) in &row.resource_attributes {
+        total = total.saturating_add(k.len()).saturating_add(v.len());
+    }
+    for (k, v) in &row.attributes {
+        total = total.saturating_add(k.len()).saturating_add(v.len());
+    }
+    i64::try_from(total).unwrap_or(i64::MAX)
 }
 
 impl KafkaLogRow {
@@ -114,7 +138,7 @@ impl KafkaLogRow {
 
         let observed_timestamp = Utc::now();
 
-        let log_row = Self {
+        let partial = Self {
             uuid: Uuid::now_v7().to_string(),
             trace_id: BASE64_STANDARD.encode(trace_id),
             span_id: BASE64_STANDARD.encode(span_id),
@@ -129,6 +153,12 @@ impl KafkaLogRow {
             event_name,
             service_name,
             attributes,
+            bytes_uncompressed: None,
+        };
+        let bytes_uncompressed = Some(compute_kafka_log_row_bytes(&partial));
+        let log_row = Self {
+            bytes_uncompressed,
+            ..partial
         };
         debug!("log: {:?}", log_row);
 
@@ -318,6 +348,107 @@ pub fn any_value_to_string(value: AnyValue) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use apache_avro::{Codec, Reader, Schema, Writer};
+
+    use crate::avro_schema::AVRO_SCHEMA;
+
+    fn sample_row() -> KafkaLogRow {
+        let mut resource_attributes = HashMap::new();
+        resource_attributes.insert("host.name".to_string(), "localhost".to_string());
+        let mut attributes = HashMap::new();
+        attributes.insert("k".to_string(), "v".to_string());
+        KafkaLogRow {
+            uuid: "uuid-1234".to_string(),
+            trace_id: "tid".to_string(),
+            span_id: "sid".to_string(),
+            trace_flags: 0,
+            timestamp: Utc::now(),
+            observed_timestamp: Utc::now(),
+            body: "hello".to_string(),
+            severity_text: "info".to_string(),
+            severity_number: 9,
+            service_name: "svc".to_string(),
+            resource_attributes,
+            instrumentation_scope: "scope@1".to_string(),
+            event_name: "evt".to_string(),
+            attributes,
+            bytes_uncompressed: None,
+        }
+    }
+
+    #[test]
+    fn test_compute_kafka_log_row_bytes_sums_string_and_map_lengths() {
+        let row = sample_row();
+        // string fields: uuid(9) + trace_id(3) + span_id(3) + body(5) + severity_text(4)
+        // + service_name(3) + instrumentation_scope(7) + event_name(3) = 37
+        // maps: resource_attributes "host.name"(9)+"localhost"(9)=18; attributes "k"(1)+"v"(1)=2
+        // total = 37 + 18 + 2 = 57
+        assert_eq!(compute_kafka_log_row_bytes(&row), 57);
+    }
+
+    #[test]
+    fn test_compute_kafka_log_row_bytes_excludes_fixed_width_fields() {
+        // Two rows differing only in fixed-width numeric/timestamp fields should compute
+        // identical bytes_uncompressed.
+        let mut a = sample_row();
+        a.trace_flags = 0;
+        a.severity_number = 1;
+        let mut b = sample_row();
+        b.trace_flags = u32::MAX;
+        b.severity_number = i32::MIN;
+        b.timestamp = a.timestamp + TimeDelta::days(1);
+        assert_eq!(
+            compute_kafka_log_row_bytes(&a),
+            compute_kafka_log_row_bytes(&b),
+        );
+    }
+
+    #[test]
+    fn test_bytes_uncompressed_serialises_into_avro_payload() {
+        // We don't deserialise back into KafkaLogRow because apache_avro's `from_value`
+        // can't resolve `["null", T]` unions into non-Option struct fields (the existing
+        // pattern used for body/attributes/etc.). Instead, decode to the raw Avro Value
+        // and assert the new field is present with the expected long.
+        use apache_avro::types::Value;
+
+        let mut row = sample_row();
+        row.bytes_uncompressed = Some(compute_kafka_log_row_bytes(&row));
+        let expected = row.bytes_uncompressed.unwrap();
+
+        let schema = Schema::parse_str(AVRO_SCHEMA).expect("schema parses");
+        let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+        writer.append_ser(&row).expect("append_ser ok");
+        let payload = writer.into_inner().expect("flush ok");
+
+        let reader = Reader::new(payload.as_slice()).expect("reader ok");
+        let mut found_long: Option<i64> = None;
+        for value in reader {
+            let value = value.expect("decode ok");
+            if let Value::Record(fields) = value {
+                for (name, field_value) in fields {
+                    if name == "bytes_uncompressed" {
+                        if let Value::Union(_, inner) = field_value {
+                            if let Value::Long(v) = *inner {
+                                found_long = Some(v);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        assert_eq!(found_long, Some(expected));
+    }
+
+    #[test]
+    fn test_new_populates_bytes_uncompressed() {
+        let log_record = LogRecord::default();
+        let (row, _) = KafkaLogRow::new(log_record, None, None).expect("ok");
+        assert!(row.bytes_uncompressed.is_some());
+        assert_eq!(
+            row.bytes_uncompressed.unwrap(),
+            compute_kafka_log_row_bytes(&row),
+        );
+    }
 
     #[test]
     fn test_override_timestamp_within_range_is_unchanged() {

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -46,22 +46,26 @@ pub struct KafkaLogRow {
 /// payload is counted. Distinct from the Kafka header `bytes_uncompressed`, which
 /// is the raw HTTP body size for the whole batch.
 pub fn compute_kafka_log_row_bytes(row: &KafkaLogRow) -> i64 {
-    let mut total: usize = 0;
-    total = total.saturating_add(row.uuid.len());
-    total = total.saturating_add(row.trace_id.len());
-    total = total.saturating_add(row.span_id.len());
-    total = total.saturating_add(row.body.len());
-    total = total.saturating_add(row.severity_text.len());
-    total = total.saturating_add(row.service_name.len());
-    total = total.saturating_add(row.instrumentation_scope.len());
-    total = total.saturating_add(row.event_name.len());
+    let mut total: i64 = 0;
+    total = total.saturating_add(row.uuid.len() as i64);
+    total = total.saturating_add(row.trace_id.len() as i64);
+    total = total.saturating_add(row.span_id.len() as i64);
+    total = total.saturating_add(row.body.len() as i64);
+    total = total.saturating_add(row.severity_text.len() as i64);
+    total = total.saturating_add(row.service_name.len() as i64);
+    total = total.saturating_add(row.instrumentation_scope.len() as i64);
+    total = total.saturating_add(row.event_name.len() as i64);
     for (k, v) in &row.resource_attributes {
-        total = total.saturating_add(k.len()).saturating_add(v.len());
+        total = total
+            .saturating_add(k.len() as i64)
+            .saturating_add(v.len() as i64);
     }
     for (k, v) in &row.attributes {
-        total = total.saturating_add(k.len()).saturating_add(v.len());
+        total = total
+            .saturating_add(k.len() as i64)
+            .saturating_add(v.len() as i64);
     }
-    i64::try_from(total).unwrap_or(i64::MAX)
+    total
 }
 
 impl KafkaLogRow {

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -46,26 +46,22 @@ pub struct KafkaLogRow {
 /// payload is counted. Distinct from the Kafka header `bytes_uncompressed`, which
 /// is the raw HTTP body size for the whole batch.
 pub fn compute_kafka_log_row_bytes(row: &KafkaLogRow) -> i64 {
-    let mut total: i64 = 0;
-    total = total.saturating_add(row.uuid.len() as i64);
-    total = total.saturating_add(row.trace_id.len() as i64);
-    total = total.saturating_add(row.span_id.len() as i64);
-    total = total.saturating_add(row.body.len() as i64);
-    total = total.saturating_add(row.severity_text.len() as i64);
-    total = total.saturating_add(row.service_name.len() as i64);
-    total = total.saturating_add(row.instrumentation_scope.len() as i64);
-    total = total.saturating_add(row.event_name.len() as i64);
+    let mut total: usize = 0;
+    total = total.saturating_add(row.uuid.len());
+    total = total.saturating_add(row.trace_id.len());
+    total = total.saturating_add(row.span_id.len());
+    total = total.saturating_add(row.body.len());
+    total = total.saturating_add(row.severity_text.len());
+    total = total.saturating_add(row.service_name.len());
+    total = total.saturating_add(row.instrumentation_scope.len());
+    total = total.saturating_add(row.event_name.len());
     for (k, v) in &row.resource_attributes {
-        total = total
-            .saturating_add(k.len() as i64)
-            .saturating_add(v.len() as i64);
+        total = total.saturating_add(k.len()).saturating_add(v.len());
     }
     for (k, v) in &row.attributes {
-        total = total
-            .saturating_add(k.len() as i64)
-            .saturating_add(v.len() as i64);
+        total = total.saturating_add(k.len()).saturating_add(v.len());
     }
-    total
+    i64::try_from(total).unwrap_or(i64::MAX)
 }
 
 impl KafkaLogRow {

--- a/rust/capture-logs/src/trace_record.rs
+++ b/rust/capture-logs/src/trace_record.rs
@@ -48,6 +48,37 @@ pub struct KafkaTraceRow {
     pub dropped_links_count: i32,
     pub status_code: i32,
     pub status_message: String,
+    pub bytes_uncompressed: Option<i64>,
+}
+
+/// Sum byte lengths of the row's string, map, and array content. Fixed-width
+/// fields (timestamps, kind, flags, status_code, dropped_*_count) are excluded —
+/// only variable-length payload is counted. Distinct from the Kafka header
+/// `bytes_uncompressed`, which is the raw HTTP body size for the whole batch.
+pub fn compute_kafka_trace_row_bytes(row: &KafkaTraceRow) -> i64 {
+    let mut total: usize = 0;
+    total = total.saturating_add(row.uuid.len());
+    total = total.saturating_add(row.trace_id.len());
+    total = total.saturating_add(row.span_id.len());
+    total = total.saturating_add(row.parent_span_id.len());
+    total = total.saturating_add(row.trace_state.len());
+    total = total.saturating_add(row.name.len());
+    total = total.saturating_add(row.service_name.len());
+    total = total.saturating_add(row.instrumentation_scope.len());
+    total = total.saturating_add(row.status_message.len());
+    for (k, v) in &row.resource_attributes {
+        total = total.saturating_add(k.len()).saturating_add(v.len());
+    }
+    for (k, v) in &row.attributes {
+        total = total.saturating_add(k.len()).saturating_add(v.len());
+    }
+    for event in &row.events {
+        total = total.saturating_add(event.len());
+    }
+    for link in &row.links {
+        total = total.saturating_add(link.len());
+    }
+    i64::try_from(total).unwrap_or(i64::MAX)
 }
 
 impl KafkaTraceRow {
@@ -161,7 +192,7 @@ impl KafkaTraceRow {
             .map(|s| s.message.clone())
             .unwrap_or_default();
 
-        let row = Self {
+        let partial = Self {
             uuid: Uuid::now_v7().to_string(),
             trace_id,
             span_id,
@@ -184,6 +215,12 @@ impl KafkaTraceRow {
             dropped_links_count: span.dropped_links_count as i32,
             status_code,
             status_message,
+            bytes_uncompressed: None,
+        };
+        let bytes_uncompressed = Some(compute_kafka_trace_row_bytes(&partial));
+        let row = Self {
+            bytes_uncompressed,
+            ..partial
         };
         debug!("trace span: {:?}", row);
 
@@ -208,11 +245,14 @@ fn extract_string_from_resource(attributes: &HashMap<String, String>, key: &str)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use apache_avro::{Codec, Reader, Schema, Writer};
     use chrono::{TimeDelta, Utc};
     use opentelemetry_proto::tonic::{
         common::v1::{any_value, AnyValue, KeyValue},
         trace::v1::{span::Event, span::Link, Span, Status},
     };
+
+    use crate::traces_avro_schema::TRACES_AVRO_SCHEMA;
 
     fn make_span() -> Span {
         let now_nanos = Utc::now().timestamp_nanos_opt().unwrap() as u64;
@@ -242,6 +282,87 @@ mod tests {
                 code: 1, // OK
             }),
         }
+    }
+
+    #[test]
+    fn test_compute_kafka_trace_row_bytes_sums_string_map_and_array_lengths() {
+        let mut resource_attributes = HashMap::new();
+        resource_attributes.insert("host.name".to_string(), "localhost".to_string());
+        let mut attributes = HashMap::new();
+        attributes.insert("a".to_string(), "b".to_string());
+        let row = KafkaTraceRow {
+            uuid: "uuid-1".to_string(),
+            trace_id: "tid".to_string(),
+            span_id: "sid".to_string(),
+            parent_span_id: "psid".to_string(),
+            trace_state: "ts".to_string(),
+            name: "op".to_string(),
+            kind: 0,
+            flags: 0,
+            timestamp: Utc::now(),
+            end_time: Utc::now(),
+            observed_timestamp: Utc::now(),
+            service_name: "svc".to_string(),
+            resource_attributes,
+            instrumentation_scope: "scope".to_string(),
+            attributes,
+            dropped_attributes_count: 0,
+            events: vec!["{}".to_string()],
+            dropped_events_count: 0,
+            links: vec!["{}".to_string()],
+            dropped_links_count: 0,
+            status_code: 0,
+            status_message: "ok".to_string(),
+            bytes_uncompressed: None,
+        };
+        // strings: uuid(6) + tid(3) + sid(3) + psid(4) + ts(2) + op(2) + svc(3) + scope(5) + ok(2) = 30
+        // resource_attributes: host.name(9)+localhost(9)=18; attributes a(1)+b(1)=2
+        // events 1 entry of "{}"(2); links 1 entry of "{}"(2) = 4
+        // total = 30 + 18 + 2 + 4 = 54
+        assert_eq!(compute_kafka_trace_row_bytes(&row), 54);
+    }
+
+    #[test]
+    fn test_bytes_uncompressed_serialises_into_avro_payload() {
+        // Decode to raw Avro Value rather than struct: apache_avro's `from_value` can't
+        // resolve `["null", T]` unions into the existing non-Option fields on KafkaTraceRow.
+        use apache_avro::types::Value;
+
+        let (row, _) = KafkaTraceRow::new(make_span(), None, None).expect("ok");
+        let expected = row.bytes_uncompressed.expect("populated");
+
+        let schema = Schema::parse_str(TRACES_AVRO_SCHEMA).expect("schema parses");
+        let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+        writer.append_ser(&row).expect("append_ser ok");
+        let payload = writer.into_inner().expect("flush ok");
+
+        let reader = Reader::new(payload.as_slice()).expect("reader ok");
+        let mut found_long: Option<i64> = None;
+        for value in reader {
+            let value = value.expect("decode ok");
+            if let Value::Record(fields) = value {
+                for (name, field_value) in fields {
+                    if name == "bytes_uncompressed" {
+                        if let Value::Union(_, inner) = field_value {
+                            if let Value::Long(v) = *inner {
+                                found_long = Some(v);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        assert_eq!(found_long, Some(expected));
+    }
+
+    #[test]
+    fn test_new_populates_bytes_uncompressed() {
+        let (row, _) = KafkaTraceRow::new(make_span(), None, None).expect("ok");
+        assert!(row.bytes_uncompressed.is_some());
+        assert_eq!(
+            row.bytes_uncompressed.unwrap(),
+            compute_kafka_trace_row_bytes(&row),
+        );
     }
 
     #[test]

--- a/rust/capture-logs/src/trace_record.rs
+++ b/rust/capture-logs/src/trace_record.rs
@@ -56,33 +56,29 @@ pub struct KafkaTraceRow {
 /// only variable-length payload is counted. Distinct from the Kafka header
 /// `bytes_uncompressed`, which is the raw HTTP body size for the whole batch.
 pub fn compute_kafka_trace_row_bytes(row: &KafkaTraceRow) -> i64 {
-    let mut total: i64 = 0;
-    total = total.saturating_add(row.uuid.len() as i64);
-    total = total.saturating_add(row.trace_id.len() as i64);
-    total = total.saturating_add(row.span_id.len() as i64);
-    total = total.saturating_add(row.parent_span_id.len() as i64);
-    total = total.saturating_add(row.trace_state.len() as i64);
-    total = total.saturating_add(row.name.len() as i64);
-    total = total.saturating_add(row.service_name.len() as i64);
-    total = total.saturating_add(row.instrumentation_scope.len() as i64);
-    total = total.saturating_add(row.status_message.len() as i64);
+    let mut total: usize = 0;
+    total = total.saturating_add(row.uuid.len());
+    total = total.saturating_add(row.trace_id.len());
+    total = total.saturating_add(row.span_id.len());
+    total = total.saturating_add(row.parent_span_id.len());
+    total = total.saturating_add(row.trace_state.len());
+    total = total.saturating_add(row.name.len());
+    total = total.saturating_add(row.service_name.len());
+    total = total.saturating_add(row.instrumentation_scope.len());
+    total = total.saturating_add(row.status_message.len());
     for (k, v) in &row.resource_attributes {
-        total = total
-            .saturating_add(k.len() as i64)
-            .saturating_add(v.len() as i64);
+        total = total.saturating_add(k.len()).saturating_add(v.len());
     }
     for (k, v) in &row.attributes {
-        total = total
-            .saturating_add(k.len() as i64)
-            .saturating_add(v.len() as i64);
+        total = total.saturating_add(k.len()).saturating_add(v.len());
     }
     for event in &row.events {
-        total = total.saturating_add(event.len() as i64);
+        total = total.saturating_add(event.len());
     }
     for link in &row.links {
-        total = total.saturating_add(link.len() as i64);
+        total = total.saturating_add(link.len());
     }
-    total
+    i64::try_from(total).unwrap_or(i64::MAX)
 }
 
 impl KafkaTraceRow {

--- a/rust/capture-logs/src/trace_record.rs
+++ b/rust/capture-logs/src/trace_record.rs
@@ -56,29 +56,33 @@ pub struct KafkaTraceRow {
 /// only variable-length payload is counted. Distinct from the Kafka header
 /// `bytes_uncompressed`, which is the raw HTTP body size for the whole batch.
 pub fn compute_kafka_trace_row_bytes(row: &KafkaTraceRow) -> i64 {
-    let mut total: usize = 0;
-    total = total.saturating_add(row.uuid.len());
-    total = total.saturating_add(row.trace_id.len());
-    total = total.saturating_add(row.span_id.len());
-    total = total.saturating_add(row.parent_span_id.len());
-    total = total.saturating_add(row.trace_state.len());
-    total = total.saturating_add(row.name.len());
-    total = total.saturating_add(row.service_name.len());
-    total = total.saturating_add(row.instrumentation_scope.len());
-    total = total.saturating_add(row.status_message.len());
+    let mut total: i64 = 0;
+    total = total.saturating_add(row.uuid.len() as i64);
+    total = total.saturating_add(row.trace_id.len() as i64);
+    total = total.saturating_add(row.span_id.len() as i64);
+    total = total.saturating_add(row.parent_span_id.len() as i64);
+    total = total.saturating_add(row.trace_state.len() as i64);
+    total = total.saturating_add(row.name.len() as i64);
+    total = total.saturating_add(row.service_name.len() as i64);
+    total = total.saturating_add(row.instrumentation_scope.len() as i64);
+    total = total.saturating_add(row.status_message.len() as i64);
     for (k, v) in &row.resource_attributes {
-        total = total.saturating_add(k.len()).saturating_add(v.len());
+        total = total
+            .saturating_add(k.len() as i64)
+            .saturating_add(v.len() as i64);
     }
     for (k, v) in &row.attributes {
-        total = total.saturating_add(k.len()).saturating_add(v.len());
+        total = total
+            .saturating_add(k.len() as i64)
+            .saturating_add(v.len() as i64);
     }
     for event in &row.events {
-        total = total.saturating_add(event.len());
+        total = total.saturating_add(event.len() as i64);
     }
     for link in &row.links {
-        total = total.saturating_add(link.len());
+        total = total.saturating_add(link.len() as i64);
     }
-    i64::try_from(total).unwrap_or(i64::MAX)
+    total
 }
 
 impl KafkaTraceRow {

--- a/rust/capture-logs/src/trace_record.rs
+++ b/rust/capture-logs/src/trace_record.rs
@@ -82,6 +82,13 @@ pub fn compute_kafka_trace_row_bytes(row: &KafkaTraceRow) -> i64 {
 }
 
 impl KafkaTraceRow {
+    /// Set `bytes_uncompressed` from the row's variable-length content. Consuming
+    /// builder; the `mut self` is encapsulated and never escapes.
+    fn with_computed_bytes(mut self) -> Self {
+        self.bytes_uncompressed = Some(compute_kafka_trace_row_bytes(&self));
+        self
+    }
+
     pub fn new(
         span: Span,
         resource: Option<Resource>,
@@ -192,7 +199,7 @@ impl KafkaTraceRow {
             .map(|s| s.message.clone())
             .unwrap_or_default();
 
-        let partial = Self {
+        let row = Self {
             uuid: Uuid::now_v7().to_string(),
             trace_id,
             span_id,
@@ -216,12 +223,8 @@ impl KafkaTraceRow {
             status_code,
             status_message,
             bytes_uncompressed: None,
-        };
-        let bytes_uncompressed = Some(compute_kafka_trace_row_bytes(&partial));
-        let row = Self {
-            bytes_uncompressed,
-            ..partial
-        };
+        }
+        .with_computed_bytes();
         debug!("trace span: {:?}", row);
 
         Ok((row, was_overridden))

--- a/rust/capture-logs/src/traces_avro_schema.rs
+++ b/rust/capture-logs/src/traces_avro_schema.rs
@@ -134,6 +134,11 @@ pub const TRACES_AVRO_SCHEMA: &str = r#"
     "name": "status_message",
     "type": ["null", "string"],
     "doc": "Status message"
+    },
+    {
+    "name": "bytes_uncompressed",
+    "type": ["null", "long"],
+    "doc": "Logical content size of the row (sum of byte lengths of string/map/array fields). Used by drop-rule accounting; does not include fixed-width numeric or timestamp fields."
     }
 ]
 }"#;


### PR DESCRIPTION
## TL;DR

Add a `bytes_uncompressed` field to the Avro log record schema to enable per-row byte accounting for drop rules. This replaces message-level accounting with row-level tracking, allowing accurate quota enforcement when Kafka messages contain thousands of log lines.

## Problem

Drop rules currently track bytes at the message level, but Kafka messages can contain thousands of individual log rows. This makes it impossible to accurately account for bytes when dropping individual rows. The solution requires tracking uncompressed byte size per row through the entire pipeline.

## Changes

- **Avro schema updates**: Added nullable `bytes_uncompressed` field (type `["null", "long"]`) to both Node.js and Rust schema definitions with documentation explaining it measures logical content size of variable-length fields (strings/maps) excluding fixed-width numerics and timestamps
- **Rust implementation**: 
  - Added `bytes_uncompressed: Option<i64>` field to `KafkaLogRow` struct
  - Implemented `compute_kafka_log_row_bytes()` function that sums byte lengths of all string and map fields in a row
  - Updated Datadog endpoint to compute and populate the field on outgoing rows
- **Node.js implementation**:
  - Extended `LogRecord` interface with optional `bytes_uncompressed?: number | null` field
  - Added encode-side backfill logic to convert `undefined` to `null` for Avsc compatibility (no impact on hot path since decoded records already have the field populated)
  - Added test coverage for field preservation across encode/decode cycles
- **Test coverage**: Added dedicated test case `preserves bytes_uncompressed across encode/decode` validating round-trip serialization

## How did you test this code?

The automated tests included in the diff verify:
- Avro schema round-trip serialization preserves the `bytes_uncompressed` field
- Null values are handled correctly in the schema
- Records with populated `bytes_uncompressed` values survive encode/decode cycles

## Publish to changelog?

feat

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*