### PR TITLE
feat(dashboards): backfill DashboardTile.team_id from dashboard (2/3)

### DIFF
--- a/products/dashboards/backend/management/commands/backfill_dashboardtile_team_id.py
+++ b/products/dashboards/backend/management/commands/backfill_dashboardtile_team_id.py
@@ -1,0 +1,47 @@
+import time
+from typing import Any
+
+from django.core.management.base import BaseCommand
+from django.db import connection, transaction
+
+BATCH_SIZE = 5000
+SLEEP_INTERVAL_SECONDS = 0.1
+
+UPDATE_BATCH_SQL = """
+UPDATE posthog_dashboardtile AS t
+SET team_id = d.team_id
+FROM posthog_dashboard AS d
+WHERE t.dashboard_id = d.id
+  AND t.team_id IS NULL
+  AND t.id IN (
+      SELECT id
+      FROM posthog_dashboardtile
+      WHERE team_id IS NULL
+      ORDER BY id
+      LIMIT %s
+  )
+"""
+
+
+class Command(BaseCommand):
+    help = "Backfill DashboardTile.team_id from the parent dashboard's team_id."
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        total_updated = 0
+        batch_index = 0
+
+        while True:
+            with transaction.atomic():
+                with connection.cursor() as cursor:
+                    cursor.execute(UPDATE_BATCH_SQL, [BATCH_SIZE])
+                    updated = cursor.rowcount
+
+            if updated == 0:
+                break
+
+            total_updated += updated
+            batch_index += 1
+            self.stdout.write(f"Batch {batch_index}: updated {updated} tile(s) (running total: {total_updated}).")
+            time.sleep(SLEEP_INTERVAL_SECONDS)
+
+        self.stdout.write(self.style.SUCCESS(f"Done. Updated {total_updated} tile(s) in {batch_index} batch(es)."))

--- a/products/dashboards/backend/management/commands/test/test_backfill_dashboardtile_team_id.py
+++ b/products/dashboards/backend/management/commands/test/test_backfill_dashboardtile_team_id.py
@@ -1,0 +1,73 @@
+from io import StringIO
+
+from posthog.test.base import BaseTest
+
+from django.core.management import call_command
+from django.db import connection
+
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+
+from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_tile import DashboardTile, Text
+
+
+def _null_out_team_ids(tile_ids: list[int]) -> None:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "UPDATE posthog_dashboardtile SET team_id = NULL WHERE id = ANY(%s)",
+            [tile_ids],
+        )
+
+
+def _team_id_for(tile_id: int) -> int | None:
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT team_id FROM posthog_dashboardtile WHERE id = %s", [tile_id])
+        row = cursor.fetchone()
+        assert row is not None
+        return row[0]
+
+
+class TestBackfillDashboardTileTeamId(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.stdout = StringIO()
+
+        self.other_organization = Organization.objects.create(name="other org")
+        self.other_team = Team.objects.create(organization=self.other_organization, name="other team")
+
+        self.dashboard_a = Dashboard.objects.create(team=self.team, name="A")
+        self.dashboard_b = Dashboard.objects.create(team=self.other_team, name="B")
+
+        text_a = Text.objects.create(team=self.team, body="hi A")
+        text_b = Text.objects.create(team=self.other_team, body="hi B")
+        self.tile_a = DashboardTile.objects.create(dashboard=self.dashboard_a, text=text_a)
+        self.tile_b = DashboardTile.objects.create(dashboard=self.dashboard_b, text=text_b)
+
+    def test_backfills_team_id_from_dashboard(self) -> None:
+        _null_out_team_ids([self.tile_a.id, self.tile_b.id])
+        self.assertIsNone(_team_id_for(self.tile_a.id))
+        self.assertIsNone(_team_id_for(self.tile_b.id))
+
+        call_command("backfill_dashboardtile_team_id", stdout=self.stdout)
+
+        self.assertEqual(_team_id_for(self.tile_a.id), self.team.id)
+        self.assertEqual(_team_id_for(self.tile_b.id), self.other_team.id)
+
+    def test_second_run_is_a_noop(self) -> None:
+        _null_out_team_ids([self.tile_a.id, self.tile_b.id])
+
+        call_command("backfill_dashboardtile_team_id", stdout=self.stdout)
+
+        second_stdout = StringIO()
+        call_command("backfill_dashboardtile_team_id", stdout=second_stdout)
+        self.assertIn("Updated 0 tile(s) in 0 batch(es)", second_stdout.getvalue())
+
+    def test_skips_tiles_that_already_have_team_id(self) -> None:
+        _null_out_team_ids([self.tile_a.id])
+
+        call_command("backfill_dashboardtile_team_id", stdout=self.stdout)
+
+        self.tile_b.refresh_from_db(fields=["team_id"])
+        self.assertEqual(self.tile_b.team_id, self.other_team.id)
+        self.assertEqual(_team_id_for(self.tile_a.id), self.team.id)

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2878,7 +2878,7 @@
     },
     "llma-personal-spend": {
         "description": "Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days (default 30, max 90). Returns a summary plus breakdowns by product, tool, model, and top traces. Pass `product` (e.g. `posthog_code`, `background_agents`) to scope the tool / model / trace breakdowns to a single product; `by_product` always returns the cross-product view. Pass `refresh=true` to bypass the 5-minute cache.",
-        "category": "LLM analytics",
+        "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get my LLM spend analysis",
         "title": "Get my LLM spend analysis",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -3191,7 +3191,7 @@
     },
     "llma-personal-spend": {
         "description": "Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days (default 30, max 90). Returns a summary plus breakdowns by product, tool, model, and top traces. Pass `product` (e.g. `posthog_code`, `background_agents`) to scope the tool / model / trace breakdowns to a single product; `by_product` always returns the cross-product view. Pass `refresh=true` to bypass the 5-minute cache.",
-        "category": "LLM analytics",
+        "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get my LLM spend analysis",
         "title": "Get my LLM spend analysis",


### PR DESCRIPTION
## Problem

Step 2 of the three-PR rollout that adds `team_id` to `DashboardTile` so the table can be exposed in HogQL. PR 1 added the column nullable; existing rows still have `team_id IS NULL`. This PR backfills them from `dashboard.team_id`.

## Changes

Adds a task to backfill the team ID onto the dashboard tiles.

## How did you test this code?

Added a test. 