### PR TITLE
fix(hogql): skip async-status redis read on fresh query cache hits

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1249,8 +1249,13 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
             if not self._is_stale(last_refresh=last_refresh_from_cached_result(cached_response)):
                 count_query_cache_hit(self.team.pk, hit="hit", trigger=cached_response.calculation_trigger or "")
-                # We have a valid result that's fresh enough, let's return it
-                cached_response.query_status = self.get_async_query_status(cache_key=cache_manager.cache_key)
+                # Fresh hit: the caller already has good data, so skip the extra Redis round-trip
+                # for async query status. There's no in-flight calculation the caller needs to track
+                # on a fresh result, and async pollers read status from the dedicated status endpoint,
+                # not from here. This is the hottest cache path (every dashboard tile and insight load),
+                # so dropping the round-trip cuts Redis load fleet-wide. query_status stays None (its
+                # default — it is never persisted to the cache); the stale/miss branches below still
+                # fetch it because there the in-flight status is meaningful.
                 return cached_response
 
             count_query_cache_hit(self.team.pk, hit="stale", trigger=cached_response.calculation_trigger or "")

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -390,6 +390,29 @@ class TestQueryRunner(BaseTest):
             self.assertEqual(response.is_cached, True)
             mock_on_commit.assert_called_once()
 
+    def test_fresh_cache_hit_skips_async_query_status_read(self):
+        TestQueryRunner = self.setup_test_query_runner_class()
+        runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
+
+        with freeze_time(datetime(2023, 2, 4, 13, 37, 42)):
+            # Prime the cache with a fresh result.
+            response = runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
+            self.assertEqual(response.is_cached, False)
+
+            # A fresh hit must not pay for the extra Redis round-trip to read async query status.
+            with mock.patch.object(runner, "get_async_query_status") as mock_status:
+                response = runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
+                self.assertEqual(response.is_cached, True)
+                self.assertIsNone(response.query_status)
+                mock_status.assert_not_called()
+
+        # Once stale, force_cache still attaches in-flight status, so the read must happen there.
+        with freeze_time(datetime(2023, 2, 4, 13, 37 + 11, 42)):
+            with mock.patch.object(runner, "get_async_query_status", return_value=None) as mock_status:
+                response = runner.run(execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE)
+                self.assertEqual(response.is_cached, True)
+                mock_status.assert_called_once()
+
     @mock.patch("django.db.transaction.on_commit")
     def test_recent_cache_calculate_async_if_stale_and_blocking_on_miss(self, mock_on_commit):
         TestQueryRunner = self.setup_test_query_runner_class()


### PR DESCRIPTION
## Problem

The interactive (`blocking`) query cache-hit path was flagged as substantially slower than the `force_cache` path, with a proposed explanation pointing at three suspects in `handle_cache_and_async_logic`: Pydantic re-validation of the cached payload, an extra Redis read for async query status, and synchronous per-event Kafka produces for event-usage logging.

Investigating each:

- **`force_cache` and `blocking` share the identical cache-hit code path.** For any query with a query runner (all real insights), both modes dispatch through `query_runner.run()` → `handle_cache_and_async_logic()`, and on a *fresh* hit they run the same branch line-for-line. The `CACHE_ONLY_NEVER_CALCULATE` short-circuit in `process_query_model` only applies to queries with *no* runner. The two modes diverge only when the cached entry is *stale* (force_cache returns it as-is; blocking recomputes). So the reported gap is a workload/measurement artifact — `force_cache` predominantly serves many small dashboard tiles and shared insights, while `blocking` serves the large, actively-viewed insight — not a code-path difference.
- **Pydantic re-validation is cheap and not safely removable.** A synthetic benchmark of the cached trends response puts validate + `model_dump` at only a couple of milliseconds even for a ~600 KB payload, because `results` is typed `list[dict[str, Any]]`, which short-circuits deep validation. It also can't be skipped safely: the cache serializes via orjson, so datetimes come back as ISO strings that validation coerces back to `datetime` (relied on by the staleness math), and the same validation is what detects schema drift to trigger recompute (`test_schema_change_triggers_recalculation`). `model_construct` would break both.
- **Event-usage logging is non-blocking** (the producer enqueues and `poll(0)`s) and fires for *both* modes, so it isn't the differentiator.

The one genuinely avoidable cost on the hot path is the extra Redis read for async query status, performed even on fresh hits.

## Changes

Skip the `get_async_query_status` Redis read on **fresh** cache hits in `handle_cache_and_async_logic`.

On a fresh hit `query_status` is already `None` in practice — it is never persisted to the cache, and async pollers read status from the dedicated status endpoint rather than from this response. The read therefore returned `None` in the common case while still costing a Redis round-trip on the hottest read path (every dashboard tile and insight load). The stale and cache-miss branches still fetch status, where an in-flight calculation is meaningful.

This is a small, surgical reduction in Redis load; it intentionally does not attempt the larger structural change (see Agent context).

## How did you test this code?

I'm an agent (Claude Code). Automated tests I actually ran locally, all passing:

- New unit test `test_fresh_cache_hit_skips_async_query_status_read` — asserts a fresh hit does not call `get_async_query_status` (and `query_status` is `None`), while a stale `force_cache` hit still does.
- Existing cache tests `TestQueryRunner`, `TestSeriesCustomNameCaching`, `TestApplySeriesCustomNames` (53 tests) — green.
- `ruff check` and `ruff format --check` on the changed files — clean.

This matches existing expectations: `test_insight.py` already asserts `query_status is None` on a fresh cache hit served via `/query/`. I did not run the full API/dashboard suites locally (they require ClickHouse); CI covers them.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Code (agent) at @aspicer's request; requires human review.

Decisions made along the way:

- **Verified the premise before acting.** Traced `process_query_model` and `run()` to establish that `force_cache` and `blocking` execute the same fresh-hit code, so the headline slowness gap is a workload/measurement artifact rather than something this branch can "fix".
- **Rejected skipping Pydantic validation** (one of the proposed directions): unsafe (datetime coercion + schema-drift detection both depend on it) and, per a local synthetic benchmark, not the bottleneck anyway (~2 ms for a ~600 KB trends payload).
- **Rejected moving event-usage logging to Celery:** the produce is already non-blocking and fires for both modes; one Celery task per cache hit would add far more load than it removes.
- **Chose the single safe, clearly-correct win:** drop the async-status Redis read on fresh hits, and locked it in with a test.

Follow-ups worth profiling (not done here — need prod traces): the residual per-hit cost lives outside the transforms examined, most likely access-control validation and `get_cache_key` (which serializes the query and reads three `Team` config relations on every call). The larger structural opportunity is a raw-bytes cache passthrough that avoids the `bytes → dict → Pydantic model → dict → bytes` round-trip for large cache hits — cross-cutting (touches the runner's return contract and several API call sites), so out of scope here.
