### PR TITLE
chore: note that PR descriptions render markdown, not fixed-width

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,4 +53,5 @@
      - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
      - Agent-authored PRs always require human review — do not self-merge or auto-approve.
      - Do NOT claim manual testing you haven't done.
+     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
 -->


### PR DESCRIPTION
## Problem

The PR template's agent context section doesn't say anything about how GitHub renders the description. Agents (and humans) keep producing PR bodies with hard-wrapped prose at ~80 columns and space-aligned tables, which look fine in a terminal but render as awkward single-line blobs or misaligned columns on GitHub.

## Changes

Adds one bullet to the "Rules for agent-authored PRs" comment in `.github/pull_request_template.md` reminding authors that PR descriptions render markdown, so they should not hard-wrap prose or use space-aligned tables, and should rely on real markdown tables, headings, and fenced code blocks instead.

## How did you test this code?

No code change — comment-only edit to the PR template. Markdown formatting handled by the existing lint-staged `format:markdown` hook on commit.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7) at Robbie's direction. Single-line addition to the agent rules block of `.github/pull_request_template.md`. No other files touched.