### PR TITLE
fix(subscriptions): skip list API call when feature not available

### DIFF
--- a/frontend/src/lib/components/Subscriptions/subscriptionsLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionsLogic.ts
@@ -1,11 +1,12 @@
-import { BreakPointFunction, actions, afterMount, kea, key, listeners, path, props, reducers } from 'kea'
+import { BreakPointFunction, actions, afterMount, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { getInsightId } from 'scenes/insights/utils'
+import { userLogic } from 'scenes/userLogic'
 
-import { SubscriptionType } from '~/types'
+import { AvailableFeature, SubscriptionType } from '~/types'
 
 import { runSubscriptionTestDelivery } from './runSubscriptionTestDelivery'
 import type { subscriptionsLogicType } from './subscriptionsLogicType'
@@ -18,6 +19,7 @@ export const subscriptionsLogic = kea<subscriptionsLogicType>([
     key(({ insightShortId, dashboardId }) =>
         insightShortId ? `insight-${insightShortId}` : dashboardId ? `dashboard-${dashboardId}` : 'subscriptions'
     ),
+    connect(() => ({ values: [userLogic, ['hasAvailableFeature']] })),
     actions({
         deleteSubscription: (id: number) => ({ id }),
         deliverSubscription: (id: number) => ({ id }),
@@ -28,11 +30,16 @@ export const subscriptionsLogic = kea<subscriptionsLogicType>([
         setSubscriptionEnabledFailure: true,
     }),
 
-    loaders(({ props }) => ({
+    loaders(({ props, values }) => ({
         subscriptions: {
             __default: [] as SubscriptionType[],
             loadSubscriptions: async (_?: any, breakpoint?: BreakPointFunction) => {
                 if (!props.dashboardId && !props.insightShortId) {
+                    return []
+                }
+                // Subscriptions is a premium-gated endpoint; skip the call so non-premium users
+                // don't surface a 402 in error tracking when the modal/list is mounted.
+                if (!values.hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS)) {
                     return []
                 }
 

--- a/frontend/src/scenes/subscriptions/subscriptionsSceneLogic.tsx
+++ b/frontend/src/scenes/subscriptions/subscriptionsSceneLogic.tsx
@@ -22,7 +22,7 @@ import {
     type PaginatedSubscriptionListApi,
     type SubscriptionsListTargetType,
 } from '~/generated/core/api.schemas'
-import { Breadcrumb } from '~/types'
+import { AvailableFeature, Breadcrumb } from '~/types'
 
 import type { subscriptionsSceneLogicType } from './subscriptionsSceneLogicType'
 
@@ -196,7 +196,7 @@ function buildSubscriptionsListOrdering(sorting: Sorting | null): string {
 export const subscriptionsSceneLogic = kea<subscriptionsSceneLogicType>([
     path(['scenes', 'subscriptions', 'subscriptionsSceneLogic']),
     tabAwareScene(),
-    connect(() => ({ values: [userLogic, ['user']] })),
+    connect(() => ({ values: [userLogic, ['user', 'hasAvailableFeature']] })),
     actions({
         loadSubscriptions: true,
         setSearch: (search: string) => ({ search }),
@@ -300,6 +300,11 @@ export const subscriptionsSceneLogic = kea<subscriptionsSceneLogicType>([
             null as PaginatedSubscriptionListApi | null,
             {
                 loadSubscriptions: async () => {
+                    // The UI renders a PayGateMini upsell for non-premium users; short-circuit the
+                    // API call so the gated 402 doesn't surface in error tracking.
+                    if (!values.hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS)) {
+                        return { count: 0, next: null, previous: null, results: [] }
+                    }
                     const projectId = String(getCurrentTeamId())
                     let resourceType: SubscriptionsListResourceType | undefined
                     if (values.currentTab === SubscriptionsTab.Dashboard) {


### PR DESCRIPTION
## Problem

Non-premium Cloud and unlicensed self-hosted users who land on `/subscriptions` (or open the legacy manage-subscriptions modal from an insight/dashboard) still surface a 402 `EnterpriseFeatureException` to error tracking, even after the earlier dashboard-level fix.

A signal report identified eight related error-tracking fingerprints firing between 2026-04-22 and 2026-04-25. Signal 7's unminified stack pinpointed `subscriptionsSceneLogic.tsx`'s `afterMount` → `loadSubscriptions` → `subscriptionsList` → `ApiError` as another mount path hitting the `PremiumFeaturePermission`-gated `GET /api/projects/:team/subscriptions` endpoint.

`Scene.Subscriptions` is registered as a plain `projectBased` scene with no `AvailableFeature` gate, so any non-premium user following a bookmark or nav entry triggers the 402. The UI already renders a `PayGateMini` upsell, so the network call is pure noise.

The same pattern exists in the legacy `lib/components/Subscriptions/subscriptionsLogic.ts`, still mounted by `ManageSubscriptions.tsx` and `EditSubscription.tsx`.

## Changes

- `subscriptionsSceneLogic.tsx`: connect `hasAvailableFeature` from `userLogic`, and short-circuit `loadSubscriptions` to return an empty `PaginatedSubscriptionListApi` when the user lacks `AvailableFeature.SUBSCRIPTIONS`.
- `subscriptionsLogic.ts` (legacy): same short-circuit on the `loadSubscriptions` loader before calling `api.subscriptions.list`.

The `PayGateMini` wrapper in `SubscriptionsScene` continues to render the upsell UI — non-premium users see no behavioral change, just no 402 noise.

## How did you test this code?

I'm an agent. No automated or manual tests were run for this change (the user explicitly asked to skip tests).

The change is small and behavior-preserving for premium users — they still call the same endpoint with the same arguments. For non-premium users the API call is skipped entirely; the `PayGateMini` wrapper already gates the UI, so no rendered content depends on the response.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code (Opus 4.7).
- Considered two approaches per the signal report's suggestion: (a) add an `availableFeature` field to `scenes.ts` to gate scene access entirely, vs. (b) short-circuit the loader. Chose (b) because `SceneConfig` has no `availableFeature` field today and the `SubscriptionsScene` UI already wraps content in `<PayGateMini feature={AvailableFeature.SUBSCRIPTIONS}>` — that's the existing upsell pattern, so the only missing piece was suppressing the API call.
- Did not extend the fix to `subscriptionSceneLogic.tsx` (the singular-subscription detail page that calls `subscriptionsRetrieve`) because the signal report only flagged the list endpoint. The same pattern likely applies there if 402s surface from that path, and the fix would be analogous.