### PR TITLE
fix(hobby): preserve .env on reinstall instead of overwriting

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -123,16 +123,14 @@ then
     export REGISTRY_URL="posthog/posthog"
 fi
 
-
-
 # Write .env only on a fresh install. On a re-run (e.g. after a partial
 # failure) preserve the existing file, so POSTHOG_SECRET and
-# ENCRYPTION_SALT_KEYS are not regenerated -- that would invalidate active
-# sessions and corrupt encrypted data on a live instance. Mirrors the
-# FileExists(".env") guard in bin/hobby-installer. Tag changes on an existing
-# instance are handled by bin/upgrade-hobby.
+# ENCRYPTION_SALT_KEYS are not regenerated, as it would invalidate active
+# sessions and corrupt encrypted data on a live instance.
+# Mirrors the FileExists(".env") guard in bin/hobby-installer.
+# Tag changes on an existing instance are handled by bin/upgrade-hobby.
 if [ -f .env ]; then
-    echo "Existing .env found - preserving configuration"
+    echo "Existing .env found, preserving configuration"
 else
     POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
     ENCRYPTION_SALT_KEYS=$(openssl rand -hex 16)

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -9,12 +9,6 @@ export DEBIAN_FRONTEND=noninteractive
 export RESTART_MODE=l
 export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest}"
 
-POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
-export POSTHOG_SECRET
-
-ENCRYPTION_SALT_KEYS=$(openssl rand -hex 16)
-export ENCRYPTION_SALT_KEYS
-
 # Talk to the user
 echo "Welcome to the single instance PostHog installer 🦔"
 echo ""
@@ -131,8 +125,18 @@ fi
 
 
 
-# Write .env file
-cat > .env <<EOF
+# Write .env only on a fresh install. On a re-run (e.g. after a partial
+# failure) preserve the existing file, so POSTHOG_SECRET and
+# ENCRYPTION_SALT_KEYS are not regenerated -- that would invalidate active
+# sessions and corrupt encrypted data on a live instance. Mirrors the
+# FileExists(".env") guard in bin/hobby-installer. Tag changes on an existing
+# instance are handled by bin/upgrade-hobby.
+if [ -f .env ]; then
+    echo "Existing .env found - preserving configuration"
+else
+    POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
+    ENCRYPTION_SALT_KEYS=$(openssl rand -hex 16)
+    cat > .env <<EOF
 POSTHOG_SECRET=$POSTHOG_SECRET
 ENCRYPTION_SALT_KEYS=$ENCRYPTION_SALT_KEYS
 DOMAIN=$DOMAIN
@@ -142,6 +146,7 @@ CADDY_TLS_BLOCK=$TLS_BLOCK
 CADDY_HOST="$DOMAIN, http://, https://"
 POSTHOG_APP_TAG=$POSTHOG_APP_TAG
 EOF
+fi
 
 # Download GeoLite2-City.mmdb if it doesn't exist
 echo "Downloading GeoIP database file"


### PR DESCRIPTION
## Problem

`bin/deploy-hobby` rewrites `.env` on every run via `cat > .env <<EOF`, regenerating `POSTHOG_SECRET` and `ENCRYPTION_SALT_KEYS` each time. Re-running the script on a live instance — or after a partial install failure — silently invalidates all active sessions and can corrupt encrypted data.

Closes #54661

## Change

Guard the `.env` write with `[ -f .env ]`, mirroring the `FileExists(".env")` check already in the Go hobby installer (`bin/hobby-installer/core/install.go`):

- **Fresh install:** generate `POSTHOG_SECRET` / `ENCRYPTION_SALT_KEYS` and write the full `.env` (unchanged behaviour). Secret generation now lives in this branch, so it never runs on a re-run.
- **Existing `.env`:** print a message and leave the file untouched.

That's the whole fix — net **+12 / −6** in one file.

## Relationship to #57753

This is a deliberately minimal alternative to #57753, which solves the same bug but also rewrites `POSTHOG_APP_TAG` in place via `sed`, adds a regex injection guard for that `sed`, backfills `ENCRYPTION_SALT_KEYS`, and handles trailing newlines / `export`-prefixed keys. Those pieces are either already covered elsewhere or out of scope for the installer:

- `bin/upgrade-hobby` already backfills `ENCRYPTION_SALT_KEYS` when missing and is the script responsible for tag changes on an existing instance.
- With no in-place `sed`, the injection guard, newline handling, and `export`-prefix matching are unnecessary.

## Testing

`bash -n bin/deploy-hobby` passes. The guard mirrors the existing `FileExists(".env")` check in the Go installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
