### PR TITLE
fix(devbox): use openssh alias for devbox:ssh

### DIFF
--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -1217,9 +1217,20 @@ def user_secret_exists(name: str) -> bool:
     return any(isinstance(s, dict) and s.get("name") == name for s in secrets)
 
 
+def _ssh_host_alias(name: str) -> str:
+    """Return the ``Host`` alias written by ``coder config-ssh`` for the given workspace."""
+    return f"coder.{name}"
+
+
 def ssh_replace(name: str) -> None:
-    """SSH into a workspace and replace the current process."""
-    _run_or_exit(["coder", "ssh", name])
+    """SSH via the ``coder.*`` host alias so ``~/.ssh/config`` applies.
+
+    Calling ``coder ssh`` directly bypasses the user's ssh config, breaking
+    ``IdentityAgent`` forwarding (Secretive, 1Password) used for commit signing.
+    The wildcard ``Host coder.*`` block written by ``coder config-ssh`` keeps
+    the Coder tunnel via its ``ProxyCommand``.
+    """
+    os.execvp("ssh", ["ssh", _ssh_host_alias(name)])
 
 
 def port_forward_replace(name: str, local_port: int, remote_port: int) -> None:
@@ -1291,8 +1302,7 @@ def open_cursor(name: str) -> None:
     cursor = shutil.which("cursor")
     if not cursor:
         _fail("`cursor` CLI is not on PATH. Open Cursor and enable Shell Integration from the Command Palette.")
-    ssh_host = f"coder.{name}"
-    os.execvp(cursor, ["cursor", "--remote", f"ssh-remote+{ssh_host}", "/home/coder/posthog"])
+    os.execvp(cursor, ["cursor", "--remote", f"ssh-remote+{_ssh_host_alias(name)}", "/home/coder/posthog"])
 
 
 def open_web_ide(name: str) -> None:

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -2607,6 +2607,22 @@ class TestEncodeSshOption:
         assert next(csv.reader([encoded]))[0] == "ProxyCommand a,b"
 
 
+class TestSshReplace:
+    """Verify devbox:ssh routes through the OpenSSH alias, not ``coder ssh``."""
+
+    def test_host_alias_matches_coder_config_ssh_default(self) -> None:
+        # `coder config-ssh` writes `Host coder.*` by default; the alias must match.
+        assert coder._ssh_host_alias("devbox-foo") == "coder.devbox-foo"
+
+    def test_execs_ssh_with_coder_host_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[tuple[str, list[str]]] = []
+        monkeypatch.setattr(coder.os, "execvp", lambda file, args: captured.append((file, args)))
+
+        coder.ssh_replace("devbox-foo")
+
+        assert captured == [("ssh", ["ssh", coder._ssh_host_alias("devbox-foo")])]
+
+
 class TestSetupGitSigning:
     """Test the Git commit signing step in devbox:setup.
 


### PR DESCRIPTION
## Problem

`hogli devbox:ssh` connects via `coder ssh <name>`, which is Coder's standalone SSH client and does not read `~/.ssh/config`. The `IdentityAgent` and `ForwardAgent yes` that `hogli devbox:setup` writes into the `Host coder.*` block are silently ignored, so `$SSH_AUTH_SOCK` is unset inside the workspace and `git commit -S` fails:

```
error: Couldn't get agent socket?
fatal: failed to write commit object
```

Affects every engineer using Secretive or 1Password for commit signing.

## Fix

`ssh_replace` invokes `ssh coder.<name>` instead of `coder ssh <name>`. OpenSSH reads the host block, the wildcard `Host coder.*` keeps the Coder tunnel via its `ProxyCommand coder ssh --stdio`, and the engineer's `IdentityAgent` / `ForwardAgent` apply -- so Secretive, 1Password, gpg-agent, anything in their ssh_config gets forwarded into the workspace. Same path VS Code Remote-SSH and Cursor already use.

The host alias is extracted into `_ssh_host_alias(name)` and shared with `open_cursor`, which was constructing the same string inline.

## How did you test this code?

I'm an agent.

Automated:
- Updated `TestSshReplace` to assert `ssh coder.<name>` is exec'd; added a constant-check on `_ssh_host_alias("devbox-foo") == "coder.devbox-foo"`.
- 196 tests pass in `tools/hogli-commands/hogli_commands/tests/test_devbox.py`.

Manual against a real devbox (1Password + Secretive both):
- Master (`coder ssh devbox-raul-n -- git commit -S`): `Couldn't get agent socket?` -- reproduces the bug.
- PR (`ssh coder.devbox-raul-n` + signed commit): `Good "git" signature for raul.n@posthog.com with ED25519 key SHA256:RRR9...`. Touch ID prompted on Mac, 1Password approved, commit signed and verified.
- Secretive validation (via per-connection `-o IdentityAgent=<secretive-socket> -o ForwardAgent=<secretive-socket>` to avoid touching ssh_config): Secretive's ECDSA key listed inside workspace via `ssh-add -l`. Same forwarding mechanism, no Secretive-specific code path.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code. First iteration threaded `--forward-agent --identity-agent <socket>` through `coder ssh`. Replaced with the OpenSSH-alias approach after reading Coder, 1Password, and Secretive docs -- all three treat `IdentityAgent` in ssh_config as the canonical setup, and `coder config-ssh` already writes the right `Host coder.*` block. Going through OpenSSH lets one config (the engineer's ssh_config) drive all three connection methods (`hogli devbox:ssh`, VS Code Remote-SSH, Cursor) uniformly.