### PR TITLE
chore(devex): drop redundant api-docs warnings snapshot test

### DIFF
--- a/posthog/api/test/__snapshots__/test_api_docs.ambr
+++ b/posthog/api/test/__snapshots__/test_api_docs.ambr
@@ -1,6 +1,0 @@
-# serializer version: 1
-# name: TestAPIDocsSchema.test_api_docs_generation_warnings_snapshot
-  list([
-    '',
-  ])
-# ---

--- a/posthog/api/test/test_api_docs.py
+++ b/posthog/api/test/test_api_docs.py
@@ -1,16 +1,7 @@
-import re
-from pathlib import Path
-
-import pytest
 from posthog.test.base import APIBaseTest
 
 
 class TestAPIDocsSchema(APIBaseTest):
-    @pytest.fixture(autouse=True)
-    def inject_fixtures(self, capsys, snapshot):
-        self._capsys = capsys
-        self._snapshot = snapshot
-
     def test_can_generate_api_docs_schema(self) -> None:
         self.client.logout()
 
@@ -21,28 +12,6 @@ class TestAPIDocsSchema(APIBaseTest):
         assert isinstance(schema_response.data, dict)
         assert schema_response.headers.get("Content-Type") == "application/vnd.oai.openapi; charset=utf-8"
         assert int(str(schema_response.headers.get("Content-Length"))) > 0
-
-    def test_api_docs_generation_warnings_snapshot(self) -> None:
-        """
-        There are a little under 200 warning from API docs generation. Lets at least not add more.
-        """
-        self.client.logout()
-
-        self.client.get("/api/schema/")
-
-        # we log lots of warnings when generating the schema
-        warnings = [self._normalize_warning_path(warning) for warning in self._capsys.readouterr().err.split("\n")]
-        assert sorted(warnings) == self._snapshot
-
-    @staticmethod
-    def _normalize_warning_path(warning: str) -> str:
-        repo_root = str(Path(__file__).resolve().parents[3])
-        warning = warning.replace(repo_root, "/home/runner/work/posthog/posthog")
-        return re.sub(
-            r"^.*?/site-packages/",
-            "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/",
-            warning,
-        )
 
     def test_llm_prompt_schema_includes_search_and_prompt_name_path_param(self) -> None:
         self.client.logout()


### PR DESCRIPTION
## Problem

`posthog/api/test/test_api_docs.py::TestAPIDocsSchema::test_api_docs_generation_warnings_snapshot` ratchets the set of drf-spectacular warnings emitted while serving `/api/schema/`. It was introduced in #54909 alongside the `--fail-on-warn` flag on the management command — back then there were ~200 warnings and the snapshot was a "don't add more" guard during cleanup.

That cleanup is done: the snapshot is empty today, and `hogli build:openapi-schema --fail-on-warn` already fails CI on _any_ new warning at build time, on the same drf-spectacular generator the HTTP endpoint uses. So this test is now strictly weaker than the existing CI gate — and it adds friction:

- Any new (or removed) warning requires a snapshot update.
- After a bot push (OpenAPI types autocommit, etc.) the snapshot mode flips to `check`, so the snapshot updater can't auto-fix the file — PRs sit blocked until a human re-pushes (see the file-download batch-exports PR from earlier today).

## Changes

- Delete `test_api_docs_generation_warnings_snapshot` plus its `_normalize_warning_path` helper and the `inject_fixtures` `capsys` / `snapshot` plumbing it required.
- Delete `posthog/api/test/__snapshots__/test_api_docs.ambr` (only held that one snapshot).
- Drop the now-unused `re` / `pathlib` / `pytest` imports.

Kept `test_can_generate_api_docs_schema` — still useful as a smoke test that `/api/schema/` returns 200 with a non-empty OpenAPI body.

## How did you test this code?

Agent-authored. Verification:

- `find_enum_collisions` on `master` already reports `No enum collisions found`, and `hogli build:openapi-schema` on `master` succeeds with zero warnings — confirming the `--fail-on-warn` gate has been the live guard for a while.
- Re-read the test file post-edit to confirm the remaining two tests don't reference any of the removed helpers/fixtures.

No CI run yet against this branch.

## Publish to changelog?

no

## Docs update

`skip-inkeep-docs` — internal CI cleanup, no user-facing surface.

## 🤖 Agent context

- Tool: Claude Code (claude-opus-4-7).
- Trigger: hit a real-world case where the snapshot blocked a PR for hours because the bot couldn't auto-update after the OpenAPI-types bot pushed last (mode=check on bot actor in `ci-backend.yml`).
- Decisions:
  - Considered keeping the test as a "different code path" safety net (HTTP endpoint vs management command). Rejected: both paths route through the same `drf_spectacular.drainage.warn()` plumbing; divergence would be an upstream bug, not a PostHog regression.
  - Considered loosening the snapshot test to be order-agnostic / partial. Rejected: that's just reinventing `--fail-on-warn`.
