### PR TITLE
feat(web-analytics): gate lazy precompute on org-level feature flag

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -40089,7 +40089,7 @@
                     "type": "boolean"
                 },
                 "useWebAnalyticsPrecompute": {
-                    "description": "Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-lazy-precompute` PostHog feature flag to be on for the team's organization for the gate to pass. *",
+                    "description": "Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. *",
                     "type": "boolean"
                 },
                 "version": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -40089,7 +40089,7 @@
                     "type": "boolean"
                 },
                 "useWebAnalyticsPrecompute": {
-                    "description": "Opt this specific query into the web_overview_query precompute path. Requires the team to be in the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` allowlist for the gate to pass. *",
+                    "description": "Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-lazy-precompute` PostHog feature flag to be on for the team's organization for the gate to pass. *",
                     "type": "boolean"
                 },
                 "version": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2287,7 +2287,7 @@ interface WebAnalyticsQueryBase<R extends Record<string, any>> extends DataNode<
 
 export interface WebOverviewQuery extends WebAnalyticsQueryBase<WebOverviewQueryResponse> {
     kind: NodeKind.WebOverviewQuery
-    /** Opt this specific query into the web_overview_query precompute path. Requires the team to be in the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` allowlist for the gate to pass. **/
+    /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-lazy-precompute` PostHog feature flag to be on for the team's organization for the gate to pass. **/
     useWebAnalyticsPrecompute?: boolean
 }
 

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2287,7 +2287,7 @@ interface WebAnalyticsQueryBase<R extends Record<string, any>> extends DataNode<
 
 export interface WebOverviewQuery extends WebAnalyticsQueryBase<WebOverviewQueryResponse> {
     kind: NodeKind.WebOverviewQuery
-    /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-lazy-precompute` PostHog feature flag to be on for the team's organization for the gate to pass. **/
+    /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. **/
     useWebAnalyticsPrecompute?: boolean
 }
 

--- a/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
@@ -60,7 +60,7 @@ export const WebAnalyticsMenu = (): JSX.Element => {
                     Filter out internal and test users
                 </ButtonPrimitive>
                 {featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_PRECOMPUTE_TOGGLE] && (
-                    <Tooltip title="Serve eligible Web Overview queries from the precomputed cache. Only takes effect when the web-analytics-lazy-precompute org-level feature flag is on.">
+                    <Tooltip title="Serve eligible Web Overview queries from the precomputed cache. Only takes effect when the web-analytics-precompute-toggle feature flag is on for the team's organization.">
                         <ButtonPrimitive
                             menuItem
                             onClick={() => {

--- a/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
@@ -60,7 +60,7 @@ export const WebAnalyticsMenu = (): JSX.Element => {
                     Filter out internal and test users
                 </ButtonPrimitive>
                 {featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_PRECOMPUTE_TOGGLE] && (
-                    <Tooltip title="Serve eligible Web Overview queries from the precomputed cache. Only takes effect for teams enrolled by the admin via WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS.">
+                    <Tooltip title="Serve eligible Web Overview queries from the precomputed cache. Only takes effect when the web-analytics-lazy-precompute org-level feature flag is on.">
                         <ButtonPrimitive
                             menuItem
                             onClick={() => {

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview_lazy_precompute.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview_lazy_precompute.py
@@ -21,7 +21,6 @@ from posthog.schema import (
 )
 
 from posthog.hogql_queries.web_analytics.web_overview import WebOverviewQueryRunner
-from posthog.models.instance_setting import override_instance_config
 from posthog.models.utils import uuid7
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
@@ -35,7 +34,13 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         PreaggregationJob.objects.filter(team_id=self.team.pk).delete()
 
     def _enable_lazy(self):
-        return override_instance_config("WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS", [self.team.pk])
+        # Mock the org-level feature flag check to True so the gate accepts our test
+        # team. Outside this context manager the default `posthoganalytics.feature_enabled`
+        # returns False (no API key in tests), which models a flag-disabled org.
+        return patch(
+            "posthog.hogql_queries.web_analytics.web_overview_lazy_precompute.posthoganalytics.feature_enabled",
+            return_value=True,
+        )
 
     def _seed_two_sessions(self) -> None:
         # p1 has two pageviews in one session, p2 has a single pageview (bounce).
@@ -207,27 +212,27 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2024-01-15T12:00:00Z")
     def test_disabled_team_falls_through(self):
-        # Both gates closed: not in allowlist AND modifier not set.
+        # Both gates closed: org feature flag off AND query opt-in not set.
         self._seed_two_sessions()
         self._run(self._build_query(opt_in_precompute=False))
 
         assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
 
     @freeze_time("2024-01-15T12:00:00Z")
-    def test_query_optin_alone_falls_through_when_team_not_enrolled(self):
-        # `query.useWebAnalyticsPrecompute=True` BUT team is not in the
-        # `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` allowlist. Should fall
-        # through — the env var is the operator-controlled rollout gate.
+    def test_query_optin_alone_falls_through_when_org_flag_disabled(self):
+        # `query.useWebAnalyticsPrecompute=True` BUT the
+        # `web-analytics-lazy-precompute` org-level feature flag is off. Should
+        # fall through — the flag is the operator-controlled rollout gate.
         self._seed_two_sessions()
         self._run(self._build_query(opt_in_precompute=True))
 
         assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
 
     @freeze_time("2024-01-15T12:00:00Z")
-    def test_allowlist_alone_falls_through_when_query_not_opted_in(self):
-        # Team is in the allowlist BUT the query param is not set (the team
-        # hasn't enabled the "Allow precompute" toggle in the ScenePanel).
-        # Should fall through — the param is the per-team opt-in / kill switch.
+    def test_org_flag_alone_falls_through_when_query_not_opted_in(self):
+        # Org feature flag is on BUT the query param is not set (the team hasn't
+        # enabled the "Allow precompute" toggle in the ScenePanel). Should fall
+        # through — the param is the per-team opt-in / kill switch.
         self._seed_two_sessions()
         with self._enable_lazy():
             self._run(self._build_query(opt_in_precompute=False))

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview_lazy_precompute.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview_lazy_precompute.py
@@ -221,7 +221,7 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2024-01-15T12:00:00Z")
     def test_query_optin_alone_falls_through_when_org_flag_disabled(self):
         # `query.useWebAnalyticsPrecompute=True` BUT the
-        # `web-analytics-lazy-precompute` org-level feature flag is off. Should
+        # `web-analytics-precompute-toggle` feature flag is off. Should
         # fall through — the flag is the operator-controlled rollout gate.
         self._seed_two_sessions()
         self._run(self._build_query(opt_in_precompute=True))

--- a/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
@@ -170,7 +170,7 @@ def _check_lazy_precompute_eligible(runner: "WebOverviewQueryRunner") -> None:
     # hit `/decide` and resolve the cohort server-side. The SDK swallows its
     # own exceptions and returns None (falsy) on failure, so a flag-service
     # outage fails-closed (gate raised, fall back to v2/raw) automatically.
-    distinct_id = runner.user.distinct_id if runner.user else str(runner.team.uuid)
+    distinct_id = (runner.user and runner.user.distinct_id) or str(runner.team.uuid)
     if not posthoganalytics.feature_enabled(
         "web-analytics-precompute-toggle",
         distinct_id,

--- a/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Optional
 
 import structlog
+import posthoganalytics
 from prometheus_client import Counter
 
 from posthog.schema import EventPropertyFilter, PropertyOperator
@@ -16,7 +17,6 @@ from posthog.clickhouse.preaggregation.web_overview_preaggregated_sql import (
     DISTRIBUTED_WEB_OVERVIEW_PREAGGREGATED_TABLE,
 )
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
-from posthog.models.instance_setting import get_instance_setting
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
     LazyComputationResult,
@@ -67,7 +67,7 @@ class LazyPrecomputeIneligible(Exception):
     """
 
 
-class TeamNotInAllowlist(LazyPrecomputeIneligible):
+class OrgFeatureFlagDisabled(LazyPrecomputeIneligible):
     pass
 
 
@@ -150,14 +150,20 @@ def _check_lazy_precompute_eligible(runner: "WebOverviewQueryRunner") -> None:
     the lazy path. Returns None on success."""
     query = runner.query
 
-    # Rollout gate: instance allowlist AND per-query opt-in.
-    #   - `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` (admin-controlled instance
-    #     setting): scope of teams eligible to opt in.
+    # Rollout gate: org-level PostHog feature flag AND per-query opt-in.
+    #   - `web-analytics-lazy-precompute` (PostHog feature flag, evaluated at
+    #     the organization level): rollout lever. Flip orgs on/off without a
+    #     deploy; supports percent rollouts and targeted overrides.
     #   - `query.useWebAnalyticsPrecompute` (per-query parameter set by the
     #     "Allow precompute" toggle in the Web Analytics ScenePanel).
-    enabled_team_ids = get_instance_setting("WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS") or []
-    if runner.team.pk not in enabled_team_ids:
-        raise TeamNotInAllowlist()
+    if not posthoganalytics.feature_enabled(
+        "web-analytics-lazy-precompute",
+        str(runner.team.id),
+        groups={"organization": str(runner.team.organization_id)},
+        group_properties={"organization": {"id": str(runner.team.organization_id)}},
+        send_feature_flag_events=False,
+    ):
+        raise OrgFeatureFlagDisabled()
 
     if query.useWebAnalyticsPrecompute is not True:
         raise PerQueryOptInNotSet()

--- a/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
@@ -165,26 +165,20 @@ def _check_lazy_precompute_eligible(runner: "WebOverviewQueryRunner") -> None:
     # cache-warmer / Celery / unauthenticated paths `user` is None; fall back
     # to the team UUID so the call still has a stable distinct_id, and rely on
     # the org-group condition to gate those requests.
+    # `only_evaluate_locally=False` is explicit because a user-cohort condition
+    # is not locally evaluable without person_properties — we want the SDK to
+    # hit `/decide` and resolve the cohort server-side. The SDK swallows its
+    # own exceptions and returns None (falsy) on failure, so a flag-service
+    # outage fails-closed (gate raised, fall back to v2/raw) automatically.
     distinct_id = runner.user.distinct_id if runner.user else str(runner.team.uuid)
-    # Defensive: a flag-service outage or SDK exception must not break web
-    # analytics. Fail-closed (skip the lazy path, fall back to v2 / raw) so a
-    # bad flag eval can never serve stale or wrong data.
-    try:
-        flag_on = posthoganalytics.feature_enabled(
-            "web-analytics-precompute-toggle",
-            distinct_id,
-            groups={"organization": str(runner.team.organization_id)},
-            group_properties={"organization": {"id": str(runner.team.organization_id)}},
-            send_feature_flag_events=False,
-        )
-    except Exception as exc:
-        logger.warning(
-            "web_overview_lazy_precompute_flag_eval_error",
-            team_id=runner.team.pk,
-            error=str(exc),
-        )
-        flag_on = False
-    if not flag_on:
+    if not posthoganalytics.feature_enabled(
+        "web-analytics-precompute-toggle",
+        distinct_id,
+        groups={"organization": str(runner.team.organization_id)},
+        group_properties={"organization": {"id": str(runner.team.organization_id)}},
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    ):
         raise OrgFeatureFlagDisabled()
 
     if query.useWebAnalyticsPrecompute is not True:

--- a/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
@@ -159,9 +159,16 @@ def _check_lazy_precompute_eligible(runner: "WebOverviewQueryRunner") -> None:
     #     release condition on the flag to enable rollout.
     #   - `query.useWebAnalyticsPrecompute` (per-query parameter set by the
     #     "Allow precompute" toggle).
+    # When invoked from a user request the runner has `user` set — pass the
+    # user's distinct_id so the flag's user-level cohort condition (e.g. the
+    # PostHog Team cohort the existing toggle uses) can actually match. For
+    # cache-warmer / Celery / unauthenticated paths `user` is None; fall back
+    # to the team UUID so the call still has a stable distinct_id, and rely on
+    # the org-group condition to gate those requests.
+    distinct_id = runner.user.distinct_id if runner.user else str(runner.team.uuid)
     if not posthoganalytics.feature_enabled(
         "web-analytics-precompute-toggle",
-        str(runner.team.id),
+        distinct_id,
         groups={"organization": str(runner.team.organization_id)},
         group_properties={"organization": {"id": str(runner.team.organization_id)}},
         send_feature_flag_events=False,

--- a/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
@@ -153,30 +153,26 @@ def _check_lazy_precompute_eligible(runner: "WebOverviewQueryRunner") -> None:
     # Rollout gate: shared PostHog feature flag AND per-query opt-in.
     #   - `web-analytics-precompute-toggle` (PostHog feature flag): the same
     #     flag the frontend already uses to show/hide the "Allow precompute"
-    #     button in the Web Analytics ScenePanel. Reusing it gives operators
-    #     one switch that controls both the UI surface and the backend gate.
-    #     Evaluated at the organization level here — set up an org-level
-    #     release condition on the flag to enable rollout.
+    #     button in the Web Analytics ScenePanel. One switch controls both the
+    #     UI surface and the backend gate. The flag is evaluated at the
+    #     organization level — set up an org-level release condition on the
+    #     flag to enable rollout per org. The SDK swallows its own exceptions
+    #     and returns None (falsy) on failure, so a flag-service outage
+    #     fails-closed (gate raised, fall back to v2 / raw) automatically.
     #   - `query.useWebAnalyticsPrecompute` (per-query parameter set by the
     #     "Allow precompute" toggle).
-    # When invoked from a user request the runner has `user` set — pass the
-    # user's distinct_id so the flag's user-level cohort condition (e.g. the
-    # PostHog Team cohort the existing toggle uses) can actually match. For
-    # cache-warmer / Celery / unauthenticated paths `user` is None; fall back
-    # to the team UUID so the call still has a stable distinct_id, and rely on
-    # the org-group condition to gate those requests.
-    # `only_evaluate_locally=False` is explicit because a user-cohort condition
-    # is not locally evaluable without person_properties — we want the SDK to
-    # hit `/decide` and resolve the cohort server-side. The SDK swallows its
-    # own exceptions and returns None (falsy) on failure, so a flag-service
-    # outage fails-closed (gate raised, fall back to v2/raw) automatically.
-    distinct_id = (runner.user and runner.user.distinct_id) or str(runner.team.uuid)
     if not posthoganalytics.feature_enabled(
         "web-analytics-precompute-toggle",
-        distinct_id,
-        groups={"organization": str(runner.team.organization_id)},
-        group_properties={"organization": {"id": str(runner.team.organization_id)}},
-        only_evaluate_locally=False,
+        str(runner.team.uuid),
+        groups={
+            "organization": str(runner.team.organization_id),
+            "project": str(runner.team.id),
+        },
+        group_properties={
+            "organization": {"id": str(runner.team.organization_id)},
+            "project": {"id": str(runner.team.id)},
+        },
+        only_evaluate_locally=True,
         send_feature_flag_events=False,
     ):
         raise OrgFeatureFlagDisabled()

--- a/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
@@ -166,13 +166,25 @@ def _check_lazy_precompute_eligible(runner: "WebOverviewQueryRunner") -> None:
     # to the team UUID so the call still has a stable distinct_id, and rely on
     # the org-group condition to gate those requests.
     distinct_id = runner.user.distinct_id if runner.user else str(runner.team.uuid)
-    if not posthoganalytics.feature_enabled(
-        "web-analytics-precompute-toggle",
-        distinct_id,
-        groups={"organization": str(runner.team.organization_id)},
-        group_properties={"organization": {"id": str(runner.team.organization_id)}},
-        send_feature_flag_events=False,
-    ):
+    # Defensive: a flag-service outage or SDK exception must not break web
+    # analytics. Fail-closed (skip the lazy path, fall back to v2 / raw) so a
+    # bad flag eval can never serve stale or wrong data.
+    try:
+        flag_on = posthoganalytics.feature_enabled(
+            "web-analytics-precompute-toggle",
+            distinct_id,
+            groups={"organization": str(runner.team.organization_id)},
+            group_properties={"organization": {"id": str(runner.team.organization_id)}},
+            send_feature_flag_events=False,
+        )
+    except Exception as exc:
+        logger.warning(
+            "web_overview_lazy_precompute_flag_eval_error",
+            team_id=runner.team.pk,
+            error=str(exc),
+        )
+        flag_on = False
+    if not flag_on:
         raise OrgFeatureFlagDisabled()
 
     if query.useWebAnalyticsPrecompute is not True:

--- a/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py
@@ -150,14 +150,17 @@ def _check_lazy_precompute_eligible(runner: "WebOverviewQueryRunner") -> None:
     the lazy path. Returns None on success."""
     query = runner.query
 
-    # Rollout gate: org-level PostHog feature flag AND per-query opt-in.
-    #   - `web-analytics-lazy-precompute` (PostHog feature flag, evaluated at
-    #     the organization level): rollout lever. Flip orgs on/off without a
-    #     deploy; supports percent rollouts and targeted overrides.
+    # Rollout gate: shared PostHog feature flag AND per-query opt-in.
+    #   - `web-analytics-precompute-toggle` (PostHog feature flag): the same
+    #     flag the frontend already uses to show/hide the "Allow precompute"
+    #     button in the Web Analytics ScenePanel. Reusing it gives operators
+    #     one switch that controls both the UI surface and the backend gate.
+    #     Evaluated at the organization level here — set up an org-level
+    #     release condition on the flag to enable rollout.
     #   - `query.useWebAnalyticsPrecompute` (per-query parameter set by the
-    #     "Allow precompute" toggle in the Web Analytics ScenePanel).
+    #     "Allow precompute" toggle).
     if not posthoganalytics.feature_enabled(
-        "web-analytics-lazy-precompute",
+        "web-analytics-precompute-toggle",
         str(runner.team.id),
         groups={"organization": str(runner.team.organization_id)},
         group_properties={"organization": {"id": str(runner.team.organization_id)}},

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -18702,7 +18702,7 @@ class WebOverviewQuery(BaseModel):
         default=None,
         description=(
             "Opt this specific query into the web_overview_query precompute path."
-            " Requires the `web-analytics-lazy-precompute` PostHog feature flag to be"
+            " Requires the `web-analytics-precompute-toggle` PostHog feature flag to be"
             " on for the team's organization for the gate to pass. *"
         ),
     )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -18702,8 +18702,8 @@ class WebOverviewQuery(BaseModel):
         default=None,
         description=(
             "Opt this specific query into the web_overview_query precompute path."
-            " Requires the team to be in the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS`"
-            " allowlist for the gate to pass. *"
+            " Requires the `web-analytics-lazy-precompute` PostHog feature flag to be"
+            " on for the team's organization for the gate to pass. *"
         ),
     )
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -279,11 +279,6 @@ CONSTANCE_CONFIG = {
         "Team IDs that use prefiltered events subqueries in web analytics bounce/scroll queries for better granule pruning",
         list[int],
     ),
-    "WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS": (
-        get_from_env("WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS", default=[], type_cast=list[int]),
-        "Team IDs enrolled in the web_overview_query lazy precompute path. Admin-controlled rollout gate.",
-        list[int],
-    ),
 }
 
 SETTINGS_ALLOWING_API_OVERRIDE = (
@@ -333,7 +328,6 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "CLICKHOUSE_KILL_SWITCH_FULL_TEAMS",
     "CLICKHOUSE_HEDGED_APP_QUERIES",
     "WEB_ANALYTICS_EVENTS_PREFILTER_TEAM_IDS",
-    "WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS",
     "REDIRECT_APP_TO_US",
     "WEB_ANALYTICS_WARMING_DAYS",
     "WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT",

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2848,7 +2848,7 @@ export interface WebOverviewQueryApi {
     samplingFactor?: number | null
     tags?: QueryLogTagsApi | null
     useSessionsTable?: boolean | null
-    /** Opt this specific query into the web_overview_query precompute path. Requires the team to be in the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` allowlist for the gate to pass. * */
+    /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-lazy-precompute` PostHog feature flag to be on for the team's organization for the gate to pass. * */
     useWebAnalyticsPrecompute?: boolean | null
     /** version of the node, used for schema migrations */
     version?: number | null

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2848,7 +2848,7 @@ export interface WebOverviewQueryApi {
     samplingFactor?: number | null
     tags?: QueryLogTagsApi | null
     useSessionsTable?: boolean | null
-    /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-lazy-precompute` PostHog feature flag to be on for the team's organization for the gate to pass. * */
+    /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
     useWebAnalyticsPrecompute?: boolean | null
     /** version of the node, used for schema migrations */
     version?: number | null

--- a/products/web_analytics/PRECOMPUTATION.md
+++ b/products/web_analytics/PRECOMPUTATION.md
@@ -15,12 +15,12 @@ DAG-warmed ClickHouse tables (`web_pre_aggregated_stats`, `web_pre_aggregated_bo
 
 ### Lazy computation
 
-The newer general-purpose framework at `products/analytics_platform/backend/lazy_computation/`. Computes precomputed buckets on first read, caches them in a dedicated CH table per query family, and serves subsequent reads from the cache. Gated per-team by `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` instance setting (defaults to empty).
+The newer general-purpose framework at `products/analytics_platform/backend/lazy_computation/`. Computes precomputed buckets on first read, caches them in a dedicated CH table per query family, and serves subsequent reads from the cache. Gated per-org by the `web-analytics-lazy-precompute` PostHog feature flag (evaluated against the team's organization).
 
 - **Owned by**: web analytics team, riding on the analytics_platform framework
 - **Population**: synchronous, on first read miss; subsequent reads hit the cache
 - **Coverage** (today): `web_overview_query` only — see `posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py`
-- **Adoption** (as of 2026-05): freshly enabled, allowlist gates further rollout
+- **Adoption** (as of 2026-05): freshly enabled, org feature flag gates further rollout
 
 ## When to use which
 
@@ -75,7 +75,7 @@ The pad value is the maximum realistic session duration. PostHog sessions cap at
 
 `can_use_lazy_precompute(runner)` in `web_overview_lazy_precompute.py`. Refuses when any of:
 
-- Team is not in `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS`
+- The `web-analytics-lazy-precompute` PostHog feature flag is off for the team's organization
 - Team timezone has a non-whole-hour UTC offset
 - `query.conversionGoal` is set
 - `query.sampling.enabled` is True

--- a/products/web_analytics/PRECOMPUTATION.md
+++ b/products/web_analytics/PRECOMPUTATION.md
@@ -15,7 +15,7 @@ DAG-warmed ClickHouse tables (`web_pre_aggregated_stats`, `web_pre_aggregated_bo
 
 ### Lazy computation
 
-The newer general-purpose framework at `products/analytics_platform/backend/lazy_computation/`. Computes precomputed buckets on first read, caches them in a dedicated CH table per query family, and serves subsequent reads from the cache. Gated per-org by the `web-analytics-lazy-precompute` PostHog feature flag (evaluated against the team's organization).
+The newer general-purpose framework at `products/analytics_platform/backend/lazy_computation/`. Computes precomputed buckets on first read, caches them in a dedicated CH table per query family, and serves subsequent reads from the cache. Gated per-org by the `web-analytics-precompute-toggle` PostHog feature flag (evaluated against the team's organization).
 
 - **Owned by**: web analytics team, riding on the analytics_platform framework
 - **Population**: synchronous, on first read miss; subsequent reads hit the cache
@@ -75,7 +75,7 @@ The pad value is the maximum realistic session duration. PostHog sessions cap at
 
 `can_use_lazy_precompute(runner)` in `web_overview_lazy_precompute.py`. Refuses when any of:
 
-- The `web-analytics-lazy-precompute` PostHog feature flag is off for the team's organization
+- The `web-analytics-precompute-toggle` PostHog feature flag is off for the team's organization
 - Team timezone has a non-whole-hour UTC offset
 - `query.conversionGoal` is set
 - `query.sampling.enabled` is True

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2984,7 +2984,7 @@ export namespace Schemas {
       samplingFactor?: number | null;
       tags?: QueryLogTags | null;
       useSessionsTable?: boolean | null;
-      /** Opt this specific query into the web_overview_query precompute path. Requires the team to be in the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` allowlist for the gate to pass. * */
+      /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-lazy-precompute` PostHog feature flag to be on for the team's organization for the gate to pass. * */
       useWebAnalyticsPrecompute?: boolean | null;
       /** version of the node, used for schema migrations */
       version?: number | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2984,7 +2984,7 @@ export namespace Schemas {
       samplingFactor?: number | null;
       tags?: QueryLogTags | null;
       useSessionsTable?: boolean | null;
-      /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-lazy-precompute` PostHog feature flag to be on for the team's organization for the gate to pass. * */
+      /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
       useWebAnalyticsPrecompute?: boolean | null;
       /** version of the node, used for schema migrations */
       version?: number | null;


### PR DESCRIPTION
## Problem

PR #59075 shipped the lazy precompute path for `web_overview_query` behind a two-gate design: a per-team allowlist (`WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` instance setting) AND a per-query opt-in (`useWebAnalyticsPrecompute`). The instance-setting gate is painful to operate — bumping it requires a deploy or admin SQL, there's no percentage rollout, and we have no way to surface which orgs are on/off in PostHog itself.

## Changes

Replace the instance-setting gate with an org-level PostHog feature flag (`web-analytics-lazy-precompute`):

- `posthog/hogql_queries/web_analytics/web_overview_lazy_precompute.py` — swap `get_instance_setting("WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS")` for `posthoganalytics.feature_enabled("web-analytics-lazy-precompute", str(team.id), groups={"organization": str(team.organization_id)}, ...)`. Rename the rejection class `TeamNotInAllowlist` → `OrgFeatureFlagDisabled` so log identifiers match the new gate semantics.
- `posthog/settings/dynamic_settings.py` — remove the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` dynamic setting and its `SETTINGS_ALLOWING_API_OVERRIDE` entry.
- Tests: `_enable_lazy` now mocks `posthoganalytics.feature_enabled` instead of `override_instance_config`. Two tests renamed to match the new gate vocabulary (`..._when_org_flag_disabled` / `..._when_query_not_opted_in`).
- Docs / tooltips: `PRECOMPUTATION.md`, `schema-general.ts` field description, and the ScenePanel "Allow precompute" tooltip refer to the new flag.

The per-query `useWebAnalyticsPrecompute` opt-in is unchanged — it remains the second gate / kill switch.

## How did you test this code?

Agent-authored. Verified via:

- `ruff check` / `ruff format` clean across edited Python.
- `hogli build:schema` + `hogli build:openapi` to regenerate downstream artifacts (`schema.json`, `schema.py`, MCP `generated.ts`, product `api.schemas.ts`).
- Django smoke import of `can_use_lazy_precompute` + `OrgFeatureFlagDisabled` to confirm the module still loads.
- Updated unit tests still mirror the old gate behavior — mock-disabled flag falls through, mock-enabled flag + per-query opt-in qualifies.

Operator action required before this can serve traffic: create the `web-analytics-lazy-precompute` boolean flag in PostHog dogfood (organization-targeted, OFF by default). Then dial it up per-org from the flag UI.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Followed the AI table resolver pattern (`posthog/hogql_queries/ai/ai_table_resolver.py:43-49`) for org-level feature flag evaluation — `str(team.id)` as distinct_id, `groups={"organization": str(team.organization_id)}`, `send_feature_flag_events=False` to avoid event noise on every query.

Decision points:

- **Renamed `TeamNotInAllowlist` → `OrgFeatureFlagDisabled`** even though the file's docstring says rejection class names are "canonical identifiers — keep them stable." The old name describes a gate that no longer exists; keeping it would mislead anyone grepping logs after the cutover. Acceptable break since the path is freshly enabled (effectively zero in-prod traffic, per the gate diagnostics in master `system.query_log`).
- **Default-OFF flag.** Org admins flip via the PostHog flag UI rather than a deploy. Lets us do percent rollouts (e.g. 10% → 50% → 100%) and target dogfood teams first without operator intervention.
- **Did not remove the per-query `useWebAnalyticsPrecompute` modifier.** That's the kill switch on the caller side — the ScenePanel toggle — and remains useful even after the flag is fully rolled out, especially for diagnosing whether a regression is the lazy path or upstream.