### PR TITLE
feat(billing): expose billing limit values to autocapture

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -79,6 +79,12 @@ export interface LemonButtonPropsBase
      * **Project settings → Data attributes**. Defaults to the same value as `data-attr` when omitted.
      */
     'data-attr-id'?: string
+    /**
+     * Arbitrary `data-*` attributes spread onto the underlying element — useful for surfacing
+     * extra context (e.g. selected values) to autocapture's `elements_chain`.
+     * Keys must start with `data-`.
+     */
+    extraDataAttrs?: Record<`data-${string}`, string | number | boolean | null | undefined>
     'aria-label'?: string
     /** Whether to truncate the button's text if necessary */
     truncate?: boolean
@@ -171,6 +177,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                 tooltipDocLink,
                 tooltipForceMount,
                 stopPropagation,
+                extraDataAttrs,
                 ...buttonProps
             },
             ref
@@ -273,6 +280,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                     aria-disabled={!!disabled}
                     {...linkDependentProps}
                     {...buttonProps}
+                    {...extraDataAttrs}
                     data-attr-id={buttonProps['data-attr-id'] ?? buttonProps['data-attr']}
                 >
                     <span className="LemonButton__chrome">

--- a/frontend/src/scenes/billing/BillingLimit.tsx
+++ b/frontend/src/scenes/billing/BillingLimit.tsx
@@ -15,8 +15,14 @@ import { billingProductLogic } from './billingProductLogic'
 export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JSX.Element | null => {
     const limitInputRef = useRef<HTMLInputElement | null>(null)
     const { billing, billingLoading } = useValues(billingLogic)
-    const { isEditingBillingLimit, customLimitUsd, hasCustomLimitSet, currentAndUpgradePlans, billingLimitNextPeriod } =
-        useValues(billingProductLogic({ product, billingLimitInputRef: limitInputRef }))
+    const {
+        isEditingBillingLimit,
+        customLimitUsd,
+        hasCustomLimitSet,
+        currentAndUpgradePlans,
+        billingLimitNextPeriod,
+        billingLimitInput,
+    } = useValues(billingProductLogic({ product, billingLimitInputRef: limitInputRef }))
     const { setIsEditingBillingLimit, setBillingLimitInput, submitBillingLimitInput, removeBillingLimitNextPeriod } =
         useActions(billingProductLogic({ product }))
 
@@ -113,6 +119,10 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                     size="small"
                                     htmlType="submit"
                                     data-attr={`save-billing-limit-${product.type}`}
+                                    extraDataAttrs={{
+                                        'data-ph-billing-product': product.type,
+                                        'data-ph-billing-limit-usd': billingLimitInput.input ?? '',
+                                    }}
                                 >
                                     Save
                                 </LemonButton>
@@ -131,6 +141,7 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                         status="danger"
                                         size="small"
                                         data-attr={`remove-billing-limit-${product.type}`}
+                                        extraDataAttrs={{ 'data-ph-billing-product': product.type }}
                                         tooltip="Remove billing limit"
                                         onClick={() => {
                                             setBillingLimitInput(null)


### PR DESCRIPTION
## Problem

We want to know which customers are setting their billing limit to 0 (or any specific value) for a given product like error tracking, but the existing autocapture event on the Save button only tells us *that* a save happened — not the product or the entered value.

Adding the product type and the entered limit as `data-*` attributes lets autocapture surface them in `elements_chain` (as `attr__data-ph-billing-product` and `attr__data-ph-billing-limit-usd`), so analytics queries can answer "who set the error tracking limit to 0" directly, no new custom event required.

## Changes

- `LemonButton` gains an `extraDataAttrs?: Record<\`data-\${string}\`, ...>` prop. The values are spread onto the underlying button/link element, so callers can attach arbitrary `data-*` attributes without each call site forcing the type to widen. Existing typing of `Pick<>`/`Omit<>` consumers of `LemonButtonProps` is unchanged.
- `BillingLimit.tsx` Save button now sets `data-ph-billing-product={product.type}` and `data-ph-billing-limit-usd={billingLimitInput.input}`. The Remove button sets `data-ph-billing-product` only (it always sets the limit to null).
- The existing `data-attr` (used in Playwright tests) is untouched.

No new custom event is fired; this is purely autocapture metadata.

## How did you test this code?

I'm an agent. I did not run the UI manually. Automated checks I ran:

- `pnpm typescript:check` — confirmed no new TypeScript errors in `BillingLimit.tsx` or `LemonButton.tsx` (the broader codebase has pre-existing errors on master unrelated to this change).

Reviewer should manually verify:
- Save click on `/organization/billing` fires `$autocapture` with `attr__data-ph-billing-product` and `attr__data-ph-billing-limit-usd` populated on the matching element in `elements_chain`.
- Remove click fires with `attr__data-ph-billing-product` populated.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

- Tool: PostHog Code (Claude).
- Considered adding an explicit `posthog.capture('billing_limit_updated', { product, limit })` call in `billingLogic.updateBillingLimits` — would give a single clean event with confirmed values. Rejected per request: user explicitly wanted to lean on autocapture rather than a new custom event.
- First attempt added a `[key: \`data-\${string}\`]: unknown` index signature to `LemonButtonPropsBase`. This broke `Pick<LemonButtonProps, ...>` consumers because the index signature changes how TS distributes optionality across picked keys. Switched to an explicit `extraDataAttrs` prop, which is destructured before the `...buttonProps` spread and applied separately.
- Did not run Playwright. The existing `playwright/e2e/billing/billing-limits.spec.ts` still passes structurally (selectors use `data-attr`, untouched).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*