### PR TITLE
chore(onboarding): drop VITE_PUBLIC_ prefix from React/Vite docs

### DIFF
--- a/docs/onboarding/feature-flags/react-router.tsx
+++ b/docs/onboarding/feature-flags/react-router.tsx
@@ -41,7 +41,7 @@ export const getReactRouterSteps = (ctx: OnboardingComponentsContext): StepDefin
                                     import type { Route } from './+types/example'
 
                                     export async function loader({ request }: Route.LoaderArgs) {
-                                        const posthog = new PostHog(process.env.VITE_POSTHOG_TOKEN!, {
+                                        const posthog = new PostHog(process.env.VITE_POSTHOG_PROJECT_TOKEN!, {
                                             host: process.env.VITE_POSTHOG_HOST
                                         })
 

--- a/docs/onboarding/feature-flags/react-router.tsx
+++ b/docs/onboarding/feature-flags/react-router.tsx
@@ -41,8 +41,8 @@ export const getReactRouterSteps = (ctx: OnboardingComponentsContext): StepDefin
                                     import type { Route } from './+types/example'
 
                                     export async function loader({ request }: Route.LoaderArgs) {
-                                        const posthog = new PostHog(process.env.VITE_PUBLIC_POSTHOG_TOKEN!, {
-                                            host: process.env.VITE_PUBLIC_POSTHOG_HOST
+                                        const posthog = new PostHog(process.env.VITE_POSTHOG_TOKEN!, {
+                                            host: process.env.VITE_POSTHOG_HOST
                                         })
 
                                         try {

--- a/docs/onboarding/feature-flags/react-router.tsx
+++ b/docs/onboarding/feature-flags/react-router.tsx
@@ -41,7 +41,7 @@ export const getReactRouterSteps = (ctx: OnboardingComponentsContext): StepDefin
                                     import type { Route } from './+types/example'
 
                                     export async function loader({ request }: Route.LoaderArgs) {
-                                        const posthog = new PostHog(process.env.VITE_POSTHOG_PROJECT_TOKEN!, {
+                                        const posthog = new PostHog(process.env.VITE_POSTHOG_TOKEN!, {
                                             host: process.env.VITE_POSTHOG_HOST
                                         })
 

--- a/docs/onboarding/product-analytics/react.tsx
+++ b/docs/onboarding/product-analytics/react.tsx
@@ -60,7 +60,7 @@ export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[
                                 language: 'bash',
                                 file: '.env',
                                 code: dedent`
-                                    VITE_POSTHOG_PROJECT_TOKEN=<ph_project_token>
+                                    VITE_POSTHOG_TOKEN=<ph_project_token>
                                     VITE_POSTHOG_HOST=<ph_client_api_host>
                                 `,
                             },
@@ -97,7 +97,7 @@ export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[
 
                                     createRoot(document.getElementById('root')).render(
                                       <StrictMode>
-                                        <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_PROJECT_TOKEN} options={options}>
+                                        <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_TOKEN} options={options}>
                                           <App />
                                         </PostHogProvider>
                                       </StrictMode>

--- a/docs/onboarding/product-analytics/react.tsx
+++ b/docs/onboarding/product-analytics/react.tsx
@@ -52,7 +52,7 @@ export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[
                 <>
                     <Markdown>
                         Add your PostHog project token and host to your environment variables. For Vite-based React
-                        apps, use the `VITE_PUBLIC_` prefix:
+                        apps, use the `VITE_` prefix to expose them to the client:
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -60,8 +60,8 @@ export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[
                                 language: 'bash',
                                 file: '.env',
                                 code: dedent`
-                                    VITE_PUBLIC_POSTHOG_PROJECT_TOKEN=<ph_project_token>
-                                    VITE_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
+                                    VITE_POSTHOG_PROJECT_TOKEN=<ph_project_token>
+                                    VITE_POSTHOG_HOST=<ph_client_api_host>
                                 `,
                             },
                         ]}
@@ -91,13 +91,13 @@ export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[
                                     import { PostHogProvider } from '@posthog/react'
 
                                     const options = {
-                                      api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+                                      api_host: import.meta.env.VITE_POSTHOG_HOST,
                                       defaults: '2026-01-30',
                                     } as const
 
                                     createRoot(document.getElementById('root')).render(
                                       <StrictMode>
-                                        <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN} options={options}>
+                                        <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_PROJECT_TOKEN} options={options}>
                                           <App />
                                         </PostHogProvider>
                                       </StrictMode>

--- a/docs/onboarding/product-analytics/tanstack.tsx
+++ b/docs/onboarding/product-analytics/tanstack.tsx
@@ -54,7 +54,7 @@ export const getTanStackSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'bash',
                                 file: '.env',
                                 code: dedent`
-                                    VITE_POSTHOG_PROJECT_TOKEN=<ph_project_token>
+                                    VITE_POSTHOG_TOKEN=<ph_project_token>
                                     VITE_POSTHOG_HOST=<ph_client_api_host>
                                 `,
                             },
@@ -91,7 +91,7 @@ export const getTanStackSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
                                     createRoot(document.getElementById('root')).render(
                                       <StrictMode>
-                                        <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_PROJECT_TOKEN} options={options}>
+                                        <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_TOKEN} options={options}>
                                           <App />
                                         </PostHogProvider>
                                       </StrictMode>

--- a/docs/onboarding/product-analytics/tanstack.tsx
+++ b/docs/onboarding/product-analytics/tanstack.tsx
@@ -54,8 +54,8 @@ export const getTanStackSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'bash',
                                 file: '.env',
                                 code: dedent`
-                                    VITE_PUBLIC_POSTHOG_PROJECT_TOKEN=<ph_project_token>
-                                    VITE_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
+                                    VITE_POSTHOG_PROJECT_TOKEN=<ph_project_token>
+                                    VITE_POSTHOG_HOST=<ph_client_api_host>
                                 `,
                             },
                         ]}
@@ -85,13 +85,13 @@ export const getTanStackSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                     import { PostHogProvider } from '@posthog/react'
 
                                     const options = {
-                                      api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+                                      api_host: import.meta.env.VITE_POSTHOG_HOST,
                                       defaults: '2026-01-30',
                                     } as const
 
                                     createRoot(document.getElementById('root')).render(
                                       <StrictMode>
-                                        <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN} options={options}>
+                                        <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_PROJECT_TOKEN} options={options}>
                                           <App />
                                         </PostHogProvider>
                                       </StrictMode>

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
@@ -14,9 +14,7 @@ function ReactEnvVarsSnippet(): JSX.Element {
 
     return (
         <CodeSnippet language={Language.Bash}>
-            {[`VITE_POSTHOG_PROJECT_TOKEN=${currentTeam?.api_token}`, `VITE_POSTHOG_HOST=${apiHostOrigin()}`].join(
-                '\n'
-            )}
+            {[`VITE_POSTHOG_TOKEN=${currentTeam?.api_token}`, `VITE_POSTHOG_HOST=${apiHostOrigin()}`].join('\n')}
         </CodeSnippet>
     )
 }
@@ -37,7 +35,7 @@ const options = {
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_PROJECT_TOKEN} options={options}>
+    <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_TOKEN} options={options}>
       <App />
     </PostHogProvider>
   </StrictMode>

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
@@ -14,10 +14,9 @@ function ReactEnvVarsSnippet(): JSX.Element {
 
     return (
         <CodeSnippet language={Language.Bash}>
-            {[
-                `VITE_POSTHOG_PROJECT_TOKEN=${currentTeam?.api_token}`,
-                `VITE_POSTHOG_HOST=${apiHostOrigin()}`,
-            ].join('\n')}
+            {[`VITE_POSTHOG_PROJECT_TOKEN=${currentTeam?.api_token}`, `VITE_POSTHOG_HOST=${apiHostOrigin()}`].join(
+                '\n'
+            )}
         </CodeSnippet>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
@@ -15,8 +15,8 @@ function ReactEnvVarsSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.Bash}>
             {[
-                `VITE_PUBLIC_POSTHOG_PROJECT_TOKEN=${currentTeam?.api_token}`,
-                `VITE_PUBLIC_POSTHOG_HOST=${apiHostOrigin()}`,
+                `VITE_POSTHOG_PROJECT_TOKEN=${currentTeam?.api_token}`,
+                `VITE_POSTHOG_HOST=${apiHostOrigin()}`,
             ].join('\n')}
         </CodeSnippet>
     )
@@ -32,13 +32,13 @@ import App from './App.jsx'
 import { PostHogProvider } from '@posthog/react'
 
 const options = {
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
   defaults: '${SDK_DEFAULTS_DATE}',
 } as const
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN} options={options}>
+    <PostHogProvider apiKey={import.meta.env.VITE_POSTHOG_PROJECT_TOKEN} options={options}>
       <App />
     </PostHogProvider>
   </StrictMode>


### PR DESCRIPTION
## Problem

The React and TanStack onboarding docs (both in-app onboarding and `/docs/onboarding/`) tell users to prefix their PostHog env vars with `VITE_PUBLIC_`. That's non-idiomatic — Vite already exposes every `VITE_`-prefixed var to the client, so the extra `PUBLIC_` is just noise that confuses developers coming from other ecosystems.

Per discussion: the `PUBLIC_` was originally a crutch to reassure people that the project token is safe to expose to the client (back when it was called `project_api_key`). That signal is no longer needed.

## Changes

- `docs/onboarding/product-analytics/react.tsx`
- `docs/onboarding/product-analytics/tanstack.tsx`
- `docs/onboarding/feature-flags/react-router.tsx`
- `frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx`

All `VITE_PUBLIC_POSTHOG_*` references renamed to `VITE_POSTHOG_*`, and the explanatory copy in the React onboarding step updated to describe the prefix as exposing vars to the client.

## How did you test this code?

I'm an agent. No manual testing performed — change is a pure string rename across four onboarding doc snippets, no logic touched. A reviewer should eyeball the rendered onboarding pages to confirm the snippets still read cleanly.

## Publish to changelog?

no

## Docs update

These snippets are surfaced through PostHog's in-app onboarding and docs onboarding pages — no separate docs update needed for this repo. Downstream `posthog.com` docs that still mention `VITE_PUBLIC_` should be updated separately.

## 🤖 Agent context

Authored by Claude (PostHog Code) at the request of a human teammate after a Slack discussion concluded the `VITE_PUBLIC_` prefix was a legacy crutch. I searched for every occurrence of `VITE_PUBLIC_` in the repo (4 files, all onboarding snippets) and renamed them to `VITE_`. No production runtime code reads these vars — they're user-facing example snippets only — so the change is safe.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*