### PR TITLE
fix(devbox): csv-escape IdentityAgent ssh-option for coder

### DIFF
--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -601,6 +601,21 @@ def ensure_coder_reachable() -> None:
     _fail(body)
 
 
+def _csv_quote_ssh_option(value: str) -> str:
+    """CSV-escape a value for ``coder config-ssh --ssh-option``.
+
+    Why: coder parses each ``--ssh-option`` argument with Go's ``encoding/csv``
+    before writing it to ``~/.ssh/config``. A bare ``"`` in the middle of an
+    unquoted CSV field is rejected with ``bare " in non-quoted-field``. We need
+    the embedded quotes (so OpenSSH sees ``IdentityAgent "<path with spaces>"``
+    as a single argument), which means wrapping the whole CSV field in quotes
+    and doubling any internal quotes per RFC 4180.
+    """
+    if any(c in value for c in ('"', ",", "\n", "\r")):
+        return '"' + value.replace('"', '""') + '"'
+    return value
+
+
 def _config_ssh_args(*, identity_agent_socket: str | None = None) -> list[str]:
     """Build the base args for ``coder config-ssh``, pinning the managed binary path.
 
@@ -617,7 +632,7 @@ def _config_ssh_args(*, identity_agent_socket: str | None = None) -> list[str]:
         args += ["--coder-binary-path", str(managed)]
     args += ["--ssh-option", "ForwardAgent yes"]
     if identity_agent_socket:
-        args += ["--ssh-option", f'IdentityAgent "{identity_agent_socket}"']
+        args += ["--ssh-option", _csv_quote_ssh_option(f'IdentityAgent "{identity_agent_socket}"')]
     return args
 
 

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import io
+import csv
 import json
 import errno
 import subprocess
@@ -2216,16 +2218,30 @@ class TestConfigSshArgs:
     @pytest.mark.parametrize(
         "socket",
         [
-            # 1Password's default path contains spaces; without quoting,
-            # OpenSSH parses the trailing path components as "extra arguments"
-            # and refuses to load the config file.
+            # 1Password's default path contains spaces; OpenSSH parses the
+            # trailing components as "extra arguments" unless the value is
+            # quoted, so the written ssh config must have IdentityAgent "<path>".
             "/Users/me/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock",
             "/tmp/agent.sock",
         ],
     )
     def test_quotes_identity_agent_socket(self, socket: str) -> None:
         args = coder._config_ssh_args(identity_agent_socket=socket)
-        assert f'IdentityAgent "{socket}"' in args
+        identity_value = self._ssh_option_value_with(args, "IdentityAgent")
+        # coder CSV-parses --ssh-option before writing the config; the parsed
+        # form is what lands in ~/.ssh/config and what OpenSSH must see quoted.
+        assert self._csv_decode(identity_value) == f'IdentityAgent "{socket}"'
+
+    @staticmethod
+    def _ssh_option_value_with(args: list[str], directive: str) -> str:
+        for i, arg in enumerate(args):
+            if arg == "--ssh-option" and directive in args[i + 1]:
+                return args[i + 1]
+        raise AssertionError(f"no --ssh-option containing {directive!r} in {args!r}")
+
+    @staticmethod
+    def _csv_decode(value: str) -> str:
+        return next(csv.reader(io.StringIO(value)))[0]
 
 
 class TestSetupGitSigning:


### PR DESCRIPTION
## Problem

After #59399 (which wraps the IdentityAgent socket in `"` so OpenSSH treats spaced paths as one argument), `hogli devbox:setup` fails on macOS the moment the resolved socket path is non-empty:

```
parsing flags ([config-ssh --coder-binary-path …/.hogli/bin/coder --ssh-option ForwardAgent yes --ssh-option IdentityAgent "/Users/<user>/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" --yes]) for "coder config-ssh": invalid argument "IdentityAgent \"…\"" for "-o, --ssh-option" flag: parse error on line 1, column 15: bare " in non-quoted-field
```

`coder config-ssh` parses every `--ssh-option` value with Go's `encoding/csv` before writing it to `~/.ssh/config`. A bare `"` mid-field is rejected unconditionally — the path having spaces is incidental; even `IdentityAgent "/tmp/agent.sock"` would error the same way. So the previous fix never actually made it past the CLI flag parser.

## Changes

- `tools/hogli-commands/hogli_commands/devbox/coder.py`: introduce `_csv_quote_ssh_option` and CSV-escape the `IdentityAgent "<socket>"` value per RFC 4180 (wrap whole field, double internal quotes). After coder's CSV parse, the directive that lands in `~/.ssh/config` is still `IdentityAgent "<socket>"`, so OpenSSH parses the value-with-whitespace correctly — keeping the intent of #59399 intact.
- `tools/hogli-commands/hogli_commands/tests/test_devbox.py`: tighten `TestConfigSshArgs::test_quotes_identity_agent_socket` to round-trip the value through `csv` and assert that the *parsed* result equals `IdentityAgent "<socket>"`. The old assertion checked the pre-CSV string and didn't catch this regression.

## How did you test this code?

I'm an automated agent (Claude Code).

- `hogli test tools/hogli-commands/hogli_commands/tests/test_devbox.py::TestConfigSshArgs` — 3 passed (no-socket case + 1Password-style spaced path + plain `/tmp/agent.sock`).
- `hogli test tools/hogli-commands/hogli_commands/tests/test_devbox.py` — full file, 172 passed.
- Confirmed `ruff check` + `ruff format` clean on both changed files.

No manual `coder config-ssh` invocation (no spaced-path Coder host in the test sandbox); the CSV round-trip assertion exercises the actual decoder behavior coder uses.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Authored by PostHog Code (Claude) in a /loop debugging session with @lricoy after he hit the bug in `hogli devbox:setup`.
- Considered alternatives: (1) reverting to the pre-#59399 unquoted form — would re-break OpenSSH config parsing for spaced socket paths, defeating #59399's stated goal; (2) symlinking the 1Password socket to a no-spaces path — engineer-side workaround, doesn't fix the embedded `"` that trips CSV regardless of path content; (3) dropping `IdentityAgent` from the ssh-option set — silently regresses agent forwarding for non-1Password setups. CSV-escaping per RFC 4180 is the minimal fix that preserves the SSH-config-quoted output for OpenSSH while satisfying coder's CSV flag parser.