### PR TITLE
feat(mcp-analytics): source session grouping from $mcp_session_id

### DIFF
--- a/posthog/temporal/mcp_analytics/backfill_sessions/activities.py
+++ b/posthog/temporal/mcp_analytics/backfill_sessions/activities.py
@@ -15,20 +15,20 @@ LOGGER = get_write_only_logger()
 
 
 # Two-pass aggregate:
-#   1. Inner subquery (cheap) — list conversation ids that received any mcp_tool_call event
+#   1. Inner subquery (cheap) — list session ids that received any mcp_tool_call event
 #      in the last lookback_hours. These are the only sessions whose Postgres row could be
 #      stale.
-#   2. Outer query — re-aggregate the FULL history of each active conversation id (bounded
+#   2. Outer query — re-aggregate the FULL history of each active session id (bounded
 #      only by the retention window) so the upsert reflects the complete picture, not just
 #      what landed in the lookback. Avoids the corruption that a naive lookback-window
 #      aggregate would cause when a long-lived session gets a fresh event late.
-# The grouping key is $mcp_conversation_id, which the MCP service stamps onto every event in
-# the same conversation. We persist it as MCPSession.session_id since that is the
+# The grouping key is $mcp_session_id, which the MCP SDK stamps onto every event in
+# the same session. We persist it as MCPSession.session_id since that is the
 # product-facing identifier of an MCP session.
 _AGGREGATE_QUERY = """
 SELECT
     team_id,
-    JSONExtractString(properties, '$mcp_conversation_id') AS session_id,
+    JSONExtractString(properties, '$mcp_session_id') AS session_id,
     toString(min(timestamp)) AS session_start,
     toString(max(timestamp)) AS session_end,
     count() AS tool_call_count,
@@ -37,11 +37,11 @@ SELECT
     argMax(JSONExtractString(properties, '$mcp_client_name'), timestamp) AS mcp_client_name
 FROM events
 WHERE event = 'mcp_tool_call'
-    AND JSONExtractString(properties, '$mcp_conversation_id') IN (
-        SELECT DISTINCT JSONExtractString(properties, '$mcp_conversation_id')
+    AND JSONExtractString(properties, '$mcp_session_id') IN (
+        SELECT DISTINCT JSONExtractString(properties, '$mcp_session_id')
         FROM events
         WHERE event = 'mcp_tool_call'
-            AND JSONExtractString(properties, '$mcp_conversation_id') != ''
+            AND JSONExtractString(properties, '$mcp_session_id') != ''
             AND timestamp >= now() - INTERVAL %(lookback_hours)s HOUR
     )
     AND timestamp >= now() - INTERVAL %(retention_days)s DAY

--- a/posthog/temporal/mcp_analytics/summarize_session_intents/activities.py
+++ b/posthog/temporal/mcp_analytics/summarize_session_intents/activities.py
@@ -22,7 +22,7 @@ logger = structlog.get_logger(__name__)
 _PRIORITY_TEAM_ID = 2
 
 # Per-team cap for non-priority teams in a single batch. Stops one team from
-# monopolising the global LLM budget by emitting many unique conversation ids.
+# monopolising the global LLM budget by emitting many unique session ids.
 _PER_TEAM_CAP = 10
 
 SYSTEM_PROMPT = (
@@ -40,7 +40,7 @@ SELECT JSONExtractString(properties, '$mcp_intent') AS intent
 FROM events
 WHERE team_id = %(team_id)s
     AND event = 'mcp_tool_call'
-    AND JSONExtractString(properties, '$mcp_conversation_id') = %(session_id)s
+    AND JSONExtractString(properties, '$mcp_session_id') = %(session_id)s
     AND JSONExtractString(properties, '$mcp_intent') != ''
 ORDER BY timestamp ASC
 LIMIT 200

--- a/products/mcp_analytics/backend/intent_clustering.py
+++ b/products/mcp_analytics/backend/intent_clustering.py
@@ -67,7 +67,7 @@ class IntentRecord:
 # TODO(mcp-sessions): when the parallel-team posthog_mcp_session table ships,
 # change MCPSession.objects.filter(...) below to point at the real model.
 # TODO(intent-routing): chaining is by $session_id today; swap to
-# $conversation_id once tool calls carry it.
+# $mcp_session_id once tool calls carry it consistently.
 _SESSION_TOOL_STATS_SQL = """
 SELECT
     properties.$session_id AS session_id,

--- a/products/mcp_analytics/backend/logic.py
+++ b/products/mcp_analytics/backend/logic.py
@@ -35,7 +35,7 @@ SELECT
     toString(properties.$mcp_duration_ms) AS duration_ms_raw
 FROM events
 WHERE event = {event}
-    AND properties.$mcp_conversation_id = {session_id}
+    AND properties.$mcp_session_id = {session_id}
 ORDER BY timestamp ASC
 LIMIT 500
 """

--- a/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
+++ b/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
@@ -170,10 +170,10 @@ class Command(BaseCommand):
             )
 
         for session_idx in range(session_count):
-            # $mcp_conversation_id is the canonical session grouping key emitted by the MCP
-            # service. Use uuid4 because that's the format the real service emits (e.g.
+            # $mcp_session_id is the canonical session grouping key emitted by the MCP
+            # SDK. Use uuid4 because that's the format the real service emits (e.g.
             # ba10420e-7ff2-4253-a6ac-3e404f14f8be).
-            conversation_id = str(uuid.uuid4())
+            mcp_session_id = str(uuid.uuid4())
             # $session_id keeps the PostHog uuid7 convention so session-replay-style
             # consumers don't choke on it.
             session_id = str(uuid7())
@@ -218,7 +218,7 @@ class Command(BaseCommand):
                     timestamp=timestamp,
                     properties={
                         "$session_id": session_id,
-                        "$mcp_conversation_id": conversation_id,
+                        "$mcp_session_id": mcp_session_id,
                         "$mcp_tool_name": tool_name,
                         "$mcp_intent": intent,
                         "$mcp_error_message": "Upstream returned 500" if is_error else "",
@@ -235,9 +235,9 @@ class Command(BaseCommand):
             # Don't write to MCPSession directly — the backfill Temporal activity is
             # the source of truth and will derive the row from the events we just
             # captured. Pre-populating here would produce duplicates keyed on the
-            # uuid7 $session_id instead of the uuid4 $mcp_conversation_id.
+            # uuid7 $session_id instead of the uuid4 $mcp_session_id.
             self.stdout.write(
-                f"  session {session_idx + 1}/{session_count}: {calls} tool calls (conversation_id={conversation_id})"
+                f"  session {session_idx + 1}/{session_count}: {calls} tool calls (mcp_session_id={mcp_session_id})"
             )
 
         self.stdout.write(

--- a/products/mcp_analytics/backend/presentation/views.py
+++ b/products/mcp_analytics/backend/presentation/views.py
@@ -125,7 +125,7 @@ class MCPSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
     @extend_schema(
         operation_id="mcp_analytics_sessions_list",
-        description="List MCP sessions for the current project, derived by grouping mcp_tool_call events by $mcp_conversation_id. Ordered by most recent activity first by default.",
+        description="List MCP sessions for the current project, derived by grouping mcp_tool_call events by $mcp_session_id. Ordered by most recent activity first by default.",
         parameters=[
             OpenApiParameter(
                 name="search",

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -164,10 +164,10 @@ function StatStrip({ summary, loading }: { summary: ToolSummary | null; loading:
             <Stat label="p95 latency" loading={loading} value={formatDurationMs(summary?.p95_ms ?? null)} />
             <Stat label="Users" loading={loading} value={humanFriendlyNumber(summary?.users ?? 0)} />
             <Stat
-                label="Conversations"
+                label="Sessions"
                 loading={loading}
                 value={humanFriendlyNumber(summary?.conversations ?? 0)}
-                tooltip="Unique $mcp_conversation_id values, falling back to $session_id where missing."
+                tooltip="Unique $mcp_session_id values, falling back to $session_id where missing."
             />
         </div>
     )

--- a/products/mcp_analytics/frontend/generated/api.ts
+++ b/products/mcp_analytics/frontend/generated/api.ts
@@ -179,7 +179,7 @@ export const getMcpAnalyticsSessionsListUrl = (projectId: string, params?: McpAn
 }
 
 /**
- * List MCP sessions for the current project, derived by grouping mcp_tool_call events by $mcp_conversation_id. Ordered by most recent activity first by default.
+ * List MCP sessions for the current project, derived by grouping mcp_tool_call events by $mcp_session_id. Ordered by most recent activity first by default.
  */
 export const mcpAnalyticsSessionsList = async (
     projectId: string,

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -69,7 +69,7 @@ SELECT
     round(quantileIf(0.5)(toFloat(properties.$mcp_duration_ms), timestamp >= now() - INTERVAL 7 DAY)) AS p50_ms,
     round(quantileIf(0.95)(toFloat(properties.$mcp_duration_ms), timestamp >= now() - INTERVAL 7 DAY)) AS p95_ms,
     uniqIf(distinct_id, timestamp >= now() - INTERVAL 7 DAY) AS users,
-    uniqIf(coalesce(nullIf(toString(properties.$mcp_conversation_id), ''), toString(properties.$session_id)), timestamp >= now() - INTERVAL 7 DAY) AS conversations,
+    uniqIf(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)), timestamp >= now() - INTERVAL 7 DAY) AS conversations,
     countIf(timestamp >= now() - INTERVAL 14 DAY AND timestamp < now() - INTERVAL 7 DAY) AS calls_prev,
     countIf(timestamp >= now() - INTERVAL 14 DAY AND timestamp < now() - INTERVAL 7 DAY AND toBool(properties.$mcp_is_error)) AS errors_prev
 FROM events
@@ -301,14 +301,14 @@ LIMIT 5
                     query: `
 WITH tool_calls AS (
     SELECT
-        coalesce(nullIf(toString(properties.$mcp_conversation_id), ''), toString(properties.$session_id)) AS conv_id,
+        coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)) AS conv_id,
         timestamp,
         ${EFFECTIVE_TOOL_HOGQL} AS tool
     FROM events
     WHERE event = 'mcp_tool_call'
         AND timestamp >= now() - INTERVAL 7 DAY
         AND ${NEW_SDK_FILTER}
-        AND notEmpty(coalesce(nullIf(toString(properties.$mcp_conversation_id), ''), toString(properties.$session_id)))
+        AND notEmpty(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)))
 )
 SELECT
     prev_tool AS tool,
@@ -344,14 +344,14 @@ LIMIT 5
                     query: `
 WITH tool_calls AS (
     SELECT
-        coalesce(nullIf(toString(properties.$mcp_conversation_id), ''), toString(properties.$session_id)) AS conv_id,
+        coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)) AS conv_id,
         timestamp,
         ${EFFECTIVE_TOOL_HOGQL} AS tool
     FROM events
     WHERE event = 'mcp_tool_call'
         AND timestamp >= now() - INTERVAL 7 DAY
         AND ${NEW_SDK_FILTER}
-        AND notEmpty(coalesce(nullIf(toString(properties.$mcp_conversation_id), ''), toString(properties.$session_id)))
+        AND notEmpty(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)))
 )
 SELECT
     next_tool AS tool,


### PR DESCRIPTION
## Problem

MCP analytics currently groups `mcp_tool_call` events by `$mcp_conversation_id`. That property is only emitted when the server has `enableConversationId` turned on — so when the MCP SDK runs without conversation tracking, every event falls into the empty-string bucket and the Sessions tab, backfill, and intent summarisation all degrade.

`$mcp_session_id` is the transport-level session handle the SDK stamps on every request. It rotates per reconnect, but it's always present, which makes it the better default source of truth for the analytics layer until/unless conversation tracking becomes universally enabled.

## Changes

Swap the source property from `$mcp_conversation_id` → `$mcp_session_id` everywhere the analytics layer groups, filters, or labels MCP sessions:

- Backend: `products/mcp_analytics/backend/logic.py` per-session tool-call SQL.
- Backend: `posthog/temporal/mcp_analytics/backfill_sessions/activities.py` aggregate + lookback subquery.
- Backend: `posthog/temporal/mcp_analytics/summarize_session_intents/activities.py` intents query.
- Backend: `products/mcp_analytics/backend/presentation/views.py` endpoint description text.
- Seed: `products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py` now emits `$mcp_session_id` (instead of `$mcp_conversation_id`) so the dev fixture matches the new source.
- Frontend: `products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts` HogQL summary + neighbour-tool queries.
- Frontend: `products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx` "Conversations" stat relabelled to "Sessions" and tooltip updated.
- Doc nit: stale TODO in `intent_clustering.py` refreshed to reference `$mcp_session_id`.

SDK emits both properties (see `services/mcp/src/lib/posthog/analytics.ts`), so live MCP traffic already carries `$mcp_session_id` — no SDK change needed.

## How did you test this code?

Agent-authored. Verified via:

- `ruff check` + `ruff format` clean across edited files.
- Django smoke import: loaded the three rewritten SQL templates (`_AGGREGATE_QUERY`, `_TOOL_CALL_INTENTS_QUERY`, `_MCP_TOOL_CALLS_SQL`) and asserted `$mcp_session_id` is present and `$mcp_conversation_id` is absent.
- Local pytest of `products/mcp_analytics/backend/tests/` was blocked by a flaky ClickHouse handshake in the dev env — CI will exercise the full suite.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). The change is a mechanical property-name swap scoped to the analytics layer only — SDK emission and event taxonomy are intentionally left alone. Decision points along the way:

- Considered renaming `MCPSession.session_id` to `MCPSession.mcp_session_id` for symmetry, but rejected — column is the product-facing identifier and the source-property swap doesn't require a Postgres migration. The aggregate just persists `$mcp_session_id` into the existing column.
- Considered emitting both properties from the seed command to keep backwards compatibility with old dashboards. Rejected — seed fixtures are short-lived and the queries that read them now exclusively look at `$mcp_session_id`. Keeping the old property in seed would only mask query-side regressions.
- Updated the frontend "Conversations" stat label to "Sessions" so the UI matches the new source. The selector name (`conversations`) was left alone to keep the diff scoped to surface text.