### PR TITLE
feat(hogli): forward multiple devbox ports at once

### DIFF
--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -1119,24 +1119,96 @@ def devbox_status(workspace: str | None) -> None:
         _print_connection_info(name)
 
 
-@click.command(name="devbox:forward", help="Forward PostHog UI to localhost")
+@click.command(name="devbox:forward", help="Forward devbox ports to localhost")
 @workspace_argument
-@click.option("--port", default=8010, type=int, help="Local port to forward to")
-def devbox_forward(workspace: str | None, port: int) -> None:
-    """Forward the PostHog UI port to localhost."""
+@click.option(
+    "--port",
+    default=None,
+    type=int,
+    help="Local port to forward to remote 8010 (PostHog UI). Defaults to 8010.",
+)
+@click.option(
+    "--tcp",
+    "tcp_specs",
+    multiple=True,
+    metavar="LOCAL[:REMOTE]",
+    help=(
+        "Forward LOCAL to REMOTE (or LOCAL:LOCAL if REMOTE is omitted). Repeatable; "
+        "e.g. `--tcp 8010 --tcp 8787` forwards both PostHog UI and the MCP server."
+    ),
+)
+def devbox_forward(workspace: str | None, port: int | None, tcp_specs: tuple[str, ...]) -> None:
+    """Forward one or more devbox ports to localhost.
+
+    No flags forwards just the PostHog UI (devbox:8010 -> localhost:8010).
+    Use `--tcp` (repeatable) to forward arbitrary ports atomically — Ctrl+C
+    tears them all down together.
+    """
+    if port is not None and tcp_specs:
+        _fail("Use either --port or --tcp, not both.")
+
     ensure_runtime_ready()
     name, _ = resolve_workspace_name(workspace)
-    if not _local_port_is_available(port):
-        _fail(
-            f"Local port {port} is already in use.\n"
-            f"Stop the process using that port or rerun with `hogli devbox:forward --port {port + 1}`."
-        )
 
-    click.echo(f"Forwarding {name}:8010 -> localhost:{port}")
-    click.echo(f"PostHog UI at http://localhost:{port}")
+    forwards = _resolve_port_forwards(port, tcp_specs)
+    _ensure_local_ports_available(forwards)
+
+    for local, remote in forwards:
+        click.echo(f"Forwarding {name}:{remote} -> localhost:{local}")
     click.echo("Ctrl+C to stop")
     click.echo()
-    port_forward_replace(name, port, 8010)
+    port_forward_replace(name, forwards)
+
+
+def _resolve_port_forwards(port: int | None, tcp_specs: tuple[str, ...]) -> list[tuple[int, int]]:
+    """Turn CLI flags into the (local, remote) pairs to forward.
+
+    The no-flag default (PostHog UI on 8010) lives here so the command body
+    stays a straight pipeline through validation and execution.
+    """
+    if tcp_specs:
+        return [_parse_tcp_spec(spec) for spec in tcp_specs]
+    return [(port if port is not None else 8010, 8010)]
+
+
+def _parse_tcp_spec(spec: str) -> tuple[int, int]:
+    """Parse a ``LOCAL[:REMOTE]`` token into a (local, remote) port pair."""
+    parts = spec.split(":")
+    if len(parts) == 1:
+        local_str = remote_str = parts[0]
+    elif len(parts) == 2:
+        local_str, remote_str = parts
+    else:
+        _fail(f"Invalid --tcp value '{spec}'. Expected LOCAL or LOCAL:REMOTE.")
+
+    try:
+        local = int(local_str)
+        remote = int(remote_str)
+    except ValueError:
+        _fail(f"Invalid --tcp value '{spec}'. Ports must be integers.")
+
+    if not (0 < local < 65536 and 0 < remote < 65536):
+        _fail(f"Invalid --tcp value '{spec}'. Ports must be between 1 and 65535.")
+
+    return local, remote
+
+
+def _ensure_local_ports_available(forwards: list[tuple[int, int]]) -> None:
+    """Fail fast if any local port in ``forwards`` is already bound.
+
+    Reporting every conflict in one pass avoids the half-up state you get
+    when coder would refuse one port mid-list, and saves the user from a
+    retry-and-rediscover loop when several ports collide.
+    """
+    conflicts = [local for local, _ in forwards if not _local_port_is_available(local)]
+    if not conflicts:
+        return
+
+    ports_str = ", ".join(str(p) for p in conflicts)
+    _fail(
+        f"Local port(s) already in use: {ports_str}.\n"
+        "Free the port(s) or pick different locals with `--port N` or `--tcp LOCAL:REMOTE`."
+    )
 
 
 def _gib(nbytes: int) -> str:

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -1200,9 +1200,17 @@ def ssh_replace(name: str) -> None:
     _run_or_exit(["coder", "ssh", name])
 
 
-def port_forward_replace(name: str, local_port: int, remote_port: int) -> None:
-    """Port-forward to a workspace and replace the current process."""
-    _run_or_exit(["coder", "port-forward", name, f"--tcp={local_port}:{remote_port}"])
+def port_forward_replace(name: str, forwards: list[tuple[int, int]]) -> None:
+    """Port-forward one or more (local, remote) pairs and replace the current process.
+
+    All pairs are handed to a single ``coder port-forward`` invocation so Ctrl+C
+    tears every forward down atomically — splitting across processes leaves
+    half-up state when one side dies.
+    """
+    args = ["coder", "port-forward", name]
+    for local_port, remote_port in forwards:
+        args.append(f"--tcp={local_port}:{remote_port}")
+    _run_or_exit(args)
 
 
 def logs_replace(name: str, follow: bool) -> None:

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -1397,16 +1397,14 @@ class TestDevboxCommands:
         monkeypatch.setattr(
             devbox_cli,
             "port_forward_replace",
-            lambda name, local_port, remote_port: captured.update(
-                {"name": name, "local_port": local_port, "remote_port": remote_port}
-            ),
+            lambda name, forwards: captured.update({"name": name, "forwards": forwards}),
         )
 
         result = runner.invoke(cli, ["devbox:forward"])
 
         assert result.exit_code == 0
         assert "Forwarding devbox-test-user:8010 -> localhost:8010" in result.output
-        assert captured == {"name": "devbox-test-user", "local_port": 8010, "remote_port": 8010}
+        assert captured == {"name": "devbox-test-user", "forwards": [(8010, 8010)]}
 
     def test_devbox_forward_fails_early_when_local_port_is_in_use(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(devbox_cli, "ensure_runtime_ready", lambda: None)
@@ -1416,8 +1414,64 @@ class TestDevboxCommands:
         result = runner.invoke(cli, ["devbox:forward", "--port", "8010"])
 
         assert result.exit_code == 1
-        assert "Local port 8010 is already in use." in result.output
-        assert "hogli devbox:forward --port 8011" in result.output
+        assert "Local port(s) already in use: 8010" in result.output
+
+    def test_devbox_forward_handles_multiple_tcp_pairs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, object] = {}
+
+        monkeypatch.setattr(devbox_cli, "ensure_runtime_ready", lambda: None)
+        monkeypatch.setattr(devbox_cli, "resolve_workspace_name", lambda ws: ("devbox-test-user", []))
+        monkeypatch.setattr(devbox_cli, "_local_port_is_available", lambda port: True)
+        monkeypatch.setattr(
+            devbox_cli,
+            "port_forward_replace",
+            lambda name, forwards: captured.update({"name": name, "forwards": forwards}),
+        )
+
+        result = runner.invoke(cli, ["devbox:forward", "--tcp", "8010", "--tcp", "9000:8787"])
+
+        assert result.exit_code == 0
+        assert "Forwarding devbox-test-user:8010 -> localhost:8010" in result.output
+        assert "Forwarding devbox-test-user:8787 -> localhost:9000" in result.output
+        assert captured == {"name": "devbox-test-user", "forwards": [(8010, 8010), (9000, 8787)]}
+
+    def test_devbox_forward_rejects_combining_port_and_tcp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(devbox_cli, "ensure_runtime_ready", lambda: None)
+        monkeypatch.setattr(devbox_cli, "resolve_workspace_name", lambda ws: ("devbox-test-user", []))
+
+        result = runner.invoke(cli, ["devbox:forward", "--port", "8010", "--tcp", "8787"])
+
+        assert result.exit_code == 1
+        assert "Use either --port or --tcp" in result.output
+
+    def test_devbox_forward_lists_every_conflict_with_tcp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(devbox_cli, "ensure_runtime_ready", lambda: None)
+        monkeypatch.setattr(devbox_cli, "resolve_workspace_name", lambda ws: ("devbox-test-user", []))
+        monkeypatch.setattr(devbox_cli, "_local_port_is_available", lambda port: port not in {8010, 8787})
+
+        result = runner.invoke(cli, ["devbox:forward", "--tcp", "8010", "--tcp", "8787", "--tcp", "9999"])
+
+        assert result.exit_code == 1
+        assert "Local port(s) already in use: 8010, 8787" in result.output
+        assert "9999" not in result.output
+
+    @pytest.mark.parametrize(
+        "spec,expected",
+        [
+            ("8010", (8010, 8010)),
+            ("8010:8787", (8010, 8787)),
+        ],
+    )
+    def test_parse_tcp_spec_accepts_short_and_full_forms(self, spec: str, expected: tuple[int, int]) -> None:
+        assert devbox_cli._parse_tcp_spec(spec) == expected
+
+    @pytest.mark.parametrize(
+        "spec",
+        ["abc", "8010:abc", "8010:8787:1", "0", "70000", "8010:0"],
+    )
+    def test_parse_tcp_spec_rejects_invalid(self, spec: str) -> None:
+        with pytest.raises(SystemExit):
+            devbox_cli._parse_tcp_spec(spec)
 
 
 class TestStartExistingWorkspace:


### PR DESCRIPTION
**Title:** `feat(hogli): forward multiple devbox ports at once`

### Problem

Running PostHog MCP from a devbox needs both 8010 (OAuth authz server from `SITE_URL`) and 8787 (MCP) forwarded to the laptop. `hogli devbox:forward` only supported one pair, and `--port N` silently forwarded `N -> 8010` because the remote was hardcoded — so `--port 8787` looked right and wasn't. Users were running two `coder port-forward` processes in separate shells.

### Changes

- `--tcp LOCAL[:REMOTE]` on `hogli devbox:forward`, repeatable. All pairs go through one `coder port-forward` so Ctrl+C tears them down atomically.
- `--tcp 8010` shorthand for `8010:8010`.
- Bare invocation still forwards `8010 -> 8010`; `--port N` still means `N -> 8010`. `--port` and `--tcp` are mutually exclusive.
- Conflicts are reported in one message listing every busy local port.

Design choices:
- General `--tcp` primitive instead of named per-service flags (`--mcp`, etc.) — named flags age badly as services are added.
- Fail-fast on conflicts: half-up forwarding silently drops requests; listing all conflicts at once avoids a retry-and-rediscover loop.

### How did you test this code?

I'm an agent — automated only.

- `hogli test tools/hogli-commands/hogli_commands/tests/test_devbox.py` — 183 passed (5 new: multi-`--tcp`, flag conflict, multi-port conflict, parametrized `_parse_tcp_spec` accept/reject).
- `ruff check` + `ruff format --check` on changed files.
- Rendered `--help` to verify wording.

Manual verify: devbox up, `hogli devbox:forward --tcp 8010 --tcp 8787`, then `curl -sI http://localhost:8010` and `http://localhost:8787` should both respond; one Ctrl+C tears both down.

### Publish to changelog?

no

### Agent context

Fully agent-authored (Claude Code, Opus 4.7); requires human review.

Considered named convenience flags (`--mcp`) and a "rerun with --port N+1" hint on conflict — both rejected. Named flags compound as services are added; the +1 hint was misleading for the OAuth case where 8010 is hardcoded by the redirect, and keeping it just for the single-port path was a special-general mixture.