### PR TITLE
chore: regen MCP types after llma spend endpoint

### DIFF
--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2878,7 +2878,7 @@
     },
     "llma-personal-spend": {
         "description": "Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days (default 30, max 90). Returns a summary plus breakdowns by product, tool, model, and top traces. Pass `product` (e.g. `posthog_code`, `background_agents`) to scope the tool / model / trace breakdowns to a single product; `by_product` always returns the cross-product view. Pass `refresh=true` to bypass the 5-minute cache.",
-        "category": "LLM analytics",
+        "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get my LLM spend analysis",
         "title": "Get my LLM spend analysis",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -3191,7 +3191,7 @@
     },
     "llma-personal-spend": {
         "description": "Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days (default 30, max 90). Returns a summary plus breakdowns by product, tool, model, and top traces. Pass `product` (e.g. `posthog_code`, `background_agents`) to scope the tool / model / trace breakdowns to a single product; `by_product` always returns the cross-product view. Pass `refresh=true` to bypass the 5-minute cache.",
-        "category": "LLM analytics",
+        "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get my LLM spend analysis",
         "title": "Get my LLM spend analysis",


### PR DESCRIPTION
## Problem

`Validate migrations and OpenAPI types` has been failing on master since `fix(llma): accept OAuth tokens on /api/llm_analytics/@me/spend` (#59392). That PR added a new `llma-personal-spend` MCP tool entry in `products/llm_analytics/mcp/tools.yaml` but didn't regenerate the JSON outputs.

## Fix

Ran `hogli build:openapi` and committed the resulting diff — two files:

- `services/mcp/schema/generated-tool-definitions.json`
- `services/mcp/schema/tool-definitions-all.json`

Diff is a single category label flip (`LLM analytics` → `AI observability`) carried over from `chore(llma): rename visible/comments from LLMA to AIO` (#59264).

## 🤖 Agent context

Generated by Claude Code under raul.n@posthog.com's direction. Unblocks all backend CI on PRs branched off recent master.